### PR TITLE
chore(self-driving): rename dataclasses to domain-concept names

### DIFF
--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -17,7 +17,7 @@ from products.mcp_store.backend.agents import (
     get_built_in_agent,
     is_builtin_agent_enforcement_enabled,
 )
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
+from products.mcp_store.backend.facade.contracts import ActiveInstallation
 from products.mcp_store.backend.models import (
     MCPServerInstallation,
     MCPServerInstallationTool,
@@ -123,13 +123,13 @@ def _to_info(
     team_id: int,
     *,
     agent_proxy_token: str | None = None,
-) -> ActiveInstallationInfo:
+) -> ActiveInstallation:
     if agent_proxy_token is not None and installation.gateway_server_id is not None:
         proxy_path = f"/api/mcp_store/gateway/servers/{installation.gateway_server_id}/proxy/"
     else:
         proxy_path = f"/api/environments/{team_id}/mcp_server_installations/{installation.id}/proxy/"
 
-    return ActiveInstallationInfo(
+    return ActiveInstallation(
         id=str(installation.id),
         name=_resolve_name(installation),
         proxy_path=proxy_path,
@@ -138,7 +138,7 @@ def _to_info(
     )
 
 
-def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallationInfo]:
+def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallation]:
     """Return active, ready-to-use personal MCP installations for a user.
 
     Filters out disabled installations and OAuth installations that
@@ -156,7 +156,7 @@ def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallat
         logger.warning("Error fetching MCP installations", error=str(e), team_id=team_id)
         return []
 
-    results: list[ActiveInstallationInfo] = []
+    results: list[ActiveInstallation] = []
     for installation in installations:
         if not _is_oauth_ready(installation):
             logger.debug(
@@ -177,7 +177,7 @@ def get_installations_for_sandbox(
     include_personal: bool = False,
     task_origin: str | None = None,
     task_agent_key: str | None = None,
-) -> list[ActiveInstallationInfo]:
+) -> list[ActiveInstallation]:
     """Return MCP installations for sandbox agent use.
 
     Generic tasks retain the legacy team-shared installation behavior. A

--- a/products/mcp_store/backend/facade/contracts.py
+++ b/products/mcp_store/backend/facade/contracts.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
-class ActiveInstallationInfo:
+class ActiveInstallation:
     """An MCP server installation that is active and ready to use."""
 
     id: str

--- a/products/mcp_store/backend/test/test_facade.py
+++ b/products/mcp_store/backend/test/test_facade.py
@@ -7,7 +7,7 @@ from posthog.models import User
 
 from products.mcp_store.backend.agents import get_built_in_agent
 from products.mcp_store.backend.facade.api import get_active_installations, get_installations_for_sandbox
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
+from products.mcp_store.backend.facade.contracts import ActiveInstallation
 from products.mcp_store.backend.models import (
     MCPGatewayServer,
     MCPServerInstallation,
@@ -36,7 +36,7 @@ class TestGetActiveInstallations(BaseTest):
         results = get_active_installations(self.team.id, self.user.id)
 
         assert results == [
-            ActiveInstallationInfo(
+            ActiveInstallation(
                 id=str(installation.id),
                 name="Linear",
                 proxy_path=f"/api/environments/{self.team.id}/mcp_server_installations/{installation.id}/proxy/",

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -4,7 +4,7 @@ from django.test import SimpleTestCase, TestCase, override_settings
 
 from parameterized import parameterized
 
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
+from products.mcp_store.backend.facade.contracts import ActiveInstallation
 from products.tasks.backend.constants import (
     DEFAULT_DIRECTORY_RESUME_SNAPSHOT_MOUNT_PATH,
     DEFAULT_SANDBOX_WORKING_DIR,
@@ -340,14 +340,14 @@ class TestFetchUserMcpServerConfigs(TestCase):
     MOCK_FACADE = "products.tasks.backend.temporal.process_task.utils.get_installations_for_sandbox"
     MOCK_API_URL = "products.tasks.backend.temporal.process_task.utils.get_sandbox_api_url"
 
-    def _make_installation(self, **kwargs) -> ActiveInstallationInfo:
+    def _make_installation(self, **kwargs) -> ActiveInstallation:
         defaults = {
             "id": "abc-123",
             "name": "Linear",
             "proxy_path": f"/api/environments/{self.TEAM_ID}/mcp_server_installations/abc-123/proxy/",
         }
         defaults.update(kwargs)
-        return ActiveInstallationInfo(**defaults)
+        return ActiveInstallation(**defaults)
 
     def _expected_user_headers(self, *, consumer: str = "posthog-code") -> list[dict[str, str]]:
         return [


### PR DESCRIPTION
## Problem

These dataclasses are named after plumbing (`*Info`/`*Data`), not the domain concept they carry, which the [backend naming convention](https://posthog.com/handbook/engineering/conventions/backend-coding) now codifies against.

## Changes

Pure renames, no behavior or field changes. Every reference is updated (imports, annotations, tests, mocks, `__all__` strings).

| old | new |
|---|---|
| `ActiveInstallationInfo` | `ActiveInstallation` |

Safety: none of these classes are pickled into durable stores, referenced by string, or part of a serialized payload shape (class names are not embedded in Temporal/JSON payloads); each rename was independently vetted for those hazards before being applied. One of several per-team slices of a repo-wide cleanup; each slice is self-contained and mergeable in any order.

## How did you test this code?

- Full repo `mypy --cache-fine-grained .`: no issues with all renames applied.
- Frontend `tsgo --noEmit`: clean (some slices touch TS mirrors of backend types).
- Repo-wide AST census: violations went from 51 to 2, the remaining two being deliberate keeps (`posthog/hogql/ast.py` `Tuple` is the AST node concept; a test double mirrors the Temporal SDK's `ActivityInfo` name).
- An adversarial reviewer agent verified rename-only diffs, zero live references to old names, and no collisions with pre-existing symbols.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal rename, no user-facing docs impact; `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code at Arnaud's direction: a scan found 51 convention-violating dataclass names; each was independently verified (violation? better name? pickle/string-reference/public-surface safety?) before renaming, then adversarially reviewed. Clusters whose files overlap the open tuple-to-dataclass PRs (#76123-#76144) are deliberately deferred until those merge, so this PR cannot conflict with them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
