### PR TITLE
chore(analytics-platform): rename dataclasses to domain-concept names

### DIFF
--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -56,7 +56,7 @@ def _next_delivery_date_display(subscription: Subscription) -> str:
 
 
 @dataclass
-class SlackMessageData:
+class SlackMessage:
     channel: str
     blocks: list[dict[str, Any]]
     title: str
@@ -147,7 +147,7 @@ def _prepare_slack_message(
     change_summary: str | None = None,
     summary_skipped_over_budget: bool = False,
     integration: Integration | None = None,
-) -> SlackMessageData:
+) -> SlackMessage:
     """Prepare Slack message content. Pure function with no side effects."""
     utm_tags = f"{UTM_TAGS_BASE}&utm_medium=slack"
 
@@ -243,7 +243,7 @@ def _prepare_slack_message(
             }
         )
 
-    return SlackMessageData(
+    return SlackMessage(
         channel=channel,
         blocks=blocks,
         title=title,
@@ -325,9 +325,9 @@ async def _send_slack_message_with_retry(client, max_retries: int = 3, **kwargs)
 async def deliver_slack_message_data(
     integration: Integration,
     subscription: Subscription,
-    message_data: SlackMessageData,
+    message_data: SlackMessage,
 ) -> SlackDeliveryResult:
-    # shared send path: callers build the SlackMessageData; retry + partial-failure handling are shared
+    # shared send path: callers build the SlackMessage; retry + partial-failure handling are shared
     slack_integration = SlackIntegration(integration)
 
     async with aiohttp.ClientSession(trust_env=True) as slack_session:

--- a/ee/tasks/subscriptions/slack_subscriptions.py
+++ b/ee/tasks/subscriptions/slack_subscriptions.py
@@ -51,7 +51,7 @@ def _next_delivery_date_display(subscription: Subscription) -> str:
 
 
 @dataclass
-class SlackMessageData:
+class SlackMessage:
     channel: str
     blocks: list[dict[str, Any]]
     title: str
@@ -142,7 +142,7 @@ def _prepare_slack_message(
     change_summary: str | None = None,
     summary_skipped_over_budget: bool = False,
     integration: Integration | None = None,
-) -> SlackMessageData:
+) -> SlackMessage:
     """Prepare Slack message content. Pure function with no side effects."""
     utm_tags = f"{UTM_TAGS_BASE}&utm_medium=slack"
 
@@ -238,7 +238,7 @@ def _prepare_slack_message(
             }
         )
 
