### PR TITLE
fix(data-management): keep the verified filter visible when it matches nothing

### DIFF
--- a/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.stories.tsx
+++ b/frontend/src/scenes/data-management/properties/PropertyDefinitionsTable.stories.tsx
@@ -107,3 +107,24 @@ export const FilteredUnverifiedOnly: Story = {
         pageUrl: urls.propertyDefinitions() + '?verified=false',
     },
 }
+
+// A project where nothing has been verified yet, filtered to verified only. The table is empty,
+// and the status dropdown still has to be there — it is the only way back to "All".
+export const FilteredVerifiedOnlyWithNoMatches: Story = {
+    parameters: {
+        pageUrl: urls.propertyDefinitions() + '?verified=true',
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/property_definitions/': ({ request }) => {
+                    const verified = new URL(request.url).searchParams.get('verified')
+                    const results = MOCK_PROPERTY_DEFINITIONS.results
+                        .filter((p) => !p.verified)
+                        .filter(() => verified !== 'true')
+                    return [200, { ...MOCK_PROPERTY_DEFINITIONS, results, count: results.length }]
+                },
+            },
+        }),
+    ],
+}

--- a/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.test.ts
+++ b/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.test.ts
@@ -20,6 +20,10 @@ describe('propertyDefinitionsTableLogic', () => {
             get: {
                 '/api/projects/:team/property_definitions/': ({ request }) => {
                     const url = new URL(request.url)
+                    // Stand in for a project where nothing has been marked verified yet.
+                    if (url.searchParams.get('verified') === 'true') {
+                        return [200, { results: [], count: 0, previous: null, next: null }]
+                    }
                     if (url.searchParams.get('limit') === '50' && !url.searchParams.get('offset')) {
                         return [
                             200,
@@ -151,6 +155,30 @@ describe('propertyDefinitionsTableLogic', () => {
                     }),
                 })
             expect(api.get).toHaveBeenCalledTimes(2)
+        })
+    })
+
+    describe('showVerifiedFilter', () => {
+        // The control is the only way to set `verified`, so hiding it on an empty result set leaves
+        // the user filtered down to nothing with no way back to "All" except reloading the page.
+        it('stays visible when filtering by verified returns no rows', async () => {
+            const url = urls.propertyDefinitions()
+            router.actions.push(url)
+            await expectLogic(logic).toDispatchActions([
+                router.actionCreators.push(url),
+                'loadPropertyDefinitions',
+                'loadPropertyDefinitionsSuccess',
+            ])
+
+            await expectLogic(logic, () => {
+                logic.actions.setFilters({ verified: true })
+            })
+                .delay(600)
+                .toDispatchActions(['loadPropertyDefinitions', 'loadPropertyDefinitionsSuccess'])
+                .toMatchValues({
+                    propertyDefinitions: partial({ results: [], count: 0 }),
+                    showVerifiedFilter: true,
+                })
         })
     })
 })

--- a/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/properties/propertyDefinitionsTableLogic.ts
@@ -128,7 +128,7 @@ export interface propertyDefinitionsTableLogicMeta {
             groupTypes: Map<GroupTypeIndex, GroupType>,
             aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
         ) => LemonSelectOption<string>[]
-        showVerifiedFilter: (propertyDefinitions: PropertyDefinitionsPaginatedResponse) => boolean
+        showVerifiedFilter: (propertyDefinitions: PropertyDefinitionsPaginatedResponse, filters: Filters) => boolean
     }
 }
 
@@ -257,9 +257,13 @@ export const propertyDefinitionsTableLogic = kea<propertyDefinitionsTableLogicTy
     })),
     selectors(() => ({
         showVerifiedFilter: [
-            (s) => [s.propertyDefinitions],
-            (propertyDefinitions: PropertyDefinitionsPaginatedResponse): boolean =>
-                propertyDefinitions.results.length > 0 && 'verified' in propertyDefinitions.results[0],
+            (s) => [s.propertyDefinitions, s.filters],
+            (propertyDefinitions: PropertyDefinitionsPaginatedResponse, filters: Filters): boolean =>
+                // Keep the control visible whenever it is filtering, even if that filter matched
+                // nothing. Hiding it on an empty result set strands the user on a filtered view
+                // with no way back to "All" short of reloading the page.
+                filters.verified !== undefined ||
+                (propertyDefinitions.results.length > 0 && 'verified' in propertyDefinitions.results[0]),
         ],
     })),
     listeners(({ actions, values, cache }) => ({


### PR DESCRIPTION
## Problem

On Data > Property definitions, the status dropdown next to the property type picker lets you narrow to "Verified only" or "Unverified only".

Pick "Verified only" in a project where nothing has been verified yet and the dropdown disappears. The filter it just applied is still in effect, so you are looking at an empty table with no control to undo it. The only way out is to leave the page and come back.


## Changes

The control was hidden whenever the current page had no rows:

```ts
propertyDefinitions.results.length > 0 && 'verified' in propertyDefinitions.results[0]
```

Reading `verified` off the first row makes sense as a way to tell whether the API returns that field at all. The catch is that it also ends up meaning "are there any rows", and filtering to verified in a project with no verified properties gives you zero rows. The control that set the filter then removes itself while the filter stays on.

Keeping it visible whenever it is actively filtering seems like the smallest way to cover that:

```ts
filters.verified !== undefined ||
(propertyDefinitions.results.length > 0 && 'verified' in propertyDefinitions.results[0])
```

I went with this shape because the events tab already handles the same situation the same way (#53282), and keeping the two selectors reading alike seemed better than introducing something new just here. I had a look around for other places with this pattern and did not find any, so I think events and properties are the only two.

| | before | after |
| --- | --- | --- |
| Verified only, some matches | dropdown shown | dropdown shown |
| Verified only, no matches | **dropdown gone, filter stuck on** | dropdown shown |

## How did you test this code?

Loaded the affected screen in a browser (Playwright against Storybook) with a project whose properties are all unverified, filtered to verified only:

| | rows | "Status:" label | dropdown present |
| --- | --- | --- | --- |
| Before | 0 | no | **no** |
| After | 0 | yes | yes |

Before, the toolbar has only the "Event properties" picker and the user is stuck. After, `Status: Verified only` is still sitting there and you can put it back to "All". I have not run this against a live dev stack, only Storybook.

Automated:

- `frontend/src/scenes/data-management/` — 42 tests across 8 suites pass.
- `typescript:check` clean, `pnpm --filter=@posthog/frontend fix` clean.
- I could not run `hogli ci:preflight` (needs a Python env I do not have set up). Frontend-only diff, no lockfile or migration changes, and I ran the lint gate directly.

On the tests:

One case added to `propertyDefinitionsTableLogic.test.ts`: filter by verified, get nothing back, and the control must still be showing. It fails against the old selector and passes with the fix.

There are already `FilteredVerifiedOnly` and `FilteredUnverifiedOnly` stories covering this control. Their fixture happens to include verified properties, so the filter always has something to return and the empty case does not come up. I added `FilteredVerifiedOnlyWithNoMatches` next to them for a project where nothing is verified.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe this control.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I ran into this filtering property definitions and had Claude (Claude Code, Opus 5) track it down and fix it. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

A couple of things you may have a view on. I mirrored the events tab rather than writing something new, so the two selectors read the same way, but if you would prefer them sharing a helper I am happy to do that instead. It just touches more than this particular bug needs. Separately, the condition is covering two things at once, whether the API returns `verified` at all and whether there are any rows. I left that alone as it felt beyond the scope of the fix, though I am glad to take a run at it if you would like.

