### PR TITLE
fix(tasks): accept Pi cloud model selection

### DIFF
--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1834,6 +1834,18 @@ def get_relayed_imported_mcp_name_collision_error(attrs: dict) -> str | None:
     return None
 
 
+def _get_task_runtime_from_serializer_context(context: dict[str, Any]) -> str | None:
+    view = context.get("view")
+    request = context.get("request")
+    view_kwargs = getattr(view, "kwargs", {})
+    task_id = view_kwargs.get("parent_lookup_task_id") or view_kwargs.get("pk")
+    team_id = getattr(view, "team_id", None)
+    user_id = getattr(getattr(request, "user", None), "id", None)
+    if not isinstance(task_id, str) or not isinstance(team_id, int):
+        return None
+    return tasks_facade.task_runtime(task_id, team_id, user_id, for_control=True)
+
+
 class TaskRunCreateRequestSerializer(ImportedMcpServersFieldMixin, RelayedMcpServersFieldMixin, serializers.Serializer):
     """Request body for creating a new task run"""
 
@@ -2185,7 +2197,8 @@ class TaskRunBootstrapCreateRequestSerializer(
                         f"'{runtime_adapter}'. Supported values: {allowed_values}."
                     )
 
-        runtime_fields = ("runtime_adapter", "model")
+        is_pi_runtime = _get_task_runtime_from_serializer_context(self.context) == tasks_facade.TaskRuntime.PI
+        runtime_fields = ("model",) if is_pi_runtime else ("runtime_adapter", "model")
         has_runtime_selection = any(
             attrs.get(field) is not None
             for field in (*runtime_fields, "reasoning_effort", "context_window", "fast_mode")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -2287,6 +2287,62 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(task_run.state["auto_publish"], True)
         mock_workflow.assert_not_called()
 
+    @patch("products.tasks.backend.presentation.views.api.tasks_facade.pi_cloud_runtime_enabled", return_value=True)
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_run_endpoint_accepts_pi_model_without_runtime_adapter(
+        self, mock_workflow: MagicMock, _mock_pi_enabled: MagicMock
+    ) -> None:
+        task = self.create_task(runtime=Task.Runtime.PI)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {
+                "environment": "cloud",
+                "mode": "interactive",
+                "model": "claude-haiku-4-5",
+                "reasoning_effort": "high",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        task_run = TaskRun.objects.get(id=response.json()["id"])
+        self.assertNotIn("runtime_adapter", task_run.state)
+        self.assertNotIn("provider", task_run.state)
+        self.assertEqual(task_run.state["model"], "claude-haiku-4-5")
+        self.assertEqual(task_run.state["reasoning_effort"], "high")
+        mock_workflow.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("missing_runtime_adapter", {"model": "gpt-5.3-codex"}, "runtime_adapter"),
+            ("missing_model", {"runtime_adapter": "codex"}, "model"),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_run_endpoint_rejects_incomplete_acp_runtime_selection(
+        self, _case_name: str, payload: dict[str, str], expected_attr: str, mock_workflow: MagicMock
+    ) -> None:
+        task = self.create_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/",
+            {"environment": "cloud", **payload},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "This field is required when selecting a cloud runtime.",
+                "attr": expected_attr,
+            },
+        )
+        mock_workflow.assert_not_called()
+
     # is_url_allowed resolves DNS for real in CI, and example.com subdomains don't resolve.
     @patch("products.tasks.backend.presentation.serializers.is_url_allowed", return_value=(True, None))
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")


### PR DESCRIPTION
## Problem

The new task view creates native Pi cloud runs with a model and reasoning effort but no runtime adapter. The run bootstrap serializer treated every cloud runtime selection as ACP and rejected the valid Pi payload before creating the run.

## Changes

- Resolve the task runtime from the serializer context.
- Require only a model for native Pi selections while retaining runtime adapter and model validation for ACP.
- Add regression coverage for Pi acceptance and incomplete ACP selections.