### PR TITLE
feat(mcp): give alerts and subscriptions per-entity _posthogUrl links

### DIFF
--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -18,6 +18,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: Create alert
         description: >
             Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For
@@ -74,6 +75,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: Get alert
         description: >
             Get a specific alert by ID. Returns the full alert configuration including check results, threshold
@@ -108,6 +110,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: Update alert
         description: >
             Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed
@@ -138,6 +141,7 @@ tools:
             destructive: false
             idempotent: true
         list: true
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: List alerts
         description: >
             List all insight alerts in the project. Returns alerts with their current state, threshold or detector

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -18,7 +18,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: ?alert_type=insights&alert_id={id}
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: Create alert
         description: >
             Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For
@@ -75,7 +75,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: ?alert_type=insights&alert_id={id}
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: Get alert
         description: >
             Get a specific alert by ID. Returns the full alert configuration including check results, threshold
@@ -110,7 +110,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: ?alert_type=insights&alert_id={id}
+        enrich_url: '?alert_type=insights&alert_id={id}'
         title: Update alert
         description: >
             Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed
@@ -140,7 +140,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: ?alert_type=insights&alert_id={id}
+        enrich_url: '?alert_type=insights&alert_id={id}'
         list: true
         title: List alerts
         description: >

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -18,7 +18,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         title: Create alert
         description: >
             Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For
@@ -75,7 +75,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         title: Get alert
         description: >
             Get a specific alert by ID. Returns the full alert configuration including check results, threshold
@@ -110,7 +110,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         title: Update alert
         description: >
             Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed
@@ -140,7 +140,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         list: true
         title: List alerts
         description: >

--- a/products/alerts/mcp/tools.yaml
+++ b/products/alerts/mcp/tools.yaml
@@ -18,7 +18,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         title: Create alert
         description: >
             Create a new alert on an insight. Alerts can use either threshold-based conditions or anomaly detection. For
@@ -75,7 +75,7 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         title: Get alert
         description: >
             Get a specific alert by ID. Returns the full alert configuration including check results, threshold
@@ -110,7 +110,7 @@ tools:
             readOnly: false
             destructive: false
             idempotent: true
-        enrich_url: '?alert_type=insights&alert_id={id}'
+        enrich_url: ?alert_type=insights&alert_id={id}
         title: Update alert
         description: >
             Update an existing alert by ID. Can update name, threshold, condition, config, detector_config, subscribed
@@ -140,8 +140,8 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
+        enrich_url: ?alert_type=insights&alert_id={id}
         list: true
-        enrich_url: '?alert_type=insights&alert_id={id}'
         title: List alerts
         description: >
             List all insight alerts in the project. Returns alerts with their current state, threshold or detector

--- a/products/subscriptions/mcp/tools.yaml
+++ b/products/subscriptions/mcp/tools.yaml
@@ -138,6 +138,7 @@ tools:
             destructive: false
             idempotent: true
         list: true
+        enrich_url: '{id}'
         title: List subscriptions
         description: >
             List the team's subscriptions. Use `search` to filter by title, insight name (including the auto-generated

--- a/products/subscriptions/mcp/tools.yaml
+++ b/products/subscriptions/mcp/tools.yaml
@@ -137,8 +137,8 @@ tools:
             readOnly: true
             destructive: false
             idempotent: true
-        list: true
         enrich_url: '{id}'
+        list: true
         title: List subscriptions
         description: >
             List the team's subscriptions. Use `search` to filter by title, insight name (including the auto-generated

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -945,6 +945,10 @@ function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar
             : notedExpression
     }
 
+    // Joiner between url_prefix and the enrich_url prefix: append `/` for path-segment enrichments,
+    // but not when the template continues with a query string (e.g. '?tab=alerts&alert_id={id}').
+    const joinerFor = (prefix: string): string => (prefix.startsWith('?') ? '' : '/')
+
     if (config.list && config.enrich_url) {
         const { prefix, field, suffix, source } = parseEnrichUrl(config.enrich_url)
         // For list endpoints, 'params.x' is not meaningful (items come from the response
@@ -954,10 +958,11 @@ function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar
                 `enrich_url '{params.${field}}' is not supported on list tools — list items are enriched from the response array`
             )
         }
+        const joiner = joinerFor(prefix)
         const enriched = [
             `await withPostHogUrl(context, {`,
             `            ...${resultVar},`,
-            `            results: await Promise.all((${resultVar}.results ?? []).map((item) => withPostHogUrl(context, item, \`${baseUrl}/${prefix}\${item.${field}}${suffix}\`))),`,
+            `            results: await Promise.all((${resultVar}.results ?? []).map((item) => withPostHogUrl(context, item, \`${baseUrl}${joiner}${prefix}\${item.${field}}${suffix}\`))),`,
             `        }, '${baseUrl}')`,
         ].join('\n')
         return `        return ${wrapped(enriched)}\n`
