### PR TITLE
fix(desktop): drop windows release smoke test

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -403,10 +403,6 @@ jobs:
                     echo "OK: codex-acp/$f"
                   }
 
-            # No packaged-app smoke test here (unlike macOS): Playwright's
-            # electron.launch times out against the packaged exe on Windows
-            # runners (v0.59.6 run). Renderer presence is asserted above.
-
             - name: Upload release artifacts
               shell: pwsh
               env:

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -403,20 +403,9 @@ jobs:
                     echo "OK: codex-acp/$f"
                   }
 
-            # No `playwright install`: the smoke test launches the packaged
-            # PostHog.exe via Playwright's Electron API, no managed browsers.
-            - name: Smoke test packaged app
-              env:
-                  CI: true
-              run: pnpm --filter code exec playwright test --config=tests/e2e/playwright.config.ts tests/e2e/tests/smoke.spec.ts
-
-            - name: Upload Playwright report
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              if: failure()
-              with:
-                  name: release-playwright-report-windows-x64
-                  path: products/desktop/apps/code/playwright-report/
-                  retention-days: 7
+            # No packaged-app smoke test here (unlike macOS): Playwright's
+            # electron.launch times out against the packaged exe on Windows
+            # runners (v0.59.6 run). Renderer presence is asserted above.
 
             - name: Upload release artifacts
               shell: pwsh


### PR DESCRIPTION
## Problem

The Windows smoke test added in #76444 blocks the release: all 4 tests time out with `Test timeout of 60000ms exceeded while setting up "electronApp"` - Playwright's `electron.launch` never gets a debug connection to the packaged exe on Windows runners. It blocked the v0.59.6 Windows upload even though the build itself was good (`Build app bundles`, `Package installer` and the renderer verify all passed).

## Changes

Remove the smoke test step from `publish-windows`. The fail-fast build split and the renderer-presence check from #76444 stay, and they alone block the bug class that shipped black-screen builds. Reintroducing the smoke test needs the Electron launch debugged on an actual Windows runner first.

## How did you test this code?

`bin/hogli lint:workflows` and `actionlint` pass. The failure evidence is in the v0.59.6 [publish-windows run](https://github.com/PostHog/posthog/actions/runs/30764660499/job/91541138568).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5), driven by @charlesvien. Follow-up to #76444 after its smoke step failed on the real release run, exactly the flagged risk. Labeled `Create release` so merging auto-tags and ships the fixed Windows build.
