### PR TITLE
chore(devex): semgrep rule and docs for the frozen dataclass convention

### DIFF
--- a/.claude/commands/conventions.md
+++ b/.claude/commands/conventions.md
@@ -83,14 +83,12 @@ Hence the explicit separation between the data and view layers.
 
 ### Dataclasses
 
-Prefer a small dataclass over a tuple when returning or passing multiple values:
-always when two or more elements share a type (callers can silently swap them, e.g. `(start, end)`),
-and when there are roughly 3+ elements, where positional access hurts readability.
-
-Use `@frozen` from `posthog.dataclasses` (applies `frozen=True`, `kw_only=True`, `slots=True`; every flag overridable, e.g. `@frozen(slots=False)` for `functools.cached_property`).
-Consume results with dot notation (`result.field`), never by unpacking into positional locals.
-Name dataclasses after the domain concept (`BillingPeriod`), never `*Info`/`*Data`/`*Tuple`; mark secret fields with `field(repr=False)`.
-A bare `@dataclass` without an explicit `frozen=` choice fails the `posthog/test/test_dataclass_defaults.py` ratchet and is flagged by the `prefer-frozen-dataclasses` semgrep rule.
+- Prefer a small dataclass over a tuple when returning or passing multiple values: always when two or more elements share a type (callers can silently swap them, e.g. `(start, end)`), and when there are roughly 3+ elements, where positional access hurts readability
+- Use `@frozen` from `posthog.dataclasses` (applies `frozen=True`, `kw_only=True`, `slots=True`; every flag overridable, e.g. `@frozen(slots=False)` for `functools.cached_property`)
+- Consume results with dot notation (`result.field`), never by unpacking into positional locals
+- Name dataclasses after the domain concept (`BillingPeriod`), never `*Info`/`*Data`/`*Tuple`
+- Mark secret fields with `field(repr=False)`
+- A bare `@dataclass` without an explicit `frozen=` choice fails the `posthog/test/test_dataclass_defaults.py` ratchet and is flagged by the `prefer-frozen-dataclasses` semgrep rule
 
 ### Logging
 

--- a/.claude/commands/conventions.md
+++ b/.claude/commands/conventions.md
@@ -81,6 +81,17 @@ Hence the explicit separation between the data and view layers.
 
 - Always place imports at the top of the file (module level), never inside functions or methods (local imports)
 
+### Dataclasses
+
+Prefer a small dataclass over a tuple when returning or passing multiple values:
+always when two or more elements share a type (callers can silently swap them, e.g. `(start, end)`),
+and when there are roughly 3+ elements, where positional access hurts readability.
+
+Use `@frozen` from `posthog.dataclasses` (applies `frozen=True`, `kw_only=True`, `slots=True`; every flag overridable, e.g. `@frozen(slots=False)` for `functools.cached_property`).
+Consume results with dot notation (`result.field`), never by unpacking into positional locals.
+Name dataclasses after the domain concept (`BillingPeriod`), never `*Info`/`*Data`/`*Tuple`; mark secret fields with `field(repr=False)`.
+A bare `@dataclass` without an explicit `frozen=` choice fails the `posthog/test/test_dataclass_defaults.py` ratchet and is flagged by the `prefer-frozen-dataclasses` semgrep rule.
+
 ### Logging
 
 As a general rule, we should have logs for every expected and unexpected actions of the application, using the appropriate _log level_.

--- a/.cursor/rules/django-python.mdc
+++ b/.cursor/rules/django-python.mdc
@@ -102,6 +102,13 @@ Unit tests
 Integration tests
   - Integration tests should ensure that the feature works end-to-end. They must cover all the important use cases of the feature.
   
