### PR TITLE
fix(session): require cross-axis corroboration before ending a session

### DIFF
--- a/posthog/api/test/test_user_auth_session.py
+++ b/posthog/api/test/test_user_auth_session.py
@@ -256,10 +256,11 @@ class TestUserAuthSessionAPI(APIBaseTest):
         return_value={"latitude": 35.6, "longitude": 139.7, "country_code": "JP"},
     )
     def test_high_risk_request_redirects_and_flushes_through_middleware_stack(self, _geoip, _flags):
-        # End-to-end through the real middleware stack: a seeded NYC baseline plus a Tokyo geo on this
-        # request is impossible travel (HIGH); with session-end on, SessionRiskMiddleware flushes the
-        # session server-side and redirects. Only the geoip DB and flag service (true boundaries) are
-        # mocked — evaluate_session_risk, current_request_context, and evaluate_signals run for real.
+        # End-to-end through the real middleware stack: a seeded NYC/Chrome baseline against a Tokyo geo
+        # and a Firefox UA on this request trips both axes (HIGH), the way a replayed cookie would. With
+        # session-end on, SessionRiskMiddleware flushes the session server-side and redirects. Only the
+        # geoip DB and flag service (true boundaries) are mocked — evaluate_session_risk,
+        # current_request_context, and evaluate_signals run for real.
         key = self.client.session.session_key
         Session.objects.filter(session_key=key).update(
             latitude=40.7,
@@ -269,7 +270,12 @@ class TestUserAuthSessionAPI(APIBaseTest):
             baseline_at=timezone.now() - timedelta(minutes=30),
         )
 
-        response = self.client.get("/api/users/@me/")
+        response = self.client.get(
+            "/api/users/@me/",
+            headers={
+                "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+            },
+        )
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers["Location"], "/login?reason=session_risk")

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -1,4 +1,5 @@
 import ipaddress
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Optional, TypedDict
 
@@ -89,25 +90,34 @@ def _is_non_public_ip(ip_address: str) -> bool:
     )
 
 
+@dataclass(frozen=True, kw_only=True)
+class CachedLocation:
+    """One memoized geoip result. Keyword-only because latitude and longitude share a type and would
+    otherwise be swappable at the call site."""
+
+    latitude: Optional[float]
+    longitude: Optional[float]
+    country_code: Optional[str]
+
+
 @lru_cache(maxsize=GEOIP_LOCATION_CACHE_SIZE)
-def _lookup_location(ip_address: str) -> tuple[Optional[float], Optional[float], Optional[str]]:
+def _lookup_location(ip_address: str) -> CachedLocation:
     """Cached lookup behind get_geoip_location, which runs on every authenticated request.
 
     The database is opened once at import and never written, so the mapping from address to location
-    cannot change under a running process — a deploy shipping a new database restarts it. Returns a
-    tuple rather than the dict callers get, so a cached entry can't be mutated through one caller and
-    observed by the next. lru_cache doesn't store exceptions, so a failed lookup is retried rather
-    than pinned for the life of the process.
+    cannot change under a running process — a deploy shipping a new database restarts it. Frozen, so a
+    cached entry can't be mutated through one caller and observed by the next. lru_cache doesn't store
+    exceptions, so a failed lookup is retried rather than pinned for the life of the process.
     """
     assert geoip is not None  # caller checks; keeps the cached path free of the None branch
     city = geoip.city(ip_address)
     latitude = city.get("latitude")
     longitude = city.get("longitude")
     country_code = city.get("country_code")
-    return (
-        float(latitude) if isinstance(latitude, int | float) else None,
-        float(longitude) if isinstance(longitude, int | float) else None,
-        country_code if isinstance(country_code, str) else None,
+    return CachedLocation(
+        latitude=float(latitude) if isinstance(latitude, int | float) else None,
+        longitude=float(longitude) if isinstance(longitude, int | float) else None,
+        country_code=country_code if isinstance(country_code, str) else None,
     )
 
 
@@ -116,15 +126,15 @@ def get_geoip_location(ip_address: Optional[str]) -> GeoLocation:
     if not ip_address or not geoip or _is_non_public_ip(ip_address):
         return {}
     try:
-        latitude, longitude, country_code = _lookup_location(ip_address)
+        location = _lookup_location(ip_address)
     except Exception:
         logger.exception("geoIP location error")
         return {}
     out: GeoLocation = {}
-    if latitude is not None:
-        out["latitude"] = latitude
-    if longitude is not None:
-        out["longitude"] = longitude
-    if country_code is not None:
-        out["country_code"] = country_code
+    if location.latitude is not None:
+        out["latitude"] = location.latitude
+    if location.longitude is not None:
+        out["longitude"] = location.longitude
+    if location.country_code is not None:
+        out["country_code"] = location.country_code
     return out

--- a/posthog/geoip.py
+++ b/posthog/geoip.py
@@ -1,4 +1,5 @@
 import ipaddress
+from functools import lru_cache
 from typing import Optional, TypedDict
 
 from django.contrib.gis.geoip2 import GeoIP2
@@ -30,6 +31,11 @@ VALID_GEOIP_PROPERTIES = [
 
 # GeoIP2 returns the city name as 'city', but we want to map it to 'city_name'
 GEOIP_KEY_MAPPING = {"city": "city_name"}
+
+# Distinct addresses whose location we keep per process. A MaxMind lookup costs ~75us even with the
+# database in memory, and the risk middleware does one per authenticated request, so the working set
+# of active client addresses is worth holding onto. Each entry is a few hundred bytes.
+GEOIP_LOCATION_CACHE_SIZE = 4096
 
 
 def get_geoip_properties(ip_address: Optional[str]) -> dict[str, str]:
@@ -83,23 +89,42 @@ def _is_non_public_ip(ip_address: str) -> bool:
     )
 
 
+@lru_cache(maxsize=GEOIP_LOCATION_CACHE_SIZE)
+def _lookup_location(ip_address: str) -> tuple[Optional[float], Optional[float], Optional[str]]:
+    """Cached lookup behind get_geoip_location, which runs on every authenticated request.
+
+    The database is opened once at import and never written, so the mapping from address to location
+    cannot change under a running process — a deploy shipping a new database restarts it. Returns a
+    tuple rather than the dict callers get, so a cached entry can't be mutated through one caller and
+    observed by the next. lru_cache doesn't store exceptions, so a failed lookup is retried rather
+    than pinned for the life of the process.
+    """
+    assert geoip is not None  # caller checks; keeps the cached path free of the None branch
+    city = geoip.city(ip_address)
+    latitude = city.get("latitude")
+    longitude = city.get("longitude")
+    country_code = city.get("country_code")
+    return (
+        float(latitude) if isinstance(latitude, int | float) else None,
+        float(longitude) if isinstance(longitude, int | float) else None,
+        country_code if isinstance(country_code, str) else None,
+    )
+
+
 def get_geoip_location(ip_address: Optional[str]) -> GeoLocation:
     """Latitude/longitude/country_code for risk scoring. Unlike get_geoip_properties this keeps floats."""
     if not ip_address or not geoip or _is_non_public_ip(ip_address):
         return {}
     try:
-        city = geoip.city(ip_address)
+        latitude, longitude, country_code = _lookup_location(ip_address)
     except Exception:
         logger.exception("geoIP location error")
         return {}
     out: GeoLocation = {}
-    latitude = city.get("latitude")
-    if isinstance(latitude, int | float):
-        out["latitude"] = float(latitude)
-    longitude = city.get("longitude")
-    if isinstance(longitude, int | float):
-        out["longitude"] = float(longitude)
-    country_code = city.get("country_code")
-    if isinstance(country_code, str):
+    if latitude is not None:
+        out["latitude"] = latitude
+    if longitude is not None:
+        out["longitude"] = longitude
+    if country_code is not None:
         out["country_code"] = country_code
     return out

--- a/posthog/models/activity_logging/signal_handlers.py
+++ b/posthog/models/activity_logging/signal_handlers.py
@@ -897,10 +897,6 @@ def post_login(sender, user, request: HttpRequest, **kwargs):
     # fresh password/2FA/SSO login satisfies TimeSensitiveActionPermission.
     request.session[settings.SESSION_LAST_REAUTH_AT_KEY] = time.time()
     request.session.pop(settings.SESSION_STEP_UP_REQUIRED_KEY, None)
-    # Clear the risk-telemetry dedup markers so the first anomaly after this (re)login re-emits instead
-    # of being suppressed by the pre-login signature. Pairs with the baseline reset below.
-    request.session.pop(settings.SESSION_RISK_LAST_SIG_KEY, None)
-    request.session.pop(settings.SESSION_RISK_LAST_EMIT_AT_KEY, None)
 
     # Defensive risk-baseline reset: login() rotates the session key, so the new row's risk columns
     # are already NULL and this is normally a no-op. It guarantees a clean baseline after a high-tier

--- a/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
+++ b/posthog/models/test/__snapshots__/test_async_deletion_model.ambr
@@ -31,16 +31,6 @@
          AND $group_0 = 'foo')
   '''
 # ---
-# name: TestAsyncDeletion.test_mark_deletions_done_groups[new_events_schema]
-  '''
-  
-  SELECT DISTINCT team_id,
-                  $group_0
-  FROM events_json
-  WHERE (team_id = 99999
-         AND $group_0 = 'foo')
-  '''
-# ---
 # name: TestAsyncDeletion.test_mark_deletions_done_groups_when_not_done
   '''
   
