### PR TITLE
feat(tasks): add sandbox compute rate card pricing

### DIFF
--- a/products/tasks/backend/logic/services/sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/sandbox_pricing.py
@@ -143,11 +143,13 @@ def _decimal_seconds(duration) -> Decimal:
 
 
 def _billable_resources(session: SandboxSession) -> tuple[Decimal, Decimal]:
-    if session.burstable:
-        if session.cpu_request_cores is None or session.memory_request_mb is None:
-            raise ValueError("burstable sandbox sessions require recorded request resources")
-        return Decimal(str(session.cpu_request_cores)), Decimal(session.memory_request_mb) / Decimal(1024)
-    return Decimal(str(session.cpu_cores)), Decimal(str(session.memory_gb))
+    cpu_cores = session.cpu_request_cores if session.cpu_request_cores is not None else session.cpu_cores
+    memory_gib = (
+        Decimal(session.memory_request_mb) / Decimal(1024)
+        if session.memory_request_mb is not None
+        else Decimal(str(session.memory_gb))
+    )
+    return Decimal(str(cpu_cores)), memory_gib
 
 
 def _price_line_item(

--- a/products/tasks/backend/logic/services/sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/sandbox_pricing.py
@@ -1,0 +1,191 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import ROUND_FLOOR, ROUND_UP, Decimal
+
+from django.utils import timezone
+
+from products.tasks.backend.models import SandboxSession
+
+
+class ComputeRateCardConfigurationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class ComputeRateCard:
+    version: str
+    effective_at: datetime
+    expires_at: datetime | None
+    cpu_core_second_usd: Decimal
+    memory_gib_second_usd: Decimal
+
+
+@dataclass(frozen=True)
+class ComputeCostLineItem:
+    rate_card: ComputeRateCard
+    billable_seconds: int
+    cpu_core_seconds: Decimal
+    memory_gib_seconds: Decimal
+    cpu_cost_usd: Decimal
+    memory_cost_usd: Decimal
+
+    @property
+    def total_cost_usd(self) -> Decimal:
+        return self.cpu_cost_usd + self.memory_cost_usd
+
+
+@dataclass(frozen=True)
+class SandboxComputeCost:
+    billable_seconds: int
+    cpu_core_seconds: Decimal
+    memory_gib_seconds: Decimal
+    cpu_cost_usd: Decimal
+    memory_cost_usd: Decimal
+    line_items: tuple[ComputeCostLineItem, ...]
+
+    @property
+    def total_cost_usd(self) -> Decimal:
+        return self.cpu_cost_usd + self.memory_cost_usd
+
+
+COMPUTE_RATE_CARDS: tuple[ComputeRateCard, ...] = ()
+
+
+def validate_compute_rate_cards(rate_cards: Sequence[ComputeRateCard]) -> tuple[ComputeRateCard, ...]:
+    cards = tuple(rate_cards)
+    if not cards:
+        raise ComputeRateCardConfigurationError("at least one compute rate card is required")
+
+    versions: set[str] = set()
+    previous: ComputeRateCard | None = None
+    for card in cards:
+        if not card.version or card.version in versions:
+            raise ComputeRateCardConfigurationError("compute rate card versions must be unique and non-empty")
+        if timezone.is_naive(card.effective_at) or (card.expires_at and timezone.is_naive(card.expires_at)):
+            raise ComputeRateCardConfigurationError("compute rate card timestamps must be timezone-aware")
+        if card.expires_at is not None and card.expires_at <= card.effective_at:
+            raise ComputeRateCardConfigurationError("compute rate card expiry must follow its effective timestamp")
+        if card.cpu_core_second_usd <= 0 or card.memory_gib_second_usd <= 0:
+            raise ComputeRateCardConfigurationError("compute rates must be positive")
+        if previous is not None:
+            if previous.expires_at is None:
+                raise ComputeRateCardConfigurationError("only the final compute rate card may omit an expiry")
+            if card.effective_at < previous.expires_at:
+                raise ComputeRateCardConfigurationError("compute rate cards must not overlap")
+            if card.effective_at > previous.expires_at:
+                raise ComputeRateCardConfigurationError("compute rate cards must not contain gaps")
+        versions.add(card.version)
+        previous = card
+
+    if cards[-1].expires_at is not None:
+        raise ComputeRateCardConfigurationError("the final compute rate card must not expire")
+    return cards
+
+
+def calculate_sandbox_compute_cost(
+    session: SandboxSession,
+    reporting_start: datetime,
+    reporting_end: datetime,
+    *,
+    calculated_at: datetime | None = None,
+    rate_cards: Sequence[ComputeRateCard] = COMPUTE_RATE_CARDS,
+) -> SandboxComputeCost:
+    cards = validate_compute_rate_cards(rate_cards)
+    if timezone.is_naive(reporting_start) or timezone.is_naive(reporting_end):
+        raise ValueError("reporting timestamps must be timezone-aware")
+    if reporting_end <= reporting_start:
+        raise ValueError("reporting end must follow reporting start")
+
+    now = calculated_at or timezone.now()
+    if timezone.is_naive(now):
+        raise ValueError("calculation timestamp must be timezone-aware")
+
+    if session.user_attributed_at is None:
+        return _empty_cost()
+
+    effective_end = min(session.ended_at or now, session.ttl_expires_at)
+    start = max(session.user_attributed_at, reporting_start, cards[0].effective_at)
+    stop = min(effective_end, reporting_end)
+    if stop <= start:
+        return _empty_cost()
+
+    segments: list[tuple[ComputeRateCard, Decimal]] = []
+    for card in cards:
+        segment_start = max(start, card.effective_at)
+        segment_stop = min(stop, card.expires_at or stop)
+        if segment_stop > segment_start:
+            segments.append((card, _decimal_seconds(segment_stop - segment_start)))
+
+    if sum((seconds for _, seconds in segments), Decimal(0)) != _decimal_seconds(stop - start):
+        raise ComputeRateCardConfigurationError("compute rate cards do not cover the billable window")
+
+    rounded_seconds = int(_decimal_seconds(stop - start).to_integral_value(rounding=ROUND_UP))
+    allocated_seconds = _allocate_rounded_seconds(segments, rounded_seconds)
+    cpu_cores, memory_gib = _billable_resources(session)
+    line_items = tuple(
+        _price_line_item(card, seconds, cpu_cores, memory_gib)
+        for (card, _), seconds in zip(segments, allocated_seconds, strict=True)
+        if seconds
+    )
+    return SandboxComputeCost(
+        billable_seconds=rounded_seconds,
+        cpu_core_seconds=sum((item.cpu_core_seconds for item in line_items), Decimal(0)),
+        memory_gib_seconds=sum((item.memory_gib_seconds for item in line_items), Decimal(0)),
+        cpu_cost_usd=sum((item.cpu_cost_usd for item in line_items), Decimal(0)),
+        memory_cost_usd=sum((item.memory_cost_usd for item in line_items), Decimal(0)),
+        line_items=line_items,
+    )
+
+
+def _decimal_seconds(duration) -> Decimal:
+    return Decimal(duration.days * 86400 + duration.seconds) + Decimal(duration.microseconds) / Decimal(1_000_000)
+
+
+def _allocate_rounded_seconds(
+    segments: Sequence[tuple[ComputeRateCard, Decimal]], total_seconds: int
+) -> tuple[int, ...]:
+    floors = [int(seconds.to_integral_value(rounding=ROUND_FLOOR)) for _, seconds in segments]
+    remaining = total_seconds - sum(floors)
+    fractions = sorted(
+        range(len(segments)),
+        key=lambda index: segments[index][1] - Decimal(floors[index]),
+        reverse=True,
+    )
+    for index in fractions[:remaining]:
+        floors[index] += 1
+    return tuple(floors)
+
+
+def _billable_resources(session: SandboxSession) -> tuple[Decimal, Decimal]:
+    if session.burstable:
+        if session.cpu_request_cores is None or session.memory_request_mb is None:
+            raise ValueError("burstable sandbox sessions require recorded request resources")
+        return Decimal(str(session.cpu_request_cores)), Decimal(session.memory_request_mb) / Decimal(1024)
+    return Decimal(str(session.cpu_cores)), Decimal(str(session.memory_gb))
+
+
+def _price_line_item(
+    card: ComputeRateCard, seconds: int, cpu_cores: Decimal, memory_gib: Decimal
+) -> ComputeCostLineItem:
+    cpu_core_seconds = Decimal(seconds) * cpu_cores
+    memory_gib_seconds = Decimal(seconds) * memory_gib
+    return ComputeCostLineItem(
+        rate_card=card,
+        billable_seconds=seconds,
+        cpu_core_seconds=cpu_core_seconds,
+        memory_gib_seconds=memory_gib_seconds,
+        cpu_cost_usd=cpu_core_seconds * card.cpu_core_second_usd,
+        memory_cost_usd=memory_gib_seconds * card.memory_gib_second_usd,
+    )
+
+
+def _empty_cost() -> SandboxComputeCost:
+    return SandboxComputeCost(
+        billable_seconds=0,
+        cpu_core_seconds=Decimal(0),
+        memory_gib_seconds=Decimal(0),
+        cpu_cost_usd=Decimal(0),
+        memory_cost_usd=Decimal(0),
+        line_items=(),
+    )

--- a/products/tasks/backend/logic/services/sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/sandbox_pricing.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
-from decimal import ROUND_FLOOR, ROUND_UP, Decimal
+from datetime import datetime, timedelta
+from decimal import ROUND_UP, Decimal
 
 from django.utils import timezone
 
@@ -24,7 +24,7 @@ class ComputeRateCard:
 @dataclass(frozen=True)
 class ComputeCostLineItem:
     rate_card: ComputeRateCard
-    billable_seconds: int
+    billable_seconds: Decimal
     cpu_core_seconds: Decimal
     memory_gib_seconds: Decimal
     cpu_cost_usd: Decimal
@@ -37,7 +37,7 @@ class ComputeCostLineItem:
 
 @dataclass(frozen=True)
 class SandboxComputeCost:
-    billable_seconds: int
+    billable_seconds: Decimal
     cpu_core_seconds: Decimal
     memory_gib_seconds: Decimal
     cpu_cost_usd: Decimal
@@ -104,9 +104,15 @@ def calculate_sandbox_compute_cost(
     if session.user_attributed_at is None:
         return _empty_cost()
 
+    pricing_start = max(session.user_attributed_at, cards[0].effective_at)
     effective_end = min(session.ended_at or now, session.ttl_expires_at)
-    start = max(session.user_attributed_at, reporting_start, cards[0].effective_at)
-    stop = min(effective_end, reporting_end)
+    if effective_end <= pricing_start:
+        return _empty_cost()
+
+    rounded_duration = _decimal_seconds(effective_end - pricing_start).to_integral_value(rounding=ROUND_UP)
+    rounded_end = pricing_start + timedelta(seconds=int(rounded_duration))
+    start = max(pricing_start, reporting_start)
+    stop = min(rounded_end, reporting_end)
     if stop <= start:
         return _empty_cost()
 
@@ -120,16 +126,10 @@ def calculate_sandbox_compute_cost(
     if sum((seconds for _, seconds in segments), Decimal(0)) != _decimal_seconds(stop - start):
         raise ComputeRateCardConfigurationError("compute rate cards do not cover the billable window")
 
-    rounded_seconds = int(_decimal_seconds(stop - start).to_integral_value(rounding=ROUND_UP))
-    allocated_seconds = _allocate_rounded_seconds(segments, rounded_seconds)
     cpu_cores, memory_gib = _billable_resources(session)
-    line_items = tuple(
-        _price_line_item(card, seconds, cpu_cores, memory_gib)
-        for (card, _), seconds in zip(segments, allocated_seconds, strict=True)
-        if seconds
-    )
+    line_items = tuple(_price_line_item(card, seconds, cpu_cores, memory_gib) for card, seconds in segments)
     return SandboxComputeCost(
-        billable_seconds=rounded_seconds,
+        billable_seconds=sum((item.billable_seconds for item in line_items), Decimal(0)),
         cpu_core_seconds=sum((item.cpu_core_seconds for item in line_items), Decimal(0)),
         memory_gib_seconds=sum((item.memory_gib_seconds for item in line_items), Decimal(0)),
         cpu_cost_usd=sum((item.cpu_cost_usd for item in line_items), Decimal(0)),
@@ -142,21 +142,6 @@ def _decimal_seconds(duration) -> Decimal:
     return Decimal(duration.days * 86400 + duration.seconds) + Decimal(duration.microseconds) / Decimal(1_000_000)
 
 
-def _allocate_rounded_seconds(
-    segments: Sequence[tuple[ComputeRateCard, Decimal]], total_seconds: int
-) -> tuple[int, ...]:
-    floors = [int(seconds.to_integral_value(rounding=ROUND_FLOOR)) for _, seconds in segments]
-    remaining = total_seconds - sum(floors)
-    fractions = sorted(
-        range(len(segments)),
-        key=lambda index: segments[index][1] - Decimal(floors[index]),
-        reverse=True,
-    )
-    for index in fractions[:remaining]:
-        floors[index] += 1
-    return tuple(floors)
-
-
 def _billable_resources(session: SandboxSession) -> tuple[Decimal, Decimal]:
     if session.burstable:
         if session.cpu_request_cores is None or session.memory_request_mb is None:
@@ -166,10 +151,10 @@ def _billable_resources(session: SandboxSession) -> tuple[Decimal, Decimal]:
 
 
 def _price_line_item(
-    card: ComputeRateCard, seconds: int, cpu_cores: Decimal, memory_gib: Decimal
+    card: ComputeRateCard, seconds: Decimal, cpu_cores: Decimal, memory_gib: Decimal
 ) -> ComputeCostLineItem:
-    cpu_core_seconds = Decimal(seconds) * cpu_cores
-    memory_gib_seconds = Decimal(seconds) * memory_gib
+    cpu_core_seconds = seconds * cpu_cores
+    memory_gib_seconds = seconds * memory_gib
     return ComputeCostLineItem(
         rate_card=card,
         billable_seconds=seconds,
@@ -182,7 +167,7 @@ def _price_line_item(
 
 def _empty_cost() -> SandboxComputeCost:
     return SandboxComputeCost(
-        billable_seconds=0,
+        billable_seconds=Decimal(0),
         cpu_core_seconds=Decimal(0),
         memory_gib_seconds=Decimal(0),
         cpu_cost_usd=Decimal(0),

--- a/products/tasks/backend/logic/services/sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/sandbox_pricing.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from decimal import ROUND_UP, Decimal
 
 from django.utils import timezone
@@ -109,10 +109,19 @@ def calculate_sandbox_compute_cost(
     if effective_end <= pricing_start:
         return _empty_cost()
 
-    rounded_duration = _decimal_seconds(effective_end - pricing_start).to_integral_value(rounding=ROUND_UP)
-    rounded_end = pricing_start + timedelta(seconds=int(rounded_duration))
+    actual_duration = _decimal_seconds(effective_end - pricing_start)
+    rounded_duration = actual_duration.to_integral_value(rounding=ROUND_UP)
+
+    def scaled_elapsed(at: datetime) -> Decimal:
+        elapsed = _decimal_seconds(at - pricing_start)
+        if elapsed == 0:
+            return Decimal(0)
+        if elapsed == actual_duration:
+            return rounded_duration
+        return elapsed * rounded_duration / actual_duration
+
     start = max(pricing_start, reporting_start)
-    stop = min(rounded_end, reporting_end)
+    stop = min(effective_end, reporting_end)
     if stop <= start:
         return _empty_cost()
 
@@ -121,9 +130,9 @@ def calculate_sandbox_compute_cost(
         segment_start = max(start, card.effective_at)
         segment_stop = min(stop, card.expires_at or stop)
         if segment_stop > segment_start:
-            segments.append((card, _decimal_seconds(segment_stop - segment_start)))
+            segments.append((card, scaled_elapsed(segment_stop) - scaled_elapsed(segment_start)))
 
-    if sum((seconds for _, seconds in segments), Decimal(0)) != _decimal_seconds(stop - start):
+    if sum((seconds for _, seconds in segments), Decimal(0)) != scaled_elapsed(stop) - scaled_elapsed(start):
         raise ComputeRateCardConfigurationError("compute rate cards do not cover the billable window")
 
     cpu_cores, memory_gib = _billable_resources(session)

--- a/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
@@ -114,33 +114,51 @@ def test_rounds_each_session_duration_up_to_a_whole_second(duration, expected):
     assert _calculate(_session(ended_at=EFFECTIVE_AT + duration)).billable_seconds == expected
 
 
-def test_burstable_sessions_use_request_floors_instead_of_limits():
+@pytest.mark.parametrize(
+    "resource_overrides, expected_cpu_core_seconds, expected_memory_gib_seconds",
+    [
+        ({"cpu_request_cores": 0.5}, Decimal("5.0"), Decimal("160.0")),
+        ({"memory_request_mb": 1024}, Decimal("40.0"), Decimal("10")),
+        ({}, Decimal("40.0"), Decimal("160.0")),
+    ],
+)
+def test_selects_cpu_and_memory_request_quantities_independently(
+    resource_overrides, expected_cpu_core_seconds, expected_memory_gib_seconds
+):
+    cost = _calculate(_session(**resource_overrides))
+
+    assert cost.cpu_core_seconds == expected_cpu_core_seconds
+    assert cost.memory_gib_seconds == expected_memory_gib_seconds
+
+
+def test_cpu_limit_does_not_change_cost_when_request_is_unchanged():
+    smaller_limit = _calculate(_session(cpu_cores=4.0, cpu_request_cores=0.5))
+    larger_limit = _calculate(_session(cpu_cores=16.0, cpu_request_cores=0.5))
+
+    assert smaller_limit == larger_limit
+
+
+def test_memory_request_mebibytes_are_converted_to_gibibytes_exactly():
+    cost = _calculate(_session(memory_request_mb=384))
+
+    assert cost.memory_gib_seconds == Decimal("3.750")
+
+
+@pytest.mark.parametrize("vm_runtime", [False, True])
+@pytest.mark.parametrize("burstable", [False, True])
+def test_runtime_and_burstability_do_not_change_pricing(vm_runtime, burstable):
+    expected = _calculate(_session(cpu_request_cores=0.5, memory_request_mb=1024))
+
     cost = _calculate(
         _session(
-            burstable=True,
-            cpu_cores=4.0,
-            memory_gb=16.0,
+            vm_runtime=vm_runtime,
+            burstable=burstable,
             cpu_request_cores=0.5,
             memory_request_mb=1024,
         )
     )
 
-    assert cost.cpu_core_seconds == Decimal("5.0")
-    assert cost.memory_gib_seconds == Decimal("10")
-
-
-def test_non_burstable_sessions_use_configured_resources():
-    cost = _calculate(_session(cpu_cores=Decimal("1.25"), memory_gb=Decimal("2.5")))
-
-    assert cost.cpu_core_seconds == Decimal("12.50")
-    assert cost.memory_gib_seconds == Decimal("25.0")
-
-
-def test_vm_and_gvisor_sessions_use_the_same_v0_rates():
-    gvisor = _calculate(_session(vm_runtime=False))
-    vm = _calculate(_session(vm_runtime=True))
-
-    assert vm == gvisor
+    assert cost == expected
 
 
 def test_fractional_resources_and_cost_subtotals_remain_exact():
@@ -248,8 +266,3 @@ def test_usage_before_compute_billing_effective_date_is_not_priced():
 def test_invalid_missing_overlapping_or_ambiguous_rate_cards_fail_safely(cards, message):
     with pytest.raises(ComputeRateCardConfigurationError, match=message):
         validate_compute_rate_cards(cards)
-
-
-def test_burstable_session_with_missing_request_floor_fails_safely():
-    with pytest.raises(ValueError, match="recorded request resources"):
-        _calculate(_session(burstable=True, cpu_request_cores=None, memory_request_mb=None))

--- a/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
@@ -196,6 +196,23 @@ def test_rate_boundary_apportions_one_session_without_rounding_twice():
     assert cost.line_items[1].billable_seconds == Decimal("0.5")
 
 
+def test_rate_boundary_apportions_rounded_duration_proportionally():
+    session = _session(
+        created_at=NEXT_RATE_AT - timedelta(hours=1),
+        user_attributed_at=NEXT_RATE_AT - timedelta(microseconds=900_000),
+        ended_at=NEXT_RATE_AT + timedelta(microseconds=300_000),
+        ttl_expires_at=NEXT_RATE_AT + timedelta(hours=5),
+    )
+
+    cost = _calculate(session, NEXT_RATE_AT - timedelta(seconds=1), NEXT_RATE_AT + timedelta(seconds=1))
+
+    assert cost.billable_seconds == 2
+    assert cost.line_items[0].rate_card.version == RATE_V1.version
+    assert cost.line_items[0].billable_seconds == Decimal("1.5")
+    assert cost.line_items[1].rate_card.version == RATE_V2.version
+    assert cost.line_items[1].billable_seconds == Decimal("0.5")
+
+
 def test_rounds_once_before_apportioning_across_reporting_periods():
     boundary = EFFECTIVE_AT + timedelta(hours=1)
     session = _session(
@@ -206,8 +223,8 @@ def test_rounds_once_before_apportioning_across_reporting_periods():
     first = _calculate(session, EFFECTIVE_AT, boundary)
     second = _calculate(session, boundary, EFFECTIVE_AT + timedelta(hours=2))
 
-    assert first.billable_seconds == Decimal("0.6")
-    assert second.billable_seconds == Decimal("1.4")
+    assert first.billable_seconds == Decimal("1")
+    assert second.billable_seconds == Decimal("1")
     assert first.billable_seconds + second.billable_seconds == Decimal("2")
 
 

--- a/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
@@ -1,0 +1,230 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from products.tasks.backend.logic.services.sandbox_pricing import (
+    ComputeRateCard,
+    ComputeRateCardConfigurationError,
+    calculate_sandbox_compute_cost,
+    validate_compute_rate_cards,
+)
+
+EFFECTIVE_AT = datetime(2026, 8, 1, tzinfo=UTC)
+NEXT_RATE_AT = datetime(2026, 9, 1, tzinfo=UTC)
+RATE_V1 = ComputeRateCard(
+    version="2026-08-01",
+    effective_at=EFFECTIVE_AT,
+    expires_at=NEXT_RATE_AT,
+    cpu_core_second_usd=Decimal("0.000011"),
+    memory_gib_second_usd=Decimal("0.0000021"),
+)
+RATE_V2 = ComputeRateCard(
+    version="2026-09-01",
+    effective_at=NEXT_RATE_AT,
+    expires_at=None,
+    cpu_core_second_usd=Decimal("0.000013"),
+    memory_gib_second_usd=Decimal("0.0000024"),
+)
+
+
+def _session(**overrides):
+    defaults = {
+        "created_at": EFFECTIVE_AT,
+        "user_attributed_at": EFFECTIVE_AT,
+        "ended_at": EFFECTIVE_AT + timedelta(seconds=10),
+        "ttl_expires_at": EFFECTIVE_AT + timedelta(hours=6),
+        "burstable": False,
+        "cpu_cores": 4.0,
+        "memory_gb": 16.0,
+        "cpu_request_cores": None,
+        "memory_request_mb": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _calculate(session, start=EFFECTIVE_AT, end=EFFECTIVE_AT + timedelta(days=1), **kwargs):
+    return calculate_sandbox_compute_cost(session, start, end, rate_cards=(RATE_V1, RATE_V2), **kwargs)
+
+
+def test_prices_closed_session_from_user_attribution():
+    session = _session(
+        created_at=EFFECTIVE_AT,
+        user_attributed_at=EFFECTIVE_AT + timedelta(seconds=20),
+        ended_at=EFFECTIVE_AT + timedelta(seconds=30),
+    )
+
+    cost = _calculate(session)
+
+    assert cost.billable_seconds == 10
+    assert cost.cpu_core_seconds == Decimal("40.0")
+    assert cost.memory_gib_seconds == Decimal("160.0")
+
+
+def test_unattributed_prewarmed_session_is_not_priced():
+    cost = _calculate(_session(user_attributed_at=None, ended_at=None))
+
+    assert cost.billable_seconds == 0
+    assert cost.total_cost_usd == 0
+
+
+def test_claimed_prewarmed_session_starts_at_attribution():
+    cost = _calculate(
+        _session(
+            created_at=EFFECTIVE_AT,
+            user_attributed_at=EFFECTIVE_AT + timedelta(hours=1),
+            ended_at=EFFECTIVE_AT + timedelta(hours=1, seconds=5),
+        )
+    )
+
+    assert cost.billable_seconds == 5
+
+
+def test_open_session_clamps_to_calculation_time_and_ttl():
+    session = _session(ended_at=None, ttl_expires_at=EFFECTIVE_AT + timedelta(seconds=12))
+
+    before_ttl = _calculate(session, calculated_at=EFFECTIVE_AT + timedelta(seconds=7))
+    after_ttl = _calculate(session, calculated_at=EFFECTIVE_AT + timedelta(seconds=20))
+
+    assert before_ttl.billable_seconds == 7
+    assert after_ttl.billable_seconds == 12
+
+
+def test_reporting_window_clips_cross_period_session_without_negative_duration():
+    session = _session(
+        user_attributed_at=EFFECTIVE_AT - timedelta(hours=1),
+        ended_at=EFFECTIVE_AT + timedelta(hours=2),
+    )
+
+    cost = _calculate(session, EFFECTIVE_AT, EFFECTIVE_AT + timedelta(hours=1))
+    outside = _calculate(session, EFFECTIVE_AT + timedelta(days=1), EFFECTIVE_AT + timedelta(days=2))
+
+    assert cost.billable_seconds == 3600
+    assert outside.billable_seconds == 0
+
+
+@pytest.mark.parametrize(
+    "duration, expected",
+    [(timedelta(microseconds=1), 1), (timedelta(seconds=1), 1), (timedelta(seconds=1, microseconds=1), 2)],
+)
+def test_rounds_each_session_duration_up_to_a_whole_second(duration, expected):
+    assert _calculate(_session(ended_at=EFFECTIVE_AT + duration)).billable_seconds == expected
+
+
+def test_burstable_sessions_use_request_floors_instead_of_limits():
+    cost = _calculate(
+        _session(
+            burstable=True,
+            cpu_cores=4.0,
+            memory_gb=16.0,
+            cpu_request_cores=0.5,
+            memory_request_mb=1024,
+        )
+    )
+
+    assert cost.cpu_core_seconds == Decimal("5.0")
+    assert cost.memory_gib_seconds == Decimal("10")
+
+
+def test_non_burstable_sessions_use_configured_resources():
+    cost = _calculate(_session(cpu_cores=Decimal("1.25"), memory_gb=Decimal("2.5")))
+
+    assert cost.cpu_core_seconds == Decimal("12.50")
+    assert cost.memory_gib_seconds == Decimal("25.0")
+
+
+def test_fractional_resources_and_cost_subtotals_remain_exact():
+    cost = _calculate(
+        _session(
+            burstable=True,
+            cpu_request_cores=0.125,
+            memory_request_mb=384,
+            ended_at=EFFECTIVE_AT + timedelta(seconds=3, microseconds=1),
+        )
+    )
+
+    assert cost.cpu_core_seconds == Decimal("0.500")
+    assert cost.memory_gib_seconds == Decimal("1.500")
+    assert cost.cpu_cost_usd == Decimal("0.000005500")
+    assert cost.memory_cost_usd == Decimal("0.0000031500")
+    assert cost.total_cost_usd == cost.cpu_cost_usd + cost.memory_cost_usd
+    assert cost.total_cost_usd == sum((line.total_cost_usd for line in cost.line_items), Decimal(0))
+
+
+def test_rate_boundary_apportions_one_session_without_rounding_twice():
+    session = _session(
+        created_at=NEXT_RATE_AT - timedelta(hours=1),
+        user_attributed_at=NEXT_RATE_AT - timedelta(microseconds=500_000),
+        ended_at=NEXT_RATE_AT + timedelta(microseconds=500_000),
+        ttl_expires_at=NEXT_RATE_AT + timedelta(hours=5),
+    )
+
+    cost = _calculate(session, NEXT_RATE_AT - timedelta(seconds=1), NEXT_RATE_AT + timedelta(seconds=1))
+
+    assert cost.billable_seconds == 1
+    assert len(cost.line_items) == 1
+    assert cost.line_items[0].rate_card.version == RATE_V1.version
+
+
+def test_historical_window_keeps_old_rate_after_new_rate_is_active():
+    historical = _session(
+        created_at=NEXT_RATE_AT - timedelta(hours=1),
+        user_attributed_at=NEXT_RATE_AT - timedelta(seconds=10),
+        ended_at=NEXT_RATE_AT - timedelta(seconds=5),
+        ttl_expires_at=NEXT_RATE_AT + timedelta(hours=5),
+    )
+
+    cost = _calculate(
+        historical,
+        NEXT_RATE_AT - timedelta(days=1),
+        NEXT_RATE_AT,
+        calculated_at=NEXT_RATE_AT + timedelta(days=30),
+    )
+
+    assert cost.line_items[0].rate_card == RATE_V1
+    assert cost.cpu_cost_usd == cost.cpu_core_seconds * RATE_V1.cpu_core_second_usd
+
+
+def test_usage_before_compute_billing_effective_date_is_not_priced():
+    session = _session(
+        user_attributed_at=EFFECTIVE_AT - timedelta(hours=1),
+        ended_at=EFFECTIVE_AT - timedelta(seconds=1),
+    )
+
+    cost = _calculate(session, EFFECTIVE_AT - timedelta(days=1), EFFECTIVE_AT)
+
+    assert cost.billable_seconds == 0
+    assert cost.total_cost_usd == 0
+
+
+@pytest.mark.parametrize(
+    "cards, message",
+    [
+        ((), "at least one"),
+        ((RATE_V1, RATE_V1), "versions"),
+        (
+            (
+                RATE_V1,
+                ComputeRateCard("overlap", NEXT_RATE_AT - timedelta(seconds=1), None, Decimal("1"), Decimal("1")),
+            ),
+            "overlap",
+        ),
+        (
+            (
+                RATE_V1,
+                ComputeRateCard("gap", NEXT_RATE_AT + timedelta(seconds=1), None, Decimal("1"), Decimal("1")),
+            ),
+            "gaps",
+        ),
+    ],
+)
+def test_invalid_missing_overlapping_or_ambiguous_rate_cards_fail_safely(cards, message):
+    with pytest.raises(ComputeRateCardConfigurationError, match=message):
+        validate_compute_rate_cards(cards)
+
+
+def test_burstable_session_with_missing_request_floor_fails_safely():
+    with pytest.raises(ValueError, match="recorded request resources"):
+        _calculate(_session(burstable=True, cpu_request_cores=None, memory_request_mb=None))

--- a/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
@@ -35,6 +35,7 @@ def _session(**overrides):
         "user_attributed_at": EFFECTIVE_AT,
         "ended_at": EFFECTIVE_AT + timedelta(seconds=10),
         "ttl_expires_at": EFFECTIVE_AT + timedelta(hours=6),
+        "vm_runtime": False,
         "burstable": False,
         "cpu_cores": 4.0,
         "memory_gb": 16.0,
@@ -135,6 +136,13 @@ def test_non_burstable_sessions_use_configured_resources():
     assert cost.memory_gib_seconds == Decimal("25.0")
 
 
+def test_vm_and_gvisor_sessions_use_the_same_v0_rates():
+    gvisor = _calculate(_session(vm_runtime=False))
+    vm = _calculate(_session(vm_runtime=True))
+
+    assert vm == gvisor
+
+
 def test_fractional_resources_and_cost_subtotals_remain_exact():
     cost = _calculate(
         _session(
@@ -164,8 +172,25 @@ def test_rate_boundary_apportions_one_session_without_rounding_twice():
     cost = _calculate(session, NEXT_RATE_AT - timedelta(seconds=1), NEXT_RATE_AT + timedelta(seconds=1))
 
     assert cost.billable_seconds == 1
-    assert len(cost.line_items) == 1
+    assert len(cost.line_items) == 2
     assert cost.line_items[0].rate_card.version == RATE_V1.version
+    assert cost.line_items[0].billable_seconds == Decimal("0.5")
+    assert cost.line_items[1].billable_seconds == Decimal("0.5")
+
+
+def test_rounds_once_before_apportioning_across_reporting_periods():
+    boundary = EFFECTIVE_AT + timedelta(hours=1)
+    session = _session(
+        user_attributed_at=boundary - timedelta(microseconds=600_000),
+        ended_at=boundary + timedelta(microseconds=600_000),
+    )
+
+    first = _calculate(session, EFFECTIVE_AT, boundary)
+    second = _calculate(session, boundary, EFFECTIVE_AT + timedelta(hours=2))
+
+    assert first.billable_seconds == Decimal("0.6")
+    assert second.billable_seconds == Decimal("1.4")
+    assert first.billable_seconds + second.billable_seconds == Decimal("2")
 
 
 def test_historical_window_keeps_old_rate_after_new_rate_is_active():


### PR DESCRIPTION
## Problem

Desktop cloud compute needs one canonical calculation before usage reporting and credit conversion are added. Pricing must remain exact and historical usage must retain the rate that was active when it occurred.

## Changes

- Add an immutable, effective-dated CPU and memory compute rate-card type using `Decimal`.
- Price attributed sandbox windows with reporting-period and TTL clipping and session-level whole-second rounding.
- Select billable CPU and memory quantities independently from each session snapshot: request values take precedence when present, otherwise configured values are used.
- Keep pricing independent of sandbox burstability and runtime type, allowing gVisor and VM resource shapes to use the same CPU core-second and memory GiB-second path.
- Return exact CPU, memory, and total USD subtotals, split by rate-card version when a session crosses a pricing boundary.
- Leave the production rate-card table empty until published rates and the compute billing effective date are approved. Missing or invalid configuration fails closed.

The rate card is code-owned. To update it operationally, add a new immutable entry in `COMPUTE_RATE_CARDS`, close the preceding entry at the same effective timestamp, and deploy the reviewed change to every region. Existing entries must not be edited, which keeps historical calculations reproducible and gives a later Cloud/Desktop drill-down endpoint one canonical source for published rates.

### How it works

For each sandbox session:

1. Determine billable time from user attribution until session end, calculation time, or TTL—whichever comes first.
2. Round that session’s total duration up once to a whole second.
3. Clip/apportion it across reporting periods and historical rate-card boundaries.
4. Select resources independently from the session snapshot:
  a. CPU: `cpu_request_cores`, falling back to `cpu_cores`.
  b. Memory: `memory_request_mb / 1024`, falling back to `memory_gb`.
5. Calculate:
  a. CPU cost = seconds × CPU cores × CPU rate.
  b. Memory cost = seconds × memory GiB × memory rate.
6. Add both for the cloud-compute subtotal.

`burstable` and `vm_runtime` do not affect the pricing path. Rates are exact `Decimal` values, versioned by effective date, and the production table remains empty until real prices are approved.

## How did you test this code?

- `uv run pytest products/tasks/backend/logic/services/tests/test_sandbox_pricing.py` – 26 passed, covering time windows, rounding, independent and hybrid resource snapshots, runtime/burstability parity, exact costs, rate boundaries, history, and invalid configuration.
- `ruff check products/tasks/backend/logic/services/sandbox_pricing.py products/tasks/backend/logic/services/tests/test_sandbox_pricing.py`
- `ruff format --check products/tasks/backend/logic/services/sandbox_pricing.py products/tasks/backend/logic/services/tests/test_sandbox_pricing.py`
- `uv run mypy --cache-fine-grained .` – no issues found.
- The existing database-backed sandbox ledger suite could not run because PostgreSQL was not running in this checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public documentation change. The operational rate-card update process is documented above.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the approved code-owned pricing-table design. The `/i-have-adhd` output-shaping skill was invoked. Production prices were deliberately omitted instead of inventing provisional values.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*