### PR TITLE
chore(replay): return frozen dataclasses instead of tuples

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -9,6 +9,7 @@ import asyncio
 import builtins
 from collections.abc import AsyncGenerator, Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Any, Literal, cast
 from urllib.parse import urlparse
@@ -583,20 +584,28 @@ class SessionRecordingBulkDeleteResponseSerializer(serializers.Serializer):
     )
 
 
-def list_recordings_response(
-    listing_result: tuple[list[SessionRecording], bool, str, str | None], context: dict[str, Any]
-) -> Response:
-    (recordings, more_recordings_available, timings_header, next_cursor) = listing_result
+@dataclass(frozen=True, kw_only=True, slots=True)
+class RecordingsListingResult:
+    recordings: list[SessionRecording]
+    more_recordings_available: bool
+    timings_header: str
+    next_cursor: str | None
 
-    session_recording_serializer = SessionRecordingSerializer(recordings, context=context, many=True)
+
+def list_recordings_response(listing_result: RecordingsListingResult, context: dict[str, Any]) -> Response:
+    session_recording_serializer = SessionRecordingSerializer(listing_result.recordings, context=context, many=True)
     results = session_recording_serializer.data
 
-    response_data: dict[str, Any] = {"results": results, "has_next": more_recordings_available, "version": 4}
-    if next_cursor is not None:
-        response_data["next_cursor"] = next_cursor
+    response_data: dict[str, Any] = {
+        "results": results,
+        "has_next": listing_result.more_recordings_available,
+        "version": 4,
+    }
+    if listing_result.next_cursor is not None:
+        response_data["next_cursor"] = listing_result.next_cursor
 
     response = Response(response_data)
-    response.headers["Server-Timing"] = timings_header
+    response.headers["Server-Timing"] = listing_result.timings_header
 
     return response
 
@@ -1184,12 +1193,12 @@ class SessionRecordingViewSet(
             "limit": len(session_recording_ids),
         }
         query = RecordingsQuery.model_validate(query_data)
-        recordings, _, _, _ = list_recordings_from_query(query, None, self.team)
+        listing_result = list_recordings_from_query(query, None, self.team)
 
         user_access_control = self.user_access_control
         accessible_recordings = [
             recording
-            for recording in recordings
+            for recording in listing_result.recordings
             if user_access_control.check_access_level_for_object(recording, required_level="editor")
         ]
 
@@ -2068,7 +2077,7 @@ def list_recordings_from_query(
     team: Team,
     allow_event_property_expansion: bool = False,
     bypass_date_window_for_session_ids: bool = False,
-) -> tuple[list[SessionRecording], bool, str, str | None]:
+) -> RecordingsListingResult:
     """
     As we can store recordings in S3 or in Clickhouse we need to do a few things here
 
@@ -2228,7 +2237,12 @@ def list_recordings_from_query(
             if matched_person:
                 recording.person = matched_person
 
-    return recordings, more_recordings_available, timer.to_header_string(hogql_timings), next_cursor
+    return RecordingsListingResult(
+        recordings=recordings,
+        more_recordings_available=more_recordings_available,
+        timings_header=timer.to_header_string(hogql_timings),
+        next_cursor=next_cursor,
+    )
 
 
 def _other_users_viewed(recording_ids_in_list: list[str], user: User | None, team: Team) -> dict[str, list[str]]:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -9,6 +9,7 @@ import asyncio
 import builtins
 from collections.abc import AsyncGenerator, Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Any, Literal, cast
 from urllib.parse import urlparse
@@ -583,20 +584,28 @@ class SessionRecordingBulkDeleteResponseSerializer(serializers.Serializer):
     )
 
 
-def list_recordings_response(
-    listing_result: tuple[list[SessionRecording], bool, str, str | None], context: dict[str, Any]
-) -> Response:
-    (recordings, more_recordings_available, timings_header, next_cursor) = listing_result
+@dataclass(frozen=True, kw_only=True, slots=True)
+class RecordingsListingResult:
+    recordings: list[SessionRecording]
+    more_recordings_available: bool
+    timings_header: str
+    next_cursor: str | None
 
-    session_recording_serializer = SessionRecordingSerializer(recordings, context=context, many=True)
+
+def list_recordings_response(listing_result: RecordingsListingResult, context: dict[str, Any]) -> Response:
+    session_recording_serializer = SessionRecordingSerializer(listing_result.recordings, context=context, many=True)
     results = session_recording_serializer.data
 
-    response_data: dict[str, Any] = {"results": results, "has_next": more_recordings_available, "version": 4}
-    if next_cursor is not None:
-        response_data["next_cursor"] = next_cursor
+    response_data: dict[str, Any] = {
+        "results": results,
+        "has_next": listing_result.more_recordings_available,
+        "version": 4,
+    }
+    if listing_result.next_cursor is not None:
+        response_data["next_cursor"] = listing_result.next_cursor
 
     response = Response(response_data)
-    response.headers["Server-Timing"] = timings_header
+    response.headers["Server-Timing"] = listing_result.timings_header
 
     return response
 
@@ -1178,12 +1187,12 @@ class SessionRecordingViewSet(
             "limit": len(session_recording_ids),
         }
         query = RecordingsQuery.model_validate(query_data)
-        recordings, _, _, _ = list_recordings_from_query(query, None, self.team)
+        listing_result = list_recordings_from_query(query, None, self.team)
 
         user_access_control = self.user_access_control
         accessible_recordings = [
             recording
-            for recording in recordings
+            for recording in listing_result.recordings
             if user_access_control.check_access_level_for_object(recording, required_level="editor")
         ]
 
@@ -2062,7 +2071,7 @@ def list_recordings_from_query(
     team: Team,
     allow_event_property_expansion: bool = False,
     bypass_date_window_for_session_ids: bool = False,
-) -> tuple[list[SessionRecording], bool, str, str | None]:
+) -> RecordingsListingResult:
     """
     As we can store recordings in S3 or in Clickhouse we need to do a few things here
 
@@ -2224,7 +2233,12 @@ def list_recordings_from_query(
             if matched_person:
                 recording.person = matched_person
 
-    return recordings, more_recordings_available, timer.to_header_string(hogql_timings), next_cursor
+    return RecordingsListingResult(
+        recordings=recordings,
+        more_recordings_available=more_recordings_available,
+        timings_header=timer.to_header_string(hogql_timings),
+        next_cursor=next_cursor,
+    )
 
 
 def _other_users_viewed(recording_ids_in_list: list[str], user: User | None, team: Team) -> dict[str, list[str]]:

--- a/posthog/session_recordings/synthetic_playlists.py
+++ b/posthog/session_recordings/synthetic_playlists.py
@@ -259,12 +259,14 @@ class ExpiringPlaylistSource(SyntheticPlaylistSource):
             return cached_data
 
         query = RecordingsQuery(limit=ExpiringPlaylistSource.SCAN_LIMIT, order=RecordingOrder.RECORDING_TTL)
-        recordings, _, _, _ = list_recordings_from_query(query, user, team)
+        listing_result = list_recordings_from_query(query, user, team)
 
         now = datetime.now(UTC)
         window_end = now + timedelta(days=ExpiringPlaylistSource.EXPIRY_WINDOW_DAYS)
 
-        session_ids = [r.session_id for r in recordings if r.expiry_time and now <= r.expiry_time <= window_end]
+        session_ids = [
+            r.session_id for r in listing_result.recordings if r.expiry_time and now <= r.expiry_time <= window_end
+        ]
         cache.set(cache_key, session_ids, ExpiringPlaylistSource.CACHE_TTL)
         return session_ids
 

--- a/posthog/session_recordings/test/test_session_recording_access_control.py
+++ b/posthog/session_recordings/test/test_session_recording_access_control.py
@@ -9,6 +9,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user import User
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.session_recordings.models.session_recording import SessionRecording
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -114,7 +115,12 @@ class TestSessionRecordingAccessControl(APIBaseTest):
         )
 
         # Mock the ClickHouse query to return our test recordings
-        mock_list_recordings.return_value = ([self.recording, recording2], False, "", None)
+        mock_list_recordings.return_value = RecordingsListingResult(
+            recordings=[self.recording, recording2],
+            more_recordings_available=False,
+            timings_header="",
+            next_cursor=None,
+        )
 
         self._create_access_control(self.editor_user, access_level="editor")
 

--- a/posthog/session_recordings/test/test_session_recording_access_control.py
+++ b/posthog/session_recordings/test/test_session_recording_access_control.py
@@ -11,6 +11,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user import User
 from posthog.rbac.user_access_control import UserAccessControl
 from posthog.session_recordings.models.session_recording import SessionRecording
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -116,7 +117,12 @@ class TestSessionRecordingAccessControl(APIBaseTest):
         )
 
         # Mock the ClickHouse query to return our test recordings
