### PR TITLE
chore(hogql): return frozen dataclasses instead of tuples

### DIFF
--- a/posthog/hogql/database/schema/information_schema.py
+++ b/posthog/hogql/database/schema/information_schema.py
@@ -15,6 +15,7 @@ semantic layers — fetched lazily only when these tables are queried.
 
 import json
 import hashlib
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, Optional
 
 from django.db.models import Q
@@ -449,6 +450,13 @@ def _rows_select(
     )
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class _CollectedCatalog:
+    table_rows: list[list[Any]]
+    column_rows: list[list[Any]]
+    relationships: list[_CollectedRelationship]
+
+
 class _Introspection:
     """Walks the live database once and produces the rows for every information_schema table."""
 
@@ -466,7 +474,7 @@ class _Introspection:
         self.materialized_view_ids = warehouse_metadata.materialized_view_ids
         self.column_stats = warehouse_metadata.column_stats
         self.table_descriptions = TableDescriptions.load(context.team_id)
-        self._collected: Optional[tuple[list[list[Any]], list[list[Any]], list[_CollectedRelationship]]] = None
+        self._collected: Optional[_CollectedCatalog] = None
         self._data_catalog_enriched_table_rows: Optional[list[list[Any]]] = None
         self._data_catalog_enriched_relationship_rows: Optional[list[list[Any]]] = None
         # Per-table certification lookup key `(table_type, resource_id)`, parallel to the table rows.
@@ -542,7 +550,7 @@ class _Introspection:
                 return self.column_stats.get((str(table_id), column_name), (None, None, None))
         return (None, None, None)
 
-    def collect(self) -> tuple[list[list[Any]], list[list[Any]], list[_CollectedRelationship]]:
+    def collect(self) -> _CollectedCatalog:
         if self._collected is not None:
             return self._collected
 
@@ -578,12 +586,13 @@ class _Introspection:
             )
 
         self._table_certification_keys = certification_keys
-        self._collected = (table_rows, column_rows, relationship_rows)
+        self._collected = _CollectedCatalog(
+            table_rows=table_rows, column_rows=column_rows, relationships=relationship_rows
+        )
         return self._collected
 
     def table_rows(self) -> list[list[Any]]:
-        table_rows, _, _ = self.collect()
-        return table_rows
+        return self.collect().table_rows
 
     def data_catalog_enriched_table_rows(self) -> list[list[Any]]:
         if self._data_catalog_enriched_table_rows is not None:
@@ -601,21 +610,18 @@ class _Introspection:
         return self._data_catalog_enriched_table_rows
 
     def column_rows(self) -> list[list[Any]]:
-        _, column_rows, _ = self.collect()
-        return column_rows
+        return self.collect().column_rows
 
     def relationship_rows(self) -> list[list[Any]]:
-        _, _, relationship_rows = self.collect()
-        return [relationship.values for relationship in relationship_rows]
+        return [relationship.values for relationship in self.collect().relationships]
 
     def data_catalog_enriched_relationship_rows(self) -> list[list[Any]]:
         if self._data_catalog_enriched_relationship_rows is not None:
             return self._data_catalog_enriched_relationship_rows
 
-        _, _, relationships = self.collect()
         accepted_relationships = _catalog_accepted_relationships(self.context, self.allowed_tables)
         enriched_rows: list[list[Any]] = []
-        for relationship in relationships:
+        for relationship in self.collect().relationships:
             confidence, reasoning = (
                 accepted_relationships.get(relationship.provenance_key, (None, None))
                 if relationship.provenance_key is not None

--- a/posthog/hogql/database/schema/util/test/test_predicate_pushdown.py
+++ b/posthog/hogql/database/schema/util/test/test_predicate_pushdown.py
@@ -197,10 +197,10 @@ class TestEventsPredicatePushdownExtractor:
         expr = parse_expr(expr_str)
 
         extractor = EventsPredicatePushdownExtractor(joined_aliases)
-        inner_where, outer_where = extractor.get_pushdown_predicates(expr)
+        split = extractor.get_pushdown_predicates(expr)
 
-        assert print_expr(inner_where) == expected_inner
-        assert print_expr(outer_where) == expected_outer
+        assert print_expr(split.inner_where) == expected_inner
+        assert print_expr(split.outer_where) == expected_outer
 
     def test_empty_joined_aliases_relies_on_type_system(self):
         """With empty joined_aliases, detection relies entirely on type system."""
@@ -217,11 +217,11 @@ class TestEventsPredicatePushdownExtractor:
         )
 
         extractor = EventsPredicatePushdownExtractor(set())
-        inner_where, outer_where = extractor.get_pushdown_predicates(comparison)
+        split = extractor.get_pushdown_predicates(comparison)
 
         # Should detect via type system even with empty joined_aliases
-        assert inner_where is None
-        assert outer_where is not None
+        assert split.inner_where is None
+        assert split.outer_where is not None
 
     def test_in_cohort_predicate_stays_outer(self):
         """An unresolved IN COHORT op (inCohortVia=LEFTJOIN) becomes a cohort LEFT JOIN after pushdown, so it
@@ -237,28 +237,33 @@ class TestEventsPredicatePushdownExtractor:
             right=ast.Constant(value=1),
         )
         extractor = EventsPredicatePushdownExtractor(set())
-        inner_where, outer_where = extractor.get_pushdown_predicates(ast.And(exprs=[timestamp, in_cohort]))
+        split = extractor.get_pushdown_predicates(ast.And(exprs=[timestamp, in_cohort]))
 
-        assert isinstance(inner_where, ast.CompareOperation) and inner_where.op == ast.CompareOperationOp.GtEq
-        assert isinstance(outer_where, ast.CompareOperation) and outer_where.op == ast.CompareOperationOp.InCohort
+        assert (
+            isinstance(split.inner_where, ast.CompareOperation) and split.inner_where.op == ast.CompareOperationOp.GtEq
+        )
+        assert (
+            isinstance(split.outer_where, ast.CompareOperation)
+            and split.outer_where.op == ast.CompareOperationOp.InCohort
+        )
 
     def test_in_cohort_only_predicate_not_pushable(self):
         """A standalone IN COHORT / NOT IN COHORT predicate is non-pushable (nothing left to push)."""
         for op in (ast.CompareOperationOp.InCohort, ast.CompareOperationOp.NotInCohort):
             in_cohort = ast.CompareOperation(op=op, left=ast.Field(chain=["person_id"]), right=ast.Constant(value=1))
             extractor = EventsPredicatePushdownExtractor(set())
-            inner_where, outer_where = extractor.get_pushdown_predicates(in_cohort)
+            split = extractor.get_pushdown_predicates(in_cohort)
 
-            assert inner_where is None, f"{op}: should not be pushable"
-            assert isinstance(outer_where, ast.CompareOperation) and outer_where.op == op
+            assert split.inner_where is None, f"{op}: should not be pushable"
+            assert isinstance(split.outer_where, ast.CompareOperation) and split.outer_where.op == op
 
     def test_subquery_predicate_stays_outer(self):
         """A predicate with a nested subquery (e.g. inCohortVia=SUBQUERY's IN (SELECT ...)) is not pushable;
         a plain events predicate alongside it still pushes."""
         expr = parse_expr("event = 'x' AND person_id IN (SELECT person_id FROM raw_cohortpeople)")
         extractor = EventsPredicatePushdownExtractor(set())
-        inner_where, outer_where = extractor.get_pushdown_predicates(expr)
+        split = extractor.get_pushdown_predicates(expr)
 
         # the bare `event = 'x'` pushes; the IN (SELECT ...) stays outer
-        assert inner_where is not None and not contains_subquery(inner_where)
-        assert outer_where is not None and contains_subquery(outer_where)
+        assert split.inner_where is not None and not contains_subquery(split.inner_where)
+        assert split.outer_where is not None and contains_subquery(split.outer_where)

--- a/posthog/hogql/database/schema/util/where_clause_extractor.py
+++ b/posthog/hogql/database/schema/util/where_clause_extractor.py
@@ -1,6 +1,7 @@
 import random
 import string
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional, cast
 
@@ -1298,6 +1299,12 @@ def references_joined_table(
     return finder.found_joined_reference
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PushdownSplit:
+    inner_where: Optional[ast.Expr]
+    outer_where: Optional[ast.Expr]
+
+
 class EventsPredicatePushdownExtractor:
     """
     Extracts predicates from a WHERE clause that can be pushed down into an events subquery.
@@ -1320,12 +1327,12 @@ class EventsPredicatePushdownExtractor:
         self.events_table_type = events_table_type
         self.select_aliases = select_aliases or {}
 
-    def get_pushdown_predicates(self, where: ast.Expr) -> tuple[Optional[ast.Expr], Optional[ast.Expr]]:
+    def get_pushdown_predicates(self, where: ast.Expr) -> PushdownSplit:
         """
         Split a WHERE expression into inner (pushable) and outer (non-pushable) parts.
 
         Returns:
-            (inner_where, outer_where) tuple where:
+            PushdownSplit where:
             - inner_where: Predicates to push into events subquery (or None if none)
             - outer_where: Predicates to keep in outer query (or None if none)
         """
@@ -1334,7 +1341,7 @@ class EventsPredicatePushdownExtractor:
         inner_where = self._combine_with_and(inner_exprs)
         outer_where = self._combine_with_and(outer_exprs)
 
-        return (inner_where, outer_where)
+        return PushdownSplit(inner_where=inner_where, outer_where=outer_where)
 
     def _split_expression(self, expr: ast.Expr) -> tuple[list[ast.Expr], list[ast.Expr]]:
         """

--- a/posthog/hogql/direct_sql/clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/clickhouse_adapter.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from dataclasses import dataclass
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 
@@ -198,9 +199,16 @@ def ensure_read_only_raw_clickhouse_statement(sql: str) -> str:
     return sql
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class CappedClickHouseRows:
+    rows: list
+    column_names: list[str]
+    column_types: list[str]
+
+
 def _fetch_capped_clickhouse_rows(
     client: "ClickHouseClient", sql: str, parameters: dict[str, Any] | None, deadline_seconds: float
-) -> tuple[list, list[str], list[str]]:
+) -> CappedClickHouseRows:
     """Stream rows up to the row cap, raising if the result would exceed it or the deadline passes.
 
     The shared client is configured with ``query_limit=0``, so ``client.query`` would buffer the
@@ -227,7 +235,7 @@ def _fetch_capped_clickhouse_rows(
             if len(rows) > DIRECT_CLICKHOUSE_MAX_ROWS:
                 DIRECT_QUERY_ROW_CAP_EXCEEDED_TOTAL.labels(dialect="clickhouse").inc()
                 raise ExposedHogQLError(DIRECT_CLICKHOUSE_ROW_CAP_ERROR)
-    return rows, column_names, column_types
+    return CappedClickHouseRows(rows=rows, column_names=column_names, column_types=column_types)
 
 
 class ClickHouseAdapter:
@@ -299,7 +307,7 @@ class ClickHouseAdapter:
                         "max_block_size": DIRECT_CLICKHOUSE_MAX_BLOCK_SIZE,
                     },
                 ) as client:
