### PR TITLE
feat(retention): slo-track the sync and emit per-team change events

### DIFF
--- a/posthog/slo/types.py
+++ b/posthog/slo/types.py
@@ -18,6 +18,7 @@ class SloOperation(StrEnum):
     QUERY_SERVICE = "query_service"
     DASHBOARD_WIDGET_DELIVERY = "dashboard_widget_delivery"
     PULSE_BRIEF_GENERATION = "pulse-brief-generation"
+    SYNC_EVENTS_RETENTION = "sync_events_retention"
 
 
 class SloOutcome(StrEnum):

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -20,6 +20,7 @@ from temporalio.client import (
     ScheduleSpec,
 )
 
+from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.ai.checkpoint_compaction.schedule import (
     create_checkpoint_compaction_schedule,
     should_register_checkpoint_compaction_schedule,
@@ -383,7 +384,16 @@ async def create_sync_events_retention_schedule(client: Client):
     sync_events_retention_schedule = Schedule(
         action=ScheduleActionStartWorkflow(
             "sync-events-retention",
-            SyncEventsRetentionInput(dry_run=False),
+            SyncEventsRetentionInput(
+                dry_run=False,
+                slo=SloConfig(
+                    operation=SloOperation.SYNC_EVENTS_RETENTION,
+                    area=SloArea.ANALYTIC_PLATFORM,
+                    team_id=0,
+                    resource_id="sync-events-retention",
+                    distinct_id="sync-events-retention",
+                ),
+            ),
             id="sync-events-retention-schedule",
             task_queue=settings.GENERAL_PURPOSE_TASK_QUEUE,
             retry_policy=common.RetryPolicy(

--- a/posthog/temporal/sync_events_retention/activities.py
+++ b/posthog/temporal/sync_events_retention/activities.py
@@ -31,6 +31,21 @@ def _capture_sync_completed(total_processed: int, total_updated: int, dry_run: b
         )
 
 
+def _capture_retention_changes(changes: list[dict]) -> None:
+    with ph_scoped_capture() as capture:
+        for change in changes:
+            capture(
+                distinct_id="sync-events-retention",
+                event="events_retention_changed",
+                properties={
+                    **change,
+                    "cloud_deployment": settings.CLOUD_DEPLOYMENT,
+                    # Personless: a mass change (e.g. a policy flip) must not mint one person per team.
+                    "$process_person_profile": False,
+                },
+            )
+
+
 @activity.defn(name="sync-events-retention")
 async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
     """Reconcile every team's events retention window with its billing entitlement.
@@ -62,17 +77,28 @@ async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
             last_pk = teams[-1].pk
 
             teams_to_update: list[Team] = []
+            changes: list[dict] = []
             for team in teams:
                 retention_feature = team.organization.get_available_feature(
                     AvailableFeature.PRODUCT_ANALYTICS_DATA_RETENTION
                 )
                 target_months = parse_events_feature_to_months(retention_feature)
                 if team.event_retention_months != target_months:
+                    changes.append(
+                        {
+                            "team_id": team.pk,
+                            "organization_id": str(team.organization_id),
+                            "retention_months_before": team.event_retention_months,
+                            "retention_months_after": target_months,
+                        }
+                    )
                     team.event_retention_months = target_months
                     teams_to_update.append(team)
 
             if teams_to_update and not input.dry_run:
                 await Team.objects.abulk_update(teams_to_update, ["event_retention_months"])
+                # Per batch and off-thread so a mass change can't stall heartbeats or overflow the client queue.
+                await asyncio.to_thread(_capture_retention_changes, changes)
 
             total_processed += len(teams)
             total_updated += len(teams_to_update)

--- a/posthog/temporal/sync_events_retention/activities.py
+++ b/posthog/temporal/sync_events_retention/activities.py
@@ -1,13 +1,34 @@
+import time
+import asyncio
+
+from django.conf import settings
+
 from temporalio import activity
 
 from posthog.constants import AvailableFeature
 from posthog.models.team import Team
 from posthog.models.team.event_retention import parse_events_feature_to_months
+from posthog.ph_client import ph_scoped_capture
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
 from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInput
 
 LOGGER = get_write_only_logger()
+
+
+def _capture_sync_completed(total_processed: int, total_updated: int, dry_run: bool, duration_seconds: float) -> None:
+    with ph_scoped_capture() as capture:
+        capture(
+            distinct_id="sync-events-retention",
+            event="events_retention_sync_completed",
+            properties={
+                "total_processed": total_processed,
+                "total_updated": total_updated,
+                "dry_run": dry_run,
+                "duration_seconds": round(duration_seconds, 1),
+                "cloud_deployment": settings.CLOUD_DEPLOYMENT,
+            },
+        )
 
 
 @activity.defn(name="sync-events-retention")
@@ -21,6 +42,7 @@ async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
         logger = LOGGER.bind()
         logger.info("Syncing events retention for all teams...")
 
+        started_at = time.monotonic()
         last_pk = 0
         total_processed = 0
         total_updated = 0
@@ -60,3 +82,8 @@ async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
             logger.info(f"DRY RUN: Would have updated {total_updated} of {total_processed} teams")
         else:
             logger.info(f"Updated {total_updated} of {total_processed} teams")
+
+        # Absence of this event is the staleness-alert signal for a dead sync; the alert filters dry_run=false.
+        await asyncio.to_thread(
+            _capture_sync_completed, total_processed, total_updated, input.dry_run, time.monotonic() - started_at
+        )

--- a/posthog/temporal/sync_events_retention/activities.py
+++ b/posthog/temporal/sync_events_retention/activities.py
@@ -1,4 +1,3 @@
-import time
 import asyncio
 
 from django.conf import settings
@@ -11,24 +10,9 @@ from posthog.models.team.event_retention import parse_events_feature_to_months
 from posthog.ph_client import ph_scoped_capture
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
-from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInput
+from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInput, SyncEventsRetentionResult
 
 LOGGER = get_write_only_logger()
-
-
-def _capture_sync_completed(total_processed: int, total_updated: int, dry_run: bool, duration_seconds: float) -> None:
-    with ph_scoped_capture() as capture:
-        capture(
-            distinct_id="sync-events-retention",
-            event="events_retention_sync_completed",
-            properties={
-                "total_processed": total_processed,
-                "total_updated": total_updated,
-                "dry_run": dry_run,
-                "duration_seconds": round(duration_seconds, 1),
-                "cloud_deployment": settings.CLOUD_DEPLOYMENT,
-            },
-        )
 
 
 def _capture_retention_changes(changes: list[dict]) -> None:
@@ -47,7 +31,7 @@ def _capture_retention_changes(changes: list[dict]) -> None:
 
 
 @activity.defn(name="sync-events-retention")
-async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
+async def sync_events_retention(input: SyncEventsRetentionInput) -> SyncEventsRetentionResult:
     """Reconcile every team's events retention window with its billing entitlement.
 
     Events retention is plan-derived and not user-editable, so we set it outright — unlike replay enforcement, which
@@ -57,7 +41,6 @@ async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
         logger = LOGGER.bind()
         logger.info("Syncing events retention for all teams...")
 
-        started_at = time.monotonic()
         last_pk = 0
         total_processed = 0
         total_updated = 0
@@ -109,7 +92,4 @@ async def sync_events_retention(input: SyncEventsRetentionInput) -> None:
         else:
             logger.info(f"Updated {total_updated} of {total_processed} teams")
 
-        # Absence of this event is the staleness-alert signal for a dead sync; the alert filters dry_run=false.
-        await asyncio.to_thread(
-            _capture_sync_completed, total_processed, total_updated, input.dry_run, time.monotonic() - started_at
-        )
+        return SyncEventsRetentionResult(total_processed=total_processed, total_updated=total_updated)

--- a/posthog/temporal/sync_events_retention/types.py
+++ b/posthog/temporal/sync_events_retention/types.py
@@ -1,7 +1,17 @@
 from dataclasses import dataclass
+from typing import Optional
+
+from posthog.slo.types import SloConfig
 
 
 @dataclass(frozen=True)
 class SyncEventsRetentionInput:
     dry_run: bool
     batch_size: int = 1000
+    slo: Optional[SloConfig] = None
+
+
+@dataclass(frozen=True)
+class SyncEventsRetentionResult:
+    total_processed: int
+    total_updated: int

--- a/posthog/temporal/sync_events_retention/workflow.py
+++ b/posthog/temporal/sync_events_retention/workflow.py
@@ -4,7 +4,7 @@ from temporalio import common, workflow
 
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.sync_events_retention.activities import sync_events_retention
-from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInput
+from posthog.temporal.sync_events_retention.types import SyncEventsRetentionInput, SyncEventsRetentionResult
 
 
 @workflow.defn(name="sync-events-retention")
@@ -13,7 +13,7 @@ class SyncEventsRetentionWorkflow(PostHogWorkflow):
 
     @workflow.run
     async def run(self, input: SyncEventsRetentionInput) -> None:
-        await workflow.execute_activity(
+        result: SyncEventsRetentionResult = await workflow.execute_activity(
             sync_events_retention,
             input,
             start_to_close_timeout=timedelta(minutes=120),
@@ -23,3 +23,7 @@ class SyncEventsRetentionWorkflow(PostHogWorkflow):
             ),
             heartbeat_timeout=timedelta(minutes=5),
         )
+        if input.slo is not None:
+            input.slo.completion_properties.update(
+                {"total_processed": result.total_processed, "total_updated": result.total_updated}
+            )

--- a/posthog/temporal/tests/sync_events_retention/test_activities.py
+++ b/posthog/temporal/tests/sync_events_retention/test_activities.py
@@ -51,8 +51,8 @@ async def test_syncs_event_retention_months_from_billing(features: list[dict], e
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_emits_completion_event_with_run_totals():
-    await _team_with_features(
+async def test_emits_completion_and_change_events():
+    team = await _team_with_features(
         [{"key": "product_analytics_data_retention", "limit": 1, "unit": "year"}], current_months=999
     )
     captured: list[dict] = []
@@ -64,11 +64,15 @@ async def test_emits_completion_event_with_run_totals():
     with patch("posthog.temporal.sync_events_retention.activities.ph_scoped_capture", fake_scoped_capture):
         await ActivityEnvironment().run(sync_events_retention, SyncEventsRetentionInput(dry_run=False))
 
-    assert len(captured) == 1
-    assert captured[0]["event"] == "events_retention_sync_completed"
-    assert captured[0]["properties"]["total_processed"] == 1
-    assert captured[0]["properties"]["total_updated"] == 1
-    assert captured[0]["properties"]["dry_run"] is False
+    assert [c["event"] for c in captured] == ["events_retention_changed", "events_retention_sync_completed"]
+    change = captured[0]["properties"]
+    assert change["team_id"] == team.pk
+    assert change["retention_months_before"] == 999
+    assert change["retention_months_after"] == 12
+    completed = captured[1]["properties"]
+    assert completed["total_processed"] == 1
+    assert completed["total_updated"] == 1
+    assert completed["dry_run"] is False
 
 
 @pytest.mark.django_db(transaction=True)

--- a/posthog/temporal/tests/sync_events_retention/test_activities.py
+++ b/posthog/temporal/tests/sync_events_retention/test_activities.py
@@ -1,4 +1,7 @@
+from contextlib import contextmanager
+
 import pytest
+from unittest.mock import patch
 
 from asgiref.sync import sync_to_async
 from temporalio.testing import ActivityEnvironment
@@ -44,6 +47,28 @@ async def test_syncs_event_retention_months_from_billing(features: list[dict], e
 
     await sync_to_async(team.refresh_from_db)()
     assert team.event_retention_months == expected_months
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_emits_completion_event_with_run_totals():
+    await _team_with_features(
+        [{"key": "product_analytics_data_retention", "limit": 1, "unit": "year"}], current_months=999
+    )
+    captured: list[dict] = []
+
+    @contextmanager
+    def fake_scoped_capture():
+        yield lambda **kwargs: captured.append(kwargs)
+
+    with patch("posthog.temporal.sync_events_retention.activities.ph_scoped_capture", fake_scoped_capture):
+        await ActivityEnvironment().run(sync_events_retention, SyncEventsRetentionInput(dry_run=False))
+
+    assert len(captured) == 1
+    assert captured[0]["event"] == "events_retention_sync_completed"
+    assert captured[0]["properties"]["total_processed"] == 1
+    assert captured[0]["properties"]["total_updated"] == 1
+    assert captured[0]["properties"]["dry_run"] is False
 
 
 @pytest.mark.django_db(transaction=True)

--- a/posthog/temporal/tests/sync_events_retention/test_activities.py
+++ b/posthog/temporal/tests/sync_events_retention/test_activities.py
@@ -51,7 +51,7 @@ async def test_syncs_event_retention_months_from_billing(features: list[dict], e
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_emits_completion_and_change_events():
+async def test_emits_change_events_and_returns_totals():
     team = await _team_with_features(
         [{"key": "product_analytics_data_retention", "limit": 1, "unit": "year"}], current_months=999
     )
@@ -62,17 +62,15 @@ async def test_emits_completion_and_change_events():
         yield lambda **kwargs: captured.append(kwargs)
 
     with patch("posthog.temporal.sync_events_retention.activities.ph_scoped_capture", fake_scoped_capture):
-        await ActivityEnvironment().run(sync_events_retention, SyncEventsRetentionInput(dry_run=False))
+        result = await ActivityEnvironment().run(sync_events_retention, SyncEventsRetentionInput(dry_run=False))
 
-    assert [c["event"] for c in captured] == ["events_retention_changed", "events_retention_sync_completed"]
+    assert [c["event"] for c in captured] == ["events_retention_changed"]
     change = captured[0]["properties"]
     assert change["team_id"] == team.pk
     assert change["retention_months_before"] == 999
     assert change["retention_months_after"] == 12
-    completed = captured[1]["properties"]
-    assert completed["total_processed"] == 1
-    assert completed["total_updated"] == 1
-    assert completed["dry_run"] is False
+    assert result.total_processed == 1
+    assert result.total_updated == 1
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Problem

The nightly `sync-events-retention` doesn't emit metrics or events so we don't know when it fails

## Changes

Opt the scheduled workflow into the SLO interceptor: it emits `slo_operation_started` / `slo_operation_completed` (outcome success or failure, with error details, duration, and run totals) plus the standard Prometheus SLO counters. Alerts on missing-success and on-failure get created in the internal project once this deploys.

Also capture an `events_retention_changed` event per team whose retention moved (`team_id`, `organization_id`, before/after months), emitted per batch off-thread and personless so a mass change stays safe.

## How did you test this code?

`pytest posthog/temporal/tests/sync_events_retention/ posthog/temporal/tests/test_slo_interceptor.py` (12 passed). `test_emits_change_events_and_returns_totals` fails if the change emission or the totals feeding the SLO event break.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal monitoring for an internal job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by Andy, continuing #75083. Started as a hand-rolled completion event; Andy pointed at the SLO module, which replaced it and added active failure events. Skills invoked: /writing-tests, /instrumenting-first-party-metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