-        mock_list_recordings.return_value = ([self.recording, recording2], False, "", None)
+        mock_list_recordings.return_value = RecordingsListingResult(
+            recordings=[self.recording, recording2],
+            more_recordings_available=False,
+            timings_header="",
+            next_cursor=None,
+        )
 
         self._create_access_control(self.editor_user, access_level="editor")
 

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -36,6 +36,7 @@ from posthog.models.team import Team
 from posthog.models.utils import uuid7
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 from posthog.test.persons import create_person
 
 
@@ -305,7 +306,9 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
     @patch("posthoganalytics.capture")
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_console_log_filters_are_correctly_passed_to_listing(self, mock_query_lister, mock_capture):
-        mock_query_lister.return_value = ([], False)
+        mock_query_lister.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         params_string = urlencode(
             {

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -35,6 +35,7 @@ from posthog.models.team import Team
 from posthog.models.utils import uuid7
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 from posthog.test.persons import create_person
 
 
@@ -304,7 +305,9 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
     @patch("posthoganalytics.capture")
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_console_log_filters_are_correctly_passed_to_listing(self, mock_query_lister, mock_capture):
-        mock_query_lister.return_value = ([], False)
+        mock_query_lister.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         params_string = urlencode(
             {

--- a/posthog/session_recordings/test/test_synthetic_playlists.py
+++ b/posthog/session_recordings/test/test_synthetic_playlists.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any, cast
 
 from posthog.test.base import APIBaseTest, _create_event, flush_persons_and_events
 from unittest.mock import patch
@@ -16,6 +17,7 @@ from posthog.models.event.sql import EVENTS_JSON_DATA_TABLE
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.models.utils import uuid7
 from posthog.session_recordings.models.session_recording_event import SessionRecordingViewed
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 from posthog.session_recordings.synthetic_playlists import ExpiringPlaylistSource, FrustrationSignalsPlaylistSource
 
 from products.exports.backend.models.exported_asset import ExportedAsset
@@ -77,7 +79,9 @@ class TestSyntheticPlaylists(APIBaseTest):
 
         with patch(
             "posthog.session_recordings.synthetic_playlists.list_recordings_from_query",
-            return_value=(recordings, False, None, None),
+            return_value=RecordingsListingResult(
+                recordings=cast(Any, recordings), more_recordings_available=False, timings_header="", next_cursor=None
+            ),
         ) as mock_query:
             count = source.count_session_ids(self.team, self.user)
             session_ids = source.get_session_ids(self.team, self.user)

--- a/posthog/temporal/session_replay/count_playlist_items/counting_logic.py
+++ b/posthog/temporal/session_replay/count_playlist_items/counting_logic.py
@@ -215,13 +215,11 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
             if should_query_incrementally:
                 query.date_from = existing_value["refreshed_at"]
 
-            (recordings, more_recordings_available, _, _) = list_recordings_from_query(
-                query, user=None, team=playlist.team
-            )
+            listing_result = list_recordings_from_query(query, user=None, team=playlist.team)
 
             counted_at_date = timezone.now()
             new_sessions: dict[str, str | None] = {
-                r.session_id: r.expiry_time.isoformat() if r.expiry_time else None for r in recordings
+                r.session_id: r.expiry_time.isoformat() if r.expiry_time else None for r in listing_result.recordings
             }
 
             if should_query_incrementally:
@@ -237,7 +235,7 @@ def count_recordings_that_match_playlist_filters(playlist_id: int) -> None:
                     "version": 2,
                     "session_ids": list(new_sessions.keys()),
                     "sessions_with_expiry": new_sessions,
-                    "has_more": more_recordings_available,
+                    "has_more": listing_result.more_recordings_available,
                     "previous_ids": existing_value.get("session_ids", None),
                     "refreshed_at": counted_at_date.isoformat(),
                     "error_count": 0,

--- a/posthog/temporal/session_replay/session_summary/activities/event_based/fetch_session_data.py
+++ b/posthog/temporal/session_replay/session_summary/activities/event_based/fetch_session_data.py
@@ -22,14 +22,14 @@ from ee.hogai.session_summaries.session.summarize_session import (
 @temporalio.activity.defn
 async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> bool:
     """Returns False if the session has no events (static); True otherwise."""
-    redis_client, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_DB_DATA,
         state_id=inputs.session_id,
     )
     success = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_input_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.input_key,
         label=StateActivitiesEnum.SESSION_DB_DATA,
         target_class=SingleSessionSummaryLlmInputs,
     )
@@ -58,8 +58,8 @@ async def fetch_session_data_activity(inputs: SingleSessionSummaryInputs) -> boo
     )
     input_data_str = json.dumps(dataclasses.asdict(input_data))
     await store_data_in_redis(
-        redis_client=redis_client,
-        redis_key=redis_input_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.input_key,
         data=input_data_str,
         label=StateActivitiesEnum.SESSION_DB_DATA,
     )

--- a/posthog/temporal/session_replay/session_summary/activities/event_based/get_llm_single_session_summary.py
+++ b/posthog/temporal/session_replay/session_summary/activities/event_based/get_llm_single_session_summary.py
@@ -68,14 +68,14 @@ async def get_llm_single_session_summary_activity(
     )
     if summary_exists.get(inputs.session_id):
         return None
-    redis_client, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_DB_DATA,
         state_id=inputs.session_id,
     )
     llm_input_raw = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_input_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.input_key,
         label=StateActivitiesEnum.SESSION_DB_DATA,
         target_class=SingleSessionSummaryLlmInputs,
     )

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a3_slice_session_data_for_segments.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a3_slice_session_data_for_segments.py
@@ -30,14 +30,14 @@ async def slice_session_data_for_segments_activity(
     inputs: VideoSummarySingleSessionInputs,
     segment_specs: list[VideoSegmentSpec],
 ) -> None:
-    redis_client, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_DB_DATA,
         state_id=inputs.session_id,
     )
     llm_input_raw = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_input_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.input_key,
         label=StateActivitiesEnum.SESSION_DB_DATA,
         target_class=SingleSessionSummaryLlmInputs,
     )
