### PR TITLE
fix(cdp): keep focus in the event filter value input while typing

### DIFF
--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.stories.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.stories.tsx
@@ -646,11 +646,18 @@ Expected to show:
             }
         })
 
-        // Fill the new condition (last Value... input)
+        // Fill the new condition (last Value... input). Typed rather than pasted: paste is a single
+        // input event, so it cannot catch the tree rebuilding itself between keystrokes and taking
+        // focus with it, which used to leave only the first character behind.
         const condInputs = document.querySelectorAll<HTMLInputElement>('input[placeholder="Value..."]')
         const newCondInput = condInputs[condInputs.length - 1]
         await userEvent.clear(newCondInput)
-        await userEvent.paste('$new_event')
+        await userEvent.type(newCondInput, '$new_event')
+        await waitFor(() => {
+            if (newCondInput.value !== '$new_event') {
+                throw new Error(`Expected the whole value to be typed, got "${newCondInput.value}"`)
+            }
+        })
 
         const testCasesBefore = document.querySelectorAll('input[placeholder="$pageview"]').length
 

--- a/frontend/src/scenes/data-pipelines/event-filtering/NodeIdMap.test.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/NodeIdMap.test.ts
@@ -1,3 +1,4 @@
+import { updateAtPath, type FilterNode } from './eventFilterLogic'
 import { NodeIdMap } from './NodeIdMap'
 import { cond, and, or, not } from './testHelpers'
 
@@ -89,6 +90,77 @@ describe('NodeIdMap', () => {
             expect(nodeIds.pathOf(nodeIds.nidOf(c1))).toEqual([0])
             // c0 is no longer in the index
             expect(nodeIds.pathOf(nodeIds.nidOf(c0))).toBeUndefined()
+        })
+    })
+
+    describe('ID stability across edits', () => {
+        const allNids = (nodeIds: NodeIdMap, node: FilterNode): string[] => {
+            const out = [nodeIds.nidOf(node)]
+            if (node.type === 'and' || node.type === 'or') {
+                node.children.forEach((child) => out.push(...allNids(nodeIds, child)))
+            } else if (node.type === 'not') {
+                out.push(...allNids(nodeIds, node.child))
+            }
+            return out
+        }
+
+        // updateAtPath rebuilds the edited node and every ancestor, so identity-only IDs churned
+        // on each keystroke. That changed the React keys, remounting the subtree and knocking
+        // focus out of the value input after a single character.
+        it('keeps IDs for the edited node and its ancestors when a value changes', () => {
+            const nodeIds = new NodeIdMap()
+            const tree = and(or(cond('event_name', 'exact', '')))
+            nodeIds.buildIndex(tree)
+            const before = allNids(nodeIds, tree)
+
+            const edited = updateAtPath(tree, [0, 0], (n) => ({ ...(n as ReturnType<typeof cond>), value: 'a' }))
+            nodeIds.buildIndex(edited)
+
+            expect(allNids(nodeIds, edited)).toEqual(before)
+        })
+
+        it('keeps IDs stable across a run of edits, as typing a word does', () => {
+            const nodeIds = new NodeIdMap()
+            let tree: FilterNode = and(cond('event_name', 'exact', ''))
+            nodeIds.buildIndex(tree)
+            const before = allNids(nodeIds, tree)
+
+            for (const value of ['p', 'pa', 'pag', 'page']) {
+                tree = updateAtPath(tree, [0], (n) => ({ ...(n as ReturnType<typeof cond>), value }))
+                nodeIds.buildIndex(tree)
+            }
+
+            expect(allNids(nodeIds, tree)).toEqual(before)
+        })
+
+        it('gives a newly added sibling its own ID rather than inheriting one', () => {
+            const nodeIds = new NodeIdMap()
+            const existing = cond('event_name', 'exact', 'a')
+            const tree = and(existing)
+            nodeIds.buildIndex(tree)
+            const existingNid = nodeIds.nidOf(existing)
+
+            const withSibling = and(existing, cond('event_name', 'exact', 'b'))
+            nodeIds.buildIndex(withSibling)
+            const [, firstNid, secondNid] = allNids(nodeIds, withSibling)
+
+            expect(firstNid).toBe(existingNid)
+            expect(secondNid).not.toBe(existingNid)
+        })
+
+        // Wrapping puts a brand new NOT where the condition used to sit while the condition itself
+        // survives one level down. Inheriting purely by path would hand both the same ID.
+        it('does not reuse a live node’s ID when a new node takes its path', () => {
+            const nodeIds = new NodeIdMap()
+            const inner = cond('event_name', 'exact', 'a')
+            const tree = and(inner)
+            nodeIds.buildIndex(tree)
+
+            const wrapped = and(not(inner))
+            nodeIds.buildIndex(wrapped)
+            const nids = allNids(nodeIds, wrapped)
+
+            expect(new Set(nids).size).toBe(nids.length)
         })
     })
 })