-    return SlackMessageData(
+    return SlackMessage(
         channel=channel,
         blocks=blocks,
         title=title,
@@ -320,9 +320,9 @@ async def _send_slack_message_with_retry(client, max_retries: int = 3, **kwargs)
 async def deliver_slack_message_data(
     integration: Integration,
     subscription: Subscription,
-    message_data: SlackMessageData,
+    message_data: SlackMessage,
 ) -> SlackDeliveryResult:
-    # shared send path: callers build the SlackMessageData; retry + partial-failure handling are shared
+    # shared send path: callers build the SlackMessage; retry + partial-failure handling are shared
     slack_integration = SlackIntegration(integration)
 
     async with aiohttp.ClientSession(trust_env=True) as slack_session:

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -515,7 +515,7 @@ def _get_ch_expires_at(job: "PreaggregationJob", table: LazyComputationTable) ->
 
 
 @dataclass
-class QueryInfo:
+class LazyComputationQuery:
     """Normalized query information for lazy computation matching."""
 
     query: ast.SelectQuery
@@ -540,9 +540,9 @@ class LazyComputationResult:
     stale: bool = False
 
 
-def compute_query_hash(query_info: QueryInfo) -> str:
+def compute_query_hash(query_info: LazyComputationQuery) -> str:
     """
-    Compute a stable hash for a QueryInfo object.
+    Compute a stable hash for a LazyComputationQuery object.
     The hash is based on the normalized query structure and timezone.
     """
     # Use repr() to get a deterministic string representation of the AST
@@ -832,7 +832,7 @@ def _written_rows(insert_result: object) -> int:
 def run_lazy_computation_insert(
     team: Team,
     job: PreaggregationJob,
-    query_info: QueryInfo,
+    query_info: LazyComputationQuery,
 ) -> int:
     """Run the INSERT query to populate lazy-computed results in ClickHouse.
 
@@ -923,7 +923,7 @@ class LazyComputationExecutor:
     def execute(
         self,
         team: Team,
-        query_info: QueryInfo,
+        query_info: LazyComputationQuery,
         start: datetime,
         end: datetime,
         run_insert: Callable[[Team, PreaggregationJob], int | None] | None = None,
@@ -1438,7 +1438,7 @@ def ensure_precomputed(
     }
     parsed_for_hash = _resolve_insert_query(insert_query, hash_placeholders)
 
-    query_info = QueryInfo(
+    query_info = LazyComputationQuery(
         query=parsed_for_hash,
         table=table,
         timezone=team.timezone,

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -450,7 +450,7 @@ def _get_ch_expires_at(job: "PreaggregationJob", table: LazyComputationTable) ->
 
 
 @dataclass
-class QueryInfo:
+class LazyComputationQuery:
     """Normalized query information for lazy computation matching."""
 
     query: ast.SelectQuery
@@ -475,9 +475,9 @@ class LazyComputationResult:
     stale: bool = False
 
 
-def compute_query_hash(query_info: QueryInfo) -> str:
+def compute_query_hash(query_info: LazyComputationQuery) -> str:
     """
-    Compute a stable hash for a QueryInfo object.
+    Compute a stable hash for a LazyComputationQuery object.
     The hash is based on the normalized query structure and timezone.
     """
     # Use repr() to get a deterministic string representation of the AST
@@ -757,7 +757,7 @@ def build_lazy_computation_insert_sql(
 def run_lazy_computation_insert(
     team: Team,
     job: PreaggregationJob,
-    query_info: QueryInfo,
+    query_info: LazyComputationQuery,
 ) -> None:
     """Run the INSERT query to populate lazy-computed results in ClickHouse."""
     ch_expires_at = _get_ch_expires_at(job, LazyComputationTable.PREAGGREGATION_RESULTS)
@@ -842,7 +842,7 @@ class LazyComputationExecutor:
     def execute(
         self,
         team: Team,
-        query_info: QueryInfo,
+        query_info: LazyComputationQuery,
         start: datetime,
         end: datetime,
         run_insert: Callable[[Team, PreaggregationJob], None] | None = None,
@@ -1330,7 +1330,7 @@ def ensure_precomputed(
     }
     parsed_for_hash = _resolve_insert_query(insert_query, hash_placeholders)
 
-    query_info = QueryInfo(
+    query_info = LazyComputationQuery(
         query=parsed_for_hash,
         table=table,
         timezone=team.timezone,

--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_transformer.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_transformer.py
@@ -12,9 +12,9 @@ from posthog.models import Team
 
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationExecutor,
+    LazyComputationQuery,
     LazyComputationResult,
     LazyComputationTable,
-    QueryInfo,
 )
 
 PREAGGREGATED_DAILY_UNIQUE_PERSONS_PAGEVIEWS_TABLE_NAME = DISTRIBUTED_PREAGGREGATION_RESULTS_TABLE()
@@ -463,11 +463,11 @@ def _run_daily_unique_persons_pageviews(
     Orchestrate lazy computation jobs for daily unique persons pageviews.
 
     This function:
-    1. Creates a QueryInfo object from the query
+    1. Creates a LazyComputationQuery object from the query
     2. Calls the executor to find/create lazy computation jobs
     3. Returns the result with job IDs for the combiner query
     """
-    query_info = QueryInfo(
+    query_info = LazyComputationQuery(
         query=query_to_insert, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=team.timezone
     )
 

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -36,9 +36,9 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     PREAGGREGATION_INSERT_QUORUM,
     PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS,
     LazyComputationExecutor,
+    LazyComputationQuery,
     LazyComputationResult,
     LazyComputationTable,
-    QueryInfo,
     TtlSchedule,
     _build_manual_insert_sql,
     _get_insert_settings,
@@ -106,8 +106,8 @@ class TestComputeQueryHash(BaseTest):
         s2 = parse_select(q2)
         assert isinstance(s1, ast.SelectQuery)
         assert isinstance(s2, ast.SelectQuery)
-        query_info1 = QueryInfo(query=s1, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t1)
-        query_info2 = QueryInfo(query=s2, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t2)
+        query_info1 = LazyComputationQuery(query=s1, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t1)
+        query_info2 = LazyComputationQuery(query=s2, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t2)
 
         hash1 = compute_query_hash(query_info1)
         hash2 = compute_query_hash(query_info2)
@@ -486,7 +486,9 @@ class TestExecuteComputationJobs(ClickhouseTestMixin, BaseTest):
         self._create_pageview_events()
 
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         result = LazyComputationExecutor().execute(
             team=self.team,
@@ -518,7 +520,9 @@ class TestExecuteComputationJobs(ClickhouseTestMixin, BaseTest):
         self._create_pageview_events()
 
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         # First: run for Jan 1-2
         first_result = LazyComputationExecutor().execute(
@@ -563,7 +567,9 @@ class TestExecuteComputationJobs(ClickhouseTestMixin, BaseTest):
         self._create_pageview_events()
 
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         # First: Create job for Jan 2 only
         jan2_result = LazyComputationExecutor().execute(
@@ -1432,7 +1438,9 @@ class TestRaceConditionHandling(BaseTest):
 
     def test_integrity_error_on_create_loops_back_and_picks_up_pending_job(self):
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
         query_hash = compute_query_hash(query_info)
 
         executor = LazyComputationExecutor(wait_timeout_seconds=2.0, poll_interval_seconds=0.05)
@@ -1495,7 +1503,9 @@ class TestRaceConditionHandling(BaseTest):
         rather than a correctness bug.
         """
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
         query_hash = compute_query_hash(query_info)
 
         range_a_start = datetime(2024, 1, 1, tzinfo=UTC)
@@ -1568,7 +1578,9 @@ class TestRaceConditionHandling(BaseTest):
 
     def test_unique_constraint_prevents_duplicate_pending_jobs(self):
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
         query_hash = compute_query_hash(query_info)
 
         # Create a PENDING job directly
@@ -1594,7 +1606,7 @@ class TestRaceConditionHandling(BaseTest):
 
 
 class TestComputationExecutorExecute(BaseTest):
-    def _make_query_info(self) -> tuple[QueryInfo, str]:
+    def _make_query_info(self) -> tuple[LazyComputationQuery, str]:
         s = parse_select(
             """
             SELECT
@@ -1607,7 +1619,7 @@ class TestComputationExecutorExecute(BaseTest):
             """
         )
         assert isinstance(s, ast.SelectQuery)
-        qi = QueryInfo(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        qi = LazyComputationQuery(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
         return qi, compute_query_hash(qi)
 
     # --- Happy path ---
@@ -2672,7 +2684,9 @@ class TestPubsubAndStaleDetection(BaseTest):
                 "SELECT toStartOfDay(timestamp) as a, [] as b, uniqExactState(person_id) as c FROM events GROUP BY a"
             )
             assert isinstance(query, ast.SelectQuery)
-            query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+            query_info = LazyComputationQuery(
+                query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+            )
 
             executor = LazyComputationExecutor()
             result = executor.execute(
@@ -2694,7 +2708,9 @@ class TestPubsubAndStaleDetection(BaseTest):
                 "SELECT toStartOfDay(timestamp) as a, [] as b, uniqExactState(person_id) as c FROM events GROUP BY a"
             )
             assert isinstance(query, ast.SelectQuery)
-            query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+            query_info = LazyComputationQuery(
+                query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+            )
 
             executor = LazyComputationExecutor(max_retries=0)
             result = executor.execute(
@@ -2735,12 +2751,12 @@ class TestJobLifecycleCounters(BaseTest):
 
     TABLE = LazyComputationTable.PREAGGREGATION_RESULTS
 
-    def _query_info(self) -> QueryInfo:
+    def _query_info(self) -> LazyComputationQuery:
         query = parse_select(
             "SELECT toStartOfDay(timestamp) as a, [] as b, uniqExactState(person_id) as c FROM events GROUP BY a"
         )
         assert isinstance(query, ast.SelectQuery)
-        return QueryInfo(query=query, table=self.TABLE, timezone="UTC")
+        return LazyComputationQuery(query=query, table=self.TABLE, timezone="UTC")
 
     @staticmethod
     def _delta(metric, labels: dict[str, str], before: float) -> float:
@@ -3092,7 +3108,7 @@ class TestInsertSettingsAppliedToInserts(BaseTest):
             },
         )
         assert isinstance(query, ast.SelectQuery)
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS)
+        query_info = LazyComputationQuery(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS)
 
         with patch(
             "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.sync_execute"
@@ -3123,7 +3139,7 @@ class TestInsertsReportRowsWritten(BaseTest):
             expires_at=django_timezone.now() + timedelta(days=7),
         )
 
-    def _query_info(self) -> QueryInfo:
+    def _query_info(self) -> LazyComputationQuery:
         query = parse_select(
             self.INSERT_QUERY,
             placeholders={
@@ -3132,7 +3148,7 @@ class TestInsertsReportRowsWritten(BaseTest):
             },
         )
         assert isinstance(query, ast.SelectQuery)
-        return QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS)
+        return LazyComputationQuery(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS)
 
     @parameterized.expand([("productive", 42, 42), ("empty_passthrough", [], 0), ("empty_none", None, 0)])
     def test_ast_insert_returns_rows_written(self, _name, sync_execute_result, expected):
@@ -3194,7 +3210,7 @@ class TestMaxWindowDaysCap(BaseTest):
 
 
 class TestExecuteOOMAndBudget(ClickhouseTestMixin, BaseTest):
-    def _query_info(self) -> QueryInfo:
+    def _query_info(self) -> LazyComputationQuery:
         s = parse_select(
             """
             SELECT toStartOfDay(timestamp) as time_window_start, [] as breakdown_value,
@@ -3203,7 +3219,7 @@ class TestExecuteOOMAndBudget(ClickhouseTestMixin, BaseTest):
             """
         )
         assert isinstance(s, ast.SelectQuery)
-        return QueryInfo(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        return LazyComputationQuery(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
 
     def test_surfaces_memory_exceeded_on_oom(self):
         def oom_insert(_t, _j) -> None:
@@ -3280,7 +3296,9 @@ class TestCheckOnlyMode(BaseTest):
     def _execute(self, start: datetime, end: datetime) -> LazyComputationResult:
         query = parse_select("SELECT 1")
         assert isinstance(query, ast.SelectQuery)
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         def forbidden_insert(team, job):
             raise AssertionError("check-only mode must never run inserts")
@@ -3299,7 +3317,7 @@ class TestCheckOnlyMode(BaseTest):
         return PreaggregationJob.objects.create(
             team=self.team,
             query_hash=compute_query_hash(
-                QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+                LazyComputationQuery(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
             ),
             time_range_start=start,
             time_range_end=end,

--- a/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/tests/test_lazy_computation_executor.py
@@ -36,9 +36,9 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     PREAGGREGATION_INSERT_QUORUM,
     PREAGGREGATION_INSERT_QUORUM_TIMEOUT_MS,
     LazyComputationExecutor,
+    LazyComputationQuery,
     LazyComputationResult,
     LazyComputationTable,
-    QueryInfo,
     TtlSchedule,
     _build_manual_insert_sql,
     _get_insert_settings,
@@ -105,8 +105,8 @@ class TestComputeQueryHash(BaseTest):
         s2 = parse_select(q2)
         assert isinstance(s1, ast.SelectQuery)
         assert isinstance(s2, ast.SelectQuery)
-        query_info1 = QueryInfo(query=s1, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t1)
-        query_info2 = QueryInfo(query=s2, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t2)
+        query_info1 = LazyComputationQuery(query=s1, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t1)
+        query_info2 = LazyComputationQuery(query=s2, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone=t2)
 
         hash1 = compute_query_hash(query_info1)
         hash2 = compute_query_hash(query_info2)
@@ -485,7 +485,9 @@ class TestExecuteComputationJobs(ClickhouseTestMixin, BaseTest):
         self._create_pageview_events()
 
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         result = LazyComputationExecutor().execute(
             team=self.team,
@@ -517,7 +519,9 @@ class TestExecuteComputationJobs(ClickhouseTestMixin, BaseTest):
         self._create_pageview_events()
 
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         # First: run for Jan 1-2
         first_result = LazyComputationExecutor().execute(
@@ -562,7 +566,9 @@ class TestExecuteComputationJobs(ClickhouseTestMixin, BaseTest):
         self._create_pageview_events()
 
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         # First: Create job for Jan 2 only
         jan2_result = LazyComputationExecutor().execute(
@@ -1395,7 +1401,9 @@ class TestRaceConditionHandling(BaseTest):
 
     def test_integrity_error_on_create_loops_back_and_picks_up_pending_job(self):
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
         query_hash = compute_query_hash(query_info)
 
         executor = LazyComputationExecutor(wait_timeout_seconds=2.0, poll_interval_seconds=0.05)
@@ -1458,7 +1466,9 @@ class TestRaceConditionHandling(BaseTest):
         rather than a correctness bug.
         """
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
         query_hash = compute_query_hash(query_info)
 
         range_a_start = datetime(2024, 1, 1, tzinfo=UTC)
@@ -1531,7 +1541,9 @@ class TestRaceConditionHandling(BaseTest):
 
     def test_unique_constraint_prevents_duplicate_pending_jobs(self):
         query = self._make_computation_query()
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
         query_hash = compute_query_hash(query_info)
 
         # Create a PENDING job directly
@@ -1557,7 +1569,7 @@ class TestRaceConditionHandling(BaseTest):
 
 
 class TestComputationExecutorExecute(BaseTest):
-    def _make_query_info(self) -> tuple[QueryInfo, str]:
+    def _make_query_info(self) -> tuple[LazyComputationQuery, str]:
         s = parse_select(
             """
             SELECT
@@ -1570,7 +1582,7 @@ class TestComputationExecutorExecute(BaseTest):
             """
         )
         assert isinstance(s, ast.SelectQuery)
-        qi = QueryInfo(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        qi = LazyComputationQuery(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
         return qi, compute_query_hash(qi)
 
     # --- Happy path ---
@@ -2516,7 +2528,9 @@ class TestPubsubAndStaleDetection(BaseTest):
                 "SELECT toStartOfDay(timestamp) as a, [] as b, uniqExactState(person_id) as c FROM events GROUP BY a"
             )
             assert isinstance(query, ast.SelectQuery)
-            query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+            query_info = LazyComputationQuery(
+                query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+            )
 
             executor = LazyComputationExecutor()
             result = executor.execute(
@@ -2538,7 +2552,9 @@ class TestPubsubAndStaleDetection(BaseTest):
                 "SELECT toStartOfDay(timestamp) as a, [] as b, uniqExactState(person_id) as c FROM events GROUP BY a"
             )
             assert isinstance(query, ast.SelectQuery)
-            query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+            query_info = LazyComputationQuery(
+                query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+            )
 
             executor = LazyComputationExecutor(max_retries=0)
             result = executor.execute(
@@ -2579,12 +2595,12 @@ class TestJobLifecycleCounters(BaseTest):
 
     TABLE = LazyComputationTable.PREAGGREGATION_RESULTS
 
-    def _query_info(self) -> QueryInfo:
+    def _query_info(self) -> LazyComputationQuery:
         query = parse_select(
             "SELECT toStartOfDay(timestamp) as a, [] as b, uniqExactState(person_id) as c FROM events GROUP BY a"
         )
         assert isinstance(query, ast.SelectQuery)
-        return QueryInfo(query=query, table=self.TABLE, timezone="UTC")
+        return LazyComputationQuery(query=query, table=self.TABLE, timezone="UTC")
 
     @staticmethod
     def _delta(metric, labels: dict[str, str], before: float) -> float:
@@ -2936,7 +2952,7 @@ class TestInsertSettingsAppliedToInserts(BaseTest):
             },
         )
         assert isinstance(query, ast.SelectQuery)
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS)
+        query_info = LazyComputationQuery(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS)
 
         with patch(
             "products.analytics_platform.backend.lazy_computation.lazy_computation_executor.sync_execute"
@@ -2974,7 +2990,7 @@ class TestMaxWindowDaysCap(BaseTest):
 
 
 class TestExecuteOOMAndBudget(ClickhouseTestMixin, BaseTest):
-    def _query_info(self) -> QueryInfo:
+    def _query_info(self) -> LazyComputationQuery:
         s = parse_select(
             """
             SELECT toStartOfDay(timestamp) as time_window_start, [] as breakdown_value,
@@ -2983,7 +2999,7 @@ class TestExecuteOOMAndBudget(ClickhouseTestMixin, BaseTest):
             """
         )
         assert isinstance(s, ast.SelectQuery)
-        return QueryInfo(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        return LazyComputationQuery(query=s, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
 
     def test_surfaces_memory_exceeded_on_oom(self):
         def oom_insert(_t, _j) -> None:
@@ -3060,7 +3076,9 @@ class TestCheckOnlyMode(BaseTest):
     def _execute(self, start: datetime, end: datetime) -> LazyComputationResult:
         query = parse_select("SELECT 1")
         assert isinstance(query, ast.SelectQuery)
-        query_info = QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+        query_info = LazyComputationQuery(
+            query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC"
+        )
 
         def forbidden_insert(team, job):
             raise AssertionError("check-only mode must never run inserts")
@@ -3079,7 +3097,7 @@ class TestCheckOnlyMode(BaseTest):
         return PreaggregationJob.objects.create(
             team=self.team,
             query_hash=compute_query_hash(
-                QueryInfo(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
+                LazyComputationQuery(query=query, table=LazyComputationTable.PREAGGREGATION_RESULTS, timezone="UTC")
             ),
             time_range_start=start,
             time_range_end=end,

--- a/products/exports/backend/models/subscription.py
+++ b/products/exports/backend/models/subscription.py
@@ -88,7 +88,7 @@ WEEKDAY_SET = {"monday", "tuesday", "wednesday", "thursday", "friday"}
 
 
 @dataclass
-class SubscriptionResourceInfo:
+class SubscriptionResource:
     kind: str
     name: str
     url: str
@@ -416,21 +416,21 @@ class Subscription(ModelActivityMixin, models.Model):
         return None
 
     @property
-    def resource_info(self) -> Optional[SubscriptionResourceInfo]:
+    def resource_info(self) -> Optional[SubscriptionResource]:
         if not self._has_resource:
             return None
         match self.resource_type:
             case self.ResourceType.INSIGHT if self.insight:
-                return SubscriptionResourceInfo(
+                return SubscriptionResource(
                     "Insight",
                     f"{self.insight.name or self.insight.derived_name}",
                     self.insight.url,
                 )
             case self.ResourceType.DASHBOARD if self.dashboard:
-                return SubscriptionResourceInfo("Dashboard", self.dashboard.name or "Dashboard", self.dashboard.url)
+                return SubscriptionResource("Dashboard", self.dashboard.name or "Dashboard", self.dashboard.url)
             case self.ResourceType.AI_PROMPT:
                 ai_name = self.title or (self.prompt or "").strip()[:AI_PROMPT_DISPLAY_MAX_LEN] or "AI report"
-                return SubscriptionResourceInfo("AI", ai_name, self.url or "")
+                return SubscriptionResource("AI", ai_name, self.url or "")
         return None
 
     @property

--- a/products/exports/backend/models/subscription.py
+++ b/products/exports/backend/models/subscription.py
@@ -88,7 +88,7 @@ WEEKDAY_SET = {"monday", "tuesday", "wednesday", "thursday", "friday"}
 
 
 @dataclass
-class SubscriptionResourceInfo:
+class SubscriptionResource:
     kind: str
     name: str
     url: str
@@ -405,21 +405,21 @@ class Subscription(ModelActivityMixin, models.Model):
         return None
 
     @property
-    def resource_info(self) -> Optional[SubscriptionResourceInfo]:
+    def resource_info(self) -> Optional[SubscriptionResource]:
         if not self._has_resource:
             return None
         match self.resource_type:
             case self.ResourceType.INSIGHT if self.insight:
-                return SubscriptionResourceInfo(
+                return SubscriptionResource(
                     "Insight",
                     f"{self.insight.name or self.insight.derived_name}",
                     self.insight.url,
                 )
             case self.ResourceType.DASHBOARD if self.dashboard:
-                return SubscriptionResourceInfo("Dashboard", self.dashboard.name or "Dashboard", self.dashboard.url)
+                return SubscriptionResource("Dashboard", self.dashboard.name or "Dashboard", self.dashboard.url)
             case self.ResourceType.AI_PROMPT:
                 ai_name = self.title or (self.prompt or "").strip()[:AI_PROMPT_DISPLAY_MAX_LEN] or "AI report"
-                return SubscriptionResourceInfo("AI", ai_name, self.url or "")
+                return SubscriptionResource("AI", ai_name, self.url or "")
         return None
 
     @property

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -33,13 +33,13 @@ from products.exports.backend.temporal.subscriptions.types import (
     CreateExportAssetsResult,
     DeliverSubscriptionInputs,
     DeliverSubscriptionResult,
+    DeliveryAbort,
+    DueSubscription,
     ExportAssetPreparationStatus,
     FetchDueSubscriptionsActivityInputs,
     NoExportableInsightsContext,
     NoExportableInsightsReason,
     RecipientResult,
-    SubscriptionAbortInfo,
-    SubscriptionInfo,
     UpdateDeliveryRecordInputs,
 )
 from products.product_analytics.backend.models.insight import Insight
@@ -184,14 +184,14 @@ async def _persist_content_snapshot(
 
 
 @temporalio.activity.defn
-async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[SubscriptionInfo]:
+async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[DueSubscription]:
     now_with_buffer = dt.datetime.now(dt.UTC) + dt.timedelta(minutes=inputs.buffer_minutes)
     await LOGGER.ainfo("Fetching due subscriptions", deadline=now_with_buffer)
 
     @database_sync_to_async(thread_sensitive=False)
-    def get_subscriptions() -> list[SubscriptionInfo]:
+    def get_subscriptions() -> list[DueSubscription]:
         return [
-            SubscriptionInfo(
+            DueSubscription(
                 subscription_id=sub["id"],
                 team_id=sub["team_id"],
                 distinct_id=str(sub["created_by__distinct_id"])
@@ -219,7 +219,7 @@ async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivity
 
 
 @temporalio.activity.defn
-async def validate_subscription_for_delivery(subscription_id: int) -> SubscriptionAbortInfo | None:
+async def validate_subscription_for_delivery(subscription_id: int) -> DeliveryAbort | None:
     """Returns abort info when delivery should not proceed; None to continue."""
     subscription = await database_sync_to_async(
         Subscription.objects.select_related("created_by", "integration").get,
@@ -230,7 +230,7 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
     # prior auto-disable committed must not re-fire side effects.
     if not subscription.enabled:
         await LOGGER.ainfo("validate_subscription.already_disabled_skipping", subscription_id=subscription_id)
-        return SubscriptionAbortInfo()
+        return DeliveryAbort()
 
     reason = get_subscription_disable_reason(subscription.target_type, subscription.integration_id)
     if reason is None:
@@ -244,7 +244,7 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
     )
     _capture_delivery_failed_event(subscription, Exception(reason.description))
     await database_sync_to_async(disable_invalid_subscription, thread_sensitive=False)(subscription, reason)
-    return SubscriptionAbortInfo(
+    return DeliveryAbort(
         failed_recipient=RecipientResult(
             recipient=subscription.target_value,
             status="failed",

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -33,13 +33,13 @@ from products.exports.backend.temporal.subscriptions.types import (
     CreateExportAssetsResult,
     DeliverSubscriptionInputs,
     DeliverSubscriptionResult,
+    DeliveryAbort,
+    DueSubscription,
     ExportAssetPreparationStatus,
     FetchDueSubscriptionsActivityInputs,
     NoExportableInsightsContext,
     NoExportableInsightsReason,
     RecipientResult,
-    SubscriptionAbortInfo,
-    SubscriptionInfo,
     UpdateDeliveryRecordInputs,
 )
 from products.product_analytics.backend.models.insight import Insight
@@ -175,14 +175,14 @@ async def _persist_content_snapshot(
 
 
 @temporalio.activity.defn
-async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[SubscriptionInfo]:
+async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivityInputs) -> list[DueSubscription]:
     now_with_buffer = dt.datetime.now(dt.UTC) + dt.timedelta(minutes=inputs.buffer_minutes)
     await LOGGER.ainfo("Fetching due subscriptions", deadline=now_with_buffer)
 
     @database_sync_to_async(thread_sensitive=False)
-    def get_subscriptions() -> list[SubscriptionInfo]:
+    def get_subscriptions() -> list[DueSubscription]:
         return [
-            SubscriptionInfo(
+            DueSubscription(
                 subscription_id=sub["id"],
                 team_id=sub["team_id"],
                 distinct_id=str(sub["created_by__distinct_id"])
@@ -210,7 +210,7 @@ async def fetch_due_subscriptions_activity(inputs: FetchDueSubscriptionsActivity
 
 
 @temporalio.activity.defn
-async def validate_subscription_for_delivery(subscription_id: int) -> SubscriptionAbortInfo | None:
+async def validate_subscription_for_delivery(subscription_id: int) -> DeliveryAbort | None:
     """Returns abort info when delivery should not proceed; None to continue."""
     subscription = await database_sync_to_async(
         Subscription.objects.select_related("created_by", "integration").get,
@@ -221,7 +221,7 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
     # prior auto-disable committed must not re-fire side effects.
     if not subscription.enabled:
         await LOGGER.ainfo("validate_subscription.already_disabled_skipping", subscription_id=subscription_id)
-        return SubscriptionAbortInfo()
+        return DeliveryAbort()
 
     reason = get_subscription_disable_reason(subscription.target_type, subscription.integration_id)
     if reason is None:
@@ -235,7 +235,7 @@ async def validate_subscription_for_delivery(subscription_id: int) -> Subscripti
     )
     _capture_delivery_failed_event(subscription, Exception(reason.description))
     await database_sync_to_async(disable_invalid_subscription, thread_sensitive=False)(subscription, reason)
-    return SubscriptionAbortInfo(
+    return DeliveryAbort(
         failed_recipient=RecipientResult(
             recipient=subscription.target_value,
             status="failed",

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/delivery.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/delivery.py
@@ -31,7 +31,7 @@ from products.exports.backend.temporal.subscriptions.types import AI_REPORT_WIND
 from ee.tasks.subscriptions.slack_subscriptions import (
     UTM_TAGS_BASE,
     SlackDeliveryResult,
-    SlackMessageData,
+    SlackMessage,
     deliver_slack_message_data,
 )
 
@@ -297,7 +297,7 @@ def _build_ai_slack_message(
     *,
     delivery_id: uuid.UUID,
     integration: Integration | None = None,
-) -> SlackMessageData:
+) -> SlackMessage:
     utm_tags = f"{UTM_TAGS_BASE}&utm_medium=slack"
     channel = subscription.target_value.split("|")[0]
     sections = _split_text_into_chunks(_SLACK_CONVERTER.convert(strip_external_links_markdown(markdown)))
@@ -352,7 +352,7 @@ def _build_ai_slack_message(
         {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": section}}]} for section in sections[1:]
     ]
     # unfurl=False: report content is LLM-generated; never let Slack auto-fetch a link it contains.
-    return SlackMessageData(channel=channel, blocks=blocks, title=title, thread_messages=thread_messages, unfurl=False)
+    return SlackMessage(channel=channel, blocks=blocks, title=title, thread_messages=thread_messages, unfurl=False)
 
 
 async def send_slack_ai_subscription_report(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/delivery.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/delivery.py
@@ -31,7 +31,7 @@ from products.exports.backend.temporal.subscriptions.types import AI_REPORT_WIND
 from ee.tasks.subscriptions.slack_subscriptions import (
     UTM_TAGS_BASE,
     SlackDeliveryResult,
-    SlackMessageData,
+    SlackMessage,
     deliver_slack_message_data,
 )
 
@@ -293,7 +293,7 @@ def _build_ai_slack_message(
     *,
     delivery_id: uuid.UUID,
     integration: Integration | None = None,
-) -> SlackMessageData:
+) -> SlackMessage:
     utm_tags = f"{UTM_TAGS_BASE}&utm_medium=slack"
     channel = subscription.target_value.split("|")[0]
     sections = _split_text_into_chunks(_SLACK_CONVERTER.convert(strip_external_links_markdown(markdown)))
@@ -348,7 +348,7 @@ def _build_ai_slack_message(
         {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": section}}]} for section in sections[1:]
     ]
     # unfurl=False: report content is LLM-generated; never let Slack auto-fetch a link it contains.
-    return SlackMessageData(channel=channel, blocks=blocks, title=title, thread_messages=thread_messages, unfurl=False)
+    return SlackMessage(channel=channel, blocks=blocks, title=title, thread_messages=thread_messages, unfurl=False)
 
 
 async def send_slack_ai_subscription_report(

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_delivery.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_delivery.py
@@ -24,7 +24,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.report_pipe
 from products.exports.backend.temporal.subscriptions.ai_subscription.spec_generator import ReportWindow
 from products.exports.backend.temporal.subscriptions.types import AI_REPORT_WINDOW_END_KEY, SubscriptionTriggerType
 
-from ee.tasks.subscriptions.slack_subscriptions import SlackMessageData
+from ee.tasks.subscriptions.slack_subscriptions import SlackMessage
 
 _DELIVERY = "products.exports.backend.temporal.subscriptions.ai_subscription.delivery"
 
@@ -196,7 +196,7 @@ def _mock_subscription() -> MagicMock:
     return sub
 
 
-def _build_message(markdown: str) -> SlackMessageData:
+def _build_message(markdown: str) -> SlackMessage:
     return _build_ai_slack_message(_mock_subscription(), markdown, delivery_id=_DELIVERY_ID)
 
 
@@ -226,11 +226,11 @@ def _mock_integration(scopes: frozenset[str]) -> MagicMock:
     return integration
 
 
-def _hint_texts(message: SlackMessageData) -> list[str]:
+def _hint_texts(message: SlackMessage) -> list[str]:
     return [el["text"] for block in message.blocks if block.get("type") == "context" for el in block["elements"]]
 
 
-def _ai_message(*, integration: MagicMock | None = None) -> SlackMessageData:
+def _ai_message(*, integration: MagicMock | None = None) -> SlackMessage:
     return _build_ai_slack_message(
         _mock_subscription(),
         "A short report.",

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -120,7 +120,7 @@ class SubscriptionTriggerType:
 
 
 @dataclasses.dataclass
-class SubscriptionInfo:
+class DueSubscription:
     subscription_id: int
     team_id: int
     distinct_id: str
@@ -306,7 +306,7 @@ class GenerateAIReportResult:
 
 
 @dataclasses.dataclass
-class SubscriptionAbortInfo:
+class DeliveryAbort:
     """Returned by `validate_subscription_for_delivery` when the workflow should abort.
     `failed_recipient` is populated only when this run auto-disabled the sub
     (workflow records FAILED). None means already-disabled — idempotency redispatch."""

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -74,7 +74,7 @@ class SubscriptionTriggerType:
 
 
 @dataclasses.dataclass
-class SubscriptionInfo:
+class DueSubscription:
     subscription_id: int
     team_id: int
     distinct_id: str
@@ -253,7 +253,7 @@ class GenerateAIReportResult:
 
 
 @dataclasses.dataclass
-class SubscriptionAbortInfo:
+class DeliveryAbort:
     """Returned by `validate_subscription_for_delivery` when the workflow should abort.
     `failed_recipient` is populated only when this run auto-disabled the sub
     (workflow records FAILED). None means already-disabled — idempotency redispatch."""

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -47,6 +47,7 @@ from products.exports.backend.temporal.subscriptions.types import (
     DeliverSubscriptionInputs,
     DeliverSubscriptionResult,
     DeliveryStatus,
+    DueSubscription,
     ExportAssetPreparationStatus,
     FetchDueSubscriptionsActivityInputs,
     GenerateAIReportInputs,
@@ -55,7 +56,6 @@ from products.exports.backend.temporal.subscriptions.types import (
     RecipientResult,
     ScheduleAllSubscriptionsWorkflowInputs,
     SnapshotInsightsInputs,
-    SubscriptionInfo,
     SubscriptionTriggerType,
     TrackedSubscriptionInputs,
     UpdateDeliveryRecordInputs,
@@ -115,7 +115,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
     @temporalio.workflow.run
     async def run(self, inputs: ScheduleAllSubscriptionsWorkflowInputs) -> None:
         fetch_inputs = FetchDueSubscriptionsActivityInputs(buffer_minutes=inputs.buffer_minutes)
-        subscription_infos: list[SubscriptionInfo] = await temporalio.workflow.execute_activity(
+        subscription_infos: list[DueSubscription] = await temporalio.workflow.execute_activity(
             fetch_due_subscriptions_activity,
             fetch_inputs,
             start_to_close_timeout=dt.timedelta(minutes=5),

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -46,6 +46,7 @@ from products.exports.backend.temporal.subscriptions.types import (
     DeliverSubscriptionInputs,
     DeliverSubscriptionResult,
     DeliveryStatus,
+    DueSubscription,
     ExportAssetPreparationStatus,
     FetchDueSubscriptionsActivityInputs,
     GenerateAIReportInputs,
@@ -54,7 +55,6 @@ from products.exports.backend.temporal.subscriptions.types import (
     RecipientResult,
     ScheduleAllSubscriptionsWorkflowInputs,
     SnapshotInsightsInputs,
-    SubscriptionInfo,
     SubscriptionTriggerType,
     TrackedSubscriptionInputs,
     UpdateDeliveryRecordInputs,
@@ -109,7 +109,7 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
     @temporalio.workflow.run
     async def run(self, inputs: ScheduleAllSubscriptionsWorkflowInputs) -> None:
         fetch_inputs = FetchDueSubscriptionsActivityInputs(buffer_minutes=inputs.buffer_minutes)
-        subscription_infos: list[SubscriptionInfo] = await temporalio.workflow.execute_activity(
+        subscription_infos: list[DueSubscription] = await temporalio.workflow.execute_activity(
             fetch_due_subscriptions_activity,
             fetch_inputs,
             start_to_close_timeout=dt.timedelta(minutes=5),


### PR DESCRIPTION
## Problem

These dataclasses are named after plumbing (`*Info`/`*Data`), not the domain concept they carry, which the [backend naming convention](https://posthog.com/handbook/engineering/conventions/backend-coding) now codifies against.

## Changes

Pure renames, no behavior or field changes. Every reference is updated (imports, annotations, tests, mocks, `__all__` strings).

| old | new |
|---|---|
| `QueryInfo` | `LazyComputationQuery` |
| `SlackMessageData` | `SlackMessage` |
| `SubscriptionAbortInfo` | `DeliveryAbort` |
| `SubscriptionInfo` | `DueSubscription` |
| `SubscriptionResourceInfo` | `SubscriptionResource` |

Safety: none of these classes are pickled into durable stores, referenced by string, or part of a serialized payload shape (class names are not embedded in Temporal/JSON payloads); each rename was independently vetted for those hazards before being applied. One of several per-team slices of a repo-wide cleanup; each slice is self-contained and mergeable in any order.

## How did you test this code?

- Full repo `mypy --cache-fine-grained .`: no issues with all renames applied.
- Frontend `tsgo --noEmit`: clean (some slices touch TS mirrors of backend types).
- Repo-wide AST census: violations went from 51 to 2, the remaining two being deliberate keeps (`posthog/hogql/ast.py` `Tuple` is the AST node concept; a test double mirrors the Temporal SDK's `ActivityInfo` name).
- An adversarial reviewer agent verified rename-only diffs, zero live references to old names, and no collisions with pre-existing symbols.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal rename, no user-facing docs impact; `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code at Arnaud's direction: a scan found 51 convention-violating dataclass names; each was independently verified (violation? better name? pickle/string-reference/public-surface safety?) before renaming, then adversarially reviewed. Clusters whose files overlap the open tuple-to-dataclass PRs (#76123-#76144) are deliberately deferred until those merge, so this PR cannot conflict with them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