+Dataclasses
+  - Prefer a small dataclass over a tuple when returning or passing multiple values: always when two or more elements share a type (silently swappable, e.g. (start, end)), and when there are roughly 3+ elements.
+  - Use @frozen from posthog.dataclasses (frozen=True, kw_only=True, slots=True by default; every flag overridable, e.g. @frozen(slots=False) for functools.cached_property).
+  - Consume results with dot notation (result.field), never by unpacking into positional locals (a, b = result.a, result.b).
+  - Name dataclasses after the domain concept (BillingPeriod), never *Info/*Data/*Tuple; mark secret fields with field(repr=False).
+  - A bare @dataclass without an explicit frozen= choice fails the posthog/test/test_dataclass_defaults.py ratchet and is flagged by the prefer-frozen-dataclasses semgrep rule.
+
 Running commands
 - Use `uv sync` instead of `pip install -r ...`, and `uv add PACKAGE` instead of `pip install PACKAGE`. If there is an import error, first activate the venv at `.flox/cache/venv/` or alternatively `.venv/`.
 Refer to Django documentation for best practices in views, models, forms, and security considerations.

--- a/.semgrep/rules/devex/prefer-frozen-dataclasses.py
+++ b/.semgrep/rules/devex/prefer-frozen-dataclasses.py
@@ -75,3 +75,10 @@ from pydantic.dataclasses import dataclass  # noqa: E402
 @dataclass
 class PydanticDataclass:
     value: int
+
+
+# The module-attribute form is stdlib even in a pydantic-importing file.
+# ruleid: prefer-frozen-dataclasses
+@dataclasses.dataclass
+class StdlibAfterPydanticImport:
+    value: int

--- a/.semgrep/rules/devex/prefer-frozen-dataclasses.py
+++ b/.semgrep/rules/devex/prefer-frozen-dataclasses.py
@@ -1,0 +1,77 @@
+# Test cases for prefer-frozen-dataclasses.
+# ruff: noqa
+import dataclasses
+from dataclasses import dataclass
+
+from posthog.dataclasses import frozen
+
+
+# ruleid: prefer-frozen-dataclasses
+@dataclass
+class BareDecorator:
+    value: int
+
+
+# ruleid: prefer-frozen-dataclasses
+@dataclass()
+class EmptyCall:
+    value: int
+
+
+# ruleid: prefer-frozen-dataclasses
+@dataclass(slots=True, kw_only=True)
+class FlagsButNoFrozenChoice:
+    value: int
+
+
+# ruleid: prefer-frozen-dataclasses
+@dataclasses.dataclass
+class BareModuleAttribute:
+    value: int
+
+
+# ruleid: prefer-frozen-dataclasses
+@dataclasses.dataclass(kw_only=True)
+class ModuleAttributeNoFrozenChoice:
+    value: int
+
+
+# ok: prefer-frozen-dataclasses
+@frozen
+class HouseDefault:
+    value: int
+
+
+# ok: prefer-frozen-dataclasses
+@frozen(slots=False)
+class HouseDefaultWithOverride:
+    value: int
+
+
+# ok: prefer-frozen-dataclasses
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ExplicitFrozen:
+    value: int
+
+
+# ok: prefer-frozen-dataclasses
+@dataclass(frozen=False)
+class ExplicitlyMutable:
+    value: int
+
+
+# ok: prefer-frozen-dataclasses
+@dataclasses.dataclass(frozen=True)
+class ExplicitFrozenModuleAttribute:
+    value: int
+
+
+# The pydantic import below excludes everything after it, mirroring real files
+# where pydantic's dataclass is imported at the top.
+from pydantic.dataclasses import dataclass  # noqa: E402
+
+
+# ok: prefer-frozen-dataclasses
+@dataclass
+class PydanticDataclass:
+    value: int

--- a/.semgrep/rules/devex/prefer-frozen-dataclasses.yaml
+++ b/.semgrep/rules/devex/prefer-frozen-dataclasses.yaml
@@ -33,12 +33,20 @@ rules:
               - '**/.semgrep/**'
       patterns:
           - pattern-either:
-                - pattern: |
-                      @dataclass
-                      class $C: ...
-                - pattern: |
-                      @dataclass(...)
-                      class $C: ...
+                # Bare @dataclass is ambiguous: skip it when pydantic's decorator
+                # (with its own validation semantics) is imported under that name.
+                - patterns:
+                      - pattern-either:
+                            - pattern: |
+                                  @dataclass
+                                  class $C: ...
+                            - pattern: |
+                                  @dataclass(...)
+                                  class $C: ...
+                      - pattern-not-inside: |
+                            from pydantic.dataclasses import dataclass
+                            ...
+                # The module-attribute form is always the stdlib decorator.
                 - pattern: |
                       @dataclasses.dataclass
                       class $C: ...
@@ -51,10 +59,6 @@ rules:
           - pattern-not: |
                 @dataclasses.dataclass(..., frozen=$V, ...)
                 class $C: ...
-          # pydantic's dataclass decorator has its own validation semantics
-          - pattern-not-inside: |
-                from pydantic.dataclasses import dataclass
-                ...
       metadata:
           category: best-practice
           subcategory:

--- a/.semgrep/rules/devex/prefer-frozen-dataclasses.yaml
+++ b/.semgrep/rules/devex/prefer-frozen-dataclasses.yaml
@@ -1,0 +1,61 @@
+rules:
+    - id: prefer-frozen-dataclasses
+      message: |
+          Bare `@dataclass` without an explicit `frozen=` choice.
+
+          House default for value/result objects is `@frozen` from `posthog.dataclasses`
+          (frozen, kw_only, slots; every flag overridable, e.g. `@frozen(slots=False)`
+          for `functools.cached_property`):
+
+              from posthog.dataclasses import frozen
+
+              @frozen
+              class BillingPeriod:
+                  start: datetime
+                  end: datetime
+
+          If mutability is intentional, say so explicitly with `@dataclass(frozen=False, ...)`.
+          The `posthog/test/test_dataclass_defaults.py` ratchet blocks new undeclared uses;
+          existing ones are grandfathered in its baseline and migrated over time.
+          Informational, not blocking. For a genuine exception, add
+          `# nosemgrep: prefer-frozen-dataclasses -- <reason>` on the class line.
+      severity: WARNING
+      languages: [python]
+      paths:
+          include:
+              - 'common/**/*.py'
+              - 'dags/**/*.py'
+              - 'ee/**/*.py'
+              - 'posthog/**/*.py'
+              - 'products/**/*.py'
+          exclude:
+              - '**/migrations/**'
+              - '**/.semgrep/**'
+      patterns:
+          - pattern-either:
+                - pattern: |
+                      @dataclass
+                      class $C: ...
+                - pattern: |
+                      @dataclass(...)
+                      class $C: ...
+                - pattern: |
+                      @dataclasses.dataclass
+                      class $C: ...
+                - pattern: |
+                      @dataclasses.dataclass(...)
+                      class $C: ...
+          - pattern-not: |
+                @dataclass(..., frozen=$V, ...)
+                class $C: ...
+          - pattern-not: |
+                @dataclasses.dataclass(..., frozen=$V, ...)
+                class $C: ...
+          # pydantic's dataclass decorator has its own validation semantics
+          - pattern-not-inside: |
+                from pydantic.dataclasses import dataclass
+                ...
+      metadata:
+          category: best-practice
+          subcategory:
+              - audit

