### PR TITLE
fix(self-driving): enable products and surface inbox

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -25,7 +25,6 @@ import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableSh
 import { RenderKeybind } from 'lib/components/Shortcuts/ShortcutMenu'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -177,7 +176,6 @@ export function NavTabBrowse(): JSX.Element {
         pathname,
     } = useValues(panelLayoutLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const isProductAutonomyEnabled = useFeatureFlag('PRODUCT_AUTONOMY')
     const { recentItems, recentItemsLoading } = useValues(navRecentsLogic)
     const { isSidebarSectionShown, isSidebarItemShown, uiCustomizationEnabled } = useValues(uiCustomizationLogic)
     const { enabledToolPaths } = useValues(customProductsLogic)
@@ -242,7 +240,7 @@ export function NavTabBrowse(): JSX.Element {
                         />
                     )}
 
-                    {isProductAutonomyEnabled && isSidebarItemShown('inbox') && (
+                    {isSidebarItemShown('inbox') && (
                         <NavLink
                             to={urls.inbox()}
                             label="Inbox"

--- a/frontend/src/layout/panel-layout/sidebarCustomization.tsx
+++ b/frontend/src/layout/panel-layout/sidebarCustomization.tsx
@@ -53,7 +53,6 @@ export const SIDEBAR_CUSTOMIZABLE_SECTIONS: SidebarCustomizableSection[] = [
                 label: 'Inbox',
                 description: 'Reports and signals that need your attention.',
                 icon: <IconNotification />,
-                flag: FEATURE_FLAGS.PRODUCT_AUTONOMY,
             },
             {
                 label: 'Activity',

--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -93,6 +93,7 @@ export const AGENT_USE_CASE_SCOPES = [
     'organization_member:read',
     'person:read',
     'person:write',
+    'product_enablement:write',
     'project:read',
     'project:write',
     'property_definition:read',

--- a/frontend/src/scenes/inbox/InboxScene.stories.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-
 import { mswDecorator } from '~/mocks/browser'
 
 import {
@@ -51,7 +49,6 @@ const meta: Meta = {
         layout: 'fullscreen',
         viewMode: 'story',
         mockDate: '2026-06-11',
-        featureFlags: [FEATURE_FLAGS.PRODUCT_AUTONOMY],
         // The scene shell keeps a loader element mounted past the VR wait window, so don't block on it.
         testOptions: { waitForLoadersToDisappear: false },
     },

--- a/frontend/src/scenes/inbox/signalSourcesLogic.test.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.test.ts
@@ -61,7 +61,7 @@ describe('signalSourcesLogic', () => {
     let logic: ReturnType<typeof signalSourcesLogic.build>
     let warehouseSources: ExternalDataSource[]
 
-    beforeEach(() => {
+    beforeEach(async () => {
         warehouseSources = []
         useMocks({
             get: {
@@ -84,10 +84,15 @@ describe('signalSourcesLogic', () => {
         initKeaTests()
         logic = signalSourcesLogic()
         logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
     })
 
     afterEach(() => {
         logic?.unmount()
+    })
+
+    it('loads source configs without the product autonomy feature flag', () => {
+        expect(logic.values.sourceConfigs).toEqual([])
     })
 
     // The cached sources list is null right after mount (loadSources is debounced). Reading it

--- a/frontend/src/scenes/inbox/signalSourcesLogic.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.ts
@@ -1064,13 +1064,9 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
 
     events(({ actions, values }) => ({
         afterMount: () => {
-            if (values.featureFlags[FEATURE_FLAGS.PRODUCT_AUTONOMY]) {
-                // The condition allows us to safely mount this logic for user without the product autonomy feature flag
-                // without needlessly loading the source configs
-                actions.loadSourceConfigs()
-                if (values.featureFlags[FEATURE_FLAGS.ENGINEERING_ANALYTICS]) {
-                    actions.loadCiSignalsConfig()
-                }
+            actions.loadSourceConfigs()
+            if (values.featureFlags[FEATURE_FLAGS.ENGINEERING_ANALYTICS]) {
+                actions.loadCiSignalsConfig()
             }
         },
     })),

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -265,9 +265,19 @@ tools:
     organizations-projects-settings-as-of-retrieve:
         operation: organizations_projects_settings_as_of_retrieve
         enabled: false
-    product-enablement-create:
+    products-enable:
         operation: product_enablement_create
-        enabled: false
+        enabled: true
+        scopes:
+            - product_enablement:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Enable products
+        description: |
+            Enable selected PostHog products for the current project using conservative defaults.
+            Session Replay and Support may require project admin access.
     project-get:
         operation: organizations_projects_retrieve
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6881,6 +6881,20 @@
         },
         "feature_flag": "engineering-analytics"
     },
+    "products-enable": {
+        "description": "Enable selected PostHog products for the current project using conservative defaults.\nSession Replay and Support may require project admin access.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Enable products",
+        "title": "Enable products",
+        "required_scopes": ["product_enablement:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "project-get": {
         "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.",
         "category": "Core",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7435,6 +7435,20 @@
         },
         "feature_flag": "engineering-analytics"
     },
+    "products-enable": {
+        "description": "Enable selected PostHog products for the current project using conservative defaults.\nSession Replay and Support may require project admin access.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Enable products",
+        "title": "Enable products",
+        "required_scopes": ["product_enablement:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "project-get": {
         "description": "Retrieve a project and its settings. Omit the ID to get the caller's active project.",
         "category": "Core",

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 4 enabled ops
+ * PostHog API - MCP 5 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -651,6 +651,27 @@ export const OrganizationsProjectsPartialUpdateBody = /* @__PURE__ */ zod
         web_analytics_pre_aggregated_tables_enabled: zod.boolean().nullish(),
     })
     .describe('Mixin for serializers to add user access control fields')
+
+export const ProductEnablementCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const ProductEnablementCreateBody = /* @__PURE__ */ zod.object({
+    products: zod
+        .array(
+            zod
+                .enum(['conversations', 'error_tracking', 'session_replay'])
+                .describe(
+                    '\* `conversations` - conversations\n\* `error_tracking` - error_tracking\n\* `session_replay` - session_replay'
+                )
+        )
+        .min(1)
+        .describe('Products to turn on for this project, each enabled with server-owned conservative defaults.'),
+})
 
 /**
  * Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user; non-staff callers may only access their own account.

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -6,6 +6,7 @@ import {
     OrganizationsProjectsPartialUpdateBody,
     OrganizationsProjectsPartialUpdateParams,
     OrganizationsProjectsRetrieveParams,
+    ProductEnablementCreateBody,
     UsersPartialUpdateBody,
     UsersPartialUpdateParams,
     UsersRetrieveParams,
@@ -13,6 +14,26 @@ import {
 import { castStringToInt } from '@/tools/cast-helpers'
 import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const ProductsEnableSchema = ProductEnablementCreateBody
+
+const productsEnable = (): ToolBase<typeof ProductsEnableSchema, Schemas.ProductEnablementResult> => ({
+    name: 'products-enable',
+    schema: ProductsEnableSchema,
+    handler: async (context: Context, params: z.infer<typeof ProductsEnableSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.products !== undefined) {
+            body['products'] = params.products
+        }
+        const result = await context.api.request<Schemas.ProductEnablementResult>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/product_enablement/`,
+            body,
+        })
+        return result
+    },
+})
 
 const ProjectGetSchema = OrganizationsProjectsRetrieveParams.omit({ organization_id: true }).extend({
     id: z
@@ -411,6 +432,7 @@ const userSettingsUpdate = (): ToolBase<typeof UserSettingsUpdateSchema, Schemas
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'products-enable': productsEnable,
     'project-get': projectGet,
     'project-settings-update': projectSettingsUpdate,
     'user-get': userGet,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/products-enable.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/products-enable.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "products": {
+            "description": "Products to turn on for this project, each enabled with server-owned conservative defaults.",
+            "items": {
+                "description": "* `conversations` - conversations\n* `error_tracking` - error_tracking\n* `session_replay` - session_replay",
+                "enum": ["conversations", "error_tracking", "session_replay"],
+                "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+        }
+    },
+    "required": ["products"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Wizard cannot enable products because the MCP tool it expects, `products-enable`, is disabled and registered under a different name.

Inbox is also hidden and does not load its source configuration unless the stale `PRODUCT_AUTONOMY` feature flag is enabled.

Closes #75977

## Changes

- Enable the `products-enable` MCP tool with the `product_enablement:write` scope and safe tool annotations.
- Regenerate the MCP definitions, handler, API types, agent scopes, and schema snapshot.
- Surface Inbox without requiring the `PRODUCT_AUTONOMY` feature flag.
- Load Inbox source configurations on mount while keeping Engineering analytics behind its own feature flag.

Before:

```mermaid
flowchart LR
    Wizard{{Wizard}} --> Expected[products-enable]
    Expected --> Missing[Disabled or unavailable]
    Flag[PRODUCT_AUTONOMY off] --> Hidden[Inbox hidden]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class Wizard phBlue;
    class Expected phYellow;
    class Missing,Flag,Hidden phRed;
```

After:

```mermaid
flowchart LR
    Wizard{{Wizard}} --> Tool[products-enable]
    Tool --> Endpoint[Product enablement endpoint]
    Project[Project] --> Inbox[Inbox visible]
    Inbox --> Configs[Source configurations loaded]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Wizard phBlue;
    class Tool,Inbox phYellow;
    class Endpoint phRed;
    class Project,Configs phGray;
```

## How did you test this code?

- Ran the focused `signalSourcesLogic` Jest suite. All 6 tests passed. The added assertion guards against source configurations remaining unloaded when `PRODUCT_AUTONOMY` is absent.
- Ran the MCP tool schema snapshot test.
- Ran the MCP tool-name validation test.
- Ran the MCP TypeScript typecheck.
- Regenerated OpenAPI and MCP artifacts. A second generation produced no diff.
- Ran `hogli ci:preflight --strict`.
- Ran the existing product-enablement API suite. All 11 tests passed.
- Rebuilt the Quill workspace successfully. The repository-wide frontend typecheck could not be confirmed because the local command runner lost its completion result. The upstream full-CI labels require maintainer permissions.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes. This restores the existing product-enablement workflow and updates its generated MCP contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Codex in T3 Code. The work was directed and reviewed interactively by the human author.

Skills used: `/implement`, `/implementing-mcp-tools`, `/writing-kea-logics`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/setting-feature-flags-in-storybook`, `/tdd`, and `/code-review`.

I treated this as a fix because the product-enablement endpoint and Inbox already exist. The change restores their intended availability. The `PRODUCT_AUTONOMY` flag remains in place for unrelated behavior, and the Inbox regression test asserts observable logic state rather than request implementation details.


