### PR TITLE
fix(data-imports): alias RunPod network volume billing startDate to time

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/runpod.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/runpod.py
@@ -132,9 +132,17 @@ def _row_id(*parts: Any) -> str:
 
 
 def _normalize_billing_record(record: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(record)
+    if "time" not in normalized and "startDate" in normalized:
+        # RunPod's network volume billing has been observed returning the bucket start under
+        # `startDate` rather than the `time` field documented for every other billing endpoint —
+        # alias it so the schema's declared "time" incremental field stays valid.
+        normalized["time"] = normalized.pop("startDate")
     return {
-        "id": _row_id(record.get("time"), record.get("podId"), record.get("endpointId"), record.get("gpuTypeId")),
-        **record,
+        "id": _row_id(
+            normalized.get("time"), normalized.get("podId"), normalized.get("endpointId"), normalized.get("gpuTypeId")
+        ),
+        **normalized,
     }
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/runpod.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/runpod.py
@@ -135,14 +135,16 @@ def _normalize_billing_record(record: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(record)
     if "time" not in normalized and "startDate" in normalized:
         # RunPod's network volume billing has been observed returning the bucket start under
-        # `startDate` rather than the `time` field documented for every other billing endpoint —
-        # alias it so the schema's declared "time" incremental field stays valid.
+        # `startDate` rather than the `time` field documented for every other billing endpoint,
+        # so alias it here to keep the schema's declared "time" incremental field valid.
         normalized["time"] = normalized.pop("startDate")
     return {
+        **normalized,
+        # Set last so a record that happens to carry its own "id" key can never override the
+        # synthesized surrogate id merge relies on for dedup.
         "id": _row_id(
             normalized.get("time"), normalized.get("podId"), normalized.get("endpointId"), normalized.get("gpuTypeId")
         ),
-        **normalized,
     }
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/tests/test_runpod.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/tests/test_runpod.py
@@ -12,6 +12,7 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.sources.runpod import runpod
 from products.warehouse_sources.backend.temporal.data_imports.sources.runpod.runpod import (
     RunPodResumeConfig,
+    _normalize_billing_record,
     _row_id,
     get_rows,
     validate_credentials,
@@ -72,6 +73,20 @@ class TestRowId:
     def test_none_and_empty_string_distinguished_positionally(self) -> None:
         assert _row_id(None, "x") != _row_id("", "x")
         assert _row_id(None, "x") != _row_id("x", None)
+
+
+class TestNormalizeBillingRecord:
+    def test_start_date_is_aliased_to_time_when_time_is_missing(self) -> None:
+        # RunPod's network volume billing endpoint has been observed returning `startDate` instead
+        # of the `time` field every other billing endpoint (and our declared incremental field)
+        # relies on — without this alias, `time` never lands in the yielded row.
+        record = _normalize_billing_record({"startDate": "2025-08-01T00:00:00Z", "amount": 1.5})
+        assert record["time"] == "2025-08-01T00:00:00Z"
+        assert "startDate" not in record
+
+    def test_time_is_left_untouched_when_already_present(self) -> None:
+        record = _normalize_billing_record({"time": "2025-08-01T00:00:00Z", "podId": "p1"})
+        assert record["time"] == "2025-08-01T00:00:00Z"
 
 
 @freeze_time("2022-05-15T12:00:00Z")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/tests/test_runpod.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/runpod/tests/test_runpod.py
@@ -79,7 +79,7 @@ class TestNormalizeBillingRecord:
     def test_start_date_is_aliased_to_time_when_time_is_missing(self) -> None:
         # RunPod's network volume billing endpoint has been observed returning `startDate` instead
         # of the `time` field every other billing endpoint (and our declared incremental field)
-        # relies on — without this alias, `time` never lands in the yielded row.
+        # relies on, so without this alias `time` never lands in the yielded row.
         record = _normalize_billing_record({"startDate": "2025-08-01T00:00:00Z", "amount": 1.5})
         assert record["time"] == "2025-08-01T00:00:00Z"
         assert "startDate" not in record


### PR DESCRIPTION
## Problem

Error tracking surfaced `IncrementalFieldMissingFromDataError` firing during incremental syncs of the RunPod `billing_network_volumes` table: "Incremental field \"time\" was not found in the data returned by the source... Available columns: _ph_debug, amount, disk_space_billed_gb, id, start_date".

RunPod's network volume billing endpoint's own OpenAPI schema documents a `time` field (matching the other two billing endpoints), but the actual response for this endpoint has been observed returning the bucket start under a `startDate` key instead. Since the source declares `time` as the incremental field for every billing table (`_TIME_INCREMENTAL_FIELD` in `settings.py`), a normal incremental sync of `billing_network_volumes` never finds that column and the schema gets paused.

## Changes

`_normalize_billing_record` in `products/warehouse_sources/backend/temporal/data_imports/sources/runpod/runpod.py` now aliases `startDate` to `time` when `time` is missing from a record, before the row's surrogate id and incremental value are derived from it. This is scoped to the RunPod source (the shared pipeline code that raised the error is doing exactly what it should — the mismatch is between the RunPod endpoint's documented and observed response shape).

## How did you test this code?

Added two cases to `TestNormalizeBillingRecord` in `products/warehouse_sources/backend/temporal/data_imports/sources/runpod/tests/test_runpod.py`:
- a record with only `startDate` gets it aliased to `time` (the exact shape that reproduced the bug — this would have caught it)
- a record that already has `time` is left untouched

Ran the full RunPod test suite locally (52 tests passed) plus `ruff check`/`ruff format --check` and a scoped `mypy` run on the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a live error-tracking issue for the RunPod incremental-sync pipeline.
- Confirmed the affected source/schema/sync type from the exception's `warehouse_sources_*` properties before reading code, then cross-checked RunPod's public OpenAPI spec (`https://rest.runpod.io/v1/openapi.json`) to confirm the documented field name for this endpoint.
- Decision: fixed at the source layer rather than the shared pipeline code (`load.py`), since the shared code's error message and behavior are correct by design — the actual bug is the RunPod endpoint's response shape not matching its own documented schema.
- Searched open PRs (by error type, module path, and the maintainer's own PRs) for a duplicate fix; found none.