### PR TITLE
fix(data-imports): classify exhausted delta commit-conflict retries as transient maintenance noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -46,7 +46,22 @@ def is_transient_object_store_error(error: BaseException) -> bool:
 # read, which delta-rs surfaces as this DeltaError. The scan failing here means the optimize aborted
 # before committing anything — the table is left exactly as it was, just still fragmented — so this is
 # safe to skip and retry on the next maintenance pass, not a bug in our logic.
-TRANSIENT_DELTA_MAINTENANCE_ERRORS = ("Optimize selected-file scan failed",)
+#
+# The same concurrent maintenance pass can instead lose the race at commit time rather than during the
+# scan: `execute_with_conflict_retry` already refreshes and retries a `CommitFailedError`
+# (DELTA_MERGE_CONFLICT_RETRIES times), but sustained contention from another still-running pass can
+# exhaust that budget too, and the error then propagates out here. Delta's conflict checker raises this
+# for its three concurrent-writer race variants — ConcurrentAppend ("a concurrent transactions added new
+# data"), ConcurrentDeleteRead ("a concurrent transaction deleted data this operation read"), and
+# ConcurrentDeleteDelete ("a concurrent transaction deleted the same data") — all sharing the "a
+# concurrent transaction" substring below. A failed commit never partially applies, so the table is left
+# exactly as it was, same as the scan-failure case above: safe to skip and retry on the next maintenance
+# pass. Deliberately narrower than matching CommitFailedError outright — MetadataChanged/ProtocolChanged
+# commit failures aren't a same-pass race and should still be captured.
+TRANSIENT_DELTA_MAINTENANCE_ERRORS = (
+    "Optimize selected-file scan failed",
+    "Commit failed: a concurrent transaction",
+)
 
 
 def is_transient_delta_maintenance_error(error: BaseException) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -50,6 +50,36 @@ class TestIsTransientDeltaMaintenanceError:
                 ),
                 True,
             ),
+            # execute_with_conflict_retry already retries a CommitFailedError, but a still-running
+            # concurrent maintenance pass can exhaust that budget too — same race, just losing at
+            # commit time instead of during the scan. Covers all three delta-rs conflict-checker
+            # variants that share this class of race.
+            (
+                "compact_commit_conflict_concurrent_delete_read",
+                deltalake.exceptions.CommitFailedError(
+                    "Commit failed: a concurrent transaction deleted data this operation read."
+                ),
+                True,
+            ),
+            (
+                "vacuum_commit_conflict_concurrent_append",
+                deltalake.exceptions.CommitFailedError("Commit failed: a concurrent transactions added new data."),
+                True,
+            ),
+            (
+                "commit_conflict_concurrent_delete_delete",
+                deltalake.exceptions.CommitFailedError(
+                    "Commit failed: a concurrent transaction deleted the same data your transaction deletes."
+                ),
+                True,
+            ),
+            # A commit failure from a metadata/protocol change isn't the same-pass race above — a
+            # genuine conflict worth capturing, not silently retried away next pass.
+            (
+                "commit_conflict_metadata_changed",
+                deltalake.exceptions.CommitFailedError("Metadata changed since last commit."),
+                False,
+            ),
             # Other DeltaErrors are real failures (e.g. a genuinely corrupt log) and must still be captured.
             ("unrelated_delta_error", deltalake.exceptions.DeltaError("no protocol found in delta log"), False),
             # Same message shape but not the DeltaError type delta-rs actually raises for it.
@@ -77,6 +107,15 @@ class TestIsTransientMaintenanceError:
             (
                 "concurrent_maintenance_race",
                 deltalake.exceptions.DeltaError("Optimize selected-file scan failed while scanning data"),
+                True,
+            ),
+            # A commit-conflict retry budget exhausted by sustained contention from another
+            # concurrent maintenance pass — see TestIsTransientDeltaMaintenanceError above.
+            (
+                "commit_conflict_retries_exhausted",
+                deltalake.exceptions.CommitFailedError(
+                    "Commit failed: a concurrent transaction deleted data this operation read."
+                ),
                 True,
             ),
             ("genuine_bug", RuntimeError("maintenance blew up"), False),

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -86,7 +86,7 @@ class TestIsTransientDeltaMaintenanceError:
             ("wrong_exception_type", RuntimeError("Optimize selected-file scan failed"), False),
         ]
     )
