### PR TITLE
ci: add names to cargo-dist release steps for readability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
             # functionality based on whether this is a pull_request, and whether it's from a fork.
             # (PRs run on the *source* but secrets are usually on the *target* -- that's *good*
             # but also really annoying to build CI around when it needs secrets to work right.)
-            - id: plan
+            - name: Plan release with cargo-dist
+              id: plan
               env:
                   DIST_COMMAND: plan
               run: |
@@ -260,7 +261,8 @@ jobs:
             - name: Verify API CLI release bundle
               run: |
                   node -e "const { existsSync, statSync } = require('node:fs'); const path = 'cli/lib/posthog-api-cli.mjs'; if (!existsSync(path) || statSync(path).size <= 0) { console.error('::error::API CLI bundle is missing or empty: ' + path); process.exit(1); }"
-            - id: cargo-dist
+            - name: Build global cargo-dist artifacts
+              id: cargo-dist
               shell: bash
               run: |
                   dist build ${{ needs.plan.outputs.tag-flag }} --output-format=json "--artifacts=global" > dist-manifest.json


### PR DESCRIPTION
## Problem

In `.github/workflows/release.yml`, long `run` steps used by cargo-dist had an `id` but no `name:`, so the Actions UI shows generic labels for planning and global artifact builds.

## Changes

Semantics are unchanged: same step `id`s, same `GITHUB_OUTPUT` keys, and the same job/step output wiring.

- Add `name: Plan release with cargo-dist` to `id: plan`
- Add `name: Build global cargo-dist artifacts` to `id: cargo-dist` in `build-global-artifacts`

## Test plan
- [ ] Confirm `plan.outputs.val` still comes from `steps.plan.outputs.manifest`
- [ ] Confirm global artifact upload still uses `steps.cargo-dist.outputs.paths`
