### PR TITLE
chore(ci): map desktop scope to feature/desktop label

### DIFF
--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -10,7 +10,7 @@
             "labels": ["team/feature-flags", "feature/cohorts"]
         },
         {
-            "scopes": ["desktop"],
+            "scopes": ["desktop", "tasks"],
             "labels": ["feature/desktop"]
         }
     ]

--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -8,6 +8,10 @@
         {
             "scopes": ["cohort", "cohorts"],
             "labels": ["team/feature-flags", "feature/cohorts"]
+        },
+        {
+            "scopes": ["desktop"],
+            "labels": ["feature/desktop"]
         }
     ]
 }

--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -10,7 +10,7 @@
             "labels": ["team/feature-flags", "feature/cohorts"]
         },
         {
-            "scopes": ["desktop", "tasks"],
+            "scopes": ["desktop", "tasks", "agent-proxy"],
             "labels": ["feature/desktop"]
         }
     ]

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -137,8 +137,10 @@ for (const scope of ['flag', 'feature-flag', 'feature_flags', 'feature_flag']) {
     })
 }
 
-// Desktop PRs rely on this rule for the `feature/desktop` label; bind the scope
-// to the shipped config so an edit that drops it regresses loudly here.
-test('the shipped config maps the desktop scope to labels', () => {
-    assert.ok(labelsForTitle('feat(desktop): x', loadRules()).length > 0, 'desktop scope maps to no labels')
-})
+// Desktop PRs rely on these scopes for the `feature/desktop` label; bind each
+// to the shipped config so an edit that drops one regresses loudly here.
+for (const scope of ['desktop', 'tasks']) {
+    test(`the shipped config maps the ${scope} scope to labels`, () => {
+        assert.ok(labelsForTitle(`feat(${scope}): x`, loadRules()).length > 0, `${scope} scope maps to no labels`)
+    })
+}

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -139,7 +139,7 @@ for (const scope of ['flag', 'feature-flag', 'feature_flags', 'feature_flag']) {
 
 // Desktop PRs rely on these scopes for the `feature/desktop` label; bind each
 // to the shipped config so an edit that drops one regresses loudly here.
-for (const scope of ['desktop', 'tasks']) {
+for (const scope of ['desktop', 'tasks', 'agent-proxy']) {
     test(`the shipped config maps the ${scope} scope to labels`, () => {
         assert.ok(labelsForTitle(`feat(${scope}): x`, loadRules()).length > 0, `${scope} scope maps to no labels`)
     })

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -136,3 +136,9 @@ for (const scope of ['flag', 'feature-flag', 'feature_flags', 'feature_flag']) {
         assert.ok(labelsForTitle(`feat(${scope}): x`, loadRules()).length > 0, `${scope} scope maps to no labels`)
     })
 }
+
+// Desktop PRs rely on this rule for the `feature/desktop` label; bind the scope
+// to the shipped config so an edit that drops it regresses loudly here.
+test('the shipped config maps the desktop scope to labels', () => {
+    assert.ok(labelsForTitle('feat(desktop): x', loadRules()).length > 0, 'desktop scope maps to no labels')
+})

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -138,9 +138,14 @@ for (const scope of ['flag', 'feature-flag', 'feature_flags', 'feature_flag']) {
 }
 
 // Desktop PRs rely on these scopes for the `feature/desktop` label; bind each
-// to the shipped config so an edit that drops one regresses loudly here.
+// to the shipped config so an edit that drops or mislabels one regresses
+// loudly here. Asserts containment rather than the exact list so the rule can
+// gain labels without breaking.
 for (const scope of ['desktop', 'tasks', 'agent-proxy']) {
-    test(`the shipped config maps the ${scope} scope to labels`, () => {
-        assert.ok(labelsForTitle(`feat(${scope}): x`, loadRules()).length > 0, `${scope} scope maps to no labels`)
+    test(`the shipped config maps the ${scope} scope to the desktop label`, () => {
+        assert.ok(
+            labelsForTitle(`feat(${scope}): x`, loadRules()).includes('feature/desktop'),
+            `${scope} scope does not map to feature/desktop`
+        )
     })
 }


### PR DESCRIPTION
## Problem

PRs touching the desktop product had no auto-labeling, so `feature/desktop` had to be applied by hand. The Auto Assign Labels workflow already maps conventional-commit scopes to labels via `.github/auto-assign-labels.json`, but had no rule for the `desktop` scope.

## Changes

Adds a config rule mapping the `desktop`, `tasks` and `agent-proxy` scopes to the existing `feature/desktop` label, so any PR titled `feat(desktop): ...`, `fix(tasks): ...` etc gets labeled on open.

## How did you test this code?

Ran `node --test .github/scripts/label-pr-from-title.test.js` (36 pass). Added one test binding the `desktop` scope to the shipped config. It catches a future config edit that drops or renames the rule, which the existing logic tests would miss since they run against a local rules mirror.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-tests. We considered path-based labeling driven by `product.yaml` (extending the ownership resolver used by assign-reviewers.js) but chose the title-scope rule since it needs only a config entry in the mechanism that already exists.

