### PR TITLE
fix(replay): return matching events when several event filters are ANDed

### DIFF
--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -521,13 +521,19 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
         return self._negative_blocklist_query()
 
     def get_query_for_event_id_matching(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        """
+        The ids of a session's events that matched ANY ONE of the query's event/action filters,
+        still combined with the query's property filters under its operand. Deliberately weaker
+        than the session-id matching path: it does not prove the session satisfied every filter
+        (that's a question about the session, which `get_queries_for_session_id_matching`
+        answers), it names the events that made the session relevant.
+        """
         # Subqueries only need to return uuid for the GlobalIn comparison
         select_queries: list[ast.SelectQuery] = self._get_queries_for_matching(
             select_expr=ast.Field(chain=["uuid"]),
             # when matching we want to select flag lists of event UUIds so we group by session_id, and then uuid
             group_by=[_event_session_id_field(), ast.Field(chain=["uuid"])],
-            # The subqueries are intersected by event id below, and an event has exactly one name.
-            # "$pageview AND signed_up" is a question about the session, not about a single event,
+            # The subqueries are intersected by event id below, and an event has exactly one name,
             # so keeping one subquery per entity would match nothing as soon as there are two.
             union_entities=True,
         )

--- a/posthog/session_recordings/queries/sub_queries/events_subquery.py
+++ b/posthog/session_recordings/queries/sub_queries/events_subquery.py
@@ -406,18 +406,28 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
 
         return sessions_query
 
-    def _get_queries_for_matching(self, select_expr: ast.Expr, group_by: list[ast.Expr]) -> list[ast.SelectQuery]:
+    def _get_queries_for_matching(
+        self, select_expr: ast.Expr, group_by: list[ast.Expr], union_entities: bool = False
+    ) -> list[ast.SelectQuery]:
         """
         takes each filter in the query that can be queried from the events table
         and makes a separate query for each
         this might be slower than the previous approach of having one huge event query
         but that approach is horribly complex, and we keep getting bug reports
         that are avoidable with a simpler approach
+
+        `union_entities` merges the event/action filters into a single subquery, for callers that
+        intersect the subqueries by event id rather than by session id (see
+        `get_query_for_event_id_matching`).
         """
         gathered_exprs: list[ast.Expr] = []
         event_where_exprs = self._event_predicates(self.entities, self._team)
         if event_where_exprs:
-            gathered_exprs += event_where_exprs
+            gathered_exprs += (
+                [ast.Or(exprs=event_where_exprs)]
+                if union_entities and len(event_where_exprs) > 1
+                else event_where_exprs
+            )
 
         # Skip event properties with negative operators since they're handled by _negative_guard_query
         skip_negative_properties = self._query.operand == "AND"
@@ -516,6 +526,10 @@ class ReplayFiltersEventsSubQuery(SessionRecordingsListingBaseQuery):
             select_expr=ast.Field(chain=["uuid"]),
             # when matching we want to select flag lists of event UUIds so we group by session_id, and then uuid
             group_by=[_event_session_id_field(), ast.Field(chain=["uuid"])],
+            # The subqueries are intersected by event id below, and an event has exactly one name.
+            # "$pageview AND signed_up" is a question about the session, not about a single event,
+            # so keeping one subquery per entity would match nothing as soon as there are two.
+            union_entities=True,
         )
         select_exprs: list[ast.Expr] = []
         for q in select_queries:

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1332,6 +1332,51 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         for result in results:
             assert "timestamp" in result
 
