### PR TITLE
feat(tasks): link repositories to spaces

### DIFF
--- a/ee/hogai/api/tests/test_serializers.py
+++ b/ee/hogai/api/tests/test_serializers.py
@@ -345,6 +345,7 @@ class TestConversationSerializerTaskField(APIBaseTest):
             origin_product=Task.OriginProduct.POSTHOG_AI,
             runtime=Task.Runtime.ACP,
             repository=None,
+            repositories=[],
             github_integration=None,
             github_user_integration=None,
             signal_report=None,

--- a/posthog/management/migration_analysis/atomic_false_acknowledged_migrations.txt
+++ b/posthog/management/migration_analysis/atomic_false_acknowledged_migrations.txt
@@ -16,3 +16,4 @@
 # posthog.1234_backfill_something_in_batches
 posthog.1264_delete_revenue_analytics_user_product_list
 product_analytics.0004_delete_revenue_analytics_insights
+tasks.0079_backfill_task_repositories

--- a/products/desktop/apps/code/src/renderer/di/container.ts
+++ b/products/desktop/apps/code/src/renderer/di/container.ts
@@ -322,6 +322,11 @@ container.bind<LocalHandoffHost>(LOCAL_HANDOFF_HOST).toConstantValue({
     trpcClient.folders.getRepositoryByRemoteUrl.query(input),
   selectDirectory: () => trpcClient.os.selectDirectory.query(),
   addFolder: (input) => trpcClient.folders.addFolder.mutate(input),
+  getWorktreeLocation: () => trpcClient.os.getWorktreeLocation.query(),
+  cloneRepository: (input) => trpcClient.git.cloneRepository.mutate(input),
+  addAdditionalDirectory: async (input) => {
+    await trpcClient.additionalDirectories.addForTask.mutate(input);
+  },
 });
 container.bind(LOCAL_HANDOFF_DIALOG).toConstantValue(localHandoffDialog);
 container.bind(LOCAL_HANDOFF_NOTIFIER).toConstantValue(localHandoffNotifier);

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -766,6 +766,10 @@ container.bind(LOCAL_HANDOFF_HOST).toConstantValue({
   selectDirectory: () => Promise.resolve(null),
   addFolder: () =>
     Promise.reject(new Error("Local handoff is not available on the web")),
+  getWorktreeLocation: () => Promise.resolve(""),
+  cloneRepository: () =>
+    Promise.reject(new Error("Local handoff is not available on the web")),
+  addAdditionalDirectory: () => Promise.resolve(),
 });
 container.bind(LOCAL_HANDOFF_DIALOG).toConstantValue(localHandoffDialog);
 container.bind(LOCAL_HANDOFF_NOTIFIER).toConstantValue(localHandoffNotifier);

