### PR TITLE
fix(data-imports): stop blaming credentials for a cancelled warehouse query

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -30,7 +30,12 @@ from posthog.hogql.escape_sql import escape_clickhouse_identifier, escape_param_
 
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
-from posthog.errors import CORRUPTED_PARQUET_METADATA_MESSAGE, wrap_clickhouse_query_error
+from posthog.errors import (
+    CORRUPTED_PARQUET_METADATA_MESSAGE,
+    QueryErrorCategory,
+    classify_query_error,
+    wrap_clickhouse_query_error,
+)
 from posthog.exceptions_capture import capture_exception
 from posthog.models.utils import CreatedMetaFields, DeletedMetaFields, UpdatedMetaFields, UUIDTModel, sane_repr
 from posthog.schema_enums import DatabaseSerializedFieldType
@@ -931,6 +936,17 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         # error (or an already user-safe one) behind a misleading user-facing message.
         if not hasattr(err, "message"):
             raise err
+
+        # A cancelled query (code 394) reaching here is virtually always our own client giving up
+        # on a slow read - a read timeout closes the connection, which cancels the still-running
+        # query server-side (the same pattern documented in
+        # products/notebooks/backend/temporal/frame_materialize.py) - not anything wrong with the
+        # files themselves. Report it as a timeout instead of blaming credentials/URL/format.
+        if classify_query_error(err) == QueryErrorCategory.CANCELLED:
+            raise Exception(
+                "Reading the files from your storage bucket took too long and the query was cancelled. "
+                "This is usually temporary - try again, or narrow the URL pattern if the dataset is very large."
+            )
 
         for key, value in ExtractErrors.items():
             if key in raw_message:

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -937,11 +937,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
         if not hasattr(err, "message"):
             raise err
 