--- a/frontend/src/scenes/data-pipelines/event-filtering/NodeIdMap.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/NodeIdMap.ts
@@ -9,15 +9,23 @@ import type { FilterNode, TreePath } from './eventFilterLogic'
  * updateAtPath uses structural sharing (unchanged subtrees keep their
  * references), IDs survive across tree mutations automatically.
  *
+ * Object identity alone is not enough for the nodes an edit actually touches:
+ * updateAtPath rebuilds the target node and every ancestor along its path, so
+ * those arrive as fresh objects. buildIndex therefore falls back to matching a
+ * rebuilt node against whatever occupied its path on the previous build.
+ *
  * The instance is owned by the scene component (via useRef) and passed
  * down to the tree editor. This avoids module-level global state.
  */
 
 let nidCounter = 0
 
+const pathKey = (path: TreePath): string => path.join('/')
+
 export class NodeIdMap {
     private ids = new WeakMap<FilterNode, string>()
     private pathIndex: Map<string, TreePath> = new Map()
+    private nidByPath: Map<string, string> = new Map()
 
     /** Get or assign a stable ID for a node. */
     nidOf(node: FilterNode): string {
@@ -34,18 +42,53 @@ export class NodeIdMap {
      * Call this once per render before using pathOf().
      */
     buildIndex(node: FilterNode): void {
+        const previousNidByPath = this.nidByPath
+        // Nodes that survived the mutation with their identity intact keep their ID, so gather
+        // those before assigning anything. An ID still held by a live node must never be
+        // inherited by a rebuilt one, or two nodes would share a key.
+        const claimed = new Set<string>()
+        this.collectClaimed(node, claimed)
+
         this.pathIndex = new Map()
-        this.indexNode(node, [])
+        this.nidByPath = new Map()
+        this.indexNode(node, [], previousNidByPath, claimed)
     }
 
-    private indexNode(node: FilterNode, path: TreePath): void {
-        this.pathIndex.set(this.nidOf(node), path)
+    private collectClaimed(node: FilterNode, claimed: Set<string>): void {
+        const existing = this.ids.get(node)
+        if (existing) {
+            claimed.add(existing)
+        }
+        this.eachChild(node, (child) => this.collectClaimed(child, claimed))
+    }
+
+    private indexNode(
+        node: FilterNode,
+        path: TreePath,
+        previousNidByPath: Map<string, string>,
+        claimed: Set<string>
+    ): void {
+        let id = this.ids.get(node)
+        if (!id) {
+            // Typing a character replaces the edited node and its ancestors, so minting a new ID
+            // here would change their React keys and remount the subtree, dropping focus from the
+            // input mid-word. A rebuilt node standing where its predecessor stood is the same node
+            // as far as the user is concerned, so it inherits that ID.
+            const inherited = previousNidByPath.get(pathKey(path))
+            id = inherited !== undefined && !claimed.has(inherited) ? inherited : `n${nidCounter++}`
+            claimed.add(id)
+            this.ids.set(node, id)
+        }
+        this.pathIndex.set(id, path)
+        this.nidByPath.set(pathKey(path), id)
+        this.eachChild(node, (child, step) => this.indexNode(child, [...path, step], previousNidByPath, claimed))
+    }
+
+    private eachChild(node: FilterNode, fn: (child: FilterNode, step: 'child' | number) => void): void {
         if (node.type === 'and' || node.type === 'or') {
-            for (let i = 0; i < node.children.length; i++) {
-                this.indexNode(node.children[i], [...path, i])
-            }
+            node.children.forEach((child, i) => fn(child, i))
         } else if (node.type === 'not') {
-            this.indexNode(node.child, [...path, 'child'])
+            fn(node.child, 'child')
         }
     }
 


### PR DESCRIPTION
## Problem

In Event ingestion filtering, when a user adds a condition and tries to type into the `Value...` box, they get one character and then focus jumps out of the input. You have to click back in for every single letter, so typing `$pageview` means nine clicks.

## Changes

### Why it breaks today

On every keystroke, React destroys the input you are typing in and renders a fresh one in its place. Focus belongs to the old element, so it goes away with it. Here is the chain:

1. Typing calls `updateTreeNode(path, { ...node, value })`, which makes a new object for the condition you are editing.
2. `updateAtPath` also copies **every group above it in the tree**, so those become new objects too.
3. `NodeIdMap` hands out IDs based on object identity. All of those fresh objects are unfamiliar to it, so they each get a brand new ID.
4. Those IDs are used as the React `key` on `SortableItem`. Changing a key is how you tell React "this is a different element", so React discards that part of the tree and builds a replacement, input and all.

Measured directly, one character into a two-level tree:

```
before typing:  root n0, condition n1
after one char: root n2, condition n3
```

Nothing here needs to be rebuilt. It is only the churning IDs that make React think otherwise.

`NodeIdMap` is built around the idea that untouched parts of the tree keep their objects, so their IDs come along for free. That holds nicely for the siblings you are not editing. The node you are editing and the groups above it are the exception, since those get rebuilt, and they happen to be the part of the tree holding the input you are typing in.

### What this changes

Keep the IDs still, and React recognizes the input as the same element it rendered last time. It updates the value in place and leaves focus alone, which is the ordinary behavior you would expect. No remounting, and nothing to restore focus afterwards.

`buildIndex` now works in two passes. First it walks the tree and notes every ID that is still spoken for, meaning the node holding it came through the edit unchanged. Then it walks again and assigns IDs. If it meets a node it does not recognize, it looks at what sat in that same spot last time and reuses that ID, as long as no one else already claimed it. Recognized nodes keep the ID they always had.

That second condition matters. Wrapping a condition in NOT puts a brand new node where the condition used to be, but the condition is still there one level down. Without the claim check, both would end up with the same ID and React would see duplicate keys.

I also looked at giving every node a permanent ID of its own, stored on the node, which is what the test cases in `eventFilterLogic` already do. I didn't go that way because the IDs would then have to be created in every place a node is made, added to trees loaded from the API, and stripped back out before saving. That is a lot of places to keep in sync for a bug that lives entirely in one file. Say the word if you would rather have it on the node and I will redo it.

> [!NOTE]
> The same IDs are used for drag and drop, so this also stops those changing on every keystroke, and stops each group's drag-highlight state resetting as you type.

## How did you test this code?

Drove a real browser (Playwright against Storybook, `EmptyState` story), adding a condition and typing `pageview` one character at a time, checking `document.activeElement` after each:

| | input value | focus after each keystroke |
| --- | --- | --- |
| Before | `p` | `XXXXXXXX` |
| After | `pageview` | `........` |

That reproduces the report exactly and shows it resolved. I did not test against a live dev stack, only Storybook.

Automated:

- `frontend/src/scenes/data-pipelines/event-filtering/` — 148 tests across 6 suites pass.
- `typescript:check` clean, `pnpm --filter=@posthog/frontend fix` clean.
- I could not run `hogli ci:preflight` (needs a Python env I do not have set up). This diff is frontend-only, no lockfile or migration changes, and I ran the lint gate directly.

On the tests:

Four cases added to `NodeIdMap.test.ts` under `ID stability across edits`.

Two of them cover the bug directly: IDs stay put for the edited node and the groups above it after one edit, and after a run of edits like typing a word. I checked both against the old code and they fail there, so they are really testing something.

The other two cover ways the new lookup could go wrong rather than the bug itself. A newly added condition has to get its own ID instead of picking up one that used to belong to something else, and wrapping a node in NOT must not leave two nodes sharing an ID.

Nothing in the existing tests covered whether IDs hold still while you edit.

On why this slipped through: the stories covering this input paste the value in, and one types a single character. Pasting arrives as one event, and a single character is exactly as far as you get before focus drops, so the symptom stays hidden either way. I changed the `AddConditionAndTestCase` story to type the whole value and check it all arrived. The end result is the same, so snapshots should not shift.

<details>
<summary>Test output</summary>

```
PASS src/scenes/data-pipelines/event-filtering/NodeIdMap.test.ts
PASS src/scenes/data-pipelines/event-filtering/filterTreeDisplay.test.ts
PASS src/scenes/data-pipelines/event-filtering/filterTreePath.test.ts
PASS src/scenes/data-pipelines/event-filtering/filterTree.integration.test.ts
PASS src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
PASS src/scenes/data-pipelines/event-filtering/filterTreeDnd.test.ts

Test Suites: 6 passed, 6 total
Tests:       148 passed, 148 total
```

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe this input's behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit this typing a filter value and had Claude (Claude Code, Opus 5) find and fix it. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

Worth a careful look: reusing the ID from whatever sat in the same spot last time is a guess, and the check for IDs already in use is the only thing stopping that guess from going wrong. The NOT test exists because that is the one case I found where the guess would have collided. If you can think of another action that drops a new node into an occupied spot while the old node is still somewhere in the tree, that is where this is most likely to break and it deserves a test.

One thing I left alone on purpose: `EventFilterScene.tsx:47` calls `nodeIds.buildIndex(...)` inside a `useMemo` for the side effect rather than to cache anything. It works and it is unrelated to this bug, so I did not want to touch it in passing. Mentioning it only in case it is useful to know while you are in here.