-                    rows, column_names, column_types = _fetch_capped_clickhouse_rows(
+                    fetch_result = _fetch_capped_clickhouse_rows(
                         client, request.sql, request.values or None, statement_timeout_seconds
                     )
         except (ClickHouseError, OSError, BaseSSHTunnelForwarderError, ExposedHogQLError) as error:
@@ -310,6 +318,8 @@ class ClickHouseAdapter:
                 )
             raise ExposedHogQLError(clickhouse_error_to_message(error)) from error
 
-        span.set_attribute("row_count", len(rows))
-        types: list[tuple[str, str]] = list(zip(column_names, column_types))
-        return DirectQueryResult(results=[list(row) for row in rows], types=types, print_columns=column_names)
+        span.set_attribute("row_count", len(fetch_result.rows))
+        types: list[tuple[str, str]] = list(zip(fetch_result.column_names, fetch_result.column_types))
+        return DirectQueryResult(
+            results=[list(row) for row in fetch_result.rows], types=types, print_columns=fetch_result.column_names
+        )

--- a/posthog/hogql/direct_sql/clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/clickhouse_adapter.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from dataclasses import dataclass
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, cast
 
@@ -197,9 +198,16 @@ def ensure_read_only_raw_clickhouse_statement(sql: str) -> str:
     return sql
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class CappedClickHouseRows:
+    rows: list
+    column_names: list[str]
+    column_types: list[str]
+
+
 def _fetch_capped_clickhouse_rows(
     client: "ClickHouseClient", sql: str, parameters: dict[str, Any] | None, deadline_seconds: float
-) -> tuple[list, list[str], list[str]]:
+) -> CappedClickHouseRows:
     """Stream rows up to the row cap, raising if the result would exceed it or the deadline passes.
 
     The shared client is configured with ``query_limit=0``, so ``client.query`` would buffer the
@@ -226,7 +234,7 @@ def _fetch_capped_clickhouse_rows(
             if len(rows) > DIRECT_CLICKHOUSE_MAX_ROWS:
                 DIRECT_QUERY_ROW_CAP_EXCEEDED_TOTAL.labels(dialect="clickhouse").inc()
                 raise ExposedHogQLError(DIRECT_CLICKHOUSE_ROW_CAP_ERROR)
-    return rows, column_names, column_types
+    return CappedClickHouseRows(rows=rows, column_names=column_names, column_types=column_types)
 
 
 class ClickHouseAdapter:
@@ -298,7 +306,7 @@ class ClickHouseAdapter:
                         "max_block_size": DIRECT_CLICKHOUSE_MAX_BLOCK_SIZE,
                     },
                 ) as client:
-                    rows, column_names, column_types = _fetch_capped_clickhouse_rows(
+                    fetch_result = _fetch_capped_clickhouse_rows(
                         client, request.sql, request.values or None, statement_timeout_seconds
                     )
         except (ClickHouseError, OSError, ExposedHogQLError) as error:
@@ -309,6 +317,8 @@ class ClickHouseAdapter:
                 )
             raise ExposedHogQLError(clickhouse_error_to_message(error)) from error
 
-        span.set_attribute("row_count", len(rows))
-        types: list[tuple[str, str]] = list(zip(column_names, column_types))
-        return DirectQueryResult(results=[list(row) for row in rows], types=types, print_columns=column_names)
+        span.set_attribute("row_count", len(fetch_result.rows))
+        types: list[tuple[str, str]] = list(zip(fetch_result.column_names, fetch_result.column_types))
+        return DirectQueryResult(
+            results=[list(row) for row in fetch_result.rows], types=types, print_columns=fetch_result.column_names
+        )

--- a/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
@@ -209,10 +209,10 @@ class TestClickHouseRowCap(SimpleTestCase):
 
     def test_returns_rows_and_types_under_cap(self):
         client = self._stream_client([[(1,), (2,)], [(3,)]])
-        rows, column_names, column_types = _fetch_capped_clickhouse_rows(client, "SELECT n FROM t", None, 600)
-        self.assertEqual(rows, [(1,), (2,), (3,)])
-        self.assertEqual(column_names, ["n"])
-        self.assertEqual(column_types, ["Int64"])
+        fetch_result = _fetch_capped_clickhouse_rows(client, "SELECT n FROM t", None, 600)
+        self.assertEqual(fetch_result.rows, [(1,), (2,), (3,)])
+        self.assertEqual(fetch_result.column_names, ["n"])
+        self.assertEqual(fetch_result.column_types, ["Int64"])
 
     def test_raises_when_result_exceeds_cap(self):
         # The streaming guard trips one row past the cap — the memory-exhaustion path a raw

--- a/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
@@ -176,10 +176,10 @@ class TestClickHouseRowCap(SimpleTestCase):
 
     def test_returns_rows_and_types_under_cap(self):
         client = self._stream_client([[(1,), (2,)], [(3,)]])
-        rows, column_names, column_types = _fetch_capped_clickhouse_rows(client, "SELECT n FROM t", None, 600)
-        self.assertEqual(rows, [(1,), (2,), (3,)])
-        self.assertEqual(column_names, ["n"])
-        self.assertEqual(column_types, ["Int64"])
+        fetch_result = _fetch_capped_clickhouse_rows(client, "SELECT n FROM t", None, 600)
+        self.assertEqual(fetch_result.rows, [(1,), (2,), (3,)])
+        self.assertEqual(fetch_result.column_names, ["n"])
+        self.assertEqual(fetch_result.column_types, ["Int64"])
 
     def test_raises_when_result_exceeds_cap(self):
         # The streaming guard trips one row past the cap — the memory-exhaustion path a raw

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -5,6 +5,7 @@ import random
 import threading
 import importlib.metadata
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import StrEnum
 from types import FrameType
 from typing import Any, cast
@@ -167,18 +168,24 @@ RULE_TO_HISTOGRAM: dict[ParseRule, Histogram] = {
 DEFAULT_BACKEND: HogQLParserBackend = "cpp-json"
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ResolvedParserBackends:
+    primary: HogQLParserBackend
+    shadow: HogQLParserBackend | None = None
+
+
 # `parserMode` (a HogQLQueryModifier) selects the parser backend per query.
-# Each mode maps to a `(primary, shadow)` backend pair: the primary parses
+# Each mode maps to a primary/shadow backend pair: the primary parses
 # the query and its result is always what's returned; a non-None shadow is
 # run on a small sample of parses purely to detect divergence.
-_PARSER_MODE_BACKENDS: dict[ParserMode, tuple[HogQLParserBackend, HogQLParserBackend | None]] = {
-    ParserMode.CPP_ONLY: ("cpp-json", None),
-    ParserMode.RUST_ONLY: ("rust-json", None),
-    ParserMode.CPP_WITH_RUST_SHADOW: ("cpp-json", "rust-json"),
-    ParserMode.CPP_WITH_RUST_PY_SHADOW: ("cpp-json", "rust-py"),
-    ParserMode.RUST_WITH_CPP_SHADOW: ("rust-json", "cpp-json"),
-    ParserMode.RUST_PY_ONLY: ("rust-py", None),
-    ParserMode.RUST_PY_WITH_CPP_SHADOW: ("rust-py", "cpp-json"),
+_PARSER_MODE_BACKENDS: dict[ParserMode, ResolvedParserBackends] = {
+    ParserMode.CPP_ONLY: ResolvedParserBackends(primary="cpp-json"),
+    ParserMode.RUST_ONLY: ResolvedParserBackends(primary="rust-json"),
+    ParserMode.CPP_WITH_RUST_SHADOW: ResolvedParserBackends(primary="cpp-json", shadow="rust-json"),
+    ParserMode.CPP_WITH_RUST_PY_SHADOW: ResolvedParserBackends(primary="cpp-json", shadow="rust-py"),
+    ParserMode.RUST_WITH_CPP_SHADOW: ResolvedParserBackends(primary="rust-json", shadow="cpp-json"),
+    ParserMode.RUST_PY_ONLY: ResolvedParserBackends(primary="rust-py"),
+    ParserMode.RUST_PY_WITH_CPP_SHADOW: ResolvedParserBackends(primary="rust-py", shadow="cpp-json"),
 }
 
 # Parser modes whose *primary* backend is the C++ parser. `parserMode` is a public
@@ -232,10 +239,8 @@ def _shadow_sample_rate() -> float:
     return 1.0 if _is_test_mode() else _SHADOW_SAMPLE_RATE
 
 
-def _resolve_parser_mode(
-    parser_mode: ParserMode | None, backend: HogQLParserBackend | None
-) -> tuple[HogQLParserBackend, HogQLParserBackend | None]:
-    """Resolve a `parserMode` modifier to `(primary, shadow)` backends.
+def _resolve_parser_mode(parser_mode: ParserMode | None, backend: HogQLParserBackend | None) -> ResolvedParserBackends:
+    """Resolve a `parserMode` modifier to primary/shadow backends.
 
     With neither `parser_mode` nor an explicit `backend=` set, the prod
     default is `RUST_PY_WITH_CPP_SHADOW`: rust-py is the primary (its result
@@ -273,12 +278,12 @@ def _resolve_parser_mode(
     if parser_mode is not None:
         return _PARSER_MODE_BACKENDS[parser_mode]
     if backend is not None:
-        return backend, None
+        return ResolvedParserBackends(primary=backend)
     if _RUST_PARSER_AVAILABLE:
         if _is_test_mode():
             return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_ONLY]
         return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_WITH_CPP_SHADOW]
-    return DEFAULT_BACKEND, None
+    return ResolvedParserBackends(primary=DEFAULT_BACKEND)
 
 
 class HogQLParserShadowMismatch(Exception):
@@ -303,10 +308,10 @@ _SHADOW_COMPARISONS = Counter(
 def _run_shadow_comparison(
     rule: ParseRule,
     statement: str,
-    primary_backend: HogQLParserBackend,
-    shadow_backend: HogQLParserBackend,
     primary_node: Any,
     start: int | None,
+    *,
+    backends: ResolvedParserBackends,
 ) -> None:
     """Cross-backend parity check, gated by `_shadow_sample_rate`. Emits telemetry only for shadowed runs, and always
     returns the primary result untouched.
