### PR TITLE
fix(stripe): classify Stripe's generic backend-error APIError as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/source.py
@@ -297,7 +297,13 @@ If automatic creation failed due to a permissions error and you're using a restr
         # A 429 is already retried in-process by _RateLimitRetryingRequestsClient's Retry-After-aware
         # backoff (see stripe.py); if that budget still exhausts, Temporal's activity retry picks it
         # back up, so this is self-recovering rather than a tracked-exception-worthy failure.
-        return {"Request rate limit exceeded"}
+        #
+        # A non-4xx `stripe.APIError` (a genuine backend problem on Stripe's side) is already retried
+        # in-process by the SDK's own 5xx backoff before it can reach here, so the same reasoning
+        # applies. Stripe's docs describe these as safe to retry. The server-generated message text
+        # varies between at least two known phrasings, so match the boilerplate phrase both share
+        # rather than the full message.
+        return {"Request rate limit exceeded", "notified of the problem"}
 
     def _get_api_key(self, config: StripeSourceConfig, team_id: int) -> str:
         if config.auth_method.selection == "api_key":

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -10,6 +10,7 @@ import stripe as stripe_lib
 from parameterized import parameterized
 from stripe import ListObject
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.webhook_s3 import WebhookSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.stripe import (
     StripeAuthMethodConfig,
@@ -253,9 +254,11 @@ class TestStripeSource:
     )
     def test_retryable_errors_match_self_recovering_errors(self, observed_error):
         # These must be classified as retryable so they're logged as a warning rather than tracked
-        # as an exception, since they're retried by Temporal at the activity level regardless.
+        # as an exception, since they're retried by Temporal at the activity level regardless. Match
+        # via the same case-insensitive helper the production path uses (`_handle_import_error`),
+        # not a case-sensitive substring check.
         retryable_errors = self.source.get_retryable_errors()
-        assert any(key in observed_error for key in retryable_errors)
+        assert error_message_matches(observed_error, retryable_errors)
 
     @pytest.mark.parametrize(
         "config,expected_message",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -229,14 +229,31 @@ class TestStripeSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
 
-    def test_retryable_errors_match_rate_limit(self):
-        # A RateLimitError that survives _RateLimitRetryingRequestsClient's in-process backoff still
-        # gets retried by Temporal at the activity level; it must be classified as retryable so it's
-        # logged as a warning rather than tracked as an exception.
-        observed_error = (
-            "Request req_abc123: Request rate limit exceeded. You can learn more about rate limits here "
-            "https://stripe.com/docs/rate-limits."
-        )
+    @parameterized.expand(
+        [
+            (
+                # A RateLimitError that survives _RateLimitRetryingRequestsClient's in-process backoff
+                # still gets retried by Temporal at the activity level.
+                "Request req_abc123: Request rate limit exceeded. You can learn more about rate limits here "
+                "https://stripe.com/docs/rate-limits.",
+            ),
+            (
+                # A generic backend APIError that survives the SDK's own in-process 5xx retries — one
+                # of at least two known server-generated phrasings for the same "our fault, try again"
+                # condition.
+                "Request req_abc123: Error while communicating with one of our backends.  Sorry about "
+                "that!  We have been notified of the problem.  If you have any questions, we can help "
+                "at https://support.stripe.com/.",
+            ),
+            (
+                "Request req_abc123: Sorry, something went wrong. We've already been notified of the "
+                "problem, but if you need any help, you can reach us at https://support.stripe.com/contact.",
+            ),
+        ]
+    )
+    def test_retryable_errors_match_self_recovering_errors(self, observed_error):
+        # These must be classified as retryable so they're logged as a warning rather than tracked
+        # as an exception, since they're retried by Temporal at the activity level regardless.
         retryable_errors = self.source.get_retryable_errors()
         assert any(key in observed_error for key in retryable_errors)
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `stripe.APIError` raised from `get_rows`/`_call_stripe` in `products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fbd39-6b21-7901-914d-387fb8eecf41)). The full stack trace confirms this originates from a genuine Stripe API call during pagination (`auto_paging_iter`), propagating out through Stripe's own `handle_error_response`.

The observed messages are Stripe's own server-generated text for a non-4xx internal problem on their side (the `else` branch of the SDK's `specific_v1_api_error`, reached for any status code outside the recognized 4xx set, raising a plain `stripe.APIError`):

- "Error while communicating with one of our backends. Sorry about that! We have been notified of the problem...."
- "Sorry, something went wrong. We've already been notified of the problem...."

Both are Stripe's generic apology text for a transient backend issue, and Stripe's own docs describe `APIError` as generally safe to retry. The SDK's HTTP client already retries any 5xx in-process (`max_network_retries=2` is configured for our client); once that budget is exhausted, Temporal's activity retry policy picks the sync back up on the next attempt — so this is a Stripe-side blip, not a PostHog bug or a customer configuration problem.

## Changes

Added the stable phrase both observed message variants share ("notified of the problem") to `StripeSource.get_retryable_errors()`, alongside the existing `"Request rate limit exceeded"` entry. This mirrors the same self-recovering-5xx classification already used elsewhere in this codebase — the error is logged as a warning and re-raised for Temporal to retry, instead of being reported as tracked exception noise.

No change to `NonRetryableErrors` or to retry policy/backoff — this isn't a stop-retrying case, and Temporal already retried this activity regardless of classification.

## How did you test this code?

Extended the single-case `test_retryable_errors_match_rate_limit` into a parameterized `test_retryable_errors_match_self_recovering_errors`, adding both observed message variants — this guards against the classification silently regressing, which the prior test didn't cover for this message shape.

Ran the full Stripe source test suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py` — 164 passed. Ran `ruff check` / `ruff format --check` on the changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry classification, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a PostHog error tracking issue delivered by webhook for the Stripe warehouse source.
- Skills invoked: `/writing-tests` (before extending the parameterized test case).
- Pulled the issue's stack trace and representative events via PostHog's error-tracking MCP tools, confirmed the failure genuinely originates in this source's code (the stack contains `get_rows` in `stripe.py`, not just serialized log context), then traced the exception back through the installed `stripe` SDK's `_api_requestor.py` to confirm the message is server-generated Stripe text for a generic non-4xx internal error, not something the SDK hardcodes.
- Checked for duplicate open PRs before starting: three open PRs (#76150, #76151, #76152) already classify a *different* generic Stripe `APIError` message ("An unknown error occurred") the same way, for separate error-tracking issues. None of them match the message text this issue's events show, so this isn't a duplicate — it's a companion fix for a different phrasing of the same underlying "generic Stripe 5xx should be retryable, not reported" gap. Left those PRs untouched.