### PR TITLE
fix(data-modeling): address recipe review follow-ups

### DIFF
--- a/products/data_modeling/skills/modeling-activation-metrics/references/posthog/activation_flag.sql
+++ b/products/data_modeling/skills/modeling-activation-metrics/references/posthog/activation_flag.sql
@@ -1,28 +1,37 @@
 -- Per-user activation flag + activation rate by signup cohort.
--- Definition (example): activated = ran the key action >= 3 times within 7 days of first ever event.
+-- Definition (example): activated = ran the key action >= 3 times within 7 days of first-ever event.
 -- Replace 'key_action' and thresholds with the validated definition (see activation-method.md).
+--
+-- signup_at must be the user's FIRST-EVER event, computed over full history. Filtering events to a
+-- reporting window BEFORE the min() would hand a long-lived, recently-active user a brand-new
+-- "signup" date and wrongly count them as freshly activated. So compute first-ever first, then
+-- restrict the report to recent cohorts. (Materialize first_seen if the full-history scan is heavy.)
 WITH first_seen AS (
     SELECT person_id, min(timestamp) AS signup_at
     FROM events
-    WHERE timestamp >= now() - INTERVAL 180 DAY
     GROUP BY person_id
+),
+cohort AS (
+    -- the signup cohorts to report on; this filter does not affect signup_at itself
+    SELECT person_id, signup_at
+    FROM first_seen
+    WHERE signup_at >= now() - INTERVAL 180 DAY
 ),
 early_actions AS (
     SELECT
-        e.person_id,
+        c.person_id,
         countIf(e.event = 'key_action'
-                AND e.timestamp <= fs.signup_at + INTERVAL 7 DAY) AS key_actions_first_week
+                AND e.timestamp <= c.signup_at + INTERVAL 7 DAY) AS key_actions_first_week
     FROM events AS e
-    INNER JOIN first_seen AS fs ON e.person_id = fs.person_id
-    WHERE e.timestamp >= now() - INTERVAL 180 DAY
-    GROUP BY e.person_id
+    INNER JOIN cohort AS c ON e.person_id = c.person_id
+    GROUP BY c.person_id
 )
 SELECT
-    toStartOfWeek(fs.signup_at)                                       AS signup_week,
-    count()                                                           AS signups,
+    toStartOfWeek(c.signup_at)                                       AS signup_week,
+    count()                                                          AS signups,
     countIf(ea.key_actions_first_week >= 3)                          AS activated,
     round(countIf(ea.key_actions_first_week >= 3) / nullif(count(), 0), 4) AS activation_rate
-FROM first_seen AS fs
-LEFT JOIN early_actions AS ea ON fs.person_id = ea.person_id
+FROM cohort AS c
+LEFT JOIN early_actions AS ea ON c.person_id = ea.person_id
 GROUP BY signup_week
 ORDER BY signup_week

--- a/products/data_modeling/skills/modeling-activation-metrics/references/posthog/activation_retention_lift.sql
+++ b/products/data_modeling/skills/modeling-activation-metrics/references/posthog/activation_retention_lift.sql
@@ -1,29 +1,41 @@
 -- Validate a candidate activation definition: does it actually predict retention?
 -- Compares week-4 retention of users who met the criteria early vs those who didn't.
 -- A good definition shows large, stable lift (retained_activated - retained_not).
+--
+-- Two correctness guards:
+--  1. signup_at is the FIRST-EVER event (full history), not the first event in a lookback window —
+--     else a long-lived, recently-active user gets a false-new signup date.
+--  2. Only cohorts old enough for a full week-4 window count. Recent signups that haven't reached
+--     day 28 would score retained_w4 = 0 and drag the lift down (right-censoring), so exclude them.
 WITH first_seen AS (
     SELECT person_id, min(timestamp) AS signup_at
     FROM events
-    WHERE timestamp >= now() - INTERVAL 180 DAY
     GROUP BY person_id
+),
+cohort AS (
+    -- eligible cohorts: recent enough to report on, but old enough to have a complete week 4
+    SELECT person_id, signup_at
+    FROM first_seen
+    WHERE signup_at >= now() - INTERVAL 180 DAY
+      AND signup_at <= now() - INTERVAL 28 DAY
 ),
 activated AS (
     SELECT
-        e.person_id,
+        c.person_id,
         countIf(e.event = 'key_action'
-                AND e.timestamp <= fs.signup_at + INTERVAL 7 DAY) >= 3 AS is_activated
+                AND e.timestamp <= c.signup_at + INTERVAL 7 DAY) >= 3 AS is_activated
     FROM events AS e
