### PR TITLE
fix(insights): show interval counts and raw counts on stickiness axes

### DIFF
--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -52,11 +52,12 @@ describe('StickinessBarChart', () => {
         )
     })
 
-    it('tooltip: formats series values as percentages of the series total', async () => {
+    it('tooltip: shows the raw actor count for the bucket, not its share of the series total', async () => {
         renderInsight({ query: stickinessBar() })
 
         const tooltip = await chart.hoverTooltip(2)
-        expect(tooltip.row('Pageview')).toMatch(/%/)
+        // Pageview canned series is [45, 82, 134, 210, 95], so bucket 2 is 134 actors.
+        expect(tooltip.row('Pageview')).toBe('134')
     })
 
     it('renders InsightEmptyState when all series are zero', async () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -5,6 +5,7 @@ import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -31,9 +32,7 @@ import {
 import { useInsightsLegendConfig } from '../../trends/shared/useInsightsLegendConfig'
 import { handleStickinessChartClick } from '../StickinessLineChart/handleStickinessChartClick'
 import {
-    buildStickinessLabels,
     buildStickinessTooltipTitle,
-    stickinessPercentFormatter,
     STICKINESS_TOOLTIP_CONFIG,
 } from '../StickinessLineChart/stickinessChartTransforms'
 import { buildStickinessBarSeries, buildStickinessBarTimeSeriesConfig } from './stickinessBarChartTransforms'
@@ -85,8 +84,7 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
 
     const resolvedGroupTypeLabel = context?.groupTypeLabel ?? resolveGroupTypeLabel(labelGroupType, aggregationLabel)
 
-    const bucketCount = currentPeriodResult?.labels?.length ?? 0
-    const labels = useMemo(() => buildStickinessLabels(bucketCount, interval), [bucketCount, interval])
+    const labels = currentPeriodResult?.labels ?? []
 
     const hasData = (indexedResults ?? []).some((r: IndexedTrendResult) => r.count !== 0)
 
@@ -104,18 +102,34 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
         [indexedResults, getTrendsColor, getLabel]
     )
 
+    const valueLabelFormatter = useCallback(
+        (value: number) => formatAggregationAxisValue(trendsFilter, value, baseCurrency),
+        [trendsFilter, baseCurrency]
+    )
+
     const chartConfig: TimeSeriesBarChartConfig = useChartConfig(
         () => ({
             ...buildStickinessBarTimeSeriesConfig({
+                trendsFilter,
+                baseCurrency,
                 yAxisScaleType,
                 isGrouped,
-                valueLabels: showValuesOnSeries ? { formatter: stickinessPercentFormatter } : false,
+                valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
                 tooltip: tooltipConfig,
             }),
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, isGrouped, showValuesOnSeries, legendConfig, tooltipConfig]
+        [
+            trendsFilter,
+            baseCurrency,
+            yAxisScaleType,
+            isGrouped,
+            showValuesOnSeries,
+            valueLabelFormatter,
+            legendConfig,
+            tooltipConfig,
+        ]
     )
 
     // Close over the primitives so the click memos don't invalidate when unrelated
@@ -159,7 +173,7 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
                 interval: interval ?? undefined,
                 breakdownFilter: breakdownFilter ?? undefined,
                 trendsFilter,
-                showPercentView: true as const,
+                showPercentView: false as const,
                 isPercentStackView: false as const,
                 baseCurrency,
                 groupTypeLabel: resolvedGroupTypeLabel,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.test.ts
@@ -14,14 +14,15 @@ describe('buildStickinessBarTimeSeriesConfig', () => {
         expect(buildStickinessBarTimeSeriesConfig({ isGrouped }).barLayout).toBe(expected)
     })
 
-    it('omits the xAxis date config (labels are pre-formatted interval counts)', () => {
+    it('omits the xAxis date config, since labels come from the API per bucket', () => {
         expect(buildStickinessBarTimeSeriesConfig({ isGrouped: false }).xAxis).toBeUndefined()
     })
 
-    it('delegates the yAxis to the shared stickiness builder (percent + scale + grid)', () => {
+    it('delegates the yAxis to the shared stickiness builder (count format + scale + grid)', () => {
         const cfg = buildStickinessBarTimeSeriesConfig({ isGrouped: false, yAxisScaleType: 'log10' })
         expect(cfg.yAxis!.scale).toBe('log')
-        expect(cfg.yAxis!.tickFormatter!(50)).toBe('50.0%')
+        expect(cfg.yAxis!.showGrid).toBe(true)
+        expect(cfg.yAxis!.format).toBe('numeric')
     })
 
     it('passes through valueLabels and tooltip', () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.ts
@@ -1,5 +1,6 @@
 import type { TimeSeriesBarChartConfig, TooltipConfig, YAxisConfig } from '@posthog/quill-charts'
 
+import type { YFormatterFields } from '../../trends/shared/trendsChartDisplayOptions'
 import {
     buildStickinessSeries,
     buildStickinessYAxisConfig,
@@ -9,6 +10,8 @@ import {
 export { buildStickinessSeries as buildStickinessBarSeries }
 
 export interface BuildStickinessBarTimeSeriesConfigOpts {
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     yAxisScaleType?: StickinessYAxisScaleType
     /** ActionsBar → stacked; ActionsUnstackedBar → grouped. */
     isGrouped: boolean
@@ -20,9 +23,14 @@ export interface BuildStickinessBarTimeSeriesConfigOpts {
 export function buildStickinessBarTimeSeriesConfig(
     opts: BuildStickinessBarTimeSeriesConfigOpts
 ): TimeSeriesBarChartConfig & { yAxis?: YAxisConfig } {
-    // No xAxis date config — labels are pre-formatted interval counts (Day 0, Day 1, …).
+    // No xAxis date config: labels come from the API's own per-bucket labels (e.g. "1 day", "2 days").
     return {
-        yAxis: buildStickinessYAxisConfig({ yAxisScaleType: opts.yAxisScaleType, showGrid: opts.showGrid }),
+        yAxis: buildStickinessYAxisConfig({
+            trendsFilter: opts.trendsFilter,
+            baseCurrency: opts.baseCurrency,
+            yAxisScaleType: opts.yAxisScaleType,
+            showGrid: opts.showGrid,
+        }),
         valueLabels: opts.valueLabels,
         barLayout: opts.isGrouped ? 'grouped' : 'stacked',
         tooltip: opts.tooltip,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -6,7 +6,7 @@ import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
 
 import { ExportType } from '~/exporter/types'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { buildStickinessQuery, chart, personsModal, renderInsight } from '~/test/insight-testing'
+import { buildStickinessQuery, chart, getHogChart, personsModal, renderInsight } from '~/test/insight-testing'
 
 configure({ asyncUtilTimeout: 5000 })
 // With asyncUtilTimeout at 5s, a single legitimate waitFor can exhaust Jest's default
@@ -37,13 +37,37 @@ describe('StickinessLineChart', () => {
         })
     })
 
+    describe('axes', () => {
+        it('labels the x-axis with the interval count per bucket, not an ordinal position', async () => {
+            renderInsight({ query: buildStickinessQuery() })
+            await screen.findByLabelText(/chart with 1 data series/i)
+
+            await waitFor(() => {
+                expect(getHogChart().xTicks()).toEqual(
+                    expect.arrayContaining(['1 day', '2 days', '3 days', '4 days', '5 days'])
+                )
+            })
+        })
+
+        it('renders the y-axis as counts rather than percentages', async () => {
+            renderInsight({ query: buildStickinessQuery() })
+            await screen.findByLabelText(/chart with 1 data series/i)
+
+            await waitFor(() => {
+                const ticks = getHogChart().yTicks()
+                expect(ticks.length).toBeGreaterThan(0)
+                expect(ticks.some((t) => t.includes('%'))).toBe(false)
+            })
+        })
+    })
+
     describe('tooltips', () => {
-        it('formats series values as percentages of the series total', async () => {
+        it('shows the raw actor count for the bucket, not its share of the series total', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             const tooltip = await chart.hoverTooltip(2)
-            // Pageview canned series is [45, 82, 134, 210, 95], total 566, so bucket 2 == 134/566 ≈ 23.7%.
-            expect(tooltip.row('Pageview')).toMatch(/%/)
+            // Pageview canned series is [45, 82, 134, 210, 95], so bucket 2 is 134 actors.
+            expect(tooltip.row('Pageview')).toBe('134')
         })
     })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -5,6 +5,7 @@ import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -31,11 +32,9 @@ import {
 import { useInsightsLegendConfig } from '../../trends/shared/useInsightsLegendConfig'
 import { handleStickinessChartClick } from './handleStickinessChartClick'
 import {
-    buildStickinessLabels,
     buildStickinessLineTimeSeriesConfig,
     buildStickinessSeries,
     buildStickinessTooltipTitle,
-    stickinessPercentFormatter,
     STICKINESS_TOOLTIP_CONFIG,
 } from './stickinessChartTransforms'
 
@@ -85,8 +84,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         [breakdownFilter, allCohorts?.results, formatPropertyValueForDisplay]
     )
 
-    const bucketCount = currentPeriodResult?.labels?.length ?? 0
-    const labels = useMemo(() => buildStickinessLabels(bucketCount, interval), [bucketCount, interval])
+    const labels = currentPeriodResult?.labels ?? []
 
     const hasData =
         indexedResults &&
@@ -108,11 +106,18 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         [indexedResults, display, getTrendsColor, getLabel, showMultipleYAxes]
     )
 
+    const valueLabelFormatter = useCallback(
+        (value: number) => formatAggregationAxisValue(trendsFilter, value, baseCurrency),
+        [trendsFilter, baseCurrency]
+    )
+
     const chartConfig: TimeSeriesLineChartConfig = useChartConfig(
         () => ({
             ...buildStickinessLineTimeSeriesConfig({
+                trendsFilter,
+                baseCurrency,
                 yAxisScaleType,
-                valueLabels: showValuesOnSeries ? { formatter: stickinessPercentFormatter } : false,
+                valueLabels: showValuesOnSeries ? { formatter: valueLabelFormatter } : false,
                 showCrosshair: true,
                 tooltip: tooltipConfig,
             }),
@@ -120,7 +125,16 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, showValuesOnSeries, legendConfig, tooltipConfig, stickinessFilter?.chartStyle]
+        [
+            trendsFilter,
+            baseCurrency,
+            yAxisScaleType,
+            showValuesOnSeries,
+            valueLabelFormatter,
+            legendConfig,
+            tooltipConfig,
+            stickinessFilter?.chartStyle,
+        ]
     )
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
@@ -160,7 +174,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                 interval: interval ?? undefined,
                 breakdownFilter: breakdownFilter ?? undefined,
                 trendsFilter,
-                showPercentView: true as const,
+                showPercentView: false as const,
                 isPercentStackView: false as const,
                 baseCurrency,
                 groupTypeLabel: resolvedGroupTypeLabel,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
@@ -7,13 +7,10 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { ChartDisplayType } from '~/types'
 
 import {
-    buildStickinessLabels,
     buildStickinessLineTimeSeriesConfig,
     buildStickinessMainSeries,
     buildStickinessSeries,
     buildStickinessTooltipTitle,
-    stickinessPercentFormatter,
-    toPercentData,
     type StickinessResultLike,
 } from './stickinessChartTransforms'
 
@@ -29,27 +26,9 @@ const makeResult = (overrides: Partial<StickinessResultLike> = {}): StickinessRe
 })
 
 describe('stickinessChartTransforms', () => {
-    describe('toPercentData', () => {
-        it.each<[string, number[], number, number[]]>([
-            ['typical share split', [50, 30, 15, 5], 100, [50, 30, 15, 5]],
-            ['fractional output', [1, 2, 3], 4, [25, 50, 75]],
-            ['count of 0 returns the raw values (avoids divide-by-zero)', [0, 0, 0], 0, [0, 0, 0]],
-            ['empty data stays empty', [], 10, []],
-        ])('%s', (_, data, count, expected) => {
-            expect(toPercentData(data, count)).toEqual(expected)
-        })
-
-        it('returns a copy when count is 0 (no aliasing of the input array)', () => {
-            const input = [1, 2, 3]
-            const out = toPercentData(input, 0)
-            expect(out).toEqual(input)
-            expect(out).not.toBe(input)
-        })
-    })
-
     describe('buildStickinessMainSeries', () => {
-        it('builds a single main series with data transformed to percentages', () => {
-            const series = buildStickinessMainSeries(makeResult(), 0, { getColor: () => RED })
+        it('builds a single main series with the raw data untouched, regardless of count', () => {
+            const series = buildStickinessMainSeries(makeResult({ count: 200 }), 0, { getColor: () => RED })
 
             expect(series).toMatchObject({
                 key: '0',
@@ -154,45 +133,14 @@ describe('stickinessChartTransforms', () => {
             expect(series.map((s) => s.yAxisId)).toEqual([DEFAULT_Y_AXIS_ID, 'y1', 'y2'])
         })
 
-        it('transforms each result independently using its own count', () => {
+        it("passes each result's raw data through unchanged regardless of its count", () => {
             const results = [
                 makeResult({ id: 'a', count: 200, data: [100, 50, 25, 25] }),
                 makeResult({ id: 'b', count: 50, data: [10, 20, 10, 10] }),
             ]
             const series = buildStickinessSeries(results, { getColor: () => RED })
-            expect(series[0].data).toEqual([50, 25, 12.5, 12.5])
-            expect(series[1].data).toEqual([20, 40, 20, 20])
-        })
-    })
-
-    describe('buildStickinessLabels', () => {
-        it.each([
-            ['day', 3, ['Day 0', 'Day 1', 'Day 2']],
-            ['week', 2, ['Week 0', 'Week 1']],
-            ['hour', 2, ['Hour 0', 'Hour 1']],
-            ['month', 2, ['Month 0', 'Month 1']],
-        ] as const)('emits "%s"-prefixed labels by index', (interval, count, expected) => {
-            expect(buildStickinessLabels(count, interval)).toEqual(expected)
-        })
-
-        it('defaults to "Day" when interval is null/undefined', () => {
-            expect(buildStickinessLabels(2, null)).toEqual(['Day 0', 'Day 1'])
-            expect(buildStickinessLabels(2, undefined)).toEqual(['Day 0', 'Day 1'])
-        })
-
-        it('returns empty array when count is 0', () => {
-            expect(buildStickinessLabels(0, 'day')).toEqual([])
-        })
-    })
-
-    describe('stickinessPercentFormatter', () => {
-        it.each([
-            [0, '0.0%'],
-            [50, '50.0%'],
-            [85.16, '85.2%'],
-            [100, '100.0%'],
-        ])('formats %s → %s', (value, expected) => {
-            expect(stickinessPercentFormatter(value)).toBe(expected)
+            expect(series[0].data).toEqual([100, 50, 25, 25])
+            expect(series[1].data).toEqual([10, 20, 10, 10])
         })
     })
 
@@ -221,14 +169,14 @@ describe('stickinessChartTransforms', () => {
     describe('buildStickinessLineTimeSeriesConfig', () => {
         const TOOLTIP: TooltipConfig = { pinnable: true, placement: 'top' }
 
-        it('returns yAxis with percent tick formatter and a linear scale by default', () => {
+        it('returns yAxis with a plain numeric (count) format and a linear scale by default', () => {
             const config = buildStickinessLineTimeSeriesConfig({})
             const yAxis = config.yAxis as YAxisConfig
             expect(yAxis).not.toBeUndefined()
             expect(yAxis.scale).toBe('linear')
             expect(yAxis.showGrid).toBe(true)
-            expect(yAxis.tickFormatter).not.toBeUndefined()
-            expect(yAxis.tickFormatter!(50)).toBe('50.0%')
+            expect(yAxis.format).toBe('numeric')
+            expect(yAxis.tickFormatter).toBeUndefined()
         })
 
         it('switches the y-scale to log when yAxisScaleType is log10', () => {
@@ -238,7 +186,17 @@ describe('stickinessChartTransforms', () => {
             expect(yAxis.scale).toBe('log')
         })
 
-        it('omits an xAxis date config — labels are pre-formatted interval counts', () => {
+        it('threads trendsFilter/baseCurrency through to the y-axis format', () => {
+            const config = buildStickinessLineTimeSeriesConfig({
+                trendsFilter: { aggregationAxisFormat: 'currency' },
+                baseCurrency: 'USD',
+            })
+            const yAxis = config.yAxis as YAxisConfig
+            expect(yAxis.format).toBe('currency')
+            expect(yAxis.currency).toBe('USD')
+        })
+
+        it('omits an xAxis date config, since labels come from the API per bucket', () => {
             const config = buildStickinessLineTimeSeriesConfig({})
             expect(config.xAxis).toBeUndefined()
         })
@@ -255,7 +213,7 @@ describe('stickinessChartTransforms', () => {
             expect(config.tooltip).toBe(TOOLTIP)
         })
 
-        it('does not enable percentStackView (stickiness already pre-percents data)', () => {
+        it('does not enable percentStackView', () => {
             const config = buildStickinessLineTimeSeriesConfig({})
             expect(config.percentStackView).toBeUndefined()
         })

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
 import type { Series, TimeSeriesLineChartConfig, TooltipConfig, YAxisConfig } from '@posthog/quill-charts'
 
-import { capitalizeFirstLetter } from 'lib/utils/strings'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 import { ChartDisplayType } from '~/types'
@@ -9,6 +8,8 @@ import { ChartDisplayType } from '~/types'
 import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
 import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../../trends/shared/compareDimming'
 import { humanizeSeriesLabel } from '../../trends/shared/humanizeSeriesLabel'
+import { buildTrendsYAxisConfig } from '../../trends/shared/trendsAxisFormat'
+import type { YFormatterFields } from '../../trends/shared/trendsChartDisplayOptions'
 
 // Shape both IndexedTrendResult (kea) and StickinessResultItem (MCP) satisfy.
 export interface StickinessResultLike {
@@ -39,15 +40,6 @@ export interface BuildStickinessSeriesOpts<R extends StickinessResultLike, M = u
     getLabel?: (r: R) => string
 }
 
-/** Convert raw counts to percentages of `count`. Mirrors the legacy `showPercentView`
- * behavior in LineGraph: each y-value becomes its share of the series total. */
-export function toPercentData(data: number[], count: number): number[] {
-    if (!count) {
-        return data.slice()
-    }
-    return data.map((v) => (v / count) * 100)
-}
-
 export function buildStickinessMainSeries<R extends StickinessResultLike, M = unknown>(
     r: R,
     index: number,
@@ -62,7 +54,7 @@ export function buildStickinessMainSeries<R extends StickinessResultLike, M = un
     return {
         key: String(r.id),
         label: opts.getLabel ? opts.getLabel(r) : humanizeSeriesLabel(r.label),
-        data: toPercentData(r.data, r.count),
+        data: r.data,
         color,
         yAxisId,
         meta,
@@ -76,19 +68,6 @@ export function buildStickinessSeries<R extends StickinessResultLike, M = unknow
     opts: BuildStickinessSeriesOpts<R, M>
 ): Series<M>[] {
     return results.map((r, index) => buildStickinessMainSeries(r, index, opts))
-}
-
-/** Produce per-bucket labels ("Day 0", "Day 1", …). The API's own "X day(s)" labels
- * duplicate the interval prefix when paired with a stickiness-style axis, so we
- * synthesize them from the bucket count. Mirrors `formatIntervalLabels` in the legacy LineGraph. */
-export function buildStickinessLabels(count: number, interval: string | null | undefined): string[] {
-    const prefix = capitalizeFirstLetter(interval ?? 'day')
-    return Array.from({ length: count }, (_, i) => `${prefix} ${i}`)
-}
-
-/** Emit `85.0%`-style ticks — legacy parity with `${value.toFixed(1)}%` in LineGraph. */
-export function stickinessPercentFormatter(value: number): string {
-    return `${value.toFixed(1)}%`
 }
 
 export const STICKINESS_TOOLTIP_CONFIG = INSIGHT_TOOLTIP_CONFIG
@@ -105,19 +84,24 @@ export function buildStickinessTooltipTitle(
     }
 }
 
-/** Shared stickiness y-axis: percent tick formatter + linear/log scale toggle. */
+/** Shared stickiness y-axis. Delegates to the trends formatter so stickiness shows a plain
+ * Count by default like every other insight type, while still respecting an explicit
+ * aggregation axis format (currency, duration, etc.) if one is set on the insight. */
 export function buildStickinessYAxisConfig(opts: {
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     yAxisScaleType?: StickinessYAxisScaleType
     showGrid?: boolean
 }): YAxisConfig {
-    return {
-        scale: opts.yAxisScaleType === 'log10' ? 'log' : 'linear',
+    return buildTrendsYAxisConfig(opts.trendsFilter, false, opts.baseCurrency, {
+        yAxisScaleType: opts.yAxisScaleType,
         showGrid: opts.showGrid ?? true,
-        tickFormatter: stickinessPercentFormatter,
-    }
+    })
 }
 
 export interface BuildStickinessLineTimeSeriesConfigOpts {
+    trendsFilter?: YFormatterFields | null
+    baseCurrency?: string
     yAxisScaleType?: StickinessYAxisScaleType
     showGrid?: boolean
     valueLabels?: TimeSeriesLineChartConfig['valueLabels']
@@ -129,8 +113,13 @@ export function buildStickinessLineTimeSeriesConfig(
     opts: BuildStickinessLineTimeSeriesConfigOpts
 ): TimeSeriesLineChartConfig {
     return {
-        // No xAxis date config — labels are pre-formatted interval counts (Day 0, Day 1, …).
-        yAxis: buildStickinessYAxisConfig({ yAxisScaleType: opts.yAxisScaleType, showGrid: opts.showGrid }),
+        // No xAxis date config: labels come from the API's own per-bucket labels (e.g. "1 day", "2 days").
+        yAxis: buildStickinessYAxisConfig({
+            trendsFilter: opts.trendsFilter,
+            baseCurrency: opts.baseCurrency,
+            yAxisScaleType: opts.yAxisScaleType,
+            showGrid: opts.showGrid,
+        }),
         valueLabels: opts.valueLabels,
         showCrosshair: opts.showCrosshair,
         tooltip: opts.tooltip,


### PR DESCRIPTION
## Problem

Two things about the stickiness axes, one clearly broken and one that no longer matches the documentation.

The x-axis is incorrect - It reads `Day 0`, `Day 1`, `Day 2`. Stickiness buckets are durations, not positions on a timeline, so they should read `1 day`, `2 days`, `3 days`. The indexing is off as well: the bucket labeled `Day 0` is the "active on 1 day" bucket, so every label is one off. The persons modal already disagrees with the axis about this. Click the point labeled `Day 2` and the modal is titled "stickiness on day 3", because it reads the real bucket number while the axis counts positions.

The y-axis does not match the docs - the [stickiness documentation](https://posthog.com/docs/product-analytics/stickiness) shows a count y-axis, while the chart shows percentages and gives you no way to switch. The two have disagreed since #29030 in March 2025. That is not a regression, so this half is reconciling the chart with the documented behavior rather than fixing a break, and the reasoning is under Changes below. If you would rather resolve it separately, the PR splits cleanly along the x and y axis.

## Changes

These are two different kinds of change and I have split them below. The x-axis is a plain defect, the labels are wrong and the API already sends the right ones. The y-axis is a year-old divergence between the chart and the docs, so it needs a decision rather than just a review.

### X-axis: the labels are already correct, the chart just does not use them

The backend returns labels in the right form. `stickiness_query_runner.py` emits `1 day`, `2 days`, and `N days or more` for cumulative mode, pluralized against the query interval. The frontend reads the length of that array and then discards it, rebuilding labels from the index:

```ts
const bucketCount = currentPeriodResult?.labels?.length ?? 0
const labels = buildStickinessLabels(bucketCount, interval)
// …
return Array.from({ length: count }, (_, i) => `${prefix} ${i}`)
```

`i` starts at 0 while the buckets start at 1, which is where the off-by-one comes from. This PR deletes that and passes `currentPeriodResult.labels` straight through. Cumulative mode and non-day intervals come along for free, since the backend already handles both.

The axis matched the API until late February. I traced how it drifted, and the trail is below in case it is useful, though nothing in this PR depends on it.

<details>
<summary>How the labels drifted, February to June</summary>

I went looking because the code carried a comment saying the API's labels "duplicate the interval prefix when paired with a stickiness-style axis", and I could not reproduce any duplication. It turns out the labels were right until late February, and the 0-indexing arrived as a side effect of fixing something else.

The key detail is that `String(value)` inside a Chart.js tick callback renders the tick index rather than the label. On a category scale, `CategoryScale.buildTicks()` pushes `{ value }` counting up from `min`, so `value` is the array position. I checked that against both chart.js 3.9.1 and 4.5.1 rather than assuming it, since the whole reading depends on it.

- **#48690** (2026-02-27) added date-aware x-axis tick formatting, with `String(value)` as the fallback when there were no dates to format. Stickiness passes numeric `days` (`[1, 2, 3, …]`) rather than date strings, and those numbers reached a parser calling `d.includes(' ')`, which numbers do not have.
- **#49858** (2026-03-04, "handle non-string days in X-axis tick formatter") fixed that by routing non-string days to the existing fallback: `typeof allDays[0] !== 'string'` now returns `String(value)`. That resolved the breakage, and because `value` is the tick index, the axis began showing `0`, `1`, `2` while `data.labels` still held the API's `"1 day"`, `"2 days"`.
- **#53655** (2026-04-08, "restore prefixed stickiness axis labels") noticed the axis had lost its unit and added a `"Day"` prefix. The numbers underneath were already positions, so the axis started reading `Day 0`.
- **#59390** (2026-05-21) moved labelling out of the tick callback into a `displayLabels` array via `formatIntervalLabels`. Output was unchanged. It also dropped the interval prefix, which meant passing the API labels through at that point would have rendered `1 day`, `2 days`; the comment about duplication describes a conflict that same change had already removed.
- **#59810** (2026-05-25) ported the chart to quill-charts, carrying the function across as `buildStickinessLabels` with tests asserting `['Day 0', 'Day 1', 'Day 2']`.
- **#63877** (2026-06-18) retired the Chart.js `LineGraph`, leaving the ported copy as the only implementation.

What makes this hard to spot is that #49858 turned a loud failure into a quiet one. Before it, the chart was visibly broken; after it, the chart looked entirely reasonable, just with the wrong numbers on one axis. Everything downstream then treated that output as intended, which is a completely natural thing to do with a chart that renders cleanly.

</details>

### Y-axis: bringing the chart back in line with the docs

`toPercentData` was converting every series to percent-of-total unconditionally, paired with a hardcoded `${value.toFixed(1)}%` tick formatter. Both are gone here. `buildStickinessYAxisConfig` now delegates to the shared `buildTrendsYAxisConfig`, so stickiness picks up the same numeric formatting as trends and still honors an explicit aggregation axis format if someone sets one.

The tooltip and the on-series value labels were separately percent-aware, so changing only the axis would have left `23.7%` floating over a count axis. I flipped `showPercentView` to false in both chart components and swapped the value-label formatter to `formatAggregationAxisValue`.

Unlike the labels, this one is working as designed, so here is the case for changing it.

The [stickiness documentation](https://posthog.com/docs/product-analytics/stickiness) shows a count y-axis. The chart shows percentages. Those have disagreed since **#29030** (2025-03-14, "Display stickiness data as percentages along with count"), which set `showPercentView={isStickiness}` with no way to turn it off. The docs have been describing the pre-#29030 chart for over a year. One of the two needs to move, and the rest of this section is the case for it being the chart.

The "along with count" in that PR's title is worth reading closely, because the two surfaces it touched ended up in different places. In the table it happened, and still works: each cell shows the percentage with the raw count beneath it, so both numbers are there.

```tsx
<div>{((item.data[index] / item.count) * 100).toFixed(1)}%</div>
<div>({formattedValue})</div>
```

On the chart it did not. The axis, the tooltip and the value labels are all percentages, and there is no toggle, so counts are simply not reachable from the chart. Compare trends, where percentage is a mode you opt into via `showPercentStackView`. Stickiness hardcodes it.

So the chart is the odd one out three ways over: the docs say counts, the table gives you both, and the underlying query returns actor counts, with the persons modal opening a list of actors when you click a point. Making the chart show counts lines it up with all three, and the table still carries the percentage for anyone who wants it.

#### The other places that already chose percentages

Worth knowing before you weigh in, since it is evidence against the y-axis half of this PR.

There is a second stickiness chart for MCP apps at `services/mcp/src/ui-apps/components/StickinessVisualizer.tsx`. It shares no code with these charts, and it converts to percent too, with its reasoning written down:

```ts
// The backend returns absolute actor counts per bucket; stickiness reads each bucket as its share
// of the series' total users (`count`). A zero-total series contributes 0% — never a raw count —
// so it can't plot unscaled values onto the percentage axis.
```

So percentage is the settled answer in three places: #29030 for the app, that comment for MCP, and the legacy Chart.js path before the quill port. This PR would leave the app showing counts while MCP still shows percentages for the same insight, which is a real cost and an argument for deciding the question before merging rather than after.

Pointing the other way, MCP's x-axis is already right. It uses the API's labels and falls back to building `N days` from the `days` values, properly pluralized. Two implementations arrived at that independently, which I take as support for the labels half of this change.

If you land the y-axis change, MCP wants the same treatment and I am happy to do it in a follow-up.

### Before and after

| | x-axis | y-axis |
| --- | --- | --- |
| Before | `Day 0`, `Day 1`, `Day 2` | `85.0%` |
| After | `1 day`, `2 days`, `3 days` | `18,000` |
| | defect, fixed | working as designed, proposed change |

Axis ticks read straight out of the rendered Storybook DOM:

```
line chart  x: ["1 day","2 days","3 days","4 days","5 days","6 days","7 days","8 days"]
line chart  y: ["0","5,000","10,000","15,000","20,000","25,000"]
bar chart   x: ["1 day","2 days","3 days","4 days","5 days","6 days","7 days","8 days"]
bar chart   y: ["0","2,000","4,000","6,000","8,000","10,000","12,000","14,000","16,000","18,000"]
```

### About the visual diffs

Both axes render differently now, so Visual Review will flag the stickiness stories. The diffs are the change working, not a surprise, so here is what to expect.

Eight baselines should move, all of them charts this PR touches:

```
insights-stickinesslinechart--default--light / --dark
insights-stickinesslinechart--area--light    / --dark
insights-stickinessbarchart--stacked--light  / --dark
insights-stickinessbarchart--unstacked--light / --dark
```

In each one the x-axis ticks go from `Day 0 … Day 7` to `1 day … 8 days`, and the y-axis goes from a `0.0%` to `100.0%` scale to actor counts. Series shapes stay the same, since percent-of-total is a linear rescale of each series and this only changes what the axis is denominated in.

Four other stickiness baselines should not move:

- `mcp-apps-stickiness--single-series--light` and `--multiple-series--light` render through `StickinessVisualizer`, which shares no code with these charts.
- `components-cards-insight-details--stickiness--light` and `--dark` render `InsightDetails`, which describes the insight's configuration and draws no chart.

If anything outside those eight shows a diff, that is worth a closer look, because I would not expect this change to reach it.

### Not in scope, but adjacent

The insight's data table labels stickiness columns separately, at `frontend/src/scenes/insights/views/InsightsTable/InsightsTable.tsx:435`:

```ts
title: isStickiness ? (
    `${interval ? capitalizeFirstLetter(interval) : 'Day'} ${index + 1}`
) : (
```

That one is `index + 1`, so the numbering there was already right. Which means the chart and the table used to disagree, and after this they line up:

| | chart axis | table column |
| --- | --- | --- |
| Before | `Day 0` | `Day 1` |
| After | `1 day` | `Day 1` |

So this change brings the two into agreement rather than pulling them apart. What remains is a wording difference, and one case worth knowing about: in cumulative mode the API returns `3 days or more` while the table shows `Day 3`, so the "or more" does not make it through. The table already has `labels` on each result, so it could read them the same way the charts now do.

I left that out to keep this diff to one surface, but happy to follow up separately or fold it in here if you would rather it landed together.

## How did you test this code?

All automated, run locally. I did not exercise this against a real project or a live dev stack.

- `products/product_analytics/frontend/insights/stickiness/` – 62 tests across 5 suites, all passing.
- Rendered `StickinessLineChart` and `StickinessBarChart` in Storybook via headless Chromium and read the axis ticks out of the DOM. Line chart: x `1 day … 8 days`, y `0 … 25,000`. Bar chart: x `1 day … 8 days`, y `0 … 18,000`. No `%` anywhere.
- `pnpm --filter=@posthog/frontend fix` clean, no unrelated files reformatted.
- `typescript:check` reports 37 errors repo-wide, all pre-existing `Cannot find module '@posthog/quill-primitives'` failures in unrelated products because the nested quill workspace is not built in my environment. Zero in stickiness or insights.
- I could not run `hogli ci:preflight`, it needs a Python env I do not have set up. The diff is frontend-only with no lockfile or migration changes, and I ran the lint gate directly.

On the tests themselves:

Two new tests in `StickinessLineChart.test.tsx` render the chart and assert the axes, covering both of the above. The existing tests pinned the previous output rather than the axis behavior (`expect(buildStickinessLabels(3, 'day')).toEqual(['Day 0', 'Day 1', 'Day 2'])`), so they moved along with the change. I checked the new x-axis test is really testing something by temporarily putting the old `Day ${i}` logic back and confirming it fails.

The tests for `buildStickinessLabels`, `toPercentData`, and `stickinessPercentFormatter` are deleted along with the functions. The rest are retargeted from percent to count, no new cases.

<details>
<summary>Test output</summary>

```
PASS ../products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
PASS ../products/product_analytics/frontend/insights/stickiness/StickinessBarChart/stickinessBarChartTransforms.test.ts
PASS ../products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
PASS ../products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
PASS ../products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx

Test Suites: 5 passed, 5 total
Tests:       62 passed, 62 total
```

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing in this repo documents the stickiness axis formatting, so there is nothing to update here.

The website does need an edit if we decide to move away from Y-axis counts. I checked the [stickiness documentation](https://posthog.com/docs/product-analytics/stickiness) and it shows counts on the y-axis, not percentages. The docs have therefore been describing pre-#29030 behavior since March 2025.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I noticed the axis labels in the stickiness builder looked off and had Claude (Claude Code, Opus 5) trace and fix them. Skills invoked from this repo: `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`.

Both changes went in as bug fixes to begin with. Going back over the history afterwards turned up #29030, which showed the percentage y-axis was intentional rather than broken, so that half is now presented as reconciling the chart with the docs instead of fixing a defect. Flagging the change of framing because the commit message still carries the original wording, and a reviewer reading only that would get the older version of the story.

Three other decisions worth surfacing:

The y-axis could have been a plain count formatter. We routed it through `buildTrendsYAxisConfig` instead so that an explicit `aggregationAxisFormat` (currency, duration) still applies, matching how trends behaves. Slightly larger diff, but it stops stickiness from being a special case again.

We left the `yAxisScaleType` / `log10` plumbing alone even though it looks unreachable. `ScalePicker` only renders when `isTrends`, and `getYAxisScaleType` returns `undefined` for anything that is not a `TrendsQuery`, so `scale` is always `linear` here. It predates this change and removing it is a product call, not a bugfix, especially since a log scale would genuinely help these charts given how much the first bucket dominates. Happy to strip it in a follow-up if you want it gone.

The two halves are independent, so if the y-axis needs more discussion the labels can go in on their own and the rest can wait. 










