### PR TITLE
fix(vercel): distinguish transient errors from a bad token on validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
@@ -126,14 +126,29 @@ class TestValidateCredentials:
         assert ok is expected_ok, f"status={status}"
         assert (error is None) is expected_ok, f"status={status}"
 
-    def test_request_exception_is_handled(self, monkeypatch: Any) -> None:
+    def test_request_exception_returns_retry_message_without_leaking_raw_error(self, monkeypatch: Any) -> None:
         session = MagicMock()
         session.get.side_effect = requests.ConnectionError("boom")
         monkeypatch.setattr(vercel, "make_tracked_session", lambda *a, **k: session)
 
         ok, error = validate_credentials("token")
         assert ok is False
-        assert error == "boom"
+        assert error == vercel._VERCEL_UNREACHABLE_ERROR
+        assert "boom" not in (error or "")
+
+    @parameterized.expand([(429,), (500,), (503,)])
+    def test_transient_status_returns_retry_message_not_token_advice(self, status: int) -> None:
+        response = requests.Response()
+        response.status_code = status
+        session = MagicMock()
+        session.get.return_value = response
+        with patch.object(vercel, "make_tracked_session", lambda *a, **k: session):
+            ok, error = validate_credentials("token")
+
+        assert ok is False
+        assert error == vercel._VERCEL_UNREACHABLE_ERROR
+        # A transient Vercel-side error must not tell the user to fix their (possibly valid) token.
+        assert "Check that it's a valid token" not in (error or "")
 
     def test_unexpected_status_does_not_leak_raw_status_code(self) -> None:
         response = requests.Response()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
@@ -44,6 +44,11 @@ BILLING_MEASURE_FIELDS = frozenset({"BilledCost", "EffectiveCost", "ConsumedQuan
 # a runaway guard, not a coverage limit — at 100 rows/page it allows ~1M rows before warning.
 MAX_PAGES = 10_000
 
+# Shown when the token check can't reach a verdict because Vercel is unreachable or returned a
+# transient error (network failure, 429, 5xx). The token may be perfectly valid, so pointing the
+# user at their credentials would send them chasing a problem they can't fix.
+_VERCEL_UNREACHABLE_ERROR = "Couldn't reach Vercel to validate your access token. Please try again in a few minutes."
+
 
 class VercelRetryableError(Exception):
     pass
@@ -129,13 +134,19 @@ def validate_credentials(access_token: str) -> tuple[bool, str | None]:
         response = make_tracked_session().get(
             f"{VERCEL_BASE_URL}/v2/user", headers=_get_headers(access_token), timeout=10
         )
-    except requests.exceptions.RequestException as e:
-        return False, str(e)
+    except requests.exceptions.RequestException:
+        # A network failure or timeout is transient and unrelated to the token; the raw exception
+        # embeds the URL and gives the user nothing actionable.
+        return False, _VERCEL_UNREACHABLE_ERROR
 
     if response.status_code == 200:
         return True, None
     if response.status_code in (401, 403):
         return False, "Invalid or unauthorized Vercel access token"
+    # 429 (rate limit) and 5xx are transient Vercel-side problems, not a bad token, so surface a
+    # retry hint rather than telling the user to fix credentials they can't fix.
+    if response.status_code == 429 or response.status_code >= 500:
+        return False, _VERCEL_UNREACHABLE_ERROR
     return (
         False,
         "Couldn't validate your Vercel access token. Check that it's a valid token from your Vercel account settings, then try again.",


### PR DESCRIPTION
## Problem

When you add a Vercel source, we validate the access token with a `GET /v2/user` probe. The check split responses three ways: 200 passes, 401/403 says "invalid or unauthorized token", and *everything else* fell into:

> Couldn't validate your Vercel access token. Check that it's a valid token from your Vercel account settings, then try again.

So a 429 rate limit, a Vercel 5xx, or a transient blip all told the user their token was the problem. On a network failure (`requests.exceptions.RequestException`) it was worse: we returned `str(e)` straight to the wizard, leaking the raw exception (which embeds the request URL) and giving the user nothing to act on.

These are transient, Vercel-side conditions. The token may be perfectly valid, so pointing the user at their credentials sends them chasing a fix that does not exist.

## Changes

`validate_credentials` now treats 429, any 5xx, and network/timeout exceptions as transient and returns a single retry message instead:

> Couldn't reach Vercel to validate your access token. Please try again in a few minutes.

401/403 (genuine auth failure) and the "check your token" fallback for other 4xx are unchanged. This mirrors how the sync path in the same module already classifies 429/5xx as retryable via `VercelRetryableError`.

## How did you test this code?

Automated, in `products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py`:

- Reworked the network-exception test to assert we return the retry message and no longer leak the raw exception string. Guards the `str(e)` leak regression.
- Added a parameterized case over 429 / 500 / 503 asserting they return the retry message and not the "check your token" advice. Guards the core regression this PR fixes: transient statuses collapsing back into bad-token wording.

Ran the validation tests locally (9 passed) and `ruff` over the touched files. I (Claude) did not exercise this against the live Vercel API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude while triaging data-warehouse source-creation validation failures. Vercel stood out because every failing attempt landed on the generic "check your token" message even though 401/403 has its own branch, which meant the failures were non-auth (5xx/429/network) yet worded as auth problems.

Invoked `/writing-tests` before touching the test file. Scoped deliberately narrow: only the validation-probe copy/classification changed, no sync or schema behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