-        # A cancelled query (code 394) reaching here is virtually always our own client giving up
-        # on a slow read - a read timeout closes the connection, which cancels the still-running
-        # query server-side (the same pattern documented in
-        # products/notebooks/backend/temporal/frame_materialize.py) - not anything wrong with the
-        # files themselves. Report it as a timeout instead of blaming credentials/URL/format.
+        # A cancelled query here means our own client timed out reading, not a bad file or bucket.
         if classify_query_error(err) == QueryErrorCategory.CANCELLED:
             raise Exception(
                 "Reading the files from your storage bucket took too long and the query was cancelled. "

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -140,6 +140,15 @@ class TestSafeExposeChError:
             DataWarehouseTable()._safe_expose_ch_error(err)
         assert exc_info.value is err
 
+    def test_cancelled_query_gets_a_timeout_message_instead_of_storage_bucket_blame(self) -> None:
+        # code 394 QUERY_WAS_CANCELLED reaching here is virtually always our own client giving up
+        # on a slow S3/Delta read (a read timeout closes the connection, cancelling the
+        # still-running query server-side), not a problem with the customer's files. Without this
+        # case it fell through to the generic "check your credentials" message, sending users
+        # chasing the wrong fix for what is really just a timeout.
+        with pytest.raises(Exception, match="took too long"):
+            DataWarehouseTable()._safe_expose_ch_error(ServerException("DB::Exception: Query was cancelled.", code=394))
+
     def test_delta_kernel_permission_error_gets_actionable_message(self) -> None:
         # Delta-format tables (the default for every warehouse_sources synced table) read via
         # ClickHouse's DeltaLake kernel, whose object_store errors use different wording than

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -141,11 +141,7 @@ class TestSafeExposeChError:
         assert exc_info.value is err
 
     def test_cancelled_query_gets_a_timeout_message_instead_of_storage_bucket_blame(self) -> None:
-        # code 394 QUERY_WAS_CANCELLED reaching here is virtually always our own client giving up
-        # on a slow S3/Delta read (a read timeout closes the connection, cancelling the
-        # still-running query server-side), not a problem with the customer's files. Without this
-        # case it fell through to the generic "check your credentials" message, sending users
-        # chasing the wrong fix for what is really just a timeout.
+        # code 394 QUERY_WAS_CANCELLED here means our own client timed out reading, not bad files.
         with pytest.raises(Exception, match="took too long"):
             DataWarehouseTable()._safe_expose_ch_error(ServerException("DB::Exception: Query was cancelled.", code=394))
 


### PR DESCRIPTION
## Problem

A ClickHouse query cancellation (error code 394, `QUERY_WAS_CANCELLED`) while introspecting an S3/Delta-backed data warehouse table fell through `DataWarehouseTable._safe_expose_ch_error`'s classifier unmatched, and got reported to the user as:

> Could not read the files from your storage bucket. Check that the files URL pattern, file format, and credentials are correct, then try again.

That message sends people chasing a credentials or file-format problem that doesn't exist. In this pipeline a cancelled query is virtually always our own client giving up on a slow read: a read timeout closes the connection, which cancels the still-running query server-side. `products/notebooks/backend/temporal/frame_materialize.py` already documents and relies on this exact pattern for its own ClickHouse client, treating code 394 (alongside socket/network transport codes) as transient rather than a real query failure.

Traced from a live error tracking event: `run_chdb_query` timed out after its 30s budget, the code fell back to the ClickHouse-cluster path via `sync_execute`, and that query was also cancelled. Neither failure has anything to do with the source files, but `_safe_expose_ch_error` didn't have a code path for "the query itself was cancelled" and defaulted to the generic storage-bucket message.

## Changes

- `DataWarehouseTable._safe_expose_ch_error` now checks `classify_query_error(err) == QueryErrorCategory.CANCELLED` before falling through to the generic message, and raises an accurate, still-retryable "took too long" exception instead.
- Scoped to this one classifier (not the shared `wrap_clickhouse_query_error` used across the whole app), so it only changes behavior for warehouse table introspection (`get_count`/`get_columns`), not other ClickHouse query paths that rely on cancellation being classified as `CANCELLED` for their own purposes (e.g. SLO tracking in `hogql_queries/query_runner.py`).
- Left retryability untouched: this stays a plain `Exception`, not added to any `NonRetryableErrors`, since a cancelled/timed-out query is exactly the kind of transient condition that should keep retrying.

## How did you test this code?

Added one case to the existing `TestSafeExposeChError` suite in `products/warehouse_sources/backend/tests/test_table.py`: a `ServerException` with code 394 now raises the timeout message instead of the generic storage-bucket one. This is the regression the live error tracking event hit — no existing test covered a cancelled/timed-out query reaching this classifier.

Ran locally:
- `pytest products/warehouse_sources/backend/tests/test_table.py -k TestSafeExposeChError` — 6 passed
- `uv run mypy --cache-fine-grained .` — clean
- `tach check --dependencies --interfaces` — clean
- `hogli ci:preflight --fix` — clean

## Docs update

Not applicable — this only changes an internal error classification, no user-facing config or documented workflow.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code cloud task), triaging a real error tracking issue (`019fc2be-dc46-7681-9632-b3d354b22879`) delivered by webhook.
- Skills invoked: `/writing-tests` before adding the regression test.
- Investigated the full exception chain from the error tracking event (`$exception_list`), traced `get_count` → `run_chdb_query` timeout → `sync_execute` fallback → `wrap_clickhouse_query_error` → `_safe_expose_ch_error`, and confirmed via `classify_query_error`/`QueryErrorCategory` that code 394 was the only ClickHouse "infrastructure" code missing special-case handling here (code 159 `TIMEOUT_EXCEEDED` already avoids this bug because it maps to an exception without a `.message` attribute).
- Considered fixing this in the shared `wrap_clickhouse_query_error` instead, but that function backs every ClickHouse call in the app (via `sync_execute`), and reclassifying code 394 there would flip SLO outcome tracking for unrelated cancelled queries (e.g. user-navigated-away insight queries) from success to failure. Kept the fix local to `_safe_expose_ch_error` instead.
- Checked for duplicate open PRs (`gh pr list --search ...` on the exception type, message, and module path, plus the author's own open PRs): found two related-but-distinct open PRs, [#74001](https://github.com/PostHog/posthog/pull/74001) (schema-drift read errors) and [#74882](https://github.com/PostHog/posthog/pull/74882) (don't fail imports on a failed row-count refresh) — neither touches this classifier, and `get_columns()` (schema validation, which does fail the job on error) still hits it regardless of #74882.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*