@@ -970,8 +975,9 @@ function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar
     if (config.enrich_url) {
         const { prefix, field, suffix, source } = parseEnrichUrl(config.enrich_url)
         const sourceExpr = source === 'params' ? `params.${field}` : `${resultVar}.${field}`
+        const joiner = joinerFor(prefix)
 
-        return `        return ${wrapped(`await withPostHogUrl(context, ${resultVar}, \`${baseUrl}/${prefix}\${${sourceExpr}}${suffix}\`)`)}\n`
+        return `        return ${wrapped(`await withPostHogUrl(context, ${resultVar}, \`${baseUrl}${joiner}${prefix}\${${sourceExpr}}${suffix}\`)`)}\n`
     }
 
     return `        return ${wrapped(resultVar)}\n`

--- a/services/mcp/scripts/generate-tools.ts
+++ b/services/mcp/scripts/generate-tools.ts
@@ -946,8 +946,9 @@ function buildEnrichment(config: ToolConfig, category: CategoryConfig, resultVar
     }
 
     // Joiner between url_prefix and the enrich_url prefix: append `/` for path-segment enrichments,
-    // but not when the template continues with a query string (e.g. '?tab=alerts&alert_id={id}').
-    const joinerFor = (prefix: string): string => (prefix.startsWith('?') ? '' : '/')
+    // but not when the template continues with a query string (e.g. '?tab=alerts&alert_id={id}')
+    // or fragment (e.g. '#runs').
+    const joinerFor = (prefix: string): string => (/^[?#]/.test(prefix) ? '' : '/')
 
     if (config.list && config.enrich_url) {
         const { prefix, field, suffix, source } = parseEnrichUrl(config.enrich_url)

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -17,7 +17,7 @@ import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AlertCreateSchema = AlertsCreateBody
 
-const alertCreate = (): ToolBase<typeof AlertCreateSchema, Schemas.Alert> => ({
+const alertCreate = (): ToolBase<typeof AlertCreateSchema, WithPostHogUrl<Schemas.Alert>> => ({
     name: 'alert-create',
     schema: AlertCreateSchema,
     handler: async (context: Context, params: z.infer<typeof AlertCreateSchema>) => {
@@ -73,7 +73,7 @@ const alertCreate = (): ToolBase<typeof AlertCreateSchema, Schemas.Alert> => ({
             path: `/api/projects/${encodeURIComponent(String(projectId))}/alerts/`,
             body,
         })
-        return result
+        return await withPostHogUrl(context, result, `/alerts?alert_type=insights&alert_id=${result.id}`)
     },
 })
 
@@ -94,7 +94,7 @@ const alertDelete = (): ToolBase<typeof AlertDeleteSchema, unknown> => ({
 
 const AlertGetSchema = AlertsRetrieveParams.omit({ project_id: true }).extend(AlertsRetrieveQueryParams.shape)
 
-const alertGet = (): ToolBase<typeof AlertGetSchema, Schemas.Alert> => ({
+const alertGet = (): ToolBase<typeof AlertGetSchema, WithPostHogUrl<Schemas.Alert>> => ({
     name: 'alert-get',
     schema: AlertGetSchema,
     handler: async (context: Context, params: z.infer<typeof AlertGetSchema>) => {
@@ -109,7 +109,7 @@ const alertGet = (): ToolBase<typeof AlertGetSchema, Schemas.Alert> => ({
                 checks_offset: params.checks_offset,
             },
         })
-        return result
+        return await withPostHogUrl(context, result, `/alerts?alert_type=insights&alert_id=${result.id}`)
     },
 })
 
@@ -147,7 +147,7 @@ const alertSimulate = (): ToolBase<typeof AlertSimulateSchema, Schemas.AlertSimu
 
 const AlertUpdateSchema = AlertsPartialUpdateParams.omit({ project_id: true }).extend(AlertsPartialUpdateBody.shape)
 
-const alertUpdate = (): ToolBase<typeof AlertUpdateSchema, Schemas.Alert> => ({
+const alertUpdate = (): ToolBase<typeof AlertUpdateSchema, WithPostHogUrl<Schemas.Alert>> => ({
     name: 'alert-update',
     schema: AlertUpdateSchema,
     handler: async (context: Context, params: z.infer<typeof AlertUpdateSchema>) => {
@@ -203,7 +203,7 @@ const alertUpdate = (): ToolBase<typeof AlertUpdateSchema, Schemas.Alert> => ({
             path: `/api/projects/${encodeURIComponent(String(projectId))}/alerts/${encodeURIComponent(String(params.id))}/`,
             body,
         })
-        return result
+        return await withPostHogUrl(context, result, `/alerts?alert_type=insights&alert_id=${result.id}`)
     },
 })
 
@@ -225,7 +225,18 @@ const alertsList = (): ToolBase<typeof AlertsListSchema, WithPostHogUrl<Schemas.
                 search: params.search,
             },
         })
-        return await withPostHogUrl(context, result, '/alerts')
+        return await withPostHogUrl(
+            context,
+            {
+                ...result,
+                results: await Promise.all(
+                    (result.results ?? []).map((item) =>
+                        withPostHogUrl(context, item, `/alerts?alert_type=insights&alert_id=${item.id}`)
+                    )
+                ),
+            },
+            '/alerts'
+        )
     },
 })
 

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -200,7 +200,7 @@ const viewCreate = (): ToolBase<typeof ViewCreateSchema, WithPostHogUrl<Schemas.
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 
@@ -231,7 +231,7 @@ const viewGet = (): ToolBase<typeof ViewGetSchema, WithPostHogUrl<Schemas.DataWa
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/`,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 
@@ -258,7 +258,7 @@ const viewList = (): ToolBase<
             {
                 ...result,
                 results: await Promise.all(
-                    (result.results ?? []).map((item) => withPostHogUrl(context, item, `/sql/?open_view=${item.id}`))
+                    (result.results ?? []).map((item) => withPostHogUrl(context, item, `/sql?open_view=${item.id}`))
                 ),
             },
             '/sql'
