### PR TITLE
fix(data-imports): don't abort CDC extraction on a heartbeat send timeout

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -602,7 +602,7 @@ class CDCExtractActivity:
             if schema is None:
                 continue
 
-            activity.heartbeat()
+            self._safe_heartbeat()
 
             # raw_table has one row per source change event (before SCD2/dedup fan-out).
             events_extracted += raw_table.num_rows
@@ -991,6 +991,17 @@ class CDCExtractActivity:
     # ------------------------------------------------------------------
     # WAL read loop with periodic micro-batch flushes
     # ------------------------------------------------------------------
+    def _safe_heartbeat(self, *details: typing.Any) -> None:
+        """Heartbeat is a best-effort liveness signal, not a required step. The SDK relays a
+        sync activity's heartbeat through the worker's event loop with its own short internal
+        timeout, and a transient miss there must never abort an otherwise-healthy multi-hour
+        WAL read.
+        """
+        try:
+            activity.heartbeat(*details)
+        except Exception:
+            self.log.debug("cdc_heartbeat_failed", exc_info=True)
+
     def _make_read_heartbeat(self) -> Callable[[], None]:
         """Throttled ``activity.heartbeat`` for ``read_changes``' per-row callback.
 
@@ -1004,7 +1015,7 @@ class CDCExtractActivity:
             nonlocal last_heartbeat
             now = time.monotonic()
             if now - last_heartbeat >= CDC_READ_HEARTBEAT_INTERVAL_SECONDS:
-                activity.heartbeat()
+                self._safe_heartbeat()
                 last_heartbeat = now
 
         return heartbeat
@@ -1029,7 +1040,7 @@ class CDCExtractActivity:
         limit = CDC_MAX_CHANGES_PER_READ
         while True:
             for event in self.reader.read_changes(upto_nchanges=limit, on_row=on_row):
-                activity.heartbeat()
+                self._safe_heartbeat()
 
                 # Resolve to the schema's stored `name` so downstream keying lines up. Log
                 # unmatched drops: a silent drop here is how a name mismatch starves a table.
@@ -1133,7 +1144,7 @@ class CDCExtractActivity:
             self._confirm_position(commit_lsn)
             self.last_confirmed_lsn = commit_lsn
             self.last_end_lsn = commit_lsn
-            activity.heartbeat()
+            self._safe_heartbeat()
             return True
         return False
 

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -2874,6 +2874,52 @@ class TestCDCBoundedReadLoop:
         assert reader.upto_nchanges_calls == [CDC_MAX_CHANGES_PER_READ, CDC_MAX_CHANGES_PER_READ * 2]
         assert reader.confirmed_positions == ["0/300"]  # nothing to advance on pass 1; pass 2 drains
 
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.PostgresProducer")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.S3BatchWriter")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataJob")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_heartbeat_timeout_does_not_abort_the_read_loop(
+        self,
+        mock_close_conns,
+        MockJob,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        MockS3Writer,
+        MockProducer,
+        mock_activity,
+    ):
+        # The Temporal SDK relays a sync activity's heartbeat through the worker's event loop
+        # with its own short internal timeout, which can trip transiently under load. That must
+        # never fail an otherwise-healthy extraction.
+        source = _make_source()
+        schema = _make_schema("users", cdc_mode="streaming", source=source)
+        schema.sync_type_config["primary_key_columns"] = ["id"]
+        events = [_make_event(op="I", table="users", position="0/100")]
+        _setup_mocks(
+            mock_activity,
+            MockProducer,
+            MockS3Writer,
+            mock_get_adapter,
+            mock_get_schemas,
+            MockSourceModel,
+            MockJob,
+            mock_close_conns,
+            source,
+            [schema],
+            events,
+        )
+        mock_activity.heartbeat.side_effect = TimeoutError()
+
+        cdc_extract_activity(CDCExtractInput(team_id=1, source_id=source.id))
+
+        assert mock_activity.heartbeat.called
+        assert schema.status == "Completed"
+
 
 @pytest.mark.django_db
 class TestReconcileOrphanedPriorJobs:


### PR DESCRIPTION
## Problem

Error tracking flagged a `TimeoutError` surfacing from `posthog/temporal/common/posthog_client.py` (the Temporal interceptor that reports activity failures), originating in the CDC extraction activity's WAL read loop (`_drain_and_advance_page`, `_read_wal_loop`).

The Temporal Python SDK relays a sync activity's `activity.heartbeat()` call through the worker's asyncio event loop, waiting up to 10 seconds internally for it to be scheduled. Under worker load that round trip can transiently miss, and `activity.heartbeat()` raises a plain `TimeoutError` straight out of the SDK — nothing is actually wrong with the sync itself.

The CDC WAL read loop calls `activity.heartbeat()` directly at several points (per event, per micro-batch flush, per page drain) without guarding against this. A single missed heartbeat therefore crashed the entire extraction activity and got reported to error tracking, even though it's a transient liveness-signal hiccup, not a real failure.

## Changes

Added `CDCExtractActivity._safe_heartbeat`, which wraps `activity.heartbeat()` in a try/except and logs on failure instead of propagating. Swapped the four direct `activity.heartbeat()` calls in the extraction path (`_process_flush`, `_make_read_heartbeat`, `_read_wal_loop`, `_drain_and_advance_page`) to use it.

This mirrors the "best-effort, must never break the extraction run" pattern already used elsewhere in this file (e.g. `_reconcile_orphaned_prior_jobs`) and in `HeartbeaterSync`/`LivenessHeartbeater` for other Temporal activities in this codebase.

## How did you test this code?

Added `TestCDCBoundedReadLoop::test_heartbeat_timeout_does_not_abort_the_read_loop`, which makes the mocked `activity.heartbeat()` raise `TimeoutError` mid-loop and asserts the schema still finishes `Completed`. Verified this test fails (reproducing the exact traceback and `cdc_extract_failed` log seen in error tracking) against the pre-fix code, and passes with the fix.

Ran the full `test_extract_activity.py` suite (71 passed; one unrelated pre-existing failure needs a live Postgres connection this sandbox doesn't have). Ran `ruff check`/`ruff format --check` and `mypy` on the changed file — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error tracking issue for a `TimeoutError` in the data-imports pipeline.
- Skills invoked: `/triaging-error-issues`, `/writing-tests`.
- Traced the stack trace through `temporalio`'s own source to confirm the timeout originates in the SDK's `asyncio.run_coroutine_threadsafe(...).result(10)` heartbeat relay, not in application logic — then found the existing `_safe_heartbeat`-style defensive pattern already used elsewhere in this file and codebase, and applied it consistently to the CDC read loop's heartbeat call sites.
- Searched open PRs and the maintainer's own PR queue for a duplicate fix; found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*