--- a/products/desktop/packages/agent/src/resume.ts
+++ b/products/desktop/packages/agent/src/resume.ts
@@ -26,6 +26,7 @@ import { Logger } from "./utils/logger";
 export interface ResumeState {
   conversation: ConversationTurn[];
   latestGitCheckpoint: GitCheckpointEvent | null;
+  latestGitCheckpoints?: GitCheckpointEvent[];
   interrupted: boolean;
   lastDevice?: DeviceInfo;
   logEntryCount: number;
@@ -93,6 +94,7 @@ export async function resumeFromLog(
   return {
     conversation: result.data.conversation as ConversationTurn[],
     latestGitCheckpoint: result.data.latestGitCheckpoint,
+    latestGitCheckpoints: result.data.latestGitCheckpoints,
     interrupted: result.data.interrupted,
     lastDevice: result.data.lastDevice,
     logEntryCount: result.data.logEntryCount,

--- a/products/desktop/packages/agent/src/sagas/resume-saga.ts
+++ b/products/desktop/packages/agent/src/sagas/resume-saga.ts
@@ -33,6 +33,7 @@ export interface ResumeInput {
 export interface ResumeOutput {
   conversation: ConversationTurn[];
   latestGitCheckpoint: GitCheckpointEvent | null;
+  latestGitCheckpoints: GitCheckpointEvent[];
   interrupted: boolean;
   lastDevice?: DeviceInfo;
   logEntryCount: number;
@@ -68,10 +69,11 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
 
     this.log.info("Fetched log entries", { count: entries.length });
 
-    const latestGitCheckpoint = await this.readOnlyStep(
+    const latestGitCheckpoints = await this.readOnlyStep(
       "find_git_checkpoint",
-      () => Promise.resolve(this.findLatestGitCheckpoint(entries)),
+      () => Promise.resolve(this.findLatestGitCheckpoints(entries)),
     );
+    const latestGitCheckpoint = latestGitCheckpoints.at(-1) ?? null;
 
     if (latestGitCheckpoint) {
       this.log.info("Found git checkpoint", {
@@ -106,6 +108,7 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
     return {
       conversation,
       latestGitCheckpoint,
+      latestGitCheckpoints,
       interrupted: false,
       lastDevice,
       logEntryCount: entries.length,
@@ -118,6 +121,7 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
     return {
       conversation: [],
       latestGitCheckpoint: null,
+      latestGitCheckpoints: [],
       interrupted: false,
       logEntryCount: 0,
       sessionId: null,
@@ -178,10 +182,11 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
     return null;
   }
 
-  private findLatestGitCheckpoint(
+  private findLatestGitCheckpoints(
     entries: StoredNotification[],
-  ): GitCheckpointEvent | null {
+  ): GitCheckpointEvent[] {
     const sdkPrefixedMethod = `_${POSTHOG_NOTIFICATIONS.GIT_CHECKPOINT}`;
+    const checkpoints = new Map<string, GitCheckpointEvent>();
 
     for (let i = entries.length - 1; i >= 0; i--) {
       const entry = entries[i];
@@ -194,11 +199,12 @@ export class ResumeSaga extends Saga<ResumeInput, ResumeOutput> {
           | GitCheckpointEvent
           | undefined;
         if (params?.checkpointId && params?.checkpointRef) {
-          return params;
+          const key = params.repository?.toLowerCase() ?? "legacy";
+          if (!checkpoints.has(key)) checkpoints.set(key, params);
         }
       }
     }
-    return null;
+    return [...checkpoints.values()].reverse();
   }
 
   private findLastDeviceInfo(

--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -3950,6 +3950,24 @@ describe("AgentServer HTTP Mode", () => {
   });
 
   describe("buildCloudSystemPrompt", () => {
+    it("describes every repository in a shared multi-repository workspace", () => {
+      const s = createServer({
+        repositoryPath: undefined,
+      }) as unknown as TestableServer & { taskRepositories: string[] };
+      s.taskRepositories = ["PostHog/posthog", "PostHog/posthog-js"];
+
+      const prompt = s.buildCloudSystemPrompt();
+
+      expect(prompt).toContain(
+        "PostHog/posthog: /tmp/workspace/repos/posthog/posthog",
+      );
+      expect(prompt).toContain(
+        "PostHog/posthog-js: /tmp/workspace/repos/posthog/posthog-js",
+      );
+      expect(prompt).toContain("Treat every repository as an equal part");
+      expect(prompt).not.toContain("No Repository Mode");
+    });
+
     it("returns review-first prompt for existing PRs on non-Slack runs", () => {
       const s = createServer();
       const prompt = (s as unknown as TestableServer).buildCloudSystemPrompt(

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -380,6 +380,7 @@ export class AgentServer {
   private suppressAdapterTurnComplete = false;
   private runUsage = new RunUsageAccumulator();
   private detectedPrUrl: string | null = null;
+  private taskRepositories: string[] = [];
   // Reset per session. `evaluatedPrUrls` dedupes per URL; `prAttributionChain` serializes
   // attributions so the most recently created PR in a run wins.
   private readonly evaluatedPrUrls = new Set<string>();
@@ -1574,6 +1575,9 @@ export class AgentServer {
         return null;
       }),
     ]);
+    this.taskRepositories =
+      preTask?.repositories ??
+      (preTask?.repository ? [preTask.repository] : []);
 
     this.prewarmedRun =
       (preTaskRun?.state as Record<string, unknown> | undefined)?.prewarmed ===
@@ -3681,6 +3685,35 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${
 `;
     }
 
+    if (this.taskRepositories.length > 1) {
+      const repositoryList = this.taskRepositories
+        .map(
+          (repository) =>
+            `- ${repository}: /tmp/workspace/repos/${repository.toLowerCase()}`,
+        )
+        .join("\n");
+      const publishing =
+        this.config.createPr === false
+          ? "Do not create branches, commits, push changes, or open pull requests in this run."
+          : shouldAutoCreatePr
+            ? "After completing code changes, create a verified commit and draft pull request in every repository you changed."
+            : "Do not create branches, commits, push changes, or open pull requests unless the user explicitly asks.";
+      return `${identityInstructions}
+# Cloud task execution
+
+The task workspace contains these repositories:
+${repositoryList}
+
+- Start from /tmp/workspace and run repository-specific commands from the matching path.
+- Treat every repository as an equal part of the task. Do not infer priority from list order.
+- Keep branches, commits, diffs, and pull requests separate for each repository.
+- ${publishing}
+${publicRepoSafetyInstruction}
+${prMentionSafetyInstruction}
+${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${artifactInstructions}
+`;
+    }
+
     if (!this.config.repositoryPath) {
       const publishInstructions =
         this.config.createPr === false
@@ -4677,7 +4710,7 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${
   private async captureCheckpointState(
     localGitState?: HandoffLocalGitState,
   ): Promise<void> {
-    if (!this.session || !this.config.repositoryPath) {
+    if (!this.session) {
       return;
     }
     if (!this.posthogAPI) {
@@ -4686,38 +4719,57 @@ ${signedCommitInstructions}${prLinkInstructions}${shellEfficiencyInstructions}${
       );
       return;
     }
+    const session = this.session;
 
-    const tracker = new HandoffCheckpointTracker({
-      repositoryPath: this.config.repositoryPath ?? "/tmp/workspace",
-      taskId: this.session.payload.task_id,
-      runId: this.session.payload.run_id,
-      apiClient: this.posthogAPI,
-      logger: this.logger.child("HandoffCheckpoint"),
-    });
+    const repositories =
+      this.taskRepositories.length > 1
+        ? this.taskRepositories.map((repository) => ({
+            repository,
+            path: `/tmp/workspace/repos/${repository.toLowerCase()}`,
+          }))
+        : this.config.repositoryPath
+          ? [
+              {
+                repository: this.taskRepositories[0],
+                path: this.config.repositoryPath,
+              },
+            ]
+          : [];
 
-    const checkpoint = await tracker.captureForHandoff(localGitState);
-    if (!checkpoint) return;
+    await Promise.all(
+      repositories.map(async ({ repository, path }) => {
+        const tracker = new HandoffCheckpointTracker({
+          repositoryPath: path,
+          taskId: session.payload.task_id,
+          runId: session.payload.run_id,
+          apiClient: this.posthogAPI,
+          logger: this.logger.child("HandoffCheckpoint"),
+        });
+        const checkpoint = await tracker.captureForHandoff(
+          repositories.length === 1 ? localGitState : undefined,
+        );
+        if (!checkpoint) return;
 
-    const checkpointWithDevice: GitCheckpointEvent = {
-      ...checkpoint,
-      device: this.session.deviceInfo,
-    };
-
-    const notification = {
-      jsonrpc: "2.0" as const,
-      method: POSTHOG_NOTIFICATIONS.GIT_CHECKPOINT,
-      params: checkpointWithDevice,
-    };
-
-    this.broadcastEvent({
-      type: "notification",
-      timestamp: new Date().toISOString(),
-      notification,
-    });
-
-    this.session.logWriter.appendRawLine(
-      this.session.payload.run_id,
-      JSON.stringify(notification),
+        const checkpointWithDevice: GitCheckpointEvent = {
+          ...checkpoint,
+          repository,
+          device: session.deviceInfo,
+        };
+        const notification = {
+          jsonrpc: "2.0" as const,
+          method: POSTHOG_NOTIFICATIONS.GIT_CHECKPOINT,
+          params: checkpointWithDevice,
+        };
+        this.broadcastEvent({
+          type: "notification",
+          timestamp: new Date().toISOString(),
+          notification,
+        });
+        session.logWriter.appendRawLine(
+          session.payload.run_id,
+          JSON.stringify(notification),
+        );
+      }),
     );
   }
 

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -2638,6 +2638,7 @@ export class PostHogAPIClient {
           Task,
           | "title"
           | "repository"
+          | "repositories"
           | "json_schema"
           | "origin_product"
           | "runtime"
@@ -2699,6 +2700,8 @@ export class PostHogAPIClient {
       description: task.description ?? "",
       title: task.title,
       repository: task.repository,
+      repositories:
+        task.repositories ?? (task.repository ? [task.repository] : []),
       json_schema: task.json_schema,
       origin_product: task.origin_product,
       github_integration: task.github_integration,
@@ -2737,6 +2740,29 @@ export class PostHogAPIClient {
     });
     if (!response.ok) {
       throw new Error(`Failed to resolve task channel: ${response.statusText}`);
+    }
+    return (await response.json()) as TaskChannel;
+  }
+
+  async updateTaskChannel(
+    channelId: string,
+    updates: {
+      github_integration: number | null;
+      repositories: string[];
+    },
+  ): Promise<TaskChannel> {
+    const teamId = await this.getTeamId();
+    const urlPath = `/api/projects/${teamId}/task_channels/${channelId}/`;
+    const response = await this.api.fetcher.fetch({
+      method: "patch",
+      url: new URL(`${this.api.baseUrl}${urlPath}`),
+      path: urlPath,
+      overrides: { body: JSON.stringify(updates) },
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Failed to update space repositories: ${response.statusText}`,
+      );
     }
     return (await response.json()) as TaskChannel;
   }

--- a/products/desktop/packages/api-client/src/task-normalization.ts
+++ b/products/desktop/packages/api-client/src/task-normalization.ts
@@ -29,6 +29,7 @@ type TaskResponseDTO = Partial<
   json_schema?: unknown | null;
   latest_run?: Record<string, unknown> | null;
   runtime?: unknown;
+  repositories?: string[];
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -185,6 +186,7 @@ export function normalizeTaskResponse(
     ...(dto.created_by === undefined ? {} : { created_by: dto.created_by }),
     origin_product: dto.origin_product ?? "",
     ...(dto.repository === undefined ? {} : { repository: dto.repository }),
+    repositories: dto.repositories ?? (dto.repository ? [dto.repository] : []),
     ...(dto.github_integration === undefined
       ? {}
       : { github_integration: dto.github_integration }),

--- a/products/desktop/packages/core/src/handoff/handoff-saga.test.ts
+++ b/products/desktop/packages/core/src/handoff/handoff-saga.test.ts
@@ -317,4 +317,40 @@ describe("HandoffSaga", () => {
       DEFAULT_LOCAL_GIT_STATE,
     );
   });
+
+  it("applies each repository checkpoint to its local checkout", async () => {
+    const posthog = createCheckpoint({ repository: "PostHog/posthog" });
+    const desktop = createCheckpoint({
+      repository: "PostHog/desktop",
+      checkpointId: "checkpoint-2",
+    });
+    const { deps, result } = await runSaga({
+      input: {
+        repositoryPaths: {
+          "posthog/posthog": "/repos/posthog",
+          "posthog/desktop": "/repos/desktop",
+        },
+      },
+      resumeState: {
+        latestGitCheckpoints: [posthog, desktop],
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(deps.applyGitCheckpoint).toHaveBeenCalledTimes(2);
+    expect(deps.applyGitCheckpoint).toHaveBeenCalledWith(
+      posthog,
+      "/repos/posthog",
+      "task-1",
+      "run-1",
+      undefined,
+    );
+    expect(deps.applyGitCheckpoint).toHaveBeenCalledWith(
+      desktop,
+      "/repos/desktop",
+      "task-1",
+      "run-1",
+      undefined,
+    );
+  });
 });

--- a/products/desktop/packages/core/src/handoff/handoff-saga.ts
+++ b/products/desktop/packages/core/src/handoff/handoff-saga.ts
@@ -18,6 +18,7 @@ export interface HandoffSagaOutput {
 export interface HandoffResumeState {
   conversation: unknown[];
   latestGitCheckpoint: GitHandoffCheckpoint | null;
+  latestGitCheckpoints?: GitHandoffCheckpoint[];
 }
 
 export interface HandoffSagaDeps extends HandoffBaseDeps {
@@ -100,8 +101,12 @@ export class HandoffSaga extends Saga<HandoffSagaInput, HandoffSagaOutput> {
     );
 
     let checkpointApplied = false;
-    const checkpoint = resumeState.latestGitCheckpoint;
-    if (checkpoint) {
+    const checkpoints = resumeState.latestGitCheckpoints?.length
+      ? resumeState.latestGitCheckpoints
+      : resumeState.latestGitCheckpoint
+        ? [resumeState.latestGitCheckpoint]
+        : [];
+    if (checkpoints.length > 0) {
       this.deps.onProgress(
         "applying_git_checkpoint",
         "Applying cloud git state locally...",
@@ -110,12 +115,24 @@ export class HandoffSaga extends Saga<HandoffSagaInput, HandoffSagaOutput> {
       await this.step({
         name: "apply_git_checkpoint",
         execute: async () => {
-          await this.deps.applyGitCheckpoint(
-            checkpoint,
-            repoPath,
-            taskId,
-            runId,
-            input.localGitState,
+          await Promise.all(
+            checkpoints.map((checkpoint) => {
+              const path = checkpoint.repository
+                ? input.repositoryPaths?.[checkpoint.repository.toLowerCase()]
+                : repoPath;
+              if (!path) {
+                throw new Error(
+                  `No local checkout found for ${checkpoint.repository}`,
+                );
+              }
+              return this.deps.applyGitCheckpoint(
+                checkpoint,
+                path,
+                taskId,
+                runId,
+                checkpoint.repository ? undefined : input.localGitState,
+              );
+            }),
           );
           checkpointApplied = true;
         },

--- a/products/desktop/packages/core/src/handoff/schemas.ts
+++ b/products/desktop/packages/core/src/handoff/schemas.ts
@@ -62,6 +62,7 @@ export const handoffPreflightResult = z.object({
 export type HandoffPreflightResult = z.infer<typeof handoffPreflightResult>;
 
 export const handoffExecuteInput = handoffApiInput.extend({
+  repositoryPaths: z.record(z.string(), z.string()).optional(),
   sessionId: z.string().optional(),
   adapter: z.enum(["claude", "codex"]).optional(),
   localGitState: handoffLocalGitStateSchema.optional(),

--- a/products/desktop/packages/core/src/handoff/types.ts
+++ b/products/desktop/packages/core/src/handoff/types.ts
@@ -18,6 +18,7 @@ export interface HandoffSagaInput {
   taskId: string;
   runId: string;
   repoPath: string;
+  repositoryPaths?: Record<string, string>;
   apiHost: string;
   teamId: number;
   sessionId?: string;

--- a/products/desktop/packages/core/src/sessions/localHandoffService.test.ts
+++ b/products/desktop/packages/core/src/sessions/localHandoffService.test.ts
@@ -21,6 +21,9 @@ function makeDeps() {
     getRepositoryByRemoteUrl: vi.fn().mockResolvedValue(null),
     selectDirectory: vi.fn().mockResolvedValue(null),
     addFolder: vi.fn().mockResolvedValue(undefined),
+    getWorktreeLocation: vi.fn().mockResolvedValue("/worktrees"),
+    cloneRepository: vi.fn().mockResolvedValue(undefined),
+    addAdditionalDirectory: vi.fn().mockResolvedValue(undefined),
   };
 
   const dialog: LocalHandoffDialog = {
@@ -114,6 +117,7 @@ describe("LocalHandoffService.afterCommit", () => {
     expect(deps.sessionService.handoffToLocal).toHaveBeenCalledWith(
       "task-1",
       "/repo",
+      undefined,
     );
   });
 
@@ -161,6 +165,7 @@ describe("LocalHandoffService.start", () => {
     expect(deps.sessionService.handoffToLocal).toHaveBeenCalledWith(
       "task-1",
       "/repo",
+      { "https://example.com/repo.git": "/repo" },
     );
   });
 
@@ -180,7 +185,48 @@ describe("LocalHandoffService.start", () => {
 
     expect(deps.dialog.openDirtyTreeForPendingHandoff).toHaveBeenCalledWith(
       [{ path: "a.ts" }],
-      { taskId: "task-1", repoPath: "/repo", branchName: "main" },
+      {
+        taskId: "task-1",
+        repoPath: "/repo",
+        branchName: "main",
+        repositoryPaths: { "https://example.com/repo.git": "/repo" },
+      },
+    );
+  });
+
+  it("reuses local repositories and clones missing ones before handoff", async () => {
+    const deps = makeDeps();
+    const multiRepoTask = {
+      repositories: ["posthog/posthog", "posthog/posthog-js"],
+    } as Task;
+    deps.host.getRepositoryByRemoteUrl = vi
+      .fn()
+      .mockResolvedValueOnce({ path: "/repos/posthog" })
+      .mockResolvedValueOnce(null);
+    deps.sessionService.preflightToLocal.mockResolvedValue({
+      canHandoff: true,
+    });
+
+    await deps.service.start("task-1", multiRepoTask);
+
+    expect(deps.host.cloneRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "posthog/posthog-js",
+        targetPath: "/worktrees/linked-repositories/posthog/posthog-js",
+      }),
+    );
+    expect(deps.host.addAdditionalDirectory).toHaveBeenCalledWith({
+      taskId: "task-1",
+      path: "/worktrees/linked-repositories/posthog/posthog-js",
+    });
+    expect(deps.sessionService.handoffToLocal).toHaveBeenCalledWith(
+      "task-1",
+      "/repos/posthog",
+      {
+        "posthog/posthog": "/repos/posthog",
+        "posthog/posthog-js":
+          "/worktrees/linked-repositories/posthog/posthog-js",
+      },
     );
   });
 });

--- a/products/desktop/packages/core/src/sessions/localHandoffService.ts
+++ b/products/desktop/packages/core/src/sessions/localHandoffService.ts
@@ -27,12 +27,23 @@ export interface LocalHandoffHost {
     folderPath: string;
     remoteUrl?: string;
   }): Promise<unknown>;
+  getWorktreeLocation(): Promise<string>;
+  cloneRepository(input: {
+    repoUrl: string;
+    targetPath: string;
+    cloneId: string;
+  }): Promise<unknown>;
+  addAdditionalDirectory(input: {
+    taskId: string;
+    path: string;
+  }): Promise<void>;
 }
 
 export interface LocalHandoffPending {
   taskId: string;
   repoPath: string;
   branchName: string | null;
+  repositoryPaths?: Record<string, string>;
 }
 
 export interface ContinueAfterDirtyTreeContext {
@@ -98,11 +109,23 @@ export class LocalHandoffService {
 
   public async start(taskId: string, task: Task): Promise<void> {
     try {
+      const repositories = task.repositories?.length
+        ? task.repositories
+        : task.repository
+          ? [task.repository]
+          : [];
+      const repositoryPaths = await this.resolveRepositoryPaths(repositories);
+      const paths = Object.values(repositoryPaths);
       const targetPath =
-        (await this.resolveRepoPathFromRemote(task.repository)) ??
-        (await this.resolveRepoPathFromPicker(task.repository));
+        paths[0] ?? (await this.resolveRepoPathFromPicker(task.repository));
 
       if (!targetPath) return;
+
+      await Promise.all(
+        paths
+          .slice(1)
+          .map((path) => this.host.addAdditionalDirectory({ taskId, path })),
+      );
 
       const preflight = await this.sessionService.preflightToLocal(
         taskId,
@@ -111,7 +134,11 @@ export class LocalHandoffService {
 
       if (preflight.canHandoff) {
         this.closeConfirm();
-        await this.sessionService.handoffToLocal(taskId, targetPath);
+        await this.sessionService.handoffToLocal(
+          taskId,
+          targetPath,
+          repositoryPaths,
+        );
         return;
       }
 
@@ -120,6 +147,7 @@ export class LocalHandoffService {
           taskId,
           repoPath: targetPath,
           branchName: preflight.localGitState?.branch ?? null,
+          repositoryPaths,
         });
         return;
       }
@@ -162,6 +190,7 @@ export class LocalHandoffService {
       await this.sessionService.handoffToLocal(
         pending.taskId,
         pending.repoPath,
+        pending.repositoryPaths,
       );
     } catch (error) {
       this.notifier.logError("Failed to resume handoff to local", error);
@@ -178,6 +207,31 @@ export class LocalHandoffService {
       remoteUrl,
     });
     return repo?.path ?? null;
+  }
+
+  private async resolveRepositoryPaths(
+    repositories: string[],
+  ): Promise<Record<string, string>> {
+    if (repositories.length === 0) return {};
+    const cloneRoot = `${(await this.host.getWorktreeLocation()).replace(/\/$/, "")}/linked-repositories`;
+    const paths = await Promise.all(
+      repositories.map(async (repository) => {
+        const existing = await this.resolveRepoPathFromRemote(repository);
+        if (existing) return [repository.toLowerCase(), existing] as const;
+        const targetPath = `${cloneRoot}/${repository.toLowerCase()}`;
+        await this.host.cloneRepository({
+          repoUrl: repository,
+          targetPath,
+          cloneId: globalThis.crypto.randomUUID(),
+        });
+        await this.host.addFolder({
+          folderPath: targetPath,
+          remoteUrl: repository,
+        });
+        return [repository.toLowerCase(), targetPath] as const;
+      }),
+    );
+    return Object.fromEntries(paths);
   }
 
   private async resolveRepoPathFromPicker(

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -6504,7 +6504,11 @@ export class SessionService {
     };
   }
 
-  async handoffToLocal(taskId: string, repoPath: string): Promise<void> {
+  async handoffToLocal(
+    taskId: string,
+    repoPath: string,
+    repositoryPaths?: Record<string, string>,
+  ): Promise<void> {
     const session = this.d.store.getSessionByTaskId(taskId);
     if (!session) {
       this.d.log.warn("No session found for handoff", { taskId });
@@ -6518,20 +6522,31 @@ export class SessionService {
     this.d.store.updateSession(runId, { handoffInProgress: true });
 
     try {
-      const preflight = await this.runHandoffPreflight(
-        taskId,
-        runId,
-        repoPath,
-        auth,
-      );
+      const paths = [...new Set(Object.values(repositoryPaths ?? {}))];
+      if (!paths.includes(repoPath)) paths.unshift(repoPath);
+      let localGitState:
+        | Awaited<
+            ReturnType<typeof this.d.trpc.handoff.preflight.query>
+          >["localGitState"]
+        | undefined;
+      for (const path of paths) {
+        const preflight = await this.runHandoffPreflight(
+          taskId,
+          runId,
+          path,
+          auth,
+        );
+        if (path === repoPath) localGitState = preflight.localGitState;
+      }
       this.stopCloudTaskWatch(taskId);
       this.d.store.updateSession(runId, { status: "connecting" });
       await this.executeHandoff(
         taskId,
         runId,
         repoPath,
+        repositoryPaths,
         auth,
-        preflight.localGitState,
+        localGitState,
       );
       this.transitionToLocalSession(runId);
       this.subscribeToChannel(runId);
@@ -6721,6 +6736,7 @@ export class SessionService {
     taskId: string,
     runId: string,
     repoPath: string,
+    repositoryPaths: Record<string, string> | undefined,
     auth: { apiHost: string; projectId: number },
     localGitState?: Awaited<
       ReturnType<typeof this.d.trpc.handoff.preflight.query>
@@ -6730,6 +6746,7 @@ export class SessionService {
       taskId,
       runId,
       repoPath,
+      repositoryPaths,
       apiHost: auth.apiHost,
       teamId: auth.projectId,
       localGitState,

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -81,6 +81,7 @@ export interface Task {
   created_by?: UserBasic | null;
   origin_product: string;
   repository?: string | null; // Format: "organization/repository" (e.g., "posthog/posthog-js")
+  repositories?: string[];
   github_integration?: number | null;
   github_user_integration?: string | null;
   json_schema?: Record<string, unknown> | null;
@@ -102,6 +103,8 @@ export interface TaskChannel {
   id: string;
   name: string;
   channel_type: "public" | "personal";
+  github_integration?: number | null;
+  repositories?: string[];
   created_at: string;
   created_by?: UserBasic | null;
 }

--- a/products/desktop/packages/shared/src/git-handoff.ts
+++ b/products/desktop/packages/shared/src/git-handoff.ts
@@ -7,6 +7,7 @@ export interface HandoffLocalGitState {
 }
 
 export interface GitHandoffCheckpoint {
+  repository?: string;
   checkpointId: string;
   commit: string;
   checkpointRef: string;

--- a/products/desktop/packages/shared/src/handoff-host.ts
+++ b/products/desktop/packages/shared/src/handoff-host.ts
@@ -29,6 +29,7 @@ export interface HandoffResumeStateResult {
   resumeState: {
     conversation: unknown[];
     latestGitCheckpoint: GitHandoffCheckpoint | null;
+    latestGitCheckpoints?: GitHandoffCheckpoint[];
   };
   cloudLogUrl: string | null;
 }

--- a/products/desktop/packages/shared/src/repository.ts
+++ b/products/desktop/packages/shared/src/repository.ts
@@ -12,6 +12,7 @@ export const parseRepository = (
 
 export function getTaskRepository(task: {
   repository?: string | null;
+  repositories?: string[];
 }): string | null {
-  return task.repository ?? null;
+  return task.repositories?.[0] ?? task.repository ?? null;
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -376,7 +376,11 @@ export function CreateChannelModal({
 
             <DialogBody viewportClassName="flex flex-col gap-4">
               {descriptionField}
-              <Field>
+              {/* Plain label + field rather than a quill Field: Field forces
+                  its children to w-full and tightens the label gap, which made
+                  the repositories row read differently here than on the space's
+                  own context page. */}
+              <div className="flex flex-col gap-2">
                 <FieldLabel>Repositories (optional)</FieldLabel>
                 <RepositoriesField
                   selected={repositories}
@@ -387,7 +391,7 @@ export function CreateChannelModal({
                     setRepoIntegration(nextIntegration);
                   }}
                 />
-              </Field>
+              </div>
             </DialogBody>
 
             <DialogFooter>

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -29,7 +29,7 @@ import { type CSSProperties, useRef, useState } from "react";
 const MAX_CONTEXT_NAME_LENGTH = 80;
 
 const DESCRIPTION_PLACEHOLDER =
-  "Grab all files relating to X feature, get all relevant pull requests, in this X repo(s)";
+  "e.g. The mobile app: screens live in app/screens, we use Redux for state, and we run the E2E suite before every release.";
 
 interface CreateChannelModalProps {
   open: boolean;

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -15,9 +15,11 @@ import {
   Textarea,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { RepositoriesField } from "@posthog/ui/features/canvas/components/RepositoriesField";
 import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useGenerateContext } from "@posthog/ui/features/canvas/hooks/useGenerateContext";
+import { useUpdateTaskChannelRepositories } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
 import { useNavigate } from "@tanstack/react-router";
@@ -56,9 +58,14 @@ export function CreateChannelModal({
   const spacesLayout = useChannelsLayout();
   const { createChannel, isCreating } = useChannelMutations();
   const { generate, isStarting } = useGenerateContext();
+  const linkRepositories = useUpdateTaskChannelRepositories();
   const navigate = useNavigate();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
+  // Repositories to link to the new space, chosen in the optional step. They
+  // must share one GitHub integration, tracked alongside the selection.
+  const [repositories, setRepositories] = useState<string[]>([]);
+  const [repoIntegration, setRepoIntegration] = useState<number | null>(null);
   // Create mode's step. Describe mode has no name step, so it starts past it.
   const [step, setStep] = useState<"name" | "describe">("name");
 
@@ -71,6 +78,8 @@ export function CreateChannelModal({
     if (open) {
       setName("");
       setDescription("");
+      setRepositories([]);
+      setRepoIntegration(null);
       setStep("name");
     }
   }
@@ -80,7 +89,7 @@ export function CreateChannelModal({
   const remaining = MAX_CONTEXT_NAME_LENGTH - name.length;
   const nameError = isDescribeMode ? null : validateChannelName(trimmedName);
 
-  const busy = isCreating || isStarting;
+  const busy = isCreating || isStarting || linkRepositories.isPending;
   const canAdvance = !busy && !!trimmedName && !nameError;
   // "Create" seeds the plan session, so it needs the description; "Skip" is the
   // way through without one.
@@ -125,6 +134,23 @@ export function CreateChannelModal({
         description: error instanceof Error ? error.message : String(error),
       });
       return;
+    }
+
+    // Link the chosen repositories to the fresh space. The space already
+    // exists, so a failure here only warns — the user can retry from its
+    // context page.
+    if (repositories.length > 0) {
+      try {
+        await linkRepositories.mutateAsync({
+          channelId: contextId,
+          githubIntegration: repoIntegration,
+          repositories,
+        });
+      } catch (error) {
+        toast.error("Couldn't link repositories", {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     if (withContextMd && trimmedDescription) {
@@ -350,6 +376,18 @@ export function CreateChannelModal({
 
             <DialogBody viewportClassName="flex flex-col gap-4">
               {descriptionField}
+              <Field>
+                <FieldLabel>Repositories (optional)</FieldLabel>
+                <RepositoriesField
+                  selected={repositories}
+                  integrationId={repoIntegration}
+                  disabled={busy}
+                  onChange={(nextRepositories, nextIntegration) => {
+                    setRepositories(nextRepositories);
+                    setRepoIntegration(nextIntegration);
+                  }}
+                />
+              </Field>
             </DialogBody>
 
             <DialogFooter>

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -67,7 +67,9 @@ export function CreateChannelModal({
   const [repositories, setRepositories] = useState<string[]>([]);
   const [repoIntegration, setRepoIntegration] = useState<number | null>(null);
   // Create mode's step. Describe mode has no name step, so it starts past it.
-  const [step, setStep] = useState<"name" | "describe">("name");
+  const [step, setStep] = useState<"name" | "describe" | "repositories">(
+    "name",
+  );
 
   // Reset the fields each time the modal opens so a previous draft never
   // lingers. Adjusted inline during render (prev-prop comparison) rather than in
@@ -91,8 +93,8 @@ export function CreateChannelModal({
 
   const busy = isCreating || isStarting || linkRepositories.isPending;
   const canAdvance = !busy && !!trimmedName && !nameError;
-  // "Create" seeds the plan session, so it needs the description; "Skip" is the
-  // way through without one.
+  // Describe mode's "Create" seeds the plan session, so it needs a description.
+  // In create mode the description is optional (the space just skips context.md).
   const canDescribe = !busy && !!trimmedDescription;
 
   // `busy` only disables the buttons a render after the mutation starts, so a
@@ -112,8 +114,9 @@ export function CreateChannelModal({
 
   // Create the channel and land in its feed — the intro (name, creation line,
   // context.md card) and "joined" row there are derived from the channel row.
-  // With a description, also launch the plan session that builds context.md.
-  const submitCreate = async (withContextMd: boolean) => {
+  // Repositories link when the repositories step's "Create" is used (not
+  // "Skip"), and a non-empty description always seeds the context.md session.
+  const submitCreate = async ({ withRepos }: { withRepos: boolean }) => {
     let contextId: string;
     try {
       const channel = await createChannel(trimmedName);
@@ -139,7 +142,7 @@ export function CreateChannelModal({
     // Link the chosen repositories to the fresh space. The space already
     // exists, so a failure here only warns — the user can retry from its
     // context page.
-    if (repositories.length > 0) {
+    if (withRepos && repositories.length > 0) {
       try {
         await linkRepositories.mutateAsync({
           channelId: contextId,
@@ -153,7 +156,7 @@ export function CreateChannelModal({
       }
     }
 
-    if (withContextMd && trimmedDescription) {
+    if (trimmedDescription) {
       track(ANALYTICS_EVENTS.CONTEXT_ACTION, {
         action_type: "generate_started",
         channel_id: contextId,
@@ -200,14 +203,15 @@ export function CreateChannelModal({
     });
   };
 
-  // The description step's primary action: seed context.md, for a channel that
-  // already exists (describe mode) or one this dialog is about to create.
+  // The description step's primary action. Describe mode seeds context.md for an
+  // existing channel; create mode advances to the optional repositories step
+  // (the description is optional, so this never blocks on it).
   const submitDescribeStep = async () => {
-    if (!canDescribe) return;
     if (isDescribeMode) {
+      if (!canDescribe) return;
       await submitDescribe();
-    } else {
-      await submitCreate(true);
+    } else if (!busy) {
+      setStep("repositories");
     }
   };
 
@@ -347,12 +351,12 @@ export function CreateChannelModal({
           </Button>
         </DialogFooter>
 
-        {/* Step two, nested inside step one rather than replacing it: quill
-            scales and dims a parent that has a nested dialog open, so the name
-            step stays visible behind — the stack is the affordance that says
-            there's another step. Dismissing it (Escape) returns here. */}
+        {/* Step two (About), nested inside step one rather than replacing it:
+            quill scales and dims a parent that has a nested dialog open, so the
+            name step stays visible behind. It stays open behind the optional
+            repositories step too, so the stack reads first-on-top. */}
         <Dialog
-          open={step === "describe"}
+          open={step === "describe" || step === "repositories"}
           onOpenChange={(next) => {
             if (!busy && !next) setStep("name");
           }}
@@ -376,43 +380,96 @@ export function CreateChannelModal({
 
             <DialogBody viewportClassName="flex flex-col gap-4">
               {descriptionField}
-              {/* Plain label + field rather than a quill Field: Field forces
-                  its children to w-full and tightens the label gap, which made
-                  the repositories row read differently here than on the space's
-                  own context page. */}
-              <div className="flex flex-col gap-2">
-                <FieldLabel>Repositories (optional)</FieldLabel>
-                <RepositoriesField
-                  selected={repositories}
-                  integrationId={repoIntegration}
-                  disabled={busy}
-                  onChange={(nextRepositories, nextIntegration) => {
-                    setRepositories(nextRepositories);
-                    setRepoIntegration(nextIntegration);
-                  }}
-                />
-              </div>
             </DialogBody>
 
             <DialogFooter>
-              {/* Skip still creates the channel — it only forgoes the
-                  context.md, which the channel's intro card offers later. */}
               <Button
-                variant="default"
+                variant="outline"
                 disabled={busy}
-                onClick={() => void submitOnce(() => submitCreate(false))}
+                onClick={() => setStep("name")}
               >
-                Skip
+                Back
               </Button>
+              {/* The description is optional; Next always advances to the
+                  repositories step and a filled description seeds context.md. */}
               <Button
                 variant="primary"
-                disabled={!canDescribe}
-                loading={busy}
+                disabled={busy}
                 onClick={() => void submitOnce(submitDescribeStep)}
               >
-                Create
+                Next
               </Button>
             </DialogFooter>
+
+            {/* Step three (Repositories, optional), nested inside step two. */}
+            <Dialog
+              open={step === "repositories"}
+              onOpenChange={(next) => {
+                if (!busy && !next) setStep("describe");
+              }}
+            >
+              <DialogContent
+                showCloseButton={false}
+                className="sm:max-w-lg"
+                style={
+                  {
+                    "--quill-dialog-top-gap": "max(1rem, 10vh + 3rem)",
+                  } as CSSProperties
+                }
+              >
+                <DialogHeader>
+                  <DialogTitle>Link repositories</DialogTitle>
+                </DialogHeader>
+
+                <DialogBody viewportClassName="flex flex-col gap-3">
+                  <p className="text-[13px] text-muted-foreground">
+                    New tasks in this {spacesLayout ? "space" : "channel"} can
+                    work across these repositories. You can change them later.
+                  </p>
+                  <RepositoriesField
+                    selected={repositories}
+                    integrationId={repoIntegration}
+                    disabled={busy}
+                    onChange={(nextRepositories, nextIntegration) => {
+                      setRepositories(nextRepositories);
+                      setRepoIntegration(nextIntegration);
+                    }}
+                  />
+                </DialogBody>
+
+                <DialogFooter>
+                  <Button
+                    variant="outline"
+                    disabled={busy}
+                    onClick={() => setStep("describe")}
+                  >
+                    Back
+                  </Button>
+                  {/* Skip creates the space without linking repos; Create links
+                      the selected ones. Either way a description seeds
+                      context.md. */}
+                  <Button
+                    variant="default"
+                    disabled={busy}
+                    onClick={() =>
+                      void submitOnce(() => submitCreate({ withRepos: false }))
+                    }
+                  >
+                    Skip
+                  </Button>
+                  <Button
+                    variant="primary"
+                    disabled={busy || repositories.length === 0}
+                    loading={busy}
+                    onClick={() =>
+                      void submitOnce(() => submitCreate({ withRepos: true }))
+                    }
+                  >
+                    Create
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           </DialogContent>
         </Dialog>
       </DialogContent>

--- a/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
@@ -1,0 +1,234 @@
+import { GithubLogoIcon, XIcon } from "@phosphor-icons/react";
+import {
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Button as QuillButton,
+} from "@posthog/quill";
+import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
+import { Flex, Spinner } from "@radix-ui/themes";
+import { useState } from "react";
+
+export const MAX_REPOSITORIES = 10;
+
+// Show the filter field only once the list is long enough to warrant scanning.
+const REPO_SEARCH_THRESHOLD = 10;
+
+// A single repository, rendered as a subtle tag. The leading GitHub glyph swaps
+// to an X on hover so the whole chip is the remove target — no separate delete
+// button crowding the tag (mirrors the message editor's attachments).
+function RepoChip({
+  repository,
+  onRemove,
+}: {
+  repository: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="group/chip inline-flex items-center gap-1 rounded-(--radius-1) bg-(--gray-a3) py-0.5 pr-2 pl-1.5 font-medium text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-a4)">
+      <button
+        type="button"
+        aria-label={`Remove ${repository}`}
+        className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0"
+        onClick={onRemove}
+      >
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-100 transition-opacity duration-150 group-hover/chip:opacity-0 motion-reduce:transition-none">
+          <GithubLogoIcon size={13} />
+        </span>
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover/chip:opacity-100 motion-reduce:transition-none">
+          <XIcon size={12} weight="bold" />
+        </span>
+      </button>
+      <span className="max-w-[200px] truncate">{repository}</span>
+    </span>
+  );
+}
+
+// The add-repository picker: a button that opens a popover listing the addable
+// repositories. A search field pins to the top once the list is long; only the
+// list scrolls, so there's a single scrollbar.
+function AddRepositoryPopover({
+  available,
+  onAdd,
+  label,
+}: {
+  available: string[];
+  onAdd: (repository: string) => void;
+  label: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const showSearch = available.length > REPO_SEARCH_THRESHOLD;
+  const trimmed = query.trim().toLowerCase();
+  const filtered = trimmed
+    ? available.filter((repository) =>
+        repository.toLowerCase().includes(trimmed),
+      )
+    : available;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger
+        render={
+          <QuillButton variant="outline" size="sm">
+            <GithubLogoIcon size={14} />
+            {label}
+          </QuillButton>
+        }
+      />
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="flex max-h-72 w-64 flex-col p-0"
+      >
+        {showSearch ? (
+          <div className="shrink-0 border-gray-5 border-b p-1.5">
+            <Input
+              autoFocus
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search repositories…"
+              className="h-7"
+            />
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1 overflow-y-auto p-1">
+          {filtered.length === 0 ? (
+            <div className="px-2 py-1.5 text-[13px] text-gray-10">
+              No repositories found
+            </div>
+          ) : (
+            filtered.map((repository) => (
+              <button
+                key={repository}
+                type="button"
+                onClick={() => {
+                  onAdd(repository);
+                  setOpen(false);
+                }}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[13px] hover:bg-[var(--fill-hover)]"
+              >
+                <GithubLogoIcon size={14} className="shrink-0" />
+                <span className="truncate">{repository}</span>
+              </button>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface RepositoriesFieldProps {
+  /** Currently linked repositories, `organization/repo` each. */
+  selected: string[];
+  /** The GitHub integration the selection belongs to, or null when empty. */
+  integrationId: number | null;
+  /** Fired with the next selection + its integration on every add/remove. */
+  onChange: (repositories: string[], integrationId: number | null) => void;
+  /** Freeze interaction (e.g. while a create flow is submitting). */
+  disabled?: boolean;
+}
+
+// Controlled row of repository chips plus an on-demand add picker. The caller
+// owns the selection (channel-backed with autosave on the context page, local
+// state in the create-space flow); this component centralizes the single-
+// integration constraint — the add list scopes to the active integration, and
+// adding a repo adopts its integration while emptying resets it.
+export function RepositoriesField({
+  selected,
+  integrationId,
+  onChange,
+  disabled = false,
+}: RepositoriesFieldProps) {
+  const {
+    repositories,
+    getIntegrationIdForRepo,
+    isLoadingRepos,
+    hasGithubIntegration,
+  } = useRepositoryIntegration();
+
+  const atLimit = selected.length >= MAX_REPOSITORIES;
+  const available = repositories.filter((repository) => {
+    const repositoryIntegration = getIntegrationIdForRepo(repository);
+    return (
+      !selected.includes(repository) &&
+      repositoryIntegration != null &&
+      (integrationId === null || repositoryIntegration === integrationId)
+    );
+  });
+
+  const addRepository = (repository: string) => {
+    if (disabled || selected.includes(repository)) return;
+    const repositoryIntegration = getIntegrationIdForRepo(repository);
+    if (repositoryIntegration == null) return;
+    onChange([...selected, repository], repositoryIntegration);
+  };
+
+  const removeRepository = (repository: string) => {
+    if (disabled) return;
+    const next = selected.filter((item) => item !== repository);
+    onChange(next, next.length === 0 ? null : integrationId);
+  };
+
+  const isLoadingList = isLoadingRepos && available.length === 0;
+  // When there's nothing to add, keep the button visible but disabled with a
+  // reason, rather than a dead-end "No repositories" control.
+  const addDisabledReason = !hasGithubIntegration
+    ? "Connect GitHub in settings to add repositories"
+    : atLimit
+      ? `You can add up to ${MAX_REPOSITORIES} repositories`
+      : available.length === 0
+        ? selected.length > 0
+          ? "All accessible repositories are already added"
+          : "No repositories available"
+        : null;
+
+  return (
+    <Flex align="center" gap="2" wrap="wrap" className="min-h-7">
+      {selected.map((repository) => (
+        <RepoChip
+          key={repository}
+          repository={repository}
+          onRemove={() => removeRepository(repository)}
+        />
+      ))}
+
+      {disabled ? (
+        <QuillButton variant="outline" size="sm" disabled>
+          <GithubLogoIcon size={14} />
+          Add repository
+        </QuillButton>
+      ) : isLoadingList && hasGithubIntegration ? (
+        <QuillButton variant="outline" size="sm" disabled>
+          <Spinner size="1" />
+          Loading repositories…
+        </QuillButton>
+      ) : addDisabledReason ? (
+        <Tooltip content={addDisabledReason}>
+          <span className="inline-flex">
+            <QuillButton variant="outline" size="sm" disabled>
+              <GithubLogoIcon size={14} />
+              Add repository
+            </QuillButton>
+          </span>
+        </Tooltip>
+      ) : (
+        <AddRepositoryPopover
+          available={available}
+          onAdd={addRepository}
+          label={selected.length > 0 ? "Add…" : "Add repository…"}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
@@ -196,14 +196,12 @@ export function RepositoriesField({
         : null;
 
   return (
+    // Tailwind gap (not Radix `gap`): this row also renders inside quill's
+    // dialog portal, which is outside the `.radix-themes` scope where the
+    // `--space-*` tokens live, so a Radix `gap` collapses to 0 there.
     // w-fit keeps the chips + add button as one tight cluster instead of
     // stretching across the row, so the group doesn't float in empty space.
-    <Flex
-      align="center"
-      gap="2"
-      wrap="wrap"
-      className="min-h-7 w-fit max-w-full"
-    >
+    <Flex align="center" wrap="wrap" className="min-h-7 w-fit max-w-full gap-2">
       {selected.map((repository) => (
         <RepoChip
           key={repository}

--- a/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
@@ -196,7 +196,14 @@ export function RepositoriesField({
         : null;
 
   return (
-    <Flex align="center" gap="2" wrap="wrap" className="min-h-7">
+    // w-fit keeps the chips + add button as one tight cluster instead of
+    // stretching across the row, so the group doesn't float in empty space.
+    <Flex
+      align="center"
+      gap="2"
+      wrap="wrap"
+      className="min-h-7 w-fit max-w-full"
+    >
       {selected.map((repository) => (
         <RepoChip
           key={repository}

--- a/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
@@ -27,18 +27,20 @@ function RepoChip({
   onRemove: () => void;
 }) {
   return (
-    <span className="group/chip inline-flex items-center gap-1 rounded-(--radius-1) bg-(--gray-a3) py-0.5 pr-2 pl-1.5 font-medium text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-a4)">
+    // h-6 + rounded-md matches the sm "Add…" button beside it, so chips and the
+    // add control line up as one row.
+    <span className="group/chip inline-flex h-6 items-center gap-1.5 rounded-md bg-(--gray-a3) pr-2.5 pl-2 font-medium text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-a4)">
       <button
         type="button"
         aria-label={`Remove ${repository}`}
-        className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0"
+        className="relative inline-flex size-4 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0"
         onClick={onRemove}
       >
         <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-100 transition-opacity duration-150 group-hover/chip:opacity-0 motion-reduce:transition-none">
-          <GithubLogoIcon size={13} />
+          <GithubLogoIcon size={14} />
         </span>
         <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover/chip:opacity-100 motion-reduce:transition-none">
-          <XIcon size={12} weight="bold" />
+          <XIcon size={13} weight="bold" />
         </span>
       </button>
       <span className="max-w-[200px] truncate">{repository}</span>

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -44,6 +44,7 @@ import {
   PageHeaderTitle,
   PageHeaderTitleRow,
 } from "@posthog/ui/primitives/PageHeader";
+import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { track } from "@posthog/ui/shell/analytics";
 import {
   Box,
@@ -202,7 +203,7 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
           </PageHeaderHeading>
         </PageHeader>
       )}
-      <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col gap-3 px-6 py-4">
+      <div className="flex min-h-0 w-full flex-1 flex-col gap-4 px-6 py-4">
         {spacesLayout && backendChannel ? (
           <>
             <SpaceRepositories channel={backendChannel} />
@@ -378,11 +379,9 @@ const MAX_REPOSITORIES = 10;
 // delete button crowding the tag (mirrors the message editor's attachments).
 function RepoChip({
   repository,
-  disabled,
   onRemove,
 }: {
   repository: string;
-  disabled: boolean;
   onRemove: () => void;
 }) {
   return (
@@ -390,8 +389,7 @@ function RepoChip({
       <button
         type="button"
         aria-label={`Remove ${repository}`}
-        disabled={disabled}
-        className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0 disabled:cursor-default disabled:opacity-50"
+        className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0"
         onClick={onRemove}
       >
         <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-100 transition-opacity duration-150 group-hover/chip:opacity-0 motion-reduce:transition-none">
@@ -406,10 +404,11 @@ function RepoChip({
   );
 }
 
-// The space's connected repositories, shown as a subtle inline strip above the
-// document: tag chips for what's connected, plus an on-demand picker to add
-// more. Changes autosave — there's no Save button. Selected repos must share
-// one GitHub integration, so the add list scopes to the active integration.
+// The space's connected repositories: a header row that matches the CONTEXT.md
+// header, then a row of tag chips plus an on-demand picker to add more. Reads
+// straight from the channel (the mutation applies each add/remove optimistically
+// to the cache), so there's no local mirror and no Save button. Selected repos
+// must share one GitHub integration, so the add list scopes to it.
 function SpaceRepositories({ channel }: { channel: TaskChannel }) {
   const {
     repositories,
@@ -420,93 +419,98 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
     hasGithubIntegration,
   } = useRepositoryIntegration();
   const update = useUpdateTaskChannelRepositories();
-  const [selected, setSelected] = useState(channel.repositories ?? []);
-  const [integrationId, setIntegrationId] = useState<number | null>(
-    channel.github_integration ?? null,
-  );
 
-  useEffect(() => {
-    setSelected(channel.repositories ?? []);
-    setIntegrationId(channel.github_integration ?? null);
-  }, [channel.github_integration, channel.repositories]);
-
+  const selected = channel.repositories ?? [];
+  const integrationId = channel.github_integration ?? null;
   const atLimit = selected.length >= MAX_REPOSITORIES;
-  const available = atLimit
-    ? []
-    : repositories.filter((repository) => {
-        const repositoryIntegration = getIntegrationIdForRepo(repository);
-        return (
-          !selected.includes(repository) &&
-          repositoryIntegration != null &&
-          (integrationId === null || repositoryIntegration === integrationId)
-        );
-      });
 
-  // Autosave: local state updates optimistically and the mutation persists the
-  // full desired set, so overlapping add/remove clicks settle last-write-wins.
-  const persist = (nextSelected: string[], nextIntegration: number | null) => {
-    setSelected(nextSelected);
-    setIntegrationId(nextIntegration);
+  const available = repositories.filter((repository) => {
+    const repositoryIntegration = getIntegrationIdForRepo(repository);
+    return (
+      !selected.includes(repository) &&
+      repositoryIntegration != null &&
+      (integrationId === null || repositoryIntegration === integrationId)
+    );
+  });
+
+  const save = (nextSelected: string[], nextIntegration: number | null) =>
     update.mutate({
       channelId: channel.id,
       githubIntegration: nextIntegration,
       repositories: nextSelected,
     });
-  };
 
   const addRepository = (repository: string | null) => {
     if (!repository || selected.includes(repository)) return;
     const repositoryIntegration = getIntegrationIdForRepo(repository);
     if (repositoryIntegration == null) return;
-    persist([...selected, repository], repositoryIntegration);
+    save([...selected, repository], repositoryIntegration);
   };
 
   const removeRepository = (repository: string) => {
     const next = selected.filter((item) => item !== repository);
-    persist(next, next.length === 0 ? null : integrationId);
+    save(next, next.length === 0 ? null : integrationId);
   };
 
+  // When there's nothing to add, keep the button visible but disabled with a
+  // reason, rather than the picker's own "No GitHub repos" dead-end state.
+  const addDisabledReason = !hasGithubIntegration
+    ? "Connect GitHub in settings to add repositories"
+    : atLimit
+      ? `You can add up to ${MAX_REPOSITORIES} repositories`
+      : isLoadingRepos && available.length === 0
+        ? "Loading repositories…"
+        : available.length === 0
+          ? "All accessible repositories are already added"
+          : null;
+
   return (
-    <Flex align="center" gap="2" wrap="wrap" className="min-h-7 shrink-0">
-      <GitBranchIcon size={14} className="shrink-0 text-gray-10" />
-      <Text size="1" color="gray" className="mr-1 shrink-0">
-        Repositories
-      </Text>
-
-      {selected.map((repository) => (
-        <RepoChip
-          key={repository}
-          repository={repository}
-          disabled={update.isPending}
-          onRemove={() => removeRepository(repository)}
-        />
-      ))}
-
-      <GitHubRepoPicker
-        value={null}
-        onChange={addRepository}
-        repositories={available}
-        isLoading={isLoadingRepos}
-        isRefreshing={isRefreshingRepos}
-        onRefresh={() => void refreshRepositories()}
-        placeholder={
-          hasGithubIntegration
-            ? selected.length > 0
-              ? "Add"
-              : "Add a repository…"
-            : "Connect GitHub"
-        }
-        size="1"
-        disabled={!hasGithubIntegration || atLimit || update.isPending}
-      />
-
-      {update.isPending ? (
-        <Spinner size="1" className="shrink-0" />
-      ) : update.error ? (
-        <Text size="1" color="red" className="shrink-0">
-          Couldn't save
+    <Flex direction="column" gap="2">
+      <Flex align="center" gap="2">
+        <GitBranchIcon size={15} className="text-gray-11" />
+        <Text size="2" weight="medium">
+          Repositories
         </Text>
-      ) : null}
+        {update.isPending ? (
+          <Spinner size="1" />
+        ) : update.error ? (
+          <Text size="1" color="red">
+            Couldn't save
+          </Text>
+        ) : null}
+      </Flex>
+
+      <Flex align="center" gap="2" wrap="wrap" className="min-h-7">
+        {selected.map((repository) => (
+          <RepoChip
+            key={repository}
+            repository={repository}
+            onRemove={() => removeRepository(repository)}
+          />
+        ))}
+
+        {addDisabledReason ? (
+          <Tooltip content={addDisabledReason}>
+            <span className="inline-flex">
+              <QuillButton variant="outline" size="sm" disabled>
+                <GithubLogoIcon size={14} />
+                Add repository
+              </QuillButton>
+            </span>
+          </Tooltip>
+        ) : (
+          <GitHubRepoPicker
+            value={null}
+            onChange={addRepository}
+            repositories={available}
+            isLoading={isLoadingRepos}
+            isRefreshing={isRefreshingRepos}
+            onRefresh={() => void refreshRepositories()}
+            placeholder={selected.length > 0 ? "Add" : "Add a repository…"}
+            size="1"
+          />
+        )}
+      </Flex>
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,13 +1,23 @@
 import {
+  ArrowsClockwiseIcon,
   FileTextIcon,
   GitBranchIcon,
   GithubLogoIcon,
   SparkleIcon,
-  XIcon,
 } from "@phosphor-icons/react";
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxListFooter,
+  ComboboxValue,
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -33,7 +43,6 @@ import {
   useUpdateTaskChannelRepositories,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
-import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
@@ -57,25 +66,9 @@ import {
   Text,
   TextArea,
 } from "@radix-ui/themes";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type Mode = "rendered" | "edit";
-
-// The anchor nav on the left of the spaces layout: one row per configurable
-// section on this screen. Future sources (Slack channels, PostHog events, …)
-// get a row here plus a section in the pane.
-const NAV_SECTIONS = [
-  {
-    id: "context-md",
-    label: "CONTEXT.md",
-    icon: <FileTextIcon size={16} />,
-  },
-  {
-    id: "repositories",
-    label: "Repositories",
-    icon: <GitBranchIcon size={16} />,
-  },
-];
 
 // Initial markdown shown when a folder has no instructions yet — gives both
 // humans and agents a structural starting point instead of a blank screen.
@@ -174,20 +167,6 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
     return versions.find((v) => v.id === selectedVersionId) ?? null;
   }, [selectedVersionId, versions]);
 
-  const sectionIds = useMemo(
-    () =>
-      spacesLayout && backendChannel
-        ? ["context-md", "repositories"]
-        : ["context-md"],
-    [spacesLayout, backendChannel],
-  );
-  const [activeSection, setActiveSection] = useState("context-md");
-  // If the repositories section vanishes (channel row still loading), fall
-  // back to the document rather than an empty pane.
-  const resolvedSection = sectionIds.includes(activeSection)
-    ? activeSection
-    : "context-md";
-
   if (isLoadingLatest) {
     return (
       <Flex align="center" justify="center" className="h-full">
@@ -232,218 +211,180 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
           </PageHeaderHeading>
         </PageHeader>
       )}
-      <div className="flex min-h-0 flex-1">
-        {sectionIds.length > 1 && (
-          <nav
-            aria-label="Context sections"
-            className="w-52 shrink-0 overflow-y-auto border-gray-5 border-r py-3"
-          >
-            {NAV_SECTIONS.filter((section) =>
-              sectionIds.includes(section.id),
-            ).map((section) => (
-              <button
-                key={section.id}
-                type="button"
-                data-active={resolvedSection === section.id || undefined}
-                onClick={() => setActiveSection(section.id)}
-                className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-4 py-1.5 text-left text-[13px] text-gray-11 transition-colors hover:bg-gray-3 data-[active]:bg-accent-4 data-[active]:text-gray-12"
-              >
-                <span className="text-gray-10">{section.icon}</span>
-                <span>{section.label}</span>
-              </button>
-            ))}
-          </nav>
-        )}
-        {resolvedSection === "context-md" ? (
-          <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col gap-3 px-6 py-5">
-            <Flex align="center" justify="between" gap="3" wrap="wrap">
-              <Flex align="center" gap="2">
-                <FileTextIcon size={15} className="text-gray-11" />
-                <Text size="2" weight="medium">
-                  CONTEXT.md
-                </Text>
-                {latest?.version != null && (
-                  <PageHeaderChip
-                    icon={channelPageIcon("context", { size: 12 })}
-                  >
-                    v{latest.version}
-                  </PageHeaderChip>
-                )}
-                {/* Background-refetch indicator: the initial load uses the
-                      full-screen spinner; this only fires on revalidations so
-                      the user knows the view is live, not stale cache. */}
-                {isFetchingLatest && !isLoadingLatest ? (
-                  <Flex align="center" gap="1">
-                    <Spinner size="1" />
-                    <Text className="text-[12px] text-gray-10">
-                      Refreshing…
-                    </Text>
-                  </Flex>
-                ) : null}
-              </Flex>
-              <Flex align="center" gap="2">
-                {versions.length > 0 ? (
-                  <Select.Root
-                    size="1"
-                    value={selectedVersionId ?? "latest"}
-                    onValueChange={(value) => {
-                      if (value === "latest") {
-                        setSelectedVersionId(null);
-                      } else {
-                        setSelectedVersionId(value);
-                        setMode("rendered");
-                      }
-                    }}
-                    disabled={isLoadingVersions}
-                  >
-                    <Select.Trigger />
-                    <Select.Content>
-                      <Select.Item value="latest">
-                        Latest (v{latest?.version ?? "—"})
-                      </Select.Item>
-                      {versions
-                        .filter((v) => !v.is_latest)
-                        .map((v) => (
-                          <Select.Item key={v.id} value={v.id}>
-                            v{v.version} · {formatTimestamp(v.created_at)}
-                          </Select.Item>
-                        ))}
-                    </Select.Content>
-                  </Select.Root>
-                ) : null}
-                <SegmentedControl.Root
-                  value={mode}
-                  onValueChange={(value) => setMode(value as Mode)}
-                  size="1"
-                >
-                  <SegmentedControl.Item value="rendered">
-                    Rendered
-                  </SegmentedControl.Item>
-                  <SegmentedControl.Item value="edit">
-                    Edit
-                  </SegmentedControl.Item>
-                </SegmentedControl.Root>
-                {mode === "edit" ? (
-                  <>
-                    {hasDraft ? (
-                      <Button
-                        size="1"
-                        variant="soft"
-                        color="gray"
-                        onClick={() => {
-                          setDraft(latest?.content ?? "");
-                          setHasDraft(false);
-                        }}
-                        disabled={isPublishing}
-                      >
-                        Discard
-                      </Button>
-                    ) : null}
-                    <Button
-                      size="1"
-                      variant="solid"
-                      onClick={onSave}
-                      disabled={
-                        isPublishing ||
-                        (hasInstructions
-                          ? !hasDraft
-                          : draft.trim().length === 0)
-                      }
-                    >
-                      {isPublishing ? <Spinner size="1" /> : null}
-                      Save new version
-                    </Button>
-                  </>
-                ) : null}
-              </Flex>
-            </Flex>
+      {spacesLayout && backendChannel ? (
+        <div className="shrink-0 border-gray-5 border-b px-6 py-3">
+          <SpaceRepositories channel={backendChannel} />
+        </div>
+      ) : null}
 
-            {publishError ? (
-              <Callout.Root color={isConflict ? "amber" : "red"} size="1">
-                <Callout.Text>
-                  {isConflict
-                    ? "Someone else saved a newer version. Reload to merge your changes."
-                    : `Save failed: ${publishError.message}`}
-                </Callout.Text>
-              </Callout.Root>
-            ) : null}
-
-            {selectedVersion ? (
-              <Callout.Root color="gray" size="1">
-                <Callout.Text>
-                  Viewing v{selectedVersion.version} metadata. Past content is
-                  not fetched today — switch to "Latest" to read or edit current
-                  content.
-                </Callout.Text>
-              </Callout.Root>
-            ) : mode === "rendered" ? (
-              hasInstructions ? (
-                <ScrollArea
-                  type="auto"
-                  scrollbars="vertical"
-                  className="scroll-area-constrain-width min-h-0 flex-1"
-                >
-                  <Box className="rounded-lg border border-gray-5 bg-gray-2 px-6 py-5 text-[13px]">
-                    <MarkdownRenderer content={renderedContent} />
-                  </Box>
-                </ScrollArea>
-              ) : (
-                <Flex
-                  align="center"
-                  justify="center"
-                  className="min-h-0 flex-1"
-                >
-                  <EmptyState
-                    channelId={channelId}
-                    channelName={channelName}
-                    onCreate={() => {
-                      setDraft(emptyTemplate);
-                      setHasDraft(true);
-                      setMode("edit");
-                    }}
-                  />
-                </Flex>
-              )
-            ) : (
-              <TextArea
-                value={draft}
-                onChange={(e) => {
-                  setDraft(e.target.value);
-                  setHasDraft(true);
-                }}
-                size="2"
-                placeholder={
-                  spacesLayout
-                    ? "# Space context\n\nWrite markdown describing this space…"
-                    : "# Channel context\n\nWrite markdown describing this channel…"
-                }
-                className="min-h-0 flex-1 font-[var(--code-font-family)]"
-              />
+      <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col gap-3 px-6 py-4">
+        <Flex align="center" justify="between" gap="3" wrap="wrap">
+          <Flex align="center" gap="2">
+            <FileTextIcon size={15} className="text-gray-11" />
+            <Text size="2" weight="medium">
+              CONTEXT.md
+            </Text>
+            {latest?.version != null && (
+              <PageHeaderChip icon={channelPageIcon("context", { size: 12 })}>
+                v{latest.version}
+              </PageHeaderChip>
             )}
-          </div>
+            {/* Background-refetch indicator: the initial load uses the
+                full-screen spinner; this only fires on revalidations so the
+                user knows the view is live, not stale cache. */}
+            {isFetchingLatest && !isLoadingLatest ? (
+              <Flex align="center" gap="1">
+                <Spinner size="1" />
+                <Text className="text-[12px] text-gray-10">Refreshing…</Text>
+              </Flex>
+            ) : null}
+          </Flex>
+          <Flex align="center" gap="2">
+            {versions.length > 0 ? (
+              <Select.Root
+                size="1"
+                value={selectedVersionId ?? "latest"}
+                onValueChange={(value) => {
+                  if (value === "latest") {
+                    setSelectedVersionId(null);
+                  } else {
+                    setSelectedVersionId(value);
+                    setMode("rendered");
+                  }
+                }}
+                disabled={isLoadingVersions}
+              >
+                <Select.Trigger />
+                <Select.Content>
+                  <Select.Item value="latest">
+                    Latest (v{latest?.version ?? "—"})
+                  </Select.Item>
+                  {versions
+                    .filter((v) => !v.is_latest)
+                    .map((v) => (
+                      <Select.Item key={v.id} value={v.id}>
+                        v{v.version} · {formatTimestamp(v.created_at)}
+                      </Select.Item>
+                    ))}
+                </Select.Content>
+              </Select.Root>
+            ) : null}
+            <SegmentedControl.Root
+              value={mode}
+              onValueChange={(value) => setMode(value as Mode)}
+              size="1"
+            >
+              <SegmentedControl.Item value="rendered">
+                Rendered
+              </SegmentedControl.Item>
+              <SegmentedControl.Item value="edit">Edit</SegmentedControl.Item>
+            </SegmentedControl.Root>
+            {mode === "edit" ? (
+              <>
+                {hasDraft ? (
+                  <Button
+                    size="1"
+                    variant="soft"
+                    color="gray"
+                    onClick={() => {
+                      setDraft(latest?.content ?? "");
+                      setHasDraft(false);
+                    }}
+                    disabled={isPublishing}
+                  >
+                    Discard
+                  </Button>
+                ) : null}
+                <Button
+                  size="1"
+                  variant="solid"
+                  onClick={onSave}
+                  disabled={
+                    isPublishing ||
+                    (hasInstructions ? !hasDraft : draft.trim().length === 0)
+                  }
+                >
+                  {isPublishing ? <Spinner size="1" /> : null}
+                  Save new version
+                </Button>
+              </>
+            ) : null}
+          </Flex>
+        </Flex>
+
+        {publishError ? (
+          <Callout.Root color={isConflict ? "amber" : "red"} size="1">
+            <Callout.Text>
+              {isConflict
+                ? "Someone else saved a newer version. Reload to merge your changes."
+                : `Save failed: ${publishError.message}`}
+            </Callout.Text>
+          </Callout.Root>
+        ) : null}
+
+        {selectedVersion ? (
+          <Callout.Root color="gray" size="1">
+            <Callout.Text>
+              Viewing v{selectedVersion.version} metadata. Past content is not
+              fetched today — switch to "Latest" to read or edit current
+              content.
+            </Callout.Text>
+          </Callout.Root>
+        ) : mode === "rendered" ? (
+          hasInstructions ? (
+            <ScrollArea
+              type="auto"
+              scrollbars="vertical"
+              className="scroll-area-constrain-width min-h-0 flex-1"
+            >
+              <Box className="rounded-lg border border-gray-5 bg-gray-2 px-6 py-5 text-[13px]">
+                <MarkdownRenderer content={renderedContent} />
+              </Box>
+            </ScrollArea>
+          ) : (
+            <Flex align="center" justify="center" className="min-h-0 flex-1">
+              <EmptyState
+                channelId={channelId}
+                channelName={channelName}
+                onCreate={() => {
+                  setDraft(emptyTemplate);
+                  setHasDraft(true);
+                  setMode("edit");
+                }}
+              />
+            </Flex>
+          )
         ) : (
-          <ScrollArea
-            type="auto"
-            scrollbars="vertical"
-            className="scroll-area-constrain-width min-h-0 flex-1"
-          >
-            <div className="mx-auto w-full max-w-3xl px-6 py-5">
-              {backendChannel ? (
-                <SpaceRepositories channel={backendChannel} />
-              ) : null}
-            </div>
-          </ScrollArea>
+          <TextArea
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              setHasDraft(true);
+            }}
+            size="2"
+            placeholder={
+              spacesLayout
+                ? "# Space context\n\nWrite markdown describing this space…"
+                : "# Channel context\n\nWrite markdown describing this channel…"
+            }
+            className="min-h-0 flex-1 font-[var(--code-font-family)]"
+          />
         )}
       </div>
     </Flex>
   );
 }
 
+const MAX_REPOSITORIES = 10;
+
+// The space's repositories rendered as a subtle inline chip picker: a single
+// row of removable chips with an inline "add" input, driven entirely by the
+// quill Combobox. Selected repos must all belong to one GitHub integration,
+// so the add list is scoped to the active integration once one is chosen.
 function SpaceRepositories({ channel }: { channel: TaskChannel }) {
   const {
     repositories,
     getIntegrationIdForRepo,
-    isLoadingRepos,
     isRefreshingRepos,
     refreshRepositories,
     hasGithubIntegration,
@@ -453,34 +394,37 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
   const [integrationId, setIntegrationId] = useState<number | null>(
     channel.github_integration ?? null,
   );
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setSelected(channel.repositories ?? []);
     setIntegrationId(channel.github_integration ?? null);
   }, [channel.github_integration, channel.repositories]);
 
-  const available = repositories.filter((repository) => {
-    const repositoryIntegration = getIntegrationIdForRepo(repository);
-    return (
-      !selected.includes(repository) &&
-      (integrationId === null || repositoryIntegration === integrationId)
-    );
-  });
+  const atLimit = selected.length >= MAX_REPOSITORIES;
+  const available = atLimit
+    ? []
+    : repositories.filter((repository) => {
+        const repositoryIntegration = getIntegrationIdForRepo(repository);
+        return (
+          !selected.includes(repository) &&
+          repositoryIntegration != null &&
+          (integrationId === null || repositoryIntegration === integrationId)
+        );
+      });
 
-  const addRepository = (repository: string | null) => {
-    if (!repository) return;
-    const repositoryIntegration = getIntegrationIdForRepo(repository);
-    if (repositoryIntegration == null) return;
-    setIntegrationId(repositoryIntegration);
-    setSelected((current) => [...current, repository]);
-  };
-
-  const removeRepository = (repository: string) => {
-    setSelected((current) => {
-      const next = current.filter((item) => item !== repository);
-      if (next.length === 0) setIntegrationId(null);
-      return next;
-    });
+  // The combobox hands back the full next selection. Adopt the added repo's
+  // integration when we're starting fresh; drop back to "any" once emptied.
+  const changeSelection = (next: string[]) => {
+    const added = next.find((repository) => !selected.includes(repository));
+    if (added) {
+      const repositoryIntegration = getIntegrationIdForRepo(added);
+      if (repositoryIntegration == null) return;
+      setIntegrationId(repositoryIntegration);
+    } else if (next.length === 0) {
+      setIntegrationId(null);
+    }
+    setSelected(next);
   };
 
   const changed =
@@ -491,90 +435,102 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
     );
 
   return (
-    <Flex direction="column" gap="3">
-      <Flex direction="column" gap="1">
-        <Flex align="center" gap="2">
-          <GitBranchIcon size={15} className="shrink-0 text-gray-11" />
-          <Text size="2" weight="medium">
-            Repositories
-          </Text>
-          {selected.length > 0 ? (
-            <Text size="1" color="gray">
-              {selected.length}/10
-            </Text>
-          ) : null}
-        </Flex>
-        <Text size="1" color="gray">
-          New tasks in this space can work across these repositories.
+    <Flex align="center" gap="3" wrap="wrap">
+      <Flex align="center" gap="2" className="shrink-0">
+        <GitBranchIcon size={15} className="text-gray-11" />
+        <Text size="2" weight="medium">
+          Repositories
         </Text>
       </Flex>
-      <Flex direction="column" gap="3" maxWidth="480px">
-        {selected.length > 0 ? (
-          <div className="flex flex-col divide-y divide-(--gray-4) overflow-hidden rounded-md border border-gray-5">
-            {selected.map((repository) => (
-              <Flex key={repository} align="center" gap="2" px="3" py="2">
-                <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
-                <Text size="2" className="min-w-0 flex-1 truncate">
+
+      <Combobox<string, true>
+        multiple
+        items={available}
+        value={selected}
+        onValueChange={(next) => changeSelection(next ?? [])}
+        itemToStringLabel={(repository) => repository}
+      >
+        <ComboboxChips
+          ref={anchorRef}
+          className="flex min-h-8 min-w-64 max-w-full flex-1 flex-wrap items-center gap-1 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-1.5 py-1"
+        >
+          <ComboboxValue>
+            {(repos: string[]) =>
+              repos.map((repository) => (
+                <ComboboxChip key={repository} showRemove title={repository}>
+                  <GithubLogoIcon size={12} className="shrink-0" />
                   {repository}
-                </Text>
-                <Button
-                  size="1"
-                  variant="ghost"
-                  color="gray"
-                  aria-label={`Remove ${repository}`}
-                  disabled={update.isPending}
-                  onClick={() => removeRepository(repository)}
-                >
-                  <XIcon size={14} />
-                </Button>
-              </Flex>
-            ))}
-          </div>
-        ) : null}
-        <GitHubRepoPicker
-          value={null}
-          onChange={addRepository}
-          repositories={available}
-          isLoading={isLoadingRepos}
-          isRefreshing={isRefreshingRepos}
-          onRefresh={() => void refreshRepositories()}
-          placeholder={
-            hasGithubIntegration
-              ? "Add repository..."
-              : "Connect GitHub to add repositories"
-          }
-          size="1"
-          disabled={
-            !hasGithubIntegration || selected.length >= 10 || update.isPending
-          }
-        />
-        {update.error ? (
-          <Callout.Root color="red" size="1">
-            <Callout.Text>
-              Couldn't save repositories. Check your GitHub access and try
-              again.
-            </Callout.Text>
-          </Callout.Root>
-        ) : null}
-        {changed ? (
-          <Flex justify="end">
-            <Button
-              size="1"
-              disabled={update.isPending}
-              onClick={() =>
-                update.mutate({
-                  channelId: channel.id,
-                  githubIntegration: integrationId,
-                  repositories: selected,
-                })
-              }
+                </ComboboxChip>
+              ))
+            }
+          </ComboboxValue>
+          <ComboboxChipsInput
+            aria-label="Add repository"
+            disabled={!hasGithubIntegration || atLimit}
+            placeholder={
+              selected.length > 0
+                ? ""
+                : hasGithubIntegration
+                  ? "Add a repository…"
+                  : "Connect GitHub to add repositories"
+            }
+            className="min-w-24 flex-1 bg-transparent text-[13px] text-gray-12 outline-none placeholder:text-gray-10"
+          />
+        </ComboboxChips>
+        <ComboboxContent anchor={anchorRef} align="start" sideOffset={4}>
+          <ComboboxEmpty>
+            {atLimit ? "Repository limit reached" : "No repositories"}
+          </ComboboxEmpty>
+          <ComboboxList>
+            {(repository: string) => (
+              <ComboboxItem key={repository} value={repository}>
+                <Flex align="center" gap="2">
+                  <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
+                  {repository}
+                </Flex>
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+          <ComboboxListFooter>
+            <QuillButton
+              variant="link-muted"
+              size="sm"
+              className="w-full justify-start"
+              disabled={isRefreshingRepos}
+              onClick={() => void refreshRepositories()}
             >
-              {update.isPending ? <Spinner size="1" /> : null}
-              Save repositories
-            </Button>
-          </Flex>
-        ) : null}
-      </Flex>
+              <ArrowsClockwiseIcon
+                size={12}
+                className={isRefreshingRepos ? "animate-spin" : undefined}
+              />
+              Refresh repositories
+            </QuillButton>
+          </ComboboxListFooter>
+        </ComboboxContent>
+      </Combobox>
+
+      {update.error ? (
+        <Text size="1" color="red" className="shrink-0">
+          Couldn't save. Check GitHub access.
+        </Text>
+      ) : null}
+      {changed ? (
+        <Button
+          size="1"
+          className="shrink-0"
+          disabled={update.isPending}
+          onClick={() =>
+            update.mutate({
+              channelId: channel.id,
+              githubIntegration: integrationId,
+              repositories: selected,
+            })
+          }
+        >
+          {update.isPending ? <Spinner size="1" /> : null}
+          Save
+        </Button>
+      ) : null}
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,6 +1,7 @@
 import {
   FileTextIcon,
   GitBranchIcon,
+  GithubLogoIcon,
   SparkleIcon,
   XIcon,
 } from "@phosphor-icons/react";
@@ -210,7 +211,7 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
         align="center"
         justify="between"
         gap="3"
-        px="4"
+        px="6"
         py="2"
         className="shrink-0 border-b border-b-(--gray-5)"
       >
@@ -301,7 +302,7 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
       </Flex>
 
       {publishError ? (
-        <Box px="4" pt="3">
+        <Box px="6" pt="3">
           <Callout.Root color={isConflict ? "amber" : "red"} size="1">
             <Callout.Text>
               {isConflict
@@ -317,52 +318,61 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
         scrollbars="vertical"
         className="scroll-area-constrain-width min-h-0 flex-1"
       >
-        <Box p="4">
-          {selectedVersion ? (
-            <Callout.Root color="gray" size="1">
-              <Callout.Text>
-                Viewing v{selectedVersion.version} metadata. Past content is not
-                fetched today — switch to "Latest" to read or edit current
-                content.
-              </Callout.Text>
-            </Callout.Root>
-          ) : mode === "rendered" ? (
-            hasInstructions ? (
-              <Box className="text-[13px]">
-                <MarkdownRenderer content={renderedContent} />
-              </Box>
-            ) : (
-              <EmptyState
-                channelId={channelId}
-                channelName={channelName}
-                onCreate={() => {
-                  setDraft(emptyTemplate);
-                  setHasDraft(true);
-                  setMode("edit");
-                }}
-              />
-            )
-          ) : (
-            <TextArea
-              value={draft}
-              onChange={(e) => {
-                setDraft(e.target.value);
-                setHasDraft(true);
-              }}
-              size="2"
-              rows={24}
-              placeholder={
-                spacesLayout
-                  ? "# Space context\n\nWrite markdown describing this space…"
-                  : "# Channel context\n\nWrite markdown describing this channel…"
-              }
-              className="font-[var(--code-font-family)]"
-            />
-          )}
-          {spacesLayout && backendChannel ? (
-            <SpaceRepositories channel={backendChannel} />
-          ) : null}
-        </Box>
+        <div className="mx-auto w-full max-w-6xl px-6 py-5">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:gap-10">
+            <div className="flex min-w-0 max-w-[84ch] flex-1 flex-col">
+              {selectedVersion ? (
+                <Callout.Root color="gray" size="1">
+                  <Callout.Text>
+                    Viewing v{selectedVersion.version} metadata. Past content is
+                    not fetched today — switch to "Latest" to read or edit
+                    current content.
+                  </Callout.Text>
+                </Callout.Root>
+              ) : mode === "rendered" ? (
+                hasInstructions ? (
+                  <Box className="rounded-lg border border-gray-5 bg-gray-2 px-6 py-5 text-[13px]">
+                    <MarkdownRenderer content={renderedContent} />
+                  </Box>
+                ) : (
+                  <EmptyState
+                    channelId={channelId}
+                    channelName={channelName}
+                    onCreate={() => {
+                      setDraft(emptyTemplate);
+                      setHasDraft(true);
+                      setMode("edit");
+                    }}
+                  />
+                )
+              ) : (
+                <TextArea
+                  value={draft}
+                  onChange={(e) => {
+                    setDraft(e.target.value);
+                    setHasDraft(true);
+                  }}
+                  size="2"
+                  rows={24}
+                  placeholder={
+                    spacesLayout
+                      ? "# Space context\n\nWrite markdown describing this space…"
+                      : "# Channel context\n\nWrite markdown describing this channel…"
+                  }
+                  className="font-[var(--code-font-family)]"
+                />
+              )}
+            </div>
+            {/* Sources rail: cards configuring what agents can reach from this
+                space. Repositories today; future sources (Slack channels,
+                PostHog events, …) stack as sibling cards here. */}
+            {spacesLayout && backendChannel ? (
+              <aside className="flex w-full shrink-0 flex-col gap-4 lg:w-80">
+                <SpaceRepositories channel={backendChannel} />
+              </aside>
+            ) : null}
+          </div>
+        </div>
       </ScrollArea>
     </Flex>
   );
@@ -420,37 +430,50 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
     );
 
   return (
-    <Box className="mt-8 border-gray-6 border-t pt-5">
-      <Flex align="center" gap="2" mb="1">
-        <GitBranchIcon size={16} />
-        <Text size="3" weight="medium">
+    <section className="overflow-hidden rounded-lg border border-gray-5">
+      <Flex
+        align="center"
+        gap="2"
+        px="4"
+        py="3"
+        className="border-gray-5 border-b bg-gray-2"
+      >
+        <GitBranchIcon size={15} className="shrink-0 text-gray-11" />
+        <Text size="2" weight="medium">
           Repositories
         </Text>
+        {selected.length > 0 ? (
+          <Text size="1" color="gray" className="ml-auto">
+            {selected.length}/10
+          </Text>
+        ) : null}
       </Flex>
-      <Text size="2" color="gray">
-        New tasks in this space can work across these repositories.
-      </Text>
-      <Flex direction="column" gap="3" mt="3" maxWidth="520px">
-        {selected.map((repository) => (
-          <Flex
-            key={repository}
-            align="center"
-            justify="between"
-            className="rounded border border-gray-6 px-3 py-2"
-          >
-            <Text size="2">{repository}</Text>
-            <Button
-              size="1"
-              variant="ghost"
-              color="gray"
-              aria-label={`Remove ${repository}`}
-              disabled={update.isPending}
-              onClick={() => removeRepository(repository)}
-            >
-              <XIcon size={14} />
-            </Button>
-          </Flex>
-        ))}
+      <Flex direction="column" gap="3" p="4">
+        <Text size="1" color="gray">
+          New tasks in this space can work across these repositories.
+        </Text>
+        {selected.length > 0 ? (
+          <div className="flex flex-col divide-y divide-(--gray-4) overflow-hidden rounded-md border border-gray-5">
+            {selected.map((repository) => (
+              <Flex key={repository} align="center" gap="2" px="3" py="2">
+                <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
+                <Text size="2" className="min-w-0 flex-1 truncate">
+                  {repository}
+                </Text>
+                <Button
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  aria-label={`Remove ${repository}`}
+                  disabled={update.isPending}
+                  onClick={() => removeRepository(repository)}
+                >
+                  <XIcon size={14} />
+                </Button>
+              </Flex>
+            ))}
+          </div>
+        ) : null}
         <GitHubRepoPicker
           value={null}
           onChange={addRepository}
@@ -463,7 +486,7 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
               ? "Add repository..."
               : "Connect GitHub to add repositories"
           }
-          size="2"
+          size="1"
           disabled={
             !hasGithubIntegration || selected.length >= 10 || update.isPending
           }
@@ -476,10 +499,10 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             </Callout.Text>
           </Callout.Root>
         ) : null}
-        <Flex justify="end">
+        {changed ? (
           <Button
-            size="2"
-            disabled={!changed || update.isPending}
+            size="1"
+            disabled={update.isPending}
             onClick={() =>
               update.mutate({
                 channelId: channel.id,
@@ -491,9 +514,9 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             {update.isPending ? <Spinner size="1" /> : null}
             Save repositories
           </Button>
-        </Flex>
+        ) : null}
       </Flex>
-    </Box>
+    </section>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,9 +1,7 @@
 import {
   FileTextIcon,
   GitBranchIcon,
-  GithubLogoIcon,
   SparkleIcon,
-  XIcon,
 } from "@phosphor-icons/react";
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
@@ -14,10 +12,6 @@ import {
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
-  Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   Button as QuillButton,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -25,6 +19,7 @@ import type { TaskChannel } from "@posthog/shared/domain-types";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { CreateChannelModal } from "@posthog/ui/features/canvas/components/CreateChannelModal";
 import { channelPageIcon } from "@posthog/ui/features/canvas/components/channelPages";
+import { RepositoriesField } from "@posthog/ui/features/canvas/components/RepositoriesField";
 import { useChannels } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import {
@@ -37,7 +32,6 @@ import {
   useUpdateTaskChannelRepositories,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
-import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
   PageHeader,
@@ -47,7 +41,6 @@ import {
   PageHeaderTitle,
   PageHeaderTitleRow,
 } from "@posthog/ui/primitives/PageHeader";
-import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { track } from "@posthog/ui/shell/analytics";
 import {
   Box,
@@ -371,100 +364,12 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
   );
 }
 
-const MAX_REPOSITORIES = 10;
-
-// The space's repositories rendered as a subtle inline chip picker: a single
-// row of removable chips with an inline "add" input, driven entirely by the
-// quill Combobox. Selected repos must all belong to one GitHub integration,
-// so the add list is scoped to the active integration once one is chosen.
-// A single repository, rendered as a subtle tag. The leading GitHub glyph
-// swaps to an X on hover so the whole chip is the remove target — no separate
-// delete button crowding the tag (mirrors the message editor's attachments).
-function RepoChip({
-  repository,
-  onRemove,
-}: {
-  repository: string;
-  onRemove: () => void;
-}) {
-  return (
-    <span className="group/chip inline-flex items-center gap-1 rounded-(--radius-1) bg-(--gray-a3) py-0.5 pr-2 pl-1.5 font-medium text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-a4)">
-      <button
-        type="button"
-        aria-label={`Remove ${repository}`}
-        className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0"
-        onClick={onRemove}
-      >
-        <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-100 transition-opacity duration-150 group-hover/chip:opacity-0 motion-reduce:transition-none">
-          <GithubLogoIcon size={13} />
-        </span>
-        <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover/chip:opacity-100 motion-reduce:transition-none">
-          <XIcon size={12} weight="bold" />
-        </span>
-      </button>
-      <span className="max-w-[200px] truncate">{repository}</span>
-    </span>
-  );
-}
-
 // The space's connected repositories: a header row that matches the CONTEXT.md
-// header, then a row of tag chips plus an on-demand picker to add more. Reads
-// straight from the channel (the mutation applies each add/remove optimistically
-// to the cache), so there's no local mirror and no Save button. Selected repos
-// must share one GitHub integration, so the add list scopes to it.
+// header, then the shared chips + add-picker field. Reads straight from the
+// channel — the mutation applies each add/remove optimistically to the cache —
+// so there's no local mirror and no Save button.
 function SpaceRepositories({ channel }: { channel: TaskChannel }) {
-  const {
-    repositories,
-    getIntegrationIdForRepo,
-    isLoadingRepos,
-    hasGithubIntegration,
-  } = useRepositoryIntegration();
   const update = useUpdateTaskChannelRepositories();
-
-  const selected = channel.repositories ?? [];
-  const integrationId = channel.github_integration ?? null;
-  const atLimit = selected.length >= MAX_REPOSITORIES;
-
-  const available = repositories.filter((repository) => {
-    const repositoryIntegration = getIntegrationIdForRepo(repository);
-    return (
-      !selected.includes(repository) &&
-      repositoryIntegration != null &&
-      (integrationId === null || repositoryIntegration === integrationId)
-    );
-  });
-
-  const save = (nextSelected: string[], nextIntegration: number | null) =>
-    update.mutate({
-      channelId: channel.id,
-      githubIntegration: nextIntegration,
-      repositories: nextSelected,
-    });
-
-  const addRepository = (repository: string | null) => {
-    if (!repository || selected.includes(repository)) return;
-    const repositoryIntegration = getIntegrationIdForRepo(repository);
-    if (repositoryIntegration == null) return;
-    save([...selected, repository], repositoryIntegration);
-  };
-
-  const removeRepository = (repository: string) => {
-    const next = selected.filter((item) => item !== repository);
-    save(next, next.length === 0 ? null : integrationId);
-  };
-
-  const isLoadingList = isLoadingRepos && available.length === 0;
-  // When there's nothing to add, keep the button visible but disabled with a
-  // reason, rather than the picker's own "No GitHub repos" dead-end state.
-  const addDisabledReason = !hasGithubIntegration
-    ? "Connect GitHub in settings to add repositories"
-    : atLimit
-      ? `You can add up to ${MAX_REPOSITORIES} repositories`
-      : available.length === 0
-        ? selected.length > 0
-          ? "All accessible repositories are already added"
-          : "No repositories available"
-        : null;
 
   return (
     <Flex direction="column" gap="2">
@@ -482,123 +387,18 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
         ) : null}
       </Flex>
 
-      <Flex align="center" gap="2" wrap="wrap" className="min-h-7">
-        {selected.map((repository) => (
-          <RepoChip
-            key={repository}
-            repository={repository}
-            onRemove={() => removeRepository(repository)}
-          />
-        ))}
-
-        {isLoadingList && hasGithubIntegration ? (
-          <QuillButton variant="outline" size="sm" disabled>
-            <Spinner size="1" />
-            Loading repositories…
-          </QuillButton>
-        ) : addDisabledReason ? (
-          <Tooltip content={addDisabledReason}>
-            <span className="inline-flex">
-              <QuillButton variant="outline" size="sm" disabled>
-                <GithubLogoIcon size={14} />
-                Add repository
-              </QuillButton>
-            </span>
-          </Tooltip>
-        ) : (
-          <AddRepositoryPopover
-            available={available}
-            onAdd={addRepository}
-            label={selected.length > 0 ? "Add…" : "Add repository…"}
-          />
-        )}
-      </Flex>
-    </Flex>
-  );
-}
-
-// Show the filter field only once the list is long enough to warrant scanning.
-const REPO_SEARCH_THRESHOLD = 10;
-
-// The add-repository picker: a button that opens a popover listing the
-// addable repositories. A search field pins to the top once the list is long;
-// only the list scrolls, so there's a single scrollbar.
-function AddRepositoryPopover({
-  available,
-  onAdd,
-  label,
-}: {
-  available: string[];
-  onAdd: (repository: string) => void;
-  label: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-
-  const showSearch = available.length > REPO_SEARCH_THRESHOLD;
-  const trimmed = query.trim().toLowerCase();
-  const filtered = trimmed
-    ? available.filter((repository) =>
-        repository.toLowerCase().includes(trimmed),
-      )
-    : available;
-
-  return (
-    <Popover
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) setQuery("");
-      }}
-    >
-      <PopoverTrigger
-        render={
-          <QuillButton variant="outline" size="sm">
-            <GithubLogoIcon size={14} />
-            {label}
-          </QuillButton>
+      <RepositoriesField
+        selected={channel.repositories ?? []}
+        integrationId={channel.github_integration ?? null}
+        onChange={(repositories, githubIntegration) =>
+          update.mutate({
+            channelId: channel.id,
+            githubIntegration,
+            repositories,
+          })
         }
       />
-      <PopoverContent
-        align="start"
-        sideOffset={6}
-        className="flex max-h-72 w-64 flex-col p-0"
-      >
-        {showSearch ? (
-          <div className="shrink-0 border-gray-5 border-b p-1.5">
-            <Input
-              autoFocus
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search repositories…"
-              className="h-7"
-            />
-          </div>
-        ) : null}
-        <div className="min-h-0 flex-1 overflow-y-auto p-1">
-          {filtered.length === 0 ? (
-            <div className="px-2 py-1.5 text-[13px] text-gray-10">
-              No repositories found
-            </div>
-          ) : (
-            filtered.map((repository) => (
-              <button
-                key={repository}
-                type="button"
-                onClick={() => {
-                  onAdd(repository);
-                  setOpen(false);
-                }}
-                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[13px] hover:bg-[var(--fill-hover)]"
-              >
-                <GithubLogoIcon size={14} className="shrink-0" />
-                <span className="truncate">{repository}</span>
-              </button>
-            ))
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+    </Flex>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -8,16 +8,16 @@ import {
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   Empty,
   EmptyContent,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Button as QuillButton,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -453,17 +453,18 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
     save(next, next.length === 0 ? null : integrationId);
   };
 
+  const isLoadingList = isLoadingRepos && available.length === 0;
   // When there's nothing to add, keep the button visible but disabled with a
   // reason, rather than the picker's own "No GitHub repos" dead-end state.
   const addDisabledReason = !hasGithubIntegration
     ? "Connect GitHub in settings to add repositories"
     : atLimit
       ? `You can add up to ${MAX_REPOSITORIES} repositories`
-      : isLoadingRepos && available.length === 0
-        ? "Loading repositories…"
-        : available.length === 0
+      : available.length === 0
+        ? selected.length > 0
           ? "All accessible repositories are already added"
-          : null;
+          : "No repositories available"
+        : null;
 
   return (
     <Flex direction="column" gap="2">
@@ -490,7 +491,12 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
           />
         ))}
 
-        {addDisabledReason ? (
+        {isLoadingList && hasGithubIntegration ? (
+          <QuillButton variant="outline" size="sm" disabled>
+            <Spinner size="1" />
+            Loading repositories…
+          </QuillButton>
+        ) : addDisabledReason ? (
           <Tooltip content={addDisabledReason}>
             <span className="inline-flex">
               <QuillButton variant="outline" size="sm" disabled>
@@ -500,33 +506,99 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             </span>
           </Tooltip>
         ) : (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <QuillButton variant="outline" size="sm">
-                  <GithubLogoIcon size={14} />
-                  {selected.length > 0 ? "Add…" : "Add repository…"}
-                </QuillButton>
-              }
-            />
-            <DropdownMenuContent
-              align="start"
-              className="max-h-72 min-w-56 overflow-y-auto"
-            >
-              {available.map((repository) => (
-                <DropdownMenuItem
-                  key={repository}
-                  onClick={() => addRepository(repository)}
-                >
-                  <GithubLogoIcon size={14} className="shrink-0" />
-                  <span className="truncate">{repository}</span>
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <AddRepositoryPopover
+            available={available}
+            onAdd={addRepository}
+            label={selected.length > 0 ? "Add…" : "Add repository…"}
+          />
         )}
       </Flex>
     </Flex>
+  );
+}
+
+// Show the filter field only once the list is long enough to warrant scanning.
+const REPO_SEARCH_THRESHOLD = 10;
+
+// The add-repository picker: a button that opens a popover listing the
+// addable repositories. A search field pins to the top once the list is long;
+// only the list scrolls, so there's a single scrollbar.
+function AddRepositoryPopover({
+  available,
+  onAdd,
+  label,
+}: {
+  available: string[];
+  onAdd: (repository: string) => void;
+  label: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const showSearch = available.length > REPO_SEARCH_THRESHOLD;
+  const trimmed = query.trim().toLowerCase();
+  const filtered = trimmed
+    ? available.filter((repository) =>
+        repository.toLowerCase().includes(trimmed),
+      )
+    : available;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+    >
+      <PopoverTrigger
+        render={
+          <QuillButton variant="outline" size="sm">
+            <GithubLogoIcon size={14} />
+            {label}
+          </QuillButton>
+        }
+      />
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="flex max-h-72 w-64 flex-col p-0"
+      >
+        {showSearch ? (
+          <div className="shrink-0 border-gray-5 border-b p-1.5">
+            <Input
+              autoFocus
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search repositories…"
+              className="h-7"
+            />
+          </div>
+        ) : null}
+        <div className="min-h-0 flex-1 overflow-y-auto p-1">
+          {filtered.length === 0 ? (
+            <div className="px-2 py-1.5 text-[13px] text-gray-10">
+              No repositories found
+            </div>
+          ) : (
+            filtered.map((repository) => (
+              <button
+                key={repository}
+                type="button"
+                onClick={() => {
+                  onAdd(repository);
+                  setOpen(false);
+                }}
+                className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[13px] hover:bg-[var(--fill-hover)]"
+              >
+                <GithubLogoIcon size={14} className="shrink-0" />
+                <span className="truncate">{repository}</span>
+              </button>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -57,7 +57,7 @@ import {
   Text,
   TextArea,
 } from "@radix-ui/themes";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type Mode = "rendered" | "edit";
 
@@ -181,10 +181,12 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
         : ["context-md"],
     [spacesLayout, backendChannel],
   );
-  const { activeSection, registerSection, scrollToSection } = useSectionSpy(
-    sectionIds,
-    !isLoadingLatest && !latestError,
-  );
+  const [activeSection, setActiveSection] = useState("context-md");
+  // If the repositories section vanishes (channel row still loading), fall
+  // back to the document rather than an empty pane.
+  const resolvedSection = sectionIds.includes(activeSection)
+    ? activeSection
+    : "context-md";
 
   if (isLoadingLatest) {
     return (
@@ -242,8 +244,8 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
               <button
                 key={section.id}
                 type="button"
-                data-active={activeSection === section.id || undefined}
-                onClick={() => scrollToSection(section.id)}
+                data-active={resolvedSection === section.id || undefined}
+                onClick={() => setActiveSection(section.id)}
                 className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-4 py-1.5 text-left text-[13px] text-gray-11 transition-colors hover:bg-gray-3 data-[active]:bg-accent-4 data-[active]:text-gray-12"
               >
                 <span className="text-gray-10">{section.icon}</span>
@@ -252,142 +254,145 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
             ))}
           </nav>
         )}
-        <ScrollArea
-          type="auto"
-          scrollbars="vertical"
-          className="scroll-area-constrain-width min-h-0 flex-1"
-        >
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-5 pb-24">
-            <section
-              ref={registerSection("context-md")}
-              className="flex scroll-mt-4 flex-col gap-3"
-            >
-              <Flex align="center" justify="between" gap="3" wrap="wrap">
-                <Flex align="center" gap="2">
-                  <FileTextIcon size={15} className="text-gray-11" />
-                  <Text size="2" weight="medium">
-                    CONTEXT.md
-                  </Text>
-                  {latest?.version != null && (
-                    <PageHeaderChip
-                      icon={channelPageIcon("context", { size: 12 })}
-                    >
-                      v{latest.version}
-                    </PageHeaderChip>
-                  )}
-                  {/* Background-refetch indicator: the initial load uses the
+        {resolvedSection === "context-md" ? (
+          <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col gap-3 px-6 py-5">
+            <Flex align="center" justify="between" gap="3" wrap="wrap">
+              <Flex align="center" gap="2">
+                <FileTextIcon size={15} className="text-gray-11" />
+                <Text size="2" weight="medium">
+                  CONTEXT.md
+                </Text>
+                {latest?.version != null && (
+                  <PageHeaderChip
+                    icon={channelPageIcon("context", { size: 12 })}
+                  >
+                    v{latest.version}
+                  </PageHeaderChip>
+                )}
+                {/* Background-refetch indicator: the initial load uses the
                       full-screen spinner; this only fires on revalidations so
                       the user knows the view is live, not stale cache. */}
-                  {isFetchingLatest && !isLoadingLatest ? (
-                    <Flex align="center" gap="1">
-                      <Spinner size="1" />
-                      <Text className="text-[12px] text-gray-10">
-                        Refreshing…
-                      </Text>
-                    </Flex>
-                  ) : null}
-                </Flex>
-                <Flex align="center" gap="2">
-                  {versions.length > 0 ? (
-                    <Select.Root
-                      size="1"
-                      value={selectedVersionId ?? "latest"}
-                      onValueChange={(value) => {
-                        if (value === "latest") {
-                          setSelectedVersionId(null);
-                        } else {
-                          setSelectedVersionId(value);
-                          setMode("rendered");
-                        }
-                      }}
-                      disabled={isLoadingVersions}
-                    >
-                      <Select.Trigger />
-                      <Select.Content>
-                        <Select.Item value="latest">
-                          Latest (v{latest?.version ?? "—"})
-                        </Select.Item>
-                        {versions
-                          .filter((v) => !v.is_latest)
-                          .map((v) => (
-                            <Select.Item key={v.id} value={v.id}>
-                              v{v.version} · {formatTimestamp(v.created_at)}
-                            </Select.Item>
-                          ))}
-                      </Select.Content>
-                    </Select.Root>
-                  ) : null}
-                  <SegmentedControl.Root
-                    value={mode}
-                    onValueChange={(value) => setMode(value as Mode)}
+                {isFetchingLatest && !isLoadingLatest ? (
+                  <Flex align="center" gap="1">
+                    <Spinner size="1" />
+                    <Text className="text-[12px] text-gray-10">
+                      Refreshing…
+                    </Text>
+                  </Flex>
+                ) : null}
+              </Flex>
+              <Flex align="center" gap="2">
+                {versions.length > 0 ? (
+                  <Select.Root
                     size="1"
+                    value={selectedVersionId ?? "latest"}
+                    onValueChange={(value) => {
+                      if (value === "latest") {
+                        setSelectedVersionId(null);
+                      } else {
+                        setSelectedVersionId(value);
+                        setMode("rendered");
+                      }
+                    }}
+                    disabled={isLoadingVersions}
                   >
-                    <SegmentedControl.Item value="rendered">
-                      Rendered
-                    </SegmentedControl.Item>
-                    <SegmentedControl.Item value="edit">
-                      Edit
-                    </SegmentedControl.Item>
-                  </SegmentedControl.Root>
-                  {mode === "edit" ? (
-                    <>
-                      {hasDraft ? (
-                        <Button
-                          size="1"
-                          variant="soft"
-                          color="gray"
-                          onClick={() => {
-                            setDraft(latest?.content ?? "");
-                            setHasDraft(false);
-                          }}
-                          disabled={isPublishing}
-                        >
-                          Discard
-                        </Button>
-                      ) : null}
+                    <Select.Trigger />
+                    <Select.Content>
+                      <Select.Item value="latest">
+                        Latest (v{latest?.version ?? "—"})
+                      </Select.Item>
+                      {versions
+                        .filter((v) => !v.is_latest)
+                        .map((v) => (
+                          <Select.Item key={v.id} value={v.id}>
+                            v{v.version} · {formatTimestamp(v.created_at)}
+                          </Select.Item>
+                        ))}
+                    </Select.Content>
+                  </Select.Root>
+                ) : null}
+                <SegmentedControl.Root
+                  value={mode}
+                  onValueChange={(value) => setMode(value as Mode)}
+                  size="1"
+                >
+                  <SegmentedControl.Item value="rendered">
+                    Rendered
+                  </SegmentedControl.Item>
+                  <SegmentedControl.Item value="edit">
+                    Edit
+                  </SegmentedControl.Item>
+                </SegmentedControl.Root>
+                {mode === "edit" ? (
+                  <>
+                    {hasDraft ? (
                       <Button
                         size="1"
-                        variant="solid"
-                        onClick={onSave}
-                        disabled={
-                          isPublishing ||
-                          (hasInstructions
-                            ? !hasDraft
-                            : draft.trim().length === 0)
-                        }
+                        variant="soft"
+                        color="gray"
+                        onClick={() => {
+                          setDraft(latest?.content ?? "");
+                          setHasDraft(false);
+                        }}
+                        disabled={isPublishing}
                       >
-                        {isPublishing ? <Spinner size="1" /> : null}
-                        Save new version
+                        Discard
                       </Button>
-                    </>
-                  ) : null}
-                </Flex>
+                    ) : null}
+                    <Button
+                      size="1"
+                      variant="solid"
+                      onClick={onSave}
+                      disabled={
+                        isPublishing ||
+                        (hasInstructions
+                          ? !hasDraft
+                          : draft.trim().length === 0)
+                      }
+                    >
+                      {isPublishing ? <Spinner size="1" /> : null}
+                      Save new version
+                    </Button>
+                  </>
+                ) : null}
               </Flex>
+            </Flex>
 
-              {publishError ? (
-                <Callout.Root color={isConflict ? "amber" : "red"} size="1">
-                  <Callout.Text>
-                    {isConflict
-                      ? "Someone else saved a newer version. Reload to merge your changes."
-                      : `Save failed: ${publishError.message}`}
-                  </Callout.Text>
-                </Callout.Root>
-              ) : null}
+            {publishError ? (
+              <Callout.Root color={isConflict ? "amber" : "red"} size="1">
+                <Callout.Text>
+                  {isConflict
+                    ? "Someone else saved a newer version. Reload to merge your changes."
+                    : `Save failed: ${publishError.message}`}
+                </Callout.Text>
+              </Callout.Root>
+            ) : null}
 
-              {selectedVersion ? (
-                <Callout.Root color="gray" size="1">
-                  <Callout.Text>
-                    Viewing v{selectedVersion.version} metadata. Past content is
-                    not fetched today — switch to "Latest" to read or edit
-                    current content.
-                  </Callout.Text>
-                </Callout.Root>
-              ) : mode === "rendered" ? (
-                hasInstructions ? (
+            {selectedVersion ? (
+              <Callout.Root color="gray" size="1">
+                <Callout.Text>
+                  Viewing v{selectedVersion.version} metadata. Past content is
+                  not fetched today — switch to "Latest" to read or edit current
+                  content.
+                </Callout.Text>
+              </Callout.Root>
+            ) : mode === "rendered" ? (
+              hasInstructions ? (
+                <ScrollArea
+                  type="auto"
+                  scrollbars="vertical"
+                  className="scroll-area-constrain-width min-h-0 flex-1"
+                >
                   <Box className="rounded-lg border border-gray-5 bg-gray-2 px-6 py-5 text-[13px]">
                     <MarkdownRenderer content={renderedContent} />
                   </Box>
-                ) : (
+                </ScrollArea>
+              ) : (
+                <Flex
+                  align="center"
+                  justify="center"
+                  className="min-h-0 flex-1"
+                >
                   <EmptyState
                     channelId={channelId}
                     channelName={channelName}
@@ -397,100 +402,41 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
                       setMode("edit");
                     }}
                   />
-                )
-              ) : (
-                <TextArea
-                  value={draft}
-                  onChange={(e) => {
-                    setDraft(e.target.value);
-                    setHasDraft(true);
-                  }}
-                  size="2"
-                  rows={24}
-                  placeholder={
-                    spacesLayout
-                      ? "# Space context\n\nWrite markdown describing this space…"
-                      : "# Channel context\n\nWrite markdown describing this channel…"
-                  }
-                  className="font-[var(--code-font-family)]"
-                />
-              )}
-            </section>
-
-            {spacesLayout && backendChannel ? (
-              <>
-                <div className="border-gray-5 border-t" />
-                <section
-                  ref={registerSection("repositories")}
-                  className="scroll-mt-4"
-                >
-                  <SpaceRepositories channel={backendChannel} />
-                </section>
-              </>
-            ) : null}
+                </Flex>
+              )
+            ) : (
+              <TextArea
+                value={draft}
+                onChange={(e) => {
+                  setDraft(e.target.value);
+                  setHasDraft(true);
+                }}
+                size="2"
+                placeholder={
+                  spacesLayout
+                    ? "# Space context\n\nWrite markdown describing this space…"
+                    : "# Channel context\n\nWrite markdown describing this channel…"
+                }
+                className="min-h-0 flex-1 font-[var(--code-font-family)]"
+              />
+            )}
           </div>
-        </ScrollArea>
+        ) : (
+          <ScrollArea
+            type="auto"
+            scrollbars="vertical"
+            className="scroll-area-constrain-width min-h-0 flex-1"
+          >
+            <div className="mx-auto w-full max-w-3xl px-6 py-5">
+              {backendChannel ? (
+                <SpaceRepositories channel={backendChannel} />
+              ) : null}
+            </div>
+          </ScrollArea>
+        )}
       </div>
     </Flex>
   );
-}
-
-/**
- * Anchor-nav state for the sections pane: which section heading was last
- * scrolled past (or clicked). Programmatic scrolls suppress the spy briefly
- * so the highlight doesn't flicker through sections mid-animation. `ready`
- * defers wiring until the sections actually rendered (the pane mounts after
- * the instructions query resolves).
- */
-function useSectionSpy(ids: string[], ready: boolean) {
-  const [activeSection, setActiveSection] = useState(ids[0] ?? "");
-  const sectionsRef = useRef(new Map<string, HTMLElement>());
-  const suppressUntilRef = useRef(0);
-
-  const registerSection = useCallback(
-    (id: string) => (el: HTMLElement | null) => {
-      if (el) {
-        sectionsRef.current.set(id, el);
-      } else {
-        sectionsRef.current.delete(id);
-      }
-    },
-    [],
-  );
-
-  const idsKey = ids.join("\n");
-  useEffect(() => {
-    const idList = idsKey.split("\n").filter(Boolean);
-    if (!ready || idList.length < 2) return;
-    const firstSection = sectionsRef.current.get(idList[0]);
-    const viewport = firstSection?.closest("[data-radix-scroll-area-viewport]");
-    if (!viewport) return;
-    const onScroll = () => {
-      if (Date.now() < suppressUntilRef.current) return;
-      const viewportTop = viewport.getBoundingClientRect().top;
-      let current = idList[0];
-      for (const id of idList) {
-        const el = sectionsRef.current.get(id);
-        // A section takes over once its heading crosses the upper band.
-        if (el && el.getBoundingClientRect().top - viewportTop < 96) {
-          current = id;
-        }
-      }
-      setActiveSection(current);
-    };
-    viewport.addEventListener("scroll", onScroll, { passive: true });
-    return () => viewport.removeEventListener("scroll", onScroll);
-  }, [idsKey, ready]);
-
-  const scrollToSection = useCallback((id: string) => {
-    setActiveSection(id);
-    suppressUntilRef.current = Date.now() + 700;
-    sectionsRef.current
-      .get(id)
-      ?.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, []);
-
-  return { activeSection, registerSection, scrollToSection };
 }
 
 function SpaceRepositories({ channel }: { channel: TaskChannel }) {

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,23 +1,13 @@
 import {
-  ArrowsClockwiseIcon,
   FileTextIcon,
   GitBranchIcon,
   GithubLogoIcon,
   SparkleIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
-  Combobox,
-  ComboboxChip,
-  ComboboxChips,
-  ComboboxChipsInput,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxListFooter,
-  ComboboxValue,
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -43,6 +33,7 @@ import {
   useUpdateTaskChannelRepositories,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
@@ -66,7 +57,7 @@ import {
   Text,
   TextArea,
 } from "@radix-ui/themes";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type Mode = "rendered" | "edit";
 
@@ -211,13 +202,14 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
           </PageHeaderHeading>
         </PageHeader>
       )}
-      {spacesLayout && backendChannel ? (
-        <div className="shrink-0 border-gray-5 border-b px-6 py-3">
-          <SpaceRepositories channel={backendChannel} />
-        </div>
-      ) : null}
-
       <div className="mx-auto flex min-h-0 w-full max-w-3xl flex-1 flex-col gap-3 px-6 py-4">
+        {spacesLayout && backendChannel ? (
+          <>
+            <SpaceRepositories channel={backendChannel} />
+            <div className="border-gray-5 border-t" />
+          </>
+        ) : null}
+
         <Flex align="center" justify="between" gap="3" wrap="wrap">
           <Flex align="center" gap="2">
             <FileTextIcon size={15} className="text-gray-11" />
@@ -381,10 +373,48 @@ const MAX_REPOSITORIES = 10;
 // row of removable chips with an inline "add" input, driven entirely by the
 // quill Combobox. Selected repos must all belong to one GitHub integration,
 // so the add list is scoped to the active integration once one is chosen.
+// A single repository, rendered as a subtle tag. The leading GitHub glyph
+// swaps to an X on hover so the whole chip is the remove target — no separate
+// delete button crowding the tag (mirrors the message editor's attachments).
+function RepoChip({
+  repository,
+  disabled,
+  onRemove,
+}: {
+  repository: string;
+  disabled: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <span className="group/chip inline-flex items-center gap-1 rounded-(--radius-1) bg-(--gray-a3) py-0.5 pr-2 pl-1.5 font-medium text-(--gray-11) text-[12px] transition-colors hover:bg-(--gray-a4)">
+      <button
+        type="button"
+        aria-label={`Remove ${repository}`}
+        disabled={disabled}
+        className="relative inline-flex size-3.5 shrink-0 cursor-pointer items-center justify-center border-none bg-transparent p-0 disabled:cursor-default disabled:opacity-50"
+        onClick={onRemove}
+      >
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-100 transition-opacity duration-150 group-hover/chip:opacity-0 motion-reduce:transition-none">
+          <GithubLogoIcon size={13} />
+        </span>
+        <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover/chip:opacity-100 motion-reduce:transition-none">
+          <XIcon size={12} weight="bold" />
+        </span>
+      </button>
+      <span className="max-w-[200px] truncate">{repository}</span>
+    </span>
+  );
+}
+
+// The space's connected repositories, shown as a subtle inline strip above the
+// document: tag chips for what's connected, plus an on-demand picker to add
+// more. Changes autosave — there's no Save button. Selected repos must share
+// one GitHub integration, so the add list scopes to the active integration.
 function SpaceRepositories({ channel }: { channel: TaskChannel }) {
   const {
     repositories,
     getIntegrationIdForRepo,
+    isLoadingRepos,
     isRefreshingRepos,
     refreshRepositories,
     hasGithubIntegration,
@@ -394,7 +424,6 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
   const [integrationId, setIntegrationId] = useState<number | null>(
     channel.github_integration ?? null,
   );
-  const anchorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setSelected(channel.repositories ?? []);
@@ -413,123 +442,70 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
         );
       });
 
-  // The combobox hands back the full next selection. Adopt the added repo's
-  // integration when we're starting fresh; drop back to "any" once emptied.
-  const changeSelection = (next: string[]) => {
-    const added = next.find((repository) => !selected.includes(repository));
-    if (added) {
-      const repositoryIntegration = getIntegrationIdForRepo(added);
-      if (repositoryIntegration == null) return;
-      setIntegrationId(repositoryIntegration);
-    } else if (next.length === 0) {
-      setIntegrationId(null);
-    }
-    setSelected(next);
+  // Autosave: local state updates optimistically and the mutation persists the
+  // full desired set, so overlapping add/remove clicks settle last-write-wins.
+  const persist = (nextSelected: string[], nextIntegration: number | null) => {
+    setSelected(nextSelected);
+    setIntegrationId(nextIntegration);
+    update.mutate({
+      channelId: channel.id,
+      githubIntegration: nextIntegration,
+      repositories: nextSelected,
+    });
   };
 
-  const changed =
-    integrationId !== (channel.github_integration ?? null) ||
-    selected.length !== (channel.repositories ?? []).length ||
-    selected.some(
-      (repository, index) => repository !== channel.repositories?.[index],
-    );
+  const addRepository = (repository: string | null) => {
+    if (!repository || selected.includes(repository)) return;
+    const repositoryIntegration = getIntegrationIdForRepo(repository);
+    if (repositoryIntegration == null) return;
+    persist([...selected, repository], repositoryIntegration);
+  };
+
+  const removeRepository = (repository: string) => {
+    const next = selected.filter((item) => item !== repository);
+    persist(next, next.length === 0 ? null : integrationId);
+  };
 
   return (
-    <Flex align="center" gap="3" wrap="wrap">
-      <Flex align="center" gap="2" className="shrink-0">
-        <GitBranchIcon size={15} className="text-gray-11" />
-        <Text size="2" weight="medium">
-          Repositories
-        </Text>
-      </Flex>
+    <Flex align="center" gap="2" wrap="wrap" className="min-h-7 shrink-0">
+      <GitBranchIcon size={14} className="shrink-0 text-gray-10" />
+      <Text size="1" color="gray" className="mr-1 shrink-0">
+        Repositories
+      </Text>
 
-      <Combobox<string, true>
-        multiple
-        items={available}
-        value={selected}
-        onValueChange={(next) => changeSelection(next ?? [])}
-        itemToStringLabel={(repository) => repository}
-      >
-        <ComboboxChips
-          ref={anchorRef}
-          className="flex min-h-8 min-w-64 max-w-full flex-1 flex-wrap items-center gap-1 rounded-(--radius-2) border border-border bg-(--color-panel-solid) px-1.5 py-1"
-        >
-          <ComboboxValue>
-            {(repos: string[]) =>
-              repos.map((repository) => (
-                <ComboboxChip key={repository} showRemove title={repository}>
-                  <GithubLogoIcon size={12} className="shrink-0" />
-                  {repository}
-                </ComboboxChip>
-              ))
-            }
-          </ComboboxValue>
-          <ComboboxChipsInput
-            aria-label="Add repository"
-            disabled={!hasGithubIntegration || atLimit}
-            placeholder={
-              selected.length > 0
-                ? ""
-                : hasGithubIntegration
-                  ? "Add a repository…"
-                  : "Connect GitHub to add repositories"
-            }
-            className="min-w-24 flex-1 bg-transparent text-[13px] text-gray-12 outline-none placeholder:text-gray-10"
-          />
-        </ComboboxChips>
-        <ComboboxContent anchor={anchorRef} align="start" sideOffset={4}>
-          <ComboboxEmpty>
-            {atLimit ? "Repository limit reached" : "No repositories"}
-          </ComboboxEmpty>
-          <ComboboxList>
-            {(repository: string) => (
-              <ComboboxItem key={repository} value={repository}>
-                <Flex align="center" gap="2">
-                  <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
-                  {repository}
-                </Flex>
-              </ComboboxItem>
-            )}
-          </ComboboxList>
-          <ComboboxListFooter>
-            <QuillButton
-              variant="link-muted"
-              size="sm"
-              className="w-full justify-start"
-              disabled={isRefreshingRepos}
-              onClick={() => void refreshRepositories()}
-            >
-              <ArrowsClockwiseIcon
-                size={12}
-                className={isRefreshingRepos ? "animate-spin" : undefined}
-              />
-              Refresh repositories
-            </QuillButton>
-          </ComboboxListFooter>
-        </ComboboxContent>
-      </Combobox>
-
-      {update.error ? (
-        <Text size="1" color="red" className="shrink-0">
-          Couldn't save. Check GitHub access.
-        </Text>
-      ) : null}
-      {changed ? (
-        <Button
-          size="1"
-          className="shrink-0"
+      {selected.map((repository) => (
+        <RepoChip
+          key={repository}
+          repository={repository}
           disabled={update.isPending}
-          onClick={() =>
-            update.mutate({
-              channelId: channel.id,
-              githubIntegration: integrationId,
-              repositories: selected,
-            })
-          }
-        >
-          {update.isPending ? <Spinner size="1" /> : null}
-          Save
-        </Button>
+          onRemove={() => removeRepository(repository)}
+        />
+      ))}
+
+      <GitHubRepoPicker
+        value={null}
+        onChange={addRepository}
+        repositories={available}
+        isLoading={isLoadingRepos}
+        isRefreshing={isRefreshingRepos}
+        onRefresh={() => void refreshRepositories()}
+        placeholder={
+          hasGithubIntegration
+            ? selected.length > 0
+              ? "Add"
+              : "Add a repository…"
+            : "Connect GitHub"
+        }
+        size="1"
+        disabled={!hasGithubIntegration || atLimit || update.isPending}
+      />
+
+      {update.isPending ? (
+        <Spinner size="1" className="shrink-0" />
+      ) : update.error ? (
+        <Text size="1" color="red" className="shrink-0">
+          Couldn't save
+        </Text>
       ) : null}
     </Flex>
   );

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -8,6 +8,10 @@ import {
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -33,7 +37,6 @@ import {
   useUpdateTaskChannelRepositories,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
-import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
@@ -497,17 +500,30 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             </span>
           </Tooltip>
         ) : (
-          <GitHubRepoPicker
-            value={null}
-            onChange={addRepository}
-            repositories={available}
-            isLoading={isLoadingRepos}
-            placeholder={selected.length > 0 ? "Add" : "Add a repository…"}
-            size="1"
-            // Multi-add strip: never auto-select the lone remaining repo, or
-            // deleting down to one addable repo would immediately re-add it.
-            autoSelectSingle={false}
-          />
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <QuillButton variant="outline" size="sm">
+                  <GithubLogoIcon size={14} />
+                  {selected.length > 0 ? "Add…" : "Add repository…"}
+                </QuillButton>
+              }
+            />
+            <DropdownMenuContent
+              align="start"
+              className="max-h-72 min-w-56 overflow-y-auto"
+            >
+              {available.map((repository) => (
+                <DropdownMenuItem
+                  key={repository}
+                  onClick={() => addRepository(repository)}
+                >
+                  <GithubLogoIcon size={14} className="shrink-0" />
+                  <span className="truncate">{repository}</span>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </Flex>
     </Flex>

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -57,9 +57,25 @@ import {
   Text,
   TextArea,
 } from "@radix-ui/themes";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type Mode = "rendered" | "edit";
+
+// The anchor nav on the left of the spaces layout: one row per configurable
+// section on this screen. Future sources (Slack channels, PostHog events, …)
+// get a row here plus a section in the pane.
+const NAV_SECTIONS = [
+  {
+    id: "context-md",
+    label: "CONTEXT.md",
+    icon: <FileTextIcon size={16} />,
+  },
+  {
+    id: "repositories",
+    label: "Repositories",
+    icon: <GitBranchIcon size={16} />,
+  },
+];
 
 // Initial markdown shown when a folder has no instructions yet — gives both
 // humans and agents a structural starting point instead of a blank screen.
@@ -158,6 +174,18 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
     return versions.find((v) => v.id === selectedVersionId) ?? null;
   }, [selectedVersionId, versions]);
 
+  const sectionIds = useMemo(
+    () =>
+      spacesLayout && backendChannel
+        ? ["context-md", "repositories"]
+        : ["context-md"],
+    [spacesLayout, backendChannel],
+  );
+  const { activeSection, registerSection, scrollToSection } = useSectionSpy(
+    sectionIds,
+    !isLoadingLatest && !latestError,
+  );
+
   if (isLoadingLatest) {
     return (
       <Flex align="center" justify="center" className="h-full">
@@ -193,11 +221,6 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
           <PageHeaderHeading>
             <PageHeaderTitleRow>
               <PageHeaderTitle>Context</PageHeaderTitle>
-              {latest?.version != null && (
-                <PageHeaderChip icon={channelPageIcon("context", { size: 12 })}>
-                  v{latest.version}
-                </PageHeaderChip>
-              )}
             </PageHeaderTitleRow>
             <PageHeaderDescription>
               Background every agent working in this{" "}
@@ -207,120 +230,150 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
           </PageHeaderHeading>
         </PageHeader>
       )}
-      <Flex
-        align="center"
-        justify="between"
-        gap="3"
-        px="6"
-        py="2"
-        className="shrink-0 border-b border-b-(--gray-5)"
-      >
-        <Flex align="center" gap="3">
-          <SegmentedControl.Root
-            value={mode}
-            onValueChange={(value) => setMode(value as Mode)}
-            size="1"
+      <div className="flex min-h-0 flex-1">
+        {sectionIds.length > 1 && (
+          <nav
+            aria-label="Context sections"
+            className="w-52 shrink-0 overflow-y-auto border-gray-5 border-r py-3"
           >
-            <SegmentedControl.Item value="rendered">
-              Rendered
-            </SegmentedControl.Item>
-            <SegmentedControl.Item value="edit">Edit</SegmentedControl.Item>
-          </SegmentedControl.Root>
-
-          {/* Background-refetch indicator: the initial load uses the full-screen
-              spinner below; this only fires on revalidations (every mount, plus
-              after publish/delete invalidations) so the user knows the view is
-              live and not just stale cache. */}
-          {isFetchingLatest && !isLoadingLatest ? (
-            <Flex align="center" gap="1">
-              <Spinner size="1" />
-              <Text className="text-[12px] text-gray-10">Refreshing…</Text>
-            </Flex>
-          ) : null}
-
-          {versions.length > 0 ? (
-            <Select.Root
-              size="1"
-              value={selectedVersionId ?? "latest"}
-              onValueChange={(value) => {
-                if (value === "latest") {
-                  setSelectedVersionId(null);
-                } else {
-                  setSelectedVersionId(value);
-                  setMode("rendered");
-                }
-              }}
-              disabled={isLoadingVersions}
-            >
-              <Select.Trigger />
-              <Select.Content>
-                <Select.Item value="latest">
-                  Latest (v{latest?.version ?? "—"})
-                </Select.Item>
-                {versions
-                  .filter((v) => !v.is_latest)
-                  .map((v) => (
-                    <Select.Item key={v.id} value={v.id}>
-                      v{v.version} · {formatTimestamp(v.created_at)}
-                    </Select.Item>
-                  ))}
-              </Select.Content>
-            </Select.Root>
-          ) : null}
-        </Flex>
-
-        {mode === "edit" ? (
-          <Flex align="center" gap="2">
-            {hasDraft ? (
-              <Button
-                size="1"
-                variant="soft"
-                color="gray"
-                onClick={() => {
-                  setDraft(latest?.content ?? "");
-                  setHasDraft(false);
-                }}
-                disabled={isPublishing}
+            {NAV_SECTIONS.filter((section) =>
+              sectionIds.includes(section.id),
+            ).map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                data-active={activeSection === section.id || undefined}
+                onClick={() => scrollToSection(section.id)}
+                className="flex w-full cursor-pointer items-center gap-2 border-0 bg-transparent px-4 py-1.5 text-left text-[13px] text-gray-11 transition-colors hover:bg-gray-3 data-[active]:bg-accent-4 data-[active]:text-gray-12"
               >
-                Discard
-              </Button>
-            ) : null}
-            <Button
-              size="1"
-              variant="solid"
-              onClick={onSave}
-              disabled={
-                isPublishing ||
-                (hasInstructions ? !hasDraft : draft.trim().length === 0)
-              }
+                <span className="text-gray-10">{section.icon}</span>
+                <span>{section.label}</span>
+              </button>
+            ))}
+          </nav>
+        )}
+        <ScrollArea
+          type="auto"
+          scrollbars="vertical"
+          className="scroll-area-constrain-width min-h-0 flex-1"
+        >
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-5 pb-24">
+            <section
+              ref={registerSection("context-md")}
+              className="flex scroll-mt-4 flex-col gap-3"
             >
-              {isPublishing ? <Spinner size="1" /> : null}
-              Save new version
-            </Button>
-          </Flex>
-        ) : null}
-      </Flex>
+              <Flex align="center" justify="between" gap="3" wrap="wrap">
+                <Flex align="center" gap="2">
+                  <FileTextIcon size={15} className="text-gray-11" />
+                  <Text size="2" weight="medium">
+                    CONTEXT.md
+                  </Text>
+                  {latest?.version != null && (
+                    <PageHeaderChip
+                      icon={channelPageIcon("context", { size: 12 })}
+                    >
+                      v{latest.version}
+                    </PageHeaderChip>
+                  )}
+                  {/* Background-refetch indicator: the initial load uses the
+                      full-screen spinner; this only fires on revalidations so
+                      the user knows the view is live, not stale cache. */}
+                  {isFetchingLatest && !isLoadingLatest ? (
+                    <Flex align="center" gap="1">
+                      <Spinner size="1" />
+                      <Text className="text-[12px] text-gray-10">
+                        Refreshing…
+                      </Text>
+                    </Flex>
+                  ) : null}
+                </Flex>
+                <Flex align="center" gap="2">
+                  {versions.length > 0 ? (
+                    <Select.Root
+                      size="1"
+                      value={selectedVersionId ?? "latest"}
+                      onValueChange={(value) => {
+                        if (value === "latest") {
+                          setSelectedVersionId(null);
+                        } else {
+                          setSelectedVersionId(value);
+                          setMode("rendered");
+                        }
+                      }}
+                      disabled={isLoadingVersions}
+                    >
+                      <Select.Trigger />
+                      <Select.Content>
+                        <Select.Item value="latest">
+                          Latest (v{latest?.version ?? "—"})
+                        </Select.Item>
+                        {versions
+                          .filter((v) => !v.is_latest)
+                          .map((v) => (
+                            <Select.Item key={v.id} value={v.id}>
+                              v{v.version} · {formatTimestamp(v.created_at)}
+                            </Select.Item>
+                          ))}
+                      </Select.Content>
+                    </Select.Root>
+                  ) : null}
+                  <SegmentedControl.Root
+                    value={mode}
+                    onValueChange={(value) => setMode(value as Mode)}
+                    size="1"
+                  >
+                    <SegmentedControl.Item value="rendered">
+                      Rendered
+                    </SegmentedControl.Item>
+                    <SegmentedControl.Item value="edit">
+                      Edit
+                    </SegmentedControl.Item>
+                  </SegmentedControl.Root>
+                  {mode === "edit" ? (
+                    <>
+                      {hasDraft ? (
+                        <Button
+                          size="1"
+                          variant="soft"
+                          color="gray"
+                          onClick={() => {
+                            setDraft(latest?.content ?? "");
+                            setHasDraft(false);
+                          }}
+                          disabled={isPublishing}
+                        >
+                          Discard
+                        </Button>
+                      ) : null}
+                      <Button
+                        size="1"
+                        variant="solid"
+                        onClick={onSave}
+                        disabled={
+                          isPublishing ||
+                          (hasInstructions
+                            ? !hasDraft
+                            : draft.trim().length === 0)
+                        }
+                      >
+                        {isPublishing ? <Spinner size="1" /> : null}
+                        Save new version
+                      </Button>
+                    </>
+                  ) : null}
+                </Flex>
+              </Flex>
 
-      {publishError ? (
-        <Box px="6" pt="3">
-          <Callout.Root color={isConflict ? "amber" : "red"} size="1">
-            <Callout.Text>
-              {isConflict
-                ? "Someone else saved a newer version. Reload to merge your changes."
-                : `Save failed: ${publishError.message}`}
-            </Callout.Text>
-          </Callout.Root>
-        </Box>
-      ) : null}
+              {publishError ? (
+                <Callout.Root color={isConflict ? "amber" : "red"} size="1">
+                  <Callout.Text>
+                    {isConflict
+                      ? "Someone else saved a newer version. Reload to merge your changes."
+                      : `Save failed: ${publishError.message}`}
+                  </Callout.Text>
+                </Callout.Root>
+              ) : null}
 
-      <ScrollArea
-        type="auto"
-        scrollbars="vertical"
-        className="scroll-area-constrain-width min-h-0 flex-1"
-      >
-        <div className="mx-auto w-full max-w-6xl px-6 py-5">
-          <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:gap-10">
-            <div className="flex min-w-0 max-w-[84ch] flex-1 flex-col">
               {selectedVersion ? (
                 <Callout.Root color="gray" size="1">
                   <Callout.Text>
@@ -362,20 +415,82 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
                   className="font-[var(--code-font-family)]"
                 />
               )}
-            </div>
-            {/* Sources rail: cards configuring what agents can reach from this
-                space. Repositories today; future sources (Slack channels,
-                PostHog events, …) stack as sibling cards here. */}
+            </section>
+
             {spacesLayout && backendChannel ? (
-              <aside className="flex w-full shrink-0 flex-col gap-4 lg:w-80">
-                <SpaceRepositories channel={backendChannel} />
-              </aside>
+              <>
+                <div className="border-gray-5 border-t" />
+                <section
+                  ref={registerSection("repositories")}
+                  className="scroll-mt-4"
+                >
+                  <SpaceRepositories channel={backendChannel} />
+                </section>
+              </>
             ) : null}
           </div>
-        </div>
-      </ScrollArea>
+        </ScrollArea>
+      </div>
     </Flex>
   );
+}
+
+/**
+ * Anchor-nav state for the sections pane: which section heading was last
+ * scrolled past (or clicked). Programmatic scrolls suppress the spy briefly
+ * so the highlight doesn't flicker through sections mid-animation. `ready`
+ * defers wiring until the sections actually rendered (the pane mounts after
+ * the instructions query resolves).
+ */
+function useSectionSpy(ids: string[], ready: boolean) {
+  const [activeSection, setActiveSection] = useState(ids[0] ?? "");
+  const sectionsRef = useRef(new Map<string, HTMLElement>());
+  const suppressUntilRef = useRef(0);
+
+  const registerSection = useCallback(
+    (id: string) => (el: HTMLElement | null) => {
+      if (el) {
+        sectionsRef.current.set(id, el);
+      } else {
+        sectionsRef.current.delete(id);
+      }
+    },
+    [],
+  );
+
+  const idsKey = ids.join("\n");
+  useEffect(() => {
+    const idList = idsKey.split("\n").filter(Boolean);
+    if (!ready || idList.length < 2) return;
+    const firstSection = sectionsRef.current.get(idList[0]);
+    const viewport = firstSection?.closest("[data-radix-scroll-area-viewport]");
+    if (!viewport) return;
+    const onScroll = () => {
+      if (Date.now() < suppressUntilRef.current) return;
+      const viewportTop = viewport.getBoundingClientRect().top;
+      let current = idList[0];
+      for (const id of idList) {
+        const el = sectionsRef.current.get(id);
+        // A section takes over once its heading crosses the upper band.
+        if (el && el.getBoundingClientRect().top - viewportTop < 96) {
+          current = id;
+        }
+      }
+      setActiveSection(current);
+    };
+    viewport.addEventListener("scroll", onScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", onScroll);
+  }, [idsKey, ready]);
+
+  const scrollToSection = useCallback((id: string) => {
+    setActiveSection(id);
+    suppressUntilRef.current = Date.now() + 700;
+    sectionsRef.current
+      .get(id)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  return { activeSection, registerSection, scrollToSection };
 }
 
 function SpaceRepositories({ channel }: { channel: TaskChannel }) {
@@ -430,28 +545,24 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
     );
 
   return (
-    <section className="overflow-hidden rounded-lg border border-gray-5">
-      <Flex
-        align="center"
-        gap="2"
-        px="4"
-        py="3"
-        className="border-gray-5 border-b bg-gray-2"
-      >
-        <GitBranchIcon size={15} className="shrink-0 text-gray-11" />
-        <Text size="2" weight="medium">
-          Repositories
-        </Text>
-        {selected.length > 0 ? (
-          <Text size="1" color="gray" className="ml-auto">
-            {selected.length}/10
+    <Flex direction="column" gap="3">
+      <Flex direction="column" gap="1">
+        <Flex align="center" gap="2">
+          <GitBranchIcon size={15} className="shrink-0 text-gray-11" />
+          <Text size="2" weight="medium">
+            Repositories
           </Text>
-        ) : null}
-      </Flex>
-      <Flex direction="column" gap="3" p="4">
+          {selected.length > 0 ? (
+            <Text size="1" color="gray">
+              {selected.length}/10
+            </Text>
+          ) : null}
+        </Flex>
         <Text size="1" color="gray">
           New tasks in this space can work across these repositories.
         </Text>
+      </Flex>
+      <Flex direction="column" gap="3" maxWidth="480px">
         {selected.length > 0 ? (
           <div className="flex flex-col divide-y divide-(--gray-4) overflow-hidden rounded-md border border-gray-5">
             {selected.map((repository) => (
@@ -500,23 +611,25 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
           </Callout.Root>
         ) : null}
         {changed ? (
-          <Button
-            size="1"
-            disabled={update.isPending}
-            onClick={() =>
-              update.mutate({
-                channelId: channel.id,
-                githubIntegration: integrationId,
-                repositories: selected,
-              })
-            }
-          >
-            {update.isPending ? <Spinner size="1" /> : null}
-            Save repositories
-          </Button>
+          <Flex justify="end">
+            <Button
+              size="1"
+              disabled={update.isPending}
+              onClick={() =>
+                update.mutate({
+                  channelId: channel.id,
+                  githubIntegration: integrationId,
+                  repositories: selected,
+                })
+              }
+            >
+              {update.isPending ? <Spinner size="1" /> : null}
+              Save repositories
+            </Button>
+          </Flex>
         ) : null}
       </Flex>
-    </section>
+    </Flex>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowsClockwiseIcon,
   FileTextIcon,
   GitBranchIcon,
   GithubLogoIcon,
@@ -9,13 +8,6 @@ import {
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxTrigger,
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -41,6 +33,7 @@ import {
   useUpdateTaskChannelRepositories,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
@@ -65,7 +58,7 @@ import {
   Text,
   TextArea,
 } from "@radix-ui/themes";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type Mode = "rendered" | "edit";
 
@@ -506,119 +499,22 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             </span>
           </Tooltip>
         ) : (
-          <AddRepositoryButton
-            available={available}
+          <GitHubRepoPicker
+            value={null}
+            onChange={addRepository}
+            repositories={available}
             isLoading={isLoadingRepos}
             isRefreshing={isRefreshingRepos}
             onRefresh={() => void refreshRepositories()}
-            onAdd={addRepository}
-            label={selected.length > 0 ? "Add" : "Add a repository"}
+            placeholder={selected.length > 0 ? "Add" : "Add a repository…"}
+            size="1"
+            // Multi-add strip: never auto-select the lone remaining repo, or
+            // deleting down to one addable repo would immediately re-add it.
+            autoSelectSingle={false}
           />
         )}
       </Flex>
     </Flex>
-  );
-}
-
-// A compact "Add repository" menu: a single-select quill Combobox with a button
-// trigger and a searchable list. Unlike the shared GitHubRepoPicker it never
-// auto-selects a lone option — auto-selection there re-adds a just-removed repo
-// and loops — so this is a deliberately minimal picker for the multi-add strip.
-function AddRepositoryButton({
-  available,
-  isLoading,
-  isRefreshing,
-  onRefresh,
-  onAdd,
-  label,
-}: {
-  available: string[];
-  isLoading: boolean;
-  isRefreshing: boolean;
-  onRefresh: () => void;
-  onAdd: (repository: string) => void;
-  label: string;
-}) {
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-
-  return (
-    <Combobox<string>
-      items={available}
-      value={null}
-      onValueChange={(repository) => {
-        if (repository) onAdd(repository as string);
-        setOpen(false);
-      }}
-      open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) setQuery("");
-      }}
-      inputValue={query}
-      onInputValueChange={setQuery}
-    >
-      <ComboboxTrigger
-        render={
-          <QuillButton
-            ref={triggerRef}
-            variant="outline"
-            size="sm"
-            aria-label="Add repository"
-          >
-            <GithubLogoIcon size={14} className="shrink-0" />
-            {label}
-          </QuillButton>
-        }
-      />
-      <ComboboxContent
-        anchor={triggerRef}
-        side="bottom"
-        sideOffset={6}
-        align="start"
-        className="min-w-[280px]"
-      >
-        <div className="flex min-w-0 items-center gap-1 pe-2">
-          <div className="min-w-0 flex-1">
-            <ComboboxInput placeholder="Search repositories…" />
-          </div>
-          <QuillButton
-            variant="outline"
-            size="sm"
-            disabled={isRefreshing}
-            aria-label="Refresh repositories"
-            onMouseDown={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-            }}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onRefresh();
-            }}
-          >
-            <ArrowsClockwiseIcon
-              size={14}
-              className={isRefreshing ? "animate-spin" : undefined}
-            />
-          </QuillButton>
-        </div>
-        <ComboboxEmpty>
-          {isLoading ? "Loading repositories…" : "No repositories found."}
-        </ComboboxEmpty>
-        <ComboboxList>
-          {(repository: string) => (
-            <ComboboxItem key={repository} value={repository}>
-              <Flex align="center" gap="2">
-                <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
-                {repository}
-              </Flex>
-            </ComboboxItem>
-          )}
-        </ComboboxList>
-      </ComboboxContent>
-    </Combobox>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,4 +1,9 @@
-import { FileTextIcon, SparkleIcon } from "@phosphor-icons/react";
+import {
+  FileTextIcon,
+  GitBranchIcon,
+  SparkleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
@@ -11,6 +16,7 @@ import {
   Button as QuillButton,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { TaskChannel } from "@posthog/shared/domain-types";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { CreateChannelModal } from "@posthog/ui/features/canvas/components/CreateChannelModal";
 import { channelPageIcon } from "@posthog/ui/features/canvas/components/channelPages";
@@ -21,7 +27,13 @@ import {
   useFolderInstructionsMutations,
   useFolderInstructionsVersions,
 } from "@posthog/ui/features/canvas/hooks/useFolderInstructions";
+import {
+  useBackendChannel,
+  useUpdateTaskChannelRepositories,
+} from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
+import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
   PageHeader,
@@ -68,6 +80,7 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
   const channelName =
     channels.find((c) => c.id === channelId)?.name ??
     (spacesLayout ? "Space" : "Channel");
+  const { channel: backendChannel } = useBackendChannel(channelName);
 
   const {
     data: latest,
@@ -346,9 +359,141 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
               className="font-[var(--code-font-family)]"
             />
           )}
+          {spacesLayout && backendChannel ? (
+            <SpaceRepositories channel={backendChannel} />
+          ) : null}
         </Box>
       </ScrollArea>
     </Flex>
+  );
+}
+
+function SpaceRepositories({ channel }: { channel: TaskChannel }) {
+  const {
+    repositories,
+    getIntegrationIdForRepo,
+    isLoadingRepos,
+    isRefreshingRepos,
+    refreshRepositories,
+    hasGithubIntegration,
+  } = useRepositoryIntegration();
+  const update = useUpdateTaskChannelRepositories();
+  const [selected, setSelected] = useState(channel.repositories ?? []);
+  const [integrationId, setIntegrationId] = useState<number | null>(
+    channel.github_integration ?? null,
+  );
+
+  useEffect(() => {
+    setSelected(channel.repositories ?? []);
+    setIntegrationId(channel.github_integration ?? null);
+  }, [channel.github_integration, channel.repositories]);
+
+  const available = repositories.filter((repository) => {
+    const repositoryIntegration = getIntegrationIdForRepo(repository);
+    return (
+      !selected.includes(repository) &&
+      (integrationId === null || repositoryIntegration === integrationId)
+    );
+  });
+
+  const addRepository = (repository: string | null) => {
+    if (!repository) return;
+    const repositoryIntegration = getIntegrationIdForRepo(repository);
+    if (repositoryIntegration == null) return;
+    setIntegrationId(repositoryIntegration);
+    setSelected((current) => [...current, repository]);
+  };
+
+  const removeRepository = (repository: string) => {
+    setSelected((current) => {
+      const next = current.filter((item) => item !== repository);
+      if (next.length === 0) setIntegrationId(null);
+      return next;
+    });
+  };
+
+  const changed =
+    integrationId !== (channel.github_integration ?? null) ||
+    selected.length !== (channel.repositories ?? []).length ||
+    selected.some(
+      (repository, index) => repository !== channel.repositories?.[index],
+    );
+
+  return (
+    <Box className="mt-8 border-gray-6 border-t pt-5">
+      <Flex align="center" gap="2" mb="1">
+        <GitBranchIcon size={16} />
+        <Text size="3" weight="medium">
+          Repositories
+        </Text>
+      </Flex>
+      <Text size="2" color="gray">
+        New tasks in this space can work across these repositories.
+      </Text>
+      <Flex direction="column" gap="3" mt="3" maxWidth="520px">
+        {selected.map((repository) => (
+          <Flex
+            key={repository}
+            align="center"
+            justify="between"
+            className="rounded border border-gray-6 px-3 py-2"
+          >
+            <Text size="2">{repository}</Text>
+            <Button
+              size="1"
+              variant="ghost"
+              color="gray"
+              aria-label={`Remove ${repository}`}
+              disabled={update.isPending}
+              onClick={() => removeRepository(repository)}
+            >
+              <XIcon size={14} />
+            </Button>
+          </Flex>
+        ))}
+        <GitHubRepoPicker
+          value={null}
+          onChange={addRepository}
+          repositories={available}
+          isLoading={isLoadingRepos}
+          isRefreshing={isRefreshingRepos}
+          onRefresh={() => void refreshRepositories()}
+          placeholder={
+            hasGithubIntegration
+              ? "Add repository..."
+              : "Connect GitHub to add repositories"
+          }
+          size="2"
+          disabled={
+            !hasGithubIntegration || selected.length >= 10 || update.isPending
+          }
+        />
+        {update.error ? (
+          <Callout.Root color="red" size="1">
+            <Callout.Text>
+              Couldn't save repositories. Check your GitHub access and try
+              again.
+            </Callout.Text>
+          </Callout.Root>
+        ) : null}
+        <Flex justify="end">
+          <Button
+            size="2"
+            disabled={!changed || update.isPending}
+            onClick={() =>
+              update.mutate({
+                channelId: channel.id,
+                githubIntegration: integrationId,
+                repositories: selected,
+              })
+            }
+          >
+            {update.isPending ? <Spinner size="1" /> : null}
+            Save repositories
+          </Button>
+        </Flex>
+      </Flex>
+    </Box>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -1,4 +1,5 @@
 import {
+  ArrowsClockwiseIcon,
   FileTextIcon,
   GitBranchIcon,
   GithubLogoIcon,
@@ -8,6 +9,13 @@ import {
 import { FolderInstructionsConflictError } from "@posthog/api-client/posthog-client";
 import { buildContextSaveProps } from "@posthog/core/canvas/canvasAnalytics";
 import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
   Empty,
   EmptyContent,
   EmptyDescription,
@@ -33,7 +41,6 @@ import {
   useUpdateTaskChannelRepositories,
 } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
-import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
 import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import {
@@ -58,7 +65,7 @@ import {
   Text,
   TextArea,
 } from "@radix-ui/themes";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type Mode = "rendered" | "edit";
 
@@ -499,19 +506,119 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             </span>
           </Tooltip>
         ) : (
-          <GitHubRepoPicker
-            value={null}
-            onChange={addRepository}
-            repositories={available}
+          <AddRepositoryButton
+            available={available}
             isLoading={isLoadingRepos}
             isRefreshing={isRefreshingRepos}
             onRefresh={() => void refreshRepositories()}
-            placeholder={selected.length > 0 ? "Add" : "Add a repository…"}
-            size="1"
+            onAdd={addRepository}
+            label={selected.length > 0 ? "Add" : "Add a repository"}
           />
         )}
       </Flex>
     </Flex>
+  );
+}
+
+// A compact "Add repository" menu: a single-select quill Combobox with a button
+// trigger and a searchable list. Unlike the shared GitHubRepoPicker it never
+// auto-selects a lone option — auto-selection there re-adds a just-removed repo
+// and loops — so this is a deliberately minimal picker for the multi-add strip.
+function AddRepositoryButton({
+  available,
+  isLoading,
+  isRefreshing,
+  onRefresh,
+  onAdd,
+  label,
+}: {
+  available: string[];
+  isLoading: boolean;
+  isRefreshing: boolean;
+  onRefresh: () => void;
+  onAdd: (repository: string) => void;
+  label: string;
+}) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  return (
+    <Combobox<string>
+      items={available}
+      value={null}
+      onValueChange={(repository) => {
+        if (repository) onAdd(repository as string);
+        setOpen(false);
+      }}
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery("");
+      }}
+      inputValue={query}
+      onInputValueChange={setQuery}
+    >
+      <ComboboxTrigger
+        render={
+          <QuillButton
+            ref={triggerRef}
+            variant="outline"
+            size="sm"
+            aria-label="Add repository"
+          >
+            <GithubLogoIcon size={14} className="shrink-0" />
+            {label}
+          </QuillButton>
+        }
+      />
+      <ComboboxContent
+        anchor={triggerRef}
+        side="bottom"
+        sideOffset={6}
+        align="start"
+        className="min-w-[280px]"
+      >
+        <div className="flex min-w-0 items-center gap-1 pe-2">
+          <div className="min-w-0 flex-1">
+            <ComboboxInput placeholder="Search repositories…" />
+          </div>
+          <QuillButton
+            variant="outline"
+            size="sm"
+            disabled={isRefreshing}
+            aria-label="Refresh repositories"
+            onMouseDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onRefresh();
+            }}
+          >
+            <ArrowsClockwiseIcon
+              size={14}
+              className={isRefreshing ? "animate-spin" : undefined}
+            />
+          </QuillButton>
+        </div>
+        <ComboboxEmpty>
+          {isLoading ? "Loading repositories…" : "No repositories found."}
+        </ComboboxEmpty>
+        <ComboboxList>
+          {(repository: string) => (
+            <ComboboxItem key={repository} value={repository}>
+              <Flex align="center" gap="2">
+                <GithubLogoIcon size={14} className="shrink-0 text-gray-11" />
+                {repository}
+              </Flex>
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -414,8 +414,6 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
     repositories,
     getIntegrationIdForRepo,
     isLoadingRepos,
-    isRefreshingRepos,
-    refreshRepositories,
     hasGithubIntegration,
   } = useRepositoryIntegration();
   const update = useUpdateTaskChannelRepositories();
@@ -504,8 +502,6 @@ function SpaceRepositories({ channel }: { channel: TaskChannel }) {
             onChange={addRepository}
             repositories={available}
             isLoading={isLoadingRepos}
-            isRefreshing={isRefreshingRepos}
-            onRefresh={() => void refreshRepositories()}
             placeholder={selected.length > 0 ? "Add" : "Add a repository…"}
             size="1"
             // Multi-add strip: never auto-select the lone remaining repo, or

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
@@ -77,6 +77,34 @@ export function useUpdateTaskChannelRepositories() {
         repositories: input.repositories,
       });
     },
+    // Autosave adds/removes from the context screen, so apply the change to the
+    // cache immediately and roll back on failure — the chip strip reads its
+    // state straight from this cache, no local mirror.
+    onMutate: async (input) => {
+      await queryClient.cancelQueries({ queryKey: TASK_CHANNELS_QUERY_KEY });
+      const previous = queryClient.getQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+      );
+      queryClient.setQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+        (channels) =>
+          channels?.map((item) =>
+            item.id === input.channelId
+              ? {
+                  ...item,
+                  github_integration: input.githubIntegration,
+                  repositories: input.repositories,
+                }
+              : item,
+          ),
+      );
+      return { previous };
+    },
+    onError: (_error, _input, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(TASK_CHANNELS_QUERY_KEY, context.previous);
+      }
+    },
     onSuccess: (channel) => {
       queryClient.setQueryData<TaskChannel[]>(
         TASK_CHANNELS_QUERY_KEY,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskChannels.ts
@@ -62,6 +62,31 @@ export function useTaskChannels(options?: { enabled?: boolean }): {
   return { channels, personalChannel, isLoading: query.isLoading };
 }
 
+export function useUpdateTaskChannelRepositories() {
+  const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      channelId: string;
+      githubIntegration: number | null;
+      repositories: string[];
+    }) => {
+      if (!client) throw new Error("Not authenticated");
+      return client.updateTaskChannel(input.channelId, {
+        github_integration: input.githubIntegration,
+        repositories: input.repositories,
+      });
+    },
+    onSuccess: (channel) => {
+      queryClient.setQueryData<TaskChannel[]>(
+        TASK_CHANNELS_QUERY_KEY,
+        (channels) =>
+          channels?.map((item) => (item.id === channel.id ? channel : item)),
+      );
+    },
+  });
+}
+
 /**
  * Map a folder channel (by display name) onto its backend channel. The "me"
  * folder is the bridge for the personal channel; any other name resolves (or

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPRButton.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPRButton.tsx
@@ -1,7 +1,7 @@
 import type { WorkspaceMode } from "@posthog/shared";
 import { PRBadgeLink } from "../../git-interaction/components/PRBadgeLink";
 import { usePrDetails } from "../../git-interaction/usePrDetails";
-import { useTaskPrUrl } from "../../git-interaction/useTaskPrUrl";
+import { useTaskPrUrls } from "../../git-interaction/useTaskPrUrl";
 
 interface CommandCenterPRButtonProps {
   taskId: string;
@@ -18,7 +18,7 @@ export function CommandCenterPRButton({
   workspaceMode,
 }: CommandCenterPRButtonProps) {
   const isCloud = workspaceMode === "cloud";
-  const prUrl = useTaskPrUrl(taskId, isCloud);
+  const { primaryUrl: prUrl, otherUrls } = useTaskPrUrls(taskId, isCloud);
 
   const {
     meta: { state, merged, draft },
@@ -33,6 +33,7 @@ export function CommandCenterPRButton({
       merged={merged}
       draft={draft}
       compact
+      otherCount={otherUrls.length}
     />
   );
 }

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -204,11 +204,11 @@ export function GitHubRepoPicker({
         className="min-w-[280px]"
       >
         {showSearchInput ? (
-          <div className="flex min-w-0 items-center gap-1 pe-2">
-            <div className="min-w-0 flex-1">
-              <ComboboxInput placeholder="Search repositories..." />
-            </div>
-            {onRefresh ? (
+          onRefresh ? (
+            <div className="flex min-w-0 items-center gap-1 pe-2">
+              <div className="min-w-0 flex-1">
+                <ComboboxInput placeholder="Search repositories..." />
+              </div>
               <Button
                 variant="outline"
                 size="sm"
@@ -229,8 +229,10 @@ export function GitHubRepoPicker({
                   className={isRefreshing ? "animate-spin" : undefined}
                 />
               </Button>
-            ) : null}
-          </div>
+            </div>
+          ) : (
+            <ComboboxInput placeholder="Search repositories..." />
+          )
         ) : null}
         <ComboboxEmpty>
           {showInlineLoadingState

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -27,12 +27,6 @@ interface GitHubRepoPickerProps {
   anchor?: RefObject<HTMLElement | null>;
   /** When false, the list is shown without a filter field (e.g. short lists in modals). */
   showSearchInput?: boolean;
-  /**
-   * When true (default), a list of exactly one repo auto-selects it. Multi-add
-   * callers that re-render the picker with a shrinking list must pass false —
-   * otherwise auto-select re-adds a just-removed repo and loops.
-   */
-  autoSelectSingle?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
   open?: boolean;
@@ -53,7 +47,6 @@ export function GitHubRepoPicker({
   disabled = false,
   anchor,
   showSearchInput = true,
-  autoSelectSingle = true,
   onRefresh,
   isRefreshing = false,
   open: controlledOpen,
@@ -78,9 +71,7 @@ export function GitHubRepoPicker({
     onLoadMore !== undefined;
   const showInlineLoadingState = remoteMode && open && isLoading;
   const onlyRepo =
-    autoSelectSingle && !remoteMode && repositories.length === 1
-      ? repositories[0]
-      : null;
+    !remoteMode && repositories.length === 1 ? repositories[0] : null;
   const trimmedSearchQuery = searchQuery.trim();
   const filteredRepositoryCount = useMemo(() => {
     if (!trimmedSearchQuery) {
@@ -204,11 +195,11 @@ export function GitHubRepoPicker({
         className="min-w-[280px]"
       >
         {showSearchInput ? (
-          onRefresh ? (
-            <div className="flex min-w-0 items-center gap-1 pe-2">
-              <div className="min-w-0 flex-1">
-                <ComboboxInput placeholder="Search repositories..." />
-              </div>
+          <div className="flex min-w-0 items-center gap-1 pe-2">
+            <div className="min-w-0 flex-1">
+              <ComboboxInput placeholder="Search repositories..." />
+            </div>
+            {onRefresh ? (
               <Button
                 variant="outline"
                 size="sm"
@@ -229,10 +220,8 @@ export function GitHubRepoPicker({
                   className={isRefreshing ? "animate-spin" : undefined}
                 />
               </Button>
-            </div>
-          ) : (
-            <ComboboxInput placeholder="Search repositories..." />
-          )
+            ) : null}
+          </div>
         ) : null}
         <ComboboxEmpty>
           {showInlineLoadingState

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -27,6 +27,12 @@ interface GitHubRepoPickerProps {
   anchor?: RefObject<HTMLElement | null>;
   /** When false, the list is shown without a filter field (e.g. short lists in modals). */
   showSearchInput?: boolean;
+  /**
+   * When true (default), a list of exactly one repo auto-selects it. Multi-add
+   * callers that re-render the picker with a shrinking list must pass false —
+   * otherwise auto-select re-adds a just-removed repo and loops.
+   */
+  autoSelectSingle?: boolean;
   onRefresh?: () => void;
   isRefreshing?: boolean;
   open?: boolean;
@@ -47,6 +53,7 @@ export function GitHubRepoPicker({
   disabled = false,
   anchor,
   showSearchInput = true,
+  autoSelectSingle = true,
   onRefresh,
   isRefreshing = false,
   open: controlledOpen,
@@ -71,7 +78,9 @@ export function GitHubRepoPicker({
     onLoadMore !== undefined;
   const showInlineLoadingState = remoteMode && open && isLoading;
   const onlyRepo =
-    !remoteMode && repositories.length === 1 ? repositories[0] : null;
+    autoSelectSingle && !remoteMode && repositories.length === 1
+      ? repositories[0]
+      : null;
   const trimmedSearchQuery = searchQuery.trim();
   const filteredRepositoryCount = useMemo(() => {
     if (!trimmedSearchQuery) {

--- a/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
@@ -23,6 +23,11 @@ interface PRBadgeLinkProps {
    * Radix Button.
    */
   compact?: boolean;
+  /**
+   * How many further PRs the task has beyond this one — rendered as a "+N"
+   * suffix so multi-repo tasks signal their other PRs at a glance.
+   */
+  otherCount?: number;
 }
 
 const COMPACT_COLOR_CLASSES: Record<PrVisualConfig["color"], string> = {
@@ -46,6 +51,7 @@ export function PRBadgeLink({
   isPrPending = false,
   attachedRight = false,
   compact = false,
+  otherCount = 0,
 }: PRBadgeLinkProps) {
   const config = getPrVisualConfig(prState, merged, draft);
   const PrIcon = getPrVisualIcon(config.icon);
@@ -69,6 +75,7 @@ export function PRBadgeLink({
           {config.label}
           {prNumber && ` #${prNumber}`}
         </span>
+        {otherCount > 0 && <span className="opacity-70">+{otherCount}</span>}
       </a>
     );
   }
@@ -96,6 +103,9 @@ export function PRBadgeLink({
           <Text size="1">
             {config.label}
             {prNumber && ` #${prNumber}`}
+            {otherCount > 0 && (
+              <span className="ml-1 opacity-60">+{otherCount}</span>
+            )}
           </Text>
         </Flex>
       </a>

--- a/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
@@ -1,4 +1,3 @@
-import { StackSimple } from "@phosphor-icons/react";
 import {
   getPrVisualConfig,
   type PrVisualConfig,
@@ -38,8 +37,8 @@ const COMPACT_COLOR_CLASSES: Record<PrVisualConfig["color"], string> = {
   purple: "bg-(--purple-3) text-(--purple-11) hover:bg-(--purple-4)",
 };
 
-// Divider ahead of the stack-count chip, tinted to the badge's own color.
-const STACK_DIVIDER_CLASSES: Record<PrVisualConfig["color"], string> = {
+// Divider ahead of the PR-count segment, tinted to the badge's own color.
+const COUNT_DIVIDER_CLASSES: Record<PrVisualConfig["color"], string> = {
   gray: "border-(--gray-a6)",
   green: "border-(--green-a6)",
   red: "border-(--red-a6)",
@@ -90,10 +89,7 @@ export function PRBadgeLink({
           {prNumber && ` #${prNumber}`}
         </span>
         {otherCount > 0 && (
-          <span className="ml-0.5 inline-flex items-center gap-0.5">
-            <StackSimple size={10} weight="bold" />
-            {totalCount}
-          </span>
+          <span className="ml-0.5 opacity-90">· {totalCount} PRs</span>
         )}
       </a>
     );
@@ -127,11 +123,9 @@ export function PRBadgeLink({
           {otherCount > 0 && (
             <Flex
               align="center"
-              gap="1"
-              className={`border-l pl-2 ${STACK_DIVIDER_CLASSES[config.color]}`}
+              className={`border-l pl-2 ${COUNT_DIVIDER_CLASSES[config.color]}`}
             >
-              <StackSimple size={11} weight="bold" />
-              <Text size="1">{totalCount}</Text>
+              <Text size="1">{totalCount} PRs</Text>
             </Flex>
           )}
         </Flex>

--- a/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
@@ -1,4 +1,3 @@
-import { StackSimple } from "@phosphor-icons/react";
 import {
   getPrVisualConfig,
   type PrVisualConfig,
@@ -89,12 +88,7 @@ export function PRBadgeLink({
           {config.label}
           {prNumber && ` #${prNumber}`}
         </span>
-        {otherCount > 0 && (
-          <span className="ml-0.5 inline-flex items-center gap-0.5">
-            <StackSimple size={10} weight="bold" />
-            {totalCount}
-          </span>
-        )}
+        {otherCount > 0 && <span className="ml-0.5">{totalCount}</span>}
       </a>
     );
   }
@@ -129,10 +123,8 @@ export function PRBadgeLink({
           {otherCount > 0 && (
             <Flex
               align="center"
-              gap="1"
               className={`border-l pl-2 ${COUNT_DIVIDER_CLASSES[config.color]}`}
             >
-              <StackSimple size={11} weight="bold" />
               <Text size="1" className="text-[12px]">
                 {totalCount}
               </Text>

--- a/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
@@ -1,3 +1,4 @@
+import { StackSimple } from "@phosphor-icons/react";
 import {
   getPrVisualConfig,
   type PrVisualConfig,
@@ -37,6 +38,14 @@ const COMPACT_COLOR_CLASSES: Record<PrVisualConfig["color"], string> = {
   purple: "bg-(--purple-3) text-(--purple-11) hover:bg-(--purple-4)",
 };
 
+// Divider ahead of the stack-count chip, tinted to the badge's own color.
+const STACK_DIVIDER_CLASSES: Record<PrVisualConfig["color"], string> = {
+  gray: "border-(--gray-a6)",
+  green: "border-(--green-a6)",
+  red: "border-(--red-a6)",
+  purple: "border-(--purple-a6)",
+};
+
 /**
  * The colored "open this PR on GitHub" badge — styled by the PR's lifecycle
  * state (open / draft / closed / merged) and rendered as an external anchor.
@@ -57,6 +66,10 @@ export function PRBadgeLink({
   const PrIcon = getPrVisualIcon(config.icon);
   const prNumber = parsePrNumber(prUrl);
 
+  const totalCount = otherCount + 1;
+  const stackTitle =
+    otherCount > 0 ? `${totalCount} pull requests on this task` : undefined;
+
   if (compact) {
     return (
       <a
@@ -64,6 +77,7 @@ export function PRBadgeLink({
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
+        title={stackTitle}
         className={`inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] no-underline ${COMPACT_COLOR_CLASSES[config.color]}`}
       >
         {isPrPending ? (
@@ -75,7 +89,12 @@ export function PRBadgeLink({
           {config.label}
           {prNumber && ` #${prNumber}`}
         </span>
-        {otherCount > 0 && <span className="opacity-70">+{otherCount}</span>}
+        {otherCount > 0 && (
+          <span className="ml-0.5 inline-flex items-center gap-0.5">
+            <StackSimple size={10} weight="bold" />
+            {totalCount}
+          </span>
+        )}
       </a>
     );
   }
@@ -93,6 +112,7 @@ export function PRBadgeLink({
         target="_blank"
         rel="noopener noreferrer"
         onClick={(e) => e.stopPropagation()}
+        title={stackTitle}
       >
         <Flex align="center" gap="2">
           {isPrPending ? (
@@ -103,10 +123,17 @@ export function PRBadgeLink({
           <Text size="1">
             {config.label}
             {prNumber && ` #${prNumber}`}
-            {otherCount > 0 && (
-              <span className="ml-1 opacity-60">+{otherCount}</span>
-            )}
           </Text>
+          {otherCount > 0 && (
+            <Flex
+              align="center"
+              gap="1"
+              className={`border-l pl-2 ${STACK_DIVIDER_CLASSES[config.color]}`}
+            >
+              <StackSimple size={11} weight="bold" />
+              <Text size="1">{totalCount}</Text>
+            </Flex>
+          )}
         </Flex>
       </a>
     </Button>

--- a/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/PRBadgeLink.tsx
@@ -1,3 +1,4 @@
+import { StackSimple } from "@phosphor-icons/react";
 import {
   getPrVisualConfig,
   type PrVisualConfig,
@@ -89,7 +90,10 @@ export function PRBadgeLink({
           {prNumber && ` #${prNumber}`}
         </span>
         {otherCount > 0 && (
-          <span className="ml-0.5 opacity-90">· {totalCount} PRs</span>
+          <span className="ml-0.5 inline-flex items-center gap-0.5">
+            <StackSimple size={10} weight="bold" />
+            {totalCount}
+          </span>
         )}
       </a>
     );
@@ -116,16 +120,22 @@ export function PRBadgeLink({
           ) : (
             <PrIcon size={12} weight="bold" />
           )}
-          <Text size="1">
+          {/* 12px matches the quill size="sm" buttons this badge sits beside
+              in the task header (the app bumps Radix --font-size-1 to 13px). */}
+          <Text size="1" className="text-[12px]">
             {config.label}
             {prNumber && ` #${prNumber}`}
           </Text>
           {otherCount > 0 && (
             <Flex
               align="center"
+              gap="1"
               className={`border-l pl-2 ${COUNT_DIVIDER_CLASSES[config.color]}`}
             >
-              <Text size="1">{totalCount} PRs</Text>
+              <StackSimple size={11} weight="bold" />
+              <Text size="1" className="text-[12px]">
+                {totalCount}
+              </Text>
             </Flex>
           )}
         </Flex>

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -7,12 +7,8 @@ import {
   GitCommit,
   GitFork,
   GitPullRequest,
-  PushPin,
 } from "@phosphor-icons/react";
-import {
-  getPrVisualConfig,
-  parsePrNumber,
-} from "@posthog/core/git-interaction/prStatus";
+import { getPrVisualConfig } from "@posthog/core/git-interaction/prStatus";
 import { parseGithubUrl } from "@posthog/git/utils";
 import {
   ButtonGroup,
@@ -26,7 +22,6 @@ import type { PrActionType } from "@posthog/shared";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { Button, DropdownMenu, Flex, Spinner, Text } from "@radix-ui/themes";
 import { ChevronDown } from "lucide-react";
-import type { SyntheticEvent } from "react";
 import { Tooltip } from "../../../primitives/Tooltip";
 import { toast } from "../../../primitives/toast";
 import { useLocalRepoPath } from "../../workspace/useLocalRepoPath";
@@ -79,10 +74,7 @@ const NO_WORK_SLOTS = new Set<GitMenuActionId>([
  *
  * Trigger is the PR badge when a PR exists (click → GitHub), otherwise the
  * primary git action button (click → execute). Chevron opens the full action
- * list; when the task has several PRs (multi-repository tasks) the badge
- * carries a "+N" count and the menu lists every PR — click opens it on
- * GitHub, the pin swaps which one the badge shows. Cloud tasks without a PR
- * render nothing.
+ * list. Cloud tasks without a PR render nothing.
  */
 export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
   // Git state (skipped for cloud — useGitInteraction handles undefined repo).
@@ -131,8 +123,8 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
             merged={merged}
             draft={draft}
             branchName={headRefName}
-            prItems={buildPrMenuItems(
-              { url: pr.url, state: pr.state, merged, draft },
+            otherPrs={buildOtherPrItems(
+              pr.url,
               otherUrls,
               prSummaries,
               otherPrDetails,
@@ -141,7 +133,7 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
             gitItems={gitItems}
             onGitSelect={gitActions.openAction}
             onPrSelect={executePrAction}
-            onPinPr={setPrimaryPr}
+            onOtherPrSelect={setPrimaryPr}
           />
         ) : (
           <GitActionControl
@@ -234,55 +226,37 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
 
 // --- Trigger when a PR exists: colored badge link + combined dropdown ---
 
-interface PrMenuItem {
+interface OtherPrItem {
   url: string;
   label: string;
   summary: string | null;
   repoLabel: string | null;
   visual: ReturnType<typeof getPrVisualConfig> | null;
-  isPrimary: boolean;
 }
 
-interface PrimaryPrDetails {
-  url: string;
-  state: string;
-  merged: boolean;
-  draft: boolean;
-}
-
-/**
- * Every PR the task has, primary first. Repo labels only appear when the PRs
- * span more than one repo (multi-repository tasks) — for single-repo tasks
- * the number alone is unambiguous.
- */
-function buildPrMenuItems(
-  primary: PrimaryPrDetails,
+function buildOtherPrItems(
+  primaryUrl: string,
   otherUrls: string[],
   summaries: Record<string, string>,
   details: Record<string, PrStateDetails>,
-): PrMenuItem[] {
-  const urls = [primary.url, ...otherUrls];
-  const parsedByUrl = new Map(urls.map((url) => [url, parseGithubUrl(url)]));
-  const repoKeys = new Set(
-    urls.map((url) => {
-      const parsed = parsedByUrl.get(url);
-      return parsed ? `${parsed.owner}/${parsed.repo}`.toLowerCase() : url;
-    }),
-  );
-  const multiRepo = repoKeys.size > 1;
-  return urls.map((url) => {
-    const parsed = parsedByUrl.get(url);
-    const isPrimary = url === primary.url;
-    const detail = isPrimary ? primary : details[url];
+): OtherPrItem[] {
+  const primary = parseGithubUrl(primaryUrl);
+  return otherUrls.map((url) => {
+    const parsed = parseGithubUrl(url);
+    const sameRepo =
+      !!parsed &&
+      !!primary &&
+      parsed.owner.toLowerCase() === primary.owner.toLowerCase() &&
+      parsed.repo.toLowerCase() === primary.repo.toLowerCase();
+    const detail = details[url];
     return {
       url,
       label: parsed?.kind === "pr" ? `#${parsed.number}` : url,
       summary: summaries[url] ?? null,
-      repoLabel: multiRepo && parsed ? `${parsed.owner}/${parsed.repo}` : null,
+      repoLabel: parsed && !sameRepo ? `${parsed.owner}/${parsed.repo}` : null,
       visual: detail
         ? getPrVisualConfig(detail.state, detail.merged, detail.draft)
         : null,
-      isPrimary,
     };
   });
 }
@@ -293,12 +267,12 @@ interface PrBadgeControlProps {
   merged: boolean;
   draft: boolean;
   branchName: string | null;
-  prItems: PrMenuItem[];
+  otherPrs: OtherPrItem[];
   isPrPending: boolean;
   gitItems: GitMenuAction[];
   onGitSelect: (id: GitMenuActionId) => void;
   onPrSelect: (action: PrActionType) => void;
-  onPinPr: (url: string) => void;
+  onOtherPrSelect: (url: string) => void;
 }
 
 function PrBadgeControl({
@@ -307,21 +281,17 @@ function PrBadgeControl({
   merged,
   draft,
   branchName,
-  prItems,
+  otherPrs,
   isPrPending,
   gitItems,
   onGitSelect,
   onPrSelect,
-  onPinPr,
+  onOtherPrSelect,
 }: PrBadgeControlProps) {
   const config = getPrVisualConfig(prState, merged, draft);
   const lifecycleItems = config.actions;
-  const hasMultiplePrs = prItems.length > 1;
-  const mergedCount = prItems.filter(
-    (item) => item.visual?.label === "Merged",
-  ).length;
   const hasMenuItems = gitItems.length + lifecycleItems.length > 0;
-  const hasDropdown = hasMenuItems || !!branchName || hasMultiplePrs;
+  const hasDropdown = hasMenuItems || !!branchName || otherPrs.length > 0;
 
   const copyBranchName = async () => {
     if (!branchName) return;
@@ -342,7 +312,7 @@ function PrBadgeControl({
         draft={draft}
         isPrPending={isPrPending}
         attachedRight={hasDropdown}
-        otherCount={prItems.length - 1}
+        otherCount={otherPrs.length}
       />
       {hasDropdown && (
         <DropdownMenu.Root>
@@ -363,26 +333,7 @@ function PrBadgeControl({
               <ChevronDownIcon />
             </Button>
           </DropdownMenu.Trigger>
-          <DropdownMenu.Content
-            size="1"
-            align="end"
-            className="min-w-[240px] max-w-[320px]"
-          >
-            {hasMultiplePrs && (
-              <>
-                <DropdownMenu.Label>
-                  Pull requests
-                  {mergedCount > 0 &&
-                    ` · ${mergedCount} of ${prItems.length} merged`}
-                </DropdownMenu.Label>
-                {prItems.map((item) => (
-                  <PrMenuRow key={item.url} item={item} onPin={onPinPr} />
-                ))}
-              </>
-            )}
-            {hasMultiplePrs && gitItems.length > 0 && (
-              <DropdownMenu.Separator />
-            )}
+          <DropdownMenu.Content size="1" align="end">
             {gitItems.map((item) => (
               <GitDropdownItem
                 key={item.id}
@@ -391,14 +342,8 @@ function PrBadgeControl({
                 renderAs="radix"
               />
             ))}
-            {(gitItems.length > 0 || hasMultiplePrs) &&
-              lifecycleItems.length > 0 && <DropdownMenu.Separator />}
-            {/* With several PRs, scope the lifecycle actions to the badge's PR
-                so "Close PR" can't read as closing all of them. */}
-            {hasMultiplePrs && lifecycleItems.length > 0 && (
-              <DropdownMenu.Label>
-                {parsePrNumber(prUrl) ? `#${parsePrNumber(prUrl)}` : "This PR"}
-              </DropdownMenu.Label>
+            {gitItems.length > 0 && lifecycleItems.length > 0 && (
+              <DropdownMenu.Separator />
             )}
             {lifecycleItems.map((action) => (
               <DropdownMenu.Item
@@ -411,9 +356,49 @@ function PrBadgeControl({
                 </Flex>
               </DropdownMenu.Item>
             ))}
+            {otherPrs.length > 0 && (
+              <>
+                {hasMenuItems && <DropdownMenu.Separator />}
+                <DropdownMenu.Sub>
+                  <DropdownMenu.SubTrigger>
+                    <Flex align="center" gap="2">
+                      <GitPullRequest size={12} weight="bold" />
+                      <Text size="1">Other PRs</Text>
+                    </Flex>
+                  </DropdownMenu.SubTrigger>
+                  <DropdownMenu.SubContent>
+                    {otherPrs.map((otherPr) => (
+                      <DropdownMenu.Item
+                        key={otherPr.url}
+                        onSelect={() => onOtherPrSelect(otherPr.url)}
+                      >
+                        <Flex align="center" gap="2">
+                          <OtherPrStateIcon visual={otherPr.visual} />
+                          <Text size="1">
+                            {otherPr.label}
+                            {otherPr.summary && <Text> {otherPr.summary}</Text>}
+                            {otherPr.visual && (
+                              <Text color={otherPr.visual.color}>
+                                {" "}
+                                · {otherPr.visual.label}
+                              </Text>
+                            )}
+                            {otherPr.repoLabel && (
+                              <Text color="gray"> · {otherPr.repoLabel}</Text>
+                            )}
+                          </Text>
+                        </Flex>
+                      </DropdownMenu.Item>
+                    ))}
+                  </DropdownMenu.SubContent>
+                </DropdownMenu.Sub>
+              </>
+            )}
             {branchName && (
               <>
-                {(hasMenuItems || hasMultiplePrs) && <DropdownMenu.Separator />}
+                {(hasMenuItems || otherPrs.length > 0) && (
+                  <DropdownMenu.Separator />
+                )}
                 <DropdownMenu.Item onSelect={copyBranchName}>
                   <Flex align="center" gap="2">
                     <Copy size={12} weight="bold" />
@@ -429,83 +414,7 @@ function PrBadgeControl({
   );
 }
 
-/**
- * One PR in the dropdown's pull-request list, stack-navigator style: state
- * icon, number, repo, and a right-aligned state column so several rows scan
- * as a group. The whole row is a link (click → GitHub); the agent's PR
- * summary rides in the tooltip. The trailing pin swaps which PR the header
- * badge shows — filled on the primary row, revealed on hover elsewhere.
- */
-function PrMenuRow({
-  item,
-  onPin,
-}: {
-  item: PrMenuItem;
-  onPin: (url: string) => void;
-}) {
-  // Swallow the full pointer sequence so pinning neither follows the link
-  // nor lets the menu treat it as selecting the row.
-  const interceptPointer = (e: SyntheticEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-  };
-
-  return (
-    <DropdownMenu.Item asChild>
-      <a
-        href={item.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        title={item.summary ?? undefined}
-        className="group"
-      >
-        <Flex align="center" gap="2" className="min-w-0 flex-1">
-          <PrStateIcon visual={item.visual} />
-          <Text size="1" className="shrink-0">
-            {item.label}
-          </Text>
-          {item.repoLabel && (
-            <Text size="1" color="gray" className="min-w-0 truncate">
-              {item.repoLabel}
-            </Text>
-          )}
-          <Flex align="center" gap="2" className="ml-auto shrink-0 pl-3">
-            {item.visual && (
-              <Text size="1" color={item.visual.color}>
-                {item.visual.label}
-              </Text>
-            )}
-            {item.isPrimary ? (
-              <PushPin
-                size={12}
-                weight="fill"
-                className="shrink-0 text-(--gray-9)"
-                aria-label="Shown in the task header"
-              />
-            ) : (
-              <button
-                type="button"
-                title={`Show ${item.label} in the task header`}
-                aria-label={`Show ${item.label} in the task header`}
-                className="shrink-0 rounded p-0.5 text-(--gray-11) opacity-0 transition-opacity hover:bg-(--gray-a4) focus-visible:opacity-100 group-hover:opacity-100"
-                onPointerDown={interceptPointer}
-                onPointerUp={interceptPointer}
-                onClick={(e) => {
-                  interceptPointer(e);
-                  onPin(item.url);
-                }}
-              >
-                <PushPin size={12} />
-              </button>
-            )}
-          </Flex>
-        </Flex>
-      </a>
-    </DropdownMenu.Item>
-  );
-}
-
-function PrStateIcon({ visual }: { visual: PrMenuItem["visual"] }) {
+function OtherPrStateIcon({ visual }: { visual: OtherPrItem["visual"] }) {
   if (!visual) return <GitPullRequest size={12} weight="bold" />;
   const StateIcon = getPrVisualIcon(visual.icon);
   return (

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -363,7 +363,11 @@ function PrBadgeControl({
               <ChevronDownIcon />
             </Button>
           </DropdownMenu.Trigger>
-          <DropdownMenu.Content size="1" align="end" className="max-w-[320px]">
+          <DropdownMenu.Content
+            size="1"
+            align="end"
+            className="min-w-[240px] max-w-[320px]"
+          >
             {hasMultiplePrs && (
               <>
                 <DropdownMenu.Label>
@@ -426,9 +430,11 @@ function PrBadgeControl({
 }
 
 /**
- * One PR in the dropdown's pull-request list. The row is a link (click →
- * GitHub); the trailing pin swaps which PR the header badge shows. The
- * primary row wears a filled pin, others reveal theirs on hover.
+ * One PR in the dropdown's pull-request list, stack-navigator style: state
+ * icon, number, repo, and a right-aligned state column so several rows scan
+ * as a group. The whole row is a link (click → GitHub); the agent's PR
+ * summary rides in the tooltip. The trailing pin swaps which PR the header
+ * badge shows — filled on the primary row, revealed on hover elsewhere.
  */
 function PrMenuRow({
   item,
@@ -450,55 +456,49 @@ function PrMenuRow({
         href={item.url}
         target="_blank"
         rel="noopener noreferrer"
-        className="group h-auto py-1"
+        title={item.summary ?? undefined}
+        className="group"
       >
         <Flex align="center" gap="2" className="min-w-0 flex-1">
           <PrStateIcon visual={item.visual} />
-          <Flex direction="column" className="min-w-0 flex-1">
-            <Flex align="center" gap="1" className="min-w-0">
-              <Text size="1" weight="medium" className="shrink-0">
-                {item.label}
-              </Text>
-              {item.visual && (
-                <Text size="1" color={item.visual.color} className="shrink-0">
-                  {item.visual.label}
-                </Text>
-              )}
-              {item.repoLabel && (
-                <Text size="1" color="gray" className="truncate">
-                  {item.repoLabel}
-                </Text>
-              )}
-            </Flex>
-            {item.summary && (
-              <Text size="1" color="gray" className="truncate">
-                {item.summary}
+          <Text size="1" className="shrink-0">
+            {item.label}
+          </Text>
+          {item.repoLabel && (
+            <Text size="1" color="gray" className="min-w-0 truncate">
+              {item.repoLabel}
+            </Text>
+          )}
+          <Flex align="center" gap="2" className="ml-auto shrink-0 pl-3">
+            {item.visual && (
+              <Text size="1" color={item.visual.color}>
+                {item.visual.label}
               </Text>
             )}
+            {item.isPrimary ? (
+              <PushPin
+                size={12}
+                weight="fill"
+                className="shrink-0 text-(--gray-9)"
+                aria-label="Shown in the task header"
+              />
+            ) : (
+              <button
+                type="button"
+                title={`Show ${item.label} in the task header`}
+                aria-label={`Show ${item.label} in the task header`}
+                className="shrink-0 rounded p-0.5 text-(--gray-11) opacity-0 transition-opacity hover:bg-(--gray-a4) focus-visible:opacity-100 group-hover:opacity-100"
+                onPointerDown={interceptPointer}
+                onPointerUp={interceptPointer}
+                onClick={(e) => {
+                  interceptPointer(e);
+                  onPin(item.url);
+                }}
+              >
+                <PushPin size={12} />
+              </button>
+            )}
           </Flex>
-          {item.isPrimary ? (
-            <PushPin
-              size={12}
-              weight="fill"
-              className="shrink-0 text-(--gray-9)"
-              aria-label="Shown in the task header"
-            />
-          ) : (
-            <button
-              type="button"
-              title={`Show ${item.label} in the task header`}
-              aria-label={`Show ${item.label} in the task header`}
-              className="shrink-0 rounded p-0.5 text-(--gray-11) opacity-0 transition-opacity hover:bg-(--gray-a4) focus-visible:opacity-100 group-hover:opacity-100"
-              onPointerDown={interceptPointer}
-              onPointerUp={interceptPointer}
-              onClick={(e) => {
-                interceptPointer(e);
-                onPin(item.url);
-              }}
-            >
-              <PushPin size={12} />
-            </button>
-          )}
         </Flex>
       </a>
     </DropdownMenu.Item>

--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -7,8 +7,12 @@ import {
   GitCommit,
   GitFork,
   GitPullRequest,
+  PushPin,
 } from "@phosphor-icons/react";
-import { getPrVisualConfig } from "@posthog/core/git-interaction/prStatus";
+import {
+  getPrVisualConfig,
+  parsePrNumber,
+} from "@posthog/core/git-interaction/prStatus";
 import { parseGithubUrl } from "@posthog/git/utils";
 import {
   ButtonGroup,
@@ -22,6 +26,7 @@ import type { PrActionType } from "@posthog/shared";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { Button, DropdownMenu, Flex, Spinner, Text } from "@radix-ui/themes";
 import { ChevronDown } from "lucide-react";
+import type { SyntheticEvent } from "react";
 import { Tooltip } from "../../../primitives/Tooltip";
 import { toast } from "../../../primitives/toast";
 import { useLocalRepoPath } from "../../workspace/useLocalRepoPath";
@@ -74,7 +79,10 @@ const NO_WORK_SLOTS = new Set<GitMenuActionId>([
  *
  * Trigger is the PR badge when a PR exists (click → GitHub), otherwise the
  * primary git action button (click → execute). Chevron opens the full action
- * list. Cloud tasks without a PR render nothing.
+ * list; when the task has several PRs (multi-repository tasks) the badge
+ * carries a "+N" count and the menu lists every PR — click opens it on
+ * GitHub, the pin swaps which one the badge shows. Cloud tasks without a PR
+ * render nothing.
  */
 export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
   // Git state (skipped for cloud — useGitInteraction handles undefined repo).
@@ -123,8 +131,8 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
             merged={merged}
             draft={draft}
             branchName={headRefName}
-            otherPrs={buildOtherPrItems(
-              pr.url,
+            prItems={buildPrMenuItems(
+              { url: pr.url, state: pr.state, merged, draft },
               otherUrls,
               prSummaries,
               otherPrDetails,
@@ -133,7 +141,7 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
             gitItems={gitItems}
             onGitSelect={gitActions.openAction}
             onPrSelect={executePrAction}
-            onOtherPrSelect={setPrimaryPr}
+            onPinPr={setPrimaryPr}
           />
         ) : (
           <GitActionControl
@@ -226,37 +234,55 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
 
 // --- Trigger when a PR exists: colored badge link + combined dropdown ---
 
-interface OtherPrItem {
+interface PrMenuItem {
   url: string;
   label: string;
   summary: string | null;
   repoLabel: string | null;
   visual: ReturnType<typeof getPrVisualConfig> | null;
+  isPrimary: boolean;
 }
 
-function buildOtherPrItems(
-  primaryUrl: string,
+interface PrimaryPrDetails {
+  url: string;
+  state: string;
+  merged: boolean;
+  draft: boolean;
+}
+
+/**
+ * Every PR the task has, primary first. Repo labels only appear when the PRs
+ * span more than one repo (multi-repository tasks) — for single-repo tasks
+ * the number alone is unambiguous.
+ */
+function buildPrMenuItems(
+  primary: PrimaryPrDetails,
   otherUrls: string[],
   summaries: Record<string, string>,
   details: Record<string, PrStateDetails>,
-): OtherPrItem[] {
-  const primary = parseGithubUrl(primaryUrl);
-  return otherUrls.map((url) => {
-    const parsed = parseGithubUrl(url);
-    const sameRepo =
-      !!parsed &&
-      !!primary &&
-      parsed.owner.toLowerCase() === primary.owner.toLowerCase() &&
-      parsed.repo.toLowerCase() === primary.repo.toLowerCase();
-    const detail = details[url];
+): PrMenuItem[] {
+  const urls = [primary.url, ...otherUrls];
+  const parsedByUrl = new Map(urls.map((url) => [url, parseGithubUrl(url)]));
+  const repoKeys = new Set(
+    urls.map((url) => {
+      const parsed = parsedByUrl.get(url);
+      return parsed ? `${parsed.owner}/${parsed.repo}`.toLowerCase() : url;
+    }),
+  );
+  const multiRepo = repoKeys.size > 1;
+  return urls.map((url) => {
+    const parsed = parsedByUrl.get(url);
+    const isPrimary = url === primary.url;
+    const detail = isPrimary ? primary : details[url];
     return {
       url,
       label: parsed?.kind === "pr" ? `#${parsed.number}` : url,
       summary: summaries[url] ?? null,
-      repoLabel: parsed && !sameRepo ? `${parsed.owner}/${parsed.repo}` : null,
+      repoLabel: multiRepo && parsed ? `${parsed.owner}/${parsed.repo}` : null,
       visual: detail
         ? getPrVisualConfig(detail.state, detail.merged, detail.draft)
         : null,
+      isPrimary,
     };
   });
 }
@@ -267,12 +293,12 @@ interface PrBadgeControlProps {
   merged: boolean;
   draft: boolean;
   branchName: string | null;
-  otherPrs: OtherPrItem[];
+  prItems: PrMenuItem[];
   isPrPending: boolean;
   gitItems: GitMenuAction[];
   onGitSelect: (id: GitMenuActionId) => void;
   onPrSelect: (action: PrActionType) => void;
-  onOtherPrSelect: (url: string) => void;
+  onPinPr: (url: string) => void;
 }
 
 function PrBadgeControl({
@@ -281,17 +307,21 @@ function PrBadgeControl({
   merged,
   draft,
   branchName,
-  otherPrs,
+  prItems,
   isPrPending,
   gitItems,
   onGitSelect,
   onPrSelect,
-  onOtherPrSelect,
+  onPinPr,
 }: PrBadgeControlProps) {
   const config = getPrVisualConfig(prState, merged, draft);
   const lifecycleItems = config.actions;
+  const hasMultiplePrs = prItems.length > 1;
+  const mergedCount = prItems.filter(
+    (item) => item.visual?.label === "Merged",
+  ).length;
   const hasMenuItems = gitItems.length + lifecycleItems.length > 0;
-  const hasDropdown = hasMenuItems || !!branchName || otherPrs.length > 0;
+  const hasDropdown = hasMenuItems || !!branchName || hasMultiplePrs;
 
   const copyBranchName = async () => {
     if (!branchName) return;
@@ -312,6 +342,7 @@ function PrBadgeControl({
         draft={draft}
         isPrPending={isPrPending}
         attachedRight={hasDropdown}
+        otherCount={prItems.length - 1}
       />
       {hasDropdown && (
         <DropdownMenu.Root>
@@ -332,7 +363,22 @@ function PrBadgeControl({
               <ChevronDownIcon />
             </Button>
           </DropdownMenu.Trigger>
-          <DropdownMenu.Content size="1" align="end">
+          <DropdownMenu.Content size="1" align="end" className="max-w-[320px]">
+            {hasMultiplePrs && (
+              <>
+                <DropdownMenu.Label>
+                  Pull requests
+                  {mergedCount > 0 &&
+                    ` · ${mergedCount} of ${prItems.length} merged`}
+                </DropdownMenu.Label>
+                {prItems.map((item) => (
+                  <PrMenuRow key={item.url} item={item} onPin={onPinPr} />
+                ))}
+              </>
+            )}
+            {hasMultiplePrs && gitItems.length > 0 && (
+              <DropdownMenu.Separator />
+            )}
             {gitItems.map((item) => (
               <GitDropdownItem
                 key={item.id}
@@ -341,8 +387,14 @@ function PrBadgeControl({
                 renderAs="radix"
               />
             ))}
-            {gitItems.length > 0 && lifecycleItems.length > 0 && (
-              <DropdownMenu.Separator />
+            {(gitItems.length > 0 || hasMultiplePrs) &&
+              lifecycleItems.length > 0 && <DropdownMenu.Separator />}
+            {/* With several PRs, scope the lifecycle actions to the badge's PR
+                so "Close PR" can't read as closing all of them. */}
+            {hasMultiplePrs && lifecycleItems.length > 0 && (
+              <DropdownMenu.Label>
+                {parsePrNumber(prUrl) ? `#${parsePrNumber(prUrl)}` : "This PR"}
+              </DropdownMenu.Label>
             )}
             {lifecycleItems.map((action) => (
               <DropdownMenu.Item
@@ -355,49 +407,9 @@ function PrBadgeControl({
                 </Flex>
               </DropdownMenu.Item>
             ))}
-            {otherPrs.length > 0 && (
-              <>
-                {hasMenuItems && <DropdownMenu.Separator />}
-                <DropdownMenu.Sub>
-                  <DropdownMenu.SubTrigger>
-                    <Flex align="center" gap="2">
-                      <GitPullRequest size={12} weight="bold" />
-                      <Text size="1">Other PRs</Text>
-                    </Flex>
-                  </DropdownMenu.SubTrigger>
-                  <DropdownMenu.SubContent>
-                    {otherPrs.map((otherPr) => (
-                      <DropdownMenu.Item
-                        key={otherPr.url}
-                        onSelect={() => onOtherPrSelect(otherPr.url)}
-                      >
-                        <Flex align="center" gap="2">
-                          <OtherPrStateIcon visual={otherPr.visual} />
-                          <Text size="1">
-                            {otherPr.label}
-                            {otherPr.summary && <Text> {otherPr.summary}</Text>}
-                            {otherPr.visual && (
-                              <Text color={otherPr.visual.color}>
-                                {" "}
-                                · {otherPr.visual.label}
-                              </Text>
-                            )}
-                            {otherPr.repoLabel && (
-                              <Text color="gray"> · {otherPr.repoLabel}</Text>
-                            )}
-                          </Text>
-                        </Flex>
-                      </DropdownMenu.Item>
-                    ))}
-                  </DropdownMenu.SubContent>
-                </DropdownMenu.Sub>
-              </>
-            )}
             {branchName && (
               <>
-                {(hasMenuItems || otherPrs.length > 0) && (
-                  <DropdownMenu.Separator />
-                )}
+                {(hasMenuItems || hasMultiplePrs) && <DropdownMenu.Separator />}
                 <DropdownMenu.Item onSelect={copyBranchName}>
                   <Flex align="center" gap="2">
                     <Copy size={12} weight="bold" />
@@ -413,7 +425,87 @@ function PrBadgeControl({
   );
 }
 
-function OtherPrStateIcon({ visual }: { visual: OtherPrItem["visual"] }) {
+/**
+ * One PR in the dropdown's pull-request list. The row is a link (click →
+ * GitHub); the trailing pin swaps which PR the header badge shows. The
+ * primary row wears a filled pin, others reveal theirs on hover.
+ */
+function PrMenuRow({
+  item,
+  onPin,
+}: {
+  item: PrMenuItem;
+  onPin: (url: string) => void;
+}) {
+  // Swallow the full pointer sequence so pinning neither follows the link
+  // nor lets the menu treat it as selecting the row.
+  const interceptPointer = (e: SyntheticEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return (
+    <DropdownMenu.Item asChild>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group h-auto py-1"
+      >
+        <Flex align="center" gap="2" className="min-w-0 flex-1">
+          <PrStateIcon visual={item.visual} />
+          <Flex direction="column" className="min-w-0 flex-1">
+            <Flex align="center" gap="1" className="min-w-0">
+              <Text size="1" weight="medium" className="shrink-0">
+                {item.label}
+              </Text>
+              {item.visual && (
+                <Text size="1" color={item.visual.color} className="shrink-0">
+                  {item.visual.label}
+                </Text>
+              )}
+              {item.repoLabel && (
+                <Text size="1" color="gray" className="truncate">
+                  {item.repoLabel}
+                </Text>
+              )}
+            </Flex>
+            {item.summary && (
+              <Text size="1" color="gray" className="truncate">
+                {item.summary}
+              </Text>
+            )}
+          </Flex>
+          {item.isPrimary ? (
+            <PushPin
+              size={12}
+              weight="fill"
+              className="shrink-0 text-(--gray-9)"
+              aria-label="Shown in the task header"
+            />
+          ) : (
+            <button
+              type="button"
+              title={`Show ${item.label} in the task header`}
+              aria-label={`Show ${item.label} in the task header`}
+              className="shrink-0 rounded p-0.5 text-(--gray-11) opacity-0 transition-opacity hover:bg-(--gray-a4) focus-visible:opacity-100 group-hover:opacity-100"
+              onPointerDown={interceptPointer}
+              onPointerUp={interceptPointer}
+              onClick={(e) => {
+                interceptPointer(e);
+                onPin(item.url);
+              }}
+            >
+              <PushPin size={12} />
+            </button>
+          )}
+        </Flex>
+      </a>
+    </DropdownMenu.Item>
+  );
+}
+
+function PrStateIcon({ visual }: { visual: PrMenuItem["visual"] }) {
   if (!visual) return <GitPullRequest size={12} weight="bold" />;
   const StateIcon = getPrVisualIcon(visual.icon);
   return (

--- a/products/desktop/packages/workspace-server/src/services/handoff/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/handoff/service.ts
@@ -94,6 +94,7 @@ export class HandoffHostService implements HandoffHost {
       resumeState: {
         conversation: resumeState.conversation,
         latestGitCheckpoint: resumeState.latestGitCheckpoint,
+        latestGitCheckpoints: resumeState.latestGitCheckpoints,
       },
       cloudLogUrl: taskRun.log_url ?? null,
     };

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4105,6 +4105,10 @@ def create_task(team_id: int, user_id: int | None, *, validated_data: dict) -> c
     pending_user_message = (validated_data.pop("pending_user_message", None) or "").strip() or None
     pending_user_artifact_ids = validated_data.pop("pending_user_artifact_ids", None) or []
     warm_auto_publish = validated_data.pop("auto_publish", None)
+    channel = validated_data.get("channel")
+    if channel is not None and "repositories" not in validated_data and "repository" not in validated_data:
+        validated_data["repositories"] = channel.repositories
+        validated_data["github_integration"] = channel.github_integration
     if "repositories" in validated_data:
         repositories = validated_data["repositories"]
         validated_data["repository"] = repositories[0] if repositories else None
@@ -5357,6 +5361,8 @@ def _channel_to_dto(channel: Channel) -> contracts.ChannelDTO:
         id=channel.id,
         name=channel.name,
         channel_type=channel.channel_type,
+        github_integration=channel.github_integration_id,
+        repositories=channel.repositories,
         created_at=channel.created_at,
         created_by=_user_basic_info(channel.created_by if channel.created_by_id else None),
     )
@@ -5451,20 +5457,35 @@ def resolve_channel(team_id: int, user_id: int | None, *, name: str) -> contract
     return _channel_to_dto(channel)
 
 
-def rename_channel(channel_id: str | UUID, team_id: int, *, name: str) -> contracts.ChannelDTO | str:
-    """Rename a public channel. Returns the DTO, or an error kind: ``not_found`` /
-    ``invalid_name`` / ``personal`` / ``name_taken``."""
+def update_channel(
+    channel_id: str | UUID,
+    team_id: int,
+    *,
+    name: str | None = None,
+    github_integration: Integration | None = None,
+    repositories: list[str] | None = None,
+) -> contracts.ChannelDTO | str:
+    """Update a channel. Personal channels allow repository configuration but not renaming."""
     channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
     if channel is None:
         return "not_found"
-    if channel.channel_type == Channel.ChannelType.PERSONAL:
+    if channel.channel_type == Channel.ChannelType.PERSONAL and name is not None:
         return "personal"
-    normalized = normalize_channel_name(name)
-    if not normalized:
-        return "invalid_name"
-    channel.name = normalized
+    update_fields: list[str] = []
+    if name is not None:
+        normalized = normalize_channel_name(name)
+        if not normalized:
+            return "invalid_name"
+        channel.name = normalized
+        update_fields.append("name")
+    if repositories is not None:
+        channel.repositories = repositories
+        channel.github_integration = github_integration if repositories else None
+        update_fields.extend(["repositories", "github_integration"])
+    if not update_fields:
+        return _channel_to_dto(channel)
     try:
-        channel.save(update_fields=["name", "updated_at"])
+        channel.save(update_fields=[*update_fields, "updated_at"])
     except IntegrityError:
         return "name_taken"
     return _channel_to_dto(channel)

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -48,6 +48,9 @@ from products.tasks.backend.constants import (
     is_blocked_sandbox_env_key,
 )
 from products.tasks.backend.error_telemetry import truncate_error_message
+from products.tasks.backend.github_repository_access import (
+    inaccessible_repositories_via_integration as _inaccessible_repositories_via_integration,
+)
 from products.tasks.backend.logic.services.image_builder import (
     ensure_image_builder_task,
     is_custom_images_enabled,
@@ -4003,6 +4006,12 @@ def _tasks_to_dtos(tasks: Iterable[Task], team_id: int) -> list[contracts.TaskDe
 def list_tasks(team_id: int, user_id: int | None, *, filters: dict) -> list[contracts.TaskDetailDTO]:
     """All visible tasks for the team as DTOs, mirroring the task list view filters."""
     return _tasks_to_dtos(_list_tasks_queryset(team_id, user_id, filters=filters), team_id)
+
+
+def inaccessible_repositories_via_integration(
+    team_id: int, integration_id: int, repositories: list[str]
+) -> list[str]:
+    return _inaccessible_repositories_via_integration(team_id, integration_id, repositories)
 
 
 def list_task_repositories(team_id: int, user_id: int | None) -> list[str]:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -414,6 +414,7 @@ def _task_detail_to_dto(
         origin_product=task.origin_product,
         runtime=task.runtime,
         repository=task.repository,
+        repositories=task.repositories or ([task.repository] if task.repository else []),
         github_integration=task.github_integration_id,
         github_user_integration=task.github_user_integration_id,
         signal_report=task.signal_report_id,
@@ -1829,6 +1830,7 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
     {
         "github_credential_source",
         "pr_authorship_mode",
+        "repositories",
         "sandbox_id",
         "sandbox_cpu_cores",
         "sandbox_memory_gb",
@@ -4005,16 +4007,13 @@ def list_tasks(team_id: int, user_id: int | None, *, filters: dict) -> list[cont
 
 def list_task_repositories(team_id: int, user_id: int | None) -> list[str]:
     """Distinct repositories used by non-deleted, non-internal visible tasks for the team."""
-    repositories = (
+    tasks = (
         Task.objects.filter(team_id=team_id, deleted=False, internal=False)
         .filter(task_visibility_q(user_id))
-        .exclude(repository__isnull=True)
-        .exclude(repository__exact="")
-        .values_list("repository", flat=True)
-        .distinct()
-        .order_by("repository")
+        .values_list("repositories", "repository")
     )
-    return [repo for repo in repositories if repo is not None]
+    repositories = {repository for plural, legacy in tasks for repository in (plural or ([legacy] if legacy else []))}
+    return sorted(repositories)
 
 
 def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[contracts.TaskSummaryDTO]:
@@ -4098,6 +4097,11 @@ def create_task(team_id: int, user_id: int | None, *, validated_data: dict) -> c
     pending_user_message = (validated_data.pop("pending_user_message", None) or "").strip() or None
     pending_user_artifact_ids = validated_data.pop("pending_user_artifact_ids", None) or []
     warm_auto_publish = validated_data.pop("auto_publish", None)
+    if "repositories" in validated_data:
+        repositories = validated_data["repositories"]
+        validated_data["repository"] = repositories[0] if repositories else None
+    elif "repository" in validated_data:
+        validated_data["repositories"] = [validated_data["repository"]] if validated_data["repository"] else []
 
     if user_id is not None:
         validated_data["created_by"] = User.objects.get(id=user_id)
@@ -4272,6 +4276,11 @@ def update_task(
     validated_data.pop("signal_report_task_relationship", None)
     validated_data.pop("origin_product", None)
     validated_data.pop("branch", None)
+    if "repositories" in validated_data:
+        repositories = validated_data["repositories"]
+        validated_data["repository"] = repositories[0] if repositories else None
+    elif "repository" in validated_data:
+        validated_data["repositories"] = [validated_data["repository"]] if validated_data["repository"] else []
     if "title" in validated_data and "title_manually_set" not in validated_data:
         validated_data["title_manually_set"] = True
     if "archived" in validated_data and validated_data["archived"] != task.archived:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -28,7 +28,7 @@ from uuid import UUID, uuid4
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import IntegrityError, transaction
-from django.db.models import CharField, Count, Exists, F, Min, OuterRef, Q, QuerySet, Subquery
+from django.db.models import CharField, Count, Exists, F, Func, Min, OuterRef, Q, QuerySet, Subquery
 from django.db.models.fields.json import KeyTextTransform
 from django.utils import timezone as django_timezone
 
@@ -73,6 +73,7 @@ from products.tasks.backend.models import (
     TaskThreadMessage,
     TaskThreadMessageMention,
 )
+from products.tasks.backend.pr_urls import merge_pr_output
 from products.tasks.backend.prompts import build_wizard_pr_agent_prompt, generate_wizard_head_branch
 from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
 
@@ -2191,7 +2192,8 @@ def update_task_run(
                 existing_output = run.output if isinstance(run.output, dict) else {}
                 # Same attested-key policy as set_task_run_output — this PATCH surface is
                 # caller-controlled too, so it can't be a back door to output.pr_merged.
-                setattr(run, key, _apply_caller_output(existing_output, value, {**existing_output, **value}))
+                merged_output = merge_pr_output(existing_output, value)
+                setattr(run, key, _apply_caller_output(existing_output, value, merged_output))
                 update_fields.add(key)
                 continue
             if key == "state_remove_keys":
@@ -2305,9 +2307,7 @@ def set_task_run_output(
     # Preserve PR facts a webhook may have written concurrently: this assignment is wholesale,
     # so a bare `= output` would drop output.pr_url recorded out of band.
     existing = run.output if isinstance(run.output, dict) else {}
-    merged = {**output}
-    if not merged.get("pr_url") and existing.get("pr_url"):
-        merged["pr_url"] = existing["pr_url"]
+    merged = merge_pr_output(existing, output)
     run.output = _apply_caller_output(existing, output, merged)
     run.save(update_fields=["output", "updated_at"])
     if task.json_schema:
@@ -4007,13 +4007,21 @@ def list_tasks(team_id: int, user_id: int | None, *, filters: dict) -> list[cont
 
 def list_task_repositories(team_id: int, user_id: int | None) -> list[str]:
     """Distinct repositories used by non-deleted, non-internal visible tasks for the team."""
-    tasks = (
-        Task.objects.filter(team_id=team_id, deleted=False, internal=False)
-        .filter(task_visibility_q(user_id))
-        .values_list("repositories", "repository")
+    tasks = Task.objects.filter(team_id=team_id, deleted=False, internal=False).filter(task_visibility_q(user_id))
+    plural = (
+        tasks.exclude(repositories=[])
+        .annotate(repository_name=Func(F("repositories"), function="unnest", output_field=CharField()))
+        .values_list("repository_name", flat=True)
+        .distinct()
     )
-    repositories = {repository for plural, legacy in tasks for repository in (plural or ([legacy] if legacy else []))}
-    return sorted(repositories)
+    legacy = (
+        tasks.filter(repositories=[])
+        .exclude(repository__isnull=True)
+        .exclude(repository="")
+        .values_list("repository", flat=True)
+        .distinct()
+    )
+    return sorted(set(plural) | set(legacy))
 
 
 def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[contracts.TaskSummaryDTO]:
@@ -4110,6 +4118,7 @@ def create_task(team_id: int, user_id: int | None, *, validated_data: dict) -> c
         warm_branch_provided
         and validated_data["origin_product"] == Task.OriginProduct.USER_CREATED
         and validated_data.get("repository")
+        and len(validated_data.get("repositories", [])) <= 1
         and user_id is not None
     ):
         warm_run = _find_idling_warm_run(
@@ -4280,7 +4289,10 @@ def update_task(
         repositories = validated_data["repositories"]
         validated_data["repository"] = repositories[0] if repositories else None
     elif "repository" in validated_data:
-        validated_data["repositories"] = [validated_data["repository"]] if validated_data["repository"] else []
+        if len(task.repositories) <= 1:
+            validated_data["repositories"] = [validated_data["repository"]] if validated_data["repository"] else []
+        else:
+            validated_data.pop("repository")
     if "title" in validated_data and "title_manually_set" not in validated_data:
         validated_data["title_manually_set"] = True
     if "archived" in validated_data and validated_data["archived"] != task.archived:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4028,7 +4028,7 @@ def list_task_repositories(team_id: int, user_id: int | None) -> list[str]:
         .values_list("repository", flat=True)
         .distinct()
     )
-    return sorted(set(plural) | set(legacy))
+    return sorted(set(plural) | {repository for repository in legacy if repository})
 
 
 def get_task_summaries(team_id: int, user_id: int | None, *, ids: list) -> list[contracts.TaskSummaryDTO]:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5467,6 +5467,7 @@ def resolve_channel(team_id: int, user_id: int | None, *, name: str) -> contract
 def update_channel(
     channel_id: str | UUID,
     team_id: int,
+    user_id: int | None,
     *,
     name: str | None = None,
     github_integration: Integration | None = None,
@@ -5476,8 +5477,16 @@ def update_channel(
     channel = Channel.objects.filter(id=channel_id, team_id=team_id, deleted=False).first()
     if channel is None:
         return "not_found"
-    if channel.channel_type == Channel.ChannelType.PERSONAL and name is not None:
-        return "personal"
+    if channel.channel_type == Channel.ChannelType.PERSONAL:
+        # A personal channel is private to its owner. Hide it from every other
+        # member — same as the read path's _visible_channel — so a teammate who
+        # learns the id can't rewrite the owner's repository config and redirect
+        # their future tasks to different repositories.
+        if channel.created_by_id != user_id:
+            return "not_found"
+        # Renaming a personal channel stays disallowed, even for its owner.
+        if name is not None:
+            return "personal"
     update_fields: list[str] = []
     if name is not None:
         normalized = normalize_channel_name(name)

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4008,9 +4008,7 @@ def list_tasks(team_id: int, user_id: int | None, *, filters: dict) -> list[cont
     return _tasks_to_dtos(_list_tasks_queryset(team_id, user_id, filters=filters), team_id)
 
 
-def inaccessible_repositories_via_integration(
-    team_id: int, integration_id: int, repositories: list[str]
-) -> list[str]:
+def inaccessible_repositories_via_integration(team_id: int, integration_id: int, repositories: list[str]) -> list[str]:
     return _inaccessible_repositories_via_integration(team_id, integration_id, repositories)
 
 

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -152,6 +152,7 @@ class TaskDetailDTO:
     origin_product: str
     runtime: str
     repository: str | None
+    repositories: list[str]
     github_integration: int | None
     github_user_integration: UUID | None
     signal_report: UUID | None

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -176,6 +176,8 @@ class ChannelDTO:
     id: UUID
     name: str
     channel_type: str
+    github_integration: int | None
+    repositories: list[str]
     created_at: datetime
     created_by: "TaskUserBasicInfo | None" = None
 

--- a/products/tasks/backend/facade/loops.py
+++ b/products/tasks/backend/facade/loops.py
@@ -35,7 +35,7 @@ from pydantic.dataclasses import dataclass
 
 from posthog.models import User
 from posthog.models.file_system.file_system import FileSystem
-from posthog.models.integration import GitHubIntegration, Integration
+from posthog.models.integration import Integration
 from posthog.models.organization import OrganizationMembership
 from posthog.models.scoping import team_scope
 from posthog.models.team.team import Team
@@ -43,6 +43,7 @@ from posthog.rbac.user_access_control import AccessControlLevel, UserAccessContr
 
 from products.mcp_store.backend.facade.api import get_active_installations
 from products.tasks.backend import loop_service
+from products.tasks.backend.github_repository_access import inaccessible_repositories_via_integration
 from products.tasks.backend.logic.services import loop_runs
 from products.tasks.backend.loop_lifecycle import (
     pause_loops_for_deactivated_user,
@@ -646,20 +647,7 @@ def repository_accessible_via_integration(team_id: int, integration_id: int, ful
     accept only an exact match against the resulting list. A missing/invalidated cache is a normal
     state, so treating it as permissive would leave the cross-project boundary bypassable; if the
     list can't be resolved (refresh error, no snapshot) we reject rather than authorize."""
-    integration = Integration.objects.filter(team_id=team_id, kind="github", id=integration_id).first()
-    if integration is None:
-        return False
-    normalized = full_name.strip().lower()
-    try:
-        repositories = GitHubIntegration(integration).list_all_cached_repositories()
-    except Exception:
-        logger.warning(
-            "loop_repository_access_check_unavailable",
-            exc_info=True,
-            extra={"team_id": team_id, "integration_id": integration_id},
-        )
-        return False
-    return any(isinstance(repo, dict) and str(repo.get("full_name", "")).lower() == normalized for repo in repositories)
+    return not inaccessible_repositories_via_integration(team_id, integration_id, [full_name])
 
 
 def _desktop_node_exists(team_id: int, node_id: str, *, node_type: str) -> bool:

--- a/products/tasks/backend/github_repository_access.py
+++ b/products/tasks/backend/github_repository_access.py
@@ -1,0 +1,26 @@
+import logging
+from collections.abc import Iterable
+
+from posthog.models.integration import GitHubIntegration, Integration
+
+logger = logging.getLogger(__name__)
+
+
+def inaccessible_repositories_via_integration(
+    team_id: int, integration_id: int, full_names: Iterable[str]
+) -> list[str]:
+    names = list(full_names)
+    integration = Integration.objects.filter(team_id=team_id, kind="github", id=integration_id).first()
+    if integration is None:
+        return names
+    try:
+        repositories = GitHubIntegration(integration).list_all_cached_repositories()
+    except Exception:
+        logger.warning(
+            "github_repository_access_check_unavailable",
+            exc_info=True,
+            extra={"team_id": team_id, "integration_id": integration_id},
+        )
+        return names
+    accessible = {str(repo.get("full_name", "")).lower() for repo in repositories if isinstance(repo, dict)}
+    return [full_name for full_name in names if full_name.strip().lower() not in accessible]

--- a/products/tasks/backend/migrations/0078_task_repositories.py
+++ b/products/tasks/backend/migrations/0078_task_repositories.py
@@ -12,13 +12,10 @@ class Migration(migrations.Migration):
             field=ArrayField(
                 base_field=models.CharField(max_length=255),
                 default=list,
+                db_default=[],
                 blank=True,
                 size=None,
                 help_text="GitHub repositories available to this task",
             ),
-        ),
-        migrations.RunSQL(
-            "UPDATE tasks_task SET repositories = ARRAY[repository] WHERE repository IS NOT NULL AND repository <> ''",
-            migrations.RunSQL.noop,
         ),
     ]

--- a/products/tasks/backend/migrations/0078_task_repositories.py
+++ b/products/tasks/backend/migrations/0078_task_repositories.py
@@ -1,0 +1,24 @@
+from django.contrib.postgres.fields import ArrayField
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("tasks", "0077_taskartifact_export_asset_id")]
+
+    operations = [
+        migrations.AddField(
+            model_name="task",
+            name="repositories",
+            field=ArrayField(
+                base_field=models.CharField(max_length=255),
+                default=list,
+                blank=True,
+                size=None,
+                help_text="GitHub repositories available to this task",
+            ),
+        ),
+        migrations.RunSQL(
+            "UPDATE tasks_task SET repositories = ARRAY[repository] WHERE repository IS NOT NULL AND repository <> ''",
+            migrations.RunSQL.noop,
+        ),
+    ]

--- a/products/tasks/backend/migrations/0079_backfill_task_repositories.py
+++ b/products/tasks/backend/migrations/0079_backfill_task_repositories.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def backfill_task_repositories(apps, schema_editor):
+    while True:
+        with schema_editor.connection.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE posthog_task
+                SET repositories = ARRAY[repository]
+                WHERE id IN (
+                    SELECT id
+                    FROM posthog_task
+                    WHERE repositories = '{}' AND repository IS NOT NULL AND repository <> ''
+                    LIMIT 10000
+                )
+                """
+            )
+            if cursor.rowcount == 0:
+                return
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [("tasks", "0078_task_repositories")]
+
+    operations = [migrations.RunPython(backfill_task_repositories, migrations.RunPython.noop)]

--- a/products/tasks/backend/migrations/0080_channel_repository_configuration.py
+++ b/products/tasks/backend/migrations/0080_channel_repository_configuration.py
@@ -1,0 +1,37 @@
+import django.db.models.deletion
+from django.contrib.postgres.fields import ArrayField
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("posthog", "1280_alter_integration_kind"),
+        ("tasks", "0079_backfill_task_repositories"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="channel",
+            name="github_integration",
+            field=models.ForeignKey(
+                blank=True,
+                limit_choices_to={"kind": "github"},
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="posthog.integration",
+            ),
+        ),
+        migrations.AddField(
+            model_name="channel",
+            name="repositories",
+            field=ArrayField(
+                base_field=models.CharField(max_length=255),
+                blank=True,
+                db_default=[],
+                default=list,
+                help_text="GitHub repositories inherited by new tasks in this channel",
+                size=None,
+            ),
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0078_task_repositories
+0079_backfill_task_repositories

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0077_taskartifact_export_asset_id
+0078_task_repositories

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0079_backfill_task_repositories
+0080_channel_repository_configuration

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -189,6 +189,12 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
     repository = models.CharField(
         max_length=255, null=True, blank=True
     )  # Format is organization/repo, for example posthog/posthog-js
+    repositories = ArrayField(
+        models.CharField(max_length=255),
+        default=list,
+        blank=True,
+        help_text="GitHub repositories available to this task",
+    )
 
     # Channel this task was kicked off in. Legacy tasks (and tasks from non-channel
     # surfaces) stay NULL. SET_NULL so deleting a channel never deletes its tasks.
@@ -402,6 +408,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         state: dict = {} if self.runtime == Task.Runtime.PI else {"mode": mode}
         if extra_state:
             state.update({k: v for k, v in extra_state.items() if k != "mode"})
+        state.setdefault("repositories", self.repositories or ([self.repository] if self.repository else []))
         # Pin the stream-routing decision once so every reader/writer agrees for this run's life.
         if "use_dedicated_stream" not in state:
             distinct_id = (self.created_by.distinct_id if self.created_by else None) or f"team_{self.team_id}"

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -192,6 +192,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
     repositories = ArrayField(
         models.CharField(max_length=255),
         default=list,
+        db_default=[],
         blank=True,
         help_text="GitHub repositories available to this task",
     )
@@ -353,6 +354,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
                 "description": self.description[:500] if self.description else "",
                 "origin_product": self.origin_product,
                 "repository": self.repository,
+                "repositories": self.repositories or ([self.repository] if self.repository else []),
             }
             if properties:
                 all_properties.update(properties)
@@ -2045,6 +2047,9 @@ class TaskRun(models.Model):
                 "run_id": str(self.id),
                 "team_id": self.team_id,
                 "repository": self.task.repository,
+                "repositories": (self.state or {}).get("repositories")
+                or self.task.repositories
+                or ([self.task.repository] if self.task.repository else []),
                 "origin_product": self.task.origin_product,
                 "title": self.task.title,
                 "signal_report_id": str(self.task.signal_report_id) if self.task.signal_report_id else None,

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -89,6 +89,21 @@ class Channel(TeamScopedRootMixin):
     created_by = models.ForeignKey(
         "posthog.User", on_delete=models.SET_NULL, null=True, blank=True, related_name="+", db_constraint=False
     )
+    github_integration = models.ForeignKey(
+        "posthog.Integration",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="+",
+        limit_choices_to={"kind": "github"},
+    )
+    repositories = ArrayField(
+        models.CharField(max_length=255),
+        default=list,
+        db_default=[],
+        blank=True,
+        help_text="GitHub repositories inherited by new tasks in this channel",
+    )
     deleted = models.BooleanField(default=False)
     created_at = models.DateTimeField(default=django_timezone.now)
     updated_at = models.DateTimeField(auto_now=True)

--- a/products/tasks/backend/pr_urls.py
+++ b/products/tasks/backend/pr_urls.py
@@ -1,0 +1,19 @@
+def read_pr_urls(output: object) -> list[str]:
+    if not isinstance(output, dict):
+        return []
+
+    urls = output.get("pr_urls") if isinstance(output.get("pr_urls"), list) else []
+    pr_url = output.get("pr_url")
+    return list(dict.fromkeys(url for url in [*urls, pr_url] if isinstance(url, str) and url))
+
+
+def merge_pr_output(existing: object, incoming: dict) -> dict:
+    current = existing if isinstance(existing, dict) else {}
+    merged = {**current, **incoming}
+    urls = list(dict.fromkeys([*read_pr_urls(incoming), *read_pr_urls(current)]))
+    if not urls:
+        return merged
+
+    primary = incoming.get("pr_url") or current.get("pr_url") or urls[0]
+    ordered = [primary, *(url for url in urls if url != primary)]
+    return {**merged, "pr_url": primary, "pr_urls": ordered}

--- a/products/tasks/backend/pr_urls.py
+++ b/products/tasks/backend/pr_urls.py
@@ -2,9 +2,11 @@ def read_pr_urls(output: object) -> list[str]:
     if not isinstance(output, dict):
         return []
 
-    urls = output.get("pr_urls") if isinstance(output.get("pr_urls"), list) else []
+    raw_urls = output.get("pr_urls")
+    urls: list[object] = raw_urls if isinstance(raw_urls, list) else []
     pr_url = output.get("pr_url")
-    return list(dict.fromkeys(url for url in [*urls, pr_url] if isinstance(url, str) and url))
+    candidates = [*urls, pr_url]
+    return list(dict.fromkeys(url for url in candidates if isinstance(url, str) and url))
 
 
 def merge_pr_output(existing: object, incoming: dict) -> dict:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -54,7 +54,6 @@ from products.tasks.backend.facade.run_config import (
     TaskArtifactType,
     get_reasoning_effort_error,
 )
-from products.tasks.backend.github_repository_access import inaccessible_repositories_via_integration
 
 logger = logging.getLogger(__name__)
 
@@ -676,7 +675,7 @@ class TaskWriteSerializer(serializers.Serializer):
                 raise serializers.ValidationError({"github_integration": "Required when repositories are configured"})
         integration = attrs.get("github_integration") or getattr(self.instance, "github_integration", None)
         if repositories and integration:
-            inaccessible = inaccessible_repositories_via_integration(
+            inaccessible = tasks_facade.inaccessible_repositories_via_integration(
                 self.context["team"].id, integration.id, repositories
             )
             if inaccessible:
@@ -1509,7 +1508,7 @@ class ChannelUpdateSerializer(serializers.Serializer):
         if repositories and integration is None:
             raise serializers.ValidationError({"github_integration": "Required when repositories are configured"})
         if repositories and integration:
-            inaccessible = inaccessible_repositories_via_integration(
+            inaccessible = tasks_facade.inaccessible_repositories_via_integration(
                 self.context["team_id"], integration.id, repositories
             )
             if inaccessible:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -376,6 +376,7 @@ class TaskSerializer(DataclassSerializer):
             "origin_product",
             "runtime",
             "repository",
+            "repositories",
             "github_integration",
             "github_user_integration",
             "signal_report",
@@ -429,6 +430,12 @@ class TaskWriteSerializer(serializers.Serializer):
         allow_blank=True,
         allow_null=True,
         help_text="Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).",
+    )
+    repositories = serializers.ListField(
+        child=serializers.CharField(max_length=255),
+        required=False,
+        max_length=10,
+        help_text="GitHub repositories available to this task, each in `organization/repo` format.",
     )
     github_integration = serializers.PrimaryKeyRelatedField(  # nosemgrep: unscoped-primary-key-related-field
         queryset=Integration.objects.filter(kind="github"),
@@ -632,6 +639,12 @@ class TaskWriteSerializer(serializers.Serializer):
 
         return value.lower()
 
+    def validate_repositories(self, value: list[str]) -> list[str]:
+        repositories = [self.validate_repository(repository) for repository in value]
+        if len(set(repositories)) != len(repositories):
+            raise serializers.ValidationError("Repositories must be unique")
+        return repositories
+
     def validate_signal_report(self, value):
         if value and value.team_id != self.context["team"].id:
             raise serializers.ValidationError("Signal report must belong to the same team")
@@ -647,6 +660,29 @@ class TaskWriteSerializer(serializers.Serializer):
         return normalized
 
     def validate(self, attrs: dict) -> dict:
+        if "repository" in attrs and "repositories" in attrs:
+            legacy = attrs["repository"]
+            repositories = attrs["repositories"]
+            if legacy != (repositories[0] if repositories else None):
+                raise serializers.ValidationError({"repositories": "Conflicts with repository"})
+        if attrs.get("repositories") and attrs.get("github_integration") is None:
+            instance_integration = getattr(self.instance, "github_integration", None)
+            if instance_integration is None:
+                raise serializers.ValidationError({"github_integration": "Required when repositories are configured"})
+        repositories = attrs.get("repositories")
+        integration = attrs.get("github_integration") or getattr(self.instance, "github_integration", None)
+        if repositories and integration:
+            from products.tasks.backend.facade.loops import repository_accessible_via_integration
+
+            inaccessible = [
+                repository
+                for repository in repositories
+                if not repository_accessible_via_integration(self.context["team"].id, integration.id, repository)
+            ]
+            if inaccessible:
+                raise serializers.ValidationError(
+                    {"repositories": f"Not accessible via the selected GitHub integration: {', '.join(inaccessible)}"}
+                )
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -54,6 +54,7 @@ from products.tasks.backend.facade.run_config import (
     TaskArtifactType,
     get_reasoning_effort_error,
 )
+from products.tasks.backend.github_repository_access import inaccessible_repositories_via_integration
 
 logger = logging.getLogger(__name__)
 
@@ -661,24 +662,23 @@ class TaskWriteSerializer(serializers.Serializer):
 
     def validate(self, attrs: dict) -> dict:
         if "repository" in attrs and "repositories" in attrs:
-            legacy = attrs["repository"]
+            legacy = attrs["repository"] or None
             repositories = attrs["repositories"]
             if legacy != (repositories[0] if repositories else None):
                 raise serializers.ValidationError({"repositories": "Conflicts with repository"})
-        if attrs.get("repositories") and attrs.get("github_integration") is None:
+        repositories = attrs.get("repositories")
+        plural_repositories = repositories
+        if repositories is None and "repository" in attrs:
+            repositories = [attrs["repository"]] if attrs["repository"] else []
+        if plural_repositories and attrs.get("github_integration") is None:
             instance_integration = getattr(self.instance, "github_integration", None)
             if instance_integration is None:
                 raise serializers.ValidationError({"github_integration": "Required when repositories are configured"})
-        repositories = attrs.get("repositories")
         integration = attrs.get("github_integration") or getattr(self.instance, "github_integration", None)
         if repositories and integration:
-            from products.tasks.backend.facade.loops import repository_accessible_via_integration
-
-            inaccessible = [
-                repository
-                for repository in repositories
-                if not repository_accessible_via_integration(self.context["team"].id, integration.id, repository)
-            ]
+            inaccessible = inaccessible_repositories_via_integration(
+                self.context["team"].id, integration.id, repositories
+            )
             if inaccessible:
                 raise serializers.ValidationError(
                     {"repositories": f"Not accessible via the selected GitHub integration: {', '.join(inaccessible)}"}

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1450,7 +1450,15 @@ class ChannelSerializer(DataclassSerializer):
 
     class Meta:
         dataclass = ChannelDTO
-        fields = ["id", "name", "channel_type", "created_at", "created_by"]
+        fields = [
+            "id",
+            "name",
+            "channel_type",
+            "github_integration",
+            "repositories",
+            "created_at",
+            "created_by",
+        ]
 
 
 class ChannelWriteSerializer(serializers.Serializer):
@@ -1459,6 +1467,56 @@ class ChannelWriteSerializer(serializers.Serializer):
     name = serializers.CharField(
         max_length=128, help_text="Channel name, rendered as #<name>. Normalized to lowercase-dashed."
     )
+
+
+class ChannelUpdateSerializer(serializers.Serializer):
+    name = serializers.CharField(
+        max_length=128,
+        required=False,
+        help_text="Channel name, rendered as #<name>. Normalized to lowercase-dashed.",
+    )
+    github_integration = serializers.PrimaryKeyRelatedField(
+        queryset=Integration.objects.filter(kind="github"),
+        required=False,
+        allow_null=True,
+        help_text="Team GitHub integration used for repositories linked to this channel.",
+    )
+    repositories = serializers.ListField(
+        child=serializers.CharField(max_length=255),
+        required=False,
+        max_length=10,
+        help_text="GitHub repositories inherited by new tasks in this channel.",
+    )
+
+    def validate_github_integration(self, value):
+        if value is not None and value.team_id != self.context["team_id"]:
+            raise serializers.ValidationError("GitHub integration must belong to this project")
+        return value
+
+    def validate_repositories(self, value: list[str]) -> list[str]:
+        repositories = [TaskWriteSerializer().validate_repository(repository) for repository in value]
+        if len(set(repositories)) != len(repositories):
+            raise serializers.ValidationError("Repositories must be unique")
+        return repositories
+
+    def validate(self, attrs: dict) -> dict:
+        repositories = attrs.get("repositories")
+        integration = attrs.get("github_integration")
+        if repositories is None:
+            if "github_integration" in attrs:
+                raise serializers.ValidationError({"repositories": "Required when changing the GitHub integration"})
+            return attrs
+        if repositories and integration is None:
+            raise serializers.ValidationError({"github_integration": "Required when repositories are configured"})
+        if repositories and integration:
+            inaccessible = inaccessible_repositories_via_integration(
+                self.context["team_id"], integration.id, repositories
+            )
+            if inaccessible:
+                raise serializers.ValidationError(
+                    {"repositories": f"Not accessible via the selected GitHub integration: {', '.join(inaccessible)}"}
+                )
+        return attrs
 
 
 class TaskThreadMessageSerializer(DataclassSerializer):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1474,7 +1474,7 @@ class ChannelUpdateSerializer(serializers.Serializer):
         required=False,
         help_text="Channel name, rendered as #<name>. Normalized to lowercase-dashed.",
     )
-    github_integration = serializers.PrimaryKeyRelatedField(
+    github_integration = TeamScopedPrimaryKeyRelatedField(
         queryset=Integration.objects.filter(kind="github"),
         required=False,
         allow_null=True,

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -84,7 +84,7 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def partial_update(self, request, pk=None, **kwargs):
         serializer = ChannelUpdateSerializer(data=request.data, context={"team_id": self.team_id}, partial=True)
         serializer.is_valid(raise_exception=True)
-        result = tasks_facade.update_channel(pk, self.team_id, **serializer.validated_data)
+        result = tasks_facade.update_channel(pk, self.team_id, self._user_id(), **serializer.validated_data)
         if result == "not_found":
             raise NotFound()
         if result == "personal":

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -20,6 +20,7 @@ from products.tasks.backend.presentation.serializers import (
     ChannelFeedMessageSerializer,
     ChannelFeedMessageWriteSerializer,
     ChannelSerializer,
+    ChannelUpdateSerializer,
     ChannelWriteSerializer,
     TaskActivityMarkReadResponseSerializer,
     TaskActivityMarkReadSerializer,
@@ -76,14 +77,14 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         return Response(ChannelSerializer(channel).data)
 
     @extend_schema(
-        request=ChannelWriteSerializer,
+        request=ChannelUpdateSerializer,
         responses={200: ChannelSerializer},
         summary="Rename a public channel",
     )
     def partial_update(self, request, pk=None, **kwargs):
-        serializer = ChannelWriteSerializer(data=request.data)
+        serializer = ChannelUpdateSerializer(data=request.data, context={"team_id": self.team_id})
         serializer.is_valid(raise_exception=True)
-        result = tasks_facade.rename_channel(pk, self.team_id, name=serializer.validated_data["name"])
+        result = tasks_facade.update_channel(pk, self.team_id, **serializer.validated_data)
         if result == "not_found":
             raise NotFound()
         if result == "personal":

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -82,7 +82,7 @@ class ChannelViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         summary="Rename a public channel",
     )
     def partial_update(self, request, pk=None, **kwargs):
-        serializer = ChannelUpdateSerializer(data=request.data, context={"team_id": self.team_id})
+        serializer = ChannelUpdateSerializer(data=request.data, context={"team_id": self.team_id}, partial=True)
         serializer.is_valid(raise_exception=True)
         result = tasks_facade.update_channel(pk, self.team_id, **serializer.validated_data)
         if result == "not_found":

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1101,19 +1101,23 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
 
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
-            for repository in repositories_to_clone:
-                await workflow.execute_activity(
-                    clone_repository_in_sandbox,
-                    CloneRepositoryInSandboxInput(
-                        context=self.context,
-                        sandbox_id=created.sandbox_id,
-                        repository=repository,
-                        github_token=prepared.github_token,
-                        shallow_clone=prepared.shallow_clone,
-                    ),
-                    start_to_close_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(maximum_attempts=3),
+            await asyncio.gather(
+                *(
+                    workflow.execute_activity(
+                        clone_repository_in_sandbox,
+                        CloneRepositoryInSandboxInput(
+                            context=self.context,
+                            sandbox_id=created.sandbox_id,
+                            repository=repository,
+                            github_token=prepared.github_token,
+                            shallow_clone=prepared.shallow_clone,
+                        ),
+                        start_to_close_timeout=timedelta(minutes=5),
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                    )
+                    for repository in repositories_to_clone
                 )
+            )
             clone_label = "Cloned repository" if len(repositories_to_clone) == 1 else "Cloned repositories"
             await self._emit_progress("clone", "completed", clone_label, "setup")
 

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1125,6 +1125,8 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))
         if will_checkout and not is_resume:
+            assert checkout_repository is not None
+            assert prepared.branch is not None
             branch_label_active = f"Checking out branch {prepared.branch}"
             branch_label_done = f"Checked out branch {prepared.branch}"
             await self._emit_progress("checkout", "in_progress", branch_label_active, "setup")

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1095,24 +1095,27 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         can_clone_without_integration = is_public_sandbox_repo(prepared.repository)
         has_clone_credentials = self.context.has_github_credentials or can_clone_without_integration
 
-        will_clone = bool(prepared.repository and not used_snapshot and has_clone_credentials)
+        repositories_to_clone = [] if used_snapshot or not has_clone_credentials else self.context.repositories
+        will_clone = bool(repositories_to_clone)
         will_checkout = bool(prepared.repository and prepared.branch and has_clone_credentials)
 
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
-            await workflow.execute_activity(
-                clone_repository_in_sandbox,
-                CloneRepositoryInSandboxInput(
-                    context=self.context,
-                    sandbox_id=created.sandbox_id,
-                    repository=prepared.repository,
-                    github_token=prepared.github_token,
-                    shallow_clone=prepared.shallow_clone,
-                ),
-                start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=3),
-            )
-            await self._emit_progress("clone", "completed", "Cloned repository", "setup")
+            for repository in repositories_to_clone:
+                await workflow.execute_activity(
+                    clone_repository_in_sandbox,
+                    CloneRepositoryInSandboxInput(
+                        context=self.context,
+                        sandbox_id=created.sandbox_id,
+                        repository=repository,
+                        github_token=prepared.github_token,
+                        shallow_clone=prepared.shallow_clone,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=5),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+            clone_label = "Cloned repository" if len(repositories_to_clone) == 1 else "Cloned repositories"
+            await self._emit_progress("clone", "completed", clone_label, "setup")
 
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1097,7 +1097,8 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
 
         repositories_to_clone = [] if used_snapshot or not has_clone_credentials else self.context.repositories
         will_clone = bool(repositories_to_clone)
-        will_checkout = bool(prepared.repository and prepared.branch and has_clone_credentials)
+        checkout_repository = self.context.repositories[0] if len(self.context.repositories) == 1 else None
+        will_checkout = bool(checkout_repository and prepared.branch and has_clone_credentials)
 
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
@@ -1132,7 +1133,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 CheckoutBranchInSandboxInput(
                     context=self.context,
                     sandbox_id=created.sandbox_id,
-                    repository=prepared.repository,
+                    repository=checkout_repository,
                     branch=prepared.branch,
                     github_token=prepared.github_token,
                     shallow_clone=prepared.shallow_clone,

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -805,12 +805,15 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
                 "falling back to the environment or default base image",
             )
 
+    repositories = state.get("repositories")
+    run_repository = repositories[0] if isinstance(repositories, list) and repositories else task.repository
+
     log_with_activity_context(
         "Task processing context created",
         task_id=str(task.id),
         run_id=run_id,
         team_id=task.team_id,
-        repository=task.repository,
+        repository=run_repository,
         origin_product=task.origin_product,
         environment=task_run.environment,
         distinct_id=distinct_id,
@@ -972,7 +975,7 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         organization_id=str(task.team.organization_id),
         github_integration_id=task.github_integration_id,
         github_user_integration_id=user_github_integration_id,
-        repository=task.repository,
+        repository=run_repository,
         distinct_id=distinct_id,
         origin_product=task.origin_product,
         task_runtime=task.runtime,

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -126,6 +126,13 @@ class TaskProcessingContext:
         return self.github_integration_id is not None or self.github_user_integration_id is not None
 
     @property
+    def repositories(self) -> list[str]:
+        repositories = (self.state or {}).get("repositories")
+        if isinstance(repositories, list) and all(isinstance(repository, str) for repository in repositories):
+            return repositories
+        return [self.repository] if self.repository else []
+
+    @property
     def github_read_access(self) -> bool:
         """Repo-less run that asked for a read-only GitHub token (see Task.create_and_run)."""
         return (self.state or {}).get("github_read_access") is True

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -432,7 +432,7 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         "prepare_sandbox_for_repository",
         **ctx.to_log_context(),
     ):
-        has_repo = ctx.repository is not None
+        has_repo = bool(ctx.repositories)
         repository = ctx.repository
 
         snapshot = None
@@ -443,9 +443,8 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         # Repo-setup snapshots come from default-base sandboxes; restoring one would silently
         # drop the custom base image. Resume snapshots were taken from this task's own sandbox.
         if has_repo and ctx.github_integration_id is not None and not ctx.custom_image_name:
-            assert repository is not None
             with StepTimer("snapshot_lookup") as snapshot_lookup_timer:
-                snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(ctx.github_integration_id, [repository])
+                snapshot = SandboxSnapshot.get_latest_snapshot_with_repos(ctx.github_integration_id, ctx.repositories)
                 used_snapshot = snapshot is not None
                 snapshot_lookup_timer.set_used_snapshot(used_snapshot)
             if snapshot is not None:
@@ -464,8 +463,9 @@ def prepare_sandbox_for_repository(input: PrepareSandboxForRepositoryInput) -> P
         shallow_clone = task.origin_product != Task.OriginProduct.SIGNAL_REPORT
 
         actor_user = get_task_run_credential_user(task, ctx.state)
+        credential_repository = repository or (ctx.repositories[0] if ctx.repositories else None)
         github_token = _resolve_sandbox_github_token(
-            ctx, task=task, actor_user=actor_user, repository=repository, has_repo=has_repo
+            ctx, task=task, actor_user=actor_user, repository=credential_repository, has_repo=has_repo
         )
 
         try:

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -109,26 +109,26 @@ def _ensure_repository_on_disk(ctx: TaskProcessingContext, sandbox: SandboxBase)
     repeated 5-minute attempts surfacing as a misleading "Failed to start agent server". Check
     the directory upfront and fail non-retryably with the actual reason instead.
     """
-    if not ctx.repository:
+    if not ctx.repositories:
         return
-    repo_path = sandbox_repo_path(ctx.repository)
-    result = sandbox.execute(f"test -d {shlex.quote(repo_path)}", timeout_seconds=10)
-    if result.exit_code == 0:
-        return
-    raise SandboxMissingRepositoryError(
-        f"Repository {ctx.repository} is not present in the sandbox at {repo_path} — it was never "
-        "cloned (no snapshot restored and no usable GitHub credentials for this task)",
-        {
-            "task_id": ctx.task_id,
-            "run_id": ctx.run_id,
-            "sandbox_id": sandbox.id,
-            "repository": ctx.repository,
-            "repo_path": repo_path,
-            "github_integration_id": ctx.github_integration_id,
-            "github_user_integration_id": ctx.github_user_integration_id,
-        },
-        cause=RuntimeError(f"missing repository directory {repo_path}"),
-    )
+    for repository in ctx.repositories:
+        repo_path = sandbox_repo_path(repository)
+        result = sandbox.execute(f"test -d {shlex.quote(repo_path)}", timeout_seconds=10)
+        if result.exit_code != 0:
+            raise SandboxMissingRepositoryError(
+                f"Repository {repository} is not present in the sandbox at {repo_path} — it was never "
+                "cloned (no snapshot restored and no usable GitHub credentials for this task)",
+                {
+                    "task_id": ctx.task_id,
+                    "run_id": ctx.run_id,
+                    "sandbox_id": sandbox.id,
+                    "repository": repository,
+                    "repo_path": repo_path,
+                    "github_integration_id": ctx.github_integration_id,
+                    "github_user_integration_id": ctx.github_user_integration_id,
+                },
+                cause=RuntimeError(f"missing repository directory {repo_path}"),
+            )
 
 
 @dataclass
@@ -332,7 +332,7 @@ def _invoke_start_agent_server(
 ) -> None:
     try:
         sandbox.start_agent_server(
-            repository=ctx.repository,
+            repository=ctx.repository if len(ctx.repositories) <= 1 else None,
             task_id=ctx.task_id,
             run_id=ctx.run_id,
             mode=ctx.mode,

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_start_agent_server.py
@@ -111,6 +111,24 @@ def test_ensure_repository_on_disk_passes_when_repo_present(mocker) -> None:
     assert sandbox_repo_path("PostHog/posthog") in sandbox.execute.call_args.args[0]
 
 
+def test_ensure_every_repository_is_on_disk(mocker) -> None:
+    sandbox = mocker.Mock()
+    sandbox.execute.return_value = ExecutionResult(stdout="", stderr="", exit_code=0)
+
+    _ensure_repository_on_disk(
+        _context(
+            repository="PostHog/posthog",
+            state={"repositories": ["PostHog/posthog", "PostHog/posthog-js"]},
+        ),
+        sandbox,
+    )
+
+    assert [call.args[0] for call in sandbox.execute.call_args_list] == [
+        f"test -d {sandbox_repo_path('PostHog/posthog')}",
+        f"test -d {sandbox_repo_path('PostHog/posthog-js')}",
+    ]
+
+
 def test_ensure_repository_on_disk_fails_non_retryably_when_repo_missing(mocker) -> None:
     # Without this, a run whose repo was never cloned (no snapshot, no GitHub credentials) burns
     # repeated 5-minute health-check timeouts and fails with a misleading "Failed to start agent

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -1431,9 +1431,10 @@ class TestProcessTaskWorkflowUnit:
 
         monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
 
-        await workflow._get_sandbox_for_repository()
+        result = await workflow._get_sandbox_for_repository()
 
         assert cloned == ["posthog/posthog", "posthog/code"]
+        assert result.clone_ms is None
 
     @pytest.mark.parametrize(
         "custom_image_name, expected_image_source, expected_image_source_label",

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -1390,6 +1390,51 @@ class TestProcessTaskWorkflowUnit:
 
         assert inject_fresh_tokens_on_resume not in activity_calls
 
+    async def test_get_sandbox_for_repository_clones_every_repository(self, monkeypatch):
+        workflow = ProcessTaskWorkflow()
+        workflow._context = _build_context(
+            github_integration_id=123,
+            state={"repositories": ["posthog/posthog", "posthog/code"]},
+        )
+        prepared = PrepareSandboxForRepositoryOutput(
+            sandbox_name="sandbox-name",
+            repository="posthog/posthog",
+            github_token="ghs_token",
+            branch=None,
+            environment_variables={},
+            snapshot_id=None,
+            snapshot_external_id=None,
+            used_snapshot=False,
+            should_create_snapshot=True,
+            shallow_clone=True,
+            image_source="base_image",
+            image_source_label="published sandbox base image",
+        )
+        created = CreateSandboxForRepositoryOutput(
+            sandbox_id="sandbox-123",
+            sandbox_url="https://sandbox.example",
+            connect_token="connect-token",
+        )
+        cloned: list[str] = []
+
+        async def fake_execute_activity(activity_fn, *args, **kwargs):
+            if activity_fn is prepare_sandbox_for_repository:
+                return prepared
+            if activity_fn is create_sandbox_for_repository:
+                return created
+            if activity_fn is clone_repository_in_sandbox:
+                cloned.append(args[0].repository)
+                return None
+            if activity_fn is emit_progress_activity:
+                return None
+            raise AssertionError(f"Unexpected activity call: {activity_fn}")
+
+        monkeypatch.setattr(process_task_workflow_module.workflow, "execute_activity", fake_execute_activity)
+
+        await workflow._get_sandbox_for_repository()
+
+        assert cloned == ["posthog/posthog", "posthog/code"]
+
     @pytest.mark.parametrize(
         "custom_image_name, expected_image_source, expected_image_source_label",
         [

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1266,7 +1266,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
 
         repositories_to_clone = [] if used_snapshot or not has_clone_credentials else self.context.repositories
         will_clone = bool(repositories_to_clone)
-        will_checkout = bool(prepared.repository and prepared.branch and has_clone_credentials)
+        checkout_repository = self.context.repositories[0] if len(self.context.repositories) == 1 else None
+        will_checkout = bool(checkout_repository and prepared.branch and has_clone_credentials)
 
         overlap = bool(self.context.overlap_clone_boot_enabled and will_clone)
         boot_path = "overlap" if overlap else "classic"
@@ -1316,7 +1317,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 CheckoutBranchInSandboxInput(
                     context=self.context,
                     sandbox_id=created.sandbox_id,
-                    repository=prepared.repository,
+                    repository=checkout_repository,
                     branch=prepared.branch,
                     github_token=prepared.github_token,
                     shallow_clone=prepared.shallow_clone,

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1279,7 +1279,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         clone_ms: int | None = None
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
-            clone_ms = 0
+            clone_durations: list[int] = []
             for repository in repositories_to_clone:
                 clone_output = await workflow.execute_activity(
                     clone_repository_in_sandbox,
@@ -1293,7 +1293,9 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                     start_to_close_timeout=timedelta(minutes=5),
                     retry_policy=RetryPolicy(maximum_attempts=3),
                 )
-                clone_ms += getattr(clone_output, "clone_ms", 0) or 0
+                if (duration := getattr(clone_output, "clone_ms", None)) is not None:
+                    clone_durations.append(duration)
+            clone_ms = sum(clone_durations) if clone_durations else None
             clone_label = "Cloned repository" if len(repositories_to_clone) == 1 else "Cloned repositories"
             await self._emit_progress("clone", "completed", clone_label, "setup")
 

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1264,7 +1264,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         can_clone_without_integration = is_public_sandbox_repo(prepared.repository)
         has_clone_credentials = self.context.has_github_credentials or can_clone_without_integration
 
-        will_clone = bool(prepared.repository and not used_snapshot and has_clone_credentials)
+        repositories_to_clone = [] if used_snapshot or not has_clone_credentials else self.context.repositories
+        will_clone = bool(repositories_to_clone)
         will_checkout = bool(prepared.repository and prepared.branch and has_clone_credentials)
 
         overlap = bool(self.context.overlap_clone_boot_enabled and will_clone)
@@ -1278,21 +1279,23 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         clone_ms: int | None = None
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
-            clone_output = await workflow.execute_activity(
-                clone_repository_in_sandbox,
-                CloneRepositoryInSandboxInput(
-                    context=self.context,
-                    sandbox_id=created.sandbox_id,
-                    repository=prepared.repository,
-                    github_token=prepared.github_token,
-                    shallow_clone=prepared.shallow_clone,
-                ),
-                start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=RetryPolicy(maximum_attempts=3),
-            )
-            # Pre-rollout histories (and mocked tests) recorded a null result here.
-            clone_ms = getattr(clone_output, "clone_ms", None)
-            await self._emit_progress("clone", "completed", "Cloned repository", "setup")
+            clone_ms = 0
+            for repository in repositories_to_clone:
+                clone_output = await workflow.execute_activity(
+                    clone_repository_in_sandbox,
+                    CloneRepositoryInSandboxInput(
+                        context=self.context,
+                        sandbox_id=created.sandbox_id,
+                        repository=repository,
+                        github_token=prepared.github_token,
+                        shallow_clone=prepared.shallow_clone,
+                    ),
+                    start_to_close_timeout=timedelta(minutes=5),
+                    retry_policy=RetryPolicy(maximum_attempts=3),
+                )
+                clone_ms += getattr(clone_output, "clone_ms", 0) or 0
+            clone_label = "Cloned repository" if len(repositories_to_clone) == 1 else "Cloned repositories"
+            await self._emit_progress("clone", "completed", clone_label, "setup")
 
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1309,6 +1309,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))
         checkout_ms: int | None = None
         if will_checkout and not is_resume:
+            assert checkout_repository is not None
+            assert prepared.branch is not None
             branch_label_active = f"Checking out branch {prepared.branch}"
             branch_label_done = f"Checked out branch {prepared.branch}"
             await self._emit_progress("checkout", "in_progress", branch_label_active, "setup")

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1279,20 +1279,25 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         clone_ms: int | None = None
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
-            clone_durations: list[int] = []
-            for repository in repositories_to_clone:
-                clone_output = await workflow.execute_activity(
-                    clone_repository_in_sandbox,
-                    CloneRepositoryInSandboxInput(
-                        context=self.context,
-                        sandbox_id=created.sandbox_id,
-                        repository=repository,
-                        github_token=prepared.github_token,
-                        shallow_clone=prepared.shallow_clone,
-                    ),
-                    start_to_close_timeout=timedelta(minutes=5),
-                    retry_policy=RetryPolicy(maximum_attempts=3),
+            clone_outputs = await asyncio.gather(
+                *(
+                    workflow.execute_activity(
+                        clone_repository_in_sandbox,
+                        CloneRepositoryInSandboxInput(
+                            context=self.context,
+                            sandbox_id=created.sandbox_id,
+                            repository=repository,
+                            github_token=prepared.github_token,
+                            shallow_clone=prepared.shallow_clone,
+                        ),
+                        start_to_close_timeout=timedelta(minutes=5),
+                        retry_policy=RetryPolicy(maximum_attempts=3),
+                    )
+                    for repository in repositories_to_clone
                 )
+            )
+            clone_durations: list[int] = []
+            for clone_output in clone_outputs:
                 if (duration := getattr(clone_output, "clone_ms", None)) is not None:
                     clone_durations.append(duration)
             clone_ms = sum(clone_durations) if clone_durations else None

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1316,14 +1316,16 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(data["repositories"], ["posthog/posthog"])
         self.assertEqual(data["runtime"], Task.Runtime.ACP)
 
-    def test_create_task_with_multiple_repositories(self):
+    @patch("products.tasks.backend.facade.api._find_idling_warm_run")
+    def test_create_task_with_multiple_repositories(self, mock_find_warm_run):
+        mock_find_warm_run.return_value = None
         integration = Integration.objects.create(
             team=self.team,
             kind="github",
             integration_id="123",
             repository_cache=[
-                {"full_name": "posthog/posthog"},
-                {"full_name": "posthog/code"},
+                {"id": 1, "name": "posthog", "full_name": "posthog/posthog"},
+                {"id": 2, "name": "code", "full_name": "posthog/code"},
             ],
             repository_cache_updated_at=django_timezone.now(),
         )
@@ -1335,6 +1337,7 @@ class TestTaskAPI(BaseTaskAPITest):
                 "description": "Update both services",
                 "github_integration": integration.id,
                 "repositories": ["PostHog/PostHog", "PostHog/Code"],
+                "branch": "main",
             },
             format="json",
         )
@@ -1343,13 +1346,24 @@ class TestTaskAPI(BaseTaskAPITest):
         task = Task.objects.get(id=response.json()["id"])
         self.assertEqual(task.repositories, ["posthog/posthog", "posthog/code"])
         self.assertEqual(task.create_run().state["repositories"], task.repositories)
+        mock_find_warm_run.assert_not_called()
+
+        update = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/",
+            {"repository": "posthog/posthog"},
+            format="json",
+        )
+        self.assertEqual(update.status_code, status.HTTP_200_OK)
+        task.refresh_from_db()
+        self.assertEqual(task.repository, "posthog/posthog")
+        self.assertEqual(task.repositories, ["posthog/posthog", "posthog/code"])
 
     def test_create_task_rejects_repository_outside_integration(self):
         integration = Integration.objects.create(
             team=self.team,
             kind="github",
             integration_id="123",
-            repository_cache=[{"full_name": "posthog/posthog"}],
+            repository_cache=[{"id": 1, "name": "posthog", "full_name": "posthog/posthog"}],
             repository_cache_updated_at=django_timezone.now(),
         )
 
@@ -1363,6 +1377,17 @@ class TestTaskAPI(BaseTaskAPITest):
             format="json",
         )
 
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Invalid legacy task",
+                "github_integration": integration.id,
+                "repository": "posthog/code",
+            },
+            format="json",
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_task_with_pi_runtime(self):
@@ -5389,7 +5414,29 @@ class TestTaskRunAPI(BaseTaskAPITest):
             {
                 "head_branch": "posthog-code/update-readme",
                 "pr_url": "https://github.com/org/repo/pull/2",
+                "pr_urls": ["https://github.com/org/repo/pull/2"],
             },
+        )
+
+        response = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/",
+            {
+                "output": {
+                    "pr_url": "https://github.com/org/repo/pull/2",
+                    "pr_urls": [
+                        "https://github.com/org/repo/pull/2",
+                        "https://github.com/org/other/pull/3",
+                    ],
+                }
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        run.refresh_from_db()
+        self.assertEqual(
+            run.output["pr_urls"],
+            ["https://github.com/org/repo/pull/2", "https://github.com/org/other/pull/3"],
         )
 
     def test_partial_update_does_not_restore_stale_state(self):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1313,7 +1313,57 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(data["title"], "New Task")
         self.assertEqual(data["description"], "New Description")
         self.assertEqual(data["repository"], "posthog/posthog")
+        self.assertEqual(data["repositories"], ["posthog/posthog"])
         self.assertEqual(data["runtime"], Task.Runtime.ACP)
+
+    def test_create_task_with_multiple_repositories(self):
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="github",
+            integration_id="123",
+            repository_cache=[
+                {"full_name": "posthog/posthog"},
+                {"full_name": "posthog/code"},
+            ],
+            repository_cache_updated_at=django_timezone.now(),
+        )
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Cross-repo task",
+                "description": "Update both services",
+                "github_integration": integration.id,
+                "repositories": ["PostHog/PostHog", "PostHog/Code"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        task = Task.objects.get(id=response.json()["id"])
+        self.assertEqual(task.repositories, ["posthog/posthog", "posthog/code"])
+        self.assertEqual(task.create_run().state["repositories"], task.repositories)
+
+    def test_create_task_rejects_repository_outside_integration(self):
+        integration = Integration.objects.create(
+            team=self.team,
+            kind="github",
+            integration_id="123",
+            repository_cache=[{"full_name": "posthog/posthog"}],
+            repository_cache_updated_at=django_timezone.now(),
+        )
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Invalid task",
+                "github_integration": integration.id,
+                "repositories": ["posthog/code"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_task_with_pi_runtime(self):
         response = self.client.post(
@@ -3943,6 +3993,7 @@ class TestTaskRepositoriesAction(BaseTaskAPITest):
             description="",
             origin_product=Task.OriginProduct.USER_CREATED,
             repository="posthog/posthog",
+            repositories=["posthog/posthog", "posthog/code"],
         )
         # Duplicate of an existing repo should be collapsed.
         Task.objects.create(
@@ -3966,7 +4017,7 @@ class TestTaskRepositoriesAction(BaseTaskAPITest):
 
         self.assertEqual(
             response.json(),
-            {"repositories": ["posthog/posthog", "posthog/posthog-js"]},
+            {"repositories": ["posthog/code", "posthog/posthog", "posthog/posthog-js"]},
         )
 
     def test_excludes_soft_deleted_tasks(self):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -5409,6 +5409,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         run.refresh_from_db()
+        assert isinstance(run.output, dict)
         self.assertEqual(
             run.output,
             {

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from posthog.models import Organization, OrganizationMembership, Team, User
+from posthog.models import Integration, Organization, OrganizationMembership, Team, User
 
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.models import Channel, ChannelFeedMessage, Task, TaskActivity, TaskRun, TaskThreadMessage
@@ -97,6 +97,33 @@ class ChannelsAPITestCase(TestCase):
         other_client.force_authenticate(self.other_user)
         listed = other_client.get(self._tasks_url(), {"channel": channel_id}).json()["results"]
         self.assertEqual([t["id"] for t in listed], [created.json()["id"]])
+
+    @patch("posthog.models.integration.GitHubIntegration.list_all_cached_repositories")
+    def test_new_tasks_inherit_channel_repositories(self, list_repositories):
+        list_repositories.return_value = [
+            {"full_name": "posthog/posthog"},
+            {"full_name": "posthog/posthog-js"},
+        ]
+        integration = Integration.objects.create(team=self.team, kind="github", integration_id="1", config={})
+        channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
+        configured = self.client.patch(
+            f"{self._channels_url()}{channel_id}/",
+            {
+                "github_integration": integration.id,
+                "repositories": ["posthog/posthog", "posthog/posthog-js"],
+            },
+            format="json",
+        )
+        self.assertEqual(configured.status_code, status.HTTP_200_OK, configured.content)
+
+        created = self.client.post(
+            self._tasks_url(),
+            {"title": "Ship it", "description": "Do the thing", "channel": channel_id},
+        )
+
+        self.assertEqual(created.status_code, status.HTTP_201_CREATED, created.content)
+        self.assertEqual(created.json()["repositories"], ["posthog/posthog", "posthog/posthog-js"])
+        self.assertEqual(created.json()["github_integration"], integration.id)
 
     def test_public_channel_task_is_readable_but_not_controllable_by_teammates(self):
         channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -84,6 +84,36 @@ class ChannelsAPITestCase(TestCase):
         delete = self.client.delete(f"{self._channels_url()}{personal.id}/")
         self.assertEqual(delete.status_code, status.HTTP_403_FORBIDDEN)
 
+    @patch("posthog.models.integration.GitHubIntegration.list_all_cached_repositories")
+    def test_cannot_configure_someone_elses_personal_channel_repositories(self, list_repositories):
+        list_repositories.return_value = [{"full_name": "posthog/posthog"}]
+        integration = Integration.objects.create(team=self.team, kind="github", integration_id="1", config={})
+        # Listing provisions the requester's personal channel.
+        self.client.get(self._channels_url())
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+
+        # A teammate who learns the id must not be able to redirect the owner's
+        # tasks — the personal channel is invisible to them, so this reads as 404.
+        other_client = APIClient()
+        other_client.force_authenticate(self.other_user)
+        sneaky = other_client.patch(
+            f"{self._channels_url()}{personal.id}/",
+            {"github_integration": integration.id, "repositories": ["posthog/posthog"]},
+            format="json",
+        )
+        self.assertEqual(sneaky.status_code, status.HTTP_404_NOT_FOUND)
+        personal.refresh_from_db()
+        self.assertEqual(personal.repositories, [])
+
+        # The owner can still configure their own personal channel's repositories.
+        owned = self.client.patch(
+            f"{self._channels_url()}{personal.id}/",
+            {"github_integration": integration.id, "repositories": ["posthog/posthog"]},
+            format="json",
+        )
+        self.assertEqual(owned.status_code, status.HTTP_200_OK, owned.content)
+        self.assertEqual(owned.json()["repositories"], ["posthog/posthog"])
+
     def test_task_created_in_public_channel_is_team_visible(self):
         channel_id = self.client.post(self._channels_url(), {"name": "growth"}).json()["id"]
         created = self.client.post(

--- a/products/tasks/backend/tests/test_loops_api.py
+++ b/products/tasks/backend/tests/test_loops_api.py
@@ -972,7 +972,7 @@ class LoopGithubTriggerValidationAPITest(LoopsAPITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.integration = Integration.objects.create(team=self.team, kind="github", integration_id="1", config={})
-        mock_github = self._start_patch("products.tasks.backend.facade.loops.GitHubIntegration")
+        mock_github = self._start_patch("products.tasks.backend.github_repository_access.GitHubIntegration")
         mock_github.return_value.list_all_cached_repositories.return_value = [{"full_name": "acme/repo"}]
 
     def _github_trigger(self, events: list, filters: dict | None = None) -> dict:
@@ -1264,7 +1264,7 @@ class LoopInternalFacadeTest(LoopsAPITestCase):
                 },
             )
 
-    @patch("products.tasks.backend.facade.loops.GitHubIntegration")
+    @patch("products.tasks.backend.github_repository_access.GitHubIntegration")
     def test_repository_access_requires_an_exact_cache_match(self, mock_github):
         integration = Integration.objects.create(team=self.team, kind="github", integration_id="1", config={})
         mock_github.return_value.list_all_cached_repositories.return_value = [{"full_name": "acme/allowed"}]
@@ -1274,7 +1274,7 @@ class LoopInternalFacadeTest(LoopsAPITestCase):
         )
         self.assertFalse(loops_facade.repository_accessible_via_integration(self.team.id, integration.id, "acme/other"))
 
-    @patch("products.tasks.backend.facade.loops.GitHubIntegration")
+    @patch("products.tasks.backend.github_repository_access.GitHubIntegration")
     def test_repository_access_fails_closed_when_the_repo_list_is_unavailable(self, mock_github):
         # A cold or invalidated cache that can't be refreshed must reject, not authorize: otherwise a
         # member could point a loop at another project's private repo reachable by the shared install.

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -197,7 +197,16 @@ class TestGitHubPRWebhook(TestCase):
         self.assertEqual(response.status_code, 200)
 
         run.refresh_from_db()
-        self.assertEqual(run.output, {"pr_url": "https://github.com/posthog/posthog/pull/10"})
+        self.assertEqual(
+            run.output,
+            {
+                "pr_url": "https://github.com/posthog/posthog/pull/10",
+                "pr_urls": [
+                    "https://github.com/posthog/posthog/pull/10",
+                    "https://github.com/posthog/posthog/pull/11",
+                ],
+            },
+        )
 
     def _merged_pr_payload(self, pr_url: str) -> dict:
         return {
@@ -563,6 +572,10 @@ class TestGitHubPRWebhook(TestCase):
         run.refresh_from_db()
         assert run.output is not None
         self.assertEqual(run.output["pr_url"], existing)
+        self.assertEqual(
+            run.output["pr_urls"],
+            [existing, "https://github.com/posthog/posthog/pull/901"],
+        )
 
     @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
     def test_invalid_signature_rejected(self, mock_get_secret):
@@ -1020,6 +1033,21 @@ class TestFindTaskRun(TestCase):
         )
         result = find_task_run(branch="feature/my-branch", repository="posthog/posthog")
         self.assertEqual(result, task_run)
+
+    def test_finds_multi_repository_run_from_snapshot(self):
+        self.task.repositories = ["posthog/posthog", "posthog/code"]
+        self.task.save(update_fields=["repositories"])
+        task_run = self.task.create_run(branch="feature/my-branch")
+        task_run.output = {"pr_urls": ["https://github.com/posthog/code/pull/123"]}
+        task_run.save(update_fields=["output"])
+
+        self.assertEqual(
+            find_task_run(
+                pr_url="https://github.com/posthog/code/pull/123",
+                repository="posthog/code",
+            ),
+            task_run,
+        )
 
     def test_pr_url_takes_priority_over_branch(self):
         pr_run = TaskRun.objects.create(

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -167,6 +167,9 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
     branch = pull_request.get("head", {}).get("ref")
     repository_full_name = (payload.get("repository") or {}).get("full_name")
     task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name)
+    claimed_pr_urls = (
+        read_pr_urls(task_run.output if isinstance(task_run.output, dict) else {}) if task_run is not None else []
+    )
 
     logger.info(
         "github_pr_webhook_processed",
@@ -202,8 +205,7 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         # Only trust the merge for the run that actually claims this PR URL. The pr_url backstop
         # above already covers branch-matched internal PRs, so requiring equality here keeps a
         # same-branch webhook for a different PR from marking this run's PR as merged.
-        run_output = task_run.output if isinstance(task_run.output, dict) else {}
-        if run_output.get("pr_url") == pr_url:
+        if pr_url in claimed_pr_urls:
             _record_run_pr_merged(task_run)
         # Ungated on the pr_url match above: unlike the run-bookkeeping calls, this keys off
         # task_id (reports_for_task_filter), not output.pr_url, so the same-branch trust rule
@@ -214,8 +216,7 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
 
     if task_run and action == "closed" and not merged:
         # Same trust rule as the merge branch: only the run that claims this PR URL.
-        run_output = task_run.output if isinstance(task_run.output, dict) else {}
-        if run_output.get("pr_url") == pr_url:
+        if pr_url in claimed_pr_urls:
             _cancel_wizard_run_on_close(task_run)
         # Ungated for the same reason as the merge branch's resolve call: a closed-unmerged PR
         # archives (suppresses) its report so it leaves the inbox instead of lingering.

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -3,7 +3,7 @@ import uuid
 import hashlib
 
 from django.db import transaction
-from django.db.models import Case, IntegerField, Value, When
+from django.db.models import Case, IntegerField, Q, Value, When
 from django.http import HttpResponse
 
 import structlog
@@ -18,6 +18,7 @@ from products.signals.backend.models import InvalidStatusTransition, SignalRepor
 from products.tasks.backend.facade.api import post_pr_created_thread_update, signal_workflow_completion
 from products.tasks.backend.facade.cancellation import cancel_task_run
 from products.tasks.backend.models import TaskRun
+from products.tasks.backend.pr_urls import merge_pr_output, read_pr_urls
 from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX
 
 logger = structlog.get_logger(__name__)
@@ -25,6 +26,14 @@ logger = structlog.get_logger(__name__)
 TASK_RUN_SELECT_RELATED = ("task", "task__created_by", "team")
 
 _TERMINAL_RUN_STATUSES = (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED)
+
+
+def _run_repository_filter(repository: str) -> Q:
+    normalized = repository.strip().lower()
+    return Q(state__repositories__contains=[normalized]) | Q(
+        state__repositories__isnull=True,
+        task__repository__iexact=normalized,
+    )
 
 
 def find_task_run(
@@ -39,9 +48,9 @@ def find_task_run(
         # original and its live resume can both claim the same PR URL. Scope to the
         # webhook's repo and prefer non-terminal runs so merge handling lands on the
         # run that can still act on it.
-        runs = TaskRun.objects.filter(output__pr_url=pr_url)
+        runs = TaskRun.objects.filter(Q(output__pr_url=pr_url) | Q(output__pr_urls__contains=[pr_url]))
         if repository:
-            runs = runs.filter(task__repository__iexact=repository)
+            runs = runs.filter(_run_repository_filter(repository))
         # Declared type keeps mypy happy: the annotated queryset yields an AnnotatedWith
         # variant that must not leak into the plain-queryset legs below.
         task_run: TaskRun | None = (
@@ -68,8 +77,8 @@ def find_task_run(
         # otherwise claim the run before the dedicated leg below is consulted.
         task_run = (
             TaskRun.objects.filter(
+                _run_repository_filter(repository),
                 branch=branch,
-                task__repository__iexact=repository,
                 state__wizard_head_branch__isnull=True,
             )
             .select_related(*TASK_RUN_SELECT_RELATED)
@@ -85,8 +94,8 @@ def find_task_run(
         if branch.startswith(WIZARD_HEAD_BRANCH_PREFIX):
             task_run = (
                 TaskRun.objects.filter(
+                    _run_repository_filter(repository),
                     state__wizard_head_branch=branch,
-                    task__repository__iexact=repository,
                     task__deleted=False,
                 )
                 .exclude(status__in=_TERMINAL_RUN_STATUSES)
@@ -226,8 +235,8 @@ def _record_run_pr_url(task_run: TaskRun, pr_url: str) -> None:
     ``output.pr_url`` stays empty, so inbox notifications, the CI follow-up loop,
     and later webhook lookups never resolve the PR.
     """
-    recorded = _record_run_output_field(task_run, "pr_url", pr_url, "github_pr_webhook_record_pr_url_failed")
-    if not recorded and not TaskRun.objects.filter(id=task_run.id, output__pr_url=pr_url).exists():
+    recorded = _append_run_pr_url(task_run, pr_url)
+    if not recorded and pr_url not in read_pr_urls(task_run.output):
         return
     post_pr_created_thread_update(task_run, pr_url)
     if not recorded:
@@ -244,6 +253,24 @@ def _record_run_pr_url(task_run: TaskRun, pr_url: str) -> None:
         task_run.publish_stream_state_event()
     except Exception:
         logger.warning("github_pr_webhook_pr_events_failed", run_id=str(task_run.id), exc_info=True)
+
+
+def _append_run_pr_url(task_run: TaskRun, pr_url: str) -> bool:
+    if pr_url in read_pr_urls(task_run.output):
+        return False
+    try:
+        with transaction.atomic():
+            locked = TaskRun.objects.select_for_update().get(id=task_run.id)
+            if pr_url in read_pr_urls(locked.output):
+                task_run.output = locked.output
+                return False
+            locked.output = merge_pr_output(locked.output, {"pr_urls": [pr_url]})
+            locked.save(update_fields=["output", "updated_at"])
+        task_run.output = locked.output
+        return True
+    except Exception:
+        logger.warning("github_pr_webhook_record_pr_url_failed", run_id=str(task_run.id), exc_info=True)
+        return False
 
 
 def _record_run_pr_merged(task_run: TaskRun) -> None:

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1128,6 +1128,9 @@ export interface ChannelDTOApi {
     id: string
     name: string
     channel_type: string
+    /** @nullable */
+    github_integration: number | null
+    repositories: string[]
     created_at: string
     created_by?: TaskUserBasicInfoApi | null
 }
@@ -1203,15 +1206,23 @@ export interface ChannelFeedMessageWriteApi {
     created_at?: string
 }
 
-/**
- * Request body for creating (resolve-or-create) or renaming a public channel.
- */
-export interface PatchedChannelWriteApi {
+export interface PatchedChannelUpdateApi {
     /**
      * Channel name, rendered as #<name>. Normalized to lowercase-dashed.
      * @maxLength 128
      */
     name?: string
+    /**
+     * Team GitHub integration used for repositories linked to this channel.
+     * @nullable
+     */
+    github_integration?: number | null
+    /**
+     * GitHub repositories inherited by new tasks in this channel.
+     * @maxItems 10
+     * @items.maxLength 255
+     */
+    repositories?: string[]
 }
 
 /**

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1411,6 +1411,7 @@ export interface TaskDetailDTOApi {
     readonly runtime: RuntimeEnumApi
     /** @nullable */
     repository: string | null
+    repositories: string[]
     /** @nullable */
     github_integration: number | null
     /** @nullable */
@@ -1532,6 +1533,12 @@ export interface TaskCreateApi {
      * @nullable
      */
     repository?: string | null
+    /**
+     * GitHub repositories available to this task, each in `organization/repo` format.
+     * @maxItems 10
+     * @items.maxLength 255
+     */
+    repositories?: string[]
     /**
      * GitHub integration for this task.
      * @nullable
@@ -1670,6 +1677,12 @@ export interface TaskWriteApi {
      */
     repository?: string | null
     /**
+     * GitHub repositories available to this task, each in `organization/repo` format.
+     * @maxItems 10
+     * @items.maxLength 255
+     */
+    repositories?: string[]
+    /**
      * GitHub integration for this task.
      * @nullable
      */
@@ -1791,6 +1804,12 @@ export interface PatchedTaskWriteApi {
      * @nullable
      */
     repository?: string | null
+    /**
+     * GitHub repositories available to this task, each in `organization/repo` format.
+     * @maxItems 10
+     * @items.maxLength 255
+     */
+    repositories?: string[]
     /**
      * GitHub integration for this task.
      * @nullable

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -38,7 +38,7 @@ import type {
     PaginatedTaskRunDetailDTOListApi,
     PaginatedTaskSummaryDTOListApi,
     PaginatedTaskThreadMessageDTOListApi,
-    PatchedChannelWriteApi,
+    PatchedChannelUpdateApi,
     PatchedLoopWriteApi,
     PatchedSandboxCustomImageUpdateApi,
     PatchedSandboxEnvironmentWriteApi,
@@ -934,14 +934,14 @@ export const getTaskChannelsPartialUpdateUrl = (projectId: string, id: string) =
 export const taskChannelsPartialUpdate = async (
     projectId: string,
     id: string,
-    patchedChannelWriteApi?: PatchedChannelWriteApi,
+    patchedChannelUpdateApi?: PatchedChannelUpdateApi,
     options?: RequestInit
 ): Promise<ChannelDTOApi> => {
     return apiMutator<ChannelDTOApi>(getTaskChannelsPartialUpdateUrl(projectId, id), {
         ...options,
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(patchedChannelWriteApi),
+        body: JSON.stringify(patchedChannelUpdateApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1064,6 +1064,10 @@ export const tasksCreateBodyTitleMax = 255
 
 export const tasksCreateBodyRepositoryMax = 255
 
+export const tasksCreateBodyRepositoriesItemMax = 255
+
+export const tasksCreateBodyRepositoriesMax = 10
+
 export const tasksCreateBodySignalReportTaskRelationshipMax = 200
 
 export const tasksCreateBodyBranchMax = 255
@@ -1118,6 +1122,11 @@ export const TasksCreateBody = /* @__PURE__ */ zod
             .max(tasksCreateBodyRepositoryMax)
             .nullish()
             .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
+        repositories: zod
+            .array(zod.string().max(tasksCreateBodyRepositoriesItemMax))
+            .max(tasksCreateBodyRepositoriesMax)
+            .optional()
+            .describe('GitHub repositories available to this task, each in `organization\/repo` format.'),
         github_integration: zod.number().nullish().describe('GitHub integration for this task.'),
         github_user_integration: zod
             .uuid()
@@ -1219,6 +1228,10 @@ export const tasksUpdateBodyTitleMax = 255
 
 export const tasksUpdateBodyRepositoryMax = 255
 
+export const tasksUpdateBodyRepositoriesItemMax = 255
+
+export const tasksUpdateBodyRepositoriesMax = 10
+
 export const tasksUpdateBodySignalReportTaskRelationshipMax = 200
 
 export const tasksUpdateBodyBranchMax = 255
@@ -1273,6 +1286,11 @@ export const TasksUpdateBody = /* @__PURE__ */ zod
             .max(tasksUpdateBodyRepositoryMax)
             .nullish()
             .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
+        repositories: zod
+            .array(zod.string().max(tasksUpdateBodyRepositoriesItemMax))
+            .max(tasksUpdateBodyRepositoriesMax)
+            .optional()
+            .describe('GitHub repositories available to this task, each in `organization\/repo` format.'),
         github_integration: zod.number().nullish().describe('GitHub integration for this task.'),
         github_user_integration: zod
             .uuid()
@@ -1359,6 +1377,10 @@ export const tasksPartialUpdateBodyTitleMax = 255
 
 export const tasksPartialUpdateBodyRepositoryMax = 255
 
+export const tasksPartialUpdateBodyRepositoriesItemMax = 255
+
+export const tasksPartialUpdateBodyRepositoriesMax = 10
+
 export const tasksPartialUpdateBodySignalReportTaskRelationshipMax = 200
 
 export const tasksPartialUpdateBodyBranchMax = 255
@@ -1413,6 +1435,11 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
             .max(tasksPartialUpdateBodyRepositoryMax)
             .nullish()
             .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
+        repositories: zod
+            .array(zod.string().max(tasksPartialUpdateBodyRepositoriesItemMax))
+            .max(tasksPartialUpdateBodyRepositoriesMax)
+            .optional()
+            .describe('GitHub repositories available to this task, each in `organization\/repo` format.'),
         github_integration: zod.number().nullish().describe('GitHub integration for this task.'),
         github_user_integration: zod
             .uuid()

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1047,15 +1047,26 @@ export const TaskChannelsFeedCreateBody = /* @__PURE__ */ zod
  */
 export const taskChannelsPartialUpdateBodyNameMax = 128
 
-export const TaskChannelsPartialUpdateBody = /* @__PURE__ */ zod
-    .object({
-        name: zod
-            .string()
-            .max(taskChannelsPartialUpdateBodyNameMax)
-            .optional()
-            .describe('Channel name, rendered as #<name>. Normalized to lowercase-dashed.'),
-    })
-    .describe('Request body for creating (resolve-or-create) or renaming a public channel.')
+export const taskChannelsPartialUpdateBodyRepositoriesItemMax = 255
+
+export const taskChannelsPartialUpdateBodyRepositoriesMax = 10
+
+export const TaskChannelsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .max(taskChannelsPartialUpdateBodyNameMax)
+        .optional()
+        .describe('Channel name, rendered as #<name>. Normalized to lowercase-dashed.'),
+    github_integration: zod
+        .number()
+        .nullish()
+        .describe('Team GitHub integration used for repositories linked to this channel.'),
+    repositories: zod
+        .array(zod.string().max(taskChannelsPartialUpdateBodyRepositoriesItemMax))
+        .max(taskChannelsPartialUpdateBodyRepositoriesMax)
+        .optional()
+        .describe('GitHub repositories inherited by new tasks in this channel.'),
+})
 
 /**
  * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13518,6 +13518,9 @@ export namespace Schemas {
       id: string;
       name: string;
       channel_type: string;
+      /** @nullable */
+      github_integration: number | null;
+      repositories: string[];
       created_at: string;
       created_by?: TaskUserBasicInfo | null;
     }
@@ -49342,15 +49345,23 @@ export namespace Schemas {
       expected_current_version_id?: string | null;
     }
 
-    /**
-     * Request body for creating (resolve-or-create) or renaming a public channel.
-     */
-    export interface PatchedChannelWrite {
+    export interface PatchedChannelUpdate {
       /**
          * Channel name, rendered as #<name>. Normalized to lowercase-dashed.
          * @maxLength 128
          */
       name?: string;
+      /**
+         * Team GitHub integration used for repositories linked to this channel.
+         * @nullable
+         */
+      github_integration?: number | null;
+      /**
+         * GitHub repositories inherited by new tasks in this channel.
+         * @maxItems 10
+         * @items.maxLength 255
+         */
+      repositories?: string[];
     }
 
     export interface PatchedClusteringJob {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -47472,6 +47472,7 @@ export namespace Schemas {
       readonly runtime: RuntimeEnum;
       /** @nullable */
       repository: string | null;
+      repositories: string[];
       /** @nullable */
       github_integration: number | null;
       /** @nullable */
@@ -55615,6 +55616,12 @@ export namespace Schemas {
          * @nullable
          */
       repository?: string | null;
+      /**
+         * GitHub repositories available to this task, each in `organization/repo` format.
+         * @maxItems 10
+         * @items.maxLength 255
+         */
+      repositories?: string[];
       /**
          * GitHub integration for this task.
          * @nullable
@@ -70409,6 +70416,12 @@ export namespace Schemas {
          */
       repository?: string | null;
       /**
+         * GitHub repositories available to this task, each in `organization/repo` format.
+         * @maxItems 10
+         * @items.maxLength 255
+         */
+      repositories?: string[];
+      /**
          * GitHub integration for this task.
          * @nullable
          */
@@ -71489,6 +71502,12 @@ export namespace Schemas {
          * @nullable
          */
       repository?: string | null;
+      /**
+         * GitHub repositories available to this task, each in `organization/repo` format.
+         * @maxItems 10
+         * @items.maxLength 255
+         */
+      repositories?: string[];
       /**
          * GitHub integration for this task.
          * @nullable

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -818,6 +818,10 @@ export const tasksCreateBodyTitleMax = 255
 
 export const tasksCreateBodyRepositoryMax = 255
 
+export const tasksCreateBodyRepositoriesItemMax = 255
+
+export const tasksCreateBodyRepositoriesMax = 10
+
 export const tasksCreateBodySignalReportTaskRelationshipMax = 200
 
 export const tasksCreateBodyBranchMax = 255
@@ -872,6 +876,11 @@ export const TasksCreateBody = /* @__PURE__ */ zod
             .max(tasksCreateBodyRepositoryMax)
             .nullish()
             .describe('Target GitHub repository in `organization\/repo` format (e.g. `posthog\/posthog-js`).'),
+        repositories: zod
+            .array(zod.string().max(tasksCreateBodyRepositoriesItemMax))
+            .max(tasksCreateBodyRepositoriesMax)
+            .optional()
+            .describe('GitHub repositories available to this task, each in `organization\/repo` format.'),
         github_integration: zod.number().nullish().describe('GitHub integration for this task.'),
         github_user_integration: zod
             .string()

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -332,6 +332,7 @@ const loopsRunsRetrieve = (): ToolBase<typeof LoopsRunsRetrieveSchema, WithPostH
 const TasksCreateSchema = TasksCreateBody.omit({
     title_manually_set: true,
     origin_product: true,
+    repositories: true,
     github_integration: true,
     github_user_integration: true,
     signal_report: true,


### PR DESCRIPTION
## Problem

Spaces need a reusable GitHub repository set so every new task starts with the complete cross-repository workspace.

**Why:** Repository setup belongs to the Space context and should carry through cloud execution, PR discovery, and local handoff without introducing another environment abstraction.

## Changes

https://github.com/user-attachments/assets/b869fc0f-a90d-41f9-928b-cc74932ccd54


- configure one GitHub integration and multiple repositories from the existing Space Context screen
- inherit and snapshot that configuration for new tasks, then clone and expose every repository to the cloud agent
- preserve multi-repository PR bookkeeping and transfer every repository's git state during local handoff

## How did you test this code?

- 59 channel/API tests, 85 webhook tests, and 14 sandbox-start tests
- 25 Desktop handoff tests, 25 resume tests, and focused multi-repository prompt coverage
- Desktop package typechecks and production Electron compile
- Ruff, generated OpenAPI contracts, migration dry-run/SQL, and repository preflight checks

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The generated Tasks API schemas include the Space and Task repository fields. No separate published documentation currently describes this internal execution contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The implementation reuses the existing channel API, GitHub repository picker, integration access checks, run snapshots, sandbox clone paths, PR URL aggregation, additional directories, and git handoff checkpoints.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
