### PR TITLE
fix(data-imports): align repartition rewrite batches to the live delta schema

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -340,8 +340,8 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
             incoming_column = incoming_table.column(delta_field.name)
 
         # Delta column is non-nullable: backfill nulls before write. Checked against the column's
-        # actual null count, not its field's own `nullable` flag — that flag is just metadata and
-        # can say non-nullable while the batch still carries a real null (e.g. a batch scanned
+        # actual null count, not its field's own `nullable` flag, because that flag is just metadata
+        # and can say non-nullable while the batch still carries a real null (e.g. a batch scanned
         # from a table whose column is otherwise declared non-nullable), which would otherwise
         # skip the backfill and let the null reach the write.
         incoming_field = incoming_table.field(delta_field.name)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -339,9 +339,13 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
 
             incoming_column = incoming_table.column(delta_field.name)
 
-        # Delta column is non-nullable: backfill nulls before write.
+        # Delta column is non-nullable: backfill nulls before write. Checked against the column's
+        # actual null count, not its field's own `nullable` flag — that flag is just metadata and
+        # can say non-nullable while the batch still carries a real null (e.g. a batch scanned
+        # from a table whose column is otherwise declared non-nullable), which would otherwise
+        # skip the backfill and let the null reach the write.
         incoming_field = incoming_table.field(delta_field.name)
-        if not delta_field.nullable and incoming_field.nullable:
+        if not delta_field.nullable and incoming_column.null_count > 0:
             filled_nulls_arr = incoming_column.fill_null(
                 fill_value=get_default_value_for_pyarrow_type(incoming_field.type)
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -32,6 +32,7 @@ from structlog.types import FilteringBoundLogger
 from products.data_warehouse.backend.facade.api import aget_s3_client
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    evolve_pyarrow_schema,
     normalize_column_name,
     realign_decimal_buffers,
 )
@@ -427,6 +428,14 @@ async def _rewrite_into_temp(
                 partition_keys=used_keys,
             )
 
