### PR TITLE
fix(data-imports): keep transient S3 blips out of error tracking at the activity boundary

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -3,6 +3,8 @@ from django.db import InterfaceError, OperationalError
 import botocore.exceptions
 import deltalake.exceptions
 
+from posthog.temporal.common.errors import NonReportableError
+
 # Substrings of the object-store errors raised talking to our own S3-backed data-warehouse bucket
 # that are transient and self-recovering, not a bug in our code or a customer credential problem:
 # - the first three come from delta-rs's Rust `object_store` crate inside `DeltaTable.is_deltatable()`
@@ -17,6 +19,16 @@ TRANSIENT_OBJECT_STORE_ERRORS = (
     "Generic S3 error",
     "Please reduce your request rate",
 )
+
+
+class TransientObjectStoreError(NonReportableError):
+    """A known-transient object-store blip (see is_transient_object_store_error), re-raised as this
+    type instead of the original OSError/DeltaError. Skipping the inline capture_exception call
+    alone isn't enough: the raw error still escapes the activity uncaught and reaches the Temporal
+    activity interceptor (posthog/temporal/common/posthog_client.py), which reports every activity
+    exception to error tracking unless it's a NonReportableError — so it minted a fresh issue per
+    blip anyway. Wrapping keeps it out of tracking at that boundary too. Temporal's retry policy is
+    unaffected either way, since NonReportableError only suppresses reporting, not retries."""
 
 
 def is_transient_object_store_error(error: BaseException) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -17,6 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
     conditional_lru_cache_async,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TransientObjectStoreError,
     is_transient_object_store_error,
 )
 
@@ -155,13 +156,16 @@ class DeltaTableHelper:
     async def _capture_unless_transient(self, e: Exception) -> None:
         """capture_exception unless `e` is a known-transient object-store blip (see
         is_transient_object_store_error) — those recover on retry and aren't a defect, so reporting
-        them to error tracking is just noise. Never suppresses the re-raise itself, so Temporal's
-        activity retry policy is unaffected either way.
+        them to error tracking is just noise. A transient blip is re-raised as
+        TransientObjectStoreError instead of letting the original propagate: the activity
+        interceptor reports any uncaught activity exception unless it's a NonReportableError, so a
+        bare re-raise here would still mint a fresh issue at that boundary. Never suppresses the
+        re-raise itself, so Temporal's activity retry policy is unaffected either way.
         """
         if is_transient_object_store_error(e):
             await self._logger.awarning(f"get_delta_table: transient object-store error, not reporting: {e}")
-        else:
-            capture_exception(e)
+            raise TransientObjectStoreError(str(e)) from e
+        capture_exception(e)
 
     @conditional_lru_cache_async(maxsize=1, condition=lambda result: result is not None)
     async def get_delta_table(self) -> deltalake.DeltaTable | None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
@@ -10,6 +10,9 @@ import deltalake
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import realign_decimal_buffers
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TransientObjectStoreError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import DeltaTableHelper
 
 _HELPER_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper"
