### PR TITLE
fix(insights): align lifecycle series so hide-incomplete-periods renders correctly

### DIFF
--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -204,16 +204,22 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
         order = {"new": 1, "returning": 2, "resurrecting": 3, "dormant": 4}
         raw_results = sorted(response.results or [], key=lambda row: order.get(row[cols["status"]], 5))
 
+        # Each status is grouped independently in ClickHouse, and groupArray does not guarantee that the
+        # per-status (date, count) arrays share the same length or ordering. The chart plots every status
+        # positionally against a single shared axis, so align all statuses to one canonical, sorted set of
+        # periods here (filling gaps with 0) to keep the series aligned.
+        all_dates = sorted({date for val in raw_results for date in val[cols["date"]]})
+        labels = [format_label_date(item, self.query_date_range, self.team.week_start_day) for item in all_dates]
+        days = [
+            item.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if self.query_date_range.interval_name == "hour" else ""))
+            for item in all_dates
+        ]
+
         results = []
         for val in raw_results:
-            counts = val[cols["total"]]
-            dates = val[cols["date"]]
+            counts_by_date = dict(zip(val[cols["date"]], val[cols["total"]]))
             status = val[cols["status"]]
-            labels = [format_label_date(item, self.query_date_range, self.team.week_start_day) for item in dates]
-            days = [
-                item.strftime("%Y-%m-%d{}".format(" %H:%M:%S" if self.query_date_range.interval_name == "hour" else ""))
-                for item in dates
-            ]
+            data = [float(counts_by_date.get(date, 0)) for date in all_dates]
 
             # legacy response compatibility object
             action_object = {}
