### PR TITLE
fix(data-modeling): use dbt datediff macro in fct_retention

### DIFF
--- a/products/data_modeling/skills/modeling-product-usage-metrics/references/dbt/fct_retention.sql
+++ b/products/data_modeling/skills/modeling-product-usage-metrics/references/dbt/fct_retention.sql
@@ -1,4 +1,5 @@
--- Weekly retention matrix (recurring). Warehouse-agnostic; adjust date_trunc/date_diff to your warehouse.
+-- Weekly retention matrix (recurring). Uses dbt's cross-database datediff macro for the interval count;
+-- date_trunc still varies by warehouse, so adjust it if yours differs.
 {{ config(materialized='table') }}
 
 with activity as (
@@ -17,7 +18,7 @@ joined as (
     select
         c.cohort_week,
         a.person_id,
-        ({{ 'datediff' }}('week', c.cohort_week, a.week)) as weeks_later
+        {{ dbt.datediff('c.cohort_week', 'a.week', 'week') }} as weeks_later
     from cohort c
     join activity a using (person_id)
     where a.week >= c.cohort_week


### PR DESCRIPTION
## Problem

Follow-up to the review on [#75458](https://github.com/PostHog/posthog/pull/75458).
A Graphite review comment flagged a bug in `fct_retention.sql`: the Jinja expression `{{ 'datediff' }}` renders the bare string `datediff`, so the macro wrapper does nothing.
It compiles to a plain `datediff(...)` call that isn't portable (Postgres has no `datediff`) and misleadingly looks like it invokes a dbt macro.

The five earlier review fixes from @thiagosalvatore already merged via [#76338](https://github.com/PostHog/posthog/pull/76338); this is the one remaining item, stacked on the same branch.

## Changes

Replace `{{ 'datediff' }}('week', ...)` with dbt's cross-database `datediff` macro so the interval count works across warehouses:

```sql
{{ dbt.datediff('c.cohort_week', 'a.week', 'week') }} as weeks_later
```

Note the macro signature is `datediff(first_date, second_date, datepart)` — datepart last — so the argument order differs from the reviewer's suggested snippet.

## How did you test this code?

This is example/template dbt SQL, not run against a warehouse.
The change is a one-line macro correction; `oxfmt` doesn't cover `.sql` so no formatting step applies.
No app code, migrations, or endpoints touched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude at Anna's direction to address the Graphite review comment on #75458.
Anna explicitly asked for this as a stacked PR.
Verified the finding independently (the quoted-literal Jinja is a real bug) and corrected the macro signature rather than copying the suggestion verbatim.
