### PR TITLE
feat(mcp-store): group installed tools by read and write/delete

### DIFF
--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -479,6 +479,10 @@ class MCPServerInstallationToolSerializer(serializers.ModelSerializer):
         help_text="True when a rule or Blocked team ceiling leaves no editable state."
     )
     decided_by = serializers.SerializerMethodField(help_text="Policy layer that decided the effective state.")
+    is_read_only = serializers.SerializerMethodField(
+        help_text="True when the server declared this tool read-only via the MCP readOnlyHint annotation. "
+        "Tools without that hint are treated as write/delete-capable."
+    )
 
     class Meta:
         model = MCPServerInstallationTool
@@ -492,6 +496,7 @@ class MCPServerInstallationToolSerializer(serializers.ModelSerializer):
             "team_state",
             "locked",
             "decided_by",
+            "is_read_only",
             "last_seen_at",
             "removed_at",
             "created_at",
@@ -536,6 +541,10 @@ class MCPServerInstallationToolSerializer(serializers.ModelSerializer):
     def get_decided_by(self, obj: MCPServerInstallationTool) -> str:
         resolved = self._resolved_policy(obj)
         return resolved.decided_by if resolved is not None else "legacy"
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_is_read_only(self, obj: MCPServerInstallationTool) -> bool:
+        return obj.annotations.get("readOnlyHint") is True
 
 
 class ToolApprovalUpdateSerializer(serializers.Serializer):

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -863,6 +863,10 @@ export interface MCPServerInstallationToolApi {
     readonly locked: boolean
     /** Policy layer that decided the effective state. */
     readonly decided_by: string
+    /**
+     * True when the server declared this tool read-only via the MCP readOnlyHint annotation. Tools without that hint are treated as write/delete-capable.
+     */
+    readonly is_read_only: boolean
     readonly last_seen_at: string
     /** @nullable */
     readonly removed_at: string | null

--- a/products/mcp_store/frontend/mcpStoreLogic.test.ts
+++ b/products/mcp_store/frontend/mcpStoreLogic.test.ts
@@ -38,6 +38,7 @@ function tool(installationId: string): MCPServerInstallationToolApi {
         team_state: null,
         locked: false,
         decided_by: 'default',
+        is_read_only: false,
         last_seen_at: '2026-01-01T00:00:00Z',
         removed_at: null,
         created_at: '2026-01-01T00:00:00Z',

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -100,7 +100,7 @@ function ToolsSection({ installation, disabledReason }: ToolsSectionProps): JSX.
     const blockedCount = countBy(tools, (t) => t.approval_state === 'do_not_use')
 
     const renderToolGroup = (groupTools: MCPServerInstallationToolApi[]): JSX.Element => (
-        <div className="border border-primary rounded overflow-hidden">
+        <div>
             {groupTools.map((tool) => (
                 <ToolRow
                     key={tool.id}

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -217,7 +217,7 @@ function ToolsSection({ installation, disabledReason }: ToolsSectionProps): JSX.
                             key: 'read',
                             header: (
                                 <div className="flex items-center gap-2">
-                                    <span>Read tools</span>
+                                    <span>Read-only tools</span>
                                     <LemonSnack>{readTools.length}</LemonSnack>
                                 </div>
                             ),

--- a/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
+++ b/products/mcp_store/frontend/scene/ServerDetailPanel.tsx
@@ -2,7 +2,16 @@ import { useActions, useValues } from 'kea'
 import { useEffect, useMemo, useState } from 'react'
 
 import { IconCheck, IconChevronLeft, IconRefresh, IconShare, IconShieldLock, IconTrash, IconX } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonDivider, LemonSnack, LemonSwitch, LemonTag, Tooltip } from '@posthog/lemon-ui'
+import {
+    LemonButton,
+    LemonCollapse,
+    LemonDialog,
+    LemonDivider,
+    LemonSnack,
+    LemonSwitch,
+    LemonTag,
+    Tooltip,
+} from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { OrganizationMembershipLevel, TeamMembershipLevel } from 'lib/constants'
@@ -83,10 +92,32 @@ function ToolsSection({ installation, disabledReason }: ToolsSectionProps): JSX.
 
     const tools: MCPServerInstallationToolApi[] = installationTools[installation.id] ?? []
     const visibleTools = useMemo(() => tools.filter((t) => showRemoved || !t.removed_at), [tools, showRemoved])
+    const readTools = useMemo(() => visibleTools.filter((t) => t.is_read_only), [visibleTools])
+    const writeDeleteTools = useMemo(() => visibleTools.filter((t) => !t.is_read_only), [visibleTools])
     const removedCount = countBy(tools, (t) => !!t.removed_at)
     const approvedCount = countBy(tools, (t) => t.approval_state === 'approved')
     const pendingCount = countBy(tools, (t) => (t.approval_state ?? 'needs_approval') === 'needs_approval')
     const blockedCount = countBy(tools, (t) => t.approval_state === 'do_not_use')
+
+    const renderToolGroup = (groupTools: MCPServerInstallationToolApi[]): JSX.Element => (
+        <div className="border border-primary rounded overflow-hidden">
+            {groupTools.map((tool) => (
+                <ToolRow
+                    key={tool.id}
+                    tool={tool}
+                    teamScope={installation.scope === 'shared'}
+                    disabledReason={disabledReason}
+                    onPolicyChange={(state: ToolApprovalState) =>
+                        setToolApprovalState({
+                            installationId: installation.id,
+                            toolName: tool.tool_name,
+                            approvalState: state,
+                        })
+                    }
+                />
+            ))}
+        </div>
+    )
 
     return (
         <div className="deprecated-space-y-3">
@@ -178,23 +209,32 @@ function ToolsSection({ installation, disabledReason }: ToolsSectionProps): JSX.
                         : 'No tools reported yet. Click "Refresh tools" after connecting.'}
                 </div>
             ) : (
-                <div className="border border-primary rounded overflow-hidden">
-                    {visibleTools.map((tool) => (
-                        <ToolRow
-                            key={tool.id}
-                            tool={tool}
-                            teamScope={installation.scope === 'shared'}
-                            disabledReason={disabledReason}
-                            onPolicyChange={(state: ToolApprovalState) =>
-                                setToolApprovalState({
-                                    installationId: installation.id,
-                                    toolName: tool.tool_name,
-                                    approvalState: state,
-                                })
-                            }
-                        />
-                    ))}
-                </div>
+                <LemonCollapse
+                    multiple
+                    defaultActiveKeys={['read', 'write_delete']}
+                    panels={[
+                        readTools.length > 0 && {
+                            key: 'read',
+                            header: (
+                                <div className="flex items-center gap-2">
+                                    <span>Read tools</span>
+                                    <LemonSnack>{readTools.length}</LemonSnack>
+                                </div>
+                            ),
+                            content: renderToolGroup(readTools),
+                        },
+                        writeDeleteTools.length > 0 && {
+                            key: 'write_delete',
+                            header: (
+                                <div className="flex items-center gap-2">
+                                    <span>Write/delete tools</span>
+                                    <LemonSnack>{writeDeleteTools.length}</LemonSnack>
+                                </div>
+                            ),
+                            content: renderToolGroup(writeDeleteTools),
+                        },
+                    ]}
+                />
             )}
         </div>
     )


### PR DESCRIPTION
## Problem

The MCP server detail panel lists every installed tool in one flat list, with no way to tell at a glance which tools only read data versus which can write or delete something. That makes it harder to review a server's footprint before approving it.

Closes #76236

## Changes

- Backend: `MCPServerInstallationToolSerializer` now exposes `is_read_only`, derived from the MCP `readOnlyHint` tool annotation (tools without that hint are treated as write/delete-capable).
- Frontend: the tools list in `ServerDetailPanel` is split into two collapsible sections, "Read tools" and "Write/delete tools", using `LemonCollapse`, each with a count badge. Both sections are expanded by default.

![Read/write tool grouping in the MCP server detail panel](https://raw.githubusercontent.com/Mithurn/posthog/pr-assets/76236-mcp-tool-grouping/pr-assets/76236-mcp-tool-grouping.png)

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the changed files.
- Existing `mcpStoreLogic.test.ts` suite passes with the updated `is_read_only` fixture field.
- `oxlint --fix` / `oxfmt` run clean on the changed file.
- Rendered `ServerDetailPanel` in Storybook with mocked data covering three cases: a mix of read and write/delete tools, only read tools, and only write/delete tools. Confirmed grouping, counts, and collapse behavior render correctly in all three, with no leftover headers or gaps when a group is empty. I didn't have the full local dev stack (Postgres/ClickHouse/Kafka) available to click through the real app end to end, so that part is unverified.

No new automated test was added for the read/write split itself since it's a straightforward filter over already-typed data with no new business logic in `mcpStoreLogic`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference this panel today, so none needed updating.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I picked up #76236 and built the read/write tool grouping, using Claude Code to help implement and verify it in Storybook.
