### PR TITLE
fix(experiments): align bayesian is_decisive with credible interval

### DIFF
--- a/products/experiments/skills/diagnosing-experiment-results/references/interpretation.md
+++ b/products/experiments/skills/diagnosing-experiment-results/references/interpretation.md
@@ -147,9 +147,11 @@ PostHog has Frequentist support (rolled out June 2025). Set in `stats_config`. Q
 
 A frequent source of confusion:
 
-- **Overlapping confidence intervals do not imply non-significance in Bayesian.** Overlapping intervals
-  are a _frequentist_ heuristic. In Bayesian, significance is determined by win probability, so
-  overlapping credible intervals can still indicate a clear winner.
+- **Bayesian `significant` matches credible-interval exclusion of 0.** The flag is still computed from
+  chance to win, but the threshold is the two-sided equivalent of `ci_level` (`1 - (1 - ci_level) / 2`,
+  so 0.975 at the default 95% level). That makes `significant` equivalent to "credible interval does
+  not contain 0," matching the in-app "How to read" tooltip and Frequentist CI semantics. A high CTW
+  alone (e.g. 96%) with an interval that still crosses 0 is **not** significant.
 - **p-values don't apply in Bayesian.** A question about "p < 0.05" is a frequentist frame. If the
   experiment is on Bayesian (default), redirect to win probability + credible interval.
 - **Frequentist is opt-in.** Most experiments are Bayesian unless `stats_config` explicitly selects

--- a/products/experiments/stats/bayesian/tests.py
+++ b/products/experiments/stats/bayesian/tests.py
@@ -63,8 +63,17 @@ class BayesianResult:
 
     @property
     def is_decisive(self) -> bool:
-        """Whether result shows clear preference (chance to win > ci_level or < 1 - ci_level)."""
-        return self.chance_to_win > self.ci_level or self.chance_to_win < 1 - self.ci_level
+        """
+        Whether the result is significant, i.e. the credible interval excludes zero.
+
+        ``chance_to_win`` is a one-sided posterior tail, while ``credible_interval`` is
+        two-sided and equal-tailed. To keep "decisive" coherent with the interval, we
+        threshold the one-sided probability at ``1 - (1 - ci_level) / 2`` (0.975 for a 95%
+        level) rather than ``ci_level`` — otherwise an effect in the 0.95–0.975 band would
+        be flagged significant while its interval still contains zero.
+        """
+        upper_threshold = 1 - (1 - self.ci_level) / 2
+        return self.chance_to_win > upper_threshold or self.chance_to_win < 1 - upper_threshold
 
     @property
     def preferred_variation(self) -> str:

--- a/products/experiments/stats/tests/test_bayesian.py
+++ b/products/experiments/stats/tests/test_bayesian.py
@@ -11,6 +11,7 @@ import pytest
 from unittest import TestCase
 
 import numpy as np
+from parameterized import parameterized
 
 from products.experiments.stats.bayesian.method import BayesianConfig, BayesianMethod, PriorType
 from products.experiments.stats.bayesian.priors import GaussianPrior
@@ -483,3 +484,54 @@ class TestNumericalStability:
         # Should handle this gracefully
         assert np.isfinite(result.effect_size)
         assert result.posterior_variance > 0
+
+
+class TestIsDecisive(TestCase):
+    @staticmethod
+    def _result_at_z(z: float, ci_level: float) -> BayesianResult:
+        posterior_mean, posterior_std = float(z), 1.0
+        ci_lower, ci_upper = credible_interval(posterior_mean, posterior_std, alpha=1 - ci_level)
+        return BayesianResult(
+            effect_size=posterior_mean,
+            credible_interval=(ci_lower, ci_upper),
+            chance_to_win=chance_to_win(posterior_mean, posterior_std),
+            risk_control=0.0,
+            risk_treatment=0.0,
+            posterior_variance=posterior_std**2,
+            ci_level=ci_level,
+            difference_type="absolute",
+            inverse=False,
+            prior_mean=0.0,
+            prior_variance=0.0,
+            proper_prior=False,
+        )
+
+    @parameterized.expand(
+        [
+            # Gap band at 95%: z in (1.645, 1.960) used to be significant while interval spanned 0.
+            (0.5, 0.95),
+            (1.645, 0.95),
+            (1.7, 0.95),
+            (1.8, 0.95),
+            (1.9, 0.95),
+            (2.0, 0.95),
+            (2.5, 0.95),
+            (-1.8, 0.95),
+            (-2.5, 0.95),
+            (1.8, 0.99),
+            (2.9, 0.99),
+        ]
+    )
+    def test_is_decisive_matches_credible_interval(self, z: float, ci_level: float) -> None:
+        result = self._result_at_z(z, ci_level)
+        excludes_zero = result.credible_interval[0] > 0 or result.credible_interval[1] < 0
+        assert result.is_decisive == excludes_zero, (
+            f"is_decisive={result.is_decisive} but credible_interval={result.credible_interval} "
+            f"(chance_to_win={result.chance_to_win:.4f}, z={z}, ci_level={ci_level})"
+        )
+
+    def test_gap_band_not_significant(self) -> None:
+        result = self._result_at_z(1.8, ci_level=0.95)
+        assert 0.95 < result.chance_to_win < 0.975
+        assert result.credible_interval[0] < 0 < result.credible_interval[1]
+        assert result.is_decisive is False


### PR DESCRIPTION
## Problem

Bayesian experiments can show `significant: true` (green/red winner) while the 95% credible interval still contains 0. That contradicts the in-app "How to read" tooltip and Frequentist semantics.

`chance_to_win` is a one-sided posterior tail (crosses 0.95 at z ≈ 1.645), but `credible_interval` is two-sided equal-tailed (excludes 0 at z ≈ 1.960). `is_decisive` thresholded CTW at `ci_level`, so the 1.645–1.960 band was flagged significant with an interval spanning zero.

Closes #72503

## Changes

- Threshold `chance_to_win` at `1 - (1 - ci_level) / 2` (0.975 at the default 95% level) so `significant` implies the credible interval excludes zero
- Add `TestIsDecisive` covering the former gap band and the coherence invariant
- Update the experiments diagnostic skill (`interpretation.md` C7) to match

No frontend changes: the chart and tooltip already teach interval-clears-0.

> [!NOTE]
> Public docs live in `PostHog/posthog.com` (`statistics-bayesian.mdx` still documents CTW > confidence_level). Companion docs PR to follow in that repo.

Supersedes the draft bot PR #72787 with the same core fix.

## How did you test this code?

- `uv run pytest products/experiments/stats/tests/test_bayesian.py` — 40 passed
- New `TestIsDecisive` catches a regression to the old `ci_level` threshold: at z=1.8 / 95%, CTW is in (0.95, 0.975) and the interval still spans 0, so `is_decisive` must be false. No prior test exercised `is_decisive`.

No manual UI testing in this session.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- Internal: `products/experiments/skills/diagnosing-experiment-results/references/interpretation.md`
- Public: companion PR on `PostHog/posthog.com` for `statistics-bayesian.mdx` (not in this repo)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Cursor agent session investigating #72503. Chose Option 1 from the issue (match interval) over Option 2 (keep CTW>0.95 and rewrite UI) because the tooltip and analyzing-results docs already claim interval duality. Skills invoked: `/writing-tests`. Did not touch frontend. Noted existing draft #72787 and re-landed the same threshold with internal skill doc updates.