### PR TITLE
fix(tasks): hide internal tasks from activity

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5710,7 +5710,8 @@ def _task_activity_qs(team_id: int, user_id: int) -> QuerySet[TaskActivity]:
     Rows outlive visibility changes (a task moving to a private channel, say), so the
     visibility gate belongs on read rather than being enforced when projecting.
     """
-    return TaskActivity.objects.filter(team_id=team_id, user_id=user_id, task__in=_visible_task_qs(team_id, user_id))
+    visible_tasks = _visible_task_qs(team_id, user_id).filter(internal=False, archived=False)
+    return TaskActivity.objects.filter(team_id=team_id, user_id=user_id, task__in=visible_tasks)
 
 
 def count_unread_task_activity(team_id: int, user_id: int | None) -> int:

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -382,6 +382,21 @@ class TaskActivityAPITestCase(ChannelTaskAPITestCase):
         # A teammate with no relationship to the task sees nothing.
         self.assertEqual(self._rows(self.peer_client), [])
 
+    @parameterized.expand(
+        [
+            ("internal", {"internal": True}),
+            ("archived", {"archived": True}),
+        ]
+    )
+    def test_hidden_tasks_are_excluded_from_activity(self, _name, task_updates):
+        Task.objects.filter(id=self.task.id).update(**task_updates)
+        self._awaiting_input()
+
+        page = self.author_client.get(self._activity_url()).json()
+
+        self.assertEqual(page["results"], [])
+        self.assertEqual(page["unread_count"], 0)
+
     def test_authored_message_shows_as_message_with_snippet(self):
         self._post_message(self.peer_client, "looking into this")
         row = self._row_for(self.peer_client, self.task)


### PR DESCRIPTION
## Problem

The task activity feed used task authorization rules but did not apply the default list visibility rules. Internal pipeline tasks and archived tasks could therefore appear in Activity even though they were hidden elsewhere.

## Changes

Filter internal and archived tasks from activity results and unread counts. Add regression coverage for both visibility states.

## How did you test this code?

- `uv run ruff check products/tasks/backend/facade/api.py products/tasks/backend/tests/test_channels_api.py`
- `uv run ruff format --check products/tasks/backend/facade/api.py products/tasks/backend/tests/test_channels_api.py`
- `git diff --check`
- The focused Django test class was collected, but could not run because PostgreSQL was not available in this fresh clone. CI will execute the added regression cases.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the mismatch between normal task-list filtering and the activity index, then implemented the backend filter and regression tests. No repository-provided skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
