### PR TITLE
fix(logs): link person logs via built-in distinct-id conventions

### DIFF
--- a/frontend/src/scenes/persons/PersonLogsTab.tsx
+++ b/frontend/src/scenes/persons/PersonLogsTab.tsx
@@ -14,7 +14,8 @@ import { DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS, logsConfigLogic } from 'produc
 // (LemonTabs renders just the active tab's content), so `logsConfigLogic` only fetches
 // the team's `logs_distinct_id_attribute_keys` on demand rather than on every team load.
 // The config only drives the caption here — the query is scoped via `personId`, which the
-// backend expands to the person's distinct ids and matches against the configured keys.
+// backend expands to the person's distinct ids and matches against the configured keys plus
+// the built-in distinct-id conventions (the same keys the logs UI links as a person).
 export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
     const { logsConfig } = useValues(logsConfigLogic)
     const distinctIdAttributeKeys =
@@ -31,7 +32,7 @@ export function PersonLogsTab({ person }: { person: PersonType }): JSX.Element {
                             <code>{key}</code>
                         </span>
                     ))}{' '}
-                    log {distinctIdAttributeKeys.length === 1 ? 'attribute' : 'attributes'}.
+                    and other common distinct ID attributes.
                 </span>
                 <LemonButton
                     size="xsmall"

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -499,23 +499,40 @@ class LogsFilterBuilder:
         # belonging to a person appears on their Logs tab even when the team hasn't configured
         # that key. Deduped, configured keys first.
         attribute_keys = list(dict.fromkeys([*configured_keys, *DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS]))
