### PR TITLE
feat(customer-analytics): add search to the custom properties settings table

### DIFF
--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconInfo, IconPencil, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTableColumns, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonTable, LemonTableColumns, Tooltip } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -30,8 +30,9 @@ const TAG_TYPE_BY_SYNC_LEVEL: Record<SourceSyncStatusLevel, LemonTagType> = {
 }
 
 export function CustomPropertiesConfig(): JSX.Element {
-    const { definitions, definitionsLoading } = useValues(customPropertyDefinitionsLogic)
-    const { openCreateModal, openEditModal, deleteDefinition } = useActions(customPropertyDefinitionsLogic)
+    const { filteredDefinitions, definitionsLoading, searchTerm } = useValues(customPropertyDefinitionsLogic)
+    const { openCreateModal, openEditModal, deleteDefinition, setSearchTerm } =
+        useActions(customPropertyDefinitionsLogic)
     const restrictionReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
@@ -157,12 +158,23 @@ export function CustomPropertiesConfig(): JSX.Element {
                     New custom property
                 </LemonButton>
             </div>
+            <LemonInput
+                type="search"
+                placeholder="Search custom properties"
+                value={searchTerm}
+                onChange={setSearchTerm}
+                className="max-w-80"
+            />
             <LemonTable
                 columns={columns}
-                dataSource={definitions}
+                dataSource={filteredDefinitions}
                 loading={definitionsLoading}
                 rowKey="id"
-                emptyState="No custom properties yet. Create one to get started."
+                emptyState={
+                    searchTerm
+                        ? 'No custom properties match your search.'
+                        : 'No custom properties yet. Create one to get started.'
+                }
             />
             <CustomPropertyModal />
         </div>

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -189,6 +189,7 @@ export interface customPropertyDefinitionsLogicValues {
     definitionsLoading: boolean
     editingDefinition: CustomPropertyDefinitionApi | null
     editingReferences: readonly CustomPropertyReferenceApi[]
+    filteredDefinitions: CustomPropertyDefinitionApi[]
     isCustomPropertyFormSubmitting: boolean
     isCustomPropertyFormValid: boolean
     materializedViews: DataWarehouseSavedQuery[]
@@ -201,6 +202,7 @@ export interface customPropertyDefinitionsLogicValues {
     runsLoadingBySourceId: Record<string, boolean>
     savedQueries: DataWarehouseSavedQuery[]
     savedQueriesLoading: boolean
+    searchTerm: string
     selectedSourceColumns: string[]
     selectedTableColumns: WarehouseColumn[]
     selectedTableColumnsLoading: boolean
@@ -390,6 +392,9 @@ export interface customPropertyDefinitionsLogicActions {
     setEditingDefinition: (definition: CustomPropertyDefinitionApi) => {
         definition: CustomPropertyDefinitionApi
     }
+    setSearchTerm: (searchTerm: string) => {
+        searchTerm: string
+    }
     submitCustomPropertyForm: () => {
         value: boolean
     }
@@ -435,6 +440,10 @@ export interface customPropertyDefinitionsLogicMeta {
             customPropertyForm: CustomPropertyFormValues,
             personPropertyDefinitions: PropertyDefinition[]
         ) => (string | null)[]
+        filteredDefinitions: (
+            definitions: CustomPropertyDefinitionApi[],
+            searchTerm: string
+        ) => CustomPropertyDefinitionApi[]
         editingReferences: (
             definitions: CustomPropertyDefinitionApi[],
             editingDefinition: CustomPropertyDefinitionApi | null
@@ -473,6 +482,7 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         }),
         openEditModal: (definition: CustomPropertyDefinitionApi) => ({ definition }),
         closeModal: true,
+        setSearchTerm: (searchTerm: string) => ({ searchTerm }),
         setEditingDefinition: (definition: CustomPropertyDefinitionApi) => ({ definition }),
         // Person sources only. triggerSync re-runs the underlying warehouse sync; triggerBackfill
         // starts a full-table backfill. add/removeTriggeringSource drive the per-row double-submit
@@ -494,6 +504,12 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         pollRunsStatus: ({ sourceId }: { sourceId: string }) => ({ sourceId }),
     }),
     reducers({
+        searchTerm: [
+            '',
+            {
+                setSearchTerm: (_, { searchTerm }) => searchTerm,
+            },
+        ],
         modalVisible: [
             false,
             {
@@ -866,6 +882,20 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                     }
                     return null
                 })
+            },
+        ],
+        filteredDefinitions: [
+            (s) => [s.definitions, s.searchTerm],
+            (definitions: CustomPropertyDefinitionApi[], searchTerm: string): CustomPropertyDefinitionApi[] => {
+                const query = searchTerm.trim().toLowerCase()
+                if (!query) {
+                    return definitions
+                }
+                return definitions.filter(
+                    (definition) =>
+                        definition.name.toLowerCase().includes(query) ||
+                        definition.description?.toLowerCase().includes(query)
+                )
             },
         ],
         editingReferences: [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

The custom properties table in customer analytics settings has no search - finding a property in a long list means scrolling.

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

- Add a search box above the table, filtering client-side by name and description
- Show a search-specific empty state when nothing matches

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

Not tested manually. No new tests - the filter is a trivial client-side selector.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code. Skills invoked: /writing-kea-logics. Search state lives in customPropertyDefinitionsLogic (setSearchTerm action + filteredDefinitions selector); client-side filtering since the definitions list is small and already loaded in full.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*