+    def test_get_matching_events_with_two_anded_event_filters(self) -> None:
+        base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
+
+        session_id = str(uuid7())
+        self.produce_replay_summary("user", session_id, base_time)
+        exposure_event_id = _create_event(
+            event="$feature_flag_called",
+            properties={"$session_id": session_id},
+            team=self.team,
+            distinct_id=uuid7(),
+            timestamp=base_time + timedelta(seconds=1),
+        )
+        metric_event_id = _create_event(
+            event="alert creation completed",
+            properties={"$session_id": session_id},
+            team=self.team,
+            distinct_id=uuid7(),
+            timestamp=base_time + timedelta(seconds=10),
+        )
+        _create_event(
+            event="an event neither filter asks for",
+            properties={"$session_id": session_id},
+            team=self.team,
+            distinct_id=uuid7(),
+            timestamp=base_time + timedelta(seconds=5),
+        )
+
+        # The shape the experiment recordings tab sends once a metric is picked: the exposure
+        # event ANDed with the metric's event. No single event carries both names, so matching
+        # them against each other rather than against the session finds nothing.
+        query_params = [
+            f'session_ids=["{session_id}"]',
+            'events=[{"id": "$feature_flag_called", "type": "events", "order": 0, "name": "$feature_flag_called"},'
+            ' {"id": "alert creation completed", "type": "events", "order": 1, "name": "alert creation completed"}]',
+            "operand=AND",
+        ]
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/session_recordings/matching_events?{'&'.join(query_params)}"
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        result_uuids = sorted([r["uuid"] for r in response.json()["results"]])
+        assert result_uuids == sorted([exposure_event_id, metric_event_id])
+
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_400_when_invalid_list_query(self) -> None:
         query_params = "&".join(

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1,4 +1,5 @@
 import os
+import json
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from urllib.parse import urlencode
@@ -1332,40 +1333,77 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         for result in results:
             assert "timestamp" in result
 
-    def test_get_matching_events_with_two_anded_event_filters(self) -> None:
+    @parameterized.expand(
+        [
+            (
+                # The shape the experiment recordings tab sends once a metric is picked: the
+                # exposure event ANDed with the metric's event. No single event carries both
+                # names, so intersecting per-filter matches by event id finds nothing — the
+                # event filters must be unioned before the session's events are matched.
+                "disjoint_event_names",
+                [
+                    {"id": "$feature_flag_called", "type": "events", "order": 0, "name": "$feature_flag_called"},
+                    {
+                        "id": "alert creation completed",
+                        "type": "events",
+                        "order": 1,
+                        "name": "alert creation completed",
+                    },
+                ],
+                [
+                    ("$feature_flag_called", {}, True),
+                    ("an event neither filter asks for", {}, False),
+                    ("alert creation completed", {}, True),
+                ],
+            ),
+            (
+                # Two predicates that can match the same event row: the union is deliberately
+                # wider than the intersection. Every pageview is returned, not only the
+                # /checkout ones — same semantics as the client-side 'name' match path, which
+                # highlights on event name alone whatever the operand.
+                "overlapping_predicates_return_the_union",
+                [
+                    {"id": "$pageview", "type": "events", "order": 0, "name": "$pageview"},
+                    {
+                        "id": "$pageview",
+                        "type": "events",
+                        "order": 1,
+                        "name": "$pageview",
+                        "properties": [
+                            {"key": "$current_url", "value": "/checkout", "operator": "icontains", "type": "event"}
+                        ],
+                    },
+                ],
+                [
+                    ("$pageview", {"$current_url": "https://example.com/home"}, True),
+                    ("an event neither filter asks for", {}, False),
+                    ("$pageview", {"$current_url": "https://example.com/checkout"}, True),
+                ],
+            ),
+        ]
+    )
+    def test_get_matching_events_with_two_anded_event_filters(
+        self, _name: str, event_filters: list[dict], session_events: list[tuple[str, dict, bool]]
+    ) -> None:
         base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
 
         session_id = str(uuid7())
         self.produce_replay_summary("user", session_id, base_time)
-        exposure_event_id = _create_event(
-            event="$feature_flag_called",
-            properties={"$session_id": session_id},
-            team=self.team,
-            distinct_id=uuid7(),
-            timestamp=base_time + timedelta(seconds=1),
-        )
-        metric_event_id = _create_event(
-            event="alert creation completed",
-            properties={"$session_id": session_id},
-            team=self.team,
-            distinct_id=uuid7(),
-            timestamp=base_time + timedelta(seconds=10),
-        )
-        _create_event(
-            event="an event neither filter asks for",
-            properties={"$session_id": session_id},
-            team=self.team,
-            distinct_id=uuid7(),
-            timestamp=base_time + timedelta(seconds=5),
-        )
+        expected_event_ids = []
+        for seconds, (event_name, extra_properties, expected) in enumerate(session_events):
+            event_id = _create_event(
+                event=event_name,
+                properties={"$session_id": session_id, **extra_properties},
+                team=self.team,
+                distinct_id=uuid7(),
+                timestamp=base_time + timedelta(seconds=seconds + 1),
+            )
+            if expected:
+                expected_event_ids.append(event_id)
 
-        # The shape the experiment recordings tab sends once a metric is picked: the exposure
-        # event ANDed with the metric's event. No single event carries both names, so matching
-        # them against each other rather than against the session finds nothing.
         query_params = [
             f'session_ids=["{session_id}"]',
-            'events=[{"id": "$feature_flag_called", "type": "events", "order": 0, "name": "$feature_flag_called"},'
-            ' {"id": "alert creation completed", "type": "events", "order": 1, "name": "alert creation completed"}]',
+            f"events={json.dumps(event_filters)}",
             "operand=AND",
         ]
 
@@ -1375,7 +1413,7 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
 
         assert response.status_code == status.HTTP_200_OK, response.json()
         result_uuids = sorted([r["uuid"] for r in response.json()["results"]])
-        assert result_uuids == sorted([exposure_event_id, metric_event_id])
+        assert result_uuids == sorted(expected_event_ids)
 
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_400_when_invalid_list_query(self) -> None:


### PR DESCRIPTION
## Problem

Following #73157, "jump to the first matching event" works on the experiment recordings tab until you pick a metric. Then the player opens at 0:00 even though the exposure and the metric events are all well inside the recording.

The skip logic is fine, but the data never arrives: `matching_events` builds one subquery per filter and then asks for event ids present in **all** of them, which is always empty ("is this event named A and named B?" No event is):

```sql
SELECT uuid, any(timestamp) FROM events
WHERE uuid GLOBAL IN (SELECT uuid FROM events WHERE event = 'exposure event' ...)
  AND uuid GLOBAL IN (SELECT uuid FROM events WHERE event = 'metric event' ...)
```

One event filter works, two return nothing since it's AND'ed. That is why the tab skips correctly with no filter and with a variant selected (exposure only, one event filter) and stops the moment a metric adds a second one.

Refs #74955, follows #73157.

## Changes

The event/action filters now share a single subquery instead of getting one each:

```diff
-WHERE uuid GLOBAL IN (event = A) AND uuid GLOBAL IN (event = B)
+WHERE uuid GLOBAL IN (event = A OR event = B)
```

Single-filter queries and the playlist query (the one that decides which recordings appear in the list) generate the same SQL as before.

## Why this is correct

"Fired A AND fired B" is a statement about a **session**. The playlist query applies it exactly there: it intersects **session ids**, and a recording only makes it into the list if it fired both. That query is untouched.

This endpoint runs after that, on one recording, and answers a smaller question: which of this recording's events matched? A single event has a single name, so at that level "matches A AND B" is impossible. The only meaningful reading is "matches A or matches B". The old code asked the impossible version, which is why it always returned an empty list.

Everything the answer feeds, all in the player:

- jumping to the first match, the behavior broken above
- marking the matched rows in the event list
- the "show only matching events" toggle, which keeps only those rows

Two surfaces fetch it: the player inspector, when you open a recording from a filtered playlist, and the dashboards session replay widget, which fetches on click and hands the result to the player. Both have the bug today. Neither reads anything into an empty result beyond "nothing to mark", so nothing treats this endpoint as proof of a claim about the recording.

Implications:

- Only the event and action filters are unioned. Property filters still apply with AND on top, because one event *can* satisfy "named A" and "browser is Chrome" at the same time. That intersection is meaningful and kept.
- The frontend already behaves this way: when the filters carry no property conditions it skips this endpoint entirely and highlights by event name in the client, a union whatever the operand. The backend was the outlier that returned nothing.
- Union and intersection only genuinely differ when two filters can match the same event, e.g. `$pageview` ANDed with `$pageview` where the url contains `/checkout`. Before: only the checkout pageviews counted as matches. Now: every pageview. The player jumps to the first match rather than proving a claim about the recording, so the union is the more useful answer here; a dedicated test case pins that as intentional.

## How did you test this code?

New test: `test_get_matching_events_with_two_anded_event_filters`, parameterized over two cases. No existing test covers either - every other `matching_events` test sends a single event filter, and the single-filter path never intersects anything.

- `disjoint_event_names` - the reported bug: an exposure event ANDed with a metric event plus an unrelated third event in the session. Verified it fails on master (`assert [] == [exposure_id, metric_id]`) and passes with the fix.
- `overlapping_predicates_return_the_union` - pins the intentional widening from the note above: `$pageview` ANDed with `$pageview` at `/checkout` returns every pageview, not only the checkout ones. On master this returned the intersection, so the case documents the semantic trade rather than a bug.

Ran locally against the dev stack:

<details>
<summary>Test output</summary>

```
posthog/session_recordings/test/test_session_recordings.py -k matching_events
9 passed

posthog/session_recordings/queries/test/ posthog/session_recordings/test/test_session_recordings.py
432 passed, 622 snapshots passed, 1 unrelated ClickHouse-connection flake
(test_bulk_delete_session_recordings) — passed on isolated retry
```

</details>

I did not exercise the experiment recordings tab in a browser. The frontend side is unchanged, and the behavior there follows from the endpoint returning ids again.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (PostHog Code cloud task). Skills invoked: `/writing-tests`.

The reported symptom pointed at the player, so I started from the #73157 diff and worked backwards. The frontend turned out to be innocent: `matchingEventsMatchType` correctly resolves to `backend` for exposure-plus-metric, the request goes out, and the response is an empty list. Confirmed the query semantics by running the same intersection shape as HogQL against a real session before touching any code, then reproduced it as a failing API test.

I considered simply OR-ing every subquery at the top level. Rejected: an event property filter ANDed with an event filter (the shape the experiments exposure fallback produces) genuinely wants the intersection, since a single event can satisfy both, and OR-ing there would highlight most of the session. Unioning only the entity predicates keeps that case intact and happens to leave single-entity SQL byte-identical.

Traced the blast radius rather than assuming it. `get_event_ids_for_session` has exactly one caller (the `matching_events` endpoint); `union_entities` defaults to False so the session-id path the playlist uses is untouched; and the `len(...) > 1` guard keeps single-entity SQL byte-identical, which is why no snapshots moved. Property, cohort, group and person-property subqueries still AND against the unioned entity subquery, so the intersection that genuinely wants to be an intersection survives. Under `operand=OR` the union is logically a no-op (`uuid IN A OR uuid IN B` == `uuid IN (A OR B)`); only the SQL shape changes. Downstream, the results feed inspector highlighting and `trySkipToFirstMatchingEvent`, both of which want the union.

Two adjacent gaps confirmed and deliberately not fixed here:

1. When the exposure event is captured server-side, the tab falls back to a bare `$feature/<key>` property filter. Add a metric and the filter becomes one property plus one property-less event, which `matchingEventsMatchType` classifies as `name` - a client-side shortcut that returns no matching events at all, so the skip stays broken for those experiments for an unrelated reason. Fixing it means dropping the `name` shortcut whenever event property filters are present, which sends every generic playlist with that filter shape to the backend. That trade seemed worth its own PR rather than riding along here.
2. The hybrid person-property subquery is appended to the same list this path wraps in `uuid GLOBAL IN (...)`, but it selects `session_id`. Confirmed at the generated-SQL level (flag forced on, `email` filter): the query runs without error and compares event uuids against session ids, which cannot match, so on teams with the hybrid PoE replay filtering flag enabled and a qualifying person-property filter this endpoint returns nothing under an AND operand - independently of this change. Pre-existing, belongs in its own PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
