### PR TITLE
feat(warehouse): add LinkedIn Ads sponsored messaging stats tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/canonical_descriptions.py
@@ -30,6 +30,21 @@ _STATS_COLUMNS = {
     "follows": "Number of new followers attributed to the ad.",
 }
 
+# Sponsored Messaging (Message Ads / Conversation Ads) metrics, on top of the base stats columns.
+_MESSAGING_STATS_COLUMNS = {
+    **_STATS_COLUMNS,
+    "sends": "Count of sends of Sponsored Messaging ads.",
+    "opens": "Count of opens of Sponsored Messaging ads.",
+    "action_clicks": "Clicks on the action button of the Sponsored Messaging ad.",
+    "ad_unit_clicks": "Clicks on the ad unit displayed alongside the Sponsored Messaging ad.",
+    "text_url_clicks": "Clicks on links (anchor tags) included in the body of the Sponsored Messaging ad.",
+    "one_click_lead_form_opens": "Times users opened the lead form for a One Click Lead Gen campaign.",
+    "lead_generation_mail_contact_info_shares": "Times users shared contact info through the One Click Lead Gen for Sponsored Messaging ads.",
+    "lead_generation_mail_interested_clicks": "Sponsored Messaging ad recipients who clicked to demonstrate interest.",
+    "headline_clicks": "Times members clicked on the headline of conversation ads.",
+    "headline_impressions": "Times members were shown the headline of conversation ads.",
+}
+
 
 CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
     "accounts": {
@@ -119,6 +134,30 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             **_STATS_COLUMNS,
             "creative_id": "ID of the creative these metrics are for.",
             "date_range": "The reporting date range these metrics cover.",
+        },
+    },
+    "campaign_messaging_stats": {
+        "description": "Daily performance analytics for LinkedIn ad campaigns including Sponsored Messaging metrics, pivoted by campaign.",
+        "docs_url": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting",
+        "columns": {
+            **_MESSAGING_STATS_COLUMNS,
+            "campaign_id": "ID of the campaign these metrics are for.",
+        },
+    },
+    "campaign_group_messaging_stats": {
+        "description": "Daily performance analytics for LinkedIn ad campaign groups including Sponsored Messaging metrics, pivoted by campaign group.",
+        "docs_url": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting",
+        "columns": {
+            **_MESSAGING_STATS_COLUMNS,
+            "campaign_group_id": "ID of the campaign group these metrics are for.",
+        },
+    },
+    "creative_messaging_stats": {
+        "description": "Daily performance analytics for LinkedIn ad creatives including Sponsored Messaging metrics, pivoted by creative.",
+        "docs_url": "https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting",
+        "columns": {
+            **_MESSAGING_STATS_COLUMNS,
+            "creative_id": "ID of the creative these metrics are for.",
         },
     },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/client.py
@@ -41,6 +41,34 @@ ANALYTICS_MIN_CHUNK_DAYS = 1
 # spike that forced a shrink doesn't keep the window small across an otherwise sparse date range.
 ANALYTICS_GROW_THRESHOLD = ANALYTICS_RESPONSE_CAP // 4
 
+# `q=analytics` rejects requests selecting more than 20 fields. Resources with wider schemas (the
+# messaging stats tables) are fetched in multiple requests per window and merged on the row key.
+ANALYTICS_MAX_FIELDS_PER_REQUEST = 20
+# The row key of an analytics element. Every field batch must include these so batches can be
+# merged back into full rows.
+ANALYTICS_ROW_KEY_FIELDS = ("dateRange", "pivotValues")
+
+
+def _analytics_field_batches(fields: list[str]) -> list[list[str]]:
+    """Split an analytics field list into request-sized batches, repeating the row-key fields in
+    each batch. Field lists within the request limit come back unchanged as a single batch."""
+    if len(fields) <= ANALYTICS_MAX_FIELDS_PER_REQUEST:
+        return [fields]
+    key_fields = [f for f in fields if f in ANALYTICS_ROW_KEY_FIELDS]
+    metric_fields = [f for f in fields if f not in ANALYTICS_ROW_KEY_FIELDS]
+    metrics_per_batch = ANALYTICS_MAX_FIELDS_PER_REQUEST - len(key_fields)
+    return [
+        key_fields + metric_fields[i : i + metrics_per_batch] for i in range(0, len(metric_fields), metrics_per_batch)
+    ]
+
+
+def _analytics_row_key(element: dict[str, Any]) -> tuple[str, tuple[Any, ...]]:
+    return (
+        json.dumps(element.get("dateRange"), sort_keys=True),
+        tuple(element.get("pivotValues") or ()),
+    )
+
+
 # Upper bound on how long we'll honour a Retry-After header before giving up, so a hostile or
 # misconfigured value can't hang the activity past its heartbeat.
 MAX_RETRY_AFTER_SECONDS = 60.0