@@ -263,8 +269,8 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
             results.append(
                 {
                     "action": action_object,
-                    "data": [float(c) for c in counts],
-                    "count": float(sum(counts)),
+                    "data": data,
+                    "count": float(sum(data)),
                     "labels": labels,
                     "days": days,
                     **additional_values,

--- a/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/lifecycle_query_runner.py
@@ -52,6 +52,14 @@ class LifecycleQueryRunner(AnalyticsQueryRunner[LifecycleQueryResponse]):
             DisallowUnsupportedDataWarehouseSettings(),
         )
 
+    def get_cache_payload(self) -> dict:
+        # Bump when format_results changes shape so old cached responses (e.g. the pre-alignment
+        # positional arrays) are invalidated rather than served stale. Lifecycle-scoped on purpose,
+        # so it doesn't invalidate every other query type's cache.
+        payload = super().get_cache_payload()
+        payload["lifecycle_formatter_version"] = 1
+        return payload
+
     def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         if self.query.samplingFactor == 0:
             counts_with_sampling: ast.Expr = ast.Constant(value=0)

--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from types import SimpleNamespace
 
 from freezegun import freeze_time
 from posthog.test.base import (
@@ -911,6 +912,63 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
             LifecycleQueryRunner(team=self.team, query=query).calculate()
 
         self.assertIn("Lifecycle insights require at least one series.", str(context.exception))
+
+    def test_format_results_aligns_misaligned_status_series(self):
+        # Regression: each lifecycle status is grouped independently in ClickHouse and groupArray does
+        # not guarantee the per-status (date, count) arrays share length or order. The chart plots every
+        # status positionally against one shared axis, so format_results must align them all to one
+        # canonical, sorted period axis. Feed deliberately misaligned per-status arrays and assert the
+        # output lines back up (gaps filled with 0).
+        runner = self._create_query_runner("2020-01-09", "2020-01-12", IntervalType.DAY)
+        d9, d10, d11, d12 = (datetime(2020, 1, day) for day in (9, 10, 11, 12))
+        response = SimpleNamespace(
+            columns=["date", "total", "status"],
+            results=[
+                ([d12, d11, d10, d9], [4, 3, 2, 1], "new"),  # reverse-ordered dates
+                ([d9, d10, d11, d12], [10, 20, 30, 40], "returning"),  # sorted, full
+                ([d9, d11], [100, 300], "resurrecting"),  # missing 10th and 12th
+                ([d10, d11, d12], [-5, -6, -7], "dormant"),  # sorted, negative, missing 9th
+            ],
+        )
+
+        results = runner.format_results(response)  # type: ignore[arg-type]
+        by_status = {r["status"]: r for r in results}
+
+        expected_days = ["2020-01-09", "2020-01-10", "2020-01-11", "2020-01-12"]
+        for r in results:
+            self.assertEqual(r["days"], expected_days)
+            self.assertEqual(len(r["data"]), len(expected_days))
+        self.assertEqual(by_status["new"]["data"], [1.0, 2.0, 3.0, 4.0])
+        self.assertEqual(by_status["returning"]["data"], [10.0, 20.0, 30.0, 40.0])
+        self.assertEqual(by_status["resurrecting"]["data"], [100.0, 0.0, 300.0, 0.0])
+        self.assertEqual(by_status["dormant"]["data"], [0.0, -5.0, -6.0, -7.0])
+
+    def test_exclude_incomplete_periods_drops_current_day_and_keeps_series_aligned(self):
+        # Lifecycle had no coverage for DateRange.excludeIncompletePeriods. With "now" mid-day, the
+        # current (incomplete) day must be dropped and all four status series must remain aligned to
+        # one shared axis.
+        self._create_events(
+            data=[
+                ("p1", ["2020-01-09T12:00:00Z", "2020-01-10T12:00:00Z", "2020-01-11T12:00:00Z"]),
+                ("p2", ["2020-01-10T12:00:00Z", "2020-01-12T12:00:00Z"]),
+            ]
+        )
+        flush_persons_and_events()
+
+        with freeze_time("2020-01-12T09:00:00Z"):
+            query = LifecycleQuery(
+                dateRange=DateRange(date_from="-4d", excludeIncompletePeriods=True),
+                interval=IntervalType.DAY,
+                series=[EventsNode(event="$pageview")],
+            )
+            response = LifecycleQueryRunner(team=self.team, query=query).calculate()
+
+        day_axes = {tuple(res["days"]) for res in response.results}
+        self.assertEqual(len(day_axes), 1)  # every status shares one aligned axis
+        days = next(iter(day_axes))
+        self.assertNotIn("2020-01-12", days)  # incomplete current day excluded
+        data_lengths = {len(res["data"]) for res in response.results}
+        self.assertEqual(data_lengths, {len(days)})
 
     def test_lifecycle_query_whole_range(self):
         self._create_test_events()

--- a/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
+++ b/posthog/hogql_queries/insights/lifecycle/test/test_lifecycle_query_runner.py
@@ -34,6 +34,7 @@ from posthog.schema import (
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.hogql_queries.insights.lifecycle.lifecycle_query_runner import LifecycleQueryRunner
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models.group.util import create_group
 from posthog.models.instance_setting import get_instance_setting
 from posthog.models.team import WeekStartDay
@@ -969,6 +970,14 @@ class TestLifecycleQueryRunner(ClickhouseTestMixin, APIBaseTest):
         self.assertNotIn("2020-01-12", days)  # incomplete current day excluded
         data_lengths = {len(res["data"]) for res in response.results}
         self.assertEqual(data_lengths, {len(days)})
+
+    def test_cache_payload_is_lifecycle_scoped_and_distinct_from_base(self):
+        # The formatter-version bump must live only in the lifecycle payload so a format_results
+        # shape change invalidates lifecycle caches without touching every other query type.
+        runner = self._create_query_runner("2020-01-09", "2020-01-12", IntervalType.DAY)
+        payload = runner.get_cache_payload()
+        self.assertEqual(payload["lifecycle_formatter_version"], 1)
+        self.assertNotIn("lifecycle_formatter_version", AnalyticsQueryRunner.get_cache_payload(runner))
 
     def test_lifecycle_query_whole_range(self):
         self._create_test_events()


### PR DESCRIPTION
## Problem

On a **lifecycle** insight with **"hide incomplete periods"** toggled on, the chart renders broken — some daily bars show only a partial set of the four series (e.g. only the dormant/negative bar, or only the positive bands), and some days render empty entirely, even though adjacent days are full.


## Root cause

Lifecycle groups each status (`new` / `returning` / `resurrecting` / `dormant`) **independently** in ClickHouse via `groupArray(...) ... GROUP BY status`. ClickHouse does **not** guarantee that the per-status `(date, count)` arrays come back with the same length or ordering (the inner `ORDER BY start_of_period` is not guaranteed to survive the outer `GROUP BY`).

- `LifecycleQueryRunner.format_results` derived each series' `days`/`labels` axis **from that series' own `date` array**.
- The chart (`TrendsLifecycleChart.tsx` → `buildTrendsLifecycleSeries`) takes a **single** series' days as the shared x-axis and plots every status's `data` array **positionally** against it — no per-series date reconciliation.

So the moment one status's array differed in length or order from the axis series, its values shifted onto the wrong days. `DateRange.excludeIncompletePeriods` (clipping `date_to` back to the last complete interval) is what pushed the arrays out of sync and made this visible.

## Fix

Align all four statuses to **one canonical, sorted period axis** in `format_results`, filling any gaps with `0`, so the series always line up index-for-index against the shared axis the chart expects. In the healthy case (all statuses already zero-filled for every period) this is a no-op; when the arrays drift it repairs the alignment.

## Tests

- `test_format_results_aligns_misaligned_status_series` — feeds deliberately misaligned per-status arrays (reversed order, missing periods) and asserts the output shares one sorted axis with values correctly aligned and gaps zero-filled. Fails before the fix.
- `test_exclude_incomplete_periods_drops_current_day_and_keeps_series_aligned` — first lifecycle coverage for `excludeIncompletePeriods`: asserts the incomplete current day is dropped and all four series share one aligned axis.

All 37 lifecycle runner tests pass; ruff + type check clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
