### PR TITLE
fix(activity): keep the date range when switching events view

### DIFF
--- a/frontend/src/queries/nodes/DataTable/SavedQueries.tsx
+++ b/frontend/src/queries/nodes/DataTable/SavedQueries.tsx
@@ -4,7 +4,7 @@ import { useValues } from 'kea'
 import { LemonButton, LemonButtonWithDropdown } from 'lib/lemon-ui/LemonButton'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { getEventsQueriesForTeam } from '~/queries/nodes/DataTable/defaultEventsQuery'
+import { applyEventsViewPreset, getEventsQueriesForTeam } from '~/queries/nodes/DataTable/defaultEventsQuery'
 import { DataTableNode, EventsQuery } from '~/queries/schema/schema-general'
 
 interface SavedQueriesProps {
@@ -20,7 +20,8 @@ export function SavedQueries({ query, setQuery }: SavedQueriesProps): JSX.Elemen
     }
 
     const eventsQueries = getEventsQueriesForTeam(currentTeam)
-    const { filterTestAccounts, ...sourceForComparison } = query.source as EventsQuery
+    const currentSource = query.source as EventsQuery
+    const { filterTestAccounts, ...sourceForComparison } = currentSource
     let selectedTitle = Object.keys(eventsQueries).find((key) => equal(eventsQueries[key], sourceForComparison))
 
     if (!selectedTitle) {
@@ -48,10 +49,7 @@ export function SavedQueries({ query, setQuery }: SavedQueriesProps): JSX.Elemen
                         onClick={() =>
                             setQuery?.({
                                 ...query,
-                                source:
-                                    filterTestAccounts !== undefined
-                                        ? { ...eventsQuery, filterTestAccounts }
-                                        : eventsQuery,
+                                source: applyEventsViewPreset(eventsQuery, currentSource),
                             })
                         }
                     >

--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.test.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.test.ts
@@ -1,6 +1,7 @@
+import { EventsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { TeamType } from '~/types'
 
-import { HOGQL_COLUMNS_KEY, getDefaultEventsQueryForTeam } from './defaultEventsQuery'
+import { HOGQL_COLUMNS_KEY, applyEventsViewPreset, getDefaultEventsQueryForTeam } from './defaultEventsQuery'
 
 describe('getDefaultEventsQueryForTeam', () => {
     it('returns null when live_events_columns is unset', () => {
@@ -43,5 +44,46 @@ describe('getDefaultEventsQueryForTeam', () => {
         expect(query!.select).toEqual(expectedSelect)
         expect(query!.orderBy).toEqual(expectedOrderBy)
         expect(query!.after).toBe('-1h')
+    })
+})
+
+describe('applyEventsViewPreset', () => {
+    const preset: EventsQuery = {
+        kind: NodeKind.EventsQuery,
+        select: ['event', 'count()'],
+        after: '-1h',
+        orderBy: ['count() DESC'],
+    }
+
+    // Every preset hardcodes its own `after`, so switching view used to drop whatever range the
+    // user had picked and drag them back to the preset's window.
+    it('keeps the date range the user picked rather than the one baked into the preset', () => {
+        const result = applyEventsViewPreset(preset, { ...preset, after: '-7d', before: '-1d' })
+
+        expect(result.after).toBe('-7d')
+        expect(result.before).toBe('-1d')
+    })
+
+    it('takes the columns and ordering from the preset', () => {
+        const result = applyEventsViewPreset(preset, {
+            kind: NodeKind.EventsQuery,
+            select: ['*', 'timestamp'],
+            orderBy: ['timestamp DESC'],
+            after: '-7d',
+        })
+
+        expect(result.select).toEqual(['event', 'count()'])
+        expect(result.orderBy).toEqual(['count() DESC'])
+    })
+
+    it.each([true, false])('carries the test-account filter across when set to %s', (filterTestAccounts) => {
+        expect(applyEventsViewPreset(preset, { ...preset, filterTestAccounts }).filterTestAccounts).toBe(
+            filterTestAccounts
+        )
+    })
+
+    it('falls back to the preset date range when the current query has none', () => {
+        const { after: _after, ...noDates } = preset
+        expect(applyEventsViewPreset(preset, noDates as EventsQuery).after).toBe('-1h')
     })
 })

--- a/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
+++ b/frontend/src/queries/nodes/DataTable/defaultEventsQuery.ts
@@ -49,6 +49,24 @@ export function getDefaultEventsQueryForTeam(team: Partial<TeamType>): EventsQue
         : null
 }
 
+/**
+ * Build the query for a view the user just picked, keeping the parts of their current query that
+ * describe how they are looking at events rather than which view they are in: the date range and
+ * the test-account toggle. Each preset carries its own `after`, so without this a view switch
+ * would silently drag the user back to the preset's window.
+ *
+ * These are the same fields `SavedQueries` leaves out when working out which view is active, since
+ * changing them does not move you off a view.
+ */
+export function applyEventsViewPreset(preset: EventsQuery, current: EventsQuery): EventsQuery {
+    return {
+        ...preset,
+        ...('filterTestAccounts' in current ? { filterTestAccounts: current.filterTestAccounts } : {}),
+        ...('after' in current ? { after: current.after } : {}),
+        ...('before' in current ? { before: current.before } : {}),
+    }
+}
+
 export function getEventsQueriesForTeam(team: Partial<TeamType>): Record<string, EventsQuery> {
     const projectDefault = getDefaultEventsQueryForTeam(team)
     return {


### PR DESCRIPTION
## Problem

On Activity > Events, set the date filter to anything other than the default "Last hour". Then switch the view dropdown between "PostHog default view" and "Event counts view". The date range resets to "Last hour".

It happens in both directions, so if you are comparing the same window across the two views you have to reset the range every time you switch.

## Changes

Each entry in the view dropdown is a complete `EventsQuery`, and every one of them carries its own `after: '-1h'`:

```ts
'Event counts view': {
    kind: NodeKind.EventsQuery,
    select: ['event', 'count()'],
    after: '-1h',
    orderBy: ['count() DESC'],
}
```

Picking one replaced `source` outright, so the preset's `after` overwrote whatever the user had chosen:

```ts
source: filterTestAccounts !== undefined ? { ...eventsQuery, filterTestAccounts } : eventsQuery,
```

`filterTestAccounts` was already being carried across, which is the same idea this extends: the view controls which columns you see, not which window you are looking at. Presets now go through a small helper that keeps the date range and the test-account filter from the current query.

Those are also exactly the fields `SavedQueries` already leaves out when it decides which view is active:

```ts
// is there any query that only changed the dates
selectedTitle = Object.keys(eventsQueries).find((key) => {
    return equal({ ...eventsQueries[key], before: '', after: '' }, { ...sourceForComparison, before: '', after: '' })
})
```

So the file already treated the date range as something that does not move you off a view. This makes the click behave the way the label does.

The dropdown is gated on `QueryFeature.savedEventsQueries`, which `queryFeatures.ts` only adds for `isEventsQuery`. Sessions tab builds a `SessionsQuery`, so it never renders this control and is unaffected.

## How did you test this code?

Drove the real UI (Playwright against the `Scenes-App/Events` story): set the date filter to "Last 7 days", then switched view and read the date filter back.

| | date filter after switching view |
| --- | --- |
| Before | `Last hour` |
| After | `Last 7 days` |

That reproduces the report and shows it resolved. I did not test against a live dev stack, only Storybook.

Automated:

- `frontend/src/queries/nodes/DataTable/` and `frontend/src/scenes/activity/` — 161 tests across 11 suites pass.
- `typescript:check` clean, `pnpm --filter=@posthog/frontend fix` clean.
- I could not run `hogli ci:preflight` (needs a Python env I do not have set up). Frontend-only diff, no lockfile or migration changes, and I ran the lint gate directly.

On the tests:

The preset-merging logic came out into a pure `applyEventsViewPreset` so it can be tested without rendering the dropdown, and four cases went into the existing `defaultEventsQuery.test.ts`. The first pins the bug: a current query on `-7d` keeps `-7d` after the switch. It fails against the old inline version and passes with the helper. The other three cover the parts that should still come from the preset (columns and ordering), the test-account filter that was already being carried, and the fallback to the preset's own range when the current query has no dates.

<details>
<summary>Test output</summary>

```
PASS src/queries/nodes/DataTable/defaultEventsQuery.test.ts
PASS src/queries/nodes/DataTable/dataTableLogic.test.ts
PASS src/queries/nodes/DataTable/dataTableSavedFiltersLogic.test.ts
PASS src/queries/nodes/DataTable/clipboardUtils.test.ts
PASS src/queries/nodes/DataTable/utils.test.ts
PASS src/queries/nodes/DataTable/queryFeatures.test.ts
PASS src/queries/nodes/DataTable/ColumnConfigurator/columnConfiguratorLogic.test.ts
PASS src/scenes/activity/explore/eventsSceneLogic.test.ts
PASS src/scenes/activity/explore/defaults.test.ts
PASS src/scenes/activity/live/liveEventsLogic.test.ts
PASS src/scenes/activity/live/deduplicateEvents.test.ts

Test Suites: 11 passed, 11 total
Tests:       161 passed, 161 total
```

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe the view dropdown's interaction with the date filter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit this switching between the two events views and had Claude (Claude Code, Opus 5) find and fix it. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

Two things worth a look. The helper preserves a field when the key is present rather than when the value is defined, so picking "All time" and switching view keeps all time instead of snapping back to the preset's hour; that felt worth the slightly odd-looking `'after' in current` checks, but say the word if you would rather keep it simpler. And property filters are deliberately not carried across, since unlike the date range they are part of what the view matcher compares, so preserving them would leave the dropdown reading "Custom query" after every switch. If you think they should persist too, that is a slightly larger change and I am happy to do it.
