### PR TITLE
fix(data-imports): retry transient RPC timeouts starting the V3 post-import hand-off

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -14,6 +14,8 @@ import posthoganalytics
 from asgiref.sync import async_to_sync
 from temporalio.common import WorkflowIDReusePolicy
 from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.service import RPCError, RPCStatusCode
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
 from posthog.exceptions_capture import capture_exception
 from posthog.utils import get_machine_id
@@ -450,6 +452,14 @@ def _mark_job_completed(export_signal: ExportSignalMessage) -> None:
     _release_pipeline_lock_for_job(export_signal)
 
 
+def _is_retryable_temporal_rpc_error(exc: BaseException) -> bool:
+    # These fire-and-forget starts run outside a Temporal workflow, so unlike
+    # `workflow.start_child_workflow` they get none of the server-side retry a durable
+    # workflow command would have — a bare client RPC timeout would otherwise drop the
+    # trigger permanently.
+    return isinstance(exc, RPCError) and exc.status in (RPCStatusCode.DEADLINE_EXCEEDED, RPCStatusCode.UNAVAILABLE)
+
+
 def _trigger_ducklake_register_data_imports(export_signal: ExportSignalMessage, prepared_queryable_folder: str) -> None:
     """Fire-and-forget start of `ducklake-register.data-imports` after a V3 final batch lands.
 
@@ -479,6 +489,11 @@ def _trigger_ducklake_register_data_imports(export_signal: ExportSignalMessage, 
         # Connect and start inside one event loop: sync_connect() builds the client in
         # asgiref's loop, and the start would then run on the loop async_to_sync spins up
         # here. Start is fire-and-forget — we only need the start ack, not the result.
+        @retry(
+            retry=retry_if_exception(_is_retryable_temporal_rpc_error),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential_jitter(initial=1, max=5),
+        )
         async def _start() -> None:
             temporal = await async_connect()
             await temporal.start_workflow(
@@ -555,6 +570,11 @@ def _trigger_post_import_workflow(export_signal: ExportSignalMessage) -> None:
         # Connect and start inside one event loop (see the DuckLake trigger above).
         # ALLOW_DUPLICATE_FAILED_ONLY keyed by job id: a redelivered final batch can't
         # double-run a completed post-import, but can retry a failed one.
+        @retry(
+            retry=retry_if_exception(_is_retryable_temporal_rpc_error),
+            stop=stop_after_attempt(3),
+            wait=wait_exponential_jitter(initial=1, max=5),
+        )
         async def _start() -> None:
             temporal = await async_connect()
             await temporal.start_workflow(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -493,6 +493,7 @@ def _trigger_ducklake_register_data_imports(export_signal: ExportSignalMessage, 
             retry=retry_if_exception(_is_retryable_temporal_rpc_error),
             stop=stop_after_attempt(3),
             wait=wait_exponential_jitter(initial=1, max=5),
+            reraise=True,
         )
         async def _start() -> None:
             temporal = await async_connect()
@@ -574,6 +575,7 @@ def _trigger_post_import_workflow(export_signal: ExportSignalMessage) -> None:
             retry=retry_if_exception(_is_retryable_temporal_rpc_error),
             stop=stop_after_attempt(3),
             wait=wait_exponential_jitter(initial=1, max=5),
+            reraise=True,
         )
         async def _start() -> None:
             temporal = await async_connect()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 from deltalake import DeltaTable, write_deltalake
 from parameterized import parameterized
 from temporalio.exceptions import WorkflowAlreadyStartedError
+from temporalio.service import RPCError, RPCStatusCode
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.batcher import (
     CDC_OP_COLUMN,
@@ -589,6 +590,53 @@ class TestPostImportTrigger:
         _trigger_post_import_workflow(signal)
 
         assert mock_capture.called is expect_captured
+
+    def _signal(self) -> MagicMock:
+        signal = MagicMock()
+        signal.sync_type = "incremental"
+        signal.cdc_write_mode = None
+        signal.team_id = 1
+        signal.job_id = "job-1"
+        signal.schema_id = "schema-1"
+        signal.source_id = "source-1"
+        return signal
+
+    @patch(f"{_PROCESSOR}.capture_exception")
+    @patch("posthog.temporal.common.client.async_connect", new_callable=AsyncMock)
+    def test_transient_rpc_timeout_is_retried_and_recovers(
+        self,
+        mock_connect: AsyncMock,
+        mock_capture: MagicMock,
+    ) -> None:
+        # This start runs as a bare client RPC outside a Temporal workflow, so it gets
+        # none of the server-side retry a `workflow.start_child_workflow` command would
+        # have — a single transient timeout must not drop the trigger permanently.
+        client = MagicMock()
+        client.start_workflow = AsyncMock(
+            side_effect=[RPCError("Timeout expired", RPCStatusCode.DEADLINE_EXCEEDED, b""), None]
+        )
+        mock_connect.return_value = client
+
+        _trigger_post_import_workflow(self._signal())
+
+        assert client.start_workflow.call_count == 2
+        mock_capture.assert_not_called()
+
+    @patch(f"{_PROCESSOR}.capture_exception")
+    @patch("posthog.temporal.common.client.async_connect", new_callable=AsyncMock)
+    def test_persistent_rpc_timeout_is_captured_after_retries_exhausted(
+        self,
+        mock_connect: AsyncMock,
+        mock_capture: MagicMock,
+    ) -> None:
+        client = MagicMock()
+        client.start_workflow = AsyncMock(side_effect=RPCError("Timeout expired", RPCStatusCode.DEADLINE_EXCEEDED, b""))
+        mock_connect.return_value = client
+
+        _trigger_post_import_workflow(self._signal())
+
+        assert client.start_workflow.call_count == 3
+        mock_capture.assert_called_once()
 
 
 # Regression guard for #70476: pyarrow 21+ string_view broke delta pushdown on string PKs.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -637,6 +637,11 @@ class TestPostImportTrigger:
 
         assert client.start_workflow.call_count == 3
         mock_capture.assert_called_once()
+        # tenacity defaults to wrapping the last attempt in a RetryError once retries are
+        # exhausted; `reraise=True` must be set so the underlying RPCError reaches capture
+        # instead, keeping the error-tracking issue actionable.
+        captured_exception = mock_capture.call_args[0][0]
+        assert isinstance(captured_exception, RPCError)
 
 
 # Regression guard for #70476: pyarrow 21+ string_view broke delta pushdown on string PKs.


### PR DESCRIPTION
## Problem

Error tracking surfaced an `RPCError: Timeout expired` raised from `_trigger_post_import_workflow` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py`. This function is the V3 load consumer's fire-and-forget hand-off that starts `PostImportWorkflow` after a final batch lands.

Unlike the V2 path (`external_data_job.py`), which starts the same workflow from *inside* a running Temporal workflow via `workflow.start_child_workflow` (a durable command with server-side retry baked in), the V3 trigger runs as a bare Temporal client RPC from plain Python code. That RPC had no retry of its own, so a single transient timeout talking to the Temporal frontend permanently dropped the post-import hand-off for that job — the failure was caught, logged, and captured to error tracking, but nothing else retries starting `PostImportWorkflow` for that job. `_trigger_ducklake_register_data_imports` has the identical shape and gap.

## Changes

- Wrap both fire-and-forget `client.start_workflow(...)` calls in a bounded retry (3 attempts, exponential backoff with jitter), scoped to the two gRPC statuses that are genuinely transient: `DEADLINE_EXCEEDED` and `UNAVAILABLE`.
- Everything else is untouched: `WorkflowAlreadyStartedError` (a real duplicate-start signal) and any other non-retryable failure still fall straight through to the existing log-and-capture handling, so the load itself still never fails because of this trigger.

This follows the same `tenacity`-based retry shape already used elsewhere in this pipeline (`sync_lock.py`, `s3/writer.py`) for the same class of transient-infra problem.

## How did you test this code?

Extended `TestPostImportTrigger` in `test_processor.py` with two cases exercising the real `tenacity`-decorated retry (not mocked away):

- `test_transient_rpc_timeout_is_retried_and_recovers` — a `DEADLINE_EXCEEDED` `RPCError` on the first call followed by success is retried and recovers, with nothing captured to error tracking. This is the regression this PR fixes: before this change there was no retry, so the mock's second `start_workflow` call would never happen and the exception would be captured on the first attempt.
- `test_persistent_rpc_timeout_is_captured_after_retries_exhausted` — a persistent `DEADLINE_EXCEEDED` still exhausts after exactly 3 attempts and gets captured once, guarding against the retry becoming unbounded or silently swallowing forever.

Ran the full `test_processor.py` suite (35 passed) plus `ruff check --fix` / `ruff format` and `hogli ci:preflight --fix`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) investigating an error-tracking issue: a single-occurrence `RPCError: Timeout expired` starting the V3 post-import workflow. Traced the raise to a bare Temporal client RPC with no retry (unlike the V2 path, which gets retry for free by being a durable workflow command). Ruled out adding this to `NonRetryableErrors` since the underlying timeout is a classic transient infra blip, not a data or logic bug — the fix is to make the already-swallowed failure retryable before it's swallowed. Checked open PRs and the maintainer's own recent PRs for overlap; found none touching this trigger. Invoked `/writing-tests` before extending test coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*