### PR TITLE
chore(ci): add umbrella Desktop Tests Pass check for desktop CI

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -54,3 +54,33 @@ jobs:
             POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY: ${{ secrets.POSTHOG_CODE_E2E_GATEWAY_PERSONAL_API_KEY }}
             POSTHOG_CODE_E2E_GATEWAY_URL: ${{ secrets.POSTHOG_CODE_E2E_GATEWAY_URL }}
             TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
+
+    # Umbrella gate for the whole desktop suite: the one check name to require in
+    # the master ruleset. Adding or removing a suite only changes this needs list,
+    # not branch protection.
+    tests-pass:
+        name: Desktop Tests Pass
+        needs: [build, quality, typecheck, test]
+        if: always()
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Check results
+              run: |
+                  if [[ "${{ needs.build.result }}" != "success" && "${{ needs.build.result }}" != "skipped" ]]; then
+                    echo "Desktop build did not succeed (result: ${{ needs.build.result }})."
+                    exit 1
+                  fi
+                  if [[ "${{ needs.quality.result }}" != "success" && "${{ needs.quality.result }}" != "skipped" ]]; then
+                    echo "Desktop quality did not succeed (result: ${{ needs.quality.result }})."
+                    exit 1
+                  fi
+                  if [[ "${{ needs.typecheck.result }}" != "success" && "${{ needs.typecheck.result }}" != "skipped" ]]; then
+                    echo "Desktop typecheck did not succeed (result: ${{ needs.typecheck.result }})."
+                    exit 1
+                  fi
+                  if [[ "${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped" ]]; then
+                    echo "Desktop tests did not succeed (result: ${{ needs.test.result }})."
+                    exit 1
+                  fi
+                  echo "All desktop suites passed or were skipped."


### PR DESCRIPTION
## Problem

Requiring the desktop suite in branch protection currently means registering four per-suite check names (`build / Desktop Build Pass`, `quality / Desktop Quality Pass`, `typecheck / Desktop Typecheck Pass`, `test / Desktop Tests Pass`) and updating the ruleset every time a suite is added or removed.

## Changes

Add a `Desktop Tests Pass` collate job to `desktop-ci.yml` that needs all four suite callers and fails unless each ended success or skipped (skipped is how non-desktop PRs pass). It follows the required-gate conventions: `if: always()`, allowlist guards per dependency, 5 minute timeout. Register just `Desktop Tests Pass` in the master ruleset; future suite changes only touch the `needs` list.

Note: `desktop-test.yml`'s internal gate has the same display name, reporting as `test / Desktop Tests Pass` on PRs, so the two are distinguishable. The bare `Desktop Tests Pass` on a PR is this umbrella.

## How did you test this code?

`hogli lint:workflows` (including the WF007 required-gate check) and `actionlint` pass. The gate reports on this PR itself, so its behavior is visible in this PR's checks.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at Charles's direction, following the /authoring-ci-workflows skill's required-gate rules (always() gate, per-dependency fail-closed allowlists, opposite worker conditions already in the child workflows).
