### PR TITLE
chore(data-modeling): rename dataclasses to domain-concept names

### DIFF
--- a/products/endpoints/backend/facade/api.py
+++ b/products/endpoints/backend/facade/api.py
@@ -118,7 +118,9 @@ def get_endpoint(team_id: int, name: str) -> contracts.EndpointSummary | None:
     return _to_endpoint_info(endpoint) if endpoint is not None else None
 
 
-def get_endpoint_version(team_id: int, name: str, version: int | None = None) -> contracts.EndpointVersionSnapshot | None:
+def get_endpoint_version(
+    team_id: int, name: str, version: int | None = None
+) -> contracts.EndpointVersionSnapshot | None:
     """Get a specific version's snapshot, or the current version when ``version`` is None."""
     endpoint = Endpoint.objects.filter(team_id=team_id, name=name, deleted=False).first()
     if endpoint is None:

--- a/products/endpoints/backend/facade/api.py
+++ b/products/endpoints/backend/facade/api.py
@@ -79,8 +79,8 @@ def __getattr__(name: str):
     return getattr(module, name)
 
 
-def _to_endpoint_info(endpoint: Endpoint) -> contracts.EndpointInfo:
-    return contracts.EndpointInfo(
+def _to_endpoint_info(endpoint: Endpoint) -> contracts.EndpointSummary:
+    return contracts.EndpointSummary(
         id=endpoint.id,
         team_id=endpoint.team_id,
         name=endpoint.name,
@@ -93,8 +93,8 @@ def _to_endpoint_info(endpoint: Endpoint) -> contracts.EndpointInfo:
     )
 
 
-def _to_version_info(version: EndpointVersion) -> contracts.EndpointVersionInfo:
-    return contracts.EndpointVersionInfo(
+def _to_version_info(version: EndpointVersion) -> contracts.EndpointVersionSnapshot:
+    return contracts.EndpointVersionSnapshot(
         id=version.id,
         endpoint_id=version.endpoint_id,
         version=version.version,
@@ -108,17 +108,17 @@ def _to_version_info(version: EndpointVersion) -> contracts.EndpointVersionInfo:
     )
 
 
-def list_endpoints(team_id: int) -> list[contracts.EndpointInfo]:
+def list_endpoints(team_id: int) -> list[contracts.EndpointSummary]:
     endpoints = Endpoint.objects.filter(team_id=team_id, deleted=False).order_by("name")
     return [_to_endpoint_info(e) for e in endpoints]
 
 
-def get_endpoint(team_id: int, name: str) -> contracts.EndpointInfo | None:
+def get_endpoint(team_id: int, name: str) -> contracts.EndpointSummary | None:
     endpoint = Endpoint.objects.filter(team_id=team_id, name=name, deleted=False).first()
     return _to_endpoint_info(endpoint) if endpoint is not None else None
 
 
-def get_endpoint_version(team_id: int, name: str, version: int | None = None) -> contracts.EndpointVersionInfo | None:
+def get_endpoint_version(team_id: int, name: str, version: int | None = None) -> contracts.EndpointVersionSnapshot | None:
     """Get a specific version's snapshot, or the current version when ``version`` is None."""
     endpoint = Endpoint.objects.filter(team_id=team_id, name=name, deleted=False).first()
     if endpoint is None:

--- a/products/endpoints/backend/facade/contracts.py
+++ b/products/endpoints/backend/facade/contracts.py
@@ -16,8 +16,8 @@ from pydantic.dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class EndpointInfo:
-    """An endpoint (team-scoped, name-addressed). Version-specific data lives on EndpointVersionInfo."""
+class EndpointSummary:
+    """An endpoint (team-scoped, name-addressed). Version-specific data lives on EndpointVersionSnapshot."""
 
     id: UUID
     team_id: int
@@ -31,7 +31,7 @@ class EndpointInfo:
 
 
 @dataclass(frozen=True)
-class EndpointVersionInfo:
+class EndpointVersionSnapshot:
     """An immutable query snapshot for one endpoint version."""
 
     id: UUID


### PR DESCRIPTION
## Problem

These dataclasses are named after plumbing (`*Info`/`*Data`), not the domain concept they carry, which the [backend naming convention](https://posthog.com/handbook/engineering/conventions/backend-coding) now codifies against.

## Changes

Pure renames, no behavior or field changes. Every reference is updated (imports, annotations, tests, mocks, `__all__` strings).

| old | new |
|---|---|
| `EndpointInfo` | `EndpointSummary` |
| `EndpointVersionInfo` | `EndpointVersionSnapshot` |

Safety: none of these classes are pickled into durable stores, referenced by string, or part of a serialized payload shape (class names are not embedded in Temporal/JSON payloads); each rename was independently vetted for those hazards before being applied. One of several per-team slices of a repo-wide cleanup; each slice is self-contained and mergeable in any order.

## How did you test this code?

- Full repo `mypy --cache-fine-grained .`: no issues with all renames applied.
- Frontend `tsgo --noEmit`: clean (some slices touch TS mirrors of backend types).
- Repo-wide AST census: violations went from 51 to 2, the remaining two being deliberate keeps (`posthog/hogql/ast.py` `Tuple` is the AST node concept; a test double mirrors the Temporal SDK's `ActivityInfo` name).
- An adversarial reviewer agent verified rename-only diffs, zero live references to old names, and no collisions with pre-existing symbols.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal rename, no user-facing docs impact; `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code at Arnaud's direction: a scan found 51 convention-violating dataclass names; each was independently verified (violation? better name? pickle/string-reference/public-surface safety?) before renaming, then adversarially reviewed. Clusters whose files overlap the open tuple-to-dataclass PRs (#76123-#76144) are deliberately deferred until those merge, so this PR cannot conflict with them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
