### PR TITLE
fix(shopify): classify exhausted rate-limit retries as retryable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -87,6 +87,18 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH: SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MESSAGE,
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_make_paginated_shopify_request`'s `execute` already retries these in-process via
+        # tenacity (5 attempts, exponential backoff honoring Shopify's throttle refill time)
+        # before re-raising `ShopifyRetryableError`. Surviving all 5 attempts means the rate
+        # limit or upstream blip is still live, but Temporal retries the whole activity and it's
+        # self-recovering, so keep it out of error tracking as noise.
+        return {
+            "Shopify: rate limit exceeded",
+            "Shopify: internal error",
+            "Shopify: connection broken while reading response",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -88,11 +88,12 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # `_make_paginated_shopify_request`'s `execute` already retries these in-process via
-        # tenacity (5 attempts, exponential backoff honoring Shopify's throttle refill time)
-        # before re-raising `ShopifyRetryableError`. Surviving all 5 attempts means the rate
-        # limit or upstream blip is still live, but Temporal retries the whole activity and it's
-        # self-recovering, so keep it out of error tracking as noise.
+        # These are the messages `ShopifyRetryableError` carries once `_make_paginated_shopify_
+        # request`'s `execute` exhausts its own tenacity retries (5 attempts, exponential backoff
+        # honoring Shopify's throttle refill time — retried alongside transient `ConnectionError`/
+        # `Timeout`) and re-raises. Surviving all 5 attempts means the rate limit or upstream blip
+        # is still live, but Temporal retries the whole activity and it's self-recovering, so keep
+        # it out of error tracking as noise.
         return {
             "Shopify: rate limit exceeded",
             "Shopify: internal error",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
@@ -90,7 +90,7 @@ def test_transient_http_errors_stay_retryable(status_code, reason):
     [
         "Shopify: rate limit exceeded...",
         "Shopify: internal error from request 500 Internal Server Error",
-        "Shopify: internal errors in payload {'errors': ['throttled']}",
+        'Shopify: internal errors in payload [{"message": "internal error", "extensions": {"code": "internal_server_error"}}]',
         "Shopify: connection broken while reading response: Connection broken: IncompleteRead(0 bytes read)",
     ],
 )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
@@ -83,3 +83,22 @@ def test_transient_http_errors_stay_retryable(status_code, reason):
     assert not any(pattern in error_message for pattern in patterns), (
         f"transient error '{error_message}' should remain retryable"
     )
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        "Shopify: rate limit exceeded...",
+        "Shopify: internal error from request 500 Internal Server Error",
+        "Shopify: internal errors in payload {'errors': ['throttled']}",
+        "Shopify: connection broken while reading response: Connection broken: IncompleteRead(0 bytes read)",
+    ],
+)
+def test_exhausted_internal_retries_are_classified_as_retryable(error_message):
+    # These messages only reach `_handle_import_error` after `_make_paginated_shopify_request`'s
+    # own tenacity retries (5 attempts) are exhausted, so they should be logged as a warning
+    # and left for Temporal's activity retry rather than reported to error tracking as noise.
+    patterns = ShopifySource().get_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"exhausted-retry error '{error_message}' should be classified as retryable"
+    )


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ShopifyRetryableError: Shopify: rate limit exceeded...` from `products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py` ([issue](https://us.posthog.com/project/2/error_tracking/019fc28b-fbbc-7430-ac02-705da9deef25)).

The stack trace shows this comes from `_make_paginated_shopify_request`'s tenacity-wrapped `execute`, which already retries rate limits and transient upstream errors in-process (5 attempts, exponential backoff that honors Shopify's throttle refill time). Once that budget is exhausted, the exception escapes to `_handle_import_error`, which is where sources get a chance to classify their own already-retried, self-recovering failures via `get_retryable_errors()` — matched errors are logged as a warning and left for Temporal's own activity retry, instead of being reported to error tracking.

`ShopifySource` never implemented `get_retryable_errors()`, unlike Stripe, Hubspot, and Google Analytics, which all classify their internally-retried rate-limit/transient errors this way. So every time Shopify's rate limit stayed hot for the full local retry budget, the benign, self-recovering failure got reported as a tracked exception instead of a warning.

This isn't a user/upstream problem (nothing for the customer to fix) and it isn't a code bug in the retry/backoff logic itself — it's a missing noise-reduction classification that its sibling sources already have.

## Changes

Added `ShopifySource.get_retryable_errors()`, matching the messages `ShopifyRetryableError` can carry out of the same retry loop:
- `"Shopify: rate limit exceeded"` — the reported error
- `"Shopify: internal error"` — covers both the 5xx-from-HTTP-status and 5xx-from-GraphQL-payload variants
- `"Shopify: connection broken while reading response"` — a dropped connection mid-response

## How did you test this code?

Added `test_exhausted_internal_retries_are_classified_as_retryable` to `test_non_retryable_errors.py`, parameterized over the messages above — this locks in that once Shopify's own retries are exhausted, the failure is classified as retryable noise rather than reported to error tracking. Ran the full test file (15 passed), `ruff check`/`ruff format`, and `mypy` on the shopify source module — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry/error-classification behavior, no user-facing or documented change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue (`ShopifyRetryableError: rate limit exceeded`) end to end: confirmed the stack trace originates in the Shopify source, read the retry mechanism in `shopify.py`, and compared against how other sources (Stripe, Hubspot, Google Analytics) classify the same category of exhausted-internal-retry error via `get_retryable_errors()`.
- Skill invoked: `/writing-tests` before adding the regression test.
- Searched open PRs and the source's own recent history for a duplicate fix; found none.