### PR TITLE
fix(warehouse_sources): stop leaking raw errors from Search Console credential checks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/source.py
@@ -12,6 +12,7 @@ from posthog.schema import (
     SourceFieldOauthConfig,
 )
 
+from posthog.exceptions_capture import capture_exception
 from posthog.models.integration import Integration
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
@@ -40,6 +41,16 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_sea
     SEARCH_ANALYTICS_SCHEMAS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+# Fallback messages for unexpected failures during credential validation. The raw exception can
+# embed OAuth tokens, ids, or an HTML error body, so we capture it for debugging and show generic
+# guidance instead of surfacing `str(e)` to the user.
+_LOAD_CONNECTION_ERROR = (
+    "PostHog couldn't load your Google Search Console connection. Please reconnect your Google account and try again."
+)
+_LIST_SITES_ERROR = (
+    "PostHog couldn't reach Google Search Console to list your properties. Please try again in a few minutes."
+)
 
 
 @SourceRegistry.register
@@ -179,10 +190,11 @@ class GoogleSearchConsoleSource(
         except Exception as e:
             if "matching query does not exist" in str(e):
                 return False, (
-                    "Your Google Search Console connection is no longer available — it may have been "
+                    "Your Google Search Console connection is no longer available. It may have been "
                     "disconnected. Please reconnect your Google Search Console account."
                 )
-            return False, f"Could not load Google Search Console credentials: {e}"
+            capture_exception(e)
+            return False, _LOAD_CONNECTION_ERROR
 
         try:
             sites = list_sites(session)
@@ -193,7 +205,8 @@ class GoogleSearchConsoleSource(
                     False,
                     "Google Search Console rejected the credentials. Please reconnect your account and ensure it has read access to the property.",
                 )
-            return False, f"Failed to list Google Search Console sites: {e}"
+            capture_exception(e)
+            return False, _LIST_SITES_ERROR
         except RefreshError:
             # Raised while AuthorizedSession refreshes the OAuth access token (e.g. invalid_scope or
             # invalid_grant): the stored token is missing the required permissions, or has expired or
@@ -206,7 +219,8 @@ class GoogleSearchConsoleSource(
                 "and grant access to Search Console.",
             )
         except Exception as e:
-            return False, f"Failed to list Google Search Console sites: {e}"
+            capture_exception(e)
+            return False, _LIST_SITES_ERROR
 
         normalized = {url: site.get("permissionLevel") for site in sites if (url := site.get("siteUrl")) is not None}
         site_url = normalize_site_url(config.site_url)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
@@ -302,10 +302,10 @@ def test_validate_credentials_handles_missing_integration():
     assert "reconnect your Google Search Console account" in (message or "")
 
 
-def _http_error(status_code: int) -> requests.HTTPError:
+def _http_error(status_code: int, message: str = "") -> requests.HTTPError:
     response = mock.MagicMock()
     response.status_code = status_code
-    return requests.HTTPError(response=response)
+    return requests.HTTPError(message, response=response)
 
 
 def test_validate_credentials_unexpected_load_error_stays_generic():
@@ -323,13 +323,13 @@ def test_validate_credentials_unexpected_load_error_stays_generic():
 
 
 @pytest.mark.parametrize(
-    "error",
+    "error,secret",
     [
-        pytest.param(_http_error(500), id="http_500"),
-        pytest.param(Exception("boom refresh_token=secret-xyz789"), id="unexpected"),
+        pytest.param(_http_error(500, "boom access_token=secret-http500"), "secret-http500", id="http_500"),
+        pytest.param(Exception("boom refresh_token=secret-xyz789"), "secret-xyz789", id="unexpected"),
     ],
 )
-def test_validate_credentials_unexpected_list_sites_error_stays_generic(error):
+def test_validate_credentials_unexpected_list_sites_error_stays_generic(error, secret):
     # A non-auth failure listing sites must fall back to a generic message, not leak the raw error.
     with (
         mock.patch(
@@ -344,4 +344,4 @@ def test_validate_credentials_unexpected_list_sites_error_stays_generic(error):
 
     assert ok is False
     assert "couldn't reach Google Search Console" in (message or "")
-    assert "secret-xyz789" not in (message or "")
+    assert secret not in (message or "")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console_source.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest import mock
 
+import requests
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.googlesearchconsole import (
     GoogleSearchConsoleSourceConfig,
 )
@@ -298,3 +300,48 @@ def test_validate_credentials_handles_missing_integration():
 
     assert ok is False
     assert "reconnect your Google Search Console account" in (message or "")
+
+
+def _http_error(status_code: int) -> requests.HTTPError:
+    response = mock.MagicMock()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+def test_validate_credentials_unexpected_load_error_stays_generic():
+    # An unexpected failure loading the connection (not the deleted-integration case) must not
+    # surface the raw exception, which can embed OAuth tokens or ids.
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_search_console.source.google_search_console_session",
+        side_effect=Exception("boom access_token=secret-abc123"),
+    ):
+        ok, message = GoogleSearchConsoleSource().validate_credentials(_config(), team_id=1)
+
+    assert ok is False
+    assert "reconnect your Google account" in (message or "")
+    assert "secret-abc123" not in (message or "")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(_http_error(500), id="http_500"),
+        pytest.param(Exception("boom refresh_token=secret-xyz789"), id="unexpected"),
+    ],
+)
+def test_validate_credentials_unexpected_list_sites_error_stays_generic(error):
+    # A non-auth failure listing sites must fall back to a generic message, not leak the raw error.
+    with (
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_search_console.source.google_search_console_session"
+        ),
+        mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_search_console.source.list_sites",
+            side_effect=error,
+        ),
+    ):
+        ok, message = GoogleSearchConsoleSource().validate_credentials(_config(), team_id=1)
+
+    assert ok is False
+    assert "couldn't reach Google Search Console" in (message or "")
+    assert "secret-xyz789" not in (message or "")


