### PR TITLE
fix(data-warehouse): stop anchor time selector corrupting on partial input

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -1034,6 +1034,11 @@ function AnchorTimeField({
                     disabledReason={accessDisabledReason ?? disabledReasonForInput()}
                     value={isSyncTimeSet ? localTime.substring(0, 5) : undefined}
                     onChange={(value) => {
+                        // Native time inputs emit '' or a partial value mid-edit; ignore those so we
+                        // never persist an "Invalid date" that corrupts the field.
+                        if (!/^\d{2}:\d{2}$/.test(value)) {
+                            return
+                        }
                         const newValue = `${value}:00`
                         const utcValue = isProjectTime
                             ? dayjs(`${dayjs().format('YYYY-MM-DD')}T${newValue}`)


### PR DESCRIPTION
## Problem

The anchor time selector on the data warehouse schema settings page (Schedule tab) was severely busted — typing a time would visibly corrupt the field, showing garbage like `Inval` instead of a time.

Root cause: the field is a native `<input type="time">`, which fires `onChange` on every edit, including while a value is still incomplete (a half-typed time reports an empty string). The handler didn't guard against that. It unconditionally appended `:00` and, when the picker was in project-timezone mode, ran the string through `dayjs`. A partial/empty value produced an `Invalid Date`, whose `.format()` returns the literal string `"Invalid date"`. That string got persisted into state and rendered straight back into the input (sliced to `Inval`), so the field self-corrupted mid-keystroke.

## Changes

Guard the `onChange` handler so it ignores partial or empty native-input events and only persists a complete `HH:mm` value. One-line regex check before the existing dayjs conversion — no behavior change for valid input.

```diff
 onChange={(value) => {
+    // Native time inputs emit '' or a partial value mid-edit; ignore those so we
+    // never persist an "Invalid date" that corrupts the field.
+    if (!/^\d{2}:\d{2}$/.test(value)) {
+        return
+    }
     const newValue = `${value}:00`
     ...
```

## How did you test this code?

I (Claude, via the PostHog Slack app) traced the corruption from the native input's per-keystroke `onChange` through the dayjs conversion to the persisted `Invalid date` string and back into the field's `value`, and confirmed the guard blocks the only path that produced it. I was not able to run the frontend typecheck or the app in this environment (`node_modules` / `tsgo` not installed here), so this hasn't been manually exercised in a browser. The change is a self-contained regex guard on the existing handler.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a Slack thread about a broken selector in data warehouse settings. I located the anchor time field in `products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx`, diagnosed the mid-edit `Invalid date` round-trip, and added the input guard. No skills were required for a change this small. Considered validating deeper in the dayjs branch only, but the empty-value case also corrupts the non-project-time path (`":00"`), so guarding at the top of the handler covers both.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1785537032039289?thread_ts=1785537032.039289&cid=C0ACRAMJUAG)*
