### PR TITLE
refactor(batch-exports): rename MinIO test references to local object storage

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -93,7 +93,7 @@ def _uses_object_storage_endpoint() -> bool:
 def _get_s3_endpoint_url() -> str:
     """Get the S3 endpoint URL for the Temporal worker.
 
-    When running the stack locally, the local object storage (SeaweedFS) runs in Docker but the Temporal workers run outside, so we need to pass in
+    When running the stack locally, the local object storage runs in Docker but the Temporal workers run outside, so we need to pass in
     localhost URL rather than the hostname of the container.
     """
     if _is_local_dev_or_test():

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -93,7 +93,7 @@ def _uses_object_storage_endpoint() -> bool:
 def _get_s3_endpoint_url() -> str:
     """Get the S3 endpoint URL for the Temporal worker.
 
-    When running the stack locally, MinIO runs in Docker but the Temporal workers run outside, so we need to pass in
+    When running the stack locally, the local object storage (SeaweedFS) runs in Docker but the Temporal workers run outside, so we need to pass in
     localhost URL rather than the hostname of the container.
     """
     if _is_local_dev_or_test():
@@ -534,12 +534,12 @@ def _get_clickhouse_s3_staging_folder_url(folder: str) -> str:
     """Get the URL for the S3 staging folder of a given batch export and attempt number.
 
     This is passed to the ClickHouse query as the `s3_folder` parameter.
-    When running the stack locally, ClickHouse and MinIO are both running in Docker so we use the hostname of the
+    When running the stack locally, ClickHouse and the local object storage are both running in Docker so we use the hostname of the
     container.
     """
     bucket = settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET
     region = settings.BATCH_EXPORT_OBJECT_STORAGE_REGION
-    # in these environments this will be a URL for MinIO
+    # in these environments this will be a URL for the local object storage
     if _uses_object_storage_endpoint():
         base_url = f"{settings.BATCH_EXPORT_OBJECT_STORAGE_ENDPOINT}/{bucket}/"
     else:

--- a/products/batch_exports/backend/tests/api/destination_tests/conftest.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/conftest.py
@@ -85,7 +85,7 @@ async def identity_role(session: aioboto3.Session) -> str:
 
 
 # Named distinctly from the test module's function-scoped `bucket_name` fixture (used by
-# the MinIO tests) so this module-scoped fixture is not shadowed, which would cause a
+# the local object storage tests) so this module-scoped fixture is not shadowed, which would cause a
 # ScopeMismatch when the module-scoped `aws_bucket` requests it.
 @pytest.fixture(scope="module")
 def aws_bucket_name() -> str:

--- a/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
@@ -33,8 +33,8 @@ def bucket_name(request) -> str:
 
 
 @pytest.fixture
-async def minio_client(bucket_name):
-    """Manage an S3 client to interact with a MinIO bucket.
+async def object_storage_client(bucket_name):
+    """Manage an S3 client to interact with a local object storage bucket.
 
     Yields the client after creating a bucket. Upon resuming, we delete
     the contents and the bucket itself.
@@ -43,17 +43,17 @@ async def minio_client(bucket_name):
         "s3",
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
-    ) as minio_client:
-        await minio_client.create_bucket(Bucket=bucket_name)
+    ) as object_storage_client:
+        await object_storage_client.create_bucket(Bucket=bucket_name)
 
-        yield minio_client
+        yield object_storage_client
 
-        await delete_all_from_s3(minio_client, bucket_name, key_prefix="/")
+        await delete_all_from_s3(object_storage_client, bucket_name, key_prefix="/")
 
-        await minio_client.delete_bucket(Bucket=bucket_name)
+        await object_storage_client.delete_bucket(Bucket=bucket_name)
 
 
-async def test_s3_check_bucket_exists_test_step(bucket_name, minio_client):
+async def test_s3_check_bucket_exists_test_step(bucket_name, object_storage_client):
     test_step = S3EnsureBucketTestStep(
         bucket_name=bucket_name,
         aws_access_key_id="object_storage_root_user",
@@ -66,7 +66,7 @@ async def test_s3_check_bucket_exists_test_step(bucket_name, minio_client):
     assert result.message is None
 
 
-async def test_s3_check_bucket_exists_test_step_without_bucket(minio_client):
+async def test_s3_check_bucket_exists_test_step_without_bucket(object_storage_client):
     test_step = S3EnsureBucketTestStep(
         bucket_name="some-other-bucket",
         aws_access_key_id="object_storage_root_user",

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -65,8 +65,8 @@ def bucket_name(request) -> str:
 
 
 @pytest_asyncio.fixture
-async def minio_client(bucket_name):
-    """Manage an S3 client to interact with a MinIO bucket.
+async def object_storage_client(bucket_name):
+    """Manage an S3 client to interact with a local object storage bucket.
 
     Yields the client after creating a bucket. Upon resuming, we delete
     the contents and the bucket itself.
@@ -75,28 +75,28 @@ async def minio_client(bucket_name):
         "s3",
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
-    ) as minio_client:
-        await minio_client.create_bucket(Bucket=bucket_name)
+    ) as object_storage_client:
+        await object_storage_client.create_bucket(Bucket=bucket_name)
 