@@ -320,12 +325,14 @@ def _run_shadow_comparison(
     primary-accepted input; a packaging-class shadow failure (broken wheel, panic) is only counted. ASTs are compared
     INCLUDING per-node `start` / `end` positions — divergent spans are flagged "position-only" for triage.
     """
+    if backends.shadow is None:
+        return
     if random.random() >= _shadow_sample_rate():
         return
     test_mode = _is_test_mode()
     rule_label = str(rule)
-    primary_version = _BACKEND_VERSION.get(primary_backend, "unknown")
-    shadow_version = _BACKEND_VERSION.get(shadow_backend, "unknown")
+    primary_version = _BACKEND_VERSION.get(backends.primary, "unknown")
+    shadow_version = _BACKEND_VERSION.get(backends.shadow, "unknown")
 
     def _count(result: str) -> None:
         _SHADOW_COMPARISONS.labels(
@@ -335,14 +342,14 @@ def _run_shadow_comparison(
     # Divergent query SQL rides error tracking (not the logs), the channel that already carries query SQL on failures.
     divergence_properties = {
         "hogql_parser_rule": rule_label,
-        "hogql_parser_primary": primary_backend,
-        "hogql_parser_shadow": shadow_backend,
+        "hogql_parser_primary": backends.primary,
+        "hogql_parser_shadow": backends.shadow,
         "hogql_parser_primary_version": primary_version,
         "hogql_parser_shadow_version": shadow_version,
         "hogql_parser_statement": statement,
     }
     try:
-        shadow_node = _invoke_parser(shadow_backend, rule, statement, start)
+        shadow_node = _invoke_parser(backends.shadow, rule, statement, start)
     except BaseHogQLError as err:
         # Shadow rejects input the primary accepted: a divergence (raises in TEST).
         _count("shadow_rejected")
@@ -372,7 +379,7 @@ def _run_shadow_comparison(
     # also attached as a capture property via `divergence_properties`.
     excerpt = statement if len(statement) <= 2000 else statement[:2000] + "…(truncated)"
     mismatch = HogQLParserShadowMismatch(
-        f"{rule} parser AST mismatch ({kind}): {primary_backend} vs {shadow_backend}\nstatement: {excerpt!r}"
+        f"{rule} parser AST mismatch ({kind}): {backends.primary} vs {backends.shadow}\nstatement: {excerpt!r}"
     )
     if test_mode:
         raise mismatch
@@ -574,20 +581,20 @@ def parse_string_template(
     """Parse a full template string without start/end quotes"""
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
+    resolved = _resolve_parser_mode(parser_mode, backend)
     # The cache is keyed on `"F'" + string` (a runtime concat that never
     # matches a frame literal), so pass the raw `string` as the classify
     # target — that keeps the frame walk on the cold path here too.
-    with timings.measure(f"parse_full_template_string_{primary}"):
+    with timings.measure(f"parse_full_template_string_{resolved.primary}"):
         node = _parse_cached(
             ParseRule.FULL_TEMPLATE_STRING,
             "F'" + string,
-            primary,
+            resolved.primary,
             cache_origin,
             classify_input=string,
         )
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.FULL_TEMPLATE_STRING, "F'" + string, primary, shadow, node, None)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.FULL_TEMPLATE_STRING, "F'" + string, node, None, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -608,11 +615,11 @@ def parse_expr(
         raise SyntaxError("Empty query")
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_expr_{primary}"):
-        node = _parse_cached(ParseRule.EXPR, expr, primary, cache_origin, start=start)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.EXPR, expr, primary, shadow, node, start)
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_expr_{resolved.primary}"):
+        node = _parse_cached(ParseRule.EXPR, expr, resolved.primary, cache_origin, start=start)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.EXPR, expr, node, start, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -630,11 +637,11 @@ def parse_order_expr(
 ) -> ast.OrderExpr:
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_order_expr_{primary}"):
-        node = _parse_cached(ParseRule.ORDER_EXPR, order_expr, primary, cache_origin)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.ORDER_EXPR, order_expr, primary, shadow, node, None)
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_order_expr_{resolved.primary}"):
+        node = _parse_cached(ParseRule.ORDER_EXPR, order_expr, resolved.primary, cache_origin)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.ORDER_EXPR, order_expr, node, None, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -652,12 +659,12 @@ def parse_select(
 ) -> ast.SelectQuery | ast.SelectSetQuery:
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_select_{primary}"):
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_select_{resolved.primary}"):
         with tracer.start_as_current_span("parse_statement_to_node"):
-            node = _parse_cached(ParseRule.SELECT, statement, primary, cache_origin)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.SELECT, statement, primary, shadow, node, None)
+            node = _parse_cached(ParseRule.SELECT, statement, resolved.primary, cache_origin)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.SELECT, statement, node, None, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"), tracer.start_as_current_span("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -674,9 +681,9 @@ def parse_program(
 ) -> ast.Program:
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_program_{primary}"):
-        node = _parse_cached(ParseRule.PROGRAM, source, primary, cache_origin)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.PROGRAM, source, primary, shadow, node, None)
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_program_{resolved.primary}"):
+        node = _parse_cached(ParseRule.PROGRAM, source, resolved.primary, cache_origin)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.PROGRAM, source, node, None, backends=resolved)
     return cast("ast.Program", node)

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -5,6 +5,7 @@ import random
 import threading
 import importlib.metadata
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import StrEnum
 from types import FrameType
 from typing import Any, cast
@@ -167,18 +168,24 @@ RULE_TO_HISTOGRAM: dict[ParseRule, Histogram] = {
 DEFAULT_BACKEND: HogQLParserBackend = "cpp-json"
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ResolvedParserBackends:
+    primary: HogQLParserBackend
+    shadow: HogQLParserBackend | None = None
+
+
 # `parserMode` (a HogQLQueryModifier) selects the parser backend per query.
-# Each mode maps to a `(primary, shadow)` backend pair: the primary parses
+# Each mode maps to a primary/shadow backend pair: the primary parses
 # the query and its result is always what's returned; a non-None shadow is
 # run on a small sample of parses purely to detect divergence.
-_PARSER_MODE_BACKENDS: dict[ParserMode, tuple[HogQLParserBackend, HogQLParserBackend | None]] = {
-    ParserMode.CPP_ONLY: ("cpp-json", None),
-    ParserMode.RUST_ONLY: ("rust-json", None),
-    ParserMode.CPP_WITH_RUST_SHADOW: ("cpp-json", "rust-json"),
-    ParserMode.CPP_WITH_RUST_PY_SHADOW: ("cpp-json", "rust-py"),
-    ParserMode.RUST_WITH_CPP_SHADOW: ("rust-json", "cpp-json"),
-    ParserMode.RUST_PY_ONLY: ("rust-py", None),
-    ParserMode.RUST_PY_WITH_CPP_SHADOW: ("rust-py", "cpp-json"),
+_PARSER_MODE_BACKENDS: dict[ParserMode, ResolvedParserBackends] = {
+    ParserMode.CPP_ONLY: ResolvedParserBackends(primary="cpp-json"),
+    ParserMode.RUST_ONLY: ResolvedParserBackends(primary="rust-json"),
+    ParserMode.CPP_WITH_RUST_SHADOW: ResolvedParserBackends(primary="cpp-json", shadow="rust-json"),
+    ParserMode.CPP_WITH_RUST_PY_SHADOW: ResolvedParserBackends(primary="cpp-json", shadow="rust-py"),
+    ParserMode.RUST_WITH_CPP_SHADOW: ResolvedParserBackends(primary="rust-json", shadow="cpp-json"),
+    ParserMode.RUST_PY_ONLY: ResolvedParserBackends(primary="rust-py"),
+    ParserMode.RUST_PY_WITH_CPP_SHADOW: ResolvedParserBackends(primary="rust-py", shadow="cpp-json"),
 }
 
 # Parser modes whose *primary* backend is the C++ parser. `parserMode` is a public
@@ -232,10 +239,8 @@ def _shadow_sample_rate() -> float:
     return 1.0 if _is_test_mode() else _SHADOW_SAMPLE_RATE
 
 
-def _resolve_parser_mode(
-    parser_mode: ParserMode | None, backend: HogQLParserBackend | None
-) -> tuple[HogQLParserBackend, HogQLParserBackend | None]:
-    """Resolve a `parserMode` modifier to `(primary, shadow)` backends.
+def _resolve_parser_mode(parser_mode: ParserMode | None, backend: HogQLParserBackend | None) -> ResolvedParserBackends:
+    """Resolve a `parserMode` modifier to primary/shadow backends.
 
     With neither `parser_mode` nor an explicit `backend=` set, the prod
     default is `RUST_PY_WITH_CPP_SHADOW`: rust-py is the primary (its result
@@ -273,12 +278,12 @@ def _resolve_parser_mode(
     if parser_mode is not None:
         return _PARSER_MODE_BACKENDS[parser_mode]
     if backend is not None:
-        return backend, None
+        return ResolvedParserBackends(primary=backend)
     if _RUST_PARSER_AVAILABLE:
         if _is_test_mode():
             return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_ONLY]
         return _PARSER_MODE_BACKENDS[ParserMode.RUST_PY_WITH_CPP_SHADOW]
-    return DEFAULT_BACKEND, None
+    return ResolvedParserBackends(primary=DEFAULT_BACKEND)
 
 
 class HogQLParserShadowMismatch(Exception):
@@ -574,20 +579,22 @@ def parse_string_template(
     """Parse a full template string without start/end quotes"""
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
+    resolved = _resolve_parser_mode(parser_mode, backend)
     # The cache is keyed on `"F'" + string` (a runtime concat that never
     # matches a frame literal), so pass the raw `string` as the classify
     # target — that keeps the frame walk on the cold path here too.
-    with timings.measure(f"parse_full_template_string_{primary}"):
+    with timings.measure(f"parse_full_template_string_{resolved.primary}"):
         node = _parse_cached(
             ParseRule.FULL_TEMPLATE_STRING,
             "F'" + string,
-            primary,
+            resolved.primary,
             cache_origin,
             classify_input=string,
         )
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.FULL_TEMPLATE_STRING, "F'" + string, primary, shadow, node, None)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(
+                ParseRule.FULL_TEMPLATE_STRING, "F'" + string, resolved.primary, resolved.shadow, node, None
+            )
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -608,11 +615,11 @@ def parse_expr(
         raise SyntaxError("Empty query")
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_expr_{primary}"):
-        node = _parse_cached(ParseRule.EXPR, expr, primary, cache_origin, start=start)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.EXPR, expr, primary, shadow, node, start)
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_expr_{resolved.primary}"):
+        node = _parse_cached(ParseRule.EXPR, expr, resolved.primary, cache_origin, start=start)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.EXPR, expr, resolved.primary, resolved.shadow, node, start)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -630,11 +637,11 @@ def parse_order_expr(
 ) -> ast.OrderExpr:
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_order_expr_{primary}"):
-        node = _parse_cached(ParseRule.ORDER_EXPR, order_expr, primary, cache_origin)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.ORDER_EXPR, order_expr, primary, shadow, node, None)
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_order_expr_{resolved.primary}"):
+        node = _parse_cached(ParseRule.ORDER_EXPR, order_expr, resolved.primary, cache_origin)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.ORDER_EXPR, order_expr, resolved.primary, resolved.shadow, node, None)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -652,12 +659,12 @@ def parse_select(
 ) -> ast.SelectQuery | ast.SelectSetQuery:
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_select_{primary}"):
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_select_{resolved.primary}"):
         with tracer.start_as_current_span("parse_statement_to_node"):
-            node = _parse_cached(ParseRule.SELECT, statement, primary, cache_origin)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.SELECT, statement, primary, shadow, node, None)
+            node = _parse_cached(ParseRule.SELECT, statement, resolved.primary, cache_origin)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.SELECT, statement, resolved.primary, resolved.shadow, node, None)
         if placeholders:
             with timings.measure("replace_placeholders"), tracer.start_as_current_span("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -674,9 +681,9 @@ def parse_program(
 ) -> ast.Program:
     if timings is None:
         timings = HogQLTimings()
-    primary, shadow = _resolve_parser_mode(parser_mode, backend)
-    with timings.measure(f"parse_program_{primary}"):
-        node = _parse_cached(ParseRule.PROGRAM, source, primary, cache_origin)
-        if shadow is not None:
-            _run_shadow_comparison(ParseRule.PROGRAM, source, primary, shadow, node, None)
+    resolved = _resolve_parser_mode(parser_mode, backend)
+    with timings.measure(f"parse_program_{resolved.primary}"):
+        node = _parse_cached(ParseRule.PROGRAM, source, resolved.primary, cache_origin)
+        if resolved.shadow is not None:
+            _run_shadow_comparison(ParseRule.PROGRAM, source, resolved.primary, resolved.shadow, node, None)
     return cast("ast.Program", node)

--- a/posthog/hogql/parser.py
+++ b/posthog/hogql/parser.py
@@ -308,10 +308,10 @@ _SHADOW_COMPARISONS = Counter(
 def _run_shadow_comparison(
     rule: ParseRule,
     statement: str,
-    primary_backend: HogQLParserBackend,
-    shadow_backend: HogQLParserBackend,
     primary_node: Any,
     start: int | None,
+    *,
+    backends: ResolvedParserBackends,
 ) -> None:
     """Cross-backend parity check, gated by `_shadow_sample_rate`. Emits telemetry only for shadowed runs, and always
     returns the primary result untouched.
@@ -325,12 +325,14 @@ def _run_shadow_comparison(
     primary-accepted input; a packaging-class shadow failure (broken wheel, panic) is only counted. ASTs are compared
     INCLUDING per-node `start` / `end` positions — divergent spans are flagged "position-only" for triage.
     """
+    if backends.shadow is None:
+        return
     if random.random() >= _shadow_sample_rate():
         return
     test_mode = _is_test_mode()
     rule_label = str(rule)
-    primary_version = _BACKEND_VERSION.get(primary_backend, "unknown")
-    shadow_version = _BACKEND_VERSION.get(shadow_backend, "unknown")
+    primary_version = _BACKEND_VERSION.get(backends.primary, "unknown")
+    shadow_version = _BACKEND_VERSION.get(backends.shadow, "unknown")
 
     def _count(result: str) -> None:
         _SHADOW_COMPARISONS.labels(
@@ -340,14 +342,14 @@ def _run_shadow_comparison(
     # Divergent query SQL rides error tracking (not the logs), the channel that already carries query SQL on failures.
     divergence_properties = {
         "hogql_parser_rule": rule_label,
-        "hogql_parser_primary": primary_backend,
-        "hogql_parser_shadow": shadow_backend,
+        "hogql_parser_primary": backends.primary,
+        "hogql_parser_shadow": backends.shadow,
         "hogql_parser_primary_version": primary_version,
         "hogql_parser_shadow_version": shadow_version,
         "hogql_parser_statement": statement,
     }
     try:
-        shadow_node = _invoke_parser(shadow_backend, rule, statement, start)
+        shadow_node = _invoke_parser(backends.shadow, rule, statement, start)
     except BaseHogQLError as err:
         # Shadow rejects input the primary accepted: a divergence (raises in TEST).
         _count("shadow_rejected")
@@ -377,7 +379,7 @@ def _run_shadow_comparison(
     # also attached as a capture property via `divergence_properties`.
     excerpt = statement if len(statement) <= 2000 else statement[:2000] + "…(truncated)"
     mismatch = HogQLParserShadowMismatch(
-        f"{rule} parser AST mismatch ({kind}): {primary_backend} vs {shadow_backend}\nstatement: {excerpt!r}"
+        f"{rule} parser AST mismatch ({kind}): {backends.primary} vs {backends.shadow}\nstatement: {excerpt!r}"
     )
     if test_mode:
         raise mismatch
@@ -592,9 +594,7 @@ def parse_string_template(
             classify_input=string,
         )
         if resolved.shadow is not None:
-            _run_shadow_comparison(
-                ParseRule.FULL_TEMPLATE_STRING, "F'" + string, resolved.primary, resolved.shadow, node, None
-            )
+            _run_shadow_comparison(ParseRule.FULL_TEMPLATE_STRING, "F'" + string, node, None, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -619,7 +619,7 @@ def parse_expr(
     with timings.measure(f"parse_expr_{resolved.primary}"):
         node = _parse_cached(ParseRule.EXPR, expr, resolved.primary, cache_origin, start=start)
         if resolved.shadow is not None:
-            _run_shadow_comparison(ParseRule.EXPR, expr, resolved.primary, resolved.shadow, node, start)
+            _run_shadow_comparison(ParseRule.EXPR, expr, node, start, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -641,7 +641,7 @@ def parse_order_expr(
     with timings.measure(f"parse_order_expr_{resolved.primary}"):
         node = _parse_cached(ParseRule.ORDER_EXPR, order_expr, resolved.primary, cache_origin)
         if resolved.shadow is not None:
-            _run_shadow_comparison(ParseRule.ORDER_EXPR, order_expr, resolved.primary, resolved.shadow, node, None)
+            _run_shadow_comparison(ParseRule.ORDER_EXPR, order_expr, node, None, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -664,7 +664,7 @@ def parse_select(
         with tracer.start_as_current_span("parse_statement_to_node"):
             node = _parse_cached(ParseRule.SELECT, statement, resolved.primary, cache_origin)
         if resolved.shadow is not None:
-            _run_shadow_comparison(ParseRule.SELECT, statement, resolved.primary, resolved.shadow, node, None)
+            _run_shadow_comparison(ParseRule.SELECT, statement, node, None, backends=resolved)
         if placeholders:
             with timings.measure("replace_placeholders"), tracer.start_as_current_span("replace_placeholders"):
                 node = replace_placeholders(node, placeholders)
@@ -685,5 +685,5 @@ def parse_program(
     with timings.measure(f"parse_program_{resolved.primary}"):
         node = _parse_cached(ParseRule.PROGRAM, source, resolved.primary, cache_origin)
         if resolved.shadow is not None:
-            _run_shadow_comparison(ParseRule.PROGRAM, source, resolved.primary, resolved.shadow, node, None)
+            _run_shadow_comparison(ParseRule.PROGRAM, source, node, None, backends=resolved)
     return cast("ast.Program", node)

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -1,5 +1,6 @@
 import re
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Literal, Optional, TypeGuard, cast
 
 from django.db import models
@@ -76,14 +77,21 @@ from products.warehouse_sources.backend.facade.hogql import get_view_or_table_by
 PERSON_METADATA_FIELDS = {"created_at"}
 
 
-def parse_semver(value: str) -> tuple[str, str, str]:
+@dataclass(frozen=True, kw_only=True, slots=True)
+class SemverParts:
+    major: str
+    minor: str
+    patch: str
+
+
+def parse_semver(value: str) -> SemverParts:
     """
-    Parse a semver string into (major, minor, patch) components.
+    Parse a semver string into major, minor and patch components.
 
     - Strips pre-release suffixes (e.g., -alpha.1)
     - Defaults missing components to "0" (e.g., 1.0 -> 1.0.0)
 
-    Returns tuple of strings for direct use in version string construction.
+    Components stay strings for direct use in version string construction.
     Raises ValueError if parsing fails.
     """
     # Strip pre-release suffix (everything after first hyphen)
@@ -100,7 +108,7 @@ def parse_semver(value: str) -> tuple[str, str, str]:
     # Validate they're actually integers
     int(major), int(minor), int(patch)
 
-    return (major, minor, patch)
+    return SemverParts(major=major, minor=minor, patch=patch)
 
 
 # Anchored, strict-semver validator used to gate semver comparisons. We can't rely on
@@ -172,12 +180,12 @@ def _tilde_bounds(value: str) -> tuple[str, str]:
     ~1.2.3 means >=1.2.3 <1.3.0 (allows patch-level changes)
     ~1 means >=1.0.0 <2.0.0 (bare major: allows minor+patch changes)
     """
-    major, minor, patch = parse_semver(value)
+    v = parse_semver(value)
     parts = value.split("-")[0].split(".")
     if len(parts) < 2:
-        return f"{major}.0.0", f"{int(major) + 1}.0.0"
-    next_minor = str(int(minor) + 1)
-    return f"{major}.{minor}.{patch}", f"{major}.{next_minor}.0"
+        return f"{v.major}.0.0", f"{int(v.major) + 1}.0.0"
+    next_minor = str(int(v.minor) + 1)
+    return f"{v.major}.{v.minor}.{v.patch}", f"{v.major}.{next_minor}.0"
 
 
 def _caret_bounds(value: str) -> tuple[str, str]:
@@ -188,15 +196,15 @@ def _caret_bounds(value: str) -> tuple[str, str]:
     ^0.0.3 means >=0.0.3 <0.0.4
     The leftmost non-zero component determines the upper bound.
     """
-    major, minor, patch = parse_semver(value)
-    lower_bound = f"{major}.{minor}.{patch}"
+    v = parse_semver(value)
+    lower_bound = f"{v.major}.{v.minor}.{v.patch}"
 
-    if int(major) > 0:
-        upper_bound = f"{int(major) + 1}.0.0"
-    elif int(minor) > 0:
-        upper_bound = f"0.{int(minor) + 1}.0"
+    if int(v.major) > 0:
+        upper_bound = f"{int(v.major) + 1}.0.0"
+    elif int(v.minor) > 0:
+        upper_bound = f"0.{int(v.minor) + 1}.0"
     else:
-        upper_bound = f"0.0.{int(patch) + 1}"
+        upper_bound = f"0.0.{int(v.patch) + 1}"
 
     return lower_bound, upper_bound
 

--- a/posthog/hogql/test/test_parser_mode.py
+++ b/posthog/hogql/test/test_parser_mode.py
@@ -12,6 +12,7 @@ from posthog.hogql import (
 from posthog.hogql.errors import SyntaxError as HogQLSyntaxError
 from posthog.hogql.parser import (
     HogQLParserShadowMismatch,
+    ResolvedParserBackends,
     _resolve_parser_mode,
     parse_expr,
     parse_select,
@@ -24,18 +25,18 @@ class TestParserMode(BaseTest):
         [
             # No mode + no explicit backend in TEST → rust-py primary, no shadow
             # (prod's default shadow pair is asserted separately below).
-            (None, None, ("rust-py", None)),
+            (None, None, ResolvedParserBackends(primary="rust-py")),
             # No mode + explicit backend → honour the explicit backend, no shadow.
-            (None, "cpp-json", ("cpp-json", None)),
-            (None, "rust-json", ("rust-json", None)),
-            (None, "rust-py", ("rust-py", None)),
-            (ParserMode.CPP_ONLY, None, ("cpp-json", None)),
-            (ParserMode.RUST_ONLY, None, ("rust-json", None)),
-            (ParserMode.CPP_WITH_RUST_SHADOW, None, ("cpp-json", "rust-json")),
-            (ParserMode.CPP_WITH_RUST_PY_SHADOW, None, ("cpp-json", "rust-py")),
-            (ParserMode.RUST_WITH_CPP_SHADOW, None, ("rust-json", "cpp-json")),
-            (ParserMode.RUST_PY_ONLY, None, ("rust-py", None)),
-            (ParserMode.RUST_PY_WITH_CPP_SHADOW, None, ("rust-py", "cpp-json")),
+            (None, "cpp-json", ResolvedParserBackends(primary="cpp-json")),
+            (None, "rust-json", ResolvedParserBackends(primary="rust-json")),
+            (None, "rust-py", ResolvedParserBackends(primary="rust-py")),
+            (ParserMode.CPP_ONLY, None, ResolvedParserBackends(primary="cpp-json")),
+            (ParserMode.RUST_ONLY, None, ResolvedParserBackends(primary="rust-json")),
+            (ParserMode.CPP_WITH_RUST_SHADOW, None, ResolvedParserBackends(primary="cpp-json", shadow="rust-json")),
+            (ParserMode.CPP_WITH_RUST_PY_SHADOW, None, ResolvedParserBackends(primary="cpp-json", shadow="rust-py")),
+            (ParserMode.RUST_WITH_CPP_SHADOW, None, ResolvedParserBackends(primary="rust-json", shadow="cpp-json")),
+            (ParserMode.RUST_PY_ONLY, None, ResolvedParserBackends(primary="rust-py")),
+            (ParserMode.RUST_PY_WITH_CPP_SHADOW, None, ResolvedParserBackends(primary="rust-py", shadow="cpp-json")),
         ]
     )
     def test_resolve_parser_mode(self, mode, backend, expected):
@@ -44,11 +45,13 @@ class TestParserMode(BaseTest):
     def test_resolve_parser_mode_default_shadows_in_prod(self):
         with patch("posthog.hogql.parser.settings") as mock_settings:
             mock_settings.TEST = False
-            self.assertEqual(_resolve_parser_mode(None, None), ("rust-py", "cpp-json"))
+            self.assertEqual(
+                _resolve_parser_mode(None, None), ResolvedParserBackends(primary="rust-py", shadow="cpp-json")
+            )
 
     def test_resolve_parser_mode_drops_shadow_when_rust_unavailable(self):
         with patch("posthog.hogql.parser._RUST_PARSER_AVAILABLE", False):
-            self.assertEqual(_resolve_parser_mode(None, None), ("cpp-json", None))
+            self.assertEqual(_resolve_parser_mode(None, None), ResolvedParserBackends(primary="cpp-json"))
 
     def test_resolve_parser_mode_rejects_both_mode_and_backend(self):
         with self.assertRaises(ValueError):

--- a/posthog/hogql/transforms/events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/events_predicate_pushdown.py
@@ -419,9 +419,13 @@ class EventsPredicatePushdownTransform(TraversingVisitor):
         new_prewhere = node.prewhere
 
         if node.where is not None:
-            inner_from_where, new_where = extractor.get_pushdown_predicates(node.where)
+            where_split = extractor.get_pushdown_predicates(node.where)
+            inner_from_where = where_split.inner_where
+            new_where = where_split.outer_where
         if node.prewhere is not None:
-            inner_from_prewhere, new_prewhere = extractor.get_pushdown_predicates(node.prewhere)
+            prewhere_split = extractor.get_pushdown_predicates(node.prewhere)
+            inner_from_prewhere = prewhere_split.inner_where
+            new_prewhere = prewhere_split.outer_where
 
         # PREWHERE is valid only on a physical scan, not a subquery. A fully-pushable PREWHERE moves into the
         # inner scan; a residual one would have to stay on the outer subquery (invalid), so bail.

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, Optional
 
@@ -126,6 +127,14 @@ class PropertyFinder(TraversingVisitor):
             node.type.resolve_database_field(self.context), DateTimeDatabaseField
         ):
             self.found_timestamps = True
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ToTimeZoneParts:
+    bare_field: ast.Expr
+    timezone: str
+    constant: ast.Expr
+    swapped: bool
 
 
 class PropertySwapper(CloningVisitor):
@@ -548,25 +557,23 @@ class PropertySwapper(CloningVisitor):
         We only do this for top-level range comparisons (not inside function
         calls like if(), coalesce()) via the _inside_call_depth guard.
         """
-        bare_field, tz, constant, swapped = self._extract_toTimeZone_parts(node)
-        if bare_field is None or tz is None or constant is None:
+        parts = self._extract_toTimeZone_parts(node)
+        if parts is None:
             return None
 
-        tz_constant = self._ensure_constant_has_timezone(constant, tz)
+        tz_constant = self._ensure_constant_has_timezone(parts.constant, parts.timezone)
 
-        if swapped:
-            return ast.CompareOperation(left=tz_constant, right=bare_field, op=node.op)
+        if parts.swapped:
+            return ast.CompareOperation(left=tz_constant, right=parts.bare_field, op=node.op)
         else:
-            return ast.CompareOperation(left=bare_field, right=tz_constant, op=node.op)
+            return ast.CompareOperation(left=parts.bare_field, right=tz_constant, op=node.op)
 
     @staticmethod
-    def _extract_toTimeZone_parts(
-        node: ast.CompareOperation,
-    ) -> tuple[ast.Expr | None, str | None, ast.Expr | None, bool]:
-        """Extract (bare_field, timezone, constant, swapped) from a comparison
+    def _extract_toTimeZone_parts(node: ast.CompareOperation) -> ToTimeZoneParts | None:
+        """Extract the bare field, timezone, constant and side from a comparison
         where one side is toTimeZone(field, tz).
 
-        Returns (None, None, None, False) if the pattern doesn't match.
+        Returns None if the pattern doesn't match.
         swapped=True means the toTimeZone was on the right side.
         """
         for left_is_tz in (True, False):
@@ -579,9 +586,14 @@ class PropertySwapper(CloningVisitor):
             if isinstance(inner, ast.Call) and inner.name == "toTimeZone" and len(inner.args) == 2:
                 tz_arg = inner.args[1]
                 if isinstance(tz_arg, ast.Constant) and isinstance(tz_arg.value, str):
-                    return inner.args[0], tz_arg.value, const_side, not left_is_tz
+                    return ToTimeZoneParts(
+                        bare_field=inner.args[0],
+                        timezone=tz_arg.value,
+                        constant=const_side,
+                        swapped=not left_is_tz,
+                    )
 
-        return None, None, None, False
+        return None
 
     @staticmethod
     def _ensure_constant_has_timezone(expr: ast.Expr, tz: str) -> ast.Expr:

--- a/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
+++ b/posthog/hogql/transforms/test/test_events_predicate_pushdown.py
@@ -421,10 +421,10 @@ class TestOuterWhereAssignment:
         where = ast.And(exprs=[timestamp_pred, session_pred])
 
         extractor = EventsPredicatePushdownExtractor(joined_table_aliases={"events__session"})
-        inner_where, outer_where = extractor.get_pushdown_predicates(where)
+        split = extractor.get_pushdown_predicates(where)
 
-        assert inner_where is not None
-        assert outer_where is not None
+        assert split.inner_where is not None
+        assert split.outer_where is not None
 
 
 class TestEventsPredicatePushdownTransformUnit:

--- a/products/notebooks/backend/sql_v2.py
+++ b/products/notebooks/backend/sql_v2.py
@@ -14,6 +14,7 @@ hardening swaps them for the RS256 sandbox event-ingest JWTs used by PostHog Des
 import hmac
 import time
 import hashlib
+from dataclasses import dataclass
 
 from django.conf import settings
 from django.core import signing
@@ -196,11 +197,22 @@ def mint_data_plane_token(notebook_short_id: str, team_id: int, user_id: int | N
     )
 
 
-def verify_data_plane_token(token: str) -> tuple[str, int, int | None]:
-    """Return (notebook_short_id, team_id, user_id) from a valid token, else raise signing.BadSignature."""
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DataPlaneClaims:
+    notebook_short_id: str
+    team_id: int
+    user_id: int | None
+
+
+def verify_data_plane_token(token: str) -> DataPlaneClaims:
+    """Return the claims from a valid token, else raise signing.BadSignature."""
     data = signing.loads(token, salt=_DATA_PLANE_TOKEN_SALT, max_age=_DATA_PLANE_TOKEN_MAX_AGE_SECONDS)
     user_id = data.get("user_id")
-    return str(data["notebook_short_id"]), int(data["team_id"]), int(user_id) if user_id is not None else None
+    return DataPlaneClaims(
+        notebook_short_id=str(data["notebook_short_id"]),
+        team_id=int(data["team_id"]),
+        user_id=int(user_id) if user_id is not None else None,
+    )
 
 
 def _find_running_runtime(notebook: Notebook, user: User | None) -> KernelRuntime | None:

--- a/products/notebooks/backend/sql_v2.py
+++ b/products/notebooks/backend/sql_v2.py
@@ -14,6 +14,7 @@ hardening swaps them for the RS256 sandbox event-ingest JWTs used by PostHog Des
 import hmac
 import time
 import hashlib
+from dataclasses import dataclass
 
 from django.conf import settings
 from django.core import signing
@@ -153,11 +154,22 @@ def mint_data_plane_token(notebook_short_id: str, team_id: int, user_id: int | N
     )
 
 
-def verify_data_plane_token(token: str) -> tuple[str, int, int | None]:
-    """Return (notebook_short_id, team_id, user_id) from a valid token, else raise signing.BadSignature."""
+@dataclass(frozen=True, kw_only=True, slots=True)
+class DataPlaneClaims:
+    notebook_short_id: str
+    team_id: int
+    user_id: int | None
+
+
+def verify_data_plane_token(token: str) -> DataPlaneClaims:
+    """Return the claims from a valid token, else raise signing.BadSignature."""
     data = signing.loads(token, salt=_DATA_PLANE_TOKEN_SALT, max_age=_DATA_PLANE_TOKEN_MAX_AGE_SECONDS)
     user_id = data.get("user_id")
-    return str(data["notebook_short_id"]), int(data["team_id"]), int(user_id) if user_id is not None else None
+    return DataPlaneClaims(
+        notebook_short_id=str(data["notebook_short_id"]),
+        team_id=int(data["team_id"]),
+        user_id=int(user_id) if user_id is not None else None,
+    )
 
 
 def _find_running_runtime(notebook: Notebook, user: User | None) -> KernelRuntime | None:

--- a/products/notebooks/backend/sql_v2_data_plane.py
+++ b/products/notebooks/backend/sql_v2_data_plane.py
@@ -39,6 +39,7 @@ from products.notebooks.backend.models import Notebook
 from products.notebooks.backend.sql_v2 import (
     DELIVERY_INLINE,
     DELIVERY_OBJECT_RELAY,
+    DataPlaneClaims,
     is_frame_store_ch_writes_enabled,
     is_frame_store_enabled,
     verify_data_plane_token,
@@ -85,7 +86,7 @@ def _rows_to_arrow_bytes(
     return sink.getvalue().to_pybytes()
 
 
-def _verify_request_token(request: HttpRequest) -> tuple[str, int, int | None] | JsonResponse:
+def _verify_request_token(request: HttpRequest) -> DataPlaneClaims | JsonResponse:
     authorization = request.headers.get("Authorization", "")
     token = authorization[len("Bearer ") :].strip() if authorization.startswith("Bearer ") else ""
     if not token:
@@ -120,7 +121,6 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
     claims = _verify_request_token(request)
     if isinstance(claims, JsonResponse):
         return claims
-    notebook_short_id, team_id, user_id = claims
 
     try:
         body = json.loads(request.body)
@@ -136,10 +136,10 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
         return JsonResponse({"error": f"Invalid request body — {detail}", "detail": serializer.errors}, status=400)
     data = serializer.validated_data
 
-    if not Notebook.objects.filter(team_id=team_id, short_id=notebook_short_id).exists():
+    if not Notebook.objects.filter(team_id=claims.team_id, short_id=claims.notebook_short_id).exists():
         return JsonResponse({"error": "Notebook not found"}, status=404)
-    team = Team.objects.get(id=team_id)
-    user = User.objects.filter(id=user_id).first() if user_id else None
+    team = Team.objects.get(id=claims.team_id)
+    user = User.objects.filter(id=claims.user_id).first() if claims.user_id else None
 
     try:
         # Validate the user's HogQL up front so syntax errors fail here with a clear
@@ -172,13 +172,15 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
                     status = enqueue_frame_materialization(
                         team=team,
                         user_id=user.id if user else None,
-                        notebook_short_id=notebook_short_id,
+                        notebook_short_id=claims.notebook_short_id,
                         query=bounded,
                         ch_writes=is_frame_store_ch_writes_enabled(user),
                         _test_only_inline=settings.TEST,
                     )
             except Exception:
-                logger.exception("notebook_frame_materialize_enqueue_failed", notebook_short_id=notebook_short_id)
+                logger.exception(
+                    "notebook_frame_materialize_enqueue_failed", notebook_short_id=claims.notebook_short_id
+                )
                 return JsonResponse({"error": "Query could not be scheduled."}, status=500)
             return JsonResponse({"query_id": status.id, "delivery": DELIVERY_OBJECT_RELAY}, status=202)
         if frame_store_configured:
@@ -193,8 +195,8 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
             FRAME_STORE_FALLBACK_COUNTER.labels(reason="not_configured").inc()
             logger.warning(
                 "notebook_frame_store_fallback_inline",
-                notebook_short_id=notebook_short_id,
-                team_id=team_id,
+                notebook_short_id=claims.notebook_short_id,
+                team_id=claims.team_id,
                 object_storage_enabled=settings.OBJECT_STORAGE_ENABLED,
             )
 
@@ -209,7 +211,7 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
                 _test_only_bypass_celery=settings.TEST,
             )
     except Exception:
-        logger.exception("notebook_sql_v2_data_plane_enqueue_failed", notebook_short_id=notebook_short_id)
+        logger.exception("notebook_sql_v2_data_plane_enqueue_failed", notebook_short_id=claims.notebook_short_id)
         return JsonResponse({"error": "Query could not be scheduled."}, status=500)
 
     # Reached either because the caller wanted inline delivery or because an object request
@@ -242,10 +244,9 @@ def notebook_sql_v2_data_plane_status(request: HttpRequest, query_id: str) -> Ht
     claims = _verify_request_token(request)
     if isinstance(claims, JsonResponse):
         return claims
-    _notebook_short_id, team_id, _user_id = claims
 
     try:
-        status = get_query_status(team_id=team_id, query_id=query_id)
+        status = get_query_status(team_id=claims.team_id, query_id=query_id)
     except QueryNotFoundError:
         return JsonResponse({"error": "Query not found or expired"}, status=404)
 
@@ -267,10 +268,10 @@ def notebook_sql_v2_data_plane_status(request: HttpRequest, query_id: str) -> Ht
             # would 404 every frame materialized in the window before that deploy.
             recorded_bucket = results.get("bucket")
             presigned_url = frame_store.presign_get(
-                str(object_key), team_id, bucket=str(recorded_bucket) if recorded_bucket else None
+                str(object_key), claims.team_id, bucket=str(recorded_bucket) if recorded_bucket else None
             )
         except frame_store.FrameStoreError:
-            logger.exception("notebook_frame_presign_failed", team_id=team_id, query_id=query_id)
+            logger.exception("notebook_frame_presign_failed", team_id=claims.team_id, query_id=query_id)
             return JsonResponse({"error": "The frame download could not be prepared. Try re-running."}, status=500)
         return HttpResponseRedirect(presigned_url)
 

--- a/products/notebooks/backend/sql_v2_data_plane.py
+++ b/products/notebooks/backend/sql_v2_data_plane.py
@@ -36,7 +36,7 @@ from posthog.models import Team, User
 
 from products.notebooks.backend import frame_store
 from products.notebooks.backend.models import Notebook
-from products.notebooks.backend.sql_v2 import verify_data_plane_token
+from products.notebooks.backend.sql_v2 import DataPlaneClaims, verify_data_plane_token
 from products.notebooks.backend.sql_v2_direct import apply_page_bounds
 from products.notebooks.backend.sql_v2_serializers import NotebookSQLV2DataPlaneRequestSerializer
 
@@ -76,7 +76,7 @@ def _rows_to_arrow_bytes(
     return sink.getvalue().to_pybytes()
 
 
-def _verify_request_token(request: HttpRequest) -> tuple[str, int, int | None] | JsonResponse:
+def _verify_request_token(request: HttpRequest) -> DataPlaneClaims | JsonResponse:
     authorization = request.headers.get("Authorization", "")
     token = authorization[len("Bearer ") :].strip() if authorization.startswith("Bearer ") else ""
     if not token:
@@ -111,7 +111,6 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
     claims = _verify_request_token(request)
     if isinstance(claims, JsonResponse):
         return claims
-    notebook_short_id, team_id, user_id = claims
 
     try:
         body = json.loads(request.body)
@@ -127,10 +126,10 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
         return JsonResponse({"error": f"Invalid request body — {detail}", "detail": serializer.errors}, status=400)
     data = serializer.validated_data
 
-    if not Notebook.objects.filter(team_id=team_id, short_id=notebook_short_id).exists():
+    if not Notebook.objects.filter(team_id=claims.team_id, short_id=claims.notebook_short_id).exists():
         return JsonResponse({"error": "Notebook not found"}, status=404)
-    team = Team.objects.get(id=team_id)
-    user = User.objects.filter(id=user_id).first() if user_id else None
+    team = Team.objects.get(id=claims.team_id)
+    user = User.objects.filter(id=claims.user_id).first() if claims.user_id else None
 
     try:
         # Validate the user's HogQL up front so syntax errors fail here with a clear
@@ -156,12 +155,14 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
                     status = enqueue_frame_materialization(
                         team=team,
                         user_id=user.id if user else None,
-                        notebook_short_id=notebook_short_id,
+                        notebook_short_id=claims.notebook_short_id,
                         query=bounded,
                         _test_only_inline=settings.TEST,
                     )
             except Exception:
-                logger.exception("notebook_frame_materialize_enqueue_failed", notebook_short_id=notebook_short_id)
+                logger.exception(
+                    "notebook_frame_materialize_enqueue_failed", notebook_short_id=claims.notebook_short_id
+                )
                 return JsonResponse({"error": "Query could not be scheduled."}, status=500)
             return JsonResponse({"query_id": status.id}, status=202)
         # Degraded mode: the cell still runs over the inline (Redis) transport, clamped at
@@ -169,8 +170,8 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
         FRAME_STORE_FALLBACK_COUNTER.inc()
         logger.warning(
             "notebook_frame_store_fallback_inline",
-            notebook_short_id=notebook_short_id,
-            team_id=team_id,
+            notebook_short_id=claims.notebook_short_id,
+            team_id=claims.team_id,
             frame_store_enabled=settings.NOTEBOOKS_FRAME_STORE_ENABLED,
             object_storage_enabled=settings.OBJECT_STORAGE_ENABLED,
         )
@@ -186,7 +187,7 @@ def notebook_sql_v2_data_plane(request: HttpRequest) -> HttpResponse:
                 _test_only_bypass_celery=settings.TEST,
             )
     except Exception:
-        logger.exception("notebook_sql_v2_data_plane_enqueue_failed", notebook_short_id=notebook_short_id)
+        logger.exception("notebook_sql_v2_data_plane_enqueue_failed", notebook_short_id=claims.notebook_short_id)
         return JsonResponse({"error": "Query could not be scheduled."}, status=500)
 
     return JsonResponse({"query_id": status.id}, status=202)
@@ -217,10 +218,9 @@ def notebook_sql_v2_data_plane_status(request: HttpRequest, query_id: str) -> Ht
     claims = _verify_request_token(request)
     if isinstance(claims, JsonResponse):
         return claims
-    _notebook_short_id, team_id, _user_id = claims
 
     try:
-        status = get_query_status(team_id=team_id, query_id=query_id)
+        status = get_query_status(team_id=claims.team_id, query_id=query_id)
     except QueryNotFoundError:
         return JsonResponse({"error": "Query not found or expired"}, status=404)
 
@@ -237,9 +237,9 @@ def notebook_sql_v2_data_plane_status(request: HttpRequest, query_id: str) -> Ht
         # above; presign_get additionally refuses keys outside this team's prefix. The
         # presigned URL is a bearer secret — it must never be logged.
         try:
-            presigned_url = frame_store.presign_get(str(object_key), team_id)
+            presigned_url = frame_store.presign_get(str(object_key), claims.team_id)
         except frame_store.FrameStoreError:
-            logger.exception("notebook_frame_presign_failed", team_id=team_id, query_id=query_id)
+            logger.exception("notebook_frame_presign_failed", team_id=claims.team_id, query_id=query_id)
             return JsonResponse({"error": "The frame download could not be prepared. Try re-running."}, status=500)
         return HttpResponseRedirect(presigned_url)
 

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -48,6 +48,7 @@ from products.notebooks.backend.sandbox.kernel.data_plane import (
 )
 from products.notebooks.backend.sql_v2 import (
     RESULT_CACHE_ROWS,
+    DataPlaneClaims,
     SQLV2KernelNotRunning,
     SQLV2PageError,
     build_callback_url,
@@ -1552,8 +1553,8 @@ class TestSQLV2Activities(APIBaseTest):
         # Dropping cache_limit silently degrades every page fetch into a ClickHouse re-query.
         self.assertGreater(payload["cache_limit"], payload["page_limit"])
         # The kernel needs both legs to complete a run: the data plane to fetch, the callback to report.
-        short_id, team_id, _user_id = verify_data_plane_token(payload["data_plane_token"])
-        self.assertEqual((short_id, team_id), (self.notebook.short_id, self.team.id))
+        claims = verify_data_plane_token(payload["data_plane_token"])
+        self.assertEqual((claims.notebook_short_id, claims.team_id), (self.notebook.short_id, self.team.id))
         self.assertIn("/internal/notebooks/data_plane/query/", payload["data_plane_url"])
         self.assertEqual(self._reload(run).status, NotebookNodeRun.Status.RUNNING)
 
@@ -1587,7 +1588,9 @@ class TestSQLV2CommandToken(SimpleTestCase):
 class TestSQLV2DataPlaneToken(SimpleTestCase):
     def test_round_trip(self):
         token = mint_data_plane_token("nb123", 7, 42)
-        self.assertEqual(verify_data_plane_token(token), ("nb123", 7, 42))
+        self.assertEqual(
+            verify_data_plane_token(token), DataPlaneClaims(notebook_short_id="nb123", team_id=7, user_id=42)
+        )
 
     @parameterized.expand(
         [

--- a/products/notebooks/backend/test/test_sql_v2.py
+++ b/products/notebooks/backend/test/test_sql_v2.py
@@ -43,6 +43,7 @@ from products.notebooks.backend.sandbox.kernel.data_plane import (
 )
 from products.notebooks.backend.sql_v2 import (
     RESULT_CACHE_ROWS,
+    DataPlaneClaims,
     SQLV2KernelNotRunning,
     SQLV2PageError,
     build_callback_url,
@@ -1305,8 +1306,8 @@ class TestSQLV2Activities(APIBaseTest):
         # Dropping cache_limit silently degrades every page fetch into a ClickHouse re-query.
         self.assertGreater(payload["cache_limit"], payload["page_limit"])
         # The kernel needs both legs to complete a run: the data plane to fetch, the callback to report.
-        short_id, team_id, _user_id = verify_data_plane_token(payload["data_plane_token"])
-        self.assertEqual((short_id, team_id), (self.notebook.short_id, self.team.id))
+        claims = verify_data_plane_token(payload["data_plane_token"])
+        self.assertEqual((claims.notebook_short_id, claims.team_id), (self.notebook.short_id, self.team.id))
         self.assertIn("/internal/notebooks/data_plane/query/", payload["data_plane_url"])
         self.assertEqual(self._reload(run).status, NotebookNodeRun.Status.RUNNING)
 
@@ -1340,7 +1341,9 @@ class TestSQLV2CommandToken(SimpleTestCase):
 class TestSQLV2DataPlaneToken(SimpleTestCase):
     def test_round_trip(self):
         token = mint_data_plane_token("nb123", 7, 42)
-        self.assertEqual(verify_data_plane_token(token), ("nb123", 7, 42))
+        self.assertEqual(
+            verify_data_plane_token(token), DataPlaneClaims(notebook_short_id="nb123", team_id=7, user_id=42)
+        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

These functions return bare tuples where same-typed elements can be silently swapped by a caller with no type error (for example `(start, end)` timestamps), or where 3+ positional elements make call sites unreadable (`recordings, _, _, _ = ...`). Found by a repo-wide scan that verified each case against its real call sites.

## Changes

Pure refactor, no behavior change. Each function below now returns a small `@dataclass(frozen=True)` (`kw_only=True` when fields share a type, `slots=True` where compatible), and every call site binds the result once and uses dot notation instead of positional unpacking.

| function | was | now returns | defined in |
|---|---|---|---|
| `collect` | `tuple[list[list[Any]], list[list[Any]], list[_CollectedRelationship]]` | `_CollectedCatalog` | `posthog/hogql/database/schema/information_schema.py` |
| `_resolve_parser_mode` | `tuple[HogQLParserBackend, HogQLParserBackend | None]` | `ResolvedParserBackends` | `posthog/hogql/parser.py` |
| `PredicatePushdownExtractor.get_pushdown_predicates` | `tuple[Optional[ast.Expr], Optional[ast.Expr]]` | `PushdownSplit` | `posthog/hogql/database/schema/util/where_clause_extractor.py` |
| `verify_data_plane_token` | `tuple[str, int, int | None]` | `DataPlaneClaims` | `products/notebooks/backend/sql_v2.py` |
| `PropertySwapper._extract_toTimeZone_parts` | `tuple[ast.Expr | None, str | None, ast.Expr | None, bool]` | `ToTimeZoneParts` | `posthog/hogql/transforms/property_types.py` |
| `parse_semver` | `tuple[str, str, str]` | `SemverParts` | `posthog/hogql/property.py` |
| `_fetch_capped_clickhouse_rows` | `tuple[list, list[str], list[str]]` | `CappedClickHouseRows` | `posthog/hogql/direct_sql/clickhouse_adapter.py` |

This PR is self-contained: the dataclass, every call site, and every test touching these functions are all in this diff. No serialization boundary changes shape (Temporal/Celery/cache/JSON contracts untouched). It is one of 21 independent per-team slices of #76108, all based on master, mergeable in any order. The `@frozen` helper in #76144 will absorb these dataclasses in a mechanical follow-up once everything lands.

## How did you test this code?

- Full repo `mypy --cache-fine-grained .` with exactly this PR's file set applied to master: no issues. This proves the slice is self-contained (a missed call site or a reference to another slice's dataclass would fail).
- Existing tests for the touched functions are updated in this diff (mocks now return the dataclass); no tests were deleted or weakened. New tests were not added since the refactor preserves behavior that existing tests already cover.
- `ruff check`, `ruff format --check`, and `py_compile` clean on all touched files.
- An adversarial reviewer agent re-read every hunk hunting for transposed field mappings, leftover tuple unpacking, indexing, splats, and stale mocks; findings were fixed before this PR was cut.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal refactor, no user-facing docs impact; `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code at Arnaud's direction. A repo-wide scan (95 findings, each adversarially verified against call sites) fed a conversion pass; the umbrella diff was then split into 21 file-disjoint per-team PRs, each independently validated with a full-repo mypy run against master plus this slice only. One finding was skipped entirely (a Temporal activity return whose payload shape is recorded in workflow histories).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