-    def test_matches_only_the_racy_optimize_scan_signature(self, _name: str, error: Exception, expected: bool):
+    def test_classifies_transient_delta_maintenance_errors(self, _name: str, error: Exception, expected: bool):
         assert is_transient_delta_maintenance_error(error) is expected
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_maintenance.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_maintenance.py
@@ -352,6 +352,16 @@ class TestRunScheduled:
             # A transient infra blip self-heals on the next scheduled pass and must not be promoted
             # into a fresh error-tracking issue.
             ("transient_blip_warned_only", OSError("Generic S3 error: Please reduce your request rate."), False),
+            # A commit conflict that exhausted execute_with_conflict_retry's budget (sustained
+            # contention from another still-running maintenance pass) is the same self-healing race,
+            # just losing at commit time instead of during compact's file scan.
+            (
+                "commit_conflict_retries_exhausted_warned_only",
+                deltalake.exceptions.CommitFailedError(
+                    "Commit failed: a concurrent transaction deleted data this operation read."
+                ),
+                False,
+            ),
         ]
     )
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

An [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fc152-dc43-7e01-be0b-760142294102) surfaced a `CommitFailedError` during delta table maintenance:

```
Failed to commit transaction: Commit failed: a concurrent transaction deleted data this operation read.
Help: This transaction's query must be rerun to exclude the removed data.
```

The call path: `run_scheduled` -> `run_maintenance` -> `compact_if_fragmented` -> `_compact` -> `execute_with_conflict_retry` -> `optimize.compact()`.

`_compact` already routes through `execute_with_conflict_retry`, which retries a `CommitFailedError` by refreshing the table and re-running the operation (`DELTA_MERGE_CONFLICT_RETRIES` times). But sustained contention from another still-running maintenance pass on the same table (e.g. a second Temporal activity attempt still finishing a compact after the first attempt's heartbeat timed out) can exhaust that retry budget too. When it does, the error propagates out to `run_scheduled`'s exception handler, which wasn't classifying it as one of the known self-healing concurrent-maintenance races — so it got captured as a fresh bug instead of logged as a warning.

This is best-effort maintenance code: the exception was already caught by `run_scheduled`'s try/except and never re-raised, so no sync was ever at risk. This only affects whether a self-healing race gets reported as a defect.

## Changes

Extend `is_transient_delta_maintenance_error`'s classifier with the `CommitFailedError` message shared by delta-rs's three concurrent-writer race variants (`ConcurrentAppend`, `ConcurrentDeleteRead`, `ConcurrentDeleteDelete`) — all of which start with "Commit failed: a concurrent transaction". Deliberately narrower than matching `CommitFailedError` outright: a `MetadataChanged`/`ProtocolChanged` commit failure isn't this same-pass race and should still be captured.

## How did you test this code?

- Added parameterized cases to `TestIsTransientDeltaMaintenanceError`, `TestIsTransientMaintenanceError`, and `TestRunScheduled.test_never_raises` covering all three race message variants (classified transient) plus a `MetadataChanged` commit failure (still captured).
- Ran the full `delta/test/` suite (56 tests), `ruff check`/`ruff format`, and `mypy --cache-fine-grained` repo-wide — all clean.

## Docs update

N/A — internal maintenance-code fix, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue (webhook-delivered) using Claude Code. Pulled the stack trace, exception samples, and `warehouse_sources_*` event properties via the PostHog MCP tools to confirm the failing frame and reproduction context (a TemporalIO incremental sync), then read delta-rs's own conflict-checker source (vendored in the CI Rust toolchain cache) to confirm the exact set of concurrent-writer race message variants worth classifying as transient.

Searched open PRs (by exception type, message phrase, module path, and the maintainer's own open PRs) before starting. Found related-but-distinct work on the same maintenance module — [#76085](https://github.com/PostHog/posthog/pull/76085) wraps `_vacuum` in the same retry helper (a different frame losing the race with zero retries), [#75240](https://github.com/PostHog/posthog/pull/75240) classifies a different `DeltaError` signature (a missing `_delta_log` commit file) as transient. Neither addresses this issue: a `CommitFailedError` that already went through `execute_with_conflict_retry` and exhausted its budget.