### PR TITLE
fix(uptimerobot): stop retrying scoped API keys hitting 403 on unauthorized endpoints

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/source.py
@@ -89,7 +89,7 @@ Use your account's **read-only API key**, created under [Integrations & API](htt
             # AUTH_ERROR_PREFIX above and instead raises via response.raise_for_status()). Match the
             # stable domain, not the per-request method in the URL path. Retrying can't grant a scoped
             # key access it was never issued.
-            "403 Client Error: Forbidden for url: https://api.uptimerobot.com": "Your UptimeRobot API key doesn't have permission to sync this table. Monitor-specific API keys only grant access to a single monitor, so alert contacts, maintenance windows, and status pages won't sync with one — reconnect with a full-account read-only API key under Integrations & API in your UptimeRobot dashboard.",
+            "403 Client Error: Forbidden for url: https://api.uptimerobot.com": "Your UptimeRobot API key doesn't have permission to sync this table. Monitor-specific API keys only grant access to a single monitor, so alert contacts, maintenance windows, and status pages won't sync with one. Reconnect with a full-account read-only API key under Integrations & API in your UptimeRobot dashboard.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/source.py
@@ -84,6 +84,12 @@ Use your account's **read-only API key**, created under [Integrations & API](htt
             # raises with this stable prefix when the API rejects the key. Retrying can never fix a
             # credential problem, so stop the sync.
             AUTH_ERROR_PREFIX: "Your UptimeRobot API key is invalid or has been revoked. Create a new read-only API key under Integrations & API in your UptimeRobot dashboard, then reconnect.",
+            # A monitor-specific API key is only scoped to one monitor, so getAlertContacts/getMWindows/
+            # getPSPs come back as a raw HTTP 403 (not an in-body {"stat": "fail"} error, so it bypasses
+            # AUTH_ERROR_PREFIX above and instead raises via response.raise_for_status()). Match the
+            # stable domain, not the per-request method in the URL path. Retrying can't grant a scoped
+            # key access it was never issued.
+            "403 Client Error: Forbidden for url: https://api.uptimerobot.com": "Your UptimeRobot API key doesn't have permission to sync this table. Monitor-specific API keys only grant access to a single monitor, so alert contacts, maintenance windows, and status pages won't sync with one — reconnect with a full-account read-only API key under Integrations & API in your UptimeRobot dashboard.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/tests/test_uptimerobot_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/tests/test_uptimerobot_source.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.uptimerobot import (
     UptimerobotSourceConfig,
 )
@@ -61,8 +62,9 @@ class TestUptimerobotSource:
         ],
     )
     def test_non_retryable_errors_match_credential_failures(self, observed_error):
+        # Mirrors the production matcher (`error_message_matches`), which is case-insensitive.
         non_retryable_errors = self.source.get_non_retryable_errors()
-        assert any(key in observed_error for key in non_retryable_errors)
+        assert error_message_matches(observed_error, non_retryable_errors)
 
     @pytest.mark.parametrize(
         "other_error",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/tests/test_uptimerobot_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/tests/test_uptimerobot_source.py
@@ -49,9 +49,18 @@ class TestUptimerobotSource:
         assert api_key_field.secret is True
         assert api_key_field.required is True
 
-    def test_non_retryable_errors_match_transport_auth_failure(self):
-        # UptimeRobot signals a bad key in-body over HTTP 200; the transport raises with this message.
-        observed_error = "UptimeRobot API key was rejected: api_key is invalid."
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            # UptimeRobot signals a bad key in-body over HTTP 200; the transport raises this message.
+            "UptimeRobot API key was rejected: api_key is invalid.",
+            # A monitor-specific key hitting a scope it isn't granted (e.g. maintenance windows)
+            # comes back as a raw HTTP 403, bypassing the in-body auth check entirely.
+            "403 Client Error: Forbidden for url: https://api.uptimerobot.com/v2/getMWindows",
+            "403 Client Error: Forbidden for url: https://api.uptimerobot.com/v2/getAlertContacts",
+        ],
+    )
+    def test_non_retryable_errors_match_credential_failures(self, observed_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert any(key in observed_error for key in non_retryable_errors)
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a live `HTTPError: 403 Client Error: Forbidden for url: https://api.uptimerobot.com/v2/getMWindows` from the UptimeRobot source ([issue](https://us.posthog.com/project/2/error_tracking/019fbfcf-45bb-7060-a04e-8ac27b749ccb)). The stack trace shows the failure raised from `_post`'s `response.raise_for_status()` call in `uptimerobot.py`, reached via `get_rows` while syncing the `maintenance_windows` schema.

UptimeRobot's source config already documents this limitation: monitor-specific API keys only grant access to a single monitor, so alert contacts, maintenance windows, and status pages tables won't sync with one. That scope mismatch surfaces as a raw HTTP 403, which is distinct from the in-body `{"stat": "fail"}` credential error the source already classifies as non-retryable via `AUTH_ERROR_PREFIX` — a raw 403 bypasses that check entirely and falls through to `response.raise_for_status()`, so the sync kept retrying a failure that retrying can never fix.

## Changes

Extended `UptimerobotSource.get_non_retryable_errors()` to match the stable `403 Client Error: Forbidden for url: https://api.uptimerobot.com` prefix (domain only, not the per-request method path) and surface a message explaining the monitor-scoped-key limitation and how to fix it.

## How did you test this code?

Added a parameterized case to the existing `test_non_retryable_errors_match_transport_auth_failure` test (renamed to `test_non_retryable_errors_match_credential_failures`) covering the observed 403 message for two different scoped endpoints, alongside the existing in-body auth-error case — catches a regression where this 403 path stops being classified as non-retryable. Ran the full `uptimerobot` test suite (78 passed), `ruff check`/`ruff format --check`, and `mypy` on the touched module — all clean.

## Docs update

N/A — no user-facing config or workflow changed, only internal retry classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a PostHog error-tracking webhook for this issue.
- Skills invoked: `/writing-tests` before adding the parameterized test case.
- Decision: classified as a user/upstream error (not a code bug) because the source's own caption text already documents that monitor-scoped keys can't reach these endpoints — there's nothing to retry, only a message to surface. Matched on the domain prefix rather than the full URL (which embeds the varying method name) to catch the same failure across all monitor-scoped endpoints, mirroring the existing Stripe source's `get_non_retryable_errors` pattern for 401/403.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*