@@ -166,25 +169,31 @@ class TestGetDeltaTableUnrecoverableErrors:
     @pytest.mark.asyncio
     async def test_is_deltatable_transient_error_is_not_captured_but_still_reraised(self):
         """A known-transient object-store blip (e.g. an S3 LIST request timing out) must not be
-        reported to error tracking as a defect — it's a self-recovering network hiccup, not a bug —
-        but it must still propagate so Temporal's activity retry policy retries the sync."""
+        reported to error tracking as a defect — it's a self-recovering network hiccup, not a bug.
+        It must still propagate (as TransientObjectStoreError, not the raw OSError) so Temporal's
+        activity retry policy retries the sync. Wrapping matters, not just suppressing the inline
+        capture_exception call here: a bare OSError would still reach the activity interceptor
+        (posthog_client.py), which reports any uncaught activity exception that isn't a
+        NonReportableError, minting a fresh error-tracking issue per blip anyway."""
         helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
         delta_uri = "s3://bucket/team_id/job_id/t"
 
         module = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper"
+        original_error = OSError(
+            "Generic S3 error\nError getting list response body\nHTTP error\n"
+            "request or response body error\noperation timed out"
+        )
         with (
             patch.object(helper, "_get_delta_table_uri", AsyncMock(return_value=delta_uri)),
             patch(f"{module}.deltalake.DeltaTable") as mock_delta_table,
             patch(f"{module}.capture_exception") as mock_capture,
         ):
-            mock_delta_table.is_deltatable.side_effect = OSError(
-                "Generic S3 error\nError getting list response body\nHTTP error\n"
-                "request or response body error\noperation timed out"
-            )
+            mock_delta_table.is_deltatable.side_effect = original_error
 
-            with pytest.raises(OSError, match="operation timed out"):
+            with pytest.raises(TransientObjectStoreError, match="operation timed out") as exc_info:
                 await helper.get_delta_table()
 
+            assert exc_info.value.__cause__ is original_error
             mock_capture.assert_not_called()
             cast(AsyncMock, helper._logger.awarning).assert_awaited_once()
             assert helper.is_first_sync is False


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OSError` raised from `DeltaTable.is_deltatable()` inside `DeltaTableHelper.get_delta_table()` in the shared data-imports pipeline (`products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py`), during a Stripe sync. The message was a "Generic S3 error" describing a redirect response missing its `Location` header while listing the data-warehouse bucket - a self-recovering network/object-store blip, not a bug in our code or a customer configuration problem.

The pipeline already has a classifier for exactly this: `is_transient_object_store_error` in `delta/errors.py` matches "Generic S3 error" and similar substrings, and `get_delta_table()` uses it to skip the inline `capture_exception()` call for known-transient blips. But that classification only silenced the inline capture - the raw `OSError` still escaped the activity uncaught. Temporal's activity interceptor (`posthog/temporal/common/posthog_client.py`) reports *any* uncaught activity exception to error tracking unless it's a `NonReportableError`, so the same blip still minted a fresh issue at that boundary every time it recurred.

## Changes

- Added `TransientObjectStoreError(NonReportableError)` in `delta/errors.py`.
- `DeltaTableHelper._capture_unless_transient` now re-raises a known-transient blip as `TransientObjectStoreError` (chained via `from e`) instead of letting the bare original exception propagate. This mirrors the existing `RESTClientRetryableError` pattern already used in the REST source client for the same "retryable but not a defect" case.
- Retry behavior is unchanged: `NonReportableError` only suppresses reporting, not retries, so Temporal's activity retry policy still applies exactly as before.
- No change to `NonRetryableErrors` and no change to backoff/timeout - this was never a retry-classification gap, only a reporting one.

## How did you test this code?

Updated `test_is_deltatable_transient_error_is_not_captured_but_still_reraised` to assert the wrapped `TransientObjectStoreError` (with the original `OSError` as `__cause__`) is raised instead of the raw `OSError` - this is the regression the fix closes: without the wrap, this same test would still pass today's assertion but the exception would still leak past the activity interceptor as tracked noise.

Ran the full `test_delta_table_helper.py` suite locally (63 passed), plus `ruff check`/`ruff format --check` and a full repo `mypy` run - all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal error-reporting classification, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a PostHog error tracking issue delivered by webhook for the data-imports pipeline.
- Skills invoked: `/writing-tests` (before extending the existing transient-error test case).
- Pulled the issue's stack trace, representative event, and exception chain via PostHog's error-tracking MCP tools. The event carried a chained exception pair (`OSError` alongside a Stripe `APIError` from `__context__`); traced the `OSError` back to `DeltaTable.is_deltatable()` in the shared pipeline code, confirming the failure isn't source-specific.
- Found that `is_transient_object_store_error` already classified this exact message as transient, which pointed to the real gap being at the activity-interceptor boundary rather than the classifier itself - traced `posthog/temporal/common/posthog_client.py`'s exception handling to confirm it reports independently of that inline classification, and found the established `NonReportableError` fix pattern already used by `RESTClientRetryableError` for the same shape of problem.
- Checked for duplicate open PRs: #76351 (same author) addresses the sibling Stripe `APIError` from this event's exception chain, but as a separate error-tracking issue and in the Stripe source's own retry classification - a different layer from this fix, not a duplicate. No open PR touches `delta_table_helper.py`'s `is_deltatable`/`get_delta_table` path or introduces this wrapping.