### PR TITLE
fix(tasks): keep local package overlays mount-only

### DIFF
--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -426,9 +426,10 @@ def _attach_local_package_mounts(
         )
         image = image.run_commands(install_command)
 
-    bin_link_commands = _local_package_bin_link_commands(packages)
-    if bin_link_commands:
-        image = image.run_commands(*bin_link_commands)
+    if install_dependencies:
+        bin_link_commands = _local_package_bin_link_commands(packages)
+        if bin_link_commands:
+            image = image.run_commands(*bin_link_commands)
 
     for package in packages:
         image = image.add_local_dir(

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -387,7 +387,12 @@ class TestAttachLocalPackageMounts:
         build_output_path = source_path / "dist"
         build_output_path.mkdir(parents=True)
         (source_path / "package.json").write_text(
-            json.dumps({"dependencies": {"@openai/codex": "0.140.0", "zod": "^4.2.0"}})
+            json.dumps(
+                {
+                    "bin": {"agent-server": "./dist/server/bin.js"},
+                    "dependencies": {"@openai/codex": "0.140.0", "zod": "^4.2.0"},
+                }
+            )
         )
         package = LocalPackage(
             name="agent",


### PR DESCRIPTION
## Problem

Mount-only local package overlays must not modify an existing Modal image. A package that declares a binary was still adding an image `run_commands` layer, so filesystem snapshot sandboxes rejected the overlay and local cloud tasks could fall back to an older agent build.

## Changes

Only create executable-link image layers when dependency installation is enabled. Mount-only overlays now remain mount-only even when the overlaid package declares a binary.
