### PR TITLE
fix(desktop): package renderer in windows release builds

### DIFF
--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -207,6 +207,9 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Build workspace packages
+              # bash, not pwsh: pwsh only fails a multi-line step on the LAST
+              # command's exit code, silently swallowing earlier failures.
+              shell: bash
               run: |
                   pnpm --filter @posthog/electron-trpc run build
                   pnpm --filter @posthog/platform run build
@@ -216,11 +219,26 @@ jobs:
                   pnpm --filter @posthog/harness run build
                   pnpm --filter @posthog/agent run build
 
-            - name: Build app
+            # Two separate steps: in a multi-line pwsh script only the last
+            # command's exit code fails the step, so a broken electron-vite
+            # build let electron-builder package an app with no renderer.
+            - name: Build app bundles
+              working-directory: products/desktop/apps/code
+              run: pnpm exec electron-vite build
+
+            - name: Package installer
+              working-directory: products/desktop/apps/code
+              run: pnpm exec electron-builder build --win --x64 --publish never --config electron-builder.ts
+
+            - name: Verify package
+              shell: pwsh
               working-directory: products/desktop/apps/code
               run: |
-                  pnpm exec electron-vite build
-                  pnpm exec electron-builder build --win --x64 --publish never --config electron-builder.ts
+                  if (!(Test-Path ".vite/renderer/main_window/index.html")) {
+                    Write-Error "FAIL: renderer bundle missing from electron-vite output"
+                    exit 1
+                  }
+                  echo "OK: renderer bundle"
 
             - name: Upload artifacts
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/desktop-build-test.yml
+++ b/.github/workflows/desktop-build-test.yml
@@ -39,9 +39,9 @@ jobs:
             npm_config_platform: darwin
             VITE_POSTHOG_API_KEY: ${{ secrets.VITE_POSTHOG_API_KEY }}
             VITE_POSTHOG_API_HOST: ${{ secrets.VITE_POSTHOG_API_HOST }}
-            POSTHOG_SOURCEMAP_API_KEY: ${{ secrets.DESKTOP_POSTHOG_SOURCEMAP_API_KEY }}
-            POSTHOG_ENV_ID: ${{ secrets.DESKTOP_POSTHOG_ENV_ID }}
-            POSTHOG_HOST: ${{ secrets.DESKTOP_POSTHOG_HOST }}
+            # No sourcemap secrets: without them the posthog vite plugin skips
+            # release creation and sourcemap upload, keeping test builds
+            # hermetic instead of calling the prod API and flaking on it.
             CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_BASE64 }}
             CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
             APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -375,17 +375,25 @@ jobs:
             - name: Build agent package
               run: pnpm --filter @posthog/agent run build
 
-            - name: Build release artifacts
-              env:
-                  APP_VERSION: ${{ steps.version.outputs.version }}
+            # Two separate steps: in a multi-line pwsh script only the last
+            # command's exit code fails the step, so a broken electron-vite
+            # build let electron-builder package an app with no renderer.
+            - name: Build app bundles
               working-directory: products/desktop/apps/code
-              run: |
-                  pnpm exec electron-vite build
-                  pnpm exec electron-builder build --win --x64 --publish never --config electron-builder.ts
+              run: pnpm exec electron-vite build
+
+            - name: Package installer
+              working-directory: products/desktop/apps/code
+              run: pnpm exec electron-builder build --win --x64 --publish never --config electron-builder.ts
 
             - name: Verify package
               shell: pwsh
               run: |
+                  if (!(Test-Path "apps/code/.vite/renderer/main_window/index.html")) {
+                    Write-Error "FAIL: renderer bundle missing from electron-vite output"
+                    exit 1
+                  }
+                  echo "OK: renderer bundle"
                   $dir = "apps/code/out/win-unpacked/resources/app.asar.unpacked/.vite/build/codex-acp"
                   foreach ($f in @("codex.exe", "codex-code-mode-host.exe", "rg.exe")) {
                     if (!(Test-Path "$dir/$f")) {
@@ -394,6 +402,22 @@ jobs:
                     }
                     echo "OK: codex-acp/$f"
                   }
+
+            - name: Install Playwright
+              run: pnpm --filter code exec playwright install
+
+            - name: Smoke test packaged app
+              env:
+                  CI: true
+              run: pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/smoke.spec.ts
+
+            - name: Upload Playwright report
+              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              if: failure()
+              with:
+                  name: release-playwright-report-windows-x64
+                  path: products/desktop/apps/code/playwright-report/
+                  retention-days: 7
 
             - name: Upload release artifacts
               shell: pwsh

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -403,9 +403,8 @@ jobs:
                     echo "OK: codex-acp/$f"
                   }
 
-            - name: Install Playwright
-              run: pnpm --filter code exec playwright install
-
+            # No `playwright install`: the smoke test launches the packaged
+            # PostHog.exe via Playwright's Electron API, no managed browsers.
             - name: Smoke test packaged app
               env:
                   CI: true

--- a/products/desktop/postcss.config.mjs
+++ b/products/desktop/postcss.config.mjs
@@ -1,0 +1,6 @@
+// Sentinel: stops PostCSS config discovery at this nested workspace. Without
+// it, on Windows postcss-load-config's resolved backslash walk never matches
+// Vite's forward-slash workspace-root stopDir, escapes past this directory and
+// loads the monorepo root postcss.config.js, whose plugins aren't installed
+// here — which killed the renderer build in Windows release CI.
+export default { plugins: [] };


### PR DESCRIPTION
## Problem

Windows desktop releases since v0.59.1 (the monorepo migration) ship without the renderer bundle, so the app opens to a black window. Two causes: on Windows, Vite's PostCSS config lookup escapes the nested `products/desktop` workspace (backslash vs forward-slash stopDir mismatch in postcss-load-config) and dies on the monorepo root `postcss.config.js`, and the pwsh build step only checks the last command's exit code, so electron-builder packaged the broken build and CI stayed green.

## Changes

- Add an empty `postcss.config.mjs` sentinel in `products/desktop` so the config lookup stops inside the workspace on every platform (restores pre-migration behavior).
- Split the Windows build into separate steps so an `electron-vite` failure fails the job, and verify the renderer bundle exists before publishing.
- Run the existing packaged-app smoke test on Windows like the mac job already does.