### PR TITLE
feat(desktop): group MCP tools by access

### DIFF
--- a/products/desktop/packages/core/src/mcp-gateway/gatewayServers.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayServers.ts
@@ -7,6 +7,7 @@ import type {
   McpResolvedToolPolicy,
 } from "@posthog/api-client/posthog-client";
 import { formatRelativeTimeShort, getLocalDayDiff } from "@posthog/shared";
+import { isLikelyMutatingToolName } from "../mcp-servers/toolDerivation";
 
 /** The rail lists the servers the caller has connected, under the rail search. */
 export function railConnectedServers(
@@ -283,10 +284,7 @@ export const AUDIT_DECISION_LABELS: Record<McpAuditDecision, string> = {
 
 // Mirrors the backend's destructive-tool heuristic; only used to seed the
 // per-tool defaults when sharing a server with an agent.
-const DESTRUCTIVE_TOOL_RE =
-  /delete|update|post|write|create|run-migration|close|drop|send/;
-
 /** Default policy offered when granting an agent access to a tool. */
 export function defaultAgentGrantPolicy(toolName: string): AgentPolicyState {
-  return DESTRUCTIVE_TOOL_RE.test(toolName) ? "do_not_use" : "approved";
+  return isLikelyMutatingToolName(toolName) ? "do_not_use" : "approved";
 }

--- a/products/desktop/packages/core/src/mcp-servers/toolDerivation.test.ts
+++ b/products/desktop/packages/core/src/mcp-servers/toolDerivation.test.ts
@@ -5,6 +5,8 @@ import {
   countRemovedTools,
   countToolsByApproval,
   filterToolsByName,
+  groupToolsByAccess,
+  isLikelyMutatingToolName,
   sortToolsForDisplay,
 } from "./toolDerivation";
 
@@ -48,6 +50,30 @@ describe("sortToolsForDisplay", () => {
       tool("mango"),
     ]);
     expect(out.map((t) => t.tool_name)).toEqual(["mango", "zebra", "apple"]);
+  });
+});
+
+describe("groupToolsByAccess", () => {
+  it("separates likely mutating tools from read tools", () => {
+    const tools = [
+      tool("get_project"),
+      tool("create_project"),
+      tool("delete_project"),
+      tool("search_events"),
+    ];
+
+    expect(groupToolsByAccess(tools)).toEqual({
+      readTools: [tools[0], tools[3]],
+      writeTools: [tools[1], tools[2]],
+    });
+  });
+
+  it.each([
+    ["list_projects", false],
+    ["create_project", true],
+    ["send_message", true],
+  ] as const)("recognizes %s as mutating: %s", (name, expected) => {
+    expect(isLikelyMutatingToolName(name)).toBe(expected);
   });
 });
 

--- a/products/desktop/packages/core/src/mcp-servers/toolDerivation.ts
+++ b/products/desktop/packages/core/src/mcp-servers/toolDerivation.ts
@@ -27,6 +27,36 @@ export function sortToolsForDisplay(
   });
 }
 
