### PR TITLE
fix(github): stop empty-repo 409 from crashing fan-out endpoint syncs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -736,6 +736,11 @@ def _iter_pages(
         except GithubOrgNotFoundError:
             logger.debug(f"Github: org-scoped endpoint not found, syncing zero rows: url={url}")
             return
+        except GithubEmptyRepositoryError:
+            # `commits` is a fan_out_parent (check_runs, commit_statuses), so this walk can hit the
+            # same empty-repo 409 that get_rows handles directly for the non-fan-out `commits` read.
+            logger.debug(f"Github: repository has no commits (empty repository), syncing zero rows: url={url}")
+            return
         data = response.json()
         if response_data_path and isinstance(data, dict):
             data = data.get(response_data_path) or []

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -97,6 +97,11 @@ def _empty_repository_response() -> mock.Mock:
     response.text = json.dumps({"message": "Git Repository is empty."})
     response.json.return_value = {"message": "Git Repository is empty."}
     response.request = None
+    # If the empty-repo 409 check ever regresses, this must raise instead of silently falling
+    # through to a passing empty page list, so the test actually fails on that regression.
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "409 Client Error: Conflict for url", response=response
+    )
     return response
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -89,6 +89,30 @@ def test_fetch_page_raises_repository_too_large_for_code_frequency_422():
             github._fetch_page("https://api.github.com/repos/o/r/stats/code_frequency", {}, mock.Mock())
 
 
+def _empty_repository_response() -> mock.Mock:
+    response = mock.Mock(spec=requests.Response)
+    response.status_code = 409
+    response.ok = False
+    response.headers = {}
+    response.text = json.dumps({"message": "Git Repository is empty."})
+    response.json.return_value = {"message": "Git Repository is empty."}
+    response.request = None
+    return response
+
+
+def test_iter_pages_stops_on_empty_repository():
+    # commits is a fan_out_parent (check_runs, commit_statuses walk it via _iter_pages), so the same
+    # empty-repo 409 that get_rows handles directly for a bare `commits` read must also be swallowed
+    # here rather than propagating out of the fan-out walk.
+    session = mock.Mock()
+    session.request.return_value = _empty_repository_response()
+
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        pages = list(github._iter_pages("https://api.github.com/repos/o/r/commits", {}, None, mock.Mock()))
+
+    assert pages == []
+
+
 def test_fetch_page_reraises_other_422_errors():
     # A generic 422 (e.g. malformed request params) is a real, fixable problem and must stay fatal
     # rather than being swallowed by the too-large-repository check.


### PR DESCRIPTION
## Problem

GitHub returns a `409 Git Repository is empty.` on the commits endpoint for a freshly created repository with no commits yet. `_fetch_page` in `github.py` signals this with `GithubEmptyRepositoryError`, and `get_rows` already catches it for a direct `commits` read, syncing zero rows instead of failing the activity.

`commits` is also a `fan_out_parent` for two child tables, `check_runs` and `commit_statuses`. That walk goes through a different helper, `_iter_pages`, which only caught `GithubOrgNotFoundError` — not `GithubEmptyRepositoryError`. So on an empty repository, the fan-out walk let the exception propagate all the way up through the pipeline instead of syncing zero rows for that table, and it showed up in error tracking as an uncaught `GithubEmptyRepositoryError`.

## Changes

- `_iter_pages` now catches `GithubEmptyRepositoryError` the same way it already catches `GithubOrgNotFoundError`, ending the walk (zero rows) instead of propagating.

## How did you test this code?

- Added `test_iter_pages_stops_on_empty_repository` in `test_github_fetch_page.py`, asserting `_iter_pages` returns no pages instead of raising when the underlying request 409s with GitHub's empty-repository body. This is the regression the fan-out walk (`check_runs`/`commit_statuses`, both children of `commits`) was hitting — no existing test exercised `_iter_pages`'s error handling before this.
- Ran the full `sources/github/tests/test_github_fetch_page.py` suite locally (9 passed).
- `ruff check`/`ruff format` clean; `uv run mypy --cache-fine-grained` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No GitHub-source-specific doc under `docs/`; this is internal error-handling in the source's page-fetch loop, not a documented workflow or API surface.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue for `GithubEmptyRepositoryError` surfacing in `products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py`. The stack trace showed the exception raised inside `_fetch_page`, called from `_iter_pages`, called from `_fan_out_get_rows` — the fan-out walk for `commits`'s child tables — rather than from `get_rows`'s own direct read loop, which already handles this case.

Checked open PRs first: [#75948](https://github.com/PostHog/posthog/pull/75948) and [#74705](https://github.com/PostHog/posthog/pull/74705) touch the same file but handle unrelated symptoms (a permanent 422 on `/stats/` endpoints, and a 403 permission skip), so this isn't duplicate work.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*