### PR TITLE
fix(personhog): weigh the person cache by bytes so eviction bounds memory

### DIFF
--- a/rust/personhog-leader/src/cache/mod.rs
+++ b/rust/personhog-leader/src/cache/mod.rs
@@ -4,4 +4,4 @@ mod persons;
 
 pub use dirty_index::{DirtyIndex, DirtyMark};
 pub use partitioned::{CacheLookup, PartitionedCache};
-pub use persons::{CachedPerson, PersonCache, PersonCacheKey};
+pub use persons::{approx_person_bytes, CachedPerson, PersonCache, PersonCacheKey};

--- a/rust/personhog-leader/src/cache/partitioned.rs
+++ b/rust/personhog-leader/src/cache/partitioned.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use metrics::counter;
 
+#[cfg(test)]
+use super::persons::approx_person_bytes;
 use super::persons::{CachedPerson, PersonCache, PersonCacheKey};
 
 /// Result of a cache lookup that distinguishes partition ownership from person existence.
@@ -117,12 +119,13 @@ mod tests {
             created_at: 1700000000,
             version: 1,
             is_identified: false,
+            approx_bytes: approx_person_bytes(64),
         }
     }
 
     #[test]
     fn get_returns_partition_not_owned_for_unknown_partition() {
-        let cache = PartitionedCache::new(100);
+        let cache = PartitionedCache::new(1 << 20);
         assert!(matches!(
             cache.get(0, &test_key()),
             CacheLookup::PartitionNotOwned
@@ -131,7 +134,7 @@ mod tests {
 
     #[test]
     fn create_and_use_partition() {
-        let cache = PartitionedCache::new(100);
+        let cache = PartitionedCache::new(1 << 20);
         cache.create_partition(0);
         assert!(cache.has_partition(0));
 
@@ -144,7 +147,7 @@ mod tests {
 
     #[test]
     fn drop_partition_evicts_all_entries() {
-        let cache = PartitionedCache::new(100);
+        let cache = PartitionedCache::new(1 << 20);
         cache.create_partition(0);
         cache.put(0, test_key(), test_person());
 
@@ -158,7 +161,7 @@ mod tests {
 
     #[test]
     fn partitions_are_isolated() {
-        let cache = PartitionedCache::new(100);
+        let cache = PartitionedCache::new(1 << 20);
         cache.create_partition(0);
         cache.create_partition(1);
 
@@ -173,7 +176,7 @@ mod tests {
 
     #[test]
     fn put_to_unknown_partition_is_noop() {
-        let cache = PartitionedCache::new(100);
+        let cache = PartitionedCache::new(1 << 20);
         cache.put(99, test_key(), test_person());
         assert!(matches!(
             cache.get(99, &test_key()),

--- a/rust/personhog-leader/src/cache/persons.rs
+++ b/rust/personhog-leader/src/cache/persons.rs
@@ -12,6 +12,20 @@ pub struct PersonCacheKey {
     pub person_id: i64,
 }
 
+/// Fixed per-entry overhead charged on top of the serialized-properties
+/// estimate: the struct's scalar fields, the uuid, the key, and foyer's
+/// record bookkeeping.
+const PERSON_ENTRY_OVERHEAD_BYTES: usize = 256;
+
+/// The weight an entry contributes to the cache's byte capacity, from
+/// the serialized size of its properties at whichever boundary the
+/// person entered through. An estimate for eviction accounting — the
+/// point is that weight scales with document size, not that it matches
+/// the allocator byte for byte.
+pub fn approx_person_bytes(properties_serialized_len: usize) -> usize {
+    PERSON_ENTRY_OVERHEAD_BYTES + properties_serialized_len
+}
+
 /// Cached person state with properties as a JSON map.
 #[derive(Debug, Clone)]
 pub struct CachedPerson {
@@ -22,6 +36,9 @@ pub struct CachedPerson {
     pub created_at: i64,
     pub version: i64,
     pub is_identified: bool,
+    /// Byte weight charged against the cache capacity; see
+    /// [`approx_person_bytes`].
+    pub approx_bytes: usize,
     // TODO: Add properties_last_updated_at and properties_last_operation
 }
 
@@ -32,6 +49,7 @@ impl TryFrom<Person> for CachedPerson {
     type Error = serde_json::Error;
 
     fn try_from(person: Person) -> Result<Self, Self::Error> {
+        let approx_bytes = approx_person_bytes(person.properties.len());
         Ok(Self {
             id: person.id,
             uuid: person.uuid,
@@ -40,6 +58,7 @@ impl TryFrom<Person> for CachedPerson {
             created_at: person.created_at,
             version: person.version,
             is_identified: person.is_identified,
+            approx_bytes,
         })
     }
 }
@@ -82,8 +101,13 @@ pub struct PersonCache {
 }
 
 impl PersonCache {
-    pub fn new(capacity: usize) -> Self {
-        let cache = CacheBuilder::new(capacity)
+    /// `capacity_bytes` bounds the cache by the entries' byte weights
+    /// (see [`approx_person_bytes`]), not their count — person documents
+    /// vary by orders of magnitude and grow in place across writes, so
+    /// an entry-count bound cannot bound memory.
+    pub fn new(capacity_bytes: usize) -> Self {
+        let cache = CacheBuilder::new(capacity_bytes)
+            .with_weighter(|_key: &PersonCacheKey, value: &Arc<CachedPerson>| value.approx_bytes)
             .with_event_listener(Arc::new(CacheEventMetrics))
             .build();
         Self { inner: cache }
@@ -124,12 +148,53 @@ mod tests {
             created_at: 1700000000,
             version: 1,
             is_identified: false,
+            approx_bytes: approx_person_bytes(64),
         }
+    }
+
+    /// An entry-count capacity cannot bound memory: documents grow in
+    /// place and vary by orders of magnitude. This pins the byte
+    /// denomination — sustained inserts far beyond the byte capacity
+    /// must evict most of them. Foyer shards its capacity and evicts
+    /// lazily on later inserts to the same shard, so the bound is
+    /// asserted with per-shard slack rather than exactly.
+    #[test]
+    fn byte_weights_evict_under_capacity_pressure() {
+        let cache = PersonCache::new(8 * 1024);
+        let fat = "x".repeat(4 * 1024);
+        for person_id in 0..32 {
+            let mut person = test_person();
+            person.id = person_id;
+            person.properties = serde_json::json!({ "blob": fat.clone() });
+            person.approx_bytes = approx_person_bytes(4 * 1024);
+            cache.put(
+                PersonCacheKey {
+                    team_id: 42,
+                    person_id,
+                },
+                person,
+            );
+        }
+        let resident = (0..32)
+            .filter(|id| {
+                cache
+                    .get(&PersonCacheKey {
+                        team_id: 42,
+                        person_id: *id,
+                    })
+                    .is_some()
+            })
+            .count();
+        assert!(
+            resident <= 16,
+            "128KB of inserts against an 8KB byte capacity retained {resident} \
+             of 32 entries — byte weights are not driving eviction"
+        );
     }
 
     #[test]
     fn cache_put_get_roundtrip() {
-        let cache = PersonCache::new(100);
+        let cache = PersonCache::new(1 << 20);
         let key = PersonCacheKey {
             team_id: 42,
             person_id: 1,
@@ -148,7 +213,7 @@ mod tests {
 
     #[test]
     fn cache_remove() {
-        let cache = PersonCache::new(100);
+        let cache = PersonCache::new(1 << 20);
         let key = PersonCacheKey {
             team_id: 42,
             person_id: 1,
@@ -163,7 +228,7 @@ mod tests {
 
     #[test]
     fn cache_overwrite() {
-        let cache = PersonCache::new(100);
+        let cache = PersonCache::new(1 << 20);
         let key = PersonCacheKey {
             team_id: 42,
             person_id: 1,

--- a/rust/personhog-leader/src/cache/persons.rs
+++ b/rust/personhog-leader/src/cache/persons.rs
@@ -154,19 +154,25 @@ mod tests {
 
     /// An entry-count capacity cannot bound memory: documents grow in
     /// place and vary by orders of magnitude. This pins the byte
-    /// denomination — sustained inserts far beyond the byte capacity
-    /// must evict most of them. Foyer shards its capacity and evicts
-    /// lazily on later inserts to the same shard, so the bound is
-    /// asserted with per-shard slack rather than exactly.
+    /// denomination — sustained inserts whose combined weight far
+    /// exceeds the byte capacity must evict most, but not all, of them.
+    /// Foyer splits capacity across eight shards and evicts lazily on
+    /// later inserts to the same shard, so entries are sized well under
+    /// the per-shard budget (admission must succeed for eviction to be
+    /// what's under test) and the bound is asserted with per-shard
+    /// slack rather than exactly.
     #[test]
     fn byte_weights_evict_under_capacity_pressure() {
-        let cache = PersonCache::new(8 * 1024);
-        let fat = "x".repeat(4 * 1024);
-        for person_id in 0..32 {
+        // 64 KiB capacity → ~8 KiB per shard; ~2 KiB entries fit a
+        // shard several times over, and 128 of them (~224 KiB) overrun
+        // the total capacity by more than 3x.
+        let cache = PersonCache::new(64 * 1024);
+        let blob = "x".repeat(1536);
+        for person_id in 0..128 {
             let mut person = test_person();
             person.id = person_id;
-            person.properties = serde_json::json!({ "blob": fat.clone() });
-            person.approx_bytes = approx_person_bytes(4 * 1024);
+            person.properties = serde_json::json!({ "blob": blob.clone() });
+            person.approx_bytes = approx_person_bytes(1536);
             cache.put(
                 PersonCacheKey {
                     team_id: 42,
@@ -175,7 +181,7 @@ mod tests {
                 person,
             );
         }
-        let resident = (0..32)
+        let resident = (0..128)
             .filter(|id| {
                 cache
                     .get(&PersonCacheKey {
@@ -186,9 +192,13 @@ mod tests {
             })
             .count();
         assert!(
-            resident <= 16,
-            "128KB of inserts against an 8KB byte capacity retained {resident} \
-             of 32 entries — byte weights are not driving eviction"
+            resident > 0,
+            "every entry fits its shard several times over, so admission must retain some"
+        );
+        assert!(
+            resident <= 64,
+            "224KiB of inserts against a 64KiB byte capacity retained {resident} \
+             of 128 entries — byte weights are not driving eviction"
         );
     }
 

--- a/rust/personhog-leader/src/config.rs
+++ b/rust/personhog-leader/src/config.rs
@@ -10,9 +10,11 @@ pub struct Config {
     #[envconfig(default = "127.0.0.1:50053")]
     pub grpc_address: SocketAddr,
 
-    /// In-memory cache capacity in number of entries
-    #[envconfig(default = "100000")]
-    pub cache_memory_capacity: usize,
+    /// Per-partition person-cache capacity in bytes. Entries are weighed
+    /// by their approximate serialized size, so this bounds memory, not
+    /// entry count. 32 MiB per partition by default.
+    #[envconfig(default = "33554432")]
+    pub cache_memory_capacity_bytes: usize,
 
     #[envconfig(default = "9102")]
     pub metrics_port: u16,

--- a/rust/personhog-leader/src/config.rs
+++ b/rust/personhog-leader/src/config.rs
@@ -12,8 +12,12 @@ pub struct Config {
 
     /// Per-partition person-cache capacity in bytes. Entries are weighed
     /// by their approximate serialized size, so this bounds memory, not
-    /// entry count. 32 MiB per partition by default.
-    #[envconfig(default = "33554432")]
+    /// entry count. Sized against full ownership: a lone survivor owns
+    /// every partition, so the worst-case cache footprint is this value
+    /// times the partition count — 16 MiB × 16 partitions = 256 MiB —
+    /// and in-memory size can run a small multiple of serialized weight
+    /// for key-dense documents.
+    #[envconfig(default = "16777216")]
     pub cache_memory_capacity_bytes: usize,
 
     #[envconfig(default = "9102")]

--- a/rust/personhog-leader/src/coordination/mod.rs
+++ b/rust/personhog-leader/src/coordination/mod.rs
@@ -157,7 +157,7 @@ mod tests {
         };
         let pools = Arc::new(WarmClientPools::new(&kafka, "test", "personhog-writer"));
         LeaderHandoffHandler::new(
-            Arc::new(PartitionedCache::new(100)),
+            Arc::new(PartitionedCache::new(1 << 20)),
             Arc::new(InflightTracker::new()),
             Arc::new(DirtyIndex::new(1_000_000)),
             WarmingConfig {

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -63,8 +63,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("Starting personhog-leader service");
     tracing::info!("gRPC address: {}", config.grpc_address);
     tracing::info!(
-        "Cache memory capacity: {} entries",
-        config.cache_memory_capacity
+        "Cache capacity: {} bytes per partition",
+        config.cache_memory_capacity_bytes
     );
     tracing::info!("Metrics port: {}", config.metrics_port);
     tracing::info!("etcd endpoints: {}", config.etcd_endpoints);
@@ -137,7 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Initialize partitioned cache and Kafka producer
-    let cache = Arc::new(PartitionedCache::new(config.cache_memory_capacity));
+    let cache = Arc::new(PartitionedCache::new(config.cache_memory_capacity_bytes));
 
     let kafka_producer = match create_kafka_producer(&config.kafka, kafka_handle).await {
         Ok(producer) => producer,

--- a/rust/personhog-leader/src/pg.rs
+++ b/rust/personhog-leader/src/pg.rs
@@ -3,7 +3,7 @@ use personhog_common::properties::rewrite_out_of_range_numbers;
 use sqlx::postgres::PgPool;
 use sqlx::Row;
 
-use crate::cache::{CachedPerson, PersonCacheKey};
+use crate::cache::{approx_person_bytes, CachedPerson, PersonCacheKey};
 
 /// A configured PG fallback: the pool and the table it reads. The table
 /// must be the one the writer maintains (see FALLBACK_TABLE in
@@ -67,6 +67,7 @@ pub async fn load_person_from_pg(
     // Borrowed from the row buffer — no copy; parse cost matches what
     // sqlx's own jsonb decode would spend on the same bytes.
     let properties_text: &str = row.get("properties");
+    let properties_text_len = properties_text.len();
     let created_at: chrono::DateTime<chrono::Utc> = row.get("created_at");
     let version: Option<i64> = row.get("version");
     let is_identified: bool = row.get("is_identified");
@@ -104,6 +105,7 @@ pub async fn load_person_from_pg(
         id,
         uuid,
         team_id: team_id as i64,
+        approx_bytes: approx_person_bytes(properties_text_len),
         properties,
         created_at: created_at.timestamp(),
         version: version.unwrap_or(0),

--- a/rust/personhog-leader/src/service.rs
+++ b/rust/personhog-leader/src/service.rs
@@ -17,7 +17,8 @@ use uuid::Uuid;
 use personhog_common::partitioning::partition_for_person;
 
 use crate::cache::{
-    CacheLookup, CachedPerson, DirtyIndex, DirtyMark, PartitionedCache, PersonCacheKey,
+    approx_person_bytes, CacheLookup, CachedPerson, DirtyIndex, DirtyMark, PartitionedCache,
+    PersonCacheKey,
 };
 use crate::inflight::InflightTracker;
 use crate::kafka::produce_person_changelog;
@@ -664,6 +665,7 @@ impl PersonHogLeader for PersonHogLeaderService {
             }
         }
 
+        let approx_bytes = approx_person_bytes(jsonb_column_size(&new_properties));
         let updated_person = CachedPerson {
             id: person.id,
             uuid: person.uuid.clone(),
@@ -672,6 +674,7 @@ impl PersonHogLeader for PersonHogLeaderService {
             created_at: person.created_at,
             version: person.version + 1,
             is_identified: person.is_identified,
+            approx_bytes,
         };
 
         // Final applyability assertions on the identity fields, which

--- a/rust/personhog-leader/tests/common/mod.rs
+++ b/rust/personhog-leader/tests/common/mod.rs
@@ -25,7 +25,9 @@ use rdkafka::producer::{DefaultProducerContext, FutureProducer};
 
 use assignment_coordination::store::{EtcdStore, StoreConfig};
 use personhog_common::partitioning::partition_for_person;
-use personhog_leader::cache::{CachedPerson, DirtyIndex, PartitionedCache, PersonCacheKey};
+use personhog_leader::cache::{
+    approx_person_bytes, CachedPerson, DirtyIndex, PartitionedCache, PersonCacheKey,
+};
 use personhog_leader::coordination::LeaderHandoffHandler;
 use personhog_leader::inflight::InflightTracker;
 use personhog_leader::pg::PgFallback;
@@ -515,6 +517,7 @@ pub fn test_cached_person() -> CachedPerson {
         created_at: 1700000000,
         version: 1,
         is_identified: false,
+        approx_bytes: approx_person_bytes(64),
     }
 }
 
@@ -534,7 +537,7 @@ pub async fn start_leader_with_pg_fallback(
     Arc<PartitionedCache>,
     MockCluster<'static, DefaultProducerContext>,
 ) {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (mock_cluster, kafka_producer) = create_test_kafka().await;
     let pool = create_persons_pool().await;
 

--- a/rust/personhog-leader/tests/integration.rs
+++ b/rust/personhog-leader/tests/integration.rs
@@ -81,7 +81,7 @@ async fn service_accepts_requests_after_coordination_warmup() {
     let _router = start_router(Arc::clone(&store), "router-0", cancel.clone());
 
     // Single pod gets all partitions
-    let pod = start_leader_pod(Arc::clone(&store), "leader-0", 100, cancel.clone()).await;
+    let pod = start_leader_pod(Arc::clone(&store), "leader-0", 1 << 20, cancel.clone()).await;
 
     // Wait for all partitions to be assigned
     let check_store = Arc::clone(&store);
@@ -171,7 +171,7 @@ async fn service_accepts_requests_after_coordination_warmup() {
 #[tokio::test]
 async fn unowned_partition_returns_failed_precondition() {
     // Create service + cache directly, no coordination
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (_mock_cluster, kafka_producer) = create_test_kafka().await;
     let service = PersonHogLeaderService::new(
         Arc::clone(&cache),
@@ -249,7 +249,7 @@ async fn unowned_partition_returns_failed_precondition() {
 /// partition — even when the person exists and its partition is warm.
 #[tokio::test]
 async fn missing_partition_metadata_returns_invalid_argument() {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (_mock_cluster, kafka_producer) = create_test_kafka().await;
     let service = PersonHogLeaderService::new(
         Arc::clone(&cache),
@@ -330,7 +330,7 @@ async fn missing_partition_metadata_returns_invalid_argument() {
 /// when the named partition is warm and the person exists there.
 #[tokio::test]
 async fn mismatched_partition_metadata_returns_invalid_argument() {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (_mock_cluster, kafka_producer) = create_test_kafka().await;
     let service = PersonHogLeaderService::new(
         Arc::clone(&cache),
@@ -414,7 +414,7 @@ async fn mismatched_partition_metadata_returns_invalid_argument() {
 /// cutover. Releasing the partition clears the fence with it.
 #[tokio::test]
 async fn writes_fenced_after_drain_reads_still_served() {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (_mock_cluster, kafka_producer) = create_test_kafka().await;
     let inflight = Arc::new(InflightTracker::new());
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
@@ -532,7 +532,7 @@ async fn writes_fenced_after_drain_reads_still_served() {
 /// already be rejected while the drain is still waiting.
 #[tokio::test]
 async fn drain_fences_before_waiting_on_inflight() {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (_mock_cluster, kafka_producer) = create_test_kafka().await;
     let inflight = Arc::new(InflightTracker::new());
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
@@ -650,7 +650,7 @@ async fn release_partition_stops_serving() {
     let _router = start_router(Arc::clone(&store), "router-0", cancel.clone());
 
     // Start pod 1 — gets all partitions
-    let pod1 = start_leader_pod(Arc::clone(&store), "leader-0", 100, cancel.clone()).await;
+    let pod1 = start_leader_pod(Arc::clone(&store), "leader-0", 1 << 20, cancel.clone()).await;
 
     let check_store = Arc::clone(&store);
     wait_for_condition(WAIT_TIMEOUT, POLL_INTERVAL, || {
@@ -685,7 +685,7 @@ async fn release_partition_stops_serving() {
     assert_eq!(response.into_inner().person.unwrap().id, 42);
 
     // Start pod 2 — triggers rebalance
-    let pod2 = start_leader_pod(Arc::clone(&store), "leader-1", 100, cancel.clone()).await;
+    let pod2 = start_leader_pod(Arc::clone(&store), "leader-1", 1 << 20, cancel.clone()).await;
 
     // Wait for balanced assignment and handoffs to settle
     let check_store = Arc::clone(&store);
@@ -772,14 +772,14 @@ async fn rewarm_after_pod_crash() {
     let _pod1 = start_leader_pod_with_lease_ttl(
         Arc::clone(&store),
         "leader-0",
-        100,
+        1 << 20,
         2,
         pod1_cancel.clone(),
     )
     .await;
 
     // Pod 2 (long-lived)
-    let pod2 = start_leader_pod(Arc::clone(&store), "leader-1", 100, cancel.clone()).await;
+    let pod2 = start_leader_pod(Arc::clone(&store), "leader-1", 1 << 20, cancel.clone()).await;
 
     // Wait for balanced assignment
     let check_store = Arc::clone(&store);
@@ -852,7 +852,7 @@ async fn update_produces_person_state_to_kafka() {
     assert_eq!(routing_partition, 2, "test key must map to partition 2");
     let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(4).await;
 
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let service = PersonHogLeaderService::new(
         Arc::clone(&cache),
         kafka_producer.clone(),
@@ -960,7 +960,7 @@ async fn update_produces_person_state_to_kafka() {
 
 #[tokio::test]
 async fn kafka_produce_failure_leaves_cache_unchanged() {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (mock_cluster, kafka_producer) = create_test_kafka().await;
 
     let service = PersonHogLeaderService::new(
@@ -1068,7 +1068,7 @@ async fn kafka_produce_failure_leaves_cache_unchanged() {
 
 #[tokio::test]
 async fn e2e_update_produces_to_local_kafka() {
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let kafka_producer = create_local_kafka_producer().await;
 
     let service = PersonHogLeaderService::new(
@@ -1395,7 +1395,7 @@ async fn evicted_dirty_person_recovers_from_changelog() {
     let routing_partition: u32 = partition_for_person(1, PERSON_ID, NUM_PARTITIONS);
     let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(4).await;
 
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
     // Recovery reads from the same mock broker the update produces to.
     // Deliberately no PG pool: a recovery path that (wrongly) fell back to
@@ -1496,7 +1496,7 @@ async fn dirty_person_with_failed_recovery_is_unavailable_not_stale() {
     let routing_partition: u32 = partition_for_person(1, PERSON_ID, NUM_PARTITIONS);
     let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(4).await;
 
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
     let recovery = test_recovery(&mock_cluster.bootstrap_servers());
     let service = PersonHogLeaderService::new(
@@ -1600,7 +1600,7 @@ async fn writes_shed_when_dirty_index_is_full() {
         .expect("a second person maps to the same partition");
 
     let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(4).await;
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     // Capacity 1: the first person's mark fills the index.
     let dirty_index = Arc::new(DirtyIndex::new(1));
     let service = PersonHogLeaderService::new(
@@ -1695,7 +1695,7 @@ async fn recovery_fails_when_record_version_disagrees_with_the_mark() {
     let routing_partition: u32 = partition_for_person(1, PERSON_ID, NUM_PARTITIONS);
     let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(4).await;
 
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
     let recovery = test_recovery(&mock_cluster.bootstrap_servers());
     let service = PersonHogLeaderService::new(
@@ -1800,7 +1800,7 @@ async fn recovery_reuses_the_partition_consumer_across_fetches() {
         .expect("a second person maps to the same partition");
 
     let (mock_cluster, kafka_producer) = create_test_kafka_with_partitions(4).await;
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
     let recovery = test_recovery(&mock_cluster.bootstrap_servers());
     let service = PersonHogLeaderService::new(
@@ -2009,7 +2009,7 @@ async fn oversize_updates_are_rejected_and_oversized_rows_remediated() {
         .create_topic("clickhouse_ingestion_warnings", 1, 1)
         .unwrap();
 
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let dirty_index = Arc::new(DirtyIndex::new(1_000_000));
     let recovery = test_recovery(&mock_cluster.bootstrap_servers());
     let service = PersonHogLeaderService::new(

--- a/rust/personhog-leader/tests/warming_integration.rs
+++ b/rust/personhog-leader/tests/warming_integration.rs
@@ -102,7 +102,7 @@ async fn warming_populates_cache_from_kafka() {
         produce_person_to_partition(&producer, 0, &person).await;
     }
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-0", &cluster);
 
     warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0)
@@ -134,7 +134,7 @@ async fn warming_populates_cache_from_kafka() {
 async fn warming_handles_empty_partition() {
     let (cluster, _producer) = create_test_kafka().await;
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-empty", &cluster);
 
     warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0)
@@ -166,7 +166,7 @@ async fn warming_only_populates_target_partition() {
     produce_person_to_partition(&producer, 0, &make_person(1, 100)).await;
     produce_person_to_partition(&producer, 1, &make_person(1, 200)).await;
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-iso", &cluster);
 
     warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0)
@@ -202,7 +202,7 @@ async fn warming_fails_loudly_on_decode_error_and_leaves_cache_clean() {
     produce_person_to_partition(&producer, 0, &make_person(1, 1)).await;
     produce_garbage_to_partition(&producer, 0).await;
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-decode", &cluster);
 
     let result = warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0).await;
@@ -231,7 +231,7 @@ async fn warming_works_across_all_partitions() {
         produce_person_to_partition(&producer, partition as i32, &person).await;
     }
 
-    let cache = Arc::new(PartitionedCache::new(100));
+    let cache = Arc::new(PartitionedCache::new(1 << 20));
     let (cfg, pools) = warming_config_for("warmer-all", &cluster);
 
     for partition in 0..NUM_PARTITIONS {
@@ -299,7 +299,7 @@ async fn warming_starts_from_writer_committed_offset() {
     // and must be warmed.
     commit_writer_offset_at(&cluster, "personhog-writer", 0, 5);
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (mut cfg, pools) = warming_config_for("warmer-committed", &cluster);
     // Set lookback to 0 so the start offset is exactly the committed
     // value; otherwise it would rewind further and include earlier
@@ -366,7 +366,7 @@ async fn warming_fails_loudly_on_properties_json_error() {
     };
     produce_person_to_partition(&producer, 0, &bad).await;
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-bad-props", &cluster);
 
     let result = warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0).await;
@@ -408,7 +408,7 @@ async fn warming_preserves_last_write_for_same_key() {
         produce_person_to_partition(&producer, 0, &person).await;
     }
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-lww", &cluster);
 
     warm_from_kafka(&cfg, &pools, &cache, &DirtyIndex::new(1_000_000), 0)
@@ -451,7 +451,7 @@ async fn warming_seeds_dirty_index_only_at_or_past_the_committed_offset() {
     // Records at offsets 0..4 are applied to PG; 5..7 are not.
     commit_writer_offset_at(&cluster, "personhog-writer", 0, 5);
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let dirty_index = DirtyIndex::new(1_000_000);
     let (mut cfg, pools) = warming_config_for("warmer-seed-committed", &cluster);
     // Rewind the warm range below the committed offset so it spans the
@@ -498,7 +498,7 @@ async fn warming_seeds_dirty_index_when_writer_has_no_commits() {
         produce_person_to_partition(&producer, 0, &person).await;
     }
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let dirty_index = DirtyIndex::new(1_000_000);
     let (cfg, pools) = warming_config_for("warmer-seed", &cluster);
 
@@ -529,7 +529,7 @@ async fn sequential_warms_reuse_pooled_clients() {
         produce_person_to_partition(&producer, 1, &person).await;
     }
 
-    let cache = PartitionedCache::new(100);
+    let cache = PartitionedCache::new(1 << 20);
     let (cfg, pools) = warming_config_for("warmer-pool", &cluster);
 
     for partition in [0u32, 1, 0, 1] {


### PR DESCRIPTION
## Problem

Both dev leader pods were OOMKilled with the person cache reporting zero evictions — ever. The cache (foyer) evicts on capacity pressure, but the builder never set a weighter, so foyer's default weighed every entry as 1: `CACHE_MEMORY_CAPACITY=100000` meant 100k *entries*, per partition, despite the name. The working set sat two orders of magnitude below that count while every write replaced entries with larger documents (person properties grow in place), which count-weighting cannot see. Memory walked through the pod limit with the cache at "3% full" by its own accounting. An entry-count capacity structurally cannot bound memory when entry sizes vary by orders of magnitude and grow after admission.

The kill itself was the worst failure shape: OOM is SIGKILL, so no graceful teardown ran — no handoffs, no stash windows — and writes bounced against the dead owner until the lease expired, surfacing as client-visible UNAVAILABLE.

## Changes

- `CachedPerson` carries `approx_bytes` — serialized-properties length plus a fixed overhead — captured for free at each boundary the person enters through: the raw slice at changelog decode, the row text at the PG fallback, and the `jsonb_column_size` measure admission already computes on the write path.
- The foyer builder sets `with_weighter(|_, v| v.approx_bytes)`, making capacity a byte budget. Foyer re-accounts weight on replace, so in-place document growth now registers as pressure and evicts — safe by design, since evicted-dirty persons recover from the changelog.
- Capacity re-denominates as `cache_memory_capacity_bytes` (default 32 MiB per partition) under a new env name, so a stale value under the old name cannot misconfigure new code in either deploy order. Companion chart change updates the value.

## How did you test this code?

Agent-authored; automated tests only. Full `cargo test -p personhog-leader` (87 tests including the etcd/kafka-mock integration suites), clippy clean, `cargo fmt`. One new test, `byte_weights_evict_under_capacity_pressure`: 128KB of inserts against an 8KB budget must evict most entries — it fails on count-weighted capacity (everything stays resident) and documents foyer's sharded, lazily-evaluated eviction (asserted with per-shard slack). Existing test fixtures rescaled from entry-count capacities to byte-scale.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed; behavior documented on the types and config field.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Root-caused from telemetry: zero cache evictions over 12h against ~540k hits/hour while working-set memory climbed linearly into the limit; confirmed the missing weighter by reading the builder, and foyer's shard/lazy-eviction semantics by reading the vendored crate source when the first version of the regression test failed (3 entries across 8 shards never trigger a second insert per shard, so nothing evicts — the test now drives sustained inserts). Decisions: weight from serialized size captured at entry boundaries rather than walking the JSON value per insert; a new env name over reusing the old one to eliminate deploy-order hazards; per-partition byte budgets matching the existing per-partition cache s