### PR TITLE
fix(ai-feedback): make manual-capture wizard sample re-send answers on completed event

### DIFF
--- a/products/ai_observability/frontend/feedback-view/wizard/codeExamples.ts
+++ b/products/ai_observability/frontend/feedback-view/wizard/codeExamples.ts
@@ -58,8 +58,8 @@ export function getManualCaptureExample({ surveyId = 'your-survey-id', followUpE
                   },
                   {
                       key: '$survey_completed',
-                      value: 'true',
-                      comment: 'or false if there is negative feedback followup',
+                      value: 'false',
+                      comment: 'a follow-up event completes this submission; use true when there is no follow-up',
                   },
               ]
             : []),
@@ -90,6 +90,7 @@ ${generateProps(thumbsProps)}
     if (followUpEnabled) {
         const followUpProps: Prop[] = [
             { key: '$survey_id', value: `'${surveyId}'` },
+            { key: '$survey_response', value: '1', comment: 're-send the thumbs response so it still shows' },
             { key: '$survey_response_1', value: "'the AI hallucinated hedgehogs everywhere'" },
             { key: '$ai_trace_id', value: 'traceId' },
             {


### PR DESCRIPTION
## Problem

The in-product AI feedback wizard's "manual event capture" sample (`getManualCaptureExample`) generated a non-cumulative pattern: the thumbs response only on the first `survey sent` event and the follow-up text only on the second. Because PostHog displays a single (completed) event per `$survey_submission_id` and reads every answer from that one event, the thumbs rating was dropped from the response and the question breakdown. A customer following this pattern hit exactly that.

## Fix

`products/ai_observability/frontend/feedback-view/wizard/codeExamples.ts`:
- Mark the intermediate thumbs event `$survey_completed: false` (it isn't the final event when a follow-up follows — leaving it `true` produced two competing "completed" events).
- Re-send the thumbs `$survey_response` on the completed follow-up event so it carries the full submission.

This matches how the SDK already emits cumulative snapshots. Pairs with a posthog.com docs PR ([PostHog/posthog.com#19172](https://github.com/PostHog/posthog.com/pull/19172)) making the same correction to the written docs.

## Note

This fixes the guidance/sample. A separate, optional follow-up (query-layer merge of `$survey_response_*` across a submission's events) would make PostHog tolerant of non-cumulative integrations too; not included here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*