### PR TITLE
fix(github): handle 204 No Content from stats endpoints

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -1032,6 +1032,13 @@ def get_rows(
             logger.debug(f"Github: statistics not ready yet, syncing zero rows: url={url}")
             break
 
+        # A 204 No Content has an empty body — GitHub answers it on the /stats/* endpoints for a
+        # repository with no commit activity. There is nothing to parse, so sync zero rows rather
+        # than crashing on response.json() (an empty body raises a JSONDecodeError).
+        if response.status_code == 204:
+            logger.debug(f"Github: statistics have no content, syncing zero rows: url={url}")
+            break
+
         data = response.json()
         # Most GitHub list endpoints return a JSON array at the top level,
         # but some (e.g. /actions/runs) wrap results in {"<resource>": [...]}, and a few

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -1032,11 +1032,11 @@ def get_rows(
             logger.debug(f"Github: statistics not ready yet, syncing zero rows: url={url}")
             break
 
-        # A 204 No Content has an empty body — GitHub answers it on the /stats/* endpoints for a
+        # A 204 No Content has an empty body, which GitHub returns on the /stats/* endpoints for a
         # repository with no commit activity. There is nothing to parse, so sync zero rows rather
-        # than crashing on response.json() (an empty body raises a JSONDecodeError).
+        # than crashing on response.json(), because an empty body raises a JSONDecodeError.
         if response.status_code == 204:
-            logger.debug(f"Github: statistics have no content, syncing zero rows: url={url}")
+            logger.debug(f"Github: 204 no content, syncing zero rows: url={url}")
             break
 
         data = response.json()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_repository_endpoints.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_repository_endpoints.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest import mock
 
 import pyarrow as pa
+import requests
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.github import github
@@ -199,6 +200,16 @@ class TestBodyTransforms:
         # GitHub answers 202 with no usable body while it recomputes a /stats aggregate. That must
         # sync nothing and end cleanly, not raise and retry the activity forever.
         rows, _calls = _run("contributor_stats", {"api.github.com": _response(None, status_code=202)})
+
+        assert rows == []
+
+    def test_statistics_no_content_syncs_zero_rows(self) -> None:
+        # GitHub answers 204 No Content on the /stats/* endpoints for a repo with no commit activity.
+        # The empty body must sync zero rows, not crash on response.json() (a JSONDecodeError).
+        no_content = _response(None, status_code=204)
+        no_content.json.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "", 0)
+
+        rows, _calls = _run("contributor_stats", {"api.github.com": no_content})
 
         assert rows == []
 


### PR DESCRIPTION
## Problem

Error tracking flagged a burst of `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` coming out of the `github` data-warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019fc08a-8d6c-7442-90be-76b1c1db5254)). The top in-app frame is `get_rows` in `github.py` at the `response.json()` call.

Root cause: GitHub's `/stats/*` endpoints (`contributor_stats`, `code_frequency_stats`, `commit_activity_stats`, `participation_stats`) answer **204 No Content** with an empty body for a repository that has no commit activity yet. A 204 passes `response.ok` and is not the already-handled 202, so `get_rows` fell straight through to `response.json()` and crashed on the empty body. The failure surfaces as a handled exception per sync attempt, so it just noisily fails the schema instead of syncing zero rows.

## Changes

Handle 204 the same way as the 202 (stats-not-ready) case right above it: log and sync zero rows instead of parsing an empty body. Scoped to the one response-parsing path where the crash originates.

```diff
 if response.status_code == 202:
     logger.debug(f"Github: statistics not ready yet, syncing zero rows: url={url}")
     break

+# A 204 No Content has an empty body — GitHub answers it on the /stats/* endpoints for a
+# repository with no commit activity. There is nothing to parse, so sync zero rows rather
+# than crashing on response.json() (an empty body raises a JSONDecodeError).
+if response.status_code == 204:
+    logger.debug(f"Github: statistics have no content, syncing zero rows: url={url}")
+    break
+
 data = response.json()
```

## How did you test this code?

Added `test_statistics_no_content_syncs_zero_rows` next to the existing 202 test in `test_github_repository_endpoints.py`. It drives `get_rows` with a 204 whose `.json()` raises the same `JSONDecodeError` seen in production and asserts zero rows. I confirmed the test reproduces the crash without the fix (fails with the exact production error) and passes with it. The existing 202 test never reaches `.json()`, so it didn't cover this path.

Ran the full `test_github_repository_endpoints.py` suite (34 passed) plus `ruff check`/`ruff format --check` on both files, all clean. I did not manually run a live sync against GitHub.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. I (Claude) pulled the issue and a representative event via the PostHog error-tracking tools, traced the top frame to `get_rows`' `response.json()`, and matched it to GitHub's documented 204 behavior on the `/stats/*` endpoints. Decided this is a fixable robustness bug rather than a user/upstream error — the response is a legitimate "no data yet" that we should skip gracefully, not a credential/permission problem — so it doesn't belong in `NonRetryableErrors`. Kept the fix mirroring the adjacent 202 handling to stay minimal.

Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