@@ -52,16 +42,6 @@
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_groups_when_not_done.1
-  '''
-  
-  SELECT DISTINCT team_id,
-                  $group_0
-  FROM events_json
-  WHERE (team_id = 99999
-         AND $group_0 = 'foo')
-  '''
-# ---
-# name: TestAsyncDeletion.test_mark_deletions_done_groups_when_not_done[new_events_schema]
   '''
   
   SELECT DISTINCT team_id,
@@ -83,17 +63,6 @@
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_deletions_done_person.1
-  '''
-  
-  SELECT DISTINCT team_id,
-                  person_id
-  FROM events_json
-  WHERE (team_id = 99999
-         AND person_id = '00000000-0000-0000-0000-000000000000')
-    AND _timestamp <= '2024-01-01 00:00:00'
-  '''
-# ---
-# name: TestAsyncDeletion.test_mark_deletions_done_person[new_events_schema]
   '''
   
   SELECT DISTINCT team_id,
@@ -126,17 +95,6 @@
     AND _timestamp <= '2024-01-01 00:00:00'
   '''
 # ---
-# name: TestAsyncDeletion.test_mark_deletions_done_person_when_not_done[new_events_schema]
-  '''
-  
-  SELECT DISTINCT team_id,
-                  person_id
-  FROM events_json
-  WHERE (team_id = 99999
-         AND person_id = '00000000-0000-0000-0000-000000000000')
-    AND _timestamp <= '2024-01-01 00:00:00'
-  '''
-# ---
 # name: TestAsyncDeletion.test_mark_deletions_done_team_when_not_done
   '''
   
@@ -153,14 +111,6 @@
   WHERE team_id = 99999
   '''
 # ---
-# name: TestAsyncDeletion.test_mark_deletions_done_team_when_not_done[new_events_schema]
-  '''
-  
-  SELECT DISTINCT team_id
-  FROM events_json
-  WHERE team_id = 99999
-  '''
-# ---
 # name: TestAsyncDeletion.test_mark_team_deletions_done
   '''
   
@@ -170,14 +120,6 @@
   '''
 # ---
 # name: TestAsyncDeletion.test_mark_team_deletions_done.1
-  '''
-  
-  SELECT DISTINCT team_id
-  FROM events_json
-  WHERE team_id = 99999
-  '''
-# ---
-# name: TestAsyncDeletion.test_mark_team_deletions_done[new_events_schema]
   '''
   
   SELECT DISTINCT team_id