+const MUTATING_TOOL_NAME_RE =
+  /delete|update|post|write|create|run-migration|close|drop|send/;
+
+/**
+ * MCP tool catalogs do not expose a machine-readable access level. Keep this
+ * deliberately conservative and use the same naming signal as the default
+ * policy for agent grants.
+ */
+export function isLikelyMutatingToolName(toolName: string): boolean {
+  return MUTATING_TOOL_NAME_RE.test(toolName);
+}
+
+export function groupToolsByAccess(tools: McpInstallationTool[]): {
+  readTools: McpInstallationTool[];
+  writeTools: McpInstallationTool[];
+} {
+  const readTools: McpInstallationTool[] = [];
+  const writeTools: McpInstallationTool[] = [];
+
+  for (const tool of tools) {
+    if (isLikelyMutatingToolName(tool.tool_name)) {
+      writeTools.push(tool);
+    } else {
+      readTools.push(tool);
+    }
+  }
+
+  return { readTools, writeTools };
+}
+
 export function filterToolsByName(
   tools: McpInstallationTool[],
   term: string,

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ToolPermissionList.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/parts/ToolPermissionList.tsx
@@ -14,6 +14,7 @@ import {
   countActiveTools,
   countToolsByApproval,
   filterToolsByName,
+  groupToolsByAccess,
   sortToolsForDisplay,
 } from "@posthog/core/mcp-servers/toolDerivation";
 import { ToolPolicyToggle } from "@posthog/ui/features/mcp-servers/components/parts/ToolPolicyToggle";
@@ -119,6 +120,10 @@ export function ToolPermissionList({
   const filteredTools = useMemo(
     () => filterToolsByName(visibleTools, toolSearch),
     [visibleTools, toolSearch],
+  );
+  const { readTools, writeTools } = useMemo(
+    () => groupToolsByAccess(filteredTools),
+    [filteredTools],
   );
 
   const bulkDisabled = disabled || bulk?.pending || filteredTools.length === 0;
@@ -294,15 +299,22 @@ export function ToolPermissionList({
               </Text>
             </Flex>
           ) : (
-            filteredTools.map((tool) => (
-              <ToolRow
-                key={tool.tool_name}
-                tool={tool}
-                onChange={(approval_state) =>
-                  onSetTool(tool.tool_name, approval_state)
-                }
-              />
-            ))
+            <Flex direction="column" gap="4">
+              {readTools.length > 0 && (
+                <ToolAccessGroup
+                  heading="Read tools"
+                  tools={readTools}
+                  onSetTool={onSetTool}
+                />
+              )}
+              {writeTools.length > 0 && (
+                <ToolAccessGroup
+                  heading="Write and delete tools"
+                  tools={writeTools}
+                  onSetTool={onSetTool}
+                />
+              )}
+            </Flex>
           )}
         </Flex>
       )}
@@ -318,6 +330,35 @@ export function ToolPermissionList({
           </button>
         </Flex>
       )}
+    </Flex>
+  );
+}
+
+function ToolAccessGroup({
+  heading,
+  tools,
+  onSetTool,
+}: {
+  heading: string;
+  tools: McpInstallationTool[];
+  onSetTool: ToolPermissionListProps["onSetTool"];
+}) {
+  return (
+    <Flex direction="column" gap="2">
+      <Text color="gray" className="font-medium text-xs uppercase tracking-wide">
+        {heading}
+      </Text>
+      <Flex direction="column" gap="2">
+        {tools.map((tool) => (
+          <ToolRow
+            key={tool.tool_name}
+            tool={tool}
+            onChange={(approval_state) =>
+              onSetTool(tool.tool_name, approval_state)
+            }
+          />
+        ))}
+      </Flex>
     </Flex>
   );
 }


### PR DESCRIPTION
## Problem

The existing desktop MCP permission list mixes low-risk read tools with tools that are likely to mutate external state. This makes it harder to scan a server's available actions and review defaults safely.

## Changes

- Group discovered tools into read and likely mutating sections.
- Reuse a single conservative name-based classifier for both display grouping and default agent grant policy.
- Add regression coverage for the grouping and classifier.

This is the requested monorepo version of PostHog/code#4068 after the desktop package migration.

## How did you test this code?

- Passed `pnpm --filter @posthog/core exec vitest run src/mcp-servers/toolDerivation.test.ts` with 8 tests.
- Ran `git diff --check` on this monorepo port.
- I did not run the full desktop UI from this sparse checkout, so there is no manual UI screenshot yet. The PR remains a draft for that final verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update needed.

## ?? Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex prepared this port after Charles Vien requested the existing desktop change be remade in the monorepo. I read the contribution and AI policies, kept the prior change scoped to the migrated desktop package, and retained the regression tests that cover the shared classifier. The PR is a draft so the desktop flow can be verified before review.