### PR TITLE
fix: keep the export rollup join in memory

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -139,9 +139,9 @@ def export_query_log_archive_day(
     leaf_sums = ",\n        ".join(f"sum(`{column}`) AS `leaf_{column}`" for column in LEAF_SUM_COLUMNS)
     leaf_columns = ",\n    ".join(f"`leaf_{column}`" for column in LEAF_SUM_COLUMNS)
     # Leaf rows of a query straddling midnight land on the next event_date, hence the two-day window.
-    # The rollup GROUP BY holds millions of initial_query_id keys and the join builds a hash table of
-    # them, sharing the query memory cap with the log_comment-heavy scan; both must spill to disk or
-    # the query exceeds the cap.
+    # The rollup keeps only parents present in the day's initial rows so its join hash table stays
+    # small enough to hold in memory; spilling the join to disk instead OOMs or times out on the
+    # read-back of the wide probe rows.
     query = f"""
 INSERT INTO FUNCTION s3('{s3_url}', 'Parquet')
 SELECT
@@ -169,11 +169,13 @@ LEFT JOIN
         {leaf_sums}
     FROM {SOURCE_TABLE}
     WHERE event_date >= toDate('{day}') AND event_date <= toDate('{day}') + 1 AND NOT is_initial_query
+        AND initial_query_id IN (
+            SELECT query_id FROM {SOURCE_TABLE} WHERE event_date = toDate('{day}') AND is_initial_query
+        )
     GROUP BY leaf_initial_query_id
 ) AS leaf ON initial_rows.query_id = leaf.leaf_initial_query_id
 SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads},
-    join_algorithm = 'grace_hash', max_bytes_in_join = 1500000000,
-    max_bytes_before_external_group_by = 2000000000
+    join_algorithm = 'hash', max_bytes_before_external_group_by = 2000000000
 """
 
     def run(client: Client) -> str:


### PR DESCRIPTION
## Problem

The grace hash spill approach failed in production: the EU run OOMed at the 20 GiB query cap while reading its spilled probe rows back (the wide query-text columns make spilled blocks enormous), and the US runs hit the 2 h execution timeout because bucket-by-bucket disk processing is too slow at US volume.

## Changes

- Filter the leaf rollup to parents present in the day's initial rows. Leaves of next-day queries can never match, so the output is identical and the join build halves.
- With the build side that small, use a plain in-memory hash join and drop the grace hash settings. Probe rows stream straight to parquet; only the aggregation spills (`max_bytes_before_external_group_by` kept).

Verified end to end on the EU OPS node against the failed day, at the job's exact 20 GiB cap: clean finish in 19 min with an 8.99 GiB peak, where the deployed grace hash variant died at 20 GiB after 35 min on the same day. US projects to roughly 45-55 min and ~15 GiB at the same settings.

## How did you test this code?

- Full query executed end to end on the EU OPS node as described above (`SELECT ... FORMAT Null` via remote execution, same caps as the job).
- Rendered SQL also validated end to end against local dev ClickHouse; `ruff check` and preflight pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs page covers this export job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in a session driven by Andy Zhao, after iterating the spill design against the real OPS nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