@@ -181,7 +209,7 @@ class LinkedinAdsClient:
     def get_analytics(
         self,
         account_id: str,
-        pivot: LinkedinAdsPivot = LinkedinAdsPivot.CAMPAIGN,
+        resource: LinkedinAdsResource = LinkedinAdsResource.CampaignStats,
         date_start: Optional[str] = None,
         date_end: Optional[str] = None,
     ) -> Generator[tuple[list[dict[str, Any]], None]]:
@@ -190,33 +218,49 @@ class LinkedinAdsClient:
         back truncated, then carries the learned size forward. A truncated response is silently
         capped by LinkedIn — we can't tell which rows were dropped — so we discard it and re-fetch
         the same start with a smaller window rather than yielding partial data. Only a single-day
-        window that still caps is surfaced (with a warning), since it can't be split further."""
-        resource_by_pivot = {
-            LinkedinAdsPivot.CAMPAIGN: LinkedinAdsResource.CampaignStats,
-            LinkedinAdsPivot.CAMPAIGN_GROUP: LinkedinAdsResource.CampaignGroupStats,
-            LinkedinAdsPivot.CREATIVE: LinkedinAdsResource.CreativeStats,
-        }
-        resource = resource_by_pivot.get(pivot, LinkedinAdsResource.CampaignStats)
-        fields = ",".join(self._get_fields_for_resource(resource))
+        window that still caps is surfaced (with a warning), since it can't be split further.
+
+        Resources with more fields than one request allows are fetched in multiple field batches
+        per window and merged on (dateRange, pivotValues); a cap on any batch caps the window."""
+        pivot = LINKEDIN_ADS_PIVOTS.get(resource, LinkedinAdsPivot.CAMPAIGN)
+        field_batches = _analytics_field_batches(self._get_fields_for_resource(resource))
         accounts = [f"{LINKEDIN_SPONSORED_URN_PREFIX}Account:{account_id}"]
 
-        def _build_params(chunk_start: Optional[str], chunk_end: Optional[str]) -> dict[str, Any]:
+        def _build_params(
+            chunk_start: Optional[str], chunk_end: Optional[str], batch_fields: list[str]
+        ) -> dict[str, Any]:
             params: dict[str, Any] = {
                 "q": "analytics",
                 "pivot": pivot.value,
                 "timeGranularity": "DAILY",
                 "accounts": accounts,
-                "fields": fields,
+                "fields": ",".join(batch_fields),
             }
             if chunk_start and chunk_end:
                 params["dateRange"] = self._format_date_range(chunk_start, chunk_end)
             return params
 
+        def _fetch_window(chunk_start: Optional[str], chunk_end: Optional[str]) -> tuple[list[dict[str, Any]], bool]:
+            """Fetch every field batch for one window and merge rows on the row key. Stops early
+            once a batch caps — the window is going to shrink and be re-fetched anyway."""
+            merged: dict[tuple[str, tuple[Any, ...]], dict[str, Any]] = {}
+            for batch_fields in field_batches:
+                elements = self._make_request(
+                    endpoint=resource,
+                    finder="analytics",
+                    extra_params=_build_params(chunk_start, chunk_end, batch_fields),
+                )
+                if len(field_batches) == 1:
+                    return elements, len(elements) >= ANALYTICS_RESPONSE_CAP
+                for element in elements:
+                    merged.setdefault(_analytics_row_key(element), {}).update(element)
+                if len(elements) >= ANALYTICS_RESPONSE_CAP:
+                    return list(merged.values()), True
+            return list(merged.values()), False
+
         if not (date_start and date_end):
-            yield (
-                self._make_request(endpoint=resource, finder="analytics", extra_params=_build_params(None, None)),
-                None,
-            )
+            elements, _ = _fetch_window(None, None)
+            yield elements, None
             return
 
         chunk_days = ANALYTICS_INITIAL_CHUNK_DAYS
@@ -224,12 +268,7 @@ class LinkedinAdsClient:
         end_date = dt.date.fromisoformat(date_end)
         while chunk_start <= end_date:
             chunk_end = min(chunk_start + dt.timedelta(days=chunk_days - 1), end_date)
-            elements = self._make_request(
-                endpoint=resource,
-                finder="analytics",
-                extra_params=_build_params(chunk_start.isoformat(), chunk_end.isoformat()),
-            )
-            capped = len(elements) >= ANALYTICS_RESPONSE_CAP
+            elements, capped = _fetch_window(chunk_start.isoformat(), chunk_end.isoformat())
             window_days = (chunk_end - chunk_start).days + 1
 
             # Truncated response and the window spans more than a day: halve it (by its real span,
@@ -278,7 +317,7 @@ class LinkedinAdsClient:
         elif resource == LinkedinAdsResource.Creatives:
             yield from self.get_creatives(account_id, starting_page_token=starting_page_token)
         elif resource in LINKEDIN_ADS_PIVOTS:
-            yield from self.get_analytics(account_id, LINKEDIN_ADS_PIVOTS[resource], date_start, date_end)
+            yield from self.get_analytics(account_id, resource, date_start, date_end)
         else:
             raise ValueError(f"Unsupported resource: {resource}")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/schemas.py
@@ -26,6 +26,9 @@ class LinkedinAdsResource(StrEnum):
     CampaignStats = "campaign_stats"
     CampaignGroupStats = "campaign_group_stats"
     CreativeStats = "creative_stats"
+    CampaignMessagingStats = "campaign_messaging_stats"
+    CampaignGroupMessagingStats = "campaign_group_messaging_stats"
+    CreativeMessagingStats = "creative_messaging_stats"
 
 
 class LinkedinAdsPivot(StrEnum):
@@ -44,6 +47,9 @@ LINKEDIN_ADS_ENDPOINTS = {
     LinkedinAdsResource.CampaignStats: "adAnalytics",
     LinkedinAdsResource.CampaignGroupStats: "adAnalytics",
     LinkedinAdsResource.CreativeStats: "adAnalytics",
+    LinkedinAdsResource.CampaignMessagingStats: "adAnalytics",
+    LinkedinAdsResource.CampaignGroupMessagingStats: "adAnalytics",
+    LinkedinAdsResource.CreativeMessagingStats: "adAnalytics",
 }
 
 # Pivot mappings for analytics resources
@@ -51,7 +57,46 @@ LINKEDIN_ADS_PIVOTS = {
     LinkedinAdsResource.CampaignStats: LinkedinAdsPivot.CAMPAIGN,
     LinkedinAdsResource.CampaignGroupStats: LinkedinAdsPivot.CAMPAIGN_GROUP,
     LinkedinAdsResource.CreativeStats: LinkedinAdsPivot.CREATIVE,
+    LinkedinAdsResource.CampaignMessagingStats: LinkedinAdsPivot.CAMPAIGN,
+    LinkedinAdsResource.CampaignGroupMessagingStats: LinkedinAdsPivot.CAMPAIGN_GROUP,
+    LinkedinAdsResource.CreativeMessagingStats: LinkedinAdsPivot.CREATIVE,
 }
+
+# The base stats field set shared by all `adAnalytics` tables. `dateRange` and `pivotValues`
+# key each row; the rest are the general-performance metrics.
+STATS_FIELD_NAMES = [
+    "impressions",
+    "clicks",
+    "dateRange",
+    "pivotValues",
+    "costInUsd",
+    "costInLocalCurrency",
+    "externalWebsiteConversions",
+    "conversionValueInLocalCurrency",
+    "landingPageClicks",
+    "totalEngagements",
+    "videoViews",
+    "videoCompletions",
+    "oneClickLeads",
+    "follows",
+]
+
+# Sponsored Messaging (Message Ads / Conversation Ads) metrics. Together with the base set this
+# exceeds LinkedIn's 20-fields-per-request limit, so the client splits the fetch into multiple
+# requests and merges rows on (dateRange, pivotValues).
+MESSAGING_STATS_FIELD_NAMES = [
+    *STATS_FIELD_NAMES,
+    "sends",
+    "opens",
+    "actionClicks",
+    "adUnitClicks",
+    "textUrlClicks",
+    "oneClickLeadFormOpens",
+    "leadGenerationMailContactInfoShares",
+    "leadGenerationMailInterestedClicks",
+    "headlineClicks",
+    "headlineImpressions",
+]
 
 
 class ResourceSchema(TypedDict):
@@ -144,22 +189,7 @@ RESOURCE_SCHEMAS: dict[LinkedinAdsResource, ResourceSchema] = {
     },
     LinkedinAdsResource.CampaignStats: {
         "resource_name": "campaign_stats",
-        "field_names": [
-            "impressions",
-            "clicks",
-            "dateRange",
-            "pivotValues",
-            "costInUsd",
-            "costInLocalCurrency",
-            "externalWebsiteConversions",
-            "conversionValueInLocalCurrency",
-            "landingPageClicks",
-            "totalEngagements",
-            "videoViews",
-            "videoCompletions",
-            "oneClickLeads",
-            "follows",
-        ],
+        "field_names": STATS_FIELD_NAMES,
         "primary_key": ["date_start", "date_end", "campaign_id"],
         "filter_field_names": [
             ("date_start", IncrementalFieldType.Date),
@@ -172,22 +202,7 @@ RESOURCE_SCHEMAS: dict[LinkedinAdsResource, ResourceSchema] = {
     },
     LinkedinAdsResource.CampaignGroupStats: {
         "resource_name": "campaign_group_stats",
-        "field_names": [
-            "impressions",
-            "clicks",
-            "dateRange",
-            "pivotValues",
-            "costInUsd",
-            "costInLocalCurrency",
-            "externalWebsiteConversions",
-            "conversionValueInLocalCurrency",
-            "landingPageClicks",
-            "totalEngagements",
-            "videoViews",
-            "videoCompletions",
-            "oneClickLeads",
-            "follows",
-        ],
+        "field_names": STATS_FIELD_NAMES,
         "primary_key": ["date_start", "date_end", "campaign_group_id"],
         "filter_field_names": [
             ("date_start", IncrementalFieldType.Date),
@@ -200,22 +215,46 @@ RESOURCE_SCHEMAS: dict[LinkedinAdsResource, ResourceSchema] = {
     },
     LinkedinAdsResource.CreativeStats: {
         "resource_name": "creative_stats",
-        "field_names": [
-            "impressions",
-            "clicks",
-            "dateRange",
-            "pivotValues",
-            "costInUsd",
-            "costInLocalCurrency",
-            "externalWebsiteConversions",
-            "conversionValueInLocalCurrency",
-            "landingPageClicks",
-            "totalEngagements",
-            "videoViews",
-            "videoCompletions",
-            "oneClickLeads",
-            "follows",
+        "field_names": STATS_FIELD_NAMES,
+        "primary_key": ["date_start", "date_end", "creative_id"],
+        "filter_field_names": [
+            ("date_start", IncrementalFieldType.Date),
         ],
+        "partition_keys": ["date_start"],
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "is_stats": True,
+        "partition_size": 1,
+    },
+    LinkedinAdsResource.CampaignMessagingStats: {
+        "resource_name": "campaign_messaging_stats",
+        "field_names": MESSAGING_STATS_FIELD_NAMES,
+        "primary_key": ["date_start", "date_end", "campaign_id"],
+        "filter_field_names": [
+            ("date_start", IncrementalFieldType.Date),
+        ],
+        "partition_keys": ["date_start"],
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "is_stats": True,
+        "partition_size": 1,
+    },
+    LinkedinAdsResource.CampaignGroupMessagingStats: {
+        "resource_name": "campaign_group_messaging_stats",
+        "field_names": MESSAGING_STATS_FIELD_NAMES,
+        "primary_key": ["date_start", "date_end", "campaign_group_id"],
+        "filter_field_names": [
+            ("date_start", IncrementalFieldType.Date),
+        ],
+        "partition_keys": ["date_start"],
+        "partition_mode": "datetime",
+        "partition_format": "week",
+        "is_stats": True,
+        "partition_size": 1,
+    },
+    LinkedinAdsResource.CreativeMessagingStats: {
+        "resource_name": "creative_messaging_stats",
+        "field_names": MESSAGING_STATS_FIELD_NAMES,
         "primary_key": ["date_start", "date_end", "creative_id"],
         "filter_field_names": [
             ("date_start", IncrementalFieldType.Date),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_client.py
@@ -11,7 +11,7 @@ from structlog.testing import capture_logs
 from products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.client import (
     LinkedinAdsClient,
     LinkedinAdsDailyRateLimitError,
-    LinkedinAdsPivot,
+    LinkedinAdsResource,
     LinkedinAdsRetryableError,
 )
 
@@ -191,7 +191,7 @@ class TestLinkedinAdsClient:
         pages = list(
             client.get_analytics(
                 account_id=self.account_id,
-                pivot=LinkedinAdsPivot.CAMPAIGN,
+                resource=LinkedinAdsResource.CampaignStats,
                 date_start="2024-01-01",
                 date_end="2024-01-05",
             )
@@ -222,7 +222,7 @@ class TestLinkedinAdsClient:
         pages = list(
             client.get_analytics(
                 account_id=self.account_id,
-                pivot=LinkedinAdsPivot.CREATIVE,
+                resource=LinkedinAdsResource.CreativeStats,
                 date_start="2024-01-01",
                 date_end="2024-07-19",
             )
@@ -265,7 +265,7 @@ class TestLinkedinAdsClient:
         pages = list(
             client.get_analytics(
                 account_id=self.account_id,
-                pivot=LinkedinAdsPivot.CAMPAIGN,
+                resource=LinkedinAdsResource.CampaignStats,
                 date_start="2024-01-01",
                 date_end="2025-12-31",
             )
@@ -306,7 +306,7 @@ class TestLinkedinAdsClient:
             pages = list(
                 client.get_analytics(
                     account_id=self.account_id,
-                    pivot=LinkedinAdsPivot.CREATIVE,
+                    resource=LinkedinAdsResource.CreativeStats,
                     date_start="2024-01-01",
                     date_end="2024-01-01",
                 )
@@ -331,7 +331,7 @@ class TestLinkedinAdsClient:
         pages = list(
             client.get_analytics(
                 account_id=self.account_id,
-                pivot=LinkedinAdsPivot.CAMPAIGN,
+                resource=LinkedinAdsResource.CampaignStats,
                 date_start="2024-01-15",
                 date_end="2024-01-15",
             )
@@ -344,6 +344,124 @@ class TestLinkedinAdsClient:
             "start": {"year": 2024, "month": 1, "day": 15},
             "end": {"year": 2024, "month": 1, "day": 15},
         }
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_get_analytics_messaging_resource_splits_fields_and_merges_rows(self, mock_restli_client):
+        """Messaging stats resources exceed LinkedIn's 20-fields-per-request limit, so one window
+        is fetched in multiple requests (each within the limit and carrying the row-key fields)
+        and merged back into full rows on (dateRange, pivotValues)."""
+        from products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.client import (
+            ANALYTICS_MAX_FIELDS_PER_REQUEST,
+        )
+        from products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.schemas import (
+            MESSAGING_STATS_FIELD_NAMES,
+        )
+
+        date_range = {"start": {"year": 2024, "month": 1, "day": 15}, "end": {"year": 2024, "month": 1, "day": 15}}
+
+        def respond(*args, **kwargs):
+            fields = kwargs["query_params"]["fields"].split(",")
+            row: dict[str, object] = {"dateRange": date_range, "pivotValues": ["urn:li:sponsoredCampaign:1"]}
+            if "impressions" in fields:
+                row["impressions"] = 100
+            if "sends" in fields:
+                row["sends"] = 7
+            response = mock.MagicMock()
+            response.status_code = 200
+            response.elements = [row]
+            return response
+
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.side_effect = respond
+
+        client = LinkedinAdsClient(self.access_token)
+        pages = list(
+            client.get_analytics(
+                account_id=self.account_id,
+                resource=LinkedinAdsResource.CampaignMessagingStats,
+                date_start="2024-01-15",
+                date_end="2024-01-15",
+            )
+        )
+
+        requested_field_lists = [
+            call[1]["query_params"]["fields"].split(",") for call in mock_client_instance.finder.call_args_list
+        ]
+        assert len(requested_field_lists) == 2
+        for fields in requested_field_lists:
+            assert len(fields) <= ANALYTICS_MAX_FIELDS_PER_REQUEST
+            assert "dateRange" in fields
+            assert "pivotValues" in fields
+        combined = set().union(*requested_field_lists)
+        assert combined == set(MESSAGING_STATS_FIELD_NAMES)
+
+        # Both batches' metrics land on the same merged row.
+        assert len(pages) == 1
+        elements, _ = pages[0]
+        assert len(elements) == 1
+        assert elements[0]["impressions"] == 100
+        assert elements[0]["sends"] == 7
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.client.RestliClient")
+    def test_get_analytics_messaging_capped_batch_discards_window_and_shrinks(self, mock_restli_client):
+        """When a field batch caps for a messaging resource, the remaining batches of that window
+        are skipped and the window is discarded and re-fetched smaller — partially merged rows are
+        never yielded."""
+        from products.warehouse_sources.backend.temporal.data_imports.sources.linkedin_ads.client import (
+            ANALYTICS_RESPONSE_CAP,
+        )
+
+        date_range = {"start": {"year": 2024, "month": 1, "day": 1}, "end": {"year": 2024, "month": 1, "day": 2}}
+        calls = 0
+
+        def respond(*args, **kwargs):
+            nonlocal calls
+            response = mock.MagicMock()
+            response.status_code = 200
+            if calls == 0:
+                response.elements = [
+                    {"dateRange": date_range, "pivotValues": [f"urn:li:sponsoredCampaign:{i}"], "impressions": i}
+                    for i in range(ANALYTICS_RESPONSE_CAP)
+                ]
+            else:
+                response.elements = [
+                    {
+                        "dateRange": date_range,
+                        "pivotValues": ["urn:li:sponsoredCampaign:1"],
+                        "impressions": 1,
+                        "sends": 2,
+                    }
+                ]
+            calls += 1
+            return response
+
+        mock_client_instance = mock_restli_client.return_value
+        mock_client_instance.finder.side_effect = respond
+
+        client = LinkedinAdsClient(self.access_token)
+        pages = list(
+            client.get_analytics(
+                account_id=self.account_id,
+                resource=LinkedinAdsResource.CampaignMessagingStats,
+                date_start="2024-01-01",
+                date_end="2024-01-02",
+            )
+        )
+
+        # The capped 2-day window is discarded: no yielded page carries its truncated rows.
+        assert all(len(page[0]) < ANALYTICS_RESPONSE_CAP for page in pages)
+        first_params, second_params = (
+            call[1]["query_params"] for call in mock_client_instance.finder.call_args_list[:2]
+        )
+        # After the cap, the very next request re-fetches batch 1 at a halved (1-day) window —
+        # the capped window's second batch is never requested.
+        assert second_params["fields"] == first_params["fields"]
+        assert second_params["dateRange"] == {
+            "start": {"year": 2024, "month": 1, "day": 1},
+            "end": {"year": 2024, "month": 1, "day": 1},
+        }
+        # The shrunken windows still merge both batches' metrics into full rows.
+        assert all(el["sends"] == 2 for page in pages for el in page[0])
 
     def test_format_date_range(self):
         """Test date range formatting for LinkedIn API."""


### PR DESCRIPTION
## Problem

The LinkedIn Ads source syncs Sponsored Messaging (Message Ads / Conversation Ads) campaigns, but the stats tables only carry general performance fields. The message-specific metrics LinkedIn reports for these campaigns (sends, opens, CTA clicks, lead form opens, ...) are missing, so users running Sponsored Messaging can't report on them from the warehouse. Requested via a support ticket.

We can't just add the metrics to the existing stats tables: the analytics finder [accepts at most 20 fields per request](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting?view=li-lms-2026-07&tabs=http#requesting-specific-metrics-in-the-analytics-finder), and the existing tables already request 14 (12 metrics + the `dateRange`/`pivotValues` row keys). The full set is 24.

## Changes

Three new opt-in tables mirroring the existing stats tables, each carrying the full base field set plus the 10 Sponsored Messaging metrics, so no joins are needed downstream:

- `campaign_messaging_stats`
- `campaign_group_messaging_stats`
- `creative_messaging_stats`

New metrics: `sends`, `opens`, `actionClicks`, `adUnitClicks`, `textUrlClicks`, `oneClickLeadFormOpens`, `leadGenerationMailContactInfoShares`, `leadGenerationMailInterestedClicks`, `headlineClicks`, `headlineImpressions` (all confirmed against LinkedIn's [metrics reference](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/ads-reporting/ads-reporting-schema?view=li-lms-2026-07)).

To fit 24 fields under the 20-field cap, the client now splits an analytics fetch into multiple field batches per date window and merges the rows back on `(dateRange, pivotValues)`:

- each batch repeats the two row-key fields so batches can be merged;
- a response cap on any batch discards the window and triggers the existing shrink-and-refetch logic (remaining batches for the doomed window are skipped);
- resources within the limit (all existing tables) keep issuing exactly one request per window, byte-for-byte unchanged.

`get_analytics` now takes the resource instead of the pivot, since two resources can share a pivot. Also added canonical column descriptions for the new tables sourced from the LinkedIn docs, and deduplicated the three identical stats field lists in `RESOURCE_SCHEMAS` into a shared constant.

Existing connected sources get the new tables offered (disabled by default) after a schema refresh; primary keys, incremental sync on `date_start`, and partitioning match the existing stats tables.

## How did you test this code?

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/` - 116 passed.
- New test: messaging resource fetch splits into 2 requests (each within the 20-field limit, each carrying the row-key fields, union covering the whole schema) and merges both batches' metrics into one row - catches a regression where batching over- or under-requests fields or merges on the wrong key, producing partial/duplicate rows.
- New test: a capped batch discards the window, skips the remaining batches, and re-fetches smaller - catches a regression where truncated rows from a capped batch get silently merged and yielded.
- No live-API testing was done; field names and the 20-field limit were verified against LinkedIn's API reference for version 2026-07.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The public docs table catalog for LinkedIn Ads renders from `get_schemas` + canonical descriptions (`lists_tables_without_credentials = True`), so the new tables show up without a docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`. Originating support request asked for 6 required metrics; we chose to add all 10 message-related metrics LinkedIn exposes. Considered squeezing the 6 required metrics into the existing stats tables (fits exactly at the 20-field cap but leaves no headroom and changes existing tables for everyone) - rejected in favor of separate opt-in messaging tables with full field mirroring, which required implementing the multi-request field batching in the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
