### PR TITLE
feat(desktop): group report findings by type in the inbox detail

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/SignalsList.stories.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SignalsList.stories.tsx
@@ -1,0 +1,109 @@
+import type { Signal } from "@posthog/shared/types";
+import type { Meta, StoryObj } from "@storybook/react";
+import { SignalsList } from "./SignalsList";
+
+const meta: Meta<typeof SignalsList> = {
+  title: "Inbox/SignalsList",
+  component: SignalsList,
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 420 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SignalsList>;
+
+let seq = 0;
+function signal(overrides: Partial<Signal>): Signal {
+  seq += 1;
+  return {
+    signal_id: `sig-${seq}`,
+    content: "Checkout requests started returning 502s after the deploy.",
+    source_product: "error_tracking",
+    source_type: "issue_created",
+    source_id: `src-${seq}`,
+    weight: 1,
+    timestamp: "2026-07-30T14:00:00Z",
+    extra: { fingerprint: `fp-${seq}` },
+    ...overrides,
+  };
+}
+
+const githubIssue = (n: number): Signal =>
+  signal({
+    source_product: "github",
+    source_type: "issue",
+    content: `Users report the export button does nothing on large projects (#${n}).`,
+    extra: {
+      html_url: `https://github.com/acme/app/issues/${n}`,
+      number: n,
+      labels: [{ name: "bug", color: "d73a4a" }],
+      created_at: "2026-07-29T09:00:00Z",
+    },
+  });
+
+/** Many findings, few types: the grouped view with counts per type. */
+export const Grouped: Story = {
+  args: {
+    signals: [
+      signal({}),
+      signal({ content: "TypeError: cannot read properties of undefined." }),
+      signal({
+        source_type: "issue_spiking",
+        content: "502 volume spiked 8x.",
+      }),
+      signal({}),
+      signal({
+        source_type: "issue_spiking",
+        content: "Timeout volume spiked.",
+      }),
+      githubIssue(101),
+      githubIssue(102),
+      signal({
+        source_product: "llm_analytics",
+        source_type: "evaluation",
+        content: "Evaluation score dropped below threshold on the support bot.",
+        extra: { evaluation_id: "eval-1", trace_id: "trace-abc123456789" },
+      }),
+      signal({}),
+    ],
+  },
+};
+
+/** Below the grouping threshold: the flat list. */
+export const Flat: Story = {
+  args: {
+    signals: [signal({}), githubIssue(103)],
+  },
+};
+
+/** Enough findings but every type distinct: grouping would not compress, stays flat. */
+export const FlatAllDistinctTypes: Story = {
+  args: {
+    signals: [
+      signal({}),
+      signal({ source_type: "issue_spiking" }),
+      githubIssue(104),
+      signal({
+        source_product: "zendesk",
+        source_type: "ticket",
+        content: "Customer cannot log in since this morning.",
+        extra: {
+          url: "https://acme.zendesk.com/api/v2/tickets/42.json",
+          priority: "high",
+          status: "open",
+        },
+      }),
+      signal({
+        source_product: "llm_analytics",
+        source_type: "evaluation",
+        content: "Hallucination rate above target.",
+        extra: { evaluation_id: "eval-2", trace_id: "trace-def123456789" },
+      }),
+    ],
+  },
+};

--- a/products/desktop/packages/ui/src/features/inbox/components/SignalsList.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SignalsList.tsx
@@ -1,18 +1,84 @@
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import type { Signal } from "@posthog/shared/types";
 import { SignalCard } from "@posthog/ui/features/inbox/components/detail/SignalCard";
-import { Box, Flex } from "@radix-ui/themes";
+import {
+  groupSignalsByType,
+  type SignalGroup,
+  shouldGroupSignals,
+} from "@posthog/ui/features/inbox/components/signalGrouping";
+import { getSourceProductMeta } from "@posthog/ui/features/inbox/components/utils/source-product-icons";
+import { Badge, Box, Flex, Text } from "@radix-ui/themes";
+import { useMemo, useState } from "react";
 
 interface SignalsListProps {
   signals: Signal[];
 }
 
 export function SignalsList({ signals }: SignalsListProps) {
+  const groups = useMemo(() => groupSignalsByType(signals), [signals]);
+
+  if (!shouldGroupSignals(groups, signals.length)) {
+    return (
+      <Flex direction="column" gap="2">
+        {signals.map((signal) => (
+          <SignalCard key={signal.signal_id} signal={signal} />
+        ))}
+      </Flex>
+    );
+  }
+
   return (
     <Flex direction="column" gap="2">
-      {signals.map((signal) => (
-        <SignalCard key={signal.signal_id} signal={signal} />
+      {groups.map((group) => (
+        <SignalGroupSection key={group.key} group={group} />
       ))}
     </Flex>
+  );
+}
+
+function SignalGroupSection({ group }: { group: SignalGroup }) {
+  const [expanded, setExpanded] = useState(false);
+  const meta = getSourceProductMeta(group.sourceProduct);
+
+  return (
+    <Box className="min-w-0 overflow-hidden rounded-(--radius-2) border border-(--gray-6) bg-gray-1">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full cursor-default items-center gap-2 p-3 text-left hover:bg-gray-2"
+      >
+        {expanded ? (
+          <CaretDownIcon size={12} className="shrink-0 text-gray-10" />
+        ) : (
+          <CaretRightIcon size={12} className="shrink-0 text-gray-10" />
+        )}
+        <span
+          className="shrink-0"
+          style={{ color: meta?.color ?? "var(--gray-9)" }}
+        >
+          {meta ? (
+            <meta.Icon size={14} />
+          ) : (
+            <span className="inline-block h-2.5 w-2.5 rounded-full bg-(--gray-9)" />
+          )}
+        </span>
+        <Text className="font-medium text-[13px] text-gray-11">
+          {group.label}
+        </Text>
+        <span className="flex-1" />
+        <Badge variant="soft" color="gray" size="1" className="text-[11px]">
+          {group.signals.length}
+        </Badge>
+      </button>
+      {expanded && (
+        <Flex direction="column" gap="2" className="px-3 pb-3">
+          {group.signals.map((signal) => (
+            <SignalCard key={signal.signal_id} signal={signal} />
+          ))}
+        </Flex>
+      )}
+    </Box>
   );
 }
 

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/SignalCard.tsx
@@ -14,6 +14,7 @@ import { RelativeTimestamp } from "@posthog/ui/primitives/RelativeTimestamp";
 import { errorTrackingIssueUrl } from "@posthog/ui/utils/posthogLinks";
 import { Badge, Box, Flex, Text } from "@radix-ui/themes";
 import { useCallback, useMemo, useRef, useState } from "react";
+import { parseExtra, signalCardSourceLine } from "./signalCardSourceLine";
 import {
   type SignalInteractionAction,
   SignalInteractionContext,
@@ -21,89 +22,6 @@ import {
 } from "./signalInteractionContext";
 
 const COLLAPSE_THRESHOLD = 300;
-
-// ── Source line labels (matching PostHog Cloud's signalCardSourceLine) ────────
-
-const ERROR_TRACKING_TYPE_LABELS: Record<string, string> = {
-  issue_created: "New issue",
-  issue_reopened: "Issue reopened",
-  issue_spiking: "Volume spike",
-};
-
-// Turn a scout's skill_name (e.g. "signals-scout-error-tracking") into a
-// human-friendly label (e.g. "Error tracking").
-function prettifyScoutName(skillName: string): string {
-  const cleaned = skillName
-    .replace(/^signals-scout-/, "")
-    .replace(/[-_]/g, " ")
-    .trim();
-  if (!cleaned) return "";
-  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
-}
-
-function signalCardSourceLine(signal: {
-  source_product: string;
-  source_type: string;
-  extra?: Record<string, unknown>;
-}): string {
-  const { source_product, source_type } = signal;
-
-  if (source_product === "error_tracking") {
-    const typeLabel =
-      ERROR_TRACKING_TYPE_LABELS[source_type] ?? source_type.replace(/_/g, " ");
-    return `Error tracking · ${typeLabel}`;
-  }
-  if (
-    source_product === "session_replay" &&
-    source_type === "session_problem"
-  ) {
-    return "Session replay · Session problem";
-  }
-  if (
-    source_product === "session_replay" &&
-    source_type === "session_segment_cluster"
-  ) {
-    return "Session replay · Session segment cluster";
-  }
-  if (
-    source_product === "session_replay" &&
-    source_type === "session_analysis_cluster"
-  ) {
-    return "Session replay · Session analysis cluster";
-  }
-  if (source_product === "llm_analytics" && source_type === "evaluation") {
-    return "AI observability · Evaluation";
-  }
-  if (source_product === "zendesk" && source_type === "ticket") {
-    return "Zendesk · Ticket";
-  }
-  if (source_product === "github" && source_type === "issue") {
-    return "GitHub · Issue";
-  }
-  if (source_product === "linear" && source_type === "issue") {
-    return "Linear · Issue";
-  }
-  if (source_product === "pganalyze" && source_type === "issue") {
-    return "pganalyze · Issue";
-  }
-  if (source_product === "health_checks" && source_type === "health_issue") {
-    return "Health checks · Issue";
-  }
-  if (
-    source_product === "signals_scout" &&
-    source_type === "cross_source_issue"
-  ) {
-    const skillName =
-      typeof signal.extra?.skill_name === "string"
-        ? prettifyScoutName(signal.extra.skill_name)
-        : "";
-    return skillName ? `Scout · ${skillName}` : "Scout · Cross-source issue";
-  }
-
-  const productLabel = source_product.replace(/_/g, " ");
-  const typeLabel = source_type.replace(/_/g, " ");
-  return `${productLabel} · ${typeLabel}`;
-}
 
 // ── Shared utilities ─────────────────────────────────────────────────────────
 
@@ -205,17 +123,6 @@ function zendeskWebUrl(apiUrl: string): string {
   if (!match) return apiUrl;
   const [, origin, id] = match;
   return `${origin}/agent/tickets/${id}`;
-}
-
-function parseExtra(raw: Record<string, unknown>): Record<string, unknown> {
-  if (typeof raw === "string") {
-    try {
-      return JSON.parse(raw) as Record<string, unknown>;
-    } catch {
-      return {};
-    }
-  }
-  return raw;
 }
 
 // ── Type guards ──────────────────────────────────────────────────────────────

--- a/products/desktop/packages/ui/src/features/inbox/components/detail/signalCardSourceLine.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/detail/signalCardSourceLine.ts
@@ -1,0 +1,95 @@
+// ── Source line labels (matching PostHog Cloud's signalCardSourceLine) ────────
+
+const ERROR_TRACKING_TYPE_LABELS: Record<string, string> = {
+  issue_created: "New issue",
+  issue_reopened: "Issue reopened",
+  issue_spiking: "Volume spike",
+};
+
+// Turn a scout's skill_name (e.g. "signals-scout-error-tracking") into a
+// human-friendly label (e.g. "Error tracking").
+function prettifyScoutName(skillName: string): string {
+  const cleaned = skillName
+    .replace(/^signals-scout-/, "")
+    .replace(/[-_]/g, " ")
+    .trim();
+  if (!cleaned) return "";
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+export function signalCardSourceLine(signal: {
+  source_product: string;
+  source_type: string;
+  extra?: Record<string, unknown>;
+}): string {
+  const { source_product, source_type } = signal;
+
+  if (source_product === "error_tracking") {
+    const typeLabel =
+      ERROR_TRACKING_TYPE_LABELS[source_type] ?? source_type.replace(/_/g, " ");
+    return `Error tracking · ${typeLabel}`;
+  }
+  if (
+    source_product === "session_replay" &&
+    source_type === "session_problem"
+  ) {
+    return "Session replay · Session problem";
+  }
+  if (
+    source_product === "session_replay" &&
+    source_type === "session_segment_cluster"
+  ) {
+    return "Session replay · Session segment cluster";
+  }
+  if (
+    source_product === "session_replay" &&
+    source_type === "session_analysis_cluster"
+  ) {
+    return "Session replay · Session analysis cluster";
+  }
+  if (source_product === "llm_analytics" && source_type === "evaluation") {
+    return "AI observability · Evaluation";
+  }
+  if (source_product === "zendesk" && source_type === "ticket") {
+    return "Zendesk · Ticket";
+  }
+  if (source_product === "github" && source_type === "issue") {
+    return "GitHub · Issue";
+  }
+  if (source_product === "linear" && source_type === "issue") {
+    return "Linear · Issue";
+  }
+  if (source_product === "pganalyze" && source_type === "issue") {
+    return "pganalyze · Issue";
+  }
+  if (source_product === "health_checks" && source_type === "health_issue") {
+    return "Health checks · Issue";
+  }
+  if (
+    source_product === "signals_scout" &&
+    source_type === "cross_source_issue"
+  ) {
+    const skillName =
+      typeof signal.extra?.skill_name === "string"
+        ? prettifyScoutName(signal.extra.skill_name)
+        : "";
+    return skillName ? `Scout · ${skillName}` : "Scout · Cross-source issue";
+  }
+
+  const productLabel = source_product.replace(/_/g, " ");
+  const typeLabel = source_type.replace(/_/g, " ");
+  return `${productLabel} · ${typeLabel}`;
+}
+
+export function parseExtra(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  return raw;
+}

--- a/products/desktop/packages/ui/src/features/inbox/components/signalGrouping.test.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/signalGrouping.test.ts
@@ -1,0 +1,128 @@
+import type { Signal } from "@posthog/shared/types";
+import { describe, expect, it } from "vitest";
+import { groupSignalsByType, shouldGroupSignals } from "./signalGrouping";
+
+function makeSignal(
+  overrides: Partial<Signal> & { signal_id: string },
+): Signal {
+  return {
+    content: "",
+    source_product: "github",
+    source_type: "issue",
+    source_id: "src-1",
+    weight: 1,
+    timestamp: "2026-08-01T00:00:00Z",
+    extra: {},
+    ...overrides,
+  };
+}
+
+describe("signalGrouping", () => {
+  it("buckets by source line and keeps incoming order within each group", () => {
+    const signals = [
+      makeSignal({ signal_id: "gh-1" }),
+      makeSignal({
+        signal_id: "err-1",
+        source_product: "error_tracking",
+        source_type: "issue_created",
+      }),
+      makeSignal({ signal_id: "gh-2" }),
+      makeSignal({
+        signal_id: "err-2",
+        source_product: "error_tracking",
+        source_type: "issue_created",
+      }),
+      makeSignal({ signal_id: "gh-3" }),
+    ];
+
+    const groups = groupSignalsByType(signals);
+
+    expect(groups.map((g) => g.label)).toEqual([
+      "GitHub · Issue",
+      "Error tracking · New issue",
+    ]);
+    expect(groups[0].signals.map((s) => s.signal_id)).toEqual([
+      "gh-1",
+      "gh-2",
+      "gh-3",
+    ]);
+    expect(groups[1].signals.map((s) => s.signal_id)).toEqual([
+      "err-1",
+      "err-2",
+    ]);
+  });
+
+  it("splits scout findings by skill instead of one scout bucket", () => {
+    const scout = (signal_id: string, skill_name: string): Signal =>
+      makeSignal({
+        signal_id,
+        source_product: "signals_scout",
+        source_type: "cross_source_issue",
+        extra: { skill_name },
+      });
+    const groups = groupSignalsByType([
+      scout("s-1", "signals-scout-error-tracking"),
+      scout("s-2", "signals-scout-session-replay"),
+      scout("s-3", "signals-scout-error-tracking"),
+    ]);
+
+    expect(groups.map((g) => [g.label, g.signals.length])).toEqual([
+      ["Scout · Error tracking", 2],
+      ["Scout · Session replay", 1],
+    ]);
+  });
+
+  it("orders groups largest first, first-appearance on ties", () => {
+    const groups = groupSignalsByType([
+      makeSignal({
+        signal_id: "z-1",
+        source_product: "zendesk",
+        source_type: "ticket",
+      }),
+      makeSignal({ signal_id: "gh-1" }),
+      makeSignal({
+        signal_id: "err-1",
+        source_product: "error_tracking",
+        source_type: "issue_spiking",
+      }),
+      makeSignal({
+        signal_id: "err-2",
+        source_product: "error_tracking",
+        source_type: "issue_spiking",
+      }),
+      makeSignal({ signal_id: "gh-2" }),
+    ]);
+
+    expect(groups.map((g) => g.label)).toEqual([
+      "GitHub · Issue",
+      "Error tracking · Volume spike",
+      "Zendesk · Ticket",
+    ]);
+    expect(groups.map((g) => g.signals.length)).toEqual([2, 2, 1]);
+  });
+
+  it.each([
+    { name: "below minimum count", total: 4, distinct: 2, expected: false },
+    { name: "no type repeats", total: 5, distinct: 5, expected: false },
+    {
+      name: "enough findings with repeats",
+      total: 5,
+      distinct: 2,
+      expected: true,
+    },
+    { name: "single repeated type", total: 6, distinct: 1, expected: true },
+  ])(
+    "grouping engages only when it compresses: $name",
+    ({ total, distinct, expected }) => {
+      const signals = Array.from({ length: total }, (_, i) =>
+        makeSignal({
+          signal_id: `s-${i}`,
+          source_type: `type_${i % distinct}`,
+        }),
+      );
+      const groups = groupSignalsByType(signals);
+      expect(groups).toHaveLength(distinct);
+      expect(shouldGroupSignals(groups, signals.length)).toBe(expected);
+    },
+  );
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/signalGrouping.ts
+++ b/products/desktop/packages/ui/src/features/inbox/components/signalGrouping.ts
@@ -1,0 +1,59 @@
+import type { Signal } from "@posthog/shared/types";
+import {
+  parseExtra,
+  signalCardSourceLine,
+} from "@posthog/ui/features/inbox/components/detail/signalCardSourceLine";
+
+export interface SignalGroup {
+  /** Grouping key: the rendered source line, so it can never disagree with the header label. */
+  key: string;
+  label: string;
+  sourceProduct: string;
+  signals: Signal[];
+}
+
+/** Minimum findings before the grouped view engages. */
+export const GROUPING_MIN_SIGNALS = 5;
+
+/**
+ * Bucket signals by their source line ("Product · Type"). Keying on the
+ * rendered label rather than raw source_product/source_type splits scout
+ * findings by skill instead of lumping every scout under one header. Groups
+ * are ordered largest first (ties keep first-appearance order); the incoming
+ * signal order is preserved within each group.
+ */
+export function groupSignalsByType(signals: Signal[]): SignalGroup[] {
+  const groups = new Map<string, SignalGroup>();
+  for (const signal of signals) {
+    const label = signalCardSourceLine({
+      ...signal,
+      extra: parseExtra(signal.extra),
+    });
+    const group = groups.get(label);
+    if (group) {
+      group.signals.push(signal);
+    } else {
+      groups.set(label, {
+        key: label,
+        label,
+        sourceProduct: signal.source_product,
+        signals: [signal],
+      });
+    }
+  }
+  return [...groups.values()].sort(
+    (a, b) => b.signals.length - a.signals.length,
+  );
+}
+
+/**
+ * The grouped view only helps when it actually compresses the list: enough
+ * findings to be worth scanning by type, and at least one type that repeats.
+ * Otherwise headers are pure overhead over the flat list.
+ */
+export function shouldGroupSignals(
+  groups: SignalGroup[],
+  signalCount: number,
+): boolean {
+  return signalCount >= GROUPING_MIN_SIGNALS && groups.length < signalCount;
+}


### PR DESCRIPTION
## Problem

Reports with many findings render them as one long flat list. When most findings are near-duplicates (the same error firing repeatedly, a batch of related traces), the evidence column becomes a wall of similar cards and the report is hard to parse.

Closes #76282

## Changes

Groups the findings list by type when that actually compresses it, following the mock in the issue:

- Findings bucket by their source line ("Error tracking · Volume spike", "GitHub · Issue", "Scout · Error tracking"). Keying on the rendered label means the header can never disagree with the cards inside it, and scout findings split per skill instead of lumping under one Scout bucket.
- Each group renders as a collapsed header row (source icon, type label, count badge). Expanding shows the existing `SignalCard`s unchanged, largest group first.
- The grouped view engages only when there are 5+ findings and at least one type repeats. Small reports and reports where every finding is a distinct type keep the flat list, so nothing changes for the common case.
- `signalCardSourceLine`/`parseExtra` moved out of `SignalCard.tsx` into `detail/signalCardSourceLine.ts` (mirroring Cloud's `frontend/src/lib/signals/signalCardSourceLine.ts`) so the grouping and the card share one labeler. No behavior change to `SignalCard`.

Grouping logic lives in `signalGrouping.ts` as pure functions; `SignalsList` stays presentational, so a Storybook story covers the grouped, flat, and all-distinct states.

## How did you test this code?

- Unit tests in `signalGrouping.test.ts` (vitest). Regressions each one pins: keying on raw `source_product`/`source_type` instead of the rendered label would merge scout skills into one bucket (scout split test); an unstable or ascending sort would reorder groups between renders (ordering test); grouping engaging on small or all-distinct reports would add header noise where the flat list is better (threshold cases, parameterized).
- `pnpm typecheck` and Biome on the touched package.
- I was not able to run the Electron app against live report data in this environment. The Storybook story (`Inbox/SignalsList`) renders the grouped, flat, and all-distinct states with fixture findings for visual review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, UI-only change within the existing inbox detail view.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (Fable 5), directed by @AlexlaGuardia (external contributor, so I can't self-assign; treat the PR author as DRI).
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments` (all read before writing), plus the repo's `storybook-stories` skill for the story.
- Decisions: grouping key is the rendered source line rather than the raw `(source_product, source_type)` pair so scout findings group per skill; the threshold (5+ findings, at least one repeated type) exists so the grouped view only appears when it compresses, per the "many very similar" framing in the issue; collapsed-by-default matches the "counts per type, with the option to dive deeper" mock. Considered adding group expand/collapse to the engagement-tracking action union and left it out to keep the diff focused; happy to add if you want it measured.