-    INNER JOIN first_seen AS fs ON e.person_id = fs.person_id
-    GROUP BY e.person_id
+    INNER JOIN cohort AS c ON e.person_id = c.person_id
+    GROUP BY c.person_id
 ),
 week4 AS (  -- did the user do anything in their 4th week after signup?
     SELECT
-        e.person_id,
-        max(e.timestamp >= fs.signup_at + INTERVAL 21 DAY
-            AND e.timestamp < fs.signup_at + INTERVAL 28 DAY) AS retained_w4
+        c.person_id,
+        max(e.timestamp >= c.signup_at + INTERVAL 21 DAY
+            AND e.timestamp < c.signup_at + INTERVAL 28 DAY) AS retained_w4
     FROM events AS e
-    INNER JOIN first_seen AS fs ON e.person_id = fs.person_id
-    GROUP BY e.person_id
+    INNER JOIN cohort AS c ON e.person_id = c.person_id
+    GROUP BY c.person_id
 )
 SELECT
     a.is_activated                                                   AS activated,

--- a/products/data_modeling/skills/modeling-conversion-metrics/references/dbt/fct_conversion.sql
+++ b/products/data_modeling/skills/modeling-conversion-metrics/references/dbt/fct_conversion.sql
@@ -1,37 +1,44 @@
--- Warehouse-agnostic funnel: compute each person's first timestamp per step, then apply the
--- conversion-window rule AND step ordering (signup <= activated <= purchased, all within N days of
--- signup) using plain SQL — matching what windowFunnel enforces on the PostHog side.
+-- Warehouse-agnostic funnel with step ordering AND a conversion window, in plain SQL — the dbt
+-- analogue of windowFunnel. Each step is the EARLIEST occurrence AFTER the previous step's timestamp
+-- (and within N days of step 1), so a valid ordered chain survives even when an out-of-order event
+-- happens to be earlier — which an independent per-step min() would wrongly pick.
 -- 14-day window shown; adjust the interval literal to your warehouse's syntax.
 {{ config(materialized='table') }}
 