+        # Align each batch against the live table's own declared schema before writing. Without
+        # this, whichever batch happens to build temp's schema on the first write fixes its
+        # nullability from what that one batch's data looked like — if a column the live schema
+        # already declares non-nullable slips through with a real null (e.g. a source NOT NULL
+        # constraint later relaxed upstream), the write aborts with "declared as non-nullable but
+        # contains null values" partway through the rewrite. Every other Delta write path in this
+        # pipeline runs incoming data through this same alignment first; the rewrite must too.
+        partitioned_table = evolve_pyarrow_schema(partitioned_table, old_delta.schema())
         partitioned_table = realign_decimal_buffers(partitioned_table)
 
         await asyncio.to_thread(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -387,6 +387,7 @@ async def _rewrite_into_temp(
     """
     dataset = await asyncio.to_thread(old_delta.to_pyarrow_dataset)
     reader = await asyncio.to_thread(lambda: dataset.scanner(batch_size=batch_size).to_reader())
+    live_schema = await asyncio.to_thread(old_delta.schema)
 
     resolved: RepartitionTarget | None = None
     rows_written = 0
@@ -430,12 +431,12 @@ async def _rewrite_into_temp(
 
         # Align each batch against the live table's own declared schema before writing. Without
         # this, whichever batch happens to build temp's schema on the first write fixes its
-        # nullability from what that one batch's data looked like — if a column the live schema
+        # nullability from what that one batch's data looked like. So if a column the live schema
         # already declares non-nullable slips through with a real null (e.g. a source NOT NULL
         # constraint later relaxed upstream), the write aborts with "declared as non-nullable but
         # contains null values" partway through the rewrite. Every other Delta write path in this
-        # pipeline runs incoming data through this same alignment first; the rewrite must too.
-        partitioned_table = evolve_pyarrow_schema(partitioned_table, old_delta.schema())
+        # pipeline runs incoming data through this same alignment first, so the rewrite must too.
+        partitioned_table = evolve_pyarrow_schema(partitioned_table, live_schema)
         partitioned_table = realign_decimal_buffers(partitioned_table)
 
         await asyncio.to_thread(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
@@ -368,6 +368,60 @@ class TestRewriteIntoTemp:
         assert resolved.partition_mode == "datetime"
         assert resolved.partition_keys == ["created_at"]
 
+    def test_batch_with_real_null_in_non_nullable_column_is_backfilled_not_crashed(self, tmp_path):
+        # The live table's own declared schema can mark a column non-nullable (e.g. a source NOT
+        # NULL constraint recorded on first sync) while a scanned batch still carries an actual
+        # null for it (the constraint was later relaxed upstream). Writing that batch straight to
+        # `write_deltalake` without aligning it to the live schema first raises "declared as
+        # non-nullable but contains null values" and aborts the rewrite.
+        delta_schema_field = pa.schema(
+            [
+                pa.field("id", pa.int64(), nullable=False),
+                pa.field("real_model", pa.string(), nullable=False),
+            ]
+        )
+        # Bypasses delta-rs's own write-time validation (which would reject this) to stand in for
+        # a batch scanned off a live table whose data no longer matches its declared schema — the
+        # scanned batch's own field still says non-nullable too, matching the live table's.
+        batch_table = pa.Table.from_arrays(
+            [pa.array([1, 2], type=pa.int64()), pa.array(["gpt-4", None], type=pa.string())],
+            schema=delta_schema_field,
+        )
+
+        class _FakeReader:
+            def __init__(self, table):
+                self._batches = table.to_batches()
+
+            def read_next_batch(self):
+                if not self._batches:
+                    raise StopIteration
+                return self._batches.pop(0)
+
+        old_delta = SimpleNamespace(
+            to_pyarrow_dataset=lambda: SimpleNamespace(
+                scanner=lambda batch_size: SimpleNamespace(to_reader=lambda: _FakeReader(batch_table))
+            ),
+            schema=lambda: deltalake.Schema.from_arrow(delta_schema_field),
+        )
+
+        rows_written, _ = asyncio.run(
+            _rewrite_into_temp(
+                old_delta=old_delta,
+                temp_uri=str(tmp_path / "tmp"),
+                storage_options={},
+                target=RepartitionTarget(
+                    partition_keys=["id"], trigger_reason="test", partition_mode="md5", partition_count=1
+                ),
+                batch_size=10,
+                logger=logger,
+            )
+        )
+
+        assert rows_written == 2
+        new_table = deltalake.DeltaTable(str(tmp_path / "tmp")).to_pyarrow_table().sort_by("id")
+        # The real null is backfilled to the column's default rather than reaching the Delta write.
+        assert new_table.column("real_model").to_pylist() == ["gpt-4", ""]
+
 
 class _FakeS3CM:
     """Minimal async-context-manager stand-in for `aget_s3_client()`."""

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
@@ -374,18 +374,18 @@ class TestRewriteIntoTemp:
         # null for it (the constraint was later relaxed upstream). Writing that batch straight to
         # `write_deltalake` without aligning it to the live schema first raises "declared as
         # non-nullable but contains null values" and aborts the rewrite.
-        delta_schema_field = pa.schema(
-            [
+        live_pa_schema = pa.schema(
+            [  # type: ignore[arg-type]
                 pa.field("id", pa.int64(), nullable=False),
                 pa.field("real_model", pa.string(), nullable=False),
             ]
         )
         # Bypasses delta-rs's own write-time validation (which would reject this) to stand in for
-        # a batch scanned off a live table whose data no longer matches its declared schema — the
+        # a batch scanned off a live table whose data no longer matches its declared schema. The
         # scanned batch's own field still says non-nullable too, matching the live table's.
         batch_table = pa.Table.from_arrays(
             [pa.array([1, 2], type=pa.int64()), pa.array(["gpt-4", None], type=pa.string())],
-            schema=delta_schema_field,
+            schema=live_pa_schema,
         )
 
         class _FakeReader:
@@ -401,12 +401,12 @@ class TestRewriteIntoTemp:
             to_pyarrow_dataset=lambda: SimpleNamespace(
                 scanner=lambda batch_size: SimpleNamespace(to_reader=lambda: _FakeReader(batch_table))
             ),
-            schema=lambda: deltalake.Schema.from_arrow(delta_schema_field),
+            schema=lambda: deltalake.Schema.from_arrow(live_pa_schema),
         )
 
         rows_written, _ = asyncio.run(
             _rewrite_into_temp(
-                old_delta=old_delta,
+                old_delta=old_delta,  # type: ignore[arg-type]
                 temp_uri=str(tmp_path / "tmp"),
                 storage_options={},
                 target=RepartitionTarget(


### PR DESCRIPTION
## Problem

Error tracking surfaced a `DeltaError` from the data-imports repartition path:

```
Generic DeltaTable error: Arrow error: Invalid argument error: Column 'real_model' is declared as non-nullable but contains null values
```

raised from `_rewrite_into_temp` (`products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py`), the in-place Delta rewrite that streams a table into a finer partition scheme when a partition grows too large to merge without OOMing.

`_rewrite_into_temp` writes each streamed batch straight to `write_deltalake` without first aligning it to the live table's own declared schema. Every *other* Delta write path in this pipeline (`pipeline_v2/pipeline.py`, `pipeline_v3/pipeline.py`, `load/processor.py`) runs incoming data through `evolve_pyarrow_schema` before writing, precisely to reconcile cases like a column the Delta schema declares non-nullable (e.g. derived from an upstream `NOT NULL` constraint at first sync) that later legitimately carries a real null (the upstream constraint was relaxed). The repartition rewrite was the one write site missing that step, so whichever batch happened to build the temp table's schema first could fix it too strictly, and a later batch with a real null in that column aborted the whole rewrite. Once that happens the table is stuck on its old, OOM-prone partition layout — the failure is silently swallowed and retried, but repartitioning never succeeds.

Separately, `evolve_pyarrow_schema`'s existing null-backfill guard only checked the incoming batch's own `nullable` field metadata (`incoming_field.nullable`) rather than whether the column's data actually contains a null. That metadata flag can say non-nullable while the array itself still holds a real null (which is exactly the shape a batch scanned off a live table like this can take), so the guard could skip the backfill it exists to do.

## Changes

- `_rewrite_into_temp` now calls `evolve_pyarrow_schema(partitioned_table, old_delta.schema())` before writing each batch, matching the alignment step every other write path already runs.
- `evolve_pyarrow_schema`'s non-nullable backfill check now looks at `incoming_column.null_count > 0` instead of the incoming field's own `nullable` flag, so a real null is caught regardless of what the batch's own schema metadata claims.

## How did you test this code?

I (Claude) reproduced the exact production error standalone first: a `pa.Table` whose field is explicitly declared non-nullable but whose array still holds a `None`, written via `deltalake.write_deltalake(..., mode="append", schema_mode="merge")`, raises the identical `DeltaError` message. That confirmed the mechanism before touching any code.

New test in `test_repartition.py::TestRewriteIntoTemp`:
- `test_batch_with_real_null_in_non_nullable_column_is_backfilled_not_crashed` — drives `_rewrite_into_temp` with a scanned batch whose column is declared non-nullable but has a real null. With the `repartition.py` fix reverted alone, this fails with the verbatim production `DeltaError`. With the `arrow_utils.py` fix reverted alone (keeping the `repartition.py` call), it still fails, with a different `ValueError` from the final cast — confirming both changes are independently required. With both in place, it passes and the null is backfilled to the column's default rather than reaching the write.

Also ran:
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py` — 259 passed, 5 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` that need an object storage service unavailable in this sandbox (reproduce identically on master).
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/` (excluding the above) — 800 passed; remaining errors are pre-existing Postgres-dependent tests with no DB available in this sandbox.
- `ruff check` / `ruff format --check` on the changed files — clean.
- `mypy --cache-fine-grained` scoped to the two changed source files — clean. The repo-wide run didn't finish within a reasonable window in this sandbox; the change itself is small (one call to an already-typed function, one condition swap), so risk of a reverse-dependency break is low.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover Delta repartition internals, so nothing to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude Code, triaging a `DeltaError` flagged by PostHog error tracking in the data-imports repartition pipeline. Skills invoked: `/writing-tests`.

I first checked whether an open PR already covered this. #74729 ("add evolved delta columns as nullable") fixes a related but different failure shape in `_evolve_delta_schema`/`delta_table_helper.py` (a column added mid-table-lifetime staying non-nullable) — different function, different error message ("missing from the physical schema" vs "contains null values"), and it doesn't touch `repartition.py`. #75819 and #75196 address cross-batch Arrow *type* conflicts (`ArrowTypeError`), not nullability. None overlap with this fix.

I considered whether this class of error was source-specific or upstream/user-caused, but the failure is purely a shared-pipeline Arrow/Delta schema-alignment gap that reproduces regardless of source, so I fixed the shared code rather than reaching for `NonRetryableErrors`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*