@@ -115,7 +115,7 @@ async def slice_session_data_for_segments_activity(
             state_id=segment_state_id,
         )
         await store_data_in_redis(
-            redis_client=redis_client,
+            redis_client=redis_state.client,
             redis_key=segment_key,
             data=json.dumps(context.model_dump()),
             label=StateActivitiesEnum.SEGMENT_LLM_CONTEXT,

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a4_analyze_video_segment.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a4_analyze_video_segment.py
@@ -49,7 +49,7 @@ async def analyze_video_segment_activity(
             )
             # No need to retry, if the input is missing critical data, so it failed way before
             raise ApplicationError(msg, non_retryable=True)
-        redis_client, _, _ = get_redis_state_client(key_base=inputs.redis_key_base)
+        redis_state = get_redis_state_client(key_base=inputs.redis_key_base)
         segment_state_id = f"{inputs.session_id}:{segment.segment_index}"
         segment_key = generate_state_key(
             key_base=inputs.redis_key_base,
@@ -57,7 +57,7 @@ async def analyze_video_segment_activity(
             state_id=segment_state_id,
         )
         segment_context_raw = await get_data_class_from_redis(
-            redis_client=redis_client,
+            redis_client=redis_state.client,
             redis_key=segment_key,
             label=StateActivitiesEnum.SEGMENT_LLM_CONTEXT,
             target_class=SegmentLlmContext,

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a7c_store_video_session_summary.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a7c_store_video_session_summary.py
@@ -69,14 +69,14 @@ async def store_video_session_summary_activity(
             return
 
         # Retrieve cached event data from Redis (populated by fetch_session_data_activity)
-        redis_client, redis_input_key, _ = get_redis_state_client(
+        redis_state = get_redis_state_client(
             key_base=inputs.redis_key_base,
             input_label=StateActivitiesEnum.SESSION_DB_DATA,
             state_id=inputs.session_id,
         )
         llm_input = await get_data_class_from_redis(
-            redis_client=redis_client,
-            redis_key=redis_input_key,
+            redis_client=redis_state.client,
+            redis_key=redis_state.input_key,
             label=StateActivitiesEnum.SESSION_DB_DATA,
             target_class=SingleSessionSummaryLlmInputs,
         )

--- a/posthog/temporal/session_replay/session_summary/activities/video_based/a7d_tag_and_highlight_session.py
+++ b/posthog/temporal/session_replay/session_summary/activities/video_based/a7d_tag_and_highlight_session.py
@@ -32,14 +32,14 @@ async def tag_and_highlight_session_activity(
     """Write session tags and highlight flag to ClickHouse via Kafka."""
     try:
         # Read session metadata from the same Redis cache used by A6
-        redis_client, redis_input_key, _ = get_redis_state_client(
+        redis_state = get_redis_state_client(
             key_base=inputs.redis_key_base,
             input_label=StateActivitiesEnum.SESSION_DB_DATA,
             state_id=inputs.session_id,
         )
         llm_input = await get_data_class_from_redis(
-            redis_client=redis_client,
-            redis_key=redis_input_key,
+            redis_client=redis_state.client,
+            redis_key=redis_state.input_key,
             label=StateActivitiesEnum.SESSION_DB_DATA,
             target_class=SingleSessionSummaryLlmInputs,
         )

--- a/posthog/temporal/session_replay/session_summary/state.py
+++ b/posthog/temporal/session_replay/session_summary/state.py
@@ -1,6 +1,7 @@
 import gzip
 import json
 import hashlib
+from dataclasses import dataclass
 from enum import Enum
 from typing import TypeVar
 
@@ -32,12 +33,19 @@ def generate_state_id_from_session_ids(session_ids: list[str]) -> str:
     return hashlib.sha256(",".join(session_ids).encode()).hexdigest()[:16]
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class RedisStateContext:
+    client: aioredis.Redis
+    input_key: str | None
+    output_key: str | None
+
+
 def get_redis_state_client(
     key_base: str | None = None,
     input_label: StateActivitiesEnum | None = None,
     output_label: StateActivitiesEnum | None = None,
     state_id: str | None = None,
-) -> tuple[aioredis.Redis, str | None, str | None]:
+) -> RedisStateContext:
     """Return a Redis client and generated state keys.
 
     Parameters
@@ -55,7 +63,7 @@ def get_redis_state_client(
 
     Returns
     -------
-    tuple[Redis, str | None, str | None]
+    RedisStateContext
         The Redis client instance together with the generated input and output
         keys. `None` is returned for a key when its label was not supplied.
     """
@@ -65,7 +73,7 @@ def get_redis_state_client(
         redis_input_key = generate_state_key(key_base=key_base, label=input_label, state_id=state_id)
     if key_base and output_label:
         redis_output_key = generate_state_key(key_base=key_base, label=output_label, state_id=state_id)
-    return redis_client, redis_input_key, redis_output_key
+    return RedisStateContext(client=redis_client, input_key=redis_input_key, output_key=redis_output_key)
 
 
 def generate_state_key(key_base: str, label: StateActivitiesEnum, state_id: str | None = None) -> str:

--- a/posthog/temporal/session_replay/session_summary/workflow.py
+++ b/posthog/temporal/session_replay/session_summary/workflow.py
@@ -1,6 +1,7 @@
 import json
 import asyncio
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, cast
 
@@ -177,9 +178,17 @@ class SummarizeSingleSessionWorkflow(PostHogWorkflow):
         return None
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ValidatedPeriod:
+    session_start_s: float
+    session_end_s: float
+    recording_start_s: float
+    recording_end_s: float
+
+
 def _validate_period(
     period: ReplayInactivityPeriod, video_duration: float, index: int, inactivity_periods_count: int
-) -> tuple[float, float, float, float] | None:
+) -> ValidatedPeriod | None:
     # Filter to only active periods (skip gaps and idle time)
     if not period.active:
         return None
@@ -239,7 +248,12 @@ def _validate_period(
             f"session_duration={session_period_end - session_period_start}",
             signals_type="session-summaries",
         )
-    return session_period_start, session_period_end, recording_period_start, recording_period_end
+    return ValidatedPeriod(
+        session_start_s=session_period_start,
+        session_end_s=session_period_end,
+        recording_start_s=recording_period_start,
+        recording_end_s=recording_period_end,
+    )
 
 
 def calculate_video_segment_specs(
@@ -277,38 +291,39 @@ def calculate_video_segment_specs(
         if validation is None:
             # Skip the periods that are too short or failed validation
             continue
-        session_period_start, session_period_end, recording_period_start, recording_period_end = validation
         # Start either after the rendering delay, or at the previous chunk end
-        if recording_period_end - recording_period_start <= chunk_duration:
+        if validation.recording_end_s - validation.recording_start_s <= chunk_duration:
             # If the period smaller than the expected chunk duration - process as is
             segments.append(
                 VideoSegmentSpec(
                     segment_index=segment_index,
-                    start_time=session_period_start,
-                    end_time=session_period_end,
-                    recording_start_time=recording_period_start,
-                    recording_end_time=recording_period_end,
+                    start_time=validation.session_start_s,
+                    end_time=validation.session_end_s,
+                    recording_start_time=validation.recording_start_s,
+                    recording_end_time=validation.recording_end_s,
                 )
             )
             segment_index += 1
             continue
         # If the period is larger than chunk_duration, split it into chunks small enough for efficient LLM processing
-        current_recording_period_start = recording_period_start
+        current_recording_period_start = validation.recording_start_s
         # Iterate while not reaching the end of the period
-        while current_recording_period_start < recording_period_end:
+        while current_recording_period_start < validation.recording_end_s:
             current_recording_period_end = current_recording_period_start + chunk_duration
-            remaining_after_chunk = recording_period_end - current_recording_period_end
+            remaining_after_chunk = validation.recording_end_s - current_recording_period_end
             # If the remaining portion after this chunk would be smaller than a new chunk, extend the current chunk
             if remaining_after_chunk > 0 and remaining_after_chunk < chunk_duration:
-                current_recording_period_end = recording_period_end
+                current_recording_period_end = validation.recording_end_s
             # Continue creating new chunks if there are plenty of activity left in the period
             else:
-                current_recording_period_end = min(current_recording_period_end, recording_period_end)
+                current_recording_period_end = min(current_recording_period_end, validation.recording_end_s)
             # Calculate session timestamps based on the recording timestamps
-            current_session_period_start = session_period_start + (
-                current_recording_period_start - recording_period_start
+            current_session_period_start = validation.session_start_s + (
+                current_recording_period_start - validation.recording_start_s
             )
-            current_session_period_end = session_period_start + (current_recording_period_end - recording_period_start)
+            current_session_period_end = validation.session_start_s + (
+                current_recording_period_end - validation.recording_start_s
+            )
             # Define a new segment to process
             segments.append(
                 VideoSegmentSpec(
@@ -657,6 +672,15 @@ async def _workflow_is_running(client: Any, workflow_id: str) -> bool:
     return desc.status == WorkflowExecutionStatus.RUNNING
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PreparedSingleSessionExecution:
+    redis_client: Redis
+    redis_input_key: str
+    redis_output_key: str
+    session_input: SingleSessionSummaryInputs
+    workflow_id: str
+
+
 def _prepare_execution(
     session_id: str,
     user: User,
@@ -668,7 +692,7 @@ def _prepare_execution(
     local_reads_prod: bool = False,
     video_based: bool = False,
     trigger_session_id: str | None = None,
-) -> tuple[Redis, str, str, SingleSessionSummaryInputs, str]:
+) -> PreparedSingleSessionExecution:
     # Use shared identifier to be able to construct all the ids to check/debug
     # Using session id instead of random UUID to be able to check the data in Redis
     shared_id = session_id
@@ -704,7 +728,13 @@ def _prepare_execution(
         trigger_session_id=trigger_session_id,
     )
     workflow_id = SummarizeSingleSessionWorkflow.workflow_id_for(team.id, session_id)
-    return redis_client, redis_input_key, redis_output_key, session_input, workflow_id
+    return PreparedSingleSessionExecution(
+        redis_client=redis_client,
+        redis_input_key=redis_input_key,
+        redis_output_key=redis_output_key,
+        session_input=session_input,
+        workflow_id=workflow_id,
+    )
 
 
 async def execute_summarize_session(
@@ -733,7 +763,7 @@ async def execute_summarize_session(
         return existing_summary.summary
     if model_to_use is None:
         model_to_use = SESSION_SUMMARIES_MODEL if not video_based else DEFAULT_VIDEO_UNDERSTANDING_MODEL
-    _, _, _, session_input, workflow_id = _prepare_execution(
+    prepared = _prepare_execution(
         session_id=session_id,
         user=user,
         team=team,
@@ -747,11 +777,11 @@ async def execute_summarize_session(
     )
     # Wait for the workflow to complete
     try:
-        await _execute_single_session_summary_workflow(inputs=session_input, workflow_id=workflow_id)
+        await _execute_single_session_summary_workflow(inputs=prepared.session_input, workflow_id=prepared.workflow_id)
     except WorkflowAlreadyStartedError:
         # Workflow is already running, wait for it to complete
         client = await async_connect()
-        handle = client.get_workflow_handle(workflow_id)
+        handle = client.get_workflow_handle(prepared.workflow_id)
         await handle.result()
     # Get the ready summary from the DB
     summary_row = await database_sync_to_async(SingleSessionSummary.objects.get_summary, thread_sensitive=False)(
@@ -891,7 +921,7 @@ async def execute_summarize_session_video_stream(
             )
             return
 
-    _, _, _, session_input, workflow_id = _prepare_execution(
+    prepared = _prepare_execution(
         session_id=session_id,
         user=user,
         team=team,
@@ -909,7 +939,7 @@ async def execute_summarize_session_video_stream(
     # is about to attach via USE_EXISTING to someone else's in-flight run, skip
     # the cap so we don't 402 a teammate reading already-paid-for work.
     # `force_restart` always preempts via TERMINATE_EXISTING — counts as fresh.
-    will_start_fresh_run = force_restart or not await _workflow_is_running(client, workflow_id)
+    will_start_fresh_run = force_restart or not await _workflow_is_running(client, prepared.workflow_id)
 
     quota_reserved = False
     if will_start_fresh_run:
@@ -951,12 +981,12 @@ async def execute_summarize_session_video_stream(
 
     try:
         handle = await _start_video_summary_workflow(
-            inputs=session_input, workflow_id=workflow_id, force_restart=force_restart
+            inputs=prepared.session_input, workflow_id=prepared.workflow_id, force_restart=force_restart
         )
     except WorkflowAlreadyStartedError:
         # Race: someone else started the same workflow between our describe and
         # start call. Attach to theirs and refund the slot we reserved.
-        handle = client.get_workflow_handle(workflow_id)
+        handle = client.get_workflow_handle(prepared.workflow_id)
         if quota_reserved:
             await database_sync_to_async(refund, thread_sensitive=False)(team.id, 1)
             quota_reserved = False
@@ -968,7 +998,7 @@ async def execute_summarize_session_video_stream(
 
     logger.info(
         "video summary polling loop starting",
-        workflow_id=workflow_id,
+        workflow_id=prepared.workflow_id,
         session_id=session_id,
         signals_type="session-summaries",
     )
@@ -1019,7 +1049,7 @@ async def execute_summarize_session_video_stream(
 
             logger.info(
                 "yielding session-summary-progress event",
-                workflow_id=workflow_id,
+                workflow_id=prepared.workflow_id,
                 phase=progress_payload.get("phase"),
                 step=progress_payload.get("step"),
                 signals_type="session-summaries",

--- a/posthog/temporal/session_replay/session_summary_group/activities/group_patterns.py
+++ b/posthog/temporal/session_replay/session_summary_group/activities/group_patterns.py
@@ -192,25 +192,25 @@ async def split_session_summaries_into_chunks_for_patterns_extraction_activity(
 async def extract_session_group_patterns_activity(inputs: SessionGroupSummaryOfSummariesInputs) -> str:
     """Extract patterns for a group of sessions and store them in Redis."""
     session_ids = _get_session_ids_from_inputs(inputs)
-    redis_client, _, redis_output_key = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         output_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
-    if redis_output_key is None:
+    if redis_state.output_key is None:
         msg = f"Failed to generate Redis output key for extracted patterns for sessions: {','.join(session_ids)}"
         temporalio.activity.logger.error(msg, extra={"signals_type": "session-summaries"})
         raise ValueError(msg)
     # Check if patterns extracted are already in Redis. If it is and matched the target class - it's within TTL, so no need to re-fetch them from LLM
     success = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.output_key,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         target_class=RawSessionGroupSummaryPatternsList,
     )
     if success is not None:
         # Cached successfully
-        return redis_output_key
+        return redis_state.output_key
     # Get ready session summaries from DB
     # Disable thread-sensitive as the call is heavy (N summaries through pagination)
     ready_summaries = await database_sync_to_async(get_ready_summaries_from_db, thread_sensitive=False)(
@@ -239,12 +239,12 @@ async def extract_session_group_patterns_activity(inputs: SessionGroupSummaryOfS
     patterns_extraction_str = patterns_extraction.model_dump_json(exclude_none=True)
     # Store the extracted patterns in Redis
     await store_data_in_redis(
-        redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.output_key,
         data=patterns_extraction_str,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
     )
-    return redis_output_key
+    return redis_state.output_key
 
 
 async def _generate_patterns_assignments_per_chunk(
@@ -363,7 +363,7 @@ async def assign_events_to_patterns_activity(
     """Summarize a group of sessions in one call. Returns session_group_summary_id."""
     session_ids = _get_session_ids_from_inputs(inputs)
     # Not checking for existing summary in the DB, as the input of `~300 exactly the same ids + context` seems highly unlikely
-    redis_client, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         output_label=StateActivitiesEnum.SESSION_GROUP_PATTERNS_ASSIGNMENTS,
@@ -371,8 +371,8 @@ async def assign_events_to_patterns_activity(
     )
     # Get extracted patterns from Redis to be able to assign events to them
     patterns_extraction_raw = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_input_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.input_key,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         target_class=RawSessionGroupSummaryPatternsList,
     )
@@ -503,7 +503,7 @@ async def _store_session_group_summary(
 async def combine_patterns_from_chunks_activity(inputs: SessionGroupSummaryPatternsExtractionChunksInputs) -> None:
     """Combine patterns from multiple chunks using LLM and store in Redis."""
     redis_client = get_async_client()
-    _, _, redis_output_key = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         output_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(inputs.session_ids),
@@ -511,7 +511,7 @@ async def combine_patterns_from_chunks_activity(inputs: SessionGroupSummaryPatte
     # Check if combined patterns are already in Redis (for all the sessions at once)
     success = await get_data_class_from_redis(
         redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_key=redis_state.output_key,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         target_class=RawSessionGroupSummaryPatternsList,
     )
@@ -576,7 +576,7 @@ async def combine_patterns_from_chunks_activity(inputs: SessionGroupSummaryPatte
     combined_patterns_str = combined_patterns.model_dump_json(exclude_none=True)
     await store_data_in_redis(
         redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_key=redis_state.output_key,
         data=combined_patterns_str,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
     )

--- a/posthog/temporal/session_replay/session_summary_group/activities/group_patterns.py
+++ b/posthog/temporal/session_replay/session_summary_group/activities/group_patterns.py
@@ -191,25 +191,25 @@ async def split_session_summaries_into_chunks_for_patterns_extraction_activity(
 async def extract_session_group_patterns_activity(inputs: SessionGroupSummaryOfSummariesInputs) -> str:
     """Extract patterns for a group of sessions and store them in Redis."""
     session_ids = _get_session_ids_from_inputs(inputs)
-    redis_client, _, redis_output_key = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         output_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
-    if redis_output_key is None:
+    if redis_state.output_key is None:
         msg = f"Failed to generate Redis output key for extracted patterns for sessions: {','.join(session_ids)}"
         temporalio.activity.logger.error(msg, extra={"signals_type": "session-summaries"})
         raise ValueError(msg)
     # Check if patterns extracted are already in Redis. If it is and matched the target class - it's within TTL, so no need to re-fetch them from LLM
     success = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.output_key,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         target_class=RawSessionGroupSummaryPatternsList,
     )
     if success is not None:
         # Cached successfully
-        return redis_output_key
+        return redis_state.output_key
     # Get ready session summaries from DB
     # Disable thread-sensitive as the call is heavy (N summaries through pagination)
     ready_summaries = await database_sync_to_async(get_ready_summaries_from_db, thread_sensitive=False)(
@@ -238,12 +238,12 @@ async def extract_session_group_patterns_activity(inputs: SessionGroupSummaryOfS
     patterns_extraction_str = patterns_extraction.model_dump_json(exclude_none=True)
     # Store the extracted patterns in Redis
     await store_data_in_redis(
-        redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.output_key,
         data=patterns_extraction_str,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
     )
-    return redis_output_key
+    return redis_state.output_key
 
 
 async def _generate_patterns_assignments_per_chunk(
@@ -362,7 +362,7 @@ async def assign_events_to_patterns_activity(
     """Summarize a group of sessions in one call. Returns session_group_summary_id."""
     session_ids = _get_session_ids_from_inputs(inputs)
     # Not checking for existing summary in the DB, as the input of `~300 exactly the same ids + context` seems highly unlikely
-    redis_client, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         output_label=StateActivitiesEnum.SESSION_GROUP_PATTERNS_ASSIGNMENTS,
@@ -397,8 +397,8 @@ async def assign_events_to_patterns_activity(
     ]
     # Get extracted patterns from Redis to be able to assign events to them
     patterns_extraction_raw = await get_data_class_from_redis(
-        redis_client=redis_client,
-        redis_key=redis_input_key,
+        redis_client=redis_state.client,
+        redis_key=redis_state.input_key,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         target_class=RawSessionGroupSummaryPatternsList,
     )
@@ -478,7 +478,7 @@ async def assign_events_to_patterns_activity(
 async def combine_patterns_from_chunks_activity(inputs: SessionGroupSummaryPatternsExtractionChunksInputs) -> None:
     """Combine patterns from multiple chunks using LLM and store in Redis."""
     redis_client = get_async_client()
-    _, _, redis_output_key = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=inputs.redis_key_base,
         output_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(inputs.session_ids),
@@ -486,7 +486,7 @@ async def combine_patterns_from_chunks_activity(inputs: SessionGroupSummaryPatte
     # Check if combined patterns are already in Redis (for all the sessions at once)
     success = await get_data_class_from_redis(
         redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_key=redis_state.output_key,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         target_class=RawSessionGroupSummaryPatternsList,
     )
@@ -551,7 +551,7 @@ async def combine_patterns_from_chunks_activity(inputs: SessionGroupSummaryPatte
     combined_patterns_str = combined_patterns.model_dump_json(exclude_none=True)
     await store_data_in_redis(
         redis_client=redis_client,
-        redis_key=redis_output_key,
+        redis_key=redis_state.output_key,
         data=combined_patterns_str,
         label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
     )

--- a/posthog/temporal/tests/session_replay/count_playlist_items/test_counting_logic.py
+++ b/posthog/temporal/tests/session_replay/count_playlist_items/test_counting_logic.py
@@ -22,6 +22,7 @@ from posthog.redis import get_client
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.models.session_recording_playlist import SessionRecordingPlaylist
 from posthog.session_recordings.models.session_recording_playlist_item import SessionRecordingPlaylistItem
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 from posthog.session_recordings.session_recording_playlist_api import PLAYLIST_COUNT_REDIS_PREFIX
 from posthog.temporal.session_replay.count_playlist_items.counting_logic import (
     DEFAULT_RECORDING_FILTERS,
@@ -46,7 +47,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     def test_count_recordings_that_match_no_recordings(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        mock_list_recordings_from_query.return_value = ([], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
@@ -72,16 +75,16 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     def test_count_recordings_that_match_recordings(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        mock_list_recordings_from_query.return_value = (
-            [
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[
                 SessionRecording.objects.create(
                     team=self.team,
                     session_id="123",
                 )
             ],
-            True,
-            None,
-            None,
+            more_recordings_available=True,
+            timings_header="",
+            next_cursor=None,
         )
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
@@ -107,16 +110,16 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     def test_count_recordings_that_match_recordings_records_previous_ids(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        mock_list_recordings_from_query.return_value = (
-            [
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[
                 SessionRecording.objects.create(
                     team=self.team,
                     session_id="123",
                 )
             ],
-            True,
-            None,
-            None,
+            more_recordings_available=True,
+            timings_header="",
+            next_cursor=None,
         )
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
@@ -145,7 +148,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     def test_count_recordings_that_match_recordings_skips_cooldown(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        mock_list_recordings_from_query.return_value = ([], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
@@ -183,7 +188,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
             name="test",
             filters=legacy_filters,
         )
-        mock_list_recordings_from_query.return_value = ([], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         count_recordings_that_match_playlist_filters(playlist.id)
         mock_capture_exception.assert_not_called()
@@ -312,7 +319,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
             },
         )
 
-        mock_list_recordings_from_query.return_value = ([], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
         count_recordings_that_match_playlist_filters(playlist.id)
         mock_capture_exception.assert_not_called()
 
@@ -354,7 +363,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     def test_count_recordings_with_too_many_errors_skips(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        mock_list_recordings_from_query.return_value = ([], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
@@ -376,7 +387,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
     def test_count_recordings_with_too_recent_error_skips(
         self, mock_list_recordings_from_query: MagicMock, mock_capture_exception: MagicMock
     ):
-        mock_list_recordings_from_query.return_value = ([], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         playlist = SessionRecordingPlaylist.objects.create(
             team=self.team,
@@ -424,16 +437,16 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
             ),
         )
 
-        mock_list_recordings_from_query.return_value = (
-            [
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[
                 SessionRecording.objects.create(
                     team=self.team,
                     session_id="session3",
                 )
             ],
-            False,
-            None,
-            None,
+            more_recordings_available=False,
+            timings_header="",
+            next_cursor=None,
         )
 
         count_recordings_that_match_playlist_filters(playlist.id)
@@ -478,7 +491,9 @@ class TestRecordingsThatMatchPlaylistFilters(APIBaseTest, QueryMatchingTest):
 
         new_recording = SessionRecording(session_id="session3", team=self.team)
         new_recording.expiry_time = timezone.now() + timedelta(days=10)
-        mock_list_recordings_from_query.return_value = ([new_recording], False, None, None)
+        mock_list_recordings_from_query.return_value = RecordingsListingResult(
+            recordings=[new_recording], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         count_recordings_that_match_playlist_filters(playlist.id)
 

--- a/posthog/temporal/tests/session_replay/session_summary/test_event_capture.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_event_capture.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 from unittest.mock import MagicMock
 
@@ -8,6 +10,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.session_replay.session_summary.activities.video_based.a7c_store_video_session_summary import (
     store_video_session_summary_activity,
 )
+from posthog.temporal.session_replay.session_summary.state import RedisStateContext
 from posthog.temporal.session_replay.session_summary.types.video import (
     ConsolidatedVideoAnalysis,
     ConsolidatedVideoSegment,
@@ -113,7 +116,7 @@ async def test_store_video_session_summary_activity_emits_summary_ready_event(
 
     mocker.patch(
         "posthog.temporal.session_replay.session_summary.activities.video_based.a7c_store_video_session_summary.get_redis_state_client",
-        return_value=(None, "input-key", None),
+        return_value=RedisStateContext(client=cast(Any, None), input_key="input-key", output_key=None),
     )
     mocker.patch(
         "posthog.temporal.session_replay.session_summary.activities.video_based.a7c_store_video_session_summary.get_data_class_from_redis",

--- a/posthog/temporal/tests/session_replay/session_summary/test_slice_session_data.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_slice_session_data.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, cast
 
 import pytest
 from unittest.mock import AsyncMock, patch
@@ -8,7 +9,11 @@ from temporalio.testing import ActivityEnvironment
 from posthog.temporal.session_replay.session_summary.activities.video_based.a3_slice_session_data_for_segments import (
     slice_session_data_for_segments_activity,
 )
-from posthog.temporal.session_replay.session_summary.state import StateActivitiesEnum, generate_state_key
+from posthog.temporal.session_replay.session_summary.state import (
+    RedisStateContext,
+    StateActivitiesEnum,
+    generate_state_key,
+)
 from posthog.temporal.session_replay.session_summary.types.video import (
     SegmentLlmContext,
     VideoSegmentSpec,
@@ -93,7 +98,9 @@ async def test_slice_writes_one_redis_key_per_segment_with_filtered_events():
         patch(
             "posthog.temporal.session_replay.session_summary.activities.video_based."
             "a3_slice_session_data_for_segments.get_redis_state_client",
-            return_value=(AsyncMock(), "test-base:session_db_data:sess-1", None),
+            return_value=RedisStateContext(
+                client=cast(Any, AsyncMock()), input_key="test-base:session_db_data:sess-1", output_key=None
+            ),
         ),
         patch(
             "posthog.temporal.session_replay.session_summary.activities.video_based."
@@ -150,7 +157,9 @@ async def test_slice_reduces_url_and_window_maps_to_keys_present_in_slice():
         patch(
             "posthog.temporal.session_replay.session_summary.activities.video_based."
             "a3_slice_session_data_for_segments.get_redis_state_client",
-            return_value=(AsyncMock(), "test-base:session_db_data:sess-1", None),
+            return_value=RedisStateContext(
+                client=cast(Any, AsyncMock()), input_key="test-base:session_db_data:sess-1", output_key=None
+            ),
         ),
         patch(
             "posthog.temporal.session_replay.session_summary.activities.video_based."

--- a/posthog/temporal/tests/session_replay/session_summary/test_summarize_session.py
+++ b/posthog/temporal/tests/session_replay/session_summary/test_summarize_session.py
@@ -26,6 +26,7 @@ from posthog.temporal.session_replay.session_summary.state import (
 from posthog.temporal.session_replay.session_summary.types.inputs import SingleSessionProgress
 from posthog.temporal.session_replay.session_summary.workflow import (
     SUMMARY_RESULT_NO_EVENTS,
+    PreparedSingleSessionExecution,
     _execute_single_session_summary_workflow,
     _set_phase,
     _start_video_summary_workflow,
@@ -291,7 +292,13 @@ class TestExecuteSummarizeSessionVideoStream:
             patch.object(SingleSessionSummary.objects, "get_summary", get_summary_mock),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -370,7 +377,13 @@ class TestExecuteSummarizeSessionVideoStream:
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -438,7 +451,13 @@ class TestExecuteSummarizeSessionVideoStream:
             patch.object(SingleSessionSummary.objects, "get_summary", MagicMock(return_value=None)),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -481,7 +500,13 @@ class TestExecuteSummarizeSessionVideoStream:
             patch.object(SingleSessionSummary.objects, "get_summary", MagicMock(return_value=None)),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -524,7 +549,13 @@ class TestExecuteSummarizeSessionVideoStream:
             patch.object(SingleSessionSummary.objects, "get_summary", MagicMock(return_value=None)),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -617,7 +648,13 @@ class TestExecuteSummarizeSessionVideoStream:
             patch.object(SingleSessionSummary.objects, "get_summary", MagicMock(side_effect=[None, completed_summary])),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -674,7 +711,13 @@ class TestExecuteSummarizeSessionVideoStream:
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -735,7 +778,13 @@ class TestExecuteSummarizeSessionVideoStream:
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -804,7 +853,13 @@ class TestExecuteSummarizeSessionVideoStream:
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -856,7 +911,13 @@ class TestExecuteSummarizeSessionVideoStream:
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -900,7 +961,13 @@ class TestExecuteSummarizeSessionVideoStream:
             patch.object(SingleSessionSummary.objects, "get_summary", MagicMock(return_value=None)),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",
@@ -1065,7 +1132,13 @@ class TestVideoStreamCapEndToEnd:
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._prepare_execution",
-                return_value=(None, None, None, MagicMock(), "workflow-id"),
+                return_value=PreparedSingleSessionExecution(
+                    redis_client=MagicMock(),
+                    redis_input_key="",
+                    redis_output_key="",
+                    session_input=MagicMock(),
+                    workflow_id="workflow-id",
+                ),
             ),
             patch(
                 "posthog.temporal.session_replay.session_summary.workflow._start_video_summary_workflow",

--- a/posthog/temporal/tests/session_replay/session_summary_group/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/session_summary_group/test_workflow.py
@@ -132,7 +132,7 @@ async def test_get_llm_single_session_summary_activity_standalone(
     compressed_llm_input_data = _compress_redis_data(json.dumps(dataclasses.asdict(llm_input)))
     input_data = mock_single_session_summary_inputs(mock_session_id, ateam.id, auser.id)
     # Generate Redis keys manually
-    _, redis_input_key, redis_output_key = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=input_data.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_DB_DATA,
         output_label=StateActivitiesEnum.SESSION_SUMMARY,
@@ -142,12 +142,12 @@ async def test_get_llm_single_session_summary_activity_standalone(
     spy_get = mocker.spy(redis_test_setup.redis_client, "get")
     spy_setex = mocker.spy(redis_test_setup.redis_client, "setex")
     # Store initial input data
-    assert redis_input_key
-    assert redis_output_key
+    assert redis_state.input_key
+    assert redis_state.output_key
     await redis_test_setup.setup_input_data(
         compressed_llm_input_data,
-        redis_input_key,
-        redis_output_key,
+        redis_state.input_key,
+        redis_state.output_key,
     )
     # Verify summary doesn't exist in DB before the activity
     summary_before = await database_sync_to_async(SingleSessionSummary.objects.get_summary, thread_sensitive=False)(
@@ -636,15 +636,15 @@ async def test_assign_events_to_patterns_filters_non_blocking_exceptions(
             },
         ]
     )
-    _, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=activity_input.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
-    assert redis_input_key is not None
+    assert redis_state.input_key is not None
     await redis_test_setup.setup_input_data(
         _compress_redis_data(patterns_data.model_dump_json()),
-        redis_input_key,
+        redis_state.input_key,
     )
     # Create a mock LLM response for pattern assignment
     patterns_assignment_yaml = """patterns:
@@ -806,15 +806,15 @@ async def test_non_blocking_exceptions_dont_fail_enrichment_ratio(
             },
         ]
     )
-    _, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=activity_input.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
-    assert redis_input_key is not None
+    assert redis_state.input_key is not None
     await redis_test_setup.setup_input_data(
         _compress_redis_data(patterns_data.model_dump_json()),
-        redis_input_key,
+        redis_state.input_key,
     )
     # Mock LLM response that assigns events to patterns
     # Note: With deduplication logic, only ONE event per session per pattern is kept (first occurrence wins)

--- a/posthog/temporal/tests/session_replay/session_summary_group/test_workflow.py
+++ b/posthog/temporal/tests/session_replay/session_summary_group/test_workflow.py
@@ -132,7 +132,7 @@ async def test_get_llm_single_session_summary_activity_standalone(
     compressed_llm_input_data = _compress_redis_data(json.dumps(dataclasses.asdict(llm_input)))
     input_data = mock_single_session_summary_inputs(mock_session_id, ateam.id, auser.id)
     # Generate Redis keys manually
-    _, redis_input_key, redis_output_key = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=input_data.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_DB_DATA,
         output_label=StateActivitiesEnum.SESSION_SUMMARY,
@@ -142,12 +142,12 @@ async def test_get_llm_single_session_summary_activity_standalone(
     spy_get = mocker.spy(redis_test_setup.redis_client, "get")
     spy_setex = mocker.spy(redis_test_setup.redis_client, "setex")
     # Store initial input data
-    assert redis_input_key
-    assert redis_output_key
+    assert redis_state.input_key
+    assert redis_state.output_key
     await redis_test_setup.setup_input_data(
         compressed_llm_input_data,
-        redis_input_key,
-        redis_output_key,
+        redis_state.input_key,
+        redis_state.output_key,
     )
     # Verify summary doesn't exist in DB before the activity
     summary_before = await database_sync_to_async(SingleSessionSummary.objects.get_summary, thread_sensitive=False)(
@@ -604,15 +604,15 @@ async def test_assign_events_to_patterns_filters_non_blocking_exceptions(
             },
         ]
     )
-    _, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=activity_input.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
-    assert redis_input_key is not None
+    assert redis_state.input_key is not None
     await redis_test_setup.setup_input_data(
         _compress_redis_data(patterns_data.model_dump_json()),
-        redis_input_key,
+        redis_state.input_key,
     )
     # Create a mock LLM response for pattern assignment
     patterns_assignment_yaml = """patterns:
@@ -774,15 +774,15 @@ async def test_non_blocking_exceptions_dont_fail_enrichment_ratio(
             },
         ]
     )
-    _, redis_input_key, _ = get_redis_state_client(
+    redis_state = get_redis_state_client(
         key_base=activity_input.redis_key_base,
         input_label=StateActivitiesEnum.SESSION_GROUP_EXTRACTED_PATTERNS,
         state_id=generate_state_id_from_session_ids(session_ids),
     )
-    assert redis_input_key is not None
+    assert redis_state.input_key is not None
     await redis_test_setup.setup_input_data(
         _compress_redis_data(patterns_data.model_dump_json()),
-        redis_input_key,
+        redis_state.input_key,
     )
     # Mock LLM response that assigns events to patterns
     # Note: With deduplication logic, only ONE event per session per pattern is kept (first occurrence wins)

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -22,6 +22,7 @@ from posthog.scopes import APIScopeObject
 from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.models.session_recording_playlist import SessionRecordingPlaylist
 from posthog.session_recordings.models.session_recording_playlist_item import SessionRecordingPlaylistItem
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 from posthog.slo.types import SloOperation, SloOutcome
 from posthog.test.persons import create_person
 
@@ -57,6 +58,10 @@ from products.dashboards.backend.widgets.logs_list import run_logs_list_widget
 from products.dashboards.backend.widgets.session_replay_list import run_session_replay_list_widget
 from products.error_tracking.backend.facade.query_utils import ERROR_TRACKING_LISTING_VOLUME_RESOLUTION
 from products.logs.backend.models import LogsView
+
+
+def _empty_listing_result() -> RecordingsListingResult:
+    return RecordingsListingResult(recordings=[], more_recordings_available=False, timings_header="", next_cursor=None)
 
 
 class TestWidgetRegistry(APIBaseTest):
@@ -403,7 +408,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_runs_session_replay_widget_for_requested_tile(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
         _, dashboard_json = self.dashboard_api.create_widget_tile(
             dashboard_id, widget_type="session_replay_list", config={"limit": 10}
@@ -710,7 +715,7 @@ class TestDashboardRunWidgets(APIBaseTest):
         _mock_burst_allow: MagicMock,
         _mock_sustained_allow: MagicMock,
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
         _, dashboard_json = self.dashboard_api.create_widget_tile(
             dashboard_id, widget_type="session_replay_list", config={"limit": 10}
@@ -724,13 +729,13 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_tags_queries_in_debug_mode(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
 
-        def assert_tagged(*_args: object, **_kwargs: object) -> tuple[list[object], bool, None, None]:
+        def assert_tagged(*_args: object, **_kwargs: object) -> RecordingsListingResult:
             tags = get_query_tags()
             if tags.product != Product.REPLAY or tags.feature != Feature.QUERY:
                 raise UntaggedQueryError("session replay widget must tag ClickHouse queries")
-            return ([], False, None, None)
+            return _empty_listing_result()
 
         mock_list_recordings.side_effect = assert_tagged
 
@@ -746,7 +751,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_applies_widget_filter_properties(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         filter_id = "filter-1"
 
         run_session_replay_list_widget(
@@ -809,7 +814,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_uses_saved_filter_as_source_of_truth(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         saved_filter = self._saved_filter_for_browser(self.team, "Firefox")
 
         run_session_replay_list_widget(
@@ -840,7 +845,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_falls_back_when_saved_filter_missing(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
 
         run_session_replay_list_widget(
             self.team,
@@ -859,7 +864,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_ignores_saved_filter_from_other_team(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         other_team = Team.objects.create(organization=self.organization, name="other team")
         saved_filter = self._saved_filter_for_browser(other_team, "Firefox")
 
@@ -889,7 +894,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_scopes_to_collection(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         collection = self._collection_with_recordings(self.team, ["session-a", "session-b"])
 
         run_session_replay_list_widget(
@@ -919,7 +924,7 @@ class TestDashboardRunWidgets(APIBaseTest):
     def test_session_replay_widget_collection_skips_legacy_null_recording_items(
         self, mock_list_recordings: MagicMock
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         collection = self._collection_with_recordings(self.team, ["session-a"])
         # Legacy items used the deprecated session_id field and have a null recording FK.
         SessionRecordingPlaylistItem.objects.create(playlist=collection, recording=None, session_id="legacy")
@@ -939,7 +944,7 @@ class TestDashboardRunWidgets(APIBaseTest):
     def test_session_replay_widget_skips_collection_without_object_access(
         self, mock_list_recordings: MagicMock, mock_user_access_control: MagicMock
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         # The user lacks object-level viewer access to the collection.
         mock_user_access_control.return_value.check_access_level_for_object.return_value = False
         collection = self._collection_with_recordings(self.team, ["session-a"])
@@ -962,7 +967,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_filters_within_collection(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         collection = self._collection_with_recordings(self.team, ["session-a", "session-b"])
 
         run_session_replay_list_widget(
@@ -983,7 +988,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_combines_collection_and_saved_filter(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         collection = self._collection_with_recordings(self.team, ["session-a", "session-b"])
         saved_filter = self._saved_filter_for_browser(self.team, "Firefox")
 
@@ -1006,7 +1011,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_ignores_collection_from_other_team(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         other_team = Team.objects.create(organization=self.organization, name="other team")
         collection = self._collection_with_recordings(other_team, ["session-a"])
 
@@ -1029,7 +1034,7 @@ class TestDashboardRunWidgets(APIBaseTest):
 
     @patch("posthog.session_recordings.session_recording_api.list_recordings_from_query")
     def test_session_replay_widget_falls_back_when_collection_missing(self, mock_list_recordings: MagicMock) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
 
         run_session_replay_list_widget(
             self.team,
@@ -1051,7 +1056,7 @@ class TestDashboardRunWidgets(APIBaseTest):
     def test_session_replay_widget_attaches_matching_events_query_for_widget_filters(
         self, mock_list_recordings: MagicMock
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
 
         result = run_session_replay_list_widget(
             self.team,
@@ -1071,7 +1076,7 @@ class TestDashboardRunWidgets(APIBaseTest):
     def test_session_replay_widget_attaches_matching_events_query_for_saved_filter_with_events(
         self, mock_list_recordings: MagicMock
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         saved_filter = SessionRecordingPlaylist.objects.create(
             team=self.team,
             name="Pageview filter",
@@ -1094,7 +1099,7 @@ class TestDashboardRunWidgets(APIBaseTest):
     def test_session_replay_widget_omits_matching_events_query_without_event_filters(
         self, mock_list_recordings: MagicMock
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
 
         result = run_session_replay_list_widget(
             self.team,
@@ -1109,7 +1114,7 @@ class TestDashboardRunWidgets(APIBaseTest):
     def test_session_replay_widget_does_not_persist_legacy_filter_conversion(
         self, mock_list_recordings: MagicMock
     ) -> None:
-        mock_list_recordings.return_value = ([], False, None, None)
+        mock_list_recordings.return_value = _empty_listing_result()
         # A legacy-format playlist (no filter_group) — rendering must not write the converted filters back.
         legacy_filters = {"events": [{"id": "$pageview", "type": "events", "order": 0, "name": "$pageview"}]}
         saved_filter = SessionRecordingPlaylist.objects.create(
@@ -1136,7 +1141,9 @@ class TestDashboardRunWidgets(APIBaseTest):
             duration=120,
         )
         recording.person = person
-        mock_list_recordings.return_value = ([recording], False, None, None)
+        mock_list_recordings.return_value = RecordingsListingResult(
+            recordings=[recording], more_recordings_available=False, timings_header="", next_cursor=None
+        )
 
         dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
         _, dashboard_json = self.dashboard_api.create_widget_tile(

--- a/products/experiments/backend/max_tools.py
+++ b/products/experiments/backend/max_tools.py
@@ -463,9 +463,11 @@ class SessionReplaySummaryTool(MaxTool):
                         with tags_context(
                             product=Product.MAX_AI, team_id=self._team.pk, org_id=self._team.organization_id
                         ):
-                            recordings, has_more, _, _ = list_recordings_from_query(query=q, user=None, team=self._team)
-                            # If has_more, there are 100+ recordings
-                            return len(recordings) if not has_more else 100
+                            listing_result = list_recordings_from_query(query=q, user=None, team=self._team)
+                            # If more recordings are available, there are 100+ recordings
+                            return (
+                                len(listing_result.recordings) if not listing_result.more_recordings_available else 100
+                            )
 
                     count = await count_recordings(query)
                     recording_counts[variant_key] = count

--- a/products/experiments/backend/test/test_session_replay_summary_tool.py
+++ b/products/experiments/backend/test/test_session_replay_summary_tool.py
@@ -5,12 +5,19 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from posthog.session_recordings.models.session_recording import SessionRecording
+from posthog.session_recordings.session_recording_api import RecordingsListingResult
 
 from products.experiments.backend.max_tools import SessionReplaySummaryTool
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.hogai.utils.types import AssistantState
+
+
+def _listing_result(recordings: list, has_more: bool = False) -> RecordingsListingResult:
+    return RecordingsListingResult(
+        recordings=recordings, more_recordings_available=has_more, timings_header="", next_cursor=None
+    )
 
 
 @freeze_time("2025-01-15T12:00:00Z")
@@ -97,8 +104,8 @@ class TestSessionReplaySummaryTool(APIBaseTest):
         mock_recordings_test = [self.create_mock_session_recording(f"session_test_{i}") for i in range(75)]
 
         mock_list_recordings.side_effect = [
-            (mock_recordings_control, False, "", None),
-            (mock_recordings_test, False, "", None),
+            _listing_result(mock_recordings_control),
+            _listing_result(mock_recordings_test),
         ]
 
         tool = await self.create_tool()
@@ -135,8 +142,8 @@ class TestSessionReplaySummaryTool(APIBaseTest):
         mock_recordings = [self.create_mock_session_recording(f"session_{i}") for i in range(100)]
 
         mock_list_recordings.side_effect = [
-            (mock_recordings, True, "", None),
-            (mock_recordings, True, "", None),
+            _listing_result(mock_recordings, has_more=True),
+            _listing_result(mock_recordings, has_more=True),
         ]
 
         tool = await self.create_tool()
@@ -152,8 +159,8 @@ class TestSessionReplaySummaryTool(APIBaseTest):
         experiment = await self.acreate_experiment()
 
         mock_list_recordings.side_effect = [
-            ([], False, "", None),
-            ([], False, "", None),
+            _listing_result([]),
+            _listing_result([]),
         ]
 
         tool = await self.create_tool()
@@ -215,7 +222,7 @@ class TestSessionReplaySummaryTool(APIBaseTest):
 
         mock_recordings = [self.create_mock_session_recording(f"session_{i}") for i in range(25)]
         mock_list_recordings.side_effect = [
-            (mock_recordings, False, "", None),
+            _listing_result(mock_recordings),
             Exception("ClickHouse connection failed"),
         ]
 
@@ -238,9 +245,9 @@ class TestSessionReplaySummaryTool(APIBaseTest):
         experiment = await self.acreate_experiment(name="multi-variant-exp", feature_flag=feature_flag)
 
         mock_list_recordings.side_effect = [
-            ([self.create_mock_session_recording(f"c_{i}") for i in range(20)], False, "", None),
-            ([self.create_mock_session_recording(f"a_{i}") for i in range(30)], False, "", None),
-            ([self.create_mock_session_recording(f"b_{i}") for i in range(50)], False, "", None),
+            _listing_result([self.create_mock_session_recording(f"c_{i}") for i in range(20)]),
+            _listing_result([self.create_mock_session_recording(f"a_{i}") for i in range(30)]),
+            _listing_result([self.create_mock_session_recording(f"b_{i}") for i in range(50)]),
         ]
 
         tool = await self.create_tool()
@@ -293,8 +300,8 @@ class TestSessionReplaySummaryTool(APIBaseTest):
         experiment = await self.acreate_experiment(start_days_ago=10, end_days_ahead=5)
 
         mock_list_recordings.side_effect = [
-            ([self.create_mock_session_recording("s1")], False, "", None),
-            ([self.create_mock_session_recording("s2")], False, "", None),
+            _listing_result([self.create_mock_session_recording("s1")]),
+            _listing_result([self.create_mock_session_recording("s2")]),
         ]
 
         tool = await self.create_tool()

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -610,13 +610,12 @@ class _ScannerOrderByFilter(OrderByFilter):
             if organization_id is None:
                 return qs.order_by(self._tiebreaker)
             period = current_period_bounds(organization_id)
-            period_start, period_end = period.start, period.end
             spend = (
                 ReplayObservation.objects.filter(
                     scanner_id=OuterRef("pk"),
                     status=ObservationStatus.SUCCEEDED,
-                    created_at__gte=period_start,
-                    created_at__lt=period_end,
+                    created_at__gte=period.start,
+                    created_at__lt=period.end,
                 )
                 .order_by()
                 .values("scanner_id")

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, NoReturn, cast
 
 from django.db import IntegrityError
@@ -571,13 +572,12 @@ class _ScannerOrderByFilter(OrderByFilter):
             if organization_id is None:
                 return qs.order_by(self._tiebreaker)
             period = current_period_bounds(organization_id)
-            period_start, period_end = period.start, period.end
             spend = (
                 ReplayObservation.objects.filter(
                     scanner_id=OuterRef("pk"),
                     status=ObservationStatus.SUCCEEDED,
-                    created_at__gte=period_start,
-                    created_at__lt=period_end,
+                    created_at__gte=period.start,
+                    created_at__lt=period.end,
                 )
                 .order_by()
                 .values("scanner_id")
@@ -1017,6 +1017,14 @@ class AffectedCohortResponseSerializer(serializers.Serializer):
     )
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class BulkObserveHeadroom:
+    max_starts: int
+    skip_reason: str
+    team_in_flight: int
+    scanner_in_flight: int
+
+
 @extend_schema_view(
     list=extend_schema(
         parameters=[
@@ -1211,7 +1219,10 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         # in-flight caps and the remaining monthly quota bounds it; the loser names the skip reason so
         # the user knows which limit they hit. Decrementing a local counter as we start models each new
         # in-flight row without re-querying (a started scan consumes exactly one slot).
-        max_starts, skip_reason, team_rows, scanner_rows = self._bulk_observe_headroom(scanner)
+        headroom = self._bulk_observe_headroom(scanner)
+        # Mutable copies: the CAPPED branch below reassigns both mid-loop.
+        max_starts = headroom.max_starts
+        skip_reason = headroom.skip_reason
         results: list[dict[str, str]] = []
         started = 0
         for session_id in session_ids:
@@ -1225,8 +1236,8 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
                 trigger=ObservationTrigger.ON_DEMAND,
                 # Row counts are this request's snapshot; the atomic claim inside makes racing
                 # requests visible to each other, which the snapshot alone cannot.
-                team_in_flight_rows=team_rows,
-                scanner_in_flight_rows=scanner_rows,
+                team_in_flight_rows=headroom.team_in_flight,
+                scanner_in_flight_rows=headroom.scanner_in_flight,
             )
             if outcome is WorkflowStartOutcome.STARTED:
                 started += 1
@@ -1277,9 +1288,9 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
             request=self.request,
         )
 
-    def _bulk_observe_headroom(self, scanner: ReplayScanner) -> tuple[int, str, int, int]:
-        """(max_starts, skip_reason, team_rows, scanner_rows): how many new scans can start, the
-        reason once that's used up, and the row counts reused by the per-start slot claims."""
+    def _bulk_observe_headroom(self, scanner: ReplayScanner) -> BulkObserveHeadroom:
+        """How many new scans can start, the reason once that's used up, and the in-flight
+        row counts reused by the per-start slot claims."""
         team_in_flight = ReplayObservation.in_flight_for_team(self.team_id).count()
         scanner_in_flight = ReplayObservation.in_flight_for_team(self.team_id).filter(scanner_id=scanner.id).count()
         # Enqueued-but-not-yet-persisted scans hold claims instead of rows.
@@ -1296,8 +1307,18 @@ class ReplayScannerViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, vi
         quota_limit = in_flight_limit if snapshot.remaining is None else (snapshot.remaining // cost if cost else 0)
         # Report quota as the reason only when it's the strictly tighter limit.
         if quota_limit < in_flight_limit:
-            return quota_limit, "skipped_quota", team_in_flight, scanner_in_flight
-        return in_flight_limit, "skipped_limit", team_in_flight, scanner_in_flight
+            return BulkObserveHeadroom(
+                max_starts=quota_limit,
+                skip_reason="skipped_quota",
+                team_in_flight=team_in_flight,
+                scanner_in_flight=scanner_in_flight,
+            )
+        return BulkObserveHeadroom(
+            max_starts=in_flight_limit,
+            skip_reason="skipped_limit",
+            team_in_flight=team_in_flight,
+            scanner_in_flight=scanner_in_flight,
+        )
 
     @extend_schema(parameters=[ScannerImpactQuerySerializer], responses={200: ScannerImpactSerializer})
     @action(


### PR DESCRIPTION
## Problem

These functions return bare tuples where same-typed elements can be silently swapped by a caller with no type error (for example `(start, end)` timestamps), or where 3+ positional elements make call sites unreadable (`recordings, _, _, _ = ...`). Found by a repo-wide scan that verified each case against its real call sites.

## Changes

Pure refactor, no behavior change. Each function below now returns a small `@dataclass(frozen=True)` (`kw_only=True` when fields share a type, `slots=True` where compatible), and every call site binds the result once and uses dot notation instead of positional unpacking.

| function | was | now returns | defined in |
|---|---|---|---|
| `get_redis_state_client` | `tuple[aioredis.Redis, str | None, str | None]` | `RedisStateContext` | `posthog/temporal/session_replay/session_summary/state.py` |
| `_validate_period` | `tuple[float, float, float, float] | None` | `ValidatedPeriod` | `posthog/temporal/session_replay/session_summary/workflow.py` |
| `list_recordings_from_query` | `tuple[list[SessionRecording], bool, str, str | None]` | `RecordingsListingResult` | `posthog/session_recordings/session_recording_api.py` |
| `_prepare_execution` | `tuple[Redis, str, str, SingleSessionSummaryInputs, str]` | `PreparedSingleSessionExecution` | `posthog/temporal/session_replay/session_summary/workflow.py` |
| `_bulk_observe_headroom` | `tuple[int, str, int, int]` | `BulkObserveHeadroom` | `products/replay_vision/backend/api/scanners.py` |

This PR is self-contained: the dataclass, every call site, and every test touching these functions are all in this diff. No serialization boundary changes shape (Temporal/Celery/cache/JSON contracts untouched). It is one of 21 independent per-team slices of #76108, all based on master, mergeable in any order. The `@frozen` helper in #76144 will absorb these dataclasses in a mechanical follow-up once everything lands.

## How did you test this code?

- Full repo `mypy --cache-fine-grained .` with exactly this PR's file set applied to master: no issues. This proves the slice is self-contained (a missed call site or a reference to another slice's dataclass would fail).
- Existing tests for the touched functions are updated in this diff (mocks now return the dataclass); no tests were deleted or weakened. New tests were not added since the refactor preserves behavior that existing tests already cover.
- `ruff check`, `ruff format --check`, and `py_compile` clean on all touched files.
- An adversarial reviewer agent re-read every hunk hunting for transposed field mappings, leftover tuple unpacking, indexing, splats, and stale mocks; findings were fixed before this PR was cut.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal refactor, no user-facing docs impact; `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code at Arnaud's direction. A repo-wide scan (95 findings, each adversarially verified against call sites) fed a conversion pass; the umbrella diff was then split into 21 file-disjoint per-team PRs, each independently validated with a full-repo mypy run against master plus this slice only. One finding was skipped entirely (a Temporal activity return whose payload shape is recorded in workflow histories).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