--- a/docs/published/handbook/engineering/conventions/backend-coding.md
+++ b/docs/published/handbook/engineering/conventions/backend-coding.md
@@ -133,6 +133,35 @@ A good test should:
 - They give greater confidence (because you avoid the mistake of just testing a mock) but they're slower
 - They are generally less brittle in response to changes because they test at a higher level than developer tests (e.g. they test a Django API not a class used inside it)
 
+### Dataclasses
+
+Prefer a small dataclass over a tuple when returning or passing multiple values:
+always when two or more elements share a type (callers can silently swap them, e.g. `(start, end)` timestamps or `(username, password)` credentials),
+and when there are roughly 3+ elements, where positional access hurts readability.
+
+Use the house-default decorator:
+
+```python
+from posthog.dataclasses import frozen
+
+
+@frozen
+class BillingPeriod:
+    start: datetime
+    end: datetime
+```
+
+`@frozen` applies `frozen=True` (immutable, hashable), `kw_only=True` (keyword-only construction, so same-typed fields can't be transposed), and `slots=True` (less memory, typo-safe attribute access).
+Every flag is overridable per class: `@frozen(slots=False)` when a class needs `functools.cached_property`, or an explicit `@dataclass(frozen=False, ...)` for a deliberately mutable builder.
+
+Consume results with dot notation (`result.field`).
+Don't unpack them back into positional locals (`a, b = result.a, result.b`), which recreates the swap hazard the dataclass exists to prevent.
+
+Name dataclasses after the domain concept (`ClickHouseCredentials`, `BillingPeriod`), never `*Info`/`*Data`/`*Tuple`; use a `*Result` suffix only when the function's outcome genuinely is the concept.
+Mark secret fields with `field(repr=False)` so they stay out of logs and tracebacks.
+
+Enforcement: a new bare `@dataclass` without an explicit `frozen=` choice fails the ratchet in `posthog/test/test_dataclass_defaults.py` (existing uses are grandfathered in its baseline) and is flagged inline by the `prefer-frozen-dataclasses` semgrep rule.
+
 ### Querying ClickHouse
 
 **Always use HogQL instead of raw ClickHouse queries in product code.**


### PR DESCRIPTION
## Problem

The frozen-dataclass convention (prefer dataclasses over multi-value tuples, `@frozen` house defaults, dot-notation consumption, domain-concept naming) currently lives in AGENTS.md and a pytest ratchet (#76144). Nothing proposes it inline on PRs, and the handbook, the Claude conventions mirror, and the Cursor rules don't mention it, so humans and AI tools working outside AGENTS.md never see it.

## Changes

One surface per tool that reads conventions, so the pattern is checkable and proposable repo-wide:

| surface | file | what it does |
|---|---|---|
| semgrep (CI, inline PR annotations) | `.semgrep/rules/devex/prefer-frozen-dataclasses.yaml` + test fixture | flags bare `@dataclass` without an explicit `frozen=` choice and proposes `@frozen` in its message. `WARNING` severity per the devex README rule (known backlog of ~2,400; the informational pass annotates without blocking). pydantic dataclasses and migrations excluded |
| handbook (humans) | `docs/published/handbook/engineering/conventions/backend-coding.md` | new "Dataclasses" section: when to prefer a dataclass, `@frozen` usage, dot notation, naming, `field(repr=False)` for secrets, enforcement pointers |
| Claude conventions mirror | `.claude/commands/conventions.md` | condensed copy of the same section (the handbook file's sync note requires mirroring) |
| Cursor rules | `.cursor/rules/django-python.mdc` | same convention in the Django/Python rule file |

Greptile needs no change: `greptile.json` reads `customContext` from AGENTS.md, which carries the convention via #76144. lint-staged wiring was evaluated and deliberately left out: the ratchet and semgrep cover enforcement in CI, and a commit-time repo scan would add seconds to every commit for marginal benefit.

> [!NOTE]
> The blocking enforcement (the `posthog/test/test_dataclass_defaults.py` ratchet) and the `posthog.dataclasses.frozen` helper land in #76144; this PR is the propose-and-document layer and is safe to merge in either order (it only references them in prose and rule messages).

## How did you test this code?

- `semgrep --test .semgrep/rules/devex/` via the CI-pinned image (`semgrep/semgrep:1.167.0`): all fixture annotations pass (5 `ruleid` positives including bare, empty-call, flags-without-frozen, and module-attribute forms; 6 `ok` negatives including explicit `frozen=True`/`frozen=False`, `@frozen`, and a pydantic-imported dataclass).
- Full scan of `posthog`, `products`, `ee`, `common`, `dags` with the rule: 2,404 findings, consistent with the ratchet's census of 2,461 (the delta is the rule's deliberate migrations and pydantic exclusions), confirming it matches real code, not just fixtures.
- Docs changes are prose only; the handbook sync note (mirror to `.claude/commands/conventions.md`) is honored in this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Docs are updated in this PR (handbook section + mirrors); `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code at Arnaud's direction, as the propose-and-check layer for the frozen dataclass convention (#76144 adds the helper + blocking ratchet; #76123-#76143 apply the pattern per team). Skills consulted: /writing-code-comments; the devex semgrep README's severity rule drove the WARNING choice. Surfaces were chosen by auditing every convention-carrying file in the repo (semgrep devex rules, greptile.json custom context, Cursor .mdc rules, handbook conventions, the Claude commands mirror); lint-staged was considered and rejected as noted above.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
