### PR TITLE
chore(ci): allow manual dispatch of desktop agent tag

### DIFF
--- a/.github/workflows/desktop-agent-tag.yml
+++ b/.github/workflows/desktop-agent-tag.yml
@@ -8,6 +8,7 @@ on:
             - 'products/desktop/packages/agent/**'
             - '.github/workflows/desktop-agent-tag.yml'
             - '.github/workflows/desktop-agent-release.yml'
+    workflow_dispatch:
 
 concurrency:
     group: desktop-agent-tag


### PR DESCRIPTION
## Problem

The `Desktop Agent Tag` workflow only fires on pushes to master touching the agent package. If a run fails or gets missed there's no way to retrigger it without landing another agent commit.

## Changes

Adds a `workflow_dispatch` trigger so the tag job can be run manually from the Actions tab. Safe to dispatch anytime, the version script already exits cleanly when there are no new agent commits or the tag exists.

## How did you test this code?

Ran `bin/hogli lint:workflows` and `actionlint` locally, both pass. No behavior change to the tag computation itself.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Invoked the repo's /authoring-ci-workflows skill and matched the bare `workflow_dispatch:` pattern from the sibling `desktop-tag.yml` rather than adding inputs, since the version math derives everything from git history.