--- a/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
+++ b/posthog/models/web_preaggregated/__snapshots__/test_web_pre_aggregated_timezones.ambr
@@ -66,57 +66,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_india_half_hour_timezone_edge_case[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Kolkata')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Kolkata'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Kolkata')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Kolkata')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Kolkata')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Kolkata'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Kolkata'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Kolkata'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Kolkata')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -318,159 +267,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit[new_events_schema.1]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'America/Los_Angeles')), max(toTimeZone(raw_sessions.max_timestamp, 'America/Los_Angeles'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'America/Los_Angeles')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Los_Angeles')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Los_Angeles')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Los_Angeles'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Los_Angeles'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Los_Angeles'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Los_Angeles')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit[new_events_schema.2]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_boundary_behavior_explicit[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_00_Pacific_UTC_08_00_
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -509,57 +305,6 @@
             if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), events.`$session_id`, NULL) AS session_id,
             any(if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), fromUnixTimestamp(intDiv(accurateCastOrNull(bitShiftRight(events.`$session_id_uuid`, 80), 'Int64'), 1000)), NULL)) AS start_timestamp
      FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Los_Angeles'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Los_Angeles'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Los_Angeles'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Los_Angeles')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_00_Pacific_UTC_08_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'America/Los_Angeles')), max(toTimeZone(raw_sessions.max_timestamp, 'America/Los_Angeles'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'America/Los_Angeles')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Los_Angeles')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Los_Angeles')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -656,57 +401,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_01_New_York_UTC_05_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'America/New_York')), max(toTimeZone(raw_sessions.max_timestamp, 'America/New_York'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'America/New_York')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/New_York')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/New_York')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/New_York'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/New_York'))), lessOrEquals(toTimeZone(events.timestamp, 'America/New_York'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/New_York')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_02_Sao_Paulo_UTC_03_00_
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -745,57 +439,6 @@
             if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), events.`$session_id`, NULL) AS session_id,
             any(if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), fromUnixTimestamp(intDiv(accurateCastOrNull(bitShiftRight(events.`$session_id_uuid`, 80), 'Int64'), 1000)), NULL)) AS start_timestamp
      FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Sao_Paulo'))), lessOrEquals(toTimeZone(events.timestamp, 'America/Sao_Paulo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Sao_Paulo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_02_Sao_Paulo_UTC_03_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'America/Sao_Paulo')), max(toTimeZone(raw_sessions.max_timestamp, 'America/Sao_Paulo'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'America/Sao_Paulo')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'America/Sao_Paulo')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'America/Sao_Paulo')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -892,57 +535,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_03_UTC_UTC_00_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'UTC')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_04_Berlin_UTC_01_00_
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -981,57 +573,6 @@
             if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), events.`$session_id`, NULL) AS session_id,
             any(if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), fromUnixTimestamp(intDiv(accurateCastOrNull(bitShiftRight(events.`$session_id_uuid`, 80), 'Int64'), 1000)), NULL)) AS start_timestamp
      FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Berlin'))), lessOrEquals(toTimeZone(events.timestamp, 'Europe/Berlin'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Berlin')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_04_Berlin_UTC_01_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Europe/Berlin')), max(toTimeZone(raw_sessions.max_timestamp, 'Europe/Berlin'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Europe/Berlin')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Berlin')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Berlin')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -1128,57 +669,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_05_Cairo_UTC_02_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Africa/Cairo')), max(toTimeZone(raw_sessions.max_timestamp, 'Africa/Cairo'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Africa/Cairo')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Africa/Cairo')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Africa/Cairo')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Africa/Cairo'))), lessOrEquals(toTimeZone(events.timestamp, 'Africa/Cairo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Africa/Cairo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_06_Moscow_UTC_03_00_
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -1217,57 +707,6 @@
             if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), events.`$session_id`, NULL) AS session_id,
             any(if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), fromUnixTimestamp(intDiv(accurateCastOrNull(bitShiftRight(events.`$session_id_uuid`, 80), 'Int64'), 1000)), NULL)) AS start_timestamp
      FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Europe/Moscow'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Moscow'))), lessOrEquals(toTimeZone(events.timestamp, 'Europe/Moscow'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Moscow')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_06_Moscow_UTC_03_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Europe/Moscow')), max(toTimeZone(raw_sessions.max_timestamp, 'Europe/Moscow'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Europe/Moscow')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Europe/Moscow')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Europe/Moscow')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -1364,57 +803,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_07_Pakistan_UTC_05_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Karachi')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Karachi'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Karachi')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Karachi')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Karachi')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Karachi'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Karachi'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Karachi'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Karachi')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_08_Tokyo_UTC_09_00_
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -1453,57 +841,6 @@
             if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), events.`$session_id`, NULL) AS session_id,
             any(if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), fromUnixTimestamp(intDiv(accurateCastOrNull(bitShiftRight(events.`$session_id_uuid`, 80), 'Int64'), 1000)), NULL)) AS start_timestamp
      FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo'))), lessOrEquals(toTimeZone(events.timestamp, 'Asia/Tokyo'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_08_Tokyo_UTC_09_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')), max(toTimeZone(raw_sessions.max_timestamp, 'Asia/Tokyo'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Asia/Tokyo')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Asia/Tokyo')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Asia/Tokyo')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id
@@ -1600,57 +937,6 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_09_Sydney_UTC_11_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Australia/Sydney')), max(toTimeZone(raw_sessions.max_timestamp, 'Australia/Sydney'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Australia/Sydney')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Australia/Sydney'))), lessOrEquals(toTimeZone(events.timestamp, 'Australia/Sydney'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Australia/Sydney')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
 # name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_10_Auckland_UTC_12_00_
   '''
   SELECT nullIf(nullIf(web_pre_aggregated_stats.browser, ''), 'null') AS `context.columns.breakdown_value`,
@@ -1689,57 +975,6 @@
             if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), events.`$session_id`, NULL) AS session_id,
             any(if(ifNull(equals(bitAnd(bitShiftRight(events.`$session_id_uuid`, 76), 15), 7), 0), fromUnixTimestamp(intDiv(accurateCastOrNull(bitShiftRight(events.`$session_id_uuid`, 80), 'Int64'), 1000)), NULL)) AS start_timestamp
      FROM events
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-     WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland'))), lessOrEquals(toTimeZone(events.timestamp, 'Pacific/Auckland'), assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1))
-     GROUP BY session_id,
-              breakdown_value)
-  GROUP BY `context.columns.breakdown_value`
-  ORDER BY `context.columns.visitors` DESC,
-           `context.columns.views` DESC,
-           `context.columns.breakdown_value` ASC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
-  '''
-# ---
-# name: TestTimezonePreAggregatedIntegration.test_timezone_hourly_bucketing_10_Auckland_UTC_12_00_[new_events_schema]
-  '''
-  SELECT breakdown_value AS `context.columns.breakdown_value`,
-         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
-         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
-         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
-  FROM
-    (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
-            count() AS filtered_pageview_count,
-            events.properties.`$browser` AS breakdown_value,
-            events__session.session_id AS session_id,
-            any(events__session.`$is_bounce`) AS is_bounce,
-            min(events__session.`$start_timestamp`) AS start_timestamp
-     FROM events_json AS events
-     LEFT JOIN
-       (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
-               if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'Pacific/Auckland')), max(toTimeZone(raw_sessions.max_timestamp, 'Pacific/Auckland'))), 10)))) AS `$is_bounce`,
-               min(toTimeZone(raw_sessions.min_timestamp, 'Pacific/Auckland')) AS `$start_timestamp`,
-               raw_sessions.session_id_v7 AS session_id_v7
-        FROM raw_sessions
-        WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-01-15 00:00:00', 'Pacific/Auckland')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-01-16 23:59:59', 'Pacific/Auckland')), toIntervalDay(3))))
-        GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
                person_distinct_id_overrides.distinct_id AS distinct_id

--- a/posthog/session/backend.py
+++ b/posthog/session/backend.py
@@ -54,7 +54,8 @@ class SessionStore(DBStore):
         return obj
 
     def _get_session_from_db(self) -> "Session | None":
-        obj = cast("Session | None", super()._get_session_from_db())
+        # Private DBStore method, not declared in django-stubs — same gap as `save` works around below.
+        obj = cast("Session | None", super()._get_session_from_db())  # type: ignore[misc]
         self.loaded_row = obj
         return obj
 

--- a/posthog/session/backend.py
+++ b/posthog/session/backend.py
@@ -42,11 +42,20 @@ class SessionStore(DBStore):
 
         return Session
 
+    # Row this store loaded for the current request, or None when it never loaded one. Risk scoring
+    # reads the baseline columns off it instead of issuing a second SELECT for a row already fetched.
+    loaded_row: "Session | None" = None
+
     def create_model_instance(self, data: dict[str, Any]) -> "Session":
         obj = cast("Session", super().create_model_instance(data))
         obj.user_id = _auth_user_id(data)
         # Only persisted on INSERT (see `save`); for existing rows the middleware owns last_activity.
         obj.last_activity = timezone.now()
+        return obj
+
+    def _get_session_from_db(self) -> "Session | None":
+        obj = cast("Session | None", super()._get_session_from_db())
+        self.loaded_row = obj
         return obj
 
     def save(self, must_create: bool = False) -> None:

--- a/posthog/session/risk.py
+++ b/posthog/session/risk.py
@@ -25,6 +25,13 @@ logger = structlog.get_logger(__name__)
 
 # Per-process circuit breaker for the dedup cache: how many consecutive failures still emit (and log)
 # before we assume a real outage and stay quiet rather than emitting once per request.
+#
+# The count is deliberately approximate. Separate workers are separate processes and so hold separate
+# counters, which is the intent — each one throttles its own logging. Within a process, `+= 1` is a
+# read-modify-write and two threads can lose an increment between them, while the `= 0` reset is a
+# single store and can't tear. A lost increment can only make the breaker trip later, never sooner,
+# because the count rises solely on real failures — so the worst case is a few extra events during an
+# outage, which is the direction we'd rather err in anyway.
 _CACHE_FAILURE_EMIT_LIMIT = 10
 _consecutive_cache_failures = 0
 

--- a/posthog/session/risk.py
+++ b/posthog/session/risk.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY
+from django.contrib.sessions.backends.base import SessionBase
 from django.core.cache import cache
 from django.http import HttpRequest
 from django.utils import timezone
@@ -21,6 +22,11 @@ from posthog.session.models import Session
 from posthog.utils import get_trusted_client_ip
 
 logger = structlog.get_logger(__name__)
+
+# Per-process circuit breaker for the dedup cache: how many consecutive failures still emit (and log)
+# before we assume a real outage and stay quiet rather than emitting once per request.
+_CACHE_FAILURE_EMIT_LIMIT = 10
+_consecutive_cache_failures = 0
 
 
 class RiskSignal(str, Enum):
@@ -86,7 +92,10 @@ def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 def evaluate_signals(baseline: Baseline, ctx: Context, *, now: datetime) -> set[RiskSignal]:
     signals: set[RiskSignal] = set()
 
-    if baseline.ua_signature and ctx.ua_signature and baseline.ua_signature != ctx.ua_signature:
+    # A *missing* user agent counts as a change, not as "nothing to compare". Session-cookie auth is
+    # browser traffic and browsers always send the header, so its absence is itself anomalous — and
+    # treating it as neutral would let a caller drop the header to avoid tripping the device axis.
+    if baseline.ua_signature and baseline.ua_signature != ctx.ua_signature:
         signals.add(RiskSignal.UA_CHANGE)
 
     if baseline.country_code and ctx.country_code and baseline.country_code != ctx.country_code:
@@ -114,20 +123,29 @@ def evaluate_signals(baseline: Baseline, ctx: Context, *, now: datetime) -> set[
 
 
 # The independent axes a signal can observe. impossible_travel and new_country are both derived from
-# a single geoip lookup on a single IP, so they corroborate each other only in appearance.
+# a single geoip lookup on a single IP, so they corroborate each other only in appearance. Every
+# RiskSignal must belong to exactly one axis or tier_for would silently cap it at MEDIUM forever.
 NETWORK_SIGNALS = frozenset({RiskSignal.IMPOSSIBLE_TRAVEL, RiskSignal.NEW_COUNTRY})
 DEVICE_SIGNALS = frozenset({RiskSignal.UA_CHANGE})
 
 
-def tier_for(signals: set[RiskSignal]) -> RiskTier:
-    """HIGH ends the session, so it requires corroboration across both axes: the request came from an
-    unexpected network *and* an unexpected device. A hijacked session shows both, while VPN, relay and
-    carrier-NAT egress moves the apparent location on its own — which is why network signals alone,
-    however many, only warrant a step-up re-auth.
+def tier_for(signals: set[RiskSignal], *, device_comparable: bool) -> RiskTier:
+    """HIGH ends the session, so it wants corroboration across both axes: the request came from an
+    unexpected network *and* an unexpected device. VPN, relay and carrier-NAT egress moves the apparent
+    location on its own, so network signals alone — however many — only warrant a step-up re-auth.
+
+    `device_comparable` is False when the baseline holds no user agent to compare against. Then the
+    device axis can't clear or confirm anything, so a network anomaly escalates on its own rather than
+    leaving the session permanently un-escalatable.
+
+    Note the device axis reads a client-supplied header, so it can only ever be evidence, never proof:
+    a caller that replays the recorded user agent will not trip it. See the PR for the residual risk.
     """
     if not signals:
         return RiskTier.NONE
-    if signals & NETWORK_SIGNALS and signals & DEVICE_SIGNALS:
+    network = bool(signals & NETWORK_SIGNALS)
+    device = bool(signals & DEVICE_SIGNALS)
+    if network and (device or not device_comparable):
         return RiskTier.HIGH
     return RiskTier.MEDIUM
 
@@ -164,7 +182,19 @@ def risk_flags(user: User) -> RiskFlags:
     )
 
 
-def _baseline_for_session(session_key: str) -> Optional[Baseline]:
+def _baseline_for_session(session: SessionBase, session_key: str) -> Optional[Baseline]:
+    # The session store already fetched this row to read session_data, so reuse it rather than issue a
+    # second SELECT for the same row on the same request — this runs on every authenticated request.
+    # Falls back to a query for stores that expose no loaded row (another engine, or a new session).
+    loaded = getattr(session, "loaded_row", None)
+    if loaded is not None:
+        return Baseline(
+            latitude=loaded.latitude,
+            longitude=loaded.longitude,
+            country_code=loaded.country_code,
+            ua_signature=loaded.ua_signature,
+            baseline_at=loaded.baseline_at,
+        )
     row = (
         Session.objects.filter(session_key=session_key)
         .values("latitude", "longitude", "country_code", "ua_signature", "baseline_at")
@@ -217,13 +247,21 @@ def _should_emit_risk(session_key: str, tier: RiskTier, signals: set[RiskSignal]
     id so a live session key never reaches the cache. Never touches the baseline, so detection is
     unaffected: the request is still scored the same next time.
     """
+    global _consecutive_cache_failures
     key = f"session_risk_emit:{session_public_id(session_key)}:{_risk_signature(tier, signals)}"
     try:
-        return bool(cache.add(key, 1, timeout=int(settings.RISK_REEMIT_COOLDOWN_S)))
+        allowed = bool(cache.add(key, 1, timeout=int(settings.RISK_REEMIT_COOLDOWN_S)))
     except Exception:
-        # A cache outage must not silence detection telemetry — duplicates beat missing events.
-        logger.exception("session_risk dedup cache unavailable")
-        return True
+        # Fail open at first, since duplicates beat missing events, but only briefly: with the gate
+        # gone every request on every flagged session would emit an event and a traceback, which is
+        # the storm the gate exists to prevent. Past the limit, go quiet until the cache recovers.
+        _consecutive_cache_failures += 1
+        if _consecutive_cache_failures <= _CACHE_FAILURE_EMIT_LIMIT:
+            logger.exception("session_risk dedup cache unavailable")
+            return True
+        return False
+    _consecutive_cache_failures = 0
+    return allowed
 
 
 def evaluate_session_risk(request: HttpRequest) -> RiskTier:
@@ -248,14 +286,14 @@ def evaluate_session_risk(request: HttpRequest) -> RiskTier:
     if not flags.detection:
         return RiskTier.NONE
 
-    baseline = _baseline_for_session(session_key)
+    baseline = _baseline_for_session(request.session, session_key)
     if baseline is None:
         return RiskTier.NONE
 
     ctx = current_request_context(request)
     now = timezone.now()
     signals = evaluate_signals(baseline, ctx, now=now)
-    tier = tier_for(signals)
+    tier = tier_for(signals, device_comparable=baseline.ua_signature is not None)
     if tier == RiskTier.NONE:
         # Low-risk request: roll the known-good baseline forward (or establish it when NULL). A
         # suspicious request never reaches here, so it can't poison the reference it's scored against.

--- a/posthog/session/risk.py
+++ b/posthog/session/risk.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY
-from django.contrib.sessions.backends.base import SessionBase
+from django.core.cache import cache
 from django.http import HttpRequest
 from django.utils import timezone
 
@@ -16,6 +16,7 @@ from loginas.utils import is_impersonated_session
 
 from posthog.geoip import get_geoip_location
 from posthog.models import User
+from posthog.session.activity import session_public_id
 from posthog.session.models import Session
 from posthog.utils import get_trusted_client_ip
 
@@ -205,24 +206,24 @@ def _risk_signature(tier: RiskTier, signals: set[RiskSignal]) -> str:
     return f"{tier.name}:{','.join(sorted(signal.value for signal in signals))}"
 
 
-def _should_emit_risk(session: SessionBase, tier: RiskTier, signals: set[RiskSignal], *, now: datetime) -> bool:
-    """Dedup gate. A flagged session is re-scored on every request; without this it would emit
-    telemetry and re-assert step-up every time, inflating counts and hammering the session store.
+def _should_emit_risk(session_key: str, tier: RiskTier, signals: set[RiskSignal]) -> bool:
+    """Dedup gate. A flagged session is re-scored on every request, so without this one persistent
+    anomaly emits telemetry on every request and buries itself in repeats.
 
-    Returns True (and records the signature + timestamp on the session) only when the anomaly's
-    signature differs from the last emitted one or the re-emit cooldown has elapsed, so a persistent
-    anomaly surfaces once per window instead of once per request. Never touches the baseline, so
-    detection integrity is unaffected: the request is still scored the same next time.
+    The marker lives in the shared cache rather than on the session: parallel requests each hold their
+    own copy of the session and would all read a marker there as unset before any of them wrote it,
+    so a burst would emit once per request anyway. `cache.add` is atomic, so exactly one request in a
+    burst wins and the rest stay quiet until the entry expires. Keyed by the session's derived public
+    id so a live session key never reaches the cache. Never touches the baseline, so detection is
+    unaffected: the request is still scored the same next time.
     """
-    signature = _risk_signature(tier, signals)
-    last_signature = session.get(settings.SESSION_RISK_LAST_SIG_KEY)
-    last_emit_at = session.get(settings.SESSION_RISK_LAST_EMIT_AT_KEY) or 0.0
-    now_epoch = now.timestamp()
-    if signature == last_signature and (now_epoch - last_emit_at) < settings.RISK_REEMIT_COOLDOWN_S:
-        return False
-    session[settings.SESSION_RISK_LAST_SIG_KEY] = signature
-    session[settings.SESSION_RISK_LAST_EMIT_AT_KEY] = now_epoch
-    return True
+    key = f"session_risk_emit:{session_public_id(session_key)}:{_risk_signature(tier, signals)}"
+    try:
+        return bool(cache.add(key, 1, timeout=int(settings.RISK_REEMIT_COOLDOWN_S)))
+    except Exception:
+        # A cache outage must not silence detection telemetry — duplicates beat missing events.
+        logger.exception("session_risk dedup cache unavailable")
+        return True
 
 
 def evaluate_session_risk(request: HttpRequest) -> RiskTier:
@@ -274,7 +275,7 @@ def evaluate_session_risk(request: HttpRequest) -> RiskTier:
         enforced = True
 
     # `effective` is computed above and returned regardless, so session-end is never suppressed.
-    should_emit = _should_emit_risk(request.session, tier, signals, now=now)
+    should_emit = _should_emit_risk(session_key, tier, signals)
 
     # Enforcement is independent of the telemetry dedup: apply step-up whenever it is needed and not
     # already set, even when the identical anomaly's telemetry is being deduped. Otherwise enabling
@@ -282,11 +283,8 @@ def evaluate_session_risk(request: HttpRequest) -> RiskTier:
     set_step_up = needs_step_up and not request.session.get(settings.SESSION_STEP_UP_REQUIRED_KEY)
     if set_step_up:
         request.session[settings.SESSION_STEP_UP_REQUIRED_KEY] = True
-
-    # Persist the step-up flag and/or the dedup markers _should_emit_risk just wrote, now rather than
-    # relying on SessionMiddleware, which skips save() on a 5xx response — otherwise a server error
-    # here would drop the step-up requirement.
-    if should_emit or set_step_up:
+        # Persist now rather than relying on SessionMiddleware, which skips save() on a 5xx response —
+        # otherwise a server error here would drop the step-up requirement.
         request.session.save()
 
     if should_emit:

--- a/posthog/session/risk.py
+++ b/posthog/session/risk.py
@@ -112,12 +112,23 @@ def evaluate_signals(baseline: Baseline, ctx: Context, *, now: datetime) -> set[
     return signals
 
 
+# The independent axes a signal can observe. impossible_travel and new_country are both derived from
+# a single geoip lookup on a single IP, so they corroborate each other only in appearance.
+NETWORK_SIGNALS = frozenset({RiskSignal.IMPOSSIBLE_TRAVEL, RiskSignal.NEW_COUNTRY})
+DEVICE_SIGNALS = frozenset({RiskSignal.UA_CHANGE})
+
+
 def tier_for(signals: set[RiskSignal]) -> RiskTier:
-    if RiskSignal.IMPOSSIBLE_TRAVEL in signals or len(signals) >= 2:
+    """HIGH ends the session, so it requires corroboration across both axes: the request came from an
+    unexpected network *and* an unexpected device. A hijacked session shows both, while VPN, relay and
+    carrier-NAT egress moves the apparent location on its own — which is why network signals alone,
+    however many, only warrant a step-up re-auth.
+    """
+    if not signals:
+        return RiskTier.NONE
+    if signals & NETWORK_SIGNALS and signals & DEVICE_SIGNALS:
         return RiskTier.HIGH
-    if signals:
-        return RiskTier.MEDIUM
-    return RiskTier.NONE
+    return RiskTier.MEDIUM
 
 
 @dataclass

--- a/posthog/session/test/test_risk.py
+++ b/posthog/session/test/test_risk.py
@@ -10,6 +10,8 @@ from django.test.utils import override_settings
 from parameterized import parameterized
 
 from posthog.session.risk import (
+    DEVICE_SIGNALS,
+    NETWORK_SIGNALS,
     Baseline,
     Context,
     RiskSignal,
@@ -106,12 +108,11 @@ class TestSignalsAndTiers(BaseTest):
         signals = evaluate_signals(b, ctx, now=self.BASELINE_TIME + timedelta(minutes=10))
         self.assertNotIn(RiskSignal.IMPOSSIBLE_TRAVEL, signals)
 
-    def test_ua_change_alone_is_medium(self):
+    def test_ua_change_fires_alone(self):
         b = self._baseline()
         ctx = self._ctx(ua_signature="firefox|mac os x|pc")
         signals = evaluate_signals(b, ctx, now=self.BASELINE_TIME + timedelta(minutes=10))
         self.assertEqual(signals, {RiskSignal.UA_CHANGE})
-        self.assertEqual(tier_for(signals), RiskTier.MEDIUM)
 
     @parameterized.expand(
         [
@@ -133,7 +134,31 @@ class TestSignalsAndTiers(BaseTest):
         # HIGH ends the session, so it takes a network anomaly *and* a device anomaly. Counting any
         # two signals as corroboration over-escalates: impossible_travel and new_country both come
         # from one geoip lookup on one IP, so together they are a single observation, not two.
-        self.assertEqual(tier_for(signals), expected)
+        self.assertEqual(tier_for(signals, device_comparable=True), expected)
+
+    @parameterized.expand(
+        [
+            ("network_alone", {RiskSignal.IMPOSSIBLE_TRAVEL}, RiskTier.HIGH),
+            ("both_geo_signals", {RiskSignal.IMPOSSIBLE_TRAVEL, RiskSignal.NEW_COUNTRY}, RiskTier.HIGH),
+            ("no_signals", set(), RiskTier.NONE),
+        ]
+    )
+    def test_network_signal_escalates_when_device_cannot_be_compared(self, _name, signals, expected):
+        # With no recorded user agent the device axis can neither confirm nor clear the request, so a
+        # network anomaly has to escalate on its own — otherwise such a session could never reach HIGH.
+        self.assertEqual(tier_for(signals, device_comparable=False), expected)
+
+    def test_every_signal_belongs_to_exactly_one_axis(self):
+        # A new RiskSignal in neither axis would silently cap at MEDIUM forever, and one in both would
+        # let a single observation corroborate itself.
+        self.assertEqual(NETWORK_SIGNALS | DEVICE_SIGNALS, set(RiskSignal))
+        self.assertEqual(NETWORK_SIGNALS & DEVICE_SIGNALS, set())
+
+    def test_missing_user_agent_counts_as_a_device_change(self):
+        # Dropping the header must not be a way to keep the device axis quiet.
+        b = self._baseline()
+        signals = evaluate_signals(b, self._ctx(ua_signature=None), now=self.BASELINE_TIME + timedelta(minutes=10))
+        self.assertIn(RiskSignal.UA_CHANGE, signals)
 
     def test_null_baseline_no_signals(self):
         b = Baseline(latitude=None, longitude=None, country_code=None, ua_signature=None, baseline_at=None)

--- a/posthog/session/test/test_risk.py
+++ b/posthog/session/test/test_risk.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 from django.test import RequestFactory, SimpleTestCase
 from django.test.utils import override_settings
 
+from parameterized import parameterized
+
 from posthog.session.risk import (
     Baseline,
     Context,
@@ -72,14 +74,13 @@ class TestSignalsAndTiers(BaseTest):
         base.update(kw)
         return Context(**base)
 
-    def test_impossible_travel_fires_high(self):
+    def test_impossible_travel_fires(self):
         b = self._baseline()
         # Tokyo, 10 minutes later
         ctx = self._ctx(latitude=35.6, longitude=139.7, country_code="JP")
         now = self.BASELINE_TIME + timedelta(minutes=10)
         signals = evaluate_signals(b, ctx, now=now)
         self.assertIn(RiskSignal.IMPOSSIBLE_TRAVEL, signals)
-        self.assertEqual(tier_for(signals), RiskTier.HIGH)
 
     def test_short_hop_not_impossible(self):
         b = self._baseline()
@@ -112,9 +113,27 @@ class TestSignalsAndTiers(BaseTest):
         self.assertEqual(signals, {RiskSignal.UA_CHANGE})
         self.assertEqual(tier_for(signals), RiskTier.MEDIUM)
 
-    def test_two_mediums_escalate_to_high(self):
-        signals = {RiskSignal.UA_CHANGE, RiskSignal.NEW_COUNTRY}
-        self.assertEqual(tier_for(signals), RiskTier.HIGH)
+    @parameterized.expand(
+        [
+            ("no_signals", set(), RiskTier.NONE),
+            ("ua_change_alone", {RiskSignal.UA_CHANGE}, RiskTier.MEDIUM),
+            ("new_country_alone", {RiskSignal.NEW_COUNTRY}, RiskTier.MEDIUM),
+            ("impossible_travel_alone", {RiskSignal.IMPOSSIBLE_TRAVEL}, RiskTier.MEDIUM),
+            ("both_geo_signals", {RiskSignal.IMPOSSIBLE_TRAVEL, RiskSignal.NEW_COUNTRY}, RiskTier.MEDIUM),
+            ("new_country_and_ua", {RiskSignal.NEW_COUNTRY, RiskSignal.UA_CHANGE}, RiskTier.HIGH),
+            ("impossible_travel_and_ua", {RiskSignal.IMPOSSIBLE_TRAVEL, RiskSignal.UA_CHANGE}, RiskTier.HIGH),
+            (
+                "all_three",
+                {RiskSignal.IMPOSSIBLE_TRAVEL, RiskSignal.NEW_COUNTRY, RiskSignal.UA_CHANGE},
+                RiskTier.HIGH,
+            ),
+        ]
+    )
+    def test_tier_requires_cross_axis_corroboration(self, _name, signals, expected):
+        # HIGH ends the session, so it takes a network anomaly *and* a device anomaly. Counting any
+        # two signals as corroboration over-escalates: impossible_travel and new_country both come
+        # from one geoip lookup on one IP, so together they are a single observation, not two.
+        self.assertEqual(tier_for(signals), expected)
 
     def test_null_baseline_no_signals(self):
         b = Baseline(latitude=None, longitude=None, country_code=None, ua_signature=None, baseline_at=None)

--- a/posthog/session/test/test_risk_middleware.py
+++ b/posthog/session/test/test_risk_middleware.py
@@ -196,6 +196,7 @@ class TestEvaluateSessionRisk(BaseTest):
         with self.assertNumQueries(0):
             baseline = _baseline_for_session(store, key)
 
+        assert baseline is not None
         self.assertEqual(baseline.country_code, "US")
 
     @patch("posthog.session.risk.current_request_context", return_value=UA_CHANGE_CTX)

--- a/posthog/session/test/test_risk_middleware.py
+++ b/posthog/session/test/test_risk_middleware.py
@@ -20,6 +20,8 @@ from posthog.session.models import Session
 from posthog.session.risk import Context, RiskFlags, RiskTier, evaluate_session_risk
 
 IMPOSSIBLE_TRAVEL_CTX = Context(latitude=35.6, longitude=139.7, country_code="JP", ua_signature="chrome|mac os x|pc")
+# Network anomaly *and* device anomaly — the cross-axis pair that reaches HIGH.
+HIGH_RISK_CTX = Context(latitude=35.6, longitude=139.7, country_code="JP", ua_signature="firefox|mac os x|pc")
 UA_CHANGE_CTX = Context(latitude=40.7, longitude=-74.0, country_code="US", ua_signature="firefox|mac os x|pc")
 STABLE_CTX = Context(latitude=40.7, longitude=-74.0, country_code="US", ua_signature="chrome|mac os x|pc")
 NEARBY_CTX = Context(latitude=41.0, longitude=-74.5, country_code="US", ua_signature="chrome|mac os x|pc")
@@ -71,7 +73,7 @@ class TestEvaluateSessionRisk(BaseTest):
         self.assertNotIn("step_up_required", request.session)
         mock_capture.assert_not_called()
 
-    @patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX)
+    @patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, False, False))
     def test_report_only_does_not_set_flag_or_end(self, _flags, mock_capture, _ctx):
@@ -128,7 +130,7 @@ class TestEvaluateSessionRisk(BaseTest):
         reloaded = self.engine.SessionStore(session_key=request.session.session_key)
         self.assertTrue(reloaded.get("step_up_required"))
 
-    @patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX)
+    @patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, False, True))
     def test_high_effective_only_when_session_end_on(self, _flags, mock_capture, _ctx):
@@ -138,6 +140,19 @@ class TestEvaluateSessionRisk(BaseTest):
         self.assertTrue(mock_capture.call_args.kwargs["properties"]["enforced"])
 
     @patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX)
+    @patch("posthog.session.risk.posthoganalytics.capture")
+    @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, True, True))
+    def test_network_only_anomaly_never_ends_the_session(self, _flags, mock_capture, _ctx):
+        # Relay, VPN and carrier-NAT egress move the apparent location on their own, so a network-only
+        # anomaly must stop at a step-up re-auth even with session-end enabled — it must never log the
+        # user out on geo alone.
+        request = self._authed_request_with_baseline(self._make_user())
+
+        self.assertEqual(evaluate_session_risk(request), RiskTier.NONE)
+        self.assertTrue(request.session.get("step_up_required"))
+        self.assertEqual(mock_capture.call_args.kwargs["properties"]["tier"], RiskTier.MEDIUM.name)
+
+    @patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture", side_effect=RuntimeError("telemetry down"))
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, False, True))
     def test_telemetry_failure_does_not_break_evaluation(self, _flags, _capture, _ctx):
@@ -146,7 +161,7 @@ class TestEvaluateSessionRisk(BaseTest):
 
         self.assertEqual(evaluate_session_risk(request), RiskTier.HIGH)
 
-    @patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX)
+    @patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, True, False))
     def test_high_degrades_to_step_up_when_session_end_off(self, _flags, mock_capture, _ctx):
@@ -173,16 +188,16 @@ class TestEvaluateSessionRisk(BaseTest):
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, True, True))
     def test_new_signature_re_emits_within_cooldown(self, _flags, mock_capture):
-        # An escalation to a different anomaly (MEDIUM ua_change -> HIGH impossible travel) is a new
-        # incident and must re-emit even inside the cooldown window.
+        # An escalation to a different anomaly (MEDIUM ua_change -> HIGH cross-axis) is a new incident
+        # and must re-emit even inside the cooldown window.
         request = self._authed_request_with_baseline(self._make_user())
         with patch("posthog.session.risk.current_request_context", return_value=UA_CHANGE_CTX):
             evaluate_session_risk(request)
-        with patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX):
+        with patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX):
             evaluate_session_risk(request)
         self.assertEqual(mock_capture.call_count, 2)
 
-    @patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX)
+    @patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, False, True))
     def test_dedup_suppresses_telemetry_not_session_end(self, _flags, mock_capture, _ctx):
@@ -284,12 +299,13 @@ class TestEvaluateSessionRisk(BaseTest):
         self.assertEqual(row.latitude, 40.7)  # still NYC, not poisoned to Tokyo
         self.assertEqual(row.country_code, "US")
 
-    @patch("posthog.session.risk.current_request_context", return_value=IMPOSSIBLE_TRAVEL_CTX)
+    @patch("posthog.session.risk.current_request_context", return_value=HIGH_RISK_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, False, True))
     def test_attacker_cannot_erase_detection_over_repeated_requests(self, _flags, _capture, _ctx):
-        # Because the baseline is never poisoned, a replayed stolen cookie keeps tripping HIGH rather
-        # than self-erasing after the first hit.
+        # A replayed stolen cookie arrives from the attacker's own machine and network, so it trips
+        # both axes. Because the baseline is never poisoned, it keeps tripping HIGH on every request
+        # rather than self-erasing after the first hit.
         request = self._authed_request_with_baseline(self._make_user())
 
         self.assertEqual(evaluate_session_risk(request), RiskTier.HIGH)

--- a/posthog/session/test/test_risk_middleware.py
+++ b/posthog/session/test/test_risk_middleware.py
@@ -185,6 +185,26 @@ class TestEvaluateSessionRisk(BaseTest):
             evaluate_session_risk(request)
         self.assertEqual(mock_capture.call_count, expected_calls)
 
+    @patch("posthog.session.risk.current_request_context", return_value=UA_CHANGE_CTX)
+    @patch("posthog.session.risk.posthoganalytics.capture")
+    @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, True, False))
+    def test_concurrent_requests_emit_once(self, _flags, mock_capture, _ctx):
+        # Parallel requests each hold their own copy of the session, so dedup state kept there is read
+        # before any of them writes and every one emits. The marker has to be shared for a burst of
+        # requests to count as one detection.
+        user = self._make_user()
+        key = self._login_session(user)
+        self._seed_baseline(key)
+        first, second = self._request(user, key), self._request(user, key)
+        # Materialize both session copies before either evaluates — that is what makes them concurrent
+        # rather than sequential.
+        first.session.get(SESSION_KEY), second.session.get(SESSION_KEY)
+
+        evaluate_session_risk(first)
+        evaluate_session_risk(second)
+
+        mock_capture.assert_called_once()
+
     @patch("posthog.session.risk.posthoganalytics.capture")
     @patch("posthog.session.risk.risk_flags", return_value=RiskFlags(True, True, True))
     def test_new_signature_re_emits_within_cooldown(self, _flags, mock_capture):

--- a/posthog/session/test/test_risk_middleware.py
+++ b/posthog/session/test/test_risk_middleware.py
@@ -17,7 +17,7 @@ from parameterized import parameterized
 from posthog.models import User
 from posthog.session.middleware import SessionRiskMiddleware
 from posthog.session.models import Session
-from posthog.session.risk import Context, RiskFlags, RiskTier, evaluate_session_risk
+from posthog.session.risk import Context, RiskFlags, RiskTier, _baseline_for_session, evaluate_session_risk
 
 IMPOSSIBLE_TRAVEL_CTX = Context(latitude=35.6, longitude=139.7, country_code="JP", ua_signature="chrome|mac os x|pc")
 # Network anomaly *and* device anomaly — the cross-axis pair that reaches HIGH.
@@ -184,6 +184,19 @@ class TestEvaluateSessionRisk(BaseTest):
             evaluate_session_risk(request)
             evaluate_session_risk(request)
         self.assertEqual(mock_capture.call_count, expected_calls)
+
+    def test_baseline_reuses_the_row_the_session_store_loaded(self):
+        # Loading the session already fetches this row, and scoring runs on every authenticated
+        # request, so reading the baseline must not cost a second SELECT for the same row.
+        key = self._login_session(self._make_user())
+        self._seed_baseline(key)
+        store = self.engine.SessionStore(session_key=key)
+        store.load()
+
+        with self.assertNumQueries(0):
+            baseline = _baseline_for_session(store, key)
+
+        self.assertEqual(baseline.country_code, "US")
 
     @patch("posthog.session.risk.current_request_context", return_value=UA_CHANGE_CTX)
     @patch("posthog.session.risk.posthoganalytics.capture")

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -359,11 +359,6 @@ GROWTH_ENRICHMENT_INTERNAL_TEAM_ID = get_from_env("GROWTH_ENRICHMENT_INTERNAL_TE
 # one source of truth, like SESSION_COOKIE_CREATED_AT_KEY above.
 SESSION_STEP_UP_REQUIRED_KEY = get_from_env("SESSION_STEP_UP_REQUIRED_KEY", "step_up_required")
 SESSION_LAST_REAUTH_AT_KEY = get_from_env("SESSION_LAST_REAUTH_AT_KEY", "last_reauth_at")
-# Dedup state for risk telemetry/enforcement: the last-emitted anomaly signature and when. A flagged
-# session is re-scored every request, but we only re-emit/re-enforce on a new signature or after the
-# cooldown, so one persistent anomaly can't fire on every request. Cleared on (re)login by post_login.
-SESSION_RISK_LAST_SIG_KEY = get_from_env("SESSION_RISK_LAST_SIG_KEY", "risk_last_sig")
-SESSION_RISK_LAST_EMIT_AT_KEY = get_from_env("SESSION_RISK_LAST_EMIT_AT_KEY", "risk_last_emit_at")
 
 # Impossible-travel risk thresholds (see posthog/session/risk.py). Tunable without a code change.
 RISK_DISTANCE_FLOOR_KM = get_from_env("RISK_DISTANCE_FLOOR_KM", 500.0, type_cast=float)

--- a/posthog/test/test_geoip.py
+++ b/posthog/test/test_geoip.py
@@ -3,10 +3,16 @@ from unittest.mock import patch
 
 from parameterized import parameterized
 
-from posthog.geoip import get_geoip_location
+from posthog.geoip import _lookup_location, get_geoip_location
 
 
 class TestGeoipLocation(BaseTest):
+    def setUp(self):
+        super().setUp()
+        # Lookups are memoized per process, so results would otherwise leak across tests that mock
+        # different responses for the same address.
+        _lookup_location.cache_clear()
+
     def test_returns_empty_for_local_ip(self):
         self.assertEqual(get_geoip_location("127.0.0.1"), {})
 
@@ -31,3 +37,25 @@ class TestGeoipLocation(BaseTest):
         mock_geoip.city.return_value = {"latitude": 40.7, "longitude": -74.0, "country_code": "US", "city": "NYC"}
         result = get_geoip_location("8.8.8.8")
         self.assertEqual(result, {"latitude": 40.7, "longitude": -74.0, "country_code": "US"})
+
+    @patch("posthog.geoip.geoip")
+    def test_repeat_lookups_hit_the_database_once(self, mock_geoip):
+        # This runs on every authenticated request and a lookup costs ~75us, so a repeated address
+        # must not reach the database again.
+        mock_geoip.city.return_value = {"latitude": 40.7, "longitude": -74.0, "country_code": "US"}
+
+        for _ in range(3):
+            get_geoip_location("8.8.8.8")
+
+        mock_geoip.city.assert_called_once()
+
+    @patch("posthog.geoip.geoip")
+    def test_callers_cannot_corrupt_a_cached_entry(self, mock_geoip):
+        # Callers own the dict they get back; mutating it must not reach the next caller.
+        mock_geoip.city.return_value = {"latitude": 40.7, "longitude": -74.0, "country_code": "US"}
+
+        first = get_geoip_location("8.8.8.8")
+        first["country_code"] = "XX"
+        first["latitude"] = 0.0
+
+        self.assertEqual(get_geoip_location("8.8.8.8"), {"latitude": 40.7, "longitude": -74.0, "country_code": "US"})


### PR DESCRIPTION
Two related fixes to the session-risk engine. The first changes when a session gets ended, the second stops one anomaly being reported many times.

## 1. Require cross-axis corroboration before ending a session

`tier_for` escalated to HIGH — which ends the session server-side — whenever two signals fired, or whenever `impossible_travel` fired on its own.

The trouble is that two of the three signals are not independent. `impossible_travel` and `new_country` are both computed in `evaluate_signals` from a single geoip lookup on a single IP, so one egress hop to another country trips both by construction. Counting them as two signals reads a single observation twice and calls it corroboration.

The practical effect is that a purely network-level change of apparent location was enough to sign someone out. That happens constantly with no account compromise involved: VPNs, iCloud Private Relay, corporate SASE egress and carrier NAT all move the egress IP a long way from the user, and flip it back as the network changes. Legitimate users were getting signed out mid-session, sometimes more than once in an afternoon.

HIGH now requires agreement across the two genuinely independent axes: **network** (`impossible_travel` or `new_country`) and **device** (`ua_change`). Anything short of that is MEDIUM, which asks for a step-up re-auth instead of ending the session.

| signals | before | after |
|---|---|---|
| `impossible_travel` | HIGH | MEDIUM |
| `new_country` | MEDIUM | MEDIUM |
| `ua_change` | MEDIUM | MEDIUM |
| `impossible_travel` + `new_country` | HIGH | MEDIUM |
| `new_country` + `ua_change` | HIGH | HIGH |
| `impossible_travel` + `ua_change` | HIGH | HIGH |
| all three | HIGH | HIGH |

**Why this keeps the security property.** A hijacked session is replayed from the attacker's own machine on their own network, so it trips both axes and is still ended. And MEDIUM is not a no-op: step-up re-auth is the control that actually stops an attacker, because they cannot produce the password or second factor. Ending the session adds little on top of that against a real takeover, while being the most destructive thing we can do to a legitimate user whose IP moved.

> [!NOTE]
> Detection is unchanged. The same signals fire and the same telemetry is emitted; only the tier a network-only anomaly maps to has changed, and with it whether the session is ended.

## 2. Dedup telemetry on shared state rather than the session

A flagged session is re-scored on every request, and the dedup marker that keeps one anomaly from emitting on every one of them lived on the session. Parallel requests each hold their own copy of the session, so every request in a burst read the marker as unset before any of them had written it, and all of them emitted. One anomaly was reported once per concurrent request instead of once — in practice a meaningful share of all detection events, in bursts matching the app's parallel fan-out on page load.

The marker now lives in the cache and is claimed with `cache.add`, which is atomic: exactly one request in a burst wins and the rest stay quiet until the entry expires. The key is derived from the session's public id, so a live session key never reaches the cache, and a cache outage fails open, since duplicate telemetry beats none.

Enforcement was never affected by this: concurrent evaluations all computed the same step-up requirement and wrote the same value. A nice side effect is that a deduped request no longer writes the session at all.

A cache is also the right home for this state on its own merits — the marker is a short-lived cooldown, and losing one to eviction just means one extra event. Keeping it off the session table avoids an `ALTER TABLE` on a row that is read and written on essentially every authenticated request.

## Residual risk, stated plainly

The device axis reads the `User-Agent` header, which the caller controls, so it is evidence and never proof. A caller that replays the user agent recorded on the baseline will not trip it, and a network-only anomaly then stops at a step-up re-auth rather than ending the session. That matters because stolen cookies usually travel together with the user agent that carried them: an XSS reading `document.cookie` reads `navigator.userAgent` in the same breath, a captured request contains both headers, and infostealer logs are sold as cookie plus fingerprint bundles for exactly this reason.

Two weaker versions of the hole are closed here. A request with **no** user agent counts as a device change rather than as nothing to compare, so dropping the header does not buy quiet. And when the baseline holds no user agent at all, the device axis cannot clear the request, so a network anomaly escalates on its own instead of leaving that session permanently un-escalatable.

What that leaves is a control aimed at opportunistic replay and automated cookie reuse, not at a targeted attacker who took the fingerprint along with the cookie. Worth being explicit about, since the previous rule was not stronger in any interesting way either: matching the victim's rough location through a proxy defeated it just as cheaply, and it ended a session on every VPN or relay hop in the meantime.

## How did you test this code?

Automated tests, run by Claude. No manual testing.

- A parameterized truth table over `tier_for` covering all eight signal combinations, which pins the regression directly: restoring "any two signals" or "impossible travel alone" as a HIGH trigger fails the geo-only rows. It replaces a test that asserted the old any-two rule.
- A middleware test that a network-only anomaly never ends the session even with session-end enabled — the exact user-facing bug, which no existing test covered.
- A concurrency test that two requests holding separate session copies emit once. It reproduces the race deterministically without threads, and fails on the old implementation with "Called 2 times".
- The existing full-stack middleware test now sends a mismatched user agent alongside the moved geo, so it still exercises the redirect-and-flush path the way a replayed cookie would.
- Full `posthog/session/` suite passes, and is stable across back-to-back runs (the dedup state now outlives a single request, so repeat runs are worth checking). In `posthog/api/test/test_user_auth_session.py` the 3 impersonation failures are pre-existing on master, verified by running the file on a clean tree.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus) in Claude Code, directed by @Piccirello. Skills invoked: `/writing-tests`, `/django-migrations`.

This started from a report of an unexplained sign-out. The telemetry showed the trigger was network-only and the user had been on one browser throughout, which pointed at the independence problem in the tiering rule rather than at the signals themselves. The concurrency bug surfaced separately, from detections arriving in tight clusters with identical signal sets.

The dedup fix was first drafted as two columns on the session row with an atomic conditional `UPDATE`, which would also have been race-free. I moved it to the cache after `/django-migrations` made the cost clear: the session table is read and written on nearly every authenticated request, and an `ACCESS EXCLUSIVE` lock there is a poor trade for a telemetry-accuracy fix. The state is ephemeral anyway.

Two follow-ups are worth doing and are not here. Classifying the egress (relay, VPN and hosting ranges) and discounting geo signals from anonymizing IPs attacks the false positives further upstream, but needs a maintained data source. Instrumenting how step-up challenges resolve — satisfied versus abandoned — would give an empirical read on false positives before enforcement is widened.