@@ -314,7 +314,7 @@ const viewMaterialize = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/materialize/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 
@@ -363,7 +363,7 @@ const viewRun = (): ToolBase<typeof ViewRunSchema, WithPostHogUrl<Schemas.DataWa
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/run/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 
@@ -378,7 +378,7 @@ const viewRunHistory = (): ToolBase<typeof ViewRunHistorySchema, WithPostHogUrl<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/run_history/`,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 
@@ -430,7 +430,7 @@ const viewUnmaterialize = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/revert_materialization/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 
@@ -480,7 +480,7 @@ const viewUpdate = (): ToolBase<typeof ViewUpdateSchema, WithPostHogUrl<Schemas.
             path: `/api/projects/${encodeURIComponent(String(projectId))}/warehouse_saved_queries/${encodeURIComponent(String(params.id))}/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/sql/?open_view=${result.id}`)
+        return await withPostHogUrl(context, result, `/sql?open_view=${result.id}`)
     },
 })
 

--- a/services/mcp/src/tools/generated/subscriptions.ts
+++ b/services/mcp/src/tools/generated/subscriptions.ts
@@ -205,7 +205,16 @@ const subscriptionsList = (): ToolBase<
             ...result,
             results: (result.results ?? []).map((item: any) => omitResponseFields(item, ['invite_message'])),
         } as typeof result
-        return await withPostHogUrl(context, filtered, '/subscriptions')
+        return await withPostHogUrl(
+            context,
+            {
+                ...filtered,
+                results: await Promise.all(
+                    (filtered.results ?? []).map((item) => withPostHogUrl(context, item, `/subscriptions/${item.id}`))
+                ),
+            },
+            '/subscriptions'
+        )
     },
 })
 

--- a/services/mcp/src/tools/generated/tracing.ts
+++ b/services/mcp/src/tools/generated/tracing.ts
@@ -266,7 +266,7 @@ const apmTraceGet = (): ToolBase<typeof ApmTraceGetSchema, unknown> =>
                 body,
             })
             const filtered = pickResponseFields(result, ['results']) as typeof result
-            return await withPostHogUrl(context, filtered, `/tracing/?trace=${params.trace_id}`)
+            return await withPostHogUrl(context, filtered, `/tracing?trace=${params.trace_id}`)
         },
     })
 

--- a/services/mcp/tests/tools/alerts.integration.test.ts
+++ b/services/mcp/tests/tools/alerts.integration.test.ts
@@ -98,6 +98,19 @@ describe('Alerts', { concurrent: false }, () => {
             expect(data._posthogUrl).toContain('/alerts')
         })
 
+        it('should return a per-alert _posthogUrl on each result', async () => {
+            const created = await createTool.handler(context, makeAlertParams())
+            const createdAlert = parseToolResponse(created)
+            createdAlertIds.push(createdAlert.id)
+
+            const result = await listTool.handler(context, { search: createdAlert.name })
+            const data = parseToolResponse(result)
+
+            const found = data.results.find((a: { id: string }) => a.id === createdAlert.id)
+            expect(found).toBeTruthy()
+            expect(found._posthogUrl).toContain(`/alerts?alert_type=insights&alert_id=${createdAlert.id}`)
+        })
+
         it('should respect the limit parameter', async () => {
             const result = await listTool.handler(context, { limit: 1 })
             const data = parseToolResponse(result)
@@ -190,6 +203,7 @@ describe('Alerts', { concurrent: false }, () => {
             expect(alert.id).toBe(createdAlert.id)
             expect(alert.name).toBe(createdAlert.name)
             expect(alert.threshold).toBeTruthy()
+            expect(alert._posthogUrl).toContain(`/alerts?alert_type=insights&alert_id=${createdAlert.id}`)
         })
 
         it('should throw for a non-existent UUID', async () => {

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -360,6 +360,29 @@ describe('generateToolCode with input_schema', () => {
         expect(result.code).toMatchSnapshot()
     })
 
+    it('applies list enrichment without inserting a path slash before a query-string prefix', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            input_schema: 'ThingListSchema',
+            list: true,
+            enrich_url: '?tab=alerts&alert_id={id}',
+        }
+        const resolved = makeResolved({ method: 'GET' })
+
+        const result = generateToolCode(
+            'things-list',
+            config,
+            resolved,
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+
+        expect(result.code).toContain('`/things?tab=alerts&alert_id=${item.id}`')
+    })
+
     it('extends the custom schema with a selectable `fields` param and narrows the response', () => {
         const config: ToolConfig = {
             operation: 'things_list',

--- a/services/mcp/tests/unit/generate-tools.test.ts
+++ b/services/mcp/tests/unit/generate-tools.test.ts
@@ -383,6 +383,29 @@ describe('generateToolCode with input_schema', () => {
         expect(result.code).toContain('`/things?tab=alerts&alert_id=${item.id}`')
     })
 
+    it('applies list enrichment without inserting a path slash before a fragment prefix', () => {
+        const config: ToolConfig = {
+            operation: 'things_list',
+            enabled: true,
+            input_schema: 'ThingListSchema',
+            list: true,
+            enrich_url: '#tab-{id}',
+        }
+        const resolved = makeResolved({ method: 'GET' })
+
+        const result = generateToolCode(
+            'things-list',
+            config,
+            resolved,
+            defaultCategory,
+            makeSpec(),
+            new Set<string>(),
+            stubGetQuerySchema
+        )
+
+        expect(result.code).toContain('`/things#tab-${item.id}`')
+    })
+
     it('extends the custom schema with a selectable `fields` param and narrows the response', () => {
         const config: ToolConfig = {
             operation: 'things_list',


### PR DESCRIPTION
## What

MCP alerts and subscriptions tools now return per-entity deep links (`_posthogUrl`) instead of one generic URL per list, so agents stop hand-constructing URLs that 404.

| Tool | Before | After |
|---|---|---|
| `alerts-list` (each item) | _none_ | `/alerts?alert_type=insights&alert_id=<uuid>` |
| `alert-get`/`alert-create`/`alert-update` | _none_ | `/alerts?alert_type=insights&alert_id=<uuid>` |
| `subscriptions-list` (each item) | _none_ | `/subscriptions/<id>` |
| `data-warehouse` views, tracing | `/sql/?open_view=X`, `/tracing/?trace=X` | `/sql?open_view=X`, `/tracing?trace=X` |

Canonical shapes confirmed against `products/alerts/manifest.tsx:18` and `frontend/src/scenes/urls.ts`.

## Why

An MCP session surfaced the failure: asked for "the alert Bryan made", the model invented `/alerts/<uuid>` (path segment), which 404s because alerts deep-link via query params. `dashboards-get-all` already ships per-item URLs; alerts/subscriptions never adopted it because `enrich_url` had no way to express a query-string prefix (generator forced a `/` after `url_prefix`).

## How

- `services/mcp/scripts/generate-tools.ts`: `joinerFor` skips the `/` when the `enrich_url` prefix starts with `?` or `#`; path-style templates unchanged.
- `products/alerts/mcp/tools.yaml`: `enrich_url: '?alert_type=insights&alert_id={id}'` on list/get/create/update (delete stays plain, 204).
- `products/subscriptions/mcp/tools.yaml`: `enrich_url: '{id}'` on list.

Regenerated TS is checked in; the `/sql` and `/tracing` diffs above fall out of the same generator fix.

## Tests

- Unit: 93/93 in `tests/unit/generate-tools.test.ts` (new `?` and `#` prefix cases).
- Integration: 22/22 in `tests/tools/alerts.integration.test.ts`, including the new per-item URL assertions.

## Docs

Internal MCP tooling. `skip-inkeep-docs`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*