### PR TITLE
fix(google_analytics): stop retrying revoked/expired OAuth refresh tokens

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -65,11 +65,11 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
             "401 Client Error": "Your Google Analytics connection is invalid or expired. Please reconnect your account.",
             "403 Client Error": "PostHog is not authorized to read this Google Analytics property. Please make sure the connected Google account has access to the property.",
             "ACCESS_TOKEN_SCOPE_INSUFFICIENT": "Insufficient permissions. Please reconnect your Google Analytics account with the required scopes.",
-            # Raised as a bare `RefreshError` from `AuthorizedSession` when the stored refresh
-            # token has been revoked or expired — the same condition `validate_credentials`
-            # already maps to a reconnect prompt, but that path only runs before a sync starts.
-            # Mid-sync, this reaches `_run_report` via `session.post()` before any HTTP status is
-            # available to match on, so match Google's stable OAuth error code instead.
+            # Raised as a bare `RefreshError` from `AuthorizedSession` when the stored refresh token
+            # has been revoked or expired. `validate_credentials` already maps this to a reconnect
+            # prompt, but only runs before a sync starts. Mid-sync it reaches `_run_report` via
+            # `session.post()` before any HTTP status is available to match on, so match Google's
+            # stable OAuth error code instead.
             "invalid_grant": "Your Google Analytics connection has expired or been revoked. Please reconnect your account.",
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -65,6 +65,12 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
             "401 Client Error": "Your Google Analytics connection is invalid or expired. Please reconnect your account.",
             "403 Client Error": "PostHog is not authorized to read this Google Analytics property. Please make sure the connected Google account has access to the property.",
             "ACCESS_TOKEN_SCOPE_INSUFFICIENT": "Insufficient permissions. Please reconnect your Google Analytics account with the required scopes.",
+            # Raised as a bare `RefreshError` from `AuthorizedSession` when the stored refresh
+            # token has been revoked or expired — the same condition `validate_credentials`
+            # already maps to a reconnect prompt, but that path only runs before a sync starts.
+            # Mid-sync, this reaches `_run_report` via `session.post()` before any HTTP status is
+            # available to match on, so match Google's stable OAuth error code instead.
+            "invalid_grant": "Your Google Analytics connection has expired or been revoked. Please reconnect your account.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -8,6 +8,7 @@ from posthog.schema import ReleaseStatus, SourceFieldOauthConfig
 
 from posthog.models.integration import Integration
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.googleanalytics import (
     GoogleAnalyticsSourceConfig,
 )
@@ -262,6 +263,17 @@ def test_non_retryable_errors_cover_auth_failures():
     assert "401 Client Error" in errors
     assert "403 Client Error" in errors
     assert "ACCESS_TOKEN_SCOPE_INSUFFICIENT" in errors
+    assert "invalid_grant" in errors
+
+
+def test_non_retryable_errors_matches_revoked_refresh_token():
+    # `_run_report` refreshes credentials via `session.post()` before any HTTP status is
+    # available, so a revoked/expired refresh token surfaces as a bare `RefreshError` whose
+    # `str()` is the raw (message, response_dict) tuple repr, e.g.:
+    # ('invalid_grant: Bad Request', {'error': 'invalid_grant', 'error_description': 'Bad Request'})
+    observed_error = str(RefreshError("invalid_grant: Bad Request", {"error": "invalid_grant"}))
+    non_retryable_errors = GoogleAnalyticsSource().get_non_retryable_errors()
+    assert error_message_matches(observed_error, non_retryable_errors)
 
 
 def test_retryable_errors_cover_exhausted_quota_retries():


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `RefreshError` from the Google Analytics data warehouse source: [`invalid_grant: Bad Request`](https://us.posthog.com/project/2/error_tracking/019fc21d-e0fb-79e2-ab5c-81cf9592290a). The stack trace shows it originates in `_run_report` in [`google_analytics.py`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py), when the `AuthorizedSession` tries to refresh the stored OAuth token before making a `runReport` call.

`invalid_grant` means Google has rejected the stored refresh token: it was revoked, expired, or the connection was disconnected on the Google side. This is a customer/upstream condition, not something PostHog can fix by retrying.

The connector's `get_non_retryable_errors()` only matched `401 Client Error`, `403 Client Error`, and `ACCESS_TOKEN_SCOPE_INSUFFICIENT` — all of which come from an HTTP response. But a `RefreshError` raised while `AuthorizedSession` refreshes its token happens *before* any HTTP response exists, so its message (a raw `(message, response_dict)` tuple repr) never matched any of those patterns. The result: the sync kept retrying and re-reporting the same unrecoverable error on every attempt instead of stopping and prompting a reconnect.

Note `validate_credentials` already catches this same `RefreshError` and returns a friendly reconnect message, but that only runs before a sync starts — it doesn't cover the mid-sync path through `_run_report`.

## Changes

Added `invalid_grant` to `GoogleAnalyticsSource.get_non_retryable_errors()`, matching Google's stable OAuth error code (rather than any part of the response that could vary) and mapping it to a reconnect-account message, consistent with the existing entries for this source and the equivalent pattern in `StripeSource.get_non_retryable_errors()`.

## How did you test this code?

Added `test_non_retryable_errors_matches_revoked_refresh_token`, which reproduces the observed `RefreshError` shape and asserts it's now recognized as non-retryable via `error_message_matches`. Also extended `test_non_retryable_errors_cover_auth_failures` to assert the new key is present.

Ran the full test file locally:

```
pytest products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
28 passed
```

Also ran `ruff check --fix` and `ruff format` on the changed files (no issues), and `mypy` on the changed source file (no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-handling classification, no user-facing config or workflow change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) investigated a `RefreshError` reported by PostHog error tracking for the Google Analytics data warehouse source, confirmed it originates in this source's `_run_report` code path (not a downstream/serialization artifact), and classified it as a customer/upstream OAuth issue rather than a PostHog bug. I checked for duplicate open PRs (by exception type, message phrase, module path, and the maintainer's own open PRs) and found none addressing this. The fix mirrors the existing `RefreshError` handling already present in `validate_credentials` and the `get_non_retryable_errors` pattern used across other sources (e.g. Stripe).

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*