-        yield minio_client
+        yield object_storage_client
 
-        await delete_all_from_s3(minio_client, bucket_name, key_prefix="/")
+        await delete_all_from_s3(object_storage_client, bucket_name, key_prefix="/")
 
-        await minio_client.delete_bucket(Bucket=bucket_name)
+        await object_storage_client.delete_bucket(Bucket=bucket_name)
 
 
-async def delete_all_from_s3(minio_client, bucket_name: str, key_prefix: str):
+async def delete_all_from_s3(object_storage_client, bucket_name: str, key_prefix: str):
     """Delete all objects in bucket_name under key_prefix."""
-    response = await minio_client.list_objects_v2(Bucket=bucket_name, Prefix=key_prefix)
+    response = await object_storage_client.list_objects_v2(Bucket=bucket_name, Prefix=key_prefix)
 
     if "Contents" in response:
         for obj in response["Contents"]:
             if "Key" in obj:
-                await minio_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
+                await object_storage_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
 
 
 def test_can_run_s3_test_step_for_new_destination(
-    client: HttpClient, bucket_name, minio_client, organization, team, user
+    client: HttpClient, bucket_name, object_storage_client, organization, team, user
 ):
     destination_data = {
         "type": "S3Compatible",
@@ -133,7 +133,7 @@ def test_can_run_s3_test_step_for_new_destination(
 
 
 def test_can_run_s3_test_step_for_destination(
-    client: HttpClient, bucket_name, minio_client, temporal, organization, team, user
+    client: HttpClient, bucket_name, object_storage_client, temporal, organization, team, user
 ):
     destination_data = {
         "type": "S3Compatible",
@@ -338,7 +338,7 @@ def test_can_run_snowflake_test_step_for_partial_config(
 
 
 def test_can_run_s3_test_step_with_additional_fields(
-    client: HttpClient, bucket_name, minio_client, temporal, organization, team, user
+    client: HttpClient, bucket_name, object_storage_client, temporal, organization, team, user
 ):
     """Test we can run test steps successfully even with additional configuration fields.
 

--- a/products/batch_exports/backend/tests/temporal/README.md
+++ b/products/batch_exports/backend/tests/temporal/README.md
@@ -71,9 +71,9 @@ DEBUG=1 AWS_ACCESS_KEY_ID="AAAA" AWS_SECRET_ACCESS_KEY="BBBB" AWS_REGION="region
 
 ## Testing S3 batch exports
 
-S3 batch exports are tested against a MinIO bucket available in the local development stack. However there are also unit tests that specifically target an S3 bucket (like `test_s3_export_workflow_with_s3_bucket`), tests that target a Google Cloud Storage (GCS) bucket, and tests that run against a playground AWS account.
+S3 batch exports are tested against a local object storage (SeaweedFS) bucket available in the local development stack. However there are also unit tests that specifically target an S3 bucket (like `test_s3_export_workflow_with_s3_bucket`), tests that target a Google Cloud Storage (GCS) bucket, and tests that run against a playground AWS account.
 
-If no environment variables are defined and no AWS credentials are present, then just the tests targeting MinIO will be run (the tests targeting S3/GCS will be skipped).
+If no environment variables are defined and no AWS credentials are present, then just the tests targeting local object storage will be run (the tests targeting S3/GCS will be skipped).
 
 ### Using an S3 bucket
 

--- a/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_backfill_workflow.py
@@ -145,8 +145,8 @@ def bucket_name() -> str:
 
 
 @pytest_asyncio.fixture
-async def minio_client(bucket_name):
-    """Manage a MinIO S3 client, creating and cleaning up a test bucket."""
+async def object_storage_client(bucket_name):
+    """Manage an S3 client for local object storage, creating and cleaning up a test bucket."""
     async with create_test_client(
         "s3",
         aws_access_key_id="object_storage_root_user",
@@ -161,7 +161,7 @@ async def minio_client(bucket_name):
 
 
 @pytest_asyncio.fixture
-async def events_batch_export(temporal_client, ateam, clickhouse_client, bucket_name, minio_client):
+async def events_batch_export(temporal_client, ateam, clickhouse_client, bucket_name, object_storage_client):
     """Create a batch export for testing backfill info (defaults to events model)."""
     await truncate_events(clickhouse_client)
 

--- a/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/redshift/test_redshift_utils.py
@@ -54,8 +54,8 @@ def bucket_name(request) -> str:
 
 
 @pytest_asyncio.fixture
-async def minio_client(bucket_name):
-    """Manage an S3 client to interact with a MinIO bucket.
+async def object_storage_client(bucket_name):
+    """Manage an S3 client to interact with a local object storage bucket.
 
     Yields the client after creating a bucket. Upon resuming, we delete
     the contents and the bucket itself.
@@ -65,24 +65,24 @@ async def minio_client(bucket_name):
         aws_access_key_id=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
         aws_secret_access_key=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
         endpoint_url=settings.OBJECT_STORAGE_ENDPOINT,
-    ) as minio_client:
-        await minio_client.create_bucket(Bucket=bucket_name)
+    ) as object_storage_client:
+        await object_storage_client.create_bucket(Bucket=bucket_name)
 
-        yield minio_client
+        yield object_storage_client
 
-        await delete_all_from_s3(minio_client, bucket_name, key_prefix="")
+        await delete_all_from_s3(object_storage_client, bucket_name, key_prefix="")
 
-        await minio_client.delete_bucket(Bucket=bucket_name)
+        await object_storage_client.delete_bucket(Bucket=bucket_name)
 
 
-async def test_upload_manifest_file(minio_client, bucket_name):
+async def test_upload_manifest_file(object_storage_client, bucket_name):
     """Test the a correctly formatted manifest is uploaded with the necessary contents."""
     test_prefix = uuid.uuid4()
 
     files_uploaded = []
     for file_number in range(3):
         key = f"{test_prefix}/file_{file_number}"
-        await minio_client.put_object(
+        await object_storage_client.put_object(
             Bucket=bucket_name,
             Key=key,
             Body=b"0",
@@ -106,7 +106,7 @@ async def test_upload_manifest_file(minio_client, bucket_name):
         manifest_key=manifest_key,
     )
 
-    obj = await minio_client.get_object(Bucket=bucket_name, Key=manifest_key)
+    obj = await object_storage_client.get_object(Bucket=bucket_name, Key=manifest_key)
     body = await obj["Body"].read()
     loaded = json.loads(body)
 
@@ -118,7 +118,7 @@ async def test_upload_manifest_file(minio_client, bucket_name):
     assert total_content_length == 3
 
 
-async def test_upload_manifest_file_raises_on_client_error(minio_client, bucket_name):
+async def test_upload_manifest_file_raises_on_client_error(object_storage_client, bucket_name):
     """Test a ClientErrorGroup is raised when tasks fail."""
     test_prefix = uuid.uuid4()
 

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/conftest.py
@@ -88,8 +88,8 @@ def file_format(request) -> str:
 
 
 @pytest_asyncio.fixture
-async def minio_client(bucket_name):
-    """Manage an S3 client to interact with a MinIO bucket.
+async def object_storage_client(bucket_name):
+    """Manage an S3 client to interact with a local object storage bucket.
 
     Yields the client after creating a bucket. Upon resuming, we delete
     the contents and the bucket itself.
@@ -98,14 +98,14 @@ async def minio_client(bucket_name):
         "s3",
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
-    ) as minio_client:
-        await minio_client.create_bucket(Bucket=bucket_name)
+    ) as object_storage_client:
+        await object_storage_client.create_bucket(Bucket=bucket_name)
 
-        yield minio_client
+        yield object_storage_client
 
-        await delete_all_from_s3(minio_client, bucket_name, key_prefix="")
+        await delete_all_from_s3(object_storage_client, bucket_name, key_prefix="")
 
-        await minio_client.delete_bucket(Bucket=bucket_name)
+        await object_storage_client.delete_bucket(Bucket=bucket_name)
 
 
 @pytest_asyncio.fixture

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py
@@ -54,7 +54,7 @@ async def test_get_s3_integration_rejects_wrong_kind(ateam):
 async def test_insert_into_s3_activity_puts_data_into_s3(
     clickhouse_client,
     bucket_name,
-    minio_client,
+    object_storage_client,
     activity_environment: ActivityEnvironment,
     compression,
     exclude_events,
@@ -135,7 +135,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(
         sort_key = "session_id"
 
     await assert_clickhouse_records_in_s3(
-        s3_compatible_client=minio_client,
+        s3_compatible_client=object_storage_client,
         clickhouse_client=clickhouse_client,
         bucket_name=bucket_name,
         key_prefix=prefix,
@@ -159,7 +159,7 @@ async def test_insert_into_s3_activity_puts_data_into_s3(
 async def test_insert_into_s3_activity_resolves_credentials_from_integration(
     clickhouse_client,
     bucket_name,
-    minio_client,
+    object_storage_client,
     activity_environment: ActivityEnvironment,
     compression,
     exclude_events,
@@ -176,8 +176,8 @@ async def test_insert_into_s3_activity_resolves_credentials_from_integration(
     integration = await Integration.objects.acreate(
         team_id=ateam.pk,
         kind=Integration.IntegrationKind.S3_COMPATIBLE,
-        integration_id="minio-test",
-        config={"name": "minio-test", "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT},
+        integration_id="object-storage-test",
+        config={"name": "object-storage-test", "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT},
         sensitive_config={
             "aws_access_key_id": "object_storage_root_user",
             "aws_secret_access_key": "object_storage_root_password",
@@ -209,7 +209,7 @@ async def test_insert_into_s3_activity_resolves_credentials_from_integration(
     assert result.bytes_exported is not None and result.bytes_exported > 0
 
     await assert_clickhouse_records_in_s3(
-        s3_compatible_client=minio_client,
+        s3_compatible_client=object_storage_client,
         clickhouse_client=clickhouse_client,
         bucket_name=bucket_name,
         key_prefix=prefix,
@@ -233,7 +233,7 @@ async def test_insert_into_s3_activity_resolves_credentials_from_integration(
 async def test_insert_into_s3_activity_with_exclude_events(
     clickhouse_client,
     bucket_name,
-    minio_client,
+    object_storage_client,
     activity_environment: ActivityEnvironment,
     compression,
     exclude_events,
@@ -301,7 +301,7 @@ async def test_insert_into_s3_activity_with_exclude_events(
         sort_key = "session_id"
 
     await assert_clickhouse_records_in_s3(
-        s3_compatible_client=minio_client,
+        s3_compatible_client=object_storage_client,
         clickhouse_client=clickhouse_client,
         bucket_name=bucket_name,
         key_prefix=prefix,
@@ -325,7 +325,7 @@ async def test_insert_into_s3_activity_with_exclude_events(
 async def test_insert_into_s3_activity_puts_splitted_files_into_s3(
     clickhouse_client,
     bucket_name,
-    minio_client,
+    object_storage_client,
     activity_environment,
     compression,
     max_file_size_mb,
@@ -408,7 +408,7 @@ async def test_insert_into_s3_activity_puts_splitted_files_into_s3(
     assert bytes_exported > 0
 
     s3_data, s3_keys = await assert_files_in_s3(
-        s3_compatible_client=minio_client,
+        s3_compatible_client=object_storage_client,
         bucket_name=bucket_name,
         key_prefix=prefix,
         file_format=file_format,
@@ -459,10 +459,10 @@ async def test_insert_into_s3_activity_puts_splitted_files_into_s3(
 
     manifest_key = f"{prefix}/{data_interval_start.isoformat()}-{data_interval_end.isoformat()}_manifest.json"
     if max_file_size_mb is None:
-        with pytest.raises(minio_client.exceptions.NoSuchKey):
-            await read_json_file_from_s3(minio_client, bucket_name, manifest_key)
+        with pytest.raises(object_storage_client.exceptions.NoSuchKey):
+            await read_json_file_from_s3(object_storage_client, bucket_name, manifest_key)
     else:
-        manifest_data: dict | list = await read_json_file_from_s3(minio_client, bucket_name, manifest_key)
+        manifest_data: dict | list = await read_json_file_from_s3(object_storage_client, bucket_name, manifest_key)
         assert isinstance(manifest_data, dict)
         assert manifest_data["files"] == expected_keys
 
@@ -472,7 +472,7 @@ async def test_insert_into_s3_activity_puts_splitted_files_into_s3(
 async def test_insert_into_s3_activity_fails_on_invalid_file_format(
     clickhouse_client,
     bucket_name,
-    minio_client,
+    object_storage_client,
     activity_environment,
     compression,
     exclude_events,
@@ -516,7 +516,7 @@ async def test_insert_into_s3_activity_fails_on_invalid_file_format(
 async def test_insert_into_s3_activity_fails_on_invalid_compression(
     clickhouse_client,
     bucket_name,
-    minio_client,
+    object_storage_client,
     activity_environment,
     compression,
     exclude_events,

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_error_handling.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_error_handling.py
@@ -232,7 +232,7 @@ async def test_s3_export_workflow_handles_cancellation(ateam, s3_compatible_batc
 async def test_s3_export_workflow_with_request_timeouts(
     clickhouse_client,
     ateam,
-    minio_client,
+    object_storage_client,
     bucket_name,
     interval,
     s3_compatible_batch_export,
@@ -354,7 +354,7 @@ async def test_s3_export_workflow_with_request_timeouts(
         second=data_interval_end.strftime("%S"),
     )
 
-    objects = await minio_client.list_objects_v2(Bucket=bucket_name, Prefix=expected_key_prefix)
+    objects = await object_storage_client.list_objects_v2(Bucket=bucket_name, Prefix=expected_key_prefix)
     key = objects["Contents"][0].get("Key")
     assert len(objects.get("Contents", [])) == 1
     assert key.startswith(expected_key_prefix)
@@ -367,7 +367,7 @@ async def test_s3_export_workflow_with_request_timeouts(
             sort_key = "session_id"
 
     await assert_clickhouse_records_in_s3(
-        s3_compatible_client=minio_client,
+        s3_compatible_client=object_storage_client,
         clickhouse_client=clickhouse_client,
         bucket_name=bucket_name,
         key_prefix=expected_key_prefix,

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_gcs_bucket.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_gcs_bucket.py
@@ -37,7 +37,7 @@ async def s3_client(bucket_name, s3_key_prefix):
     the contents of the bucket under the key prefix we are testing. This opens up the door
     to bugs that could delete all other data in your bucket. I *strongly* recommend
     using a disposable bucket to run these tests or sticking to other tests that use the
-    local development MinIO.
+    local development object storage.
     """
     async with aioboto3.Session().client("s3", endpoint_url="https://storage.googleapis.com") as s3_client:
         yield s3_client

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_local_object_storage.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_local_object_storage.py
@@ -23,9 +23,9 @@ TEST_DATA_INTERVAL_END = dt.datetime.now(tz=dt.UTC).replace(hour=0, minute=0, se
 @pytest.mark.parametrize("compression", [None], indirect=True)
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
 @pytest.mark.parametrize("file_format", ["Parquet"], indirect=True)
-async def test_s3_export_workflow_with_minio_bucket_with_various_models(
+async def test_s3_export_workflow_with_local_object_storage_with_various_models(
     clickhouse_client,
-    minio_client,
+    object_storage_client,
     ateam,
     s3_compatible_batch_export,
     bucket_name,
@@ -39,10 +39,10 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_models(
     model: BatchExportModel | BatchExportSchema | None,
     generate_test_data,
 ):
-    """Test S3BatchExport Workflow end-to-end by using a local MinIO bucket instead of S3.
+    """Test S3BatchExport Workflow end-to-end by using a local object storage bucket instead of S3.
 
     The workflow should update the batch export run status to completed and produce the expected
-    records to the MinIO bucket.
+    records to the local object storage bucket.
 
     We use a BatchExport model to provide accurate inputs to the Workflow and because the Workflow
     will require its presence in the database when running. This model is indirectly parameterized
@@ -60,7 +60,7 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_models(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         destination_type="S3Compatible",
     )
 
@@ -70,9 +70,9 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_models(
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
 @pytest.mark.parametrize("compression", [*COMPRESSION_EXTENSIONS.keys(), None], indirect=True)
 @pytest.mark.parametrize("file_format", FILE_FORMAT_EXTENSIONS.keys(), indirect=True)
-async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and_file_formats(
+async def test_s3_export_workflow_with_local_object_storage_with_various_compression_and_file_formats(
     clickhouse_client,
-    minio_client,
+    object_storage_client,
     ateam,
     s3_compatible_batch_export,
     bucket_name,
@@ -86,7 +86,7 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and
     model: BatchExportModel | BatchExportSchema | None,
     generate_test_data,
 ):
-    """Test S3BatchExport Workflow end-to-end by using a local MinIO bucket and various compression and file formats."""
+    """Test S3BatchExport Workflow end-to-end by using a local object storage bucket and various compression and file formats."""
 
     if compression and compression not in SUPPORTED_COMPRESSIONS[file_format]:
         pytest.skip(f"Compression {compression} is not supported for file format {file_format}")
@@ -100,7 +100,7 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         destination_type="S3Compatible",
     )
 
@@ -110,9 +110,9 @@ async def test_s3_export_workflow_with_minio_bucket_with_various_compression_and
 @pytest.mark.parametrize("file_format", ["JSONLines"], indirect=True)
 @pytest.mark.parametrize("exclude_events", [["test-exclude"]], indirect=True)
 @pytest.mark.parametrize("model", TEST_S3_MODELS)
-async def test_s3_export_workflow_with_minio_bucket_with_exclude_events(
+async def test_s3_export_workflow_with_local_object_storage_with_exclude_events(
     clickhouse_client,
-    minio_client,
+    object_storage_client,
     ateam,
     s3_compatible_batch_export,
     bucket_name,
@@ -126,7 +126,7 @@ async def test_s3_export_workflow_with_minio_bucket_with_exclude_events(
     model: BatchExportModel | BatchExportSchema | None,
     generate_test_data,
 ):
-    """Test S3BatchExport Workflow end-to-end by using a local MinIO bucket and excluding events."""
+    """Test S3BatchExport Workflow end-to-end by using a local object storage bucket and excluding events."""
     if isinstance(model, BatchExportModel) and model.name in ["persons", "sessions"]:
         pytest.skip(f"Unnecessary test case as {model.name} batch export is not affected by 'exclude_events'")
 
@@ -139,7 +139,7 @@ async def test_s3_export_workflow_with_minio_bucket_with_exclude_events(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         destination_type="S3Compatible",
     )
 
@@ -153,9 +153,9 @@ async def test_s3_export_workflow_with_minio_bucket_with_exclude_events(
 )
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)
 @pytest.mark.parametrize("model", [BatchExportModel(name="persons", schema=None)])
-async def test_s3_export_workflow_backfill_earliest_persons_with_minio_bucket(
+async def test_s3_export_workflow_backfill_earliest_persons_with_local_object_storage(
     clickhouse_client,
-    minio_client,
+    object_storage_client,
     ateam,
     s3_compatible_batch_export,
     bucket_name,
@@ -195,7 +195,7 @@ async def test_s3_export_workflow_backfill_earliest_persons_with_minio_bucket(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         backfill_details=backfill_details,
         destination_type="S3Compatible",
     )
@@ -206,9 +206,9 @@ async def test_s3_export_workflow_backfill_earliest_persons_with_minio_bucket(
 @pytest.mark.parametrize("exclude_events", [None], indirect=True)
 @pytest.mark.parametrize("file_format", ["JSONLines"], indirect=True)
 @pytest.mark.parametrize("model", TEST_S3_MODELS)
-async def test_s3_export_workflow_with_minio_bucket_without_events(
+async def test_s3_export_workflow_with_local_object_storage_without_events(
     clickhouse_client,
-    minio_client,
+    object_storage_client,
     ateam,
     s3_compatible_batch_export,
     bucket_name,
@@ -234,7 +234,7 @@ async def test_s3_export_workflow_with_minio_bucket_without_events(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         expect_no_data=True,
         destination_type="S3Compatible",
     )
@@ -247,7 +247,7 @@ async def test_s3_export_workflow_with_minio_bucket_without_events(
 @pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
 async def test_s3_export_workflow_with_legacy_s3_destination_type(
     clickhouse_client,
-    minio_client,
+    object_storage_client,
     ateam,
     s3_compatible_batch_export,
     bucket_name,
@@ -277,7 +277,7 @@ async def test_s3_export_workflow_with_legacy_s3_destination_type(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         destination_type="S3",
     )
 
@@ -294,10 +294,10 @@ async def test_s3_export_workflow_with_legacy_s3_destination_type(
     indirect=True,
 )
 @pytest.mark.parametrize("model", [TEST_S3_MODELS[1], TEST_S3_MODELS[3], None])
-async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(
+async def test_s3_export_workflow_with_local_object_storage_and_custom_key_prefix(
     clickhouse_client,
     ateam,
-    minio_client,
+    object_storage_client,
     bucket_name,
     compression,
     interval,
@@ -310,7 +310,7 @@ async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(
 ):
     """Test the S3BatchExport Workflow end-to-end by specifying a custom key prefix.
 
-    This test is the same as test_s3_export_workflow_with_minio_bucket, but we create events with None as
+    This test is the same as test_s3_export_workflow_with_local_object_storage, but we create events with None as
     inserted_at to assert we properly default to _timestamp. This is relevant for rows inserted before inserted_at
     was added.
     """
@@ -324,6 +324,6 @@ async def test_s3_export_workflow_with_minio_bucket_and_custom_key_prefix(
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
         clickhouse_client=clickhouse_client,
-        s3_client=minio_client,
+        s3_client=object_storage_client,
         destination_type="S3Compatible",
     )

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_s3_bucket.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_with_s3_bucket.py
@@ -38,7 +38,7 @@ async def s3_client(bucket_name, s3_key_prefix):
     the contents of the bucket under the key prefix we are testing. This opens up the door
     to bugs that could delete all other data in your bucket. I *strongly* recommend
     using a disposable bucket to run these tests or sticking to other tests that use the
-    local development MinIO.
+    local development object storage.
     """
     async with aioboto3.Session().client("s3") as s3_client:
         yield s3_client

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/utils.py
@@ -191,7 +191,7 @@ async def assert_clickhouse_records_in_s3(
     """Assert ClickHouse records are written to JSON in key_prefix in S3 bucket_name.
 
     Arguments:
-        s3_compatible_client: An S3 client used to read records; can be MinIO if doing local testing.
+        s3_compatible_client: An S3 client used to read records; can point at local object storage if doing local testing.
         clickhouse_client: A ClickHouseClient used to read records that are expected to be exported.
         team_id: The ID of the team that we are testing for.
         bucket_name: S3 bucket name where records are exported to.
@@ -332,7 +332,7 @@ async def run_s3_batch_export_workflow(
 ):
     """Run the S3 batch export workflow and assert it completes successfully.
 
-    This is a shared helper function used by tests for S3, GCS, and MinIO buckets.
+    This is a shared helper function used by tests for S3, GCS, and local object storage buckets.
 
     `destination_type` selects which input dataclass is constructed and passed
     to the workflow — exercising the per-destination → canonical-inputs adaptation

--- a/products/batch_exports/backend/tests/temporal/pipeline/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/conftest.py
@@ -6,13 +6,13 @@ from products.batch_exports.backend.tests.temporal.utils.s3 import create_test_c
 
 
 @pytest_asyncio.fixture
-async def minio_client():
-    """Manage an S3 client to interact with a MinIO bucket."""
+async def object_storage_client():
+    """Manage an S3 client to interact with a local object storage bucket."""
     async with create_test_client(
         "s3",
         aws_access_key_id="object_storage_root_user",
         aws_secret_access_key="object_storage_root_password",
-    ) as minio_client:
-        yield minio_client
+    ) as object_storage_client:
+        yield object_storage_client
 
-        await delete_all_from_s3(minio_client, settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, key_prefix="")
+        await delete_all_from_s3(object_storage_client, settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, key_prefix="")

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py
@@ -248,7 +248,7 @@ async def _generate_record_batches_from_internal_stage(
 
 async def _run_activity(
     activity_environment: ActivityEnvironment,
-    minio_client,
+    object_storage_client,
     team_id,
     data_interval_start: dt.datetime,
     data_interval_end: dt.datetime,
@@ -276,7 +276,7 @@ async def _run_activity(
     stage_result = await activity_environment.run(insert_into_internal_stage_activity, insert_inputs)
     stage_folder = stage_result.stage_folder
     await assert_files_in_s3(
-        minio_client,
+        object_storage_client,
         bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
         key_prefix=stage_folder,
         file_format="Arrow",
@@ -306,7 +306,7 @@ async def test_insert_into_stage_activity_for_events_model(
     interval,
     activity_environment,
     data_interval_start,
-    minio_client,
+    object_storage_client,
     data_interval_end,
     ateam,
     model: BatchExportModel,
@@ -320,7 +320,7 @@ async def test_insert_into_stage_activity_for_events_model(
 
     records_exported = await _run_activity(
         activity_environment=activity_environment,
-        minio_client=minio_client,
+        object_storage_client=object_storage_client,
         team_id=ateam.pk,
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
@@ -346,7 +346,7 @@ async def test_insert_into_stage_activity_reports_records_total_for_events_model
     interval,
     activity_environment,
     data_interval_start,
-    minio_client,
+    object_storage_client,
     data_interval_end,
     ateam,
     model: BatchExportModel,
@@ -357,7 +357,7 @@ async def test_insert_into_stage_activity_reports_records_total_for_events_model
     with capture_logs() as cap_logs:
         records_exported = await _run_activity(
             activity_environment=activity_environment,
-            minio_client=minio_client,
+            object_storage_client=object_storage_client,
             team_id=ateam.pk,
             data_interval_start=data_interval_start,
             data_interval_end=data_interval_end,
@@ -506,7 +506,7 @@ async def test_insert_into_stage_activity_for_persons_model(
     interval,
     activity_environment,
     data_interval_start,
-    minio_client,
+    object_storage_client,
     data_interval_end,
     ateam,
     test_person_properties,
@@ -537,7 +537,7 @@ async def test_insert_into_stage_activity_for_persons_model(
 
     records_exported = await _run_activity(
         activity_environment=activity_environment,
-        minio_client=minio_client,
+        object_storage_client=object_storage_client,
         team_id=ateam.pk,
         data_interval_start=data_interval_start,
         data_interval_end=data_interval_end,
@@ -631,7 +631,7 @@ async def test_insert_into_stage_activity_for_persons_model(
     with override_settings(BATCH_EXPORTS_PERSONS_LIMITED_EXPORT_TEAM_IDS=[str(ateam.pk)] if limited_export else []):
         records_exported = await _run_activity(
             activity_environment=activity_environment,
-            minio_client=minio_client,
+            object_storage_client=object_storage_client,
             team_id=ateam.pk,
             data_interval_start=next_data_interval_start,
             data_interval_end=next_data_interval_end,
@@ -956,7 +956,7 @@ async def test_insert_into_stage_activity_writes_dynamic_number_of_files(
     interval,
     activity_environment,
     data_interval_start,
-    minio_client,
+    object_storage_client,
     data_interval_end,
     ateam,
     model: BatchExportModel,
@@ -997,7 +997,7 @@ async def test_insert_into_stage_activity_writes_dynamic_number_of_files(
         stage_folder = stage_result.stage_folder
 
     _, keys = await assert_files_in_s3(
-        minio_client,
+        object_storage_client,
         bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
         key_prefix=stage_folder,
         file_format="Arrow",
@@ -1016,7 +1016,7 @@ async def test_insert_into_stage_activity_uses_static_default_without_previous_r
     interval,
     activity_environment,
     data_interval_start,
-    minio_client,
+    object_storage_client,
     data_interval_end,
     ateam,
     model: BatchExportModel,
@@ -1047,7 +1047,7 @@ async def test_insert_into_stage_activity_uses_static_default_without_previous_r
         stage_folder = stage_result.stage_folder
 
     _, keys = await assert_files_in_s3(
-        minio_client,
+        object_storage_client,
         bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
         key_prefix=stage_folder,
         file_format="Arrow",
@@ -1110,7 +1110,7 @@ async def _fetch_staging_query_settings(
 )
 async def test_insert_into_stage_activity_applies_settings_and_log_comment(
     activity_environment,
-    minio_client,
+    object_storage_client,
     ateam,
     clickhouse_client,
     data_interval_start,
@@ -1275,7 +1275,7 @@ class TestHogQLModel:
         self,
         hogql_model_test_data,
         activity_environment,
-        minio_client,
+        object_storage_client,
         ateam,
         data_interval_start,
         data_interval_end,
@@ -1297,7 +1297,7 @@ class TestHogQLModel:
         ) as mock_wait:
             exported_rows = await _run_activity(
                 activity_environment=activity_environment,
-                minio_client=minio_client,
+                object_storage_client=object_storage_client,
                 team_id=ateam.pk,
                 data_interval_start=data_interval_start,
                 data_interval_end=data_interval_end,
@@ -1314,7 +1314,7 @@ class TestHogQLModel:
         self,
         hogql_model_test_data,
         activity_environment,
-        minio_client,
+        object_storage_client,
         ateam,
         data_interval_start,
         data_interval_end,
@@ -1337,7 +1337,7 @@ class TestHogQLModel:
 
         exported_rows = await _run_activity(
             activity_environment=activity_environment,
-            minio_client=minio_client,
+            object_storage_client=object_storage_client,
             team_id=ateam.pk,
             data_interval_start=data_interval_start,
             data_interval_end=data_interval_end,
@@ -1354,7 +1354,7 @@ class TestHogQLModel:
         # also assert doing a SELECT * works (should give same result)
         exported_rows_2 = await _run_activity(
             activity_environment=activity_environment,
-            minio_client=minio_client,
+            object_storage_client=object_storage_client,
             team_id=ateam.pk,
             data_interval_start=data_interval_start,
             data_interval_end=data_interval_end,
@@ -1368,7 +1368,7 @@ class TestHogQLModel:
         self,
         hogql_model_test_data,
         activity_environment,
-        minio_client,
+        object_storage_client,
         ateam,
         clickhouse_client,
         data_interval_start,
@@ -1383,7 +1383,7 @@ class TestHogQLModel:
 
         await _run_activity(
             activity_environment=activity_environment,
-            minio_client=minio_client,
+            object_storage_client=object_storage_client,
             team_id=ateam.pk,
             data_interval_start=data_interval_start,
             data_interval_end=data_interval_end,

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -310,7 +310,7 @@ async def test_producer_resumes_from_offset_after_mid_file_failure(
     activity_environment,
     data_interval_start,
     data_interval_end,
-    minio_client,
+    object_storage_client,
     ateam,
     clickhouse_client,
     model: BatchExportModel,
@@ -357,7 +357,7 @@ async def test_producer_resumes_from_offset_after_mid_file_failure(
     stage_folder = stage_result.stage_folder
 
     _, keys = await assert_files_in_s3(
-        minio_client,
+        object_storage_client,
         bucket_name=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
         key_prefix=stage_folder,
         file_format="Arrow",
@@ -367,7 +367,9 @@ async def test_producer_resumes_from_offset_after_mid_file_failure(
     assert len(keys) == 1
     key = keys[0]
 
-    file_response = await minio_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+    file_response = await object_storage_client.get_object(
+        Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key
+    )
     file_bytes = await file_response["Body"].read()
     offsets = await record_batch_end_offsets(file_bytes)
     assert len(offsets) > 1, "test needs a multi-record-batch file to exercise resume"


### PR DESCRIPTION
## Problem

The local dev/CI object storage backend moved from MinIO to SeaweedFS after MinIO's licensing change, but the batch export tests still say "MinIO" everywhere: fixtures, test names, docstrings, comments. That's misleading for anyone reading or debugging these tests today.

## Changes

Pure rename within `products/batch_exports/**`, using backend-agnostic "local object storage" terminology (matching the `objectstorage` docker service and `OBJECT_STORAGE_*` settings, so nothing needs renaming if the backend ever changes again):

- `minio_client` fixtures and params → `object_storage_client` (the duplicated fixture copies are left as-is, this PR is rename-only)
- `test_workflow_with_minio_bucket.py` → `test_workflow_with_local_object_storage.py`, and `test_..._with_minio_bucket` functions → `test_..._with_local_object_storage`
- `"minio-test"` test data strings → `"object-storage-test"`
- Docstrings/comments now say "local object storage (SeaweedFS)"

Left alone on purpose: the "e.g. MinIO, R2" docstring in `service.py` (lists real third-party S3-compatible providers customers export to), and all MinIO naming debt outside batch exports (posthog/temporal tests, hogql tests, Rust tests). Verified nothing outside batch exports references the renamed test names – the Depot CI `--deselect` quarantine only touches data-modeling tests.

## How did you test this code?

No behavior changes, rename only. Ran locally against the dev stack:

- `pytest products/batch_exports/backend/tests --collect-only` – 2024 tests collected, no errors
- `test_workflow_with_local_object_storage.py::test_s3_export_workflow_with_local_object_storage_without_events` (7 passed), `test_s3_destination_tests.py` (13 passed, 4 skipped), `test_producer.py::test_producer_resumes_from_offset_after_mid_file_failure` (1 passed) – covers the renamed fixture copies in the s3, api, and pipeline conftests
- `ruff check` and `ruff format` clean; `rg -i minio products/batch_exports` only hits the intentional `service.py` mention

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Ross directed the rename after the SeaweedFS migration; the agent scoped the sweep, chose `object_storage_client` naming with Ross, and deliberately limited scope to batch exports (wider MinIO naming debt in posthog/temporal, hogql, and Rust tests was catalogued but left for a follow-up).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
