### PR TITLE
fix(annotations): normalize date range filters to UTC

### DIFF
--- a/products/annotations/backend/api/annotation.py
+++ b/products/annotations/backend/api/annotation.py
@@ -1,8 +1,10 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from django.db.models import Q, QuerySet
 
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema, extend_schema_field, extend_schema_view
 from rest_framework import filters, pagination, serializers, viewsets
 
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
@@ -132,6 +134,40 @@ class AnnotationsLimitOffsetPagination(pagination.LimitOffsetPagination):
     default_limit = 1000
 
 
+@extend_schema_field(OpenApiTypes.STR)
+class AnnotationDateTimeField(serializers.DateTimeField):
+    pass
+
+
+class AnnotationListQuerySerializer(serializers.Serializer):
+    date_from = AnnotationDateTimeField(
+        required=False,
+        default_timezone=UTC,
+        help_text=(
+            "Inclusive start of the annotation date range in ISO 8601 format. "
+            "Values without a time or timezone are interpreted as UTC."
+        ),
+        error_messages={"invalid": "Invalid date range: date_from must be a valid ISO 8601 date"},
+    )
+    date_to = AnnotationDateTimeField(
+        required=False,
+        default_timezone=UTC,
+        help_text=(
+            "Inclusive end of the annotation date range in ISO 8601 format. "
+            "Values without a time or timezone are interpreted as UTC."
+        ),
+        error_messages={"invalid": "Invalid date range: date_to must be a valid ISO 8601 date"},
+    )
+
+    def validate(self, attrs: dict[str, datetime]) -> dict[str, datetime]:
+        date_from = attrs.get("date_from")
+        date_to = attrs.get("date_to")
+        if date_from is not None and date_to is not None and date_from > date_to:
+            raise serializers.ValidationError("Invalid date range: date_from must be before date_to")
+        return attrs
+
+
+@extend_schema_view(list=extend_schema(parameters=[AnnotationListQuerySerializer]))
 class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelViewSet):
     """
     Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more information on annotations.
@@ -171,28 +207,15 @@ class AnnotationsViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.Mo
             queryset = queryset.filter(scope=scope)
 
         # Add date range filtering
-        date_from = self.request.query_params.get("date_from")
-        date_to = self.request.query_params.get("date_to")
+        query_serializer = AnnotationListQuerySerializer(data=self.request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+        date_from = query_serializer.validated_data.get("date_from")
+        date_to = query_serializer.validated_data.get("date_to")
 
-        date_from_parsed = None
-        date_to_parsed = None
-
-        if date_from:
-            try:
-                date_from_parsed = datetime.fromisoformat(date_from.replace("Z", "+00:00"))
-                queryset = queryset.filter(date_marker__gte=date_from_parsed)
-            except ValueError:
-                raise serializers.ValidationError("Invalid date range: date_from must be a valid ISO 8601 date")
-
-        if date_to:
-            try:
-                date_to_parsed = datetime.fromisoformat(date_to.replace("Z", "+00:00"))
-                queryset = queryset.filter(date_marker__lte=date_to_parsed)
-            except ValueError:
-                raise serializers.ValidationError("Invalid date range: date_to must be a valid ISO 8601 date")
-
-        if date_from_parsed and date_to_parsed and date_from_parsed > date_to_parsed:
-            raise serializers.ValidationError("Invalid date range: date_from must be before date_to")
+        if date_from is not None:
+            queryset = queryset.filter(date_marker__gte=date_from)
+        if date_to is not None:
+            queryset = queryset.filter(date_marker__lte=date_to)
 
         # Add is_emoji filtering
         is_emoji = self.request.query_params.get("is_emoji")

--- a/products/annotations/backend/api/test/test_annotation.py
+++ b/products/annotations/backend/api/test/test_annotation.py
@@ -428,6 +428,33 @@ class TestAnnotation(APIBaseTest, QueryMatchingTest):
         else:
             assert len(results) == 0
 
+    def test_filter_annotations_by_mixed_timezone_date_range(self) -> None:
+        included_annotation = Annotation.objects.create(
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="Included annotation",
+            date_marker=datetime(2026, 1, 1, 12, tzinfo=ZoneInfo("UTC")),
+        )
+        Annotation.objects.create(
+            organization=self.organization,
+            team=self.team,
+            created_by=self.user,
+            content="Excluded annotation",
+            date_marker=datetime(2025, 12, 31, 12, tzinfo=ZoneInfo("UTC")),
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/annotations/",
+            {
+                "date_from": "2026-01-01",
+                "date_to": "2026-01-02T00:00:00Z",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [result["id"] for result in response.json()["results"]] == [included_annotation.id]
+
     def test_filter_annotations_400_for_invalid_scope(self) -> None:
         response = self.client.get(
             f"/api/projects/{self.team.id}/annotations/",

--- a/products/annotations/frontend/generated/api.schemas.ts
+++ b/products/annotations/frontend/generated/api.schemas.ts
@@ -215,6 +215,14 @@ export interface PatchedAnnotationApi {
 
 export type AnnotationsListParams = {
     /**
+     * Inclusive start of the annotation date range in ISO 8601 format. Values without a time or timezone are interpreted as UTC.
+     */
+    date_from?: string
+    /**
+     * Inclusive end of the annotation date range in ISO 8601 format. Values without a time or timezone are interpreted as UTC.
+     */
+    date_to?: string
+    /**
      * Number of results to return per page.
      */
     limit?: number

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -75154,6 +75154,14 @@ export namespace Schemas {
 
     export type AnnotationsListParams = {
     /**
+     * Inclusive start of the annotation date range in ISO 8601 format. Values without a time or timezone are interpreted as UTC.
+     */
+    date_from?: string;
+    /**
+     * Inclusive end of the annotation date range in ISO 8601 format. Values without a time or timezone are interpreted as UTC.
+     */
+    date_to?: string;
+    /**
      * Number of results to return per page.
      */
     limit?: number;

--- a/services/mcp/src/generated/annotations/api.ts
+++ b/services/mcp/src/generated/annotations/api.ts
@@ -20,6 +20,18 @@ export const AnnotationsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const AnnotationsListQueryParams = /* @__PURE__ */ zod.object({
+    date_from: zod
+        .string()
+        .optional()
+        .describe(
+            'Inclusive start of the annotation date range in ISO 8601 format. Values without a time or timezone are interpreted as UTC.'
+        ),
+    date_to: zod
+        .string()
+        .optional()
+        .describe(
+            'Inclusive end of the annotation date range in ISO 8601 format. Values without a time or timezone are interpreted as UTC.'
+        ),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
     search: zod.string().optional().describe('A search term.'),

--- a/services/mcp/src/tools/generated/annotations.ts
+++ b/services/mcp/src/tools/generated/annotations.ts
@@ -103,6 +103,8 @@ const annotationsList = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/annotations/`,
             query: {
+                date_from: params.date_from,
+                date_to: params.date_to,
                 limit: params.limit,
                 offset: params.offset,
                 search: params.search,


### PR DESCRIPTION
## Problem

Filtering annotations with mixed datetime formats can return a 500 response. For example, a date-only `date_from` value is timezone-naive, while a `date_to` value ending in `Z` is timezone-aware, and comparing the two raises an error.

The date range query parameters were also missing from the generated TypeScript API types.

## Changes

- Validate `date_from` and `date_to` with a DRF query serializer.
- Interpret date-only and other timezone-less values as UTC before comparing or filtering.
- Document both query parameters in the OpenAPI schema and regenerate the frontend and MCP TypeScript clients.
- Add regression coverage for a date-only lower bound combined with a timezone-aware upper bound.

## How did you test this code?

500 error example (replace `project_id` with a real one):

`https://eu.posthog.com/api/projects/<project_id>/annotations?date_from=2026-01-01&date_to=2026-01-02T10:00:00Z`

Ran:

```bash
hogli test products/annotations/backend/api/test/test_annotation.py::TestAnnotation::test_filter_annotations_by_mixed_timezone_date_range
```

The regression test verifies that a mixed-format date range returns the matching annotation with a 200 response instead of failing with a 500 response.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. The existing API behavior is preserved, and the missing query parameters are now included in the generated API schema.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex inspected the committed diff, drafted this PR description, and ran the focused regression test. The `/writing-user-facing-copy` skill was used to keep the public description concise and factual.
