### PR TITLE
fix(desktop): spin the sidebar dot for starting cloud runs

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -85,7 +85,16 @@ describe("ChannelItemRow", () => {
       "Pending — no work in flight",
     ],
     [
+      // Launching: a sandbox is being claimed and the backend leaves this state
+      // on its own, so the motion is honest.
       "a queued cloud run",
+      { taskRunStatus: "queued" as const, workspaceMode: "cloud" as const },
+      "Starting",
+    ],
+    [
+      // A local run's status is never advanced, so queued here means "was
+      // launched at some point", not "is starting". Seen parked for hours.
+      "a local run parked at queued",
       { taskRunStatus: "queued" as const },
       "Pending — no work in flight",
     ],

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -68,7 +68,8 @@ beforeEach(() => {
 describe("ChannelItemRow", () => {
   // The dot vocabulary in one table: what the row's leading mark says for each
   // state a task can be in. Only the states a reader can act on get a voice —
-  // run mechanics (queued, failed) resolve to "working" or "something to read".
+  // run mechanics (queued, failed) resolve to a dot that describes the work
+  // rather than the status: starting, live but stalled, or something to read.
   it.each([
     [
       "a permission prompt",
@@ -97,6 +98,19 @@ describe("ChannelItemRow", () => {
       "a local run parked at queued",
       { taskRunStatus: "queued" as const },
       "Pending — no work in flight",
+    ],
+    [
+      // A PR outranks a run that only claims to be working, but not one that is
+      // demonstrably coming up. Re-running a task that already shipped a PR
+      // leaves the url on the session and the state in the PR query, so this is
+      // the ordinary shape of a second run, not an edge case.
+      "a re-queued cloud run on a task that already has a PR",
+      {
+        taskRunStatus: "queued" as const,
+        workspaceMode: "cloud" as const,
+        prState: "open" as const,
+      },
+      "Starting",
     ],
     [
       "a broken run with unseen output",

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -107,10 +107,11 @@ export interface TaskDot {
  * the reader actually gets is output they haven't seen, which is `isUnread`, and
  * the run's real story lives in the task detail where there's room to tell it.
  *
- * Queued is folded into pending for the same reason. "Waiting on a sandbox" and
- * "a run that hasn't been closed out" are one fact to the reader — it's live but
- * nothing is moving — so they share the still yellow dot. Only a prompt in
- * flight spins.
+ * Queued is folded into working for the same reason. "Waiting on a sandbox" and
+ * "a sandbox is writing code" are one fact to the reader — it's under way — so
+ * they share the spinner. What doesn't share it is a run sitting at
+ * `in_progress` with nothing streaming: that claim outlives the work, and a
+ * spinner that never stops is a lie about the machine.
  *
  * And a run that has already opened a PR is not working, whatever its status
  * says. The cloud workflow keeps the run `in_progress` while it babysits CI
@@ -128,21 +129,26 @@ export function taskDot(props: TaskStatusInput): TaskDot {
       label: "Needs permission — blocked on you",
     };
   }
-  // The spinner is reserved for a prompt actually in flight — the agent typing
-  // right now. A run status can't earn it: nothing writes a terminal status when
-  // a local agent goes idle, and the cloud workflow holds `in_progress` while it
-  // babysits CI, so both keep claiming work for as long as the row exists. A
-  // spinner that never stops is a lie about the machine, so the claim gets the
-  // still dot below instead.
-  if (props.isGenerating) {
+  // Spinning means something is moving on its own: a prompt in flight, or a
+  // cloud run still coming up. Cloud `queued` is a sandbox being claimed — the
+  // backend leaves that state by itself, so the motion is bounded. A LOCAL run
+  // queued is not a launch: nothing advances a local run's persisted status, so
+  // it can sit there for hours after the agent is done with it.
+  const isStartingCloudRun =
+    props.taskRunStatus === "queued" && props.workspaceMode === "cloud";
+  if (props.isGenerating || isStartingCloudRun) {
     return {
       tone: "yellow",
       style: "solid",
       pulse: false,
       spinner: true,
-      label: "Working",
+      label: props.isGenerating ? "Working" : "Starting",
     };
   }
+  // The statuses that lie. Nothing writes a terminal status when a local agent
+  // goes idle, and the cloud workflow holds in_progress while it babysits CI, so
+  // the claim outlives the work — sometimes for the row's whole life. Live, but
+  // nothing moving: the still dot.
   const runClaimsWork =
     props.taskRunStatus === "in_progress" || props.taskRunStatus === "queued";
   if (runClaimsWork && !hasPullRequest(props)) {

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -107,10 +107,11 @@ export interface TaskDot {
  * the reader actually gets is output they haven't seen, which is `isUnread`, and
  * the run's real story lives in the task detail where there's room to tell it.
  *
- * Queued is folded into working for the same reason. "Waiting on a sandbox" and
- * "a sandbox is writing code" are one fact to the reader — it's under way — so
- * they share the spinner. What doesn't share it is a run sitting at
- * `in_progress` with nothing streaming: that claim outlives the work, and a
+ * A cloud run's queued is folded into working for the same reason. "Waiting on a
+ * sandbox" and "a sandbox is writing code" are one fact to the reader, that it's
+ * under way, so they share the spinner. Two states don't share it: a local run
+ * at `queued`, whose persisted status nothing ever advances, and a run at
+ * `in_progress` with nothing streaming. Both claims outlive the work, and a
  * spinner that never stops is a lie about the machine.
  *
  * And a run that has already opened a PR is not working, whatever its status
@@ -130,10 +131,10 @@ export function taskDot(props: TaskStatusInput): TaskDot {
     };
   }
   // Spinning means something is moving on its own: a prompt in flight, or a
-  // cloud run still coming up. Cloud `queued` is a sandbox being claimed — the
-  // backend leaves that state by itself, so the motion is bounded. A LOCAL run
-  // queued is not a launch: nothing advances a local run's persisted status, so
-  // it can sit there for hours after the agent is done with it.
+  // cloud run still coming up. Cloud `queued` is a sandbox being claimed, and
+  // the backend leaves that state by itself, so the motion is bounded. A local
+  // run at `queued` is not a launch: nothing advances a local run's persisted
+  // status, so it can sit there for hours after the agent is done with it.
   const isStartingCloudRun =
     props.taskRunStatus === "queued" && props.workspaceMode === "cloud";
   if (props.isGenerating || isStartingCloudRun) {
@@ -147,7 +148,7 @@ export function taskDot(props: TaskStatusInput): TaskDot {
   }
   // The statuses that lie. Nothing writes a terminal status when a local agent
   // goes idle, and the cloud workflow holds in_progress while it babysits CI, so
-  // the claim outlives the work — sometimes for the row's whole life. Live, but
+  // the claim outlives the work, sometimes for the row's whole life. Live, but
   // nothing moving: the still dot.
   const runClaimsWork =
     props.taskRunStatus === "in_progress" || props.taskRunStatus === "queued";

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -119,7 +119,9 @@ export interface TaskDot {
  * after opening the PR, and under a merge queue that wait ends only when someone
  * enqueues the merge — so the run can claim to be working for hours after the
  * agent stopped. The PR is the deliverable; once it exists the badge carries the
- * story and the dot goes quiet.
+ * story and the dot goes quiet. This beats a status that merely claims work, not
+ * one that is visibly starting: a re-queued cloud run keeps its spinner even
+ * with last run's PR still on the task.
  */
 export function taskDot(props: TaskStatusInput): TaskDot {
   if (props.needsPermission) {


### PR DESCRIPTION
## Problem

Follow-up nits on top of PostHog/code#4008, which reworked the sidebar row status dots. That PR folded `queued` into pending, so a cloud task waiting on a sandbox showed the same still yellow dot as a run that had simply never been closed out. Those are not the same fact to a reader. A sandbox being claimed is bounded motion the backend leaves on its own, and it should look like it.

## What the dot does

One node changes. A cloud run's first few seconds stop reading as "nothing is happening".

**Cloud run, before:**

```mermaid
flowchart LR
    A(["send"]) --> Q["queued<br/>● Pending"]
    Q --> S["streaming<br/>⠋ Working"]
    S --> P["in_progress, idle<br/>● Pending"]
    P --> D["PR opened<br/>○ All caught up"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class Q,P phGray;
    class S phBlue;
    class D phGray;
```

**Cloud run, after:**

```mermaid
flowchart LR
    A(["send"]) --> Q["queued<br/>⠋ Starting"]
    Q --> S["streaming<br/>⠋ Working"]
    S --> P["in_progress, idle<br/>● Pending"]
    P --> D["PR opened<br/>○ All caught up"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class Q,S phBlue;
    class P,D phGray;
```

**Local run, unchanged:**

```mermaid
flowchart LR
    A(["send"]) --> Q["queued<br/>● Pending"]
    Q --> S["streaming<br/>⠋ Working"]
    S --> P["never advances<br/>● Pending"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class Q,P phGray;
    class S phBlue;
```

`⠋` spins, `●` is still and solid, `○` is hollow and quiet.

Timings below are from a real cloud run in the dev app, polled once a second from the moment of send:

| t | dot | why |
| --- | --- | --- |
| 0-4s | row not in the list yet | task still being created |
| **5-12s** | **⠋ Starting** | cloud `queued`, sandbox being claimed. This is the new state |
| 13-14s | ⠋ Working | agent streaming, `isPromptPending` |
| 15s+ | ● Pending, no work in flight | `in_progress` with nothing streaming |

Eight seconds is long enough that the old still dot read as a click that did not register.

## Changes

`taskStatusVocabulary.ts`:

- Cloud `queued` now earns the spinner, labelled "Starting". The backend advances that state by itself, so the motion terminates.
- Local `queued` does not. Nothing writes a terminal status when a local agent goes idle, so a local run can sit at `queued` for hours after the work is done. It keeps the still dot alongside `in_progress` runs whose claim outlives the work.
- Comments reworked to say why each case gets the treatment it does, rather than restating the branch.

`ChannelItemRow.test.tsx`: two cases, the new starting state and its precedence over an existing PR.

> [!NOTE]
> The cloud-queued branch returns before the PR check, so a re-queued cloud run on a task that already has a PR spins rather than going quiet. That is deliberate. The PR rule exists because `in_progress` lies (the workflow holds it while babysitting CI); cloud `queued` does not lie, and a re-run genuinely is starting. The docblock now says the PR beats a status that merely claims work, not one that is visibly starting, and a test pins it.

The changes originate on the PostHog/code branch `ux/task-icons-rework-nits` (commit `0edbe86`). No PR was ever opened there, and PostHog/code main is frozen after the desktop import, so it is remade here. It only became portable once #76339 resynced `products/desktop` to `fc991d3`, which brought PostHog/code#4008 and the file this edits into the monorepo.

## How did you test this code?

I (Claude) ran these from `products/desktop`, on the rebased branch:

- `pnpm install --frozen-lockfile`, clean
- `pnpm --filter @posthog/ui test`, 2499 tests across 301 files pass, including both new `ChannelItemRow` cases
- `pnpm --filter @posthog/ui typecheck`, 3 errors, all pre-existing. I ran the same command on the base commit and got the identical 3 (`CLOUD_STREAM_IDLE_TIMEOUT`, `MCP_GATEWAY_FLAG`, `@posthog/harness/extensions/posthog-provider/model-catalog`). None are in files this PR touches.

Then I drove the running dev app over CDP with agent-browser and started both a cloud run and a local run in a space, polling the row's accessible name once a second. The dot's accessible name is the exact `label` string `taskDot()` returns, so the snapshot reads the real value rather than a rendering of it. The cloud table above is that run. The local run sat at "Pending, no work in flight" from creation onward and never spun, which is the branch this change deliberately excludes.

<details>
<summary>Raw polling output, cloud run</summary>

```
--- t=4s
    - button "Pending — no work in flight Respond with greeting message Cloud"
--- t=5s
    - button "Starting Say hello Cloud"
--- t=12s
    - button "Starting Say hello Cloud"
--- t=13s
    - button "Working Say hello Cloud"
--- t=15s
    - button "Pending — no work in flight Say hello Cloud"
```

</details>

The two new tests assert that a cloud run at `queued` gets the spinner while a local run at `queued` does not, and that the spinner survives an existing PR on the task. No existing test covered the workspace mode split (both used to fall through to the same still dot), and the two PR-precedence cases both used `in_progress`, so nothing pinned the interaction between a starting run and a PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover the sidebar dot vocabulary.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Ported by Claude Code (Opus 5) using the repo's `/porting-code-prs` skill, with `/writing-code-comments` and `/writing-tests` for the follow-up rounds. The skill's normal path is `gh pr diff` into `git am --directory=products/desktop/`, but there was no source PR here, just a branch with one commit, so the patch came from `git format-patch` on the fetched branch instead. `git am -3` preserved the original authorship.

The interesting part was the base. The skill is explicit that merged PostHog/code changes must arrive through the resync protocol in MIGRATION.md and must never be hand-ported, since that duplicates the diff. PostHog/code#4008 is merged and sat after what was then the pinned SHA, so the file this commit edits was absent from master and the port was blocked. I first built this stacked on the open resync PR, then found #76339 had already merged an hour earlier, so it was rebased straight onto master and the stack thrown away.

A review pass afterwards found the PR-precedence gap called out above, plus a docblock that claimed queued folds into working without qualifying it to cloud. Both are fixed in follow-up commits. The commit message was reworded from `nits` to conventional-commit format.
