### PR TITLE
feat(dashboards): one color per breakdown value across properties

### DIFF
--- a/.github/scripts/preview-seed/dashboard-fixture.json
+++ b/.github/scripts/preview-seed/dashboard-fixture.json
@@ -6229,6 +6229,151 @@
             "order": 36,
             "last_refresh": "2026-07-27T11:14:51.078174Z",
             "is_cached": true
+        },
+        {
+            "id": 90000001,
+            "text": {
+                "body": "## Repeated values across properties\n\nQuery kind names repeat under `query_type` (tiles above) and `kind`; `true`/`false` repeat under `cache_hit` and `retried`. Each value keeps one color across tiles."
+            },
+            "layouts": {
+                "sm": {
+                    "x": 0,
+                    "y": 77,
+                    "w": 12,
+                    "h": 2,
+                    "minW": 1,
+                    "minH": 1
+                }
+            }
+        },
+        {
+            "id": 90000002,
+            "insight": {
+                "name": "Query failures by kind",
+                "description": "`kind` re-uses the query type names — its values should copy the query_type tile colors, incl. a pinned one.",
+                "query": {
+                    "kind": "InsightVizNode",
+                    "source": {
+                        "kind": "TrendsQuery",
+                        "dateRange": {
+                            "date_from": "-14d"
+                        },
+                        "interval": "day",
+                        "series": [
+                            {
+                                "kind": "EventsNode",
+                                "event": "query failed",
+                                "math": "total"
+                            }
+                        ],
+                        "breakdownFilter": {
+                            "breakdowns": [
+                                {
+                                    "property": "kind",
+                                    "type": "event"
+                                }
+                            ]
+                        },
+                        "filterTestAccounts": false
+                    }
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "x": 0,
+                    "y": 79,
+                    "w": 4,
+                    "h": 5,
+                    "minW": 1,
+                    "minH": 1
+                }
+            }
+        },
+        {
+            "id": 90000003,
+            "insight": {
+                "name": "Query volume by cache hit",
+                "description": "true/false under `cache_hit` — on one tile per property, they only qualify for a dashboard color counted across properties.",
+                "query": {
+                    "kind": "InsightVizNode",
+                    "source": {
+                        "kind": "TrendsQuery",
+                        "dateRange": {
+                            "date_from": "-14d"
+                        },
+                        "interval": "day",
+                        "series": [
+                            {
+                                "kind": "EventsNode",
+                                "event": "query executed",
+                                "math": "total"
+                            }
+                        ],
+                        "breakdownFilter": {
+                            "breakdowns": [
+                                {
+                                    "property": "cache_hit",
+                                    "type": "event"
+                                }
+                            ]
+                        },
+                        "filterTestAccounts": false
+                    }
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "x": 4,
+                    "y": 79,
+                    "w": 4,
+                    "h": 5,
+                    "minW": 1,
+                    "minH": 1
+                }
+            }
+        },
+        {
+            "id": 90000004,
+            "insight": {
+                "name": "Request failures by retried",
+                "description": "true/false under `retried`, mirroring the cache-hit tile.",
+                "query": {
+                    "kind": "InsightVizNode",
+                    "source": {
+                        "kind": "TrendsQuery",
+                        "dateRange": {
+                            "date_from": "-14d"
+                        },
+                        "interval": "day",
+                        "series": [
+                            {
+                                "kind": "EventsNode",
+                                "event": "client_request_failure",
+                                "math": "total"
+                            }
+                        ],
+                        "breakdownFilter": {
+                            "breakdowns": [
+                                {
+                                    "property": "retried",
+                                    "type": "event"
+                                }
+                            ]
+                        },
+                        "filterTestAccounts": false
+                    }
+                }
+            },
+            "layouts": {
+                "sm": {
+                    "x": 8,
+                    "y": 79,
+                    "w": 4,
+                    "h": 5,
+                    "minW": 1,
+                    "minH": 1
+                }
+            }
         }
     ],
     "tags": [],

--- a/.github/scripts/preview-seed/generate_events.py
+++ b/.github/scripts/preview-seed/generate_events.py
@@ -14,6 +14,11 @@ window). Breakdown VALUES are exact prod values (incl. cross-tile shared
 exception messages — the palette-exhaustion repro depends on that overlap);
 volumes are scaled down ~3 orders.
 