### PR DESCRIPTION
## Problem

Replay Vision watched real users go through data-warehouse new-source onboarding, and Google Search Console showed up as a recurring friction point (rejected credentials, failing to load properties).

When a credential check hits an unexpected failure, three fallback branches in the Search Console validator returned the raw exception straight to the wizard:

```
Could not load Google Search Console credentials: <raw str(e)>
Failed to list Google Search Console sites: <raw str(e)>
```

That raw string can embed an OAuth token, an internal id, or an HTML error body, and it gives the user nothing to act on. The file already guards against exactly this for the 401/403 and `RefreshError` paths (its tests assert the raw OAuth error text must not appear in the message), but these three fallbacks slipped through.

## Changes

Aligned the three fallbacks with the pattern BigQuery already uses in this codebase: capture the exception for debugging, then return a generic, actionable message.

- Load failure that isn't the known deleted-integration case: "PostHog couldn't load your Google Search Console connection. Please reconnect your Google account and try again."
- Any non-auth failure listing properties (unexpected HTTP status or unexpected error): "PostHog couldn't reach Google Search Console to list your properties. Please try again in a few minutes."

Also removed an em-dash from an existing message to match the user-facing copy guidelines. No change to the 401/403, `RefreshError`, deleted-integration, or unknown-property branches, which already return clear guidance. Behaviour is otherwise unchanged: same `(False, message)` shape, same control flow.

## How did you test this code?

Added three parameterized cases to `test_google_search_console_source.py` covering the three fallback branches (unexpected load error, unexpected HTTP status listing sites, unexpected error listing sites). Each asserts the generic message is returned and a planted secret substring in the raw exception does not leak. No existing test exercised these branches, so a future edit re-leaking `str(e)` would have gone uncaught.

Ran the file's suite locally: 26 passed. Ran ruff check + format over both touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Opus 4.8) via PostHog Code while synthesizing onboarding friction themes from Replay Vision session summaries. Invoked the `/writing-user-facing-copy` and `/writing-tests` skills while shaping the copy and the tests.

I considered but deliberately did not action several adjacent themes in this PR to keep it self-contained: the same raw-exception leak exists in one Google Ads fallback, and the post-OAuth survey modal reported in onboarding is a product-side survey configured outside this repo. Those are recorded as recommendations rather than folded in here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
