### PR TITLE
fix(etsy): form encode token refresh requests

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/etsy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/etsy.py
@@ -87,7 +87,7 @@ class EtsyClient:
     def _mint_token(self) -> str:
         response = self._session.post(
             ETSY_TOKEN_URL,
-            json={
+            data={
                 "grant_type": "refresh_token",
                 "client_id": self._api_key,
                 "refresh_token": self._refresh_token,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/tests/test_etsy.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/etsy/tests/test_etsy.py
@@ -62,6 +62,7 @@ class _FakeSession:
     def __init__(self, get_responses: list[Response], post_responses: Optional[list[Response]] = None) -> None:
         self.get_calls: list[tuple[str, dict[str, Any], dict[str, str]]] = []
         self.post_bodies: list[dict[str, Any]] = []
+        self.post_form_bodies: list[dict[str, Any]] = []
         self._get_responses = list(get_responses)
         self._post_responses = list(post_responses) if post_responses is not None else [_token()]
 
@@ -77,8 +78,15 @@ class _FakeSession:
             raise AssertionError(f"unexpected extra GET: {url} {params}")
         return self._get_responses.pop(0)
 
-    def post(self, url: str, json: Optional[dict[str, Any]] = None, timeout: Optional[float] = None) -> Response:  # noqa: A002 — matches requests' keyword name
+    def post(
+        self,
+        url: str,
+        json: Optional[dict[str, Any]] = None,
+        data: Optional[dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Response:  # noqa: A002 — matches requests' keyword names
         self.post_bodies.append(dict(json or {}))
+        self.post_form_bodies.append(dict(data or {}))
         if not self._post_responses:
             raise AssertionError("unexpected extra token request")
         return self._post_responses.pop(0)
@@ -131,13 +139,14 @@ def _collect(
 
 
 class TestEtsyTransport:
-    def test_token_is_minted_from_the_refresh_token_and_reused(self) -> None:
+    def test_token_refresh_is_form_encoded_and_reused(self) -> None:
         session = _FakeSession([_page(_rows(1), 1)])
         _collect(session, "shop_sections")
 
-        assert session.post_bodies == [
+        assert session.post_form_bodies == [
             {"grant_type": "refresh_token", "client_id": _API_KEY, "refresh_token": _REFRESH_TOKEN}
         ]
+        assert session.post_bodies == [{}]
         assert session.get_calls[0][2]["Authorization"] == "Bearer token-1"
 
     def test_secrets_are_redacted_and_api_key_header_is_set(self) -> None:


### PR DESCRIPTION
## Problem

Etsy token refresh requests were serialized as JSON, while the OAuth token endpoint expects form-encoded parameters. This prevented valid refresh credentials from minting an access token.

Closes #76014

## Changes

- Send the OAuth refresh grant payload with `data=` so the request uses form encoding.
- Extend the transport fake and regression to distinguish form data from JSON bodies.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/etsy/tests/test_etsy.py -q` – 59 passed. The updated transport regression proves the token refresh fields are passed as form data and no JSON body is sent.
- `ruff check` on the changed Etsy source and test files.
- Repository pre-commit hooks: Python lint, formatting, and `ty check`.

No manual Etsy-account verification was run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex assisted with the focused protocol fix and regression. Tools used: Codex agent, local pytest, Ruff, repository hooks, and GitHub CLI. Skills invoked: none. The change intentionally stays limited to request encoding; broader error-message behavior was not changed.

The contributor account cannot set a PR assignee in this repository, so the requested DRI assignment could not be applied.