+Two shapes exist purely for the cross-property color test (values repeated under a
+second breakdown property): "query failed" carries QUERY_TYPES names under `kind`,
+and client_request_failure carries a `retried` boolean mirroring `cache_hit`. The
+matching tiles live at the bottom of dashboard-fixture.json.
+
 Idempotent: wipes previously generated rows (distinct_id 'synth-%') first.
 """
 
@@ -147,6 +152,16 @@ FAILURES = {
     ),
 }
 
+# (kind, per_day) — repeats QUERY_TYPES values under a second property (`kind`) for the
+# cross-property color test; HogQLQuery/EventsQuery appear only here (single-property values).
+QUERY_FAILURES = [
+    ("TrendsQuery", 18),
+    ("HogQLQuery", 11),
+    ("FunnelsQuery", 7),
+    ("RetentionQuery", 4),
+    ("EventsQuery", 3),
+]
+
 # (browser, per-day, p50 dropped_frames, p95 dropped_frames)
 BROWSERS = [
     ("Chrome", 86, 1, 899),
@@ -246,6 +261,10 @@ for day in range(DAYS):
                     backend_pool,
                 )
 
+    for kind, per_day in QUERY_FAILURES:
+        for _ in range(per_day):
+            emit("query failed", day, {"kind": kind}, backend_pool)
+
     for ctx, msgs in EXCEPTIONS.items():
         for i, (msg, per_day, _) in enumerate(msgs):
             for _ in range(per_day):
@@ -286,6 +305,8 @@ for day in range(DAYS):
                     {
                         "pathname": api_path,
                         "status": status,
+                        # true/false repeat under cache_hit — cross-property boolean color test
+                        "retried": rng.random() < 0.25,
                         "$pathname": PATHNAMES["ins"],
                         "$current_url": f"https://{HOST}{PATHNAMES['ins']}",
                     },

--- a/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
+++ b/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
@@ -15,6 +15,7 @@ import { BreakdownFilter } from '~/queries/schema/schema-general'
 import { DashboardMode } from '~/types'
 
 import {
+    BOOLEAN_BREAKDOWN_PROPERTY_KEY,
     BreakdownColorConfig,
     BreakdownValueAndType,
     COHORT_BREAKDOWN_PROPERTY_KEY,
@@ -34,6 +35,9 @@ function BreakdownPropertyGroupTitle({ breakdownProperty }: { breakdownProperty?
     }
     if (breakdownProperty === COHORT_BREAKDOWN_PROPERTY_KEY) {
         return <LemonTag type="muted">Cohorts</LemonTag>
+    }
+    if (breakdownProperty === BOOLEAN_BREAKDOWN_PROPERTY_KEY) {
+        return <LemonTag type="muted">True/false</LemonTag>
     }
     return (
         <div className="flex flex-wrap items-center gap-1">
@@ -172,8 +176,9 @@ export function DashboardInsightColorsModal(): JSX.Element {
             <LemonLabel className="mt-4">Breakdown colors</LemonLabel>
             <LemonBanner type="info" className="mt-2 mb-4">
                 Colors are grouped by breakdown property. A value shown on two or more insights gets one color across
-                the dashboard, and each property picks its colors on its own. Values on a single insight keep their own
-                colors. Pick a color to pin a value to it.
+                the dashboard, and each property picks its colors on its own — except true and false, which share one
+                group across properties. Values on a single insight keep their own colors. Pick a color to pin a value
+                to it.
             </LemonBanner>
             {breakdownValueGroups.length === 0 ? (
                 <LemonTable columns={columns} dataSource={[]} loading={insightTilesLoading || undefined} />

--- a/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
+++ b/frontend/src/scenes/dashboard/DashboardInsightColorsModal.tsx
@@ -15,7 +15,6 @@ import { BreakdownFilter } from '~/queries/schema/schema-general'
 import { DashboardMode } from '~/types'
 
 import {
-    BOOLEAN_BREAKDOWN_PROPERTY_KEY,
     BreakdownColorConfig,
     BreakdownValueAndType,
     COHORT_BREAKDOWN_PROPERTY_KEY,
@@ -35,9 +34,6 @@ function BreakdownPropertyGroupTitle({ breakdownProperty }: { breakdownProperty?
     }
     if (breakdownProperty === COHORT_BREAKDOWN_PROPERTY_KEY) {
         return <LemonTag type="muted">Cohorts</LemonTag>
-    }
-    if (breakdownProperty === BOOLEAN_BREAKDOWN_PROPERTY_KEY) {
-        return <LemonTag type="muted">True/false</LemonTag>
     }
     return (
         <div className="flex flex-wrap items-center gap-1">
@@ -175,10 +171,10 @@ export function DashboardInsightColorsModal(): JSX.Element {
 
             <LemonLabel className="mt-4">Breakdown colors</LemonLabel>
             <LemonBanner type="info" className="mt-2 mb-4">
-                Colors are grouped by breakdown property. A value shown on two or more insights gets one color across
-                the dashboard, and each property picks its colors on its own — except true and false, which share one
-                group across properties. Values on a single insight keep their own colors. Pick a color to pin a value
-                to it.
+                Colors are grouped by breakdown property, so each property picks its colors on its own. A value shown on
+                two or more insights gets one color across the dashboard, and keeps that color under every property it
+                shows up under, as far as the palette allows. Values on a single insight keep their own colors. Pick a
+                color to pin a value to it.
             </LemonBanner>
             {breakdownValueGroups.length === 0 ? (
                 <LemonTable columns={columns} dataSource={[]} loading={insightTilesLoading || undefined} />

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
@@ -2,10 +2,12 @@ import { InsightQueryNode, InsightVizNode, NodeKind } from '~/queries/schema/sch
 import { AccessControlLevel, DashboardTile, FunnelVizType, InsightShortId, QueryBasedInsightModel } from '~/types'
 
 import {
+    BOOLEAN_BREAKDOWN_PROPERTY_KEY,
     BreakdownColorConfig,
     BreakdownValueAndType,
     MULTI_BREAKDOWN_SEPARATOR,
     applyAutoBreakdownColors,
+    breakdownValuePropertyKey,
     buildSharedBreakdownValueLookup,
     computeTileFallbackTokens,
     extractBreakdownValues,
@@ -106,6 +108,20 @@ describe('dashboardBreakdownColors', () => {
             ],
         ] as const)('normalizes %s', (_name, breakdownFilter, expected) => {
             expect(getBreakdownPropertyKey(breakdownFilter as any)).toEqual(expected)
+        })
+    })
+
+    describe('breakdownValuePropertyKey', () => {
+        it.each([
+            ['a boolean value to the shared boolean group', 'true', 'event::is_admin', 'boolean'],
+            ['a boolean value regardless of its tile', 'false', 'person::has_paid', 'boolean'],
+            ['a differently-cased boolean', 'True', 'event::is_admin', 'boolean'],
+            ['a boolean value on a tile without a breakdown key', 'true', null, 'boolean'],
+            ['any other value to its tile property', 'Chrome', 'event::$browser', 'event::$browser'],
+            ['a value merely starting with a boolean', 'truest', 'event::$browser', 'event::$browser'],
+            ['a non-boolean value without a tile property', 'Chrome', null, null],
+        ] as const)('keys %s', (_name, breakdownValue, tilePropertyKey, expected) => {
+            expect(breakdownValuePropertyKey(breakdownValue, tilePropertyKey)).toEqual(expected)
         })
     })
 
@@ -362,6 +378,32 @@ describe('dashboardBreakdownColors', () => {
             ])
         })
 
+        it('keys boolean values to the shared boolean group, whatever property they came from', () => {
+            const tiles = [
+                trendsTile(
+                    [
+                        { action: { order: 0 }, breakdown_value: ['true'] },
+                        { action: { order: 0 }, breakdown_value: ['false'] },
+                    ],
+                    { breakdown: 'is_admin' }
+                ),
+                trendsTile(
+                    [
+                        { action: { order: 0 }, breakdown_value: ['false'] },
+                        { action: { order: 0 }, breakdown_value: ['true'] },
+                    ],
+                    { breakdown: 'is_mobile' }
+                ),
+            ]
+
+            // chart order follows volume, so "true" leads one chart and trails the other; both
+            // are on both charts and tie on rank, leaving value order to settle the listing
+            expect(extractBreakdownValues(tiles)).toEqual([
+                { breakdownValue: 'false', breakdownType: 'event', breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY },
+                { breakdownValue: 'true', breakdownType: 'event', breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY },
+            ])
+        })
+
         it('clusters values by property in tile order before ranking within each property', () => {
             const tiles = [
                 trendsTile([{ action: { order: 0 }, breakdown_value: ['Mac OS X'] }], { breakdown: '$os' }),
@@ -419,6 +461,31 @@ describe('dashboardBreakdownColors', () => {
                 [
                     { breakdownValue: 'Baseline', breakdownType: 'event' },
                     { breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' },
+                ],
+            ])
+        })
+
+        it('groups only the boolean values of a mixed result', () => {
+            const tile = trendsTile(
+                [
+                    { action: { order: 0 }, breakdown_value: ['true'] },
+                    { action: { order: 0 }, breakdown_value: ['unknown'] },
+                ],
+                { breakdown: 'properties.flag', breakdown_type: 'hogql' }
+            )
+
+            expect(extractBreakdownValuesByTile([tile])).toEqual([
+                [
+                    {
+                        breakdownValue: 'true',
+                        breakdownType: 'hogql',
+                        breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY,
+                    },
+                    {
+                        breakdownValue: 'unknown',
+                        breakdownType: 'hogql',
+                        breakdownProperty: 'hogql::properties.flag',
+                    },
                 ],
             ])
         })
@@ -753,25 +820,56 @@ describe('dashboardBreakdownColors', () => {
 
         it('keeps one value under different properties apart', () => {
             const result = applyAutoBreakdownColors(
-                [...scopedTiles('event::is_admin', 'true'), ...scopedTiles('event::is_mobile', 'true')],
+                [...scopedTiles('event::$geoip_country_code', 'US'), ...scopedTiles('event::billing_country', 'US')],
                 []
             )
 
-            // "true" under two boolean properties is a coincidence of names, not one series:
+            // "US" under two country properties is a coincidence of names, not one series:
             // each property gets its own entry, free to diverge via pinning
             expect(result).toEqual([
-                scopedAutoConfig('true', 'event::is_admin', 'preset-1'),
-                scopedAutoConfig('true', 'event::is_mobile', 'preset-1'),
+                scopedAutoConfig('US', 'event::$geoip_country_code', 'preset-1'),
+                scopedAutoConfig('US', 'event::billing_country', 'preset-1'),
             ])
         })
 
         it('does not treat a value on single tiles of two different properties as shared', () => {
             const result = applyAutoBreakdownColors(
-                [[scopedValue('true', 'event::is_admin')], [scopedValue('true', 'event::is_mobile')]],
+                [[scopedValue('US', 'event::$geoip_country_code')], [scopedValue('US', 'event::billing_country')]],
                 []
             )
 
             expect(result).toEqual([])
+        })
+
+        it('shares one entry for a boolean value on tiles of different properties', () => {
+            // extraction keys both tiles' booleans to the shared group, so a single tile each
+            // adds up to a shared value, where two other properties would not
+            const result = applyAutoBreakdownColors(
+                [
+                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY)],
+                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY)],
+                ],
+                []
+            )
+
+            expect(result).toEqual([scopedAutoConfig('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY, 'preset-1')])
+        })
+
+        it("keeps a boolean value off the slots of its tile's other values", () => {
+            const result = applyAutoBreakdownColors(
+                [
+                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY), scopedValue('unknown', 'hogql::flag')],
+                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY), scopedValue('unknown', 'hogql::flag')],
+                ],
+                []
+            )
+
+            // the boolean group and the tile's own property are separate pools, but these two
+            // values do meet on a chart, so "unknown" has to move off the slot "true" took
+            expect(result).toEqual([
+                scopedAutoConfig('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY, 'preset-1'),
+                scopedAutoConfig('unknown', 'hogql::flag', 'preset-2'),
+            ])
         })
 
         it('lets a property-less pin cover its value and claim its slot under every property', () => {
@@ -842,25 +940,38 @@ describe('dashboardBreakdownColors', () => {
             const isShared = buildSharedBreakdownValueLookup([
                 [
                     { breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' },
-                    { breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::$browser' },
+                    { breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::$browser' },
                 ],
                 [{ breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' }],
-                [{ breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::is_admin' }],
+                [{ breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::billing_country' }],
             ])
 
             expect(
                 isShared({ breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' })
             ).toBe(true)
-            // "true" is on two tiles, but of different properties, so neither side is shared
+            // "US" is on two tiles, but of different properties, so neither side is shared
             expect(
-                isShared({ breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::$browser' })
+                isShared({ breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::$browser' })
             ).toBe(false)
             expect(
-                isShared({ breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::is_admin' })
+                isShared({ breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::billing_country' })
             ).toBe(false)
             // property-less legacy entries follow the value's best single-property tile count
-            expect(isShared({ breakdownValue: 'true', breakdownType: 'event' })).toBe(false)
+            expect(isShared({ breakdownValue: 'US', breakdownType: 'event' })).toBe(false)
             expect(isShared({ breakdownValue: 'Chrome', breakdownType: 'event' })).toBe(true)
+        })
+
+        it('shares a boolean value across the properties it appears under', () => {
+            const trueValue = {
+                breakdownValue: 'true',
+                breakdownType: 'event' as const,
+                breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY,
+            }
+            // the two tiles break down by different boolean properties, which extraction keys
+            // to one group, so "true" reaches the two tiles it needs
+            const isShared = buildSharedBreakdownValueLookup([[trueValue], [trueValue]])
+
+            expect(isShared(trueValue)).toBe(true)
         })
     })
 
@@ -1029,6 +1140,26 @@ describe('dashboardBreakdownColors', () => {
         it('returns undefined for null or undefined dataset values', () => {
             expect(findBreakdownColorConfig(configs, undefined, 'event')).toBeUndefined()
             expect(findBreakdownColorConfig(configs, null, 'event')).toBeUndefined()
+        })
+
+        it('matches a boolean entry on a tile of any property', () => {
+            const booleanConfigs: BreakdownColorConfig[] = [
+                {
+                    breakdownValue: 'true',
+                    breakdownType: 'event',
+                    breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY,
+                    colorToken: 'preset-7',
+                },
+            ]
+
+            expect(findBreakdownColorConfig(booleanConfigs, 'true', 'event', 'event::is_admin')?.colorToken).toBe(
+                'preset-7'
+            )
+            expect(findBreakdownColorConfig(booleanConfigs, 'true', 'event', 'event::is_mobile')?.colorToken).toBe(
+                'preset-7'
+            )
+            // a value that only looks boolean still belongs to its tile's property
+            expect(findBreakdownColorConfig(booleanConfigs, 'truest', 'event', 'event::is_admin')).toBeUndefined()
         })
 
         it('prefers a property-scoped entry and falls back to a property-less one', () => {

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
@@ -2,12 +2,10 @@ import { InsightQueryNode, InsightVizNode, NodeKind } from '~/queries/schema/sch
 import { AccessControlLevel, DashboardTile, FunnelVizType, InsightShortId, QueryBasedInsightModel } from '~/types'
 
 import {
-    BOOLEAN_BREAKDOWN_PROPERTY_KEY,
     BreakdownColorConfig,
     BreakdownValueAndType,
     MULTI_BREAKDOWN_SEPARATOR,
     applyAutoBreakdownColors,
-    breakdownValuePropertyKey,
     buildSharedBreakdownValueLookup,
     computeTileFallbackTokens,
     extractBreakdownValues,
@@ -108,20 +106,6 @@ describe('dashboardBreakdownColors', () => {
             ],
         ] as const)('normalizes %s', (_name, breakdownFilter, expected) => {
             expect(getBreakdownPropertyKey(breakdownFilter as any)).toEqual(expected)
-        })
-    })
-
-    describe('breakdownValuePropertyKey', () => {
-        it.each([
-            ['a boolean value to the shared boolean group', 'true', 'event::is_admin', 'boolean'],
-            ['a boolean value regardless of its tile', 'false', 'person::has_paid', 'boolean'],
-            ['a differently-cased boolean', 'True', 'event::is_admin', 'boolean'],
-            ['a boolean value on a tile without a breakdown key', 'true', null, 'boolean'],
-            ['any other value to its tile property', 'Chrome', 'event::$browser', 'event::$browser'],
-            ['a value merely starting with a boolean', 'truest', 'event::$browser', 'event::$browser'],
-            ['a non-boolean value without a tile property', 'Chrome', null, null],
-        ] as const)('keys %s', (_name, breakdownValue, tilePropertyKey, expected) => {
-            expect(breakdownValuePropertyKey(breakdownValue, tilePropertyKey)).toEqual(expected)
         })
     })
 
@@ -378,32 +362,6 @@ describe('dashboardBreakdownColors', () => {
             ])
         })
 
-        it('keys boolean values to the shared boolean group, whatever property they came from', () => {
-            const tiles = [
-                trendsTile(
-                    [
-                        { action: { order: 0 }, breakdown_value: ['true'] },
-                        { action: { order: 0 }, breakdown_value: ['false'] },
-                    ],
-                    { breakdown: 'is_admin' }
-                ),
-                trendsTile(
-                    [
-                        { action: { order: 0 }, breakdown_value: ['false'] },
-                        { action: { order: 0 }, breakdown_value: ['true'] },
-                    ],
-                    { breakdown: 'is_mobile' }
-                ),
-            ]
-
-            // chart order follows volume, so "true" leads one chart and trails the other; both
-            // are on both charts and tie on rank, leaving value order to settle the listing
-            expect(extractBreakdownValues(tiles)).toEqual([
-                { breakdownValue: 'false', breakdownType: 'event', breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY },
-                { breakdownValue: 'true', breakdownType: 'event', breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY },
-            ])
-        })
-
         it('clusters values by property in tile order before ranking within each property', () => {
             const tiles = [
                 trendsTile([{ action: { order: 0 }, breakdown_value: ['Mac OS X'] }], { breakdown: '$os' }),
@@ -461,31 +419,6 @@ describe('dashboardBreakdownColors', () => {
                 [
                     { breakdownValue: 'Baseline', breakdownType: 'event' },
                     { breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' },
-                ],
-            ])
-        })
-
-        it('groups only the boolean values of a mixed result', () => {
-            const tile = trendsTile(
-                [
-                    { action: { order: 0 }, breakdown_value: ['true'] },
-                    { action: { order: 0 }, breakdown_value: ['unknown'] },
-                ],
-                { breakdown: 'properties.flag', breakdown_type: 'hogql' }
-            )
-
-            expect(extractBreakdownValuesByTile([tile])).toEqual([
-                [
-                    {
-                        breakdownValue: 'true',
-                        breakdownType: 'hogql',
-                        breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY,
-                    },
-                    {
-                        breakdownValue: 'unknown',
-                        breakdownType: 'hogql',
-                        breakdownProperty: 'hogql::properties.flag',
-                    },
                 ],
             ])
         })
@@ -818,57 +751,95 @@ describe('dashboardBreakdownColors', () => {
             ])
         })
 
-        it('keeps one value under different properties apart', () => {
+        it('gives one value the same color under every property it appears under', () => {
             const result = applyAutoBreakdownColors(
-                [...scopedTiles('event::$geoip_country_code', 'US'), ...scopedTiles('event::billing_country', 'US')],
+                [...scopedTiles('event::is_admin', 'true'), ...scopedTiles('event::is_mobile', 'true')],
                 []
             )
 
-            // "US" under two country properties is a coincidence of names, not one series:
-            // each property gets its own entry, free to diverge via pinning
+            // "true" reads as one value wherever it shows up, so each property keeps its own
+            // entry, free to diverge via pinning, but both land on one color
             expect(result).toEqual([
-                scopedAutoConfig('US', 'event::$geoip_country_code', 'preset-1'),
-                scopedAutoConfig('US', 'event::billing_country', 'preset-1'),
+                scopedAutoConfig('true', 'event::is_admin', 'preset-1'),
+                scopedAutoConfig('true', 'event::is_mobile', 'preset-1'),
             ])
         })
 
-        it('does not treat a value on single tiles of two different properties as shared', () => {
+        it('counts a value on single tiles of two different properties as shared', () => {
             const result = applyAutoBreakdownColors(
-                [[scopedValue('US', 'event::$geoip_country_code')], [scopedValue('US', 'event::billing_country')]],
+                [[scopedValue('true', 'event::is_admin')], [scopedValue('true', 'event::is_mobile')]],
                 []
             )
 
-            expect(result).toEqual([])
-        })
-
-        it('shares one entry for a boolean value on tiles of different properties', () => {
-            // extraction keys both tiles' booleans to the shared group, so a single tile each
-            // adds up to a shared value, where two other properties would not
-            const result = applyAutoBreakdownColors(
-                [
-                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY)],
-                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY)],
-                ],
-                []
-            )
-
-            expect(result).toEqual([scopedAutoConfig('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY, 'preset-1')])
-        })
-
-        it("keeps a boolean value off the slots of its tile's other values", () => {
-            const result = applyAutoBreakdownColors(
-                [
-                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY), scopedValue('unknown', 'hogql::flag')],
-                    [scopedValue('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY), scopedValue('unknown', 'hogql::flag')],
-                ],
-                []
-            )
-
-            // the boolean group and the tile's own property are separate pools, but these two
-            // values do meet on a chart, so "unknown" has to move off the slot "true" took
+            // one tile each is a value the reader meets twice, and per-property counting is
+            // what used to leave it with no dashboard color and a position color that flips
             expect(result).toEqual([
-                scopedAutoConfig('true', BOOLEAN_BREAKDOWN_PROPERTY_KEY, 'preset-1'),
-                scopedAutoConfig('unknown', 'hogql::flag', 'preset-2'),
+                scopedAutoConfig('true', 'event::is_admin', 'preset-1'),
+                scopedAutoConfig('true', 'event::is_mobile', 'preset-1'),
+            ])
+        })
+
+        it('ranks a value by its charts across properties, so the wider one claims first', () => {
+            const result = applyAutoBreakdownColors(
+                [
+                    [scopedValue('Chrome', 'event::$browser'), scopedValue('Firefox', 'event::$browser')],
+                    [scopedValue('Chrome', 'event::$browser'), scopedValue('Firefox', 'event::$browser')],
+                    [scopedValue('Firefox', 'event::browser_name')],
+                ],
+                []
+            )
+
+            // Firefox trails Chrome on both $browser charts, but it is on three charts against
+            // Chrome's two, so it claims the first slot and carries it into browser_name
+            expect(result).toEqual([
+                scopedAutoConfig('Firefox', 'event::$browser', 'preset-1'),
+                scopedAutoConfig('Firefox', 'event::browser_name', 'preset-1'),
+                scopedAutoConfig('Chrome', 'event::$browser', 'preset-2'),
+            ])
+        })
+
+        it('copies the color a value was pinned to under another property', () => {
+            const pin: BreakdownColorConfig = {
+                breakdownValue: 'Chrome',
+                breakdownType: 'event',
+                breakdownProperty: 'event::$browser',
+                colorToken: 'preset-6',
+                source: 'manual',
+            }
+
+            const result = applyAutoBreakdownColors(
+                [[scopedValue('Chrome', 'event::$browser')], [scopedValue('Chrome', 'event::browser_name')]],
+                [pin]
+            )
+
+            // pins claim before auto entries, so the pinned color is the one that spreads
+            // instead of the palette's first free slot
+            expect(result).toEqual([pin, scopedAutoConfig('Chrome', 'event::browser_name', 'preset-6')])
+        })
+
+        it('gives up copying a color when the slot is taken within the other property', () => {
+            const pin: BreakdownColorConfig = {
+                breakdownValue: 'Opera',
+                breakdownType: 'event',
+                breakdownProperty: 'event::browser_name',
+                colorToken: 'preset-1',
+                source: 'manual',
+            }
+
+            const result = applyAutoBreakdownColors(
+                [
+                    [scopedValue('Chrome', 'event::$browser')],
+                    [scopedValue('Chrome', 'event::browser_name'), scopedValue('Opera', 'event::browser_name')],
+                ],
+                [pin]
+            )
+
+            // Chrome takes the first slot under $browser, but Opera's pin holds it under
+            // browser_name, and sharing a chart with Opera is worse than a second color
+            expect(result).toEqual([
+                pin,
+                scopedAutoConfig('Chrome', 'event::$browser', 'preset-1'),
+                scopedAutoConfig('Chrome', 'event::browser_name', 'preset-2'),
             ])
         })
 
@@ -936,42 +907,34 @@ describe('dashboardBreakdownColors', () => {
             expect(isShared({ breakdownValue: 'Chrome', breakdownType: 'person' })).toBe(false)
         })
 
-        it('scopes sharing to one property', () => {
+        it('counts a value across the properties it appears under', () => {
             const isShared = buildSharedBreakdownValueLookup([
                 [
                     { breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' },
-                    { breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::$browser' },
+                    { breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::$browser' },
                 ],
                 [{ breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' }],
-                [{ breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::billing_country' }],
+                [{ breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::is_admin' }],
             ])
 
             expect(
                 isShared({ breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::$browser' })
             ).toBe(true)
-            // "US" is on two tiles, but of different properties, so neither side is shared
+            // "true" is on one tile of each of two properties, which is still a value the
+            // reader meets twice, so both entries qualify and aim for one color
             expect(
-                isShared({ breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::$browser' })
-            ).toBe(false)
+                isShared({ breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::$browser' })
+            ).toBe(true)
             expect(
-                isShared({ breakdownValue: 'US', breakdownType: 'event', breakdownProperty: 'event::billing_country' })
-            ).toBe(false)
-            // property-less legacy entries follow the value's best single-property tile count
-            expect(isShared({ breakdownValue: 'US', breakdownType: 'event' })).toBe(false)
+                isShared({ breakdownValue: 'true', breakdownType: 'event', breakdownProperty: 'event::is_admin' })
+            ).toBe(true)
+            // property-less legacy entries read the same count, wherever the value appears
+            expect(isShared({ breakdownValue: 'true', breakdownType: 'event' })).toBe(true)
             expect(isShared({ breakdownValue: 'Chrome', breakdownType: 'event' })).toBe(true)
-        })
-
-        it('shares a boolean value across the properties it appears under', () => {
-            const trueValue = {
-                breakdownValue: 'true',
-                breakdownType: 'event' as const,
-                breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY,
-            }
-            // the two tiles break down by different boolean properties, which extraction keys
-            // to one group, so "true" reaches the two tiles it needs
-            const isShared = buildSharedBreakdownValueLookup([[trueValue], [trueValue]])
-
-            expect(isShared(trueValue)).toBe(true)
+            // a value on one tile only still keeps its insight's own colors
+            expect(
+                isShared({ breakdownValue: 'Chrome', breakdownType: 'event', breakdownProperty: 'event::is_admin' })
+            ).toBe(false)
         })
     })
 
@@ -1140,26 +1103,6 @@ describe('dashboardBreakdownColors', () => {
         it('returns undefined for null or undefined dataset values', () => {
             expect(findBreakdownColorConfig(configs, undefined, 'event')).toBeUndefined()
             expect(findBreakdownColorConfig(configs, null, 'event')).toBeUndefined()
-        })
-
-        it('matches a boolean entry on a tile of any property', () => {
-            const booleanConfigs: BreakdownColorConfig[] = [
-                {
-                    breakdownValue: 'true',
-                    breakdownType: 'event',
-                    breakdownProperty: BOOLEAN_BREAKDOWN_PROPERTY_KEY,
-                    colorToken: 'preset-7',
-                },
-            ]
-
-            expect(findBreakdownColorConfig(booleanConfigs, 'true', 'event', 'event::is_admin')?.colorToken).toBe(
-                'preset-7'
-            )
-            expect(findBreakdownColorConfig(booleanConfigs, 'true', 'event', 'event::is_mobile')?.colorToken).toBe(
-                'preset-7'
-            )
-            // a value that only looks boolean still belongs to its tile's property
-            expect(findBreakdownColorConfig(booleanConfigs, 'truest', 'event', 'event::is_admin')).toBeUndefined()
         })
 
         it('prefers a property-scoped entry and falls back to a property-less one', () => {

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
@@ -11,7 +11,7 @@ export type BreakdownColorConfig = {
     colorToken: DataColorToken | null
     breakdownValue: string
     breakdownType: BreakdownFilter['breakdown_type']
-    /** Normalized breakdown property the value belongs to (see getBreakdownPropertyKey).
+    /** Normalized breakdown property the value belongs to (see breakdownValuePropertyKey).
      * Scopes the color to tiles breaking down by that property. Entries without one predate
      * property scoping and match their value under any property. */
     breakdownProperty?: string
@@ -33,6 +33,25 @@ export const MULTI_BREAKDOWN_SEPARATOR = '\u001f'
  * property, so all cohort breakdowns form one color group, matching their pre-scoping
  * behavior of one identity per cohort id. */
 export const COHORT_BREAKDOWN_PROPERTY_KEY = 'cohort'
+
+/** Property key of every boolean breakdown value. Like a cohort id, `true` denotes the same
+ * thing under every property, so booleans form one color group instead of one per property.
+ * They are also the values most likely to swap chart position between tiles, because series
+ * order follows volume, which is exactly what a dashboard-wide color fixes. */
+export const BOOLEAN_BREAKDOWN_PROPERTY_KEY = 'boolean'
+
+// Matched case-insensitively, so a property serializing booleans as "True" joins the group.
+// Grouping only decides which values compete for slots, so "true" and "True" still get a
+// color each — they read as two labels.
+const BOOLEAN_BREAKDOWN_VALUES = new Set(['true', 'false'])
+
+/** Property scope of a single normalized value: the shared boolean group, or the property its
+ * tile breaks down by. Narrows a tile's key (getBreakdownPropertyKey) per value, so a mixed
+ * result — a HogQL breakdown returning "true", "false", and "unknown" — keeps its non-boolean
+ * values scoped to the tile's property. */
+export function breakdownValuePropertyKey(breakdownValue: string, tilePropertyKey: string | null): string | null {
+    return BOOLEAN_BREAKDOWN_VALUES.has(breakdownValue.toLowerCase()) ? BOOLEAN_BREAKDOWN_PROPERTY_KEY : tilePropertyKey
+}
 
 /** Breakdown values arrive as string | number | boolean | array depending on insight type and
  * persistence round-trips, while configs compare with strict equality. One canonical string form
@@ -63,7 +82,9 @@ function breakdownPropertyPart(
  * each part, multi parts joined in order. A single breakdown and a one-entry multi breakdown
  * of the same property produce the same key, so their values share colors. Display options
  * (URL normalization, histogram bins, limits) stay out of the key because they change how
- * values render, not which property they come from. Returns null without a breakdown. */
+ * values render, not which property they come from. Returns null without a breakdown.
+ *
+ * This is the tile's key; breakdownValuePropertyKey narrows it to a single value. */
 export function getBreakdownPropertyKey(breakdownFilter: BreakdownFilter | null | undefined): string | null {
     if (breakdownFilter?.breakdowns?.length) {
         return breakdownFilter.breakdowns
@@ -93,7 +114,8 @@ export type BreakdownPropertyKeyPart = {
     property: string
 }
 
-/** Type and property name of a key's parts, for display. Not meaningful for the cohort key. */
+/** Type and property name of a key's parts, for display. Not meaningful for the cohort or
+ * boolean keys, which the colors modal labels itself. */
 export function parseBreakdownPropertyKey(key: string): BreakdownPropertyKeyPart[] {
     // The first two colon-separated fields are type and group index; the property itself may
     // contain colons, so everything past the second one belongs to it.
@@ -116,7 +138,7 @@ export function breakdownConfigMatches(
     // A property key already encodes each part's type, so scoped entries match on it alone;
     // property-less entries keep the legacy value-and-type match under any property.
     return config.breakdownProperty != null
-        ? config.breakdownProperty === breakdownPropertyKey
+        ? config.breakdownProperty === breakdownValuePropertyKey(normalized, breakdownPropertyKey ?? null)
         : config.breakdownType === (breakdownType ?? 'event')
 }
 
@@ -137,13 +159,14 @@ export function findBreakdownColorConfig(
     breakdownType: BreakdownFilter['breakdown_type'] | null | undefined,
     breakdownPropertyKey?: string | null
 ): BreakdownColorConfig | undefined {
-    if (normalizeBreakdownValue(breakdownValue) == null) {
+    const normalized = normalizeBreakdownValue(breakdownValue)
+    if (normalized == null) {
         return undefined
     }
     // A property-scoped entry beats a property-less one, which acts as a fallback pin
     // across all properties.
     const scoped =
-        breakdownPropertyKey != null
+        breakdownValuePropertyKey(normalized, breakdownPropertyKey ?? null) != null
             ? configs?.find(
                   (config) =>
                       config.breakdownProperty != null &&
@@ -192,9 +215,10 @@ function makeBreakdownValue(
     breakdownType: BreakdownFilter['breakdown_type'],
     breakdownPropertyKey: string | null
 ): BreakdownValueAndType {
-    return breakdownPropertyKey == null
+    const propertyKey = breakdownValuePropertyKey(breakdownValue, breakdownPropertyKey)
+    return propertyKey == null
         ? { breakdownValue, breakdownType }
-        : { breakdownValue, breakdownType, breakdownProperty: breakdownPropertyKey }
+        : { breakdownValue, breakdownType, breakdownProperty: propertyKey }
 }
 
 function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>): BreakdownValueAndType[] {
@@ -411,9 +435,16 @@ function collectValueTileStats(tileBreakdownValues: BreakdownValueAndType[][]): 
     const byValue: ValueTileStats['byValue'] = new Map()
     const tileProperties: (string | null)[] = []
     tileBreakdownValues.forEach((values, tileIndex) => {
-        // All real values of a tile share the tile's breakdown property; only sentinel rows
-        // (the funnel baseline) are property-less.
-        tileProperties.push(values.find((value) => value.breakdownProperty != null)?.breakdownProperty ?? null)
+        // All real values of a tile share the tile's breakdown property, except booleans, which
+        // belong to the shared boolean group. Prefer a real property key, so a tile mixing
+        // boolean and other values books its slots under the property it breaks down by; only
+        // sentinel rows (the funnel baseline) are property-less.
+        const scopedProperties = values
+            .map((value) => value.breakdownProperty)
+            .filter((key): key is string => key != null)
+        tileProperties.push(
+            scopedProperties.find((key) => key !== BOOLEAN_BREAKDOWN_PROPERTY_KEY) ?? scopedProperties[0] ?? null
+        )
         values.forEach((value, position) => {
             const identityEntry = byIdentity.get(breakdownIdentityKey(value))
             if (identityEntry) {
@@ -469,9 +500,10 @@ function buildAssignmentRankComparator(
 
 /** Membership test for values that appear on two or more tiles of one breakdown property.
  * Only those receive a dashboard-wide auto color: cross-tile consistency is what the feature
- * buys, and it only means something between tiles breaking down by the same property. A
- * value spread across different properties (say "true" under two boolean properties) is a
- * coincidence of names, not one series to keep consistent. Property-less entries count the
+ * buys, and it only means something between tiles breaking down by the same property: a value
+ * spread across different properties is usually a coincidence of names, not one series to keep
+ * consistent. Booleans are the exception, forming one group across properties, so "true" on a
+ * tile of each of two boolean properties does count as shared. Property-less entries count the
  * value's best tile count under any single property, so legacy configs prune the same way. */
 export function buildSharedBreakdownValueLookup(
     tileBreakdownValues: BreakdownValueAndType[][]
@@ -490,8 +522,10 @@ export function buildSharedBreakdownValueLookup(
  * dashboard breaking down by several properties reuses the palette from the first slot for
  * each of them, the way standalone insights do, instead of exhausting it across the union of
  * all values. Values under different properties may share a color; they never meet on one
- * tile, since a tile breaks down by exactly one property. Property-less legacy entries keep
- * matching their value everywhere and claim their slot in every property they appear under.
+ * tile, since a tile breaks down by exactly one property. Booleans opt out of the split and
+ * form one group, so "true" keeps one color across every boolean breakdown on the dashboard.
+ * Property-less legacy entries keep matching their value everywhere and claim their slot in
+ * every property they appear under.
  *
  * Stability comes from persistence, not from the algorithm: manual pins never move, and
  * persisted auto entries keep their slots unless two of them meet on one tile with the same

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
@@ -11,7 +11,7 @@ export type BreakdownColorConfig = {
     colorToken: DataColorToken | null
     breakdownValue: string
     breakdownType: BreakdownFilter['breakdown_type']
-    /** Normalized breakdown property the value belongs to (see breakdownValuePropertyKey).
+    /** Normalized breakdown property the value belongs to (see getBreakdownPropertyKey).
      * Scopes the color to tiles breaking down by that property. Entries without one predate
      * property scoping and match their value under any property. */
     breakdownProperty?: string
@@ -33,25 +33,6 @@ export const MULTI_BREAKDOWN_SEPARATOR = '\u001f'
  * property, so all cohort breakdowns form one color group, matching their pre-scoping
  * behavior of one identity per cohort id. */
 export const COHORT_BREAKDOWN_PROPERTY_KEY = 'cohort'
-
-/** Property key of every boolean breakdown value. Like a cohort id, `true` denotes the same
- * thing under every property, so booleans form one color group instead of one per property.
- * They are also the values most likely to swap chart position between tiles, because series
- * order follows volume, which is exactly what a dashboard-wide color fixes. */
-export const BOOLEAN_BREAKDOWN_PROPERTY_KEY = 'boolean'
-
-// Matched case-insensitively, so a property serializing booleans as "True" joins the group.
-// Grouping only decides which values compete for slots, so "true" and "True" still get a
-// color each — they read as two labels.
-const BOOLEAN_BREAKDOWN_VALUES = new Set(['true', 'false'])
-
-/** Property scope of a single normalized value: the shared boolean group, or the property its
- * tile breaks down by. Narrows a tile's key (getBreakdownPropertyKey) per value, so a mixed
- * result — a HogQL breakdown returning "true", "false", and "unknown" — keeps its non-boolean
- * values scoped to the tile's property. */
-export function breakdownValuePropertyKey(breakdownValue: string, tilePropertyKey: string | null): string | null {
-    return BOOLEAN_BREAKDOWN_VALUES.has(breakdownValue.toLowerCase()) ? BOOLEAN_BREAKDOWN_PROPERTY_KEY : tilePropertyKey
-}
 
 /** Breakdown values arrive as string | number | boolean | array depending on insight type and
  * persistence round-trips, while configs compare with strict equality. One canonical string form
@@ -82,9 +63,7 @@ function breakdownPropertyPart(
  * each part, multi parts joined in order. A single breakdown and a one-entry multi breakdown
  * of the same property produce the same key, so their values share colors. Display options
  * (URL normalization, histogram bins, limits) stay out of the key because they change how
- * values render, not which property they come from. Returns null without a breakdown.
- *
- * This is the tile's key; breakdownValuePropertyKey narrows it to a single value. */
+ * values render, not which property they come from. Returns null without a breakdown. */
 export function getBreakdownPropertyKey(breakdownFilter: BreakdownFilter | null | undefined): string | null {
     if (breakdownFilter?.breakdowns?.length) {
         return breakdownFilter.breakdowns
@@ -114,8 +93,7 @@ export type BreakdownPropertyKeyPart = {
     property: string
 }
 
-/** Type and property name of a key's parts, for display. Not meaningful for the cohort or
- * boolean keys, which the colors modal labels itself. */
+/** Type and property name of a key's parts, for display. Not meaningful for the cohort key. */
 export function parseBreakdownPropertyKey(key: string): BreakdownPropertyKeyPart[] {
     // The first two colon-separated fields are type and group index; the property itself may
     // contain colons, so everything past the second one belongs to it.
@@ -138,7 +116,7 @@ export function breakdownConfigMatches(
     // A property key already encodes each part's type, so scoped entries match on it alone;
     // property-less entries keep the legacy value-and-type match under any property.
     return config.breakdownProperty != null
-        ? config.breakdownProperty === breakdownValuePropertyKey(normalized, breakdownPropertyKey ?? null)
+        ? config.breakdownProperty === breakdownPropertyKey
         : config.breakdownType === (breakdownType ?? 'event')
 }
 
@@ -159,14 +137,13 @@ export function findBreakdownColorConfig(
     breakdownType: BreakdownFilter['breakdown_type'] | null | undefined,
     breakdownPropertyKey?: string | null
 ): BreakdownColorConfig | undefined {
-    const normalized = normalizeBreakdownValue(breakdownValue)
-    if (normalized == null) {
+    if (normalizeBreakdownValue(breakdownValue) == null) {
         return undefined
     }
     // A property-scoped entry beats a property-less one, which acts as a fallback pin
     // across all properties.
     const scoped =
-        breakdownValuePropertyKey(normalized, breakdownPropertyKey ?? null) != null
+        breakdownPropertyKey != null
             ? configs?.find(
                   (config) =>
                       config.breakdownProperty != null &&
@@ -215,10 +192,9 @@ function makeBreakdownValue(
     breakdownType: BreakdownFilter['breakdown_type'],
     breakdownPropertyKey: string | null
 ): BreakdownValueAndType {
-    const propertyKey = breakdownValuePropertyKey(breakdownValue, breakdownPropertyKey)
-    return propertyKey == null
+    return breakdownPropertyKey == null
         ? { breakdownValue, breakdownType }
-        : { breakdownValue, breakdownType, breakdownProperty: propertyKey }
+        : { breakdownValue, breakdownType, breakdownProperty: breakdownPropertyKey }
 }
 
 function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>): BreakdownValueAndType[] {
@@ -422,10 +398,10 @@ type TileStats = { tiles: number[]; positionSum: number }
 type ValueTileStats = {
     /** Keyed by property, type, and value: the unit colors are assigned to. */
     byIdentity: Map<string, TileStats & { value: BreakdownValueAndType }>
-    /** Keyed by type and value across all properties, for property-less legacy configs,
-     * which match their value wherever it appears. maxIdentityTiles is the largest tile
-     * count the value reaches under a single property, deciding sharing for such configs. */
-    byValue: Map<string, TileStats & { maxIdentityTiles: number }>
+    /** Keyed by type and value across all properties. Decides sharing and rank for every
+     * value, so a value re-used under different properties counts as re-used, and covers
+     * property-less legacy configs, which match their value wherever it appears. */
+    byValue: Map<string, TileStats>
     /** Property key of each tile, for per-property slot bookkeeping. */
     tileProperties: (string | null)[]
 }
@@ -435,16 +411,9 @@ function collectValueTileStats(tileBreakdownValues: BreakdownValueAndType[][]): 
     const byValue: ValueTileStats['byValue'] = new Map()
     const tileProperties: (string | null)[] = []
     tileBreakdownValues.forEach((values, tileIndex) => {
-        // All real values of a tile share the tile's breakdown property, except booleans, which
-        // belong to the shared boolean group. Prefer a real property key, so a tile mixing
-        // boolean and other values books its slots under the property it breaks down by; only
-        // sentinel rows (the funnel baseline) are property-less.
-        const scopedProperties = values
-            .map((value) => value.breakdownProperty)
-            .filter((key): key is string => key != null)
-        tileProperties.push(
-            scopedProperties.find((key) => key !== BOOLEAN_BREAKDOWN_PROPERTY_KEY) ?? scopedProperties[0] ?? null
-        )
+        // All real values of a tile share the tile's breakdown property; only sentinel rows
+        // (the funnel baseline) are property-less.
+        tileProperties.push(values.find((value) => value.breakdownProperty != null)?.breakdownProperty ?? null)
         values.forEach((value, position) => {
             const identityEntry = byIdentity.get(breakdownIdentityKey(value))
             if (identityEntry) {
@@ -458,25 +427,26 @@ function collectValueTileStats(tileBreakdownValues: BreakdownValueAndType[][]): 
                 valueEntry.tiles.push(tileIndex)
                 valueEntry.positionSum += position
             } else {
-                byValue.set(breakdownValueKey(value), {
-                    tiles: [tileIndex],
-                    positionSum: position,
-                    maxIdentityTiles: 0,
-                })
+                byValue.set(breakdownValueKey(value), { tiles: [tileIndex], positionSum: position })
             }
         })
     })
-    for (const { value, tiles } of byIdentity.values()) {
-        const valueEntry = byValue.get(breakdownValueKey(value))!
-        valueEntry.maxIdentityTiles = Math.max(valueEntry.maxIdentityTiles, tiles.length)
-    }
     return { byIdentity, byValue, tileProperties }
 }
 
+// Which tiles an entry shows on, for collision checks: the tiles of its own scope. A scoped
+// entry only colors its property's tiles, while a property-less one colors the value everywhere.
 function statsOf(stats: ValueTileStats, value: BreakdownValueAndType): TileStats | undefined {
     return value.breakdownProperty != null
         ? stats.byIdentity.get(breakdownIdentityKey(value))
         : stats.byValue.get(breakdownValueKey(value))
+}
+
+// How often a value is re-used, counted across every property it appears under. Sharing and
+// rank read this rather than the per-property count, so a value carried by several properties
+// is treated as one re-used value.
+function valueStatsOf(stats: ValueTileStats, value: BreakdownValueAndType): TileStats | undefined {
+    return stats.byValue.get(breakdownValueKey(value))
 }
 
 // Rank by re-use first, so the values shared by the most charts claim the earliest
@@ -484,12 +454,14 @@ function statsOf(stats: ValueTileStats, value: BreakdownValueAndType): TileStats
 // list is in chart series order, and positions are summed across a value's tiles,
 // which compares like the average because tile counts are equal whenever the sum is
 // reached. Plain value order settles full ties (e.g. values leading disjoint tiles).
+// Both terms count the value across properties, so its entries rank next to each other
+// and the first one assigned sets the color the others copy.
 function buildAssignmentRankComparator(
     stats: ValueTileStats
 ): (a: BreakdownValueAndType, b: BreakdownValueAndType) => number {
     return (a, b) => {
-        const entryA = statsOf(stats, a)
-        const entryB = statsOf(stats, b)
+        const entryA = valueStatsOf(stats, a)
+        const entryB = valueStatsOf(stats, b)
         return (
             (entryB?.tiles.length ?? 0) - (entryA?.tiles.length ?? 0) ||
             (entryA?.positionSum ?? 0) - (entryB?.positionSum ?? 0) ||
@@ -498,34 +470,39 @@ function buildAssignmentRankComparator(
     }
 }
 
-/** Membership test for values that appear on two or more tiles of one breakdown property.
- * Only those receive a dashboard-wide auto color: cross-tile consistency is what the feature
- * buys, and it only means something between tiles breaking down by the same property: a value
- * spread across different properties is usually a coincidence of names, not one series to keep
- * consistent. Booleans are the exception, forming one group across properties, so "true" on a
- * tile of each of two boolean properties does count as shared. Property-less entries count the
- * value's best tile count under any single property, so legacy configs prune the same way. */
+/** Membership test for values that appear on two or more tiles, counted across every property
+ * they appear under. Only those receive a dashboard-wide auto color: cross-tile consistency is
+ * what the feature buys, and a value on a single insight has nothing to stay consistent with.
+ * The count ignores which property carried the value, so one tile of each of two properties is
+ * enough, those being the values whose color would otherwise be settled per property.
+ *
+ * An entry also has to still show somewhere in its own scope, so pruning drops an entry scoped
+ * to a property the dashboard no longer breaks down by, even while the value lives on
+ * elsewhere. */
 export function buildSharedBreakdownValueLookup(
     tileBreakdownValues: BreakdownValueAndType[][]
 ): (value: BreakdownValueAndType) => boolean {
     const stats = collectValueTileStats(tileBreakdownValues)
     return (value) =>
-        value.breakdownProperty != null
-            ? (stats.byIdentity.get(breakdownIdentityKey(value))?.tiles.length ?? 0) >= 2
-            : (stats.byValue.get(breakdownValueKey(value))?.maxIdentityTiles ?? 0) >= 2
+        (statsOf(stats, value)?.tiles.length ?? 0) >= 1 && (valueStatsOf(stats, value)?.tiles.length ?? 0) >= 2
 }
 
-/** Complete existing configs with palette slots for breakdown values shared by 2+ tiles of
- * the same breakdown property.
+/** Complete existing configs with palette slots for breakdown values shared by 2+ tiles.
  *
  * Each property is its own color world: slot exclusivity is tracked per property, so a
  * dashboard breaking down by several properties reuses the palette from the first slot for
  * each of them, the way standalone insights do, instead of exhausting it across the union of
- * all values. Values under different properties may share a color; they never meet on one
- * tile, since a tile breaks down by exactly one property. Booleans opt out of the split and
- * form one group, so "true" keeps one color across every boolean breakdown on the dashboard.
- * Property-less legacy entries keep matching their value everywhere and claim their slot in
- * every property they appear under.
+ * all values. Unrelated values under different properties may therefore share a color; they
+ * never meet on one tile, since a tile breaks down by exactly one property.
+ *
+ * A value carried by several properties is one value to a reader, so its entries aim for one
+ * color: whichever is assigned first sets the slot, and the rest copy it unless that slot is
+ * taken within their own property. Ranking counts a value's tiles across properties, so those
+ * entries sort next to each other and copy before other values claim slots. Copying can still
+ * fail, which is visible as one value in two colors and is the honest outcome: within a
+ * property, two values sharing a color on one chart would be worse. Property-less legacy
+ * entries keep matching their value everywhere and claim their slot in every property they
+ * appear under.
  *
  * Stability comes from persistence, not from the algorithm: manual pins never move, and
  * persisted auto entries keep their slots unless two of them meet on one tile with the same
@@ -566,10 +543,16 @@ export function applyAutoBreakdownColors(
         }
         used.add(slot)
     }
-    const claimSlot = (slot: number, tiles: number[], ownProperty: string | null): void => {
+    // The slot each value settled on, so its entries under other properties can copy it. First
+    // claim wins, and pins claim before auto entries, so a pinned color is the one copied.
+    const slotByValue = new Map<string, number>()
+    const claimSlot = (slot: number, value: BreakdownValueAndType, tiles: number[]): void => {
         // Claiming for the entry's own property even without visible tiles keeps a
         // temporarily hidden value's slot reserved within its property.
-        markUsed(ownProperty, slot)
+        markUsed(value.breakdownProperty ?? null, slot)
+        if (!slotByValue.has(breakdownValueKey(value))) {
+            slotByValue.set(breakdownValueKey(value), slot)
+        }
         for (const tile of tiles) {
             markUsed(stats.tileProperties[tile] ?? null, slot)
             tileSlotCounts[tile].set(slot, (tileSlotCounts[tile].get(slot) ?? 0) + 1)
@@ -595,7 +578,7 @@ export function applyAutoBreakdownColors(
         if (config.source === 'auto') {
             autoConfigs.push(config)
         } else {
-            claimSlot(slot, tilesOf(config), config.breakdownProperty ?? null)
+            claimSlot(slot, config, tilesOf(config))
         }
     }
 
@@ -611,13 +594,13 @@ export function applyAutoBreakdownColors(
                 makeBreakdownValue(config.breakdownValue, config.breakdownType, config.breakdownProperty ?? null)
             )
         } else {
-            claimSlot(slot, tiles, config.breakdownProperty ?? null)
+            claimSlot(slot, config, tiles)
         }
     }
 
     const uncovered = [...stats.byIdentity.values()]
-        .filter(({ tiles }) => tiles.length >= 2)
         .map(({ value }) => value)
+        .filter((value) => (valueStatsOf(stats, value)?.tiles.length ?? 0) >= 2)
         .filter(
             (value) =>
                 isAutoAssignableBreakdownValue(value.breakdownValue) &&
@@ -636,11 +619,15 @@ export function applyAutoBreakdownColors(
         const used = usedFor(candidate)
         const usedOnOwnTiles = (slot: number): number =>
             tiles.reduce((sum, tile) => sum + (tileSlotCounts[tile].get(slot) ?? 0), 0)
+        // The slot this value took under another property comes first, even when a lower one is
+        // free: one color per value reads better than the palette's earliest colors.
+        const sharedSlot = slotByValue.get(breakdownValueKey(candidate))
         const slot =
+            (sharedSlot != null && !used.has(sharedSlot) ? sharedSlot : undefined) ??
             allSlots.find((slot) => !used.has(slot)) ??
             allSlots.find((slot) => usedOnOwnTiles(slot) === 0) ??
             allSlots.reduce((best, slot) => (usedOnOwnTiles(slot) < usedOnOwnTiles(best) ? slot : best))
-        claimSlot(slot, tiles, candidate.breakdownProperty ?? null)
+        claimSlot(slot, candidate, tiles)
         assignments.set(breakdownIdentityKey(candidate), {
             ...makeBreakdownValue(
                 candidate.breakdownValue,


### PR DESCRIPTION
## TL;DR

A breakdown value that shows up under more than one breakdown property now keeps one color across all of them. `Chrome` under `$browser` and `Chrome` under a `browser_name` breakdown get the same color, and so do `true` and `false` under two different boolean properties. Before this, each property picked its colors on its own, so the same value could come out in two colors, and a value appearing on just one tile per property got no dashboard color at all.

## Problem

Stacked on #74545 (per-property color groups), which is the base branch.

Per-property groups fixed palette exhaustion, but they turned "same value, same color" into a per-property promise. Two gaps fall out:

- A value carried by two properties could land on two colors. Nothing tied the groups together, so it was down to luck.
- Sharing was counted per property, so a value on one tile of each of two properties failed the 2+ insights rule under both. It got no dashboard color and kept its position color, which follows volume and therefore flips between tiles. Booleans hit this constantly, since a boolean breakdown is two series ordered purely by volume.

## Changes

Sharing and ranking now count a value's tiles across every property it appears under, instead of per property. One tile under each of two properties is a value the reader meets twice, so it qualifies.

Assignment keeps the per-property slot pools and adds one rule: a value copies the slot it already took under another property, unless that slot is taken inside its own property. Pins claim before auto entries, so a pinned color is the one that spreads. Ranking by cross-property tile count sorts a value's entries next to each other, so they copy before other values start claiming slots.

Copying is best effort. When the slot really is taken within the other property, the value takes a second color rather than colliding with a neighbour on one chart. Two values sharing a color on one chart is worse than one value in two colors on two charts.

Entries stay per property, so `breakdown_colors` still holds a row per value and property, and the modal still lists a value under each property it appears in, now with the same color. Pinning one of those rows still lets you break the tie on purpose.

Pruning picked up a second condition: an entry has to still show somewhere in its own scope, so an entry scoped to a property the dashboard no longer breaks down by is dropped even while the value lives on elsewhere.

> [!NOTE]
> No migration. Persisted entries keep their slots, and a value that gains a second property carries its existing color into the new one rather than moving.

The first revision of this PR did this for `true` and `false` only, through a hardcoded boolean group. The general rule covers booleans as one case of it and needs no value list, so that commit is superseded.

## How did you test this code?

Automated only, written and run by the agent. No browser run, so no screenshot of the modal.

New cases in `dashboardBreakdownColors.test.ts`, each naming what it catches:

- `counts a value on single tiles of two different properties as shared` (this replaces a case that asserted the opposite): catches sharing counted per property, the reason such a value got no color at all.
- `ranks a value by its charts across properties, so the wider one claims first`: catches ranking still reading per-identity counts, which lets a narrower value take the slot first and leaves the wider one unable to copy.
- `copies the color a value was pinned to under another property`: catches assignment ignoring a slot the same value already holds, and pins losing precedence to the palette's first free slot.
- `gives up copying a color when the slot is taken within the other property`: catches copying that overrides per-property exclusivity, which would draw two values of one chart in one color.
- `counts a value across the properties it appears under` (renamed from `scopes sharing to one property`, expectations inverted): its false case pins the new pruning condition.

One case, `gives one value the same color under every property it appears under`, passed before this change too, because each property starts from the palette's first slot anyway. It is kept as documentation of the guarantee rather than as a regression test, and it now holds for a reason instead of by coincidence.

Ran locally: `dashboardBreakdownColors` and `dashboardLogic` suites together, 161 passed and 1 skipped. oxlint clean on the three files, formatted with oxfmt 0.57.0, and `tsgo --noEmit` reports nothing in them. The repo has 199 pre-existing type errors elsewhere on this base, none in these files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. Still behind the `dashboard-colors` flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code). No repo skills were invoked.

The first attempt keyed booleans to a shared pseudo-property, in the shape of the existing `COHORT_BREAKDOWN_PROPERTY_KEY`. It worked, but it only helped a hardcoded pair of values, and the general question behind it was whether any re-used value should hold one color.

Two shapes were on the table for the general version. One was to re-key cross-property values as property-less, reusing the existing wildcard machinery, which would mean one entry and one pin covering every property. It was rejected: a value's key would then depend on the rest of the dashboard, so adding a tile would re-scope a persisted entry, and the entry would have to be rewritten mid-flight or pruned and reassigned, which shows up as a color jumping. The chosen shape leaves identities and persistence untouched and expresses the whole feature as a slot preference, which also spends less of the palette, because the value occupies the same index in several pools rather than one globally exclusive slot.

Worth a reviewer's eye: two entries for one value that were *both* already persisted with different colors are left alone rather than forced together, since moving a persisted color is the one thing this feature avoids. They converge only when one of them is reassigned for another reason.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
