### PR TITLE
fix: shrink export join keys and cap sink buffering

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -180,7 +180,7 @@ LEFT JOIN
 SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads},
     join_algorithm = 'hash', max_bytes_before_external_group_by = 2000000000,
     min_insert_block_size_rows = 65536, min_insert_block_size_bytes = 134217728,
-    output_format_parquet_row_group_size = 131072
+    output_format_parquet_row_group_size = 131072, output_format_parquet_row_group_size_bytes = 134217728
 """
 
     def run(client: Client) -> str:

--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -141,7 +141,9 @@ def export_query_log_archive_day(
     # Leaf rows of a query straddling midnight land on the next event_date, hence the two-day window.
     # The rollup keeps only parents present in the day's initial rows so its join hash table stays
     # small enough to hold in memory; spilling the join to disk instead OOMs or times out on the
-    # read-back of the wide probe rows.
+    # read-back of the wide probe rows. Parents are matched on cityHash64(query_id) rather than the
+    # 36-char id string, shrinking the IN set and hash table keys 5x; a 64-bit collision would merge
+    # one pair of queries' rollups (~once per 160 years of daily exports).
     query = f"""
 INSERT INTO FUNCTION s3('{s3_url}', 'Parquet')
 SELECT
@@ -155,6 +157,7 @@ FROM
 (
     SELECT
         {columns},
+        cityHash64(query_id) AS parent_key,
         query,
         lc_query__query
     FROM {SOURCE_TABLE}
@@ -163,19 +166,21 @@ FROM
 LEFT JOIN
 (
     SELECT
-        initial_query_id AS leaf_initial_query_id,
+        cityHash64(initial_query_id) AS leaf_parent_key,
         count() AS leaf_count,
         max(memory_usage) AS leaf_memory_usage_max,
         {leaf_sums}
     FROM {SOURCE_TABLE}
     WHERE event_date >= toDate('{day}') AND event_date <= toDate('{day}') + 1 AND NOT is_initial_query
-        AND initial_query_id IN (
-            SELECT query_id FROM {SOURCE_TABLE} WHERE event_date = toDate('{day}') AND is_initial_query
+        AND cityHash64(initial_query_id) IN (
+            SELECT cityHash64(query_id) FROM {SOURCE_TABLE} WHERE event_date = toDate('{day}') AND is_initial_query
         )
-    GROUP BY leaf_initial_query_id
-) AS leaf ON initial_rows.query_id = leaf.leaf_initial_query_id
+    GROUP BY leaf_parent_key
+) AS leaf ON initial_rows.parent_key = leaf.leaf_parent_key
 SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads},
-    join_algorithm = 'hash', max_bytes_before_external_group_by = 2000000000
+    join_algorithm = 'hash', max_bytes_before_external_group_by = 2000000000,
+    min_insert_block_size_rows = 65536, min_insert_block_size_bytes = 134217728,
+    output_format_parquet_row_group_size = 131072
 """
 
     def run(client: Client) -> str:


### PR DESCRIPTION
## Problem

The in-memory rollup join fit EU but not US, and both regions' real runs failed where read-only tests passed. Two causes: the `IN` set and join hash table are keyed by 36-character `query_id` strings whose footprint scales with volume (US peaked over the 20 GiB cap solo), and the real `INSERT` buffers ~1M-row blocks of very wide rows for the parquet writer, which the read-only test harness replaced with a null sink and so never measured.

## Changes

- Match parents on `cityHash64(query_id)` instead of the id string, shrinking the `IN` set and hash-table keys from ~50 bytes to 8 per entry. 
- Cap sink buffering: `min_insert_block_size_rows/bytes` down to 64k rows / 128 MB and `output_format_parquet_row_group_size` to 128k rows, bounding what the parquet writer holds at a couple of GB in exchange for smaller row groups.

## How did you test this code?

- Verified on both OPS nodes at the job's exact 20 GiB cap, on the day every prior configuration failed: EU finished clean in 28 min at 6.43 GiB peak, US in 30 min at 12.12 GiB peak.
- The sink settings are the one part not covered by that harness (its read-only user cannot INSERT); the first post-deploy retry validates them. Rendered SQL also runs end to end on local dev ClickHouse; ruff and preflight pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs page covers this export job.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in a session driven by Andy Zhao, iterating against live OPS-node measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