-        # Force the __str map: attributes_map_str holds every attribute value (stringified),
-        # while attributes_map_float only exists for numeric values — all-numeric distinct ids
-        # must not route there via the usual value-type detection.
-        key_exprs = [
-            property_to_expr(
-                LogPropertyFilter(
-                    key=f"{attribute_key}__str",
-                    operator=PropertyOperator.EXACT,
-                    type=LogPropertyFilterType.LOG_ATTRIBUTE,
-                    value=list(distinct_ids),
-                ),
-                team=self.team,
+        distinct_id_values = list(distinct_ids)
+        key_exprs: list[ast.Expr] = []
+        for attribute_key in attribute_keys:
+            # Log attribute: force the __str map. attributes_map_str holds every attribute value
+            # (stringified), while attributes_map_float only exists for numeric values — all-numeric
+            # distinct ids must not route there via the usual value-type detection.
+            key_exprs.append(
+                property_to_expr(
+                    LogPropertyFilter(
+                        key=f"{attribute_key}__str",
+                        operator=PropertyOperator.EXACT,
+                        type=LogPropertyFilterType.LOG_ATTRIBUTE,
+                        value=distinct_id_values,
+                    ),
+                    team=self.team,
+                )
             )
-            for attribute_key in attribute_keys
-        ]
-        # A log links to the person when any configured attribute key holds one of their
-        # distinct ids — mirrors the OR the person tab previously pinned client-side.
+            # Resource attribute: the logs UI links these keys under resource_attributes too
+            # (LogAttributes.tsx renders the person link regardless of attribute vs
+            # resource_attribute), so scope on both. resource_attributes is a plain string map on
+            # the row — no typed __str/__float split — so match the key directly.
+            key_exprs.append(
+                property_to_expr(
+                    LogPropertyFilter(
+                        key=attribute_key,
+                        operator=PropertyOperator.EXACT,
+                        type=LogPropertyFilterType.LOG_RESOURCE_ATTRIBUTE,
+                        value=distinct_id_values,
+                    ),
+                    team=self.team,
+                )
+            )
+        # A log links to the person when any of these attribute keys — in either the log
+        # attributes or the resource attributes — holds one of their distinct ids.
         return key_exprs[0] if len(key_exprs) == 1 else ast.Or(exprs=key_exprs)
 
     def resource_filter(self, *, existing_filters):

--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -33,7 +33,11 @@ from posthog.models.person.util import get_person_by_pk_or_uuid
 from posthog.personhog_client.caller_tag import personhog_caller_tag
 
 from products.logs.backend.column_expressions import canonical_key, column_to_expr
-from products.logs.backend.models import DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS, TeamLogsConfig
+from products.logs.backend.models import (
+    DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS,
+    DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS,
+    TeamLogsConfig,
+)
 
 if TYPE_CHECKING:
     from posthog.models import Team, User
@@ -487,9 +491,14 @@ class LogsFilterBuilder:
             # treats an empty value list as always-true, which would return every log.
             return ast.Constant(value=False)
         config = TeamLogsConfig.objects.filter(team=self.team).first()
-        attribute_keys = (
+        configured_keys = (
             config.logs_distinct_id_attribute_keys if config else None
         ) or DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS
+        # Also scope on the built-in convention keys the logs UI renders as clickable person
+        # links (isDistinctIdKey in products/logs/frontend/utils.tsx), so a log the UI shows as
+        # belonging to a person appears on their Logs tab even when the team hasn't configured
+        # that key. Deduped, configured keys first.
+        attribute_keys = list(dict.fromkeys([*configured_keys, *DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS]))
         # Force the __str map: attributes_map_str holds every attribute value (stringified),
         # while attributes_map_float only exists for numeric values — all-numeric distinct ids
         # must not route there via the usual value-type detection.

--- a/products/logs/backend/models.py
+++ b/products/logs/backend/models.py
@@ -34,6 +34,26 @@ def default_logs_distinct_id_attribute_keys() -> list[str]:
     return list(DEFAULT_LOGS_DISTINCT_ID_ATTRIBUTE_KEYS)
 
 
+# Built-in distinct-id attribute key conventions. Mirror of the frontend DISTINCT_ID_KEYS in
+# products/logs/frontend/utils.tsx — keep the two in sync. The logs UI renders a value under
+# any of these keys as a clickable person link (isDistinctIdKey), so the person Logs tab scopes
+# on them too (on top of a team's configured keys), otherwise a log shown as belonging to a
+# person would not appear on that person's tab. Literal keys only: the frontend additionally
+# matches dot-suffixed variants (e.g. `span.distinct_id`), which an exact attribute filter can't
+# express.
+DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS = [
+    "distinct.id",
+    "distinct_id",
+    "distinctId",
+    "distinctID",
+    "posthogDistinctId",
+    "posthogDistinctID",
+    "posthog_distinct_id",
+    "posthog.distinct.id",
+    "posthog.distinct_id",
+]
+
+
 # Default log attribute keys whose values hold the PostHog session ID. `posthogSessionId`
 # is the key the posthog-js / posthog-react-native SDKs auto-attach to every log they
 # emit (see https://posthog.com/docs/logs/link-session-replay). Ordered: detection checks

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -1265,23 +1265,24 @@ class TestLogsPersonIdFilter(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            ("single_key", ["user.id"], {"user.id"}),
-            ("multiple_keys", ["user.id", "posthogDistinctId"], {"user.id", "posthogDistinctId"}),
+            ("single_key", ["team_ref"], {"team_ref"}),
+            ("multiple_keys", ["team_ref", "account_ref"], {"team_ref", "account_ref"}),
         ]
     )
     def test_person_id_respects_configured_attribute_keys(
         self, _name: str, configured_keys: list[str], matching_keys: set[str]
     ):
         # Matching only the first configured key (or the legacy singular column) would
-        # silently drop logs linked via the other keys.
+        # silently drop logs linked via the other keys. Custom keys (not built-in
+        # conventions) isolate configured-key handling from the convention fallback.
         TeamLogsConfig.objects.update_or_create(
             team=self.team, defaults={"logs_distinct_id_attribute_keys": configured_keys}
         )
         person = create_person(team=self.team, distinct_ids=["person-id-test-cfg"])
         self._insert_logs(
             [
-                self._log_row("person-id-test-cfg", attribute_key="user.id"),
-                self._log_row("person-id-test-cfg", attribute_key="posthogDistinctId"),
+                self._log_row("person-id-test-cfg", attribute_key="team_ref"),
+                self._log_row("person-id-test-cfg", attribute_key="account_ref"),
             ]
         )
 
@@ -1289,6 +1290,26 @@ class TestLogsPersonIdFilter(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual({key for r in results for key in r["attributes"]}, matching_keys)
         self.assertEqual(len(results), len(matching_keys))
+
+    def test_person_id_matches_builtin_convention_keys(self):
+        # A log stamped under a built-in distinct-id convention key (e.g. `distinct_id`) is
+        # rendered as a clickable person link in the logs UI (isDistinctIdKey), so it must also
+        # appear on that person's Logs tab even when the team never configured that key. Here
+        # only the default `posthogDistinctId` is configured; `distinct_id` is convention-only.
+        person = create_person(team=self.team, distinct_ids=["person-id-test-conv"])
+        self._insert_logs(
+            [
+                self._log_row("person-id-test-conv", attribute_key="distinct_id"),
+                self._log_row("person-id-test-conv", attribute_key="posthogDistinctId"),
+            ]
+        )
+
+        results = self._run(str(person.uuid))
+
+        self.assertEqual(
+            {key for r in results for key in r["attributes"]},
+            {"distinct_id", "posthogDistinctId"},
+        )
 
     def test_person_id_filter_targets_string_attribute_map_for_numeric_ids(self):
         # All-numeric distinct ids must not route to the float attribute map — only the

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -1203,8 +1203,10 @@ class TestLogsPersonIdFilter(ClickhouseTestMixin, APIBaseTest):
             {payload}
         """)
 
-    def _log_row(self, distinct_id_value: str, attribute_key: str = "posthogDistinctId") -> dict:
-        return {
+    def _log_row(
+        self, distinct_id_value: str, attribute_key: str = "posthogDistinctId", *, resource: bool = False
+    ) -> dict:
+        row: dict = {
             "uuid": str(uuid4()),
             "timestamp": "2026-03-01 10:00:00.000000",
             "observed_timestamp": "2026-03-01 10:00:01.000000",
@@ -1213,8 +1215,14 @@ class TestLogsPersonIdFilter(ClickhouseTestMixin, APIBaseTest):
             "severity_number": 9,
             "service_name": "person-id-test-svc",
             "resource_attributes": {"service.name": "person-id-test-svc"},
-            "attributes_map_str": {f"{attribute_key}__str": distinct_id_value},
+            "attributes_map_str": {},
         }
+        # Place the distinct id under a resource attribute or a log attribute.
+        if resource:
+            row["resource_attributes"][attribute_key] = distinct_id_value
+        else:
+            row["attributes_map_str"][f"{attribute_key}__str"] = distinct_id_value
+        return row
 
     def _person_query(self, person_id: str) -> LogsQuery:
         return LogsQuery(
@@ -1310,6 +1318,19 @@ class TestLogsPersonIdFilter(ClickhouseTestMixin, APIBaseTest):
             {key for r in results for key in r["attributes"]},
             {"distinct_id", "posthogDistinctId"},
         )
+
+    def test_person_id_matches_distinct_id_in_resource_attributes(self):
+        # The logs UI renders a distinct-id convention key as a clickable person link whether the
+        # value sits in attributes or resource_attributes (LogAttributes.tsx), so a distinct id
+        # under resource_attributes must link the log to the person's tab too — not just log
+        # attributes.
+        person = create_person(team=self.team, distinct_ids=["person-id-test-res"])
+        self._insert_logs([self._log_row("person-id-test-res", attribute_key="distinct_id", resource=True)])
+
+        results = self._run(str(person.uuid))
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["resource_attributes"]["distinct_id"], "person-id-test-res")
 
     def test_person_id_filter_targets_string_attribute_map_for_numeric_ids(self):
         # All-numeric distinct ids must not route to the float attribute map — only the

--- a/products/logs/frontend/utils.tsx
+++ b/products/logs/frontend/utils.tsx
@@ -69,6 +69,9 @@ export function getFiltersSummaryLines(filters: Record<string, any>): FiltersSum
     return lines
 }
 
+// Mirror of DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS in products/logs/backend/models.py — keep the
+// two in sync. Values under these keys render as clickable person links here, and the person
+// Logs tab scopes on them server-side so those logs appear on the person's tab.
 const DISTINCT_ID_KEYS = [
     'distinct.id',
     'distinct_id',


### PR DESCRIPTION
## Problem

"Link to person" and "link to session" both recognise a broad set of built-in attribute-key conventions in the logs UI, but only *display* used that breadth for persons — the person **Logs tab** did not.

Concretely: the logs list renders a value under any built-in distinct-id convention key (`distinct_id`, `distinctId`, `posthog_distinct_id`, `distinct.id`, …) as a clickable person link (`isDistinctIdKey`). But the person profile Logs tab scoped its query only on the team's configured `logs_distinct_id_attribute_keys` (default `posthogDistinctId`). So a log the UI shows as belonging to a person could be missing from that same person's Logs tab — the value is surfaced as an ID in the UI, yet not linked on the person tab.

## Changes

- **Backend** (`_person_scope_expr` in `logs_query_runner.py`): scope the person query on the union of the team's configured keys **and** the built-in distinct-id conventions — deduped, configured keys first — mirroring the OR the logs UI already uses to decide clickability.
- **Convention list** now lives on the backend (`DISTINCT_ID_ATTRIBUTE_KEY_CONVENTIONS` in `models.py`) as a byte-for-byte mirror of the frontend `DISTINCT_ID_KEYS`. Both sides carry a cross-reference comment to keep them in sync (same hand-mirroring precedent as the existing default-key constants).
- **Caption** on the Logs tab updated to note that common distinct ID attributes are matched in addition to the configured keys.

This is safe: the person filter is an exact match against *this person's own* `distinct_ids`, so adding candidate keys can only surface logs that genuinely reference them — never mislink to someone else. Only literal convention keys are added (the frontend also matches dot-suffixed variants like `span.distinct_id`, which an exact attribute filter can't express); the OR width stays bounded.

## How did you test this code?

- Added a ClickHouse-backed test (`test_person_id_matches_builtin_convention_keys`) to the existing `TestLogsPersonIdFilter` harness: a log stamped under the convention-only key `distinct_id` (never configured) now appears on the person's tab. Guards the exact regression this PR fixes.
- Reworked `test_person_id_respects_configured_attribute_keys` to use custom, non-convention keys so it still isolates configured-key OR handling without convention interference.
- Verified the frontend and backend convention lists are identical (the fix depends on it); `ruff` clean; the logs `utils.test.ts` jest suite passes. The ClickHouse-backed cases run in CI (the DB/ClickHouse stack isn't stood up in this environment).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change needed — this makes the person Logs tab consistent with attribute keys the logs UI already treats as person links.

## 🤖 Agent context

Fully autonomous.

- Investigated the two link paths: session extraction (`getSessionIdWithKey`) already falls back to its broad convention list, while person-tab querying (now server-side via `personId` → `_person_scope_expr`) only used configured keys. Fix aligns the person query with the convention set that drives `isDistinctIdKey` clickability, so "surfaced as an ID in the logs UI" and "linked on the person tab" agree.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