-with steps as (
-    select
-        person_id,
-        min(case when event_name = 'signed_up' then event_at end) as t_signup,
-        min(case when event_name = 'activated' then event_at end) as t_activated,
-        min(case when event_name = 'purchased' then event_at end) as t_purchased
-    from {{ ref('stg_funnel_events') }}
+with events as (
+    select person_id, event_name, event_at from {{ ref('stg_funnel_events') }}
+),
+step1 as (
+    select person_id, min(event_at) as t_signup
+    from events
+    where event_name = 'signed_up'
     group by person_id
 ),
-flags as (
-    select
-        person_id,
-        t_signup is not null as entered,
-        -- step 2 must land in [signup, signup + window]
-        (t_activated is not null
-         and t_activated between t_signup and t_signup + interval '14 day') as reached_activated,
-        -- step 3 must come AFTER step 2 (ordering) and still inside the window from signup
-        (t_activated is not null
-         and t_activated between t_signup and t_signup + interval '14 day'
-         and t_purchased is not null
-         and t_purchased between t_activated and t_signup + interval '14 day') as reached_purchased
-    from steps
-    where t_signup is not null
+step2 as (
+    -- first activation at/after signup and within the window
+    select s.person_id, s.t_signup, min(e.event_at) as t_activated
+    from step1 s
+    join events e
+        on e.person_id = s.person_id
+       and e.event_name = 'activated'
+       and e.event_at between s.t_signup and s.t_signup + interval '14 day'
+    group by s.person_id, s.t_signup
+),
+step3 as (
+    -- first purchase at/after activation and still within the window from signup
+    select a.person_id, min(e.event_at) as t_purchased
+    from step2 a
+    join events e
+        on e.person_id = a.person_id
+       and e.event_name = 'purchased'
+       and e.event_at between a.t_activated and a.t_signup + interval '14 day'
+    group by a.person_id
 )
 select
-    count(*)                                                            as entered_step_1,
-    sum(case when reached_activated then 1 else 0 end)                  as reached_activated,
-    sum(case when reached_purchased then 1 else 0 end)                 as reached_purchased,
-    round(sum(case when reached_purchased then 1 else 0 end)::numeric
-          / nullif(count(*), 0), 4)                                     as overall_conversion
-from flags
+    count(s1.person_id)                                                     as entered_step_1,
+    count(s2.person_id)                                                     as reached_activated,
+    count(s3.person_id)                                                     as reached_purchased,
+    round(count(s3.person_id)::numeric / nullif(count(s1.person_id), 0), 4) as overall_conversion
+from step1 s1
+left join step2 s2 using (person_id)
+left join step3 s3 using (person_id)

--- a/products/data_modeling/skills/modeling-product-usage-metrics/references/posthog/lifecycle.sql
+++ b/products/data_modeling/skills/modeling-product-usage-metrics/references/posthog/lifecycle.sql
@@ -1,5 +1,7 @@
 -- Lifecycle: classify each person's weekly activity as new / returning / resurrecting, and count dormant.
--- Compares each active week to the person's previous active week and their first-ever active week.
+-- Compares each active week to the person's previous active week and their first active week in the window.
+-- Note: first_week is the earliest week WITHIN this window, so a user active just before it can show as
+-- "new" at the window's left edge. Extend the window one interval earlier if that boundary matters.
 WITH activity AS (
     SELECT DISTINCT
         person_id,

--- a/products/data_modeling/skills/modeling-product-usage-metrics/references/posthog/retention_matrix.sql
+++ b/products/data_modeling/skills/modeling-product-usage-metrics/references/posthog/retention_matrix.sql
@@ -1,5 +1,7 @@
--- Weekly retention matrix: cohort by week of first event, % active in each subsequent week.
+-- Weekly retention matrix: % active in each subsequent week, by acquisition cohort.
 -- Recurring definition (active IN week N, independent per week). Replace 'core_action' with the value event.
+-- Cohort = the person's first active week WITHIN the analysis window (the standard retention convention),
+-- not their first-ever week. Widen the window, or anchor on a true first-seen week, if you need lifetime cohorts.
 WITH activity AS (
     SELECT
         person_id,

--- a/products/data_modeling/skills/modeling-revenue-metrics/references/dbt/fct_revenue_item.sql
+++ b/products/data_modeling/skills/modeling-revenue-metrics/references/dbt/fct_revenue_item.sql
@@ -1,6 +1,9 @@
 -- Line-item grain revenue fact, the dbt analogue of PostHog's managed revenue_item view.
--- Converts each line item to the reporting base currency via the currency_rates seed
--- (dbt has no convertCurrency()). Config it as incremental once history is large.
+-- Recognizes deferred revenue: each recurring line item is spread evenly across the calendar months
+-- of its service period [period_start, period_end], so an annual plan feeds 1/12 of its value into
+-- each month's MRR rather than the whole amount into a single month. One-time (non-subscription)
+-- items resolve to just the month they were charged. Grain is one row per (line item, service month).
+-- Converts to the reporting base currency via the currency_rates seed (dbt has no convertCurrency()).
 {{ config(materialized='table') }}
 
 with items as (
@@ -8,21 +11,55 @@ with items as (
 ),
 rates as (
     select currency, rate_date, rate_to_base from {{ ref('currency_rates') }}
+),
+-- month spine covering the full span of all line items; generate_series over dates is
+-- Postgres/DuckDB syntax — swap in your warehouse's month generator if it differs.
+month_spine as (
+    select generate_series(
+        date_trunc('month', min(period_start)),
+        date_trunc('month', max(coalesce(period_end, period_start))),
+        interval '1 month'
+    ) as month
+    from items
+),
+recognized as (
+    select
+        i.id,
+        i.subscription_id,
+        i.customer_id,
+        i.product_id,
+        i.period_start::date as period_start,
+        i.period_end::date   as period_end,
+        i.currency,
+        i.amount             as line_amount,
+        (i.subscription_id is not null) as is_recurring,
+        s.month::date        as month,
+        -- number of service months, to split the line amount evenly across the period
+        count(*) over (partition by i.id) as service_months
+    from items i
+    join month_spine s
+        on s.month >= date_trunc('month', i.period_start)
+       and s.month <= date_trunc('month', case
+               when i.subscription_id is not null then coalesce(i.period_end, i.period_start)
+               else i.period_start
+           end)
 )
 select
-    i.id                                             as revenue_item_id,
-    i.subscription_id,
-    i.customer_id,
-    i.product_id,
-    i.period_start::date                             as period_start,
-    i.period_end::date                               as period_end,
-    date_trunc('month', i.period_start)              as month,
-    i.subscription_id is not null                    as is_recurring,
-    i.currency                                       as original_currency,
-    i.amount                                         as original_amount,
-    -- amount in base currency at the item's rate:
-    i.amount * coalesce(r.rate_to_base, 1.0)         as amount
-from items i
-left join rates r
-    on r.currency = i.currency
-   and r.rate_date = i.period_start::date
+    r.id                               as revenue_item_id,
+    r.month,
+    r.subscription_id,
+    r.customer_id,
+    r.product_id,
+    r.period_start,
+    r.period_end,
+    r.is_recurring,
+    r.currency                         as original_currency,
+    r.line_amount / r.service_months   as original_amount,
+    -- base-currency amount at the month's rate. A MISSING rate stays NULL on purpose so the
+    -- not_null test on `amount` fails loudly instead of silently assuming 1:1 parity. Seed the
+    -- base currency itself at rate_to_base = 1.0 so base-currency rows resolve.
+    (r.line_amount / r.service_months) * rt.rate_to_base as amount
+from recognized r
+left join rates rt
+    on rt.currency = r.currency
+   and rt.rate_date = r.month

--- a/products/data_modeling/skills/modeling-revenue-metrics/references/dbt/schema.yml
+++ b/products/data_modeling/skills/modeling-revenue-metrics/references/dbt/schema.yml
@@ -9,10 +9,13 @@ models:
           - name: country
 
     - name: fct_revenue_item
-      description: Line-item grain revenue, converted to the base currency.
+      description: Deferred-revenue recognition at (line item, service month) grain, in base currency.
+      data_tests:
+          - dbt_utils.unique_combination_of_columns:
+                combination_of_columns: [revenue_item_id, month]
       columns:
           - name: revenue_item_id
-            data_tests: [unique, not_null]
+            data_tests: [not_null]
           - name: customer_id
             data_tests:
                 - not_null
@@ -20,7 +23,7 @@ models:
                       to: ref('dim_customer')
                       field: customer_id
           - name: amount
-            description: Revenue in the reporting base currency.
+            description: Revenue recognized in this month, in the reporting base currency.
             data_tests: [not_null]
 
     - name: fct_mrr


### PR DESCRIPTION
## Problem

Follow-up to [#75458](https://github.com/PostHog/posthog/pull/75458), which adds the data-modeling skill set. A review on that PR by @thiagosalvatore flagged five correctness issues in the copy-paste example recipes. This PR applies all five.

> [!NOTE]
> This is **stacked on `posthog-code/data-modeling-skills`** (the head branch of #75458) and contains only the recipe fixes. The task tooling for this resumed run declined to commit directly onto #75458's head, so the fixes are delivered here on top of it. Fast-forwarding #75458's branch to this commit (or merging this PR into it) folds them in; the diff is exactly the 5 flagged files plus the revenue schema test.

## Changes

| Recipe | Fix |
|--------|-----|
| `dbt/fct_revenue_item.sql` | Recognize **deferred revenue** — spread each recurring line item evenly across the calendar months of its service period, so an annual plan feeds 1/12 per month into MRR instead of its full value into one month. Grain becomes (line item, service month); `schema.yml` switches to a compound uniqueness test. |
| `dbt/fct_revenue_item.sql` | Drop `coalesce(rate, 1.0)` so a **missing FX rate** yields `NULL` and trips the `not_null` test instead of silently assuming base-currency parity. Seed the base currency at 1.0 so its own rows resolve. |
| `dbt/fct_conversion.sql` | Enforce **step ordering** — derive each step as the earliest occurrence *after* the previous step's timestamp (within the window), matching `windowFunnel`, instead of an independent per-step `min()` that could discard a valid ordered chain. |
| `posthog/activation_flag.sql`, `posthog/activation_retention_lift.sql` | Compute `signup_at` as the **first-ever** event over full history, then filter cohorts — so a long-lived, recently-active user isn't counted as freshly activated. The lift query also excludes **right-censored** cohorts (signup within the last 28 days) whose week-4 window is incomplete. |
| `posthog/retention_matrix.sql`, `posthog/lifecycle.sql` | Correct the comments to say *first active week within the analysis window* (the standard convention), not "first-ever", and note the window-boundary caveat. |

## How did you test this code?

I (Claude) validated the restructured HogQL against a live project via `execute-sql` (bounded scan): activated users showed ~37% week-4 retention vs ~0.3% for non-activated — the lift the recipe is meant to teach, with the 28-day right-censoring guard active. The dbt SQL is example/template code and was not run against a warehouse. `oxfmt --check` passes on the changed YAML/markdown. These are documentation recipes only — no app code, migrations, or endpoints.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude at Anna's direction to address the review comments from @thiagosalvatore on #75458. All five were legitimate correctness issues in my own recipe files, so I applied each. Note: the resumed-run task tooling refused to commit onto #75458's head branch (it's treated as the run's base), so these land on a stacked branch — see the note above.
