### PR TITLE
fix(experiments): allow sorting the experiment list by result

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -599,7 +599,15 @@ class ExperimentService:
         "-duration",
         "status",
         "-status",
+        "conclusion",
+        "-conclusion",
     }
+
+    # Ranks conclusions by outcome instead of alphabetically, matching the Result column's
+    # sorter in Experiments.tsx. LemonTable re-sorts every page it receives with that sorter,
+    # so a backend order that disagreed would reshuffle the rows the server had already
+    # paginated, and rows would appear to jump between pages.
+    CONCLUSION_SORT_ORDER = ("won", "lost", "inconclusive", "stopped_early", "invalid")
 
     @classmethod
     def validate_stats_config(cls, stats_config: dict | None, variant_keys: list[str] | None = None) -> None:
@@ -3778,6 +3786,21 @@ class ExperimentService:
                     queryset = queryset.order_by(F("status_sort_key").desc())
                 else:
                     queryset = queryset.order_by(F("status_sort_key").asc())
+            elif order_value in ["conclusion", "-conclusion"]:
+                # Experiments with no conclusion rank after every real one rather than sorting
+                # as NULL, so ascending and descending stay exact mirrors of each other. Most
+                # experiments are still running and have no conclusion, so that bucket is large
+                # and needs a stable tiebreaker for pagination to return each row exactly once.
+                prefix = "-" if order_value.startswith("-") else ""
+                queryset = queryset.annotate(
+                    conclusion_sort_key=Case(
+                        *[
+                            When(conclusion=value, then=Value(rank))
+                            for rank, value in enumerate(self.CONCLUSION_SORT_ORDER)
+                        ],
+                        default=Value(len(self.CONCLUSION_SORT_ORDER)),
+                    )
+                ).order_by(f"{prefix}conclusion_sort_key", "-created_at")
             elif order_value in ["created_by", "-created_by"]:
                 # Match the frontend column's `first_name || email` sorter — treat an
                 # empty `first_name` as missing and fall back to `email`, so users with

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -5109,6 +5109,64 @@ class TestExperimentService(APIBaseTest):
 
         assert list(queryset.values_list("name", flat=True)[:3]) == expected_order
 
+    @parameterized.expand(
+        [
+            (
+                "ascending",
+                "conclusion",
+                ["Won", "Lost", "Inconclusive", "Stopped early", "Invalid", "No conclusion"],
+            ),
+            (
+                "descending",
+                "-conclusion",
+                ["No conclusion", "Invalid", "Stopped early", "Inconclusive", "Lost", "Won"],
+            ),
+        ]
+    )
+    def test_filter_experiments_queryset_orders_by_conclusion(
+        self, _: str, order: str, expected_order: list[str]
+    ) -> None:
+        service = self._service()
+        for name, conclusion in [
+            ("Inconclusive", "inconclusive"),
+            ("Won", "won"),
+            ("No conclusion", None),
+            ("Invalid", "invalid"),
+            ("Lost", "lost"),
+            ("Stopped early", "stopped_early"),
+        ]:
+            service.create_experiment(
+                name=name,
+                feature_flag_key=f"order-conclusion-{name.lower().replace(' ', '-')}",
+                conclusion=conclusion,
+            )
+
+        queryset = service.filter_experiments_queryset(
+            Experiment.objects.filter(team=self.team),
+            action="list",
+            query_params={"order": order},
+        )
+
+        assert list(queryset.values_list("name", flat=True)[:6]) == expected_order
+
+    def test_filter_experiments_queryset_breaks_conclusion_ties_by_recency(self) -> None:
+        service = self._service()
+        now = timezone.now()
+        for index, name in enumerate(["Oldest", "Middle", "Newest"]):
+            experiment = service.create_experiment(
+                name=name,
+                feature_flag_key=f"conclusion-tie-{name.lower()}",
+            )
+            Experiment.objects.filter(id=experiment.id).update(created_at=now - timedelta(days=3 - index))
+
+        queryset = service.filter_experiments_queryset(
+            Experiment.objects.filter(team=self.team),
+            action="list",
+            query_params={"order": "conclusion"},
+        )
+
+        assert list(queryset.values_list("name", flat=True)[:3]) == ["Newest", "Middle", "Oldest"]
+
     def test_filter_experiments_queryset_validates_feature_flag_id(self) -> None:
         with self.assertRaises(ValidationError) as ctx:
             self._service().filter_experiments_queryset(


### PR DESCRIPTION
## Problem

Sorting the experiments list by the **Result** column breaks the page. Clicking the header sets `order=conclusion` in the URL, the list endpoint rejects it, and the whole list fails to load with:

> Load experiments failed: Invalid order field: 'conclusion'

The column advertises itself as sortable, so the only thing a user can do is undo it by navigating away. This came in through support, and I reproduced it on PostHog Cloud EU before touching any code.

`conclusion` was simply never added to `EXPERIMENT_ORDER_ALLOWLIST`, so the request is rejected before any query runs.

The `created_by` half of the original report is already fixed on master by #60532, so this PR only covers the Result column.

Closes #63621

## Changes

Allowlist `conclusion` / `-conclusion` and order by a ranked sort key rather than by the raw column.

The ranking is the interesting part. A plain `order_by("conclusion")` sorts the stored strings alphabetically, which gives inconclusive, invalid, lost, stopped_early, won. That ordering means nothing to a user, and worse, it disagrees with the frontend.

`LemonTable` re-sorts every page it receives using the column's own `sorter` function, even when sorting is server driven:

```ts
const sortedDataSource = useMemo(() => {
    if (currentSorting) {
        ...
        if (typeof sorter === 'function') {
            return dataSource.slice().sort((a, b) => sortOrder * sorter(a, b))
        }
    }
    return dataSource
}, [dataSource, currentSorting, baseColumns])
```

The Result column's sorter ranks by outcome (won, lost, inconclusive, stopped early, invalid) and puts experiments with no conclusion last. So if the backend paginates by one order and the client re-sorts by another, the rows on screen are a reshuffled slice of a differently ordered list, and experiments appear to jump between pages. The backend has to match the client sorter, not just return something sorted.

Two details fall out of that:

- **Experiments with no conclusion get a rank of their own instead of sorting as `NULL`.** The client sorter scores a missing conclusion as 6 and flips the sign for descending, so the empty bucket moves to the top when you reverse. Forcing nulls last in both directions (`nulls_last=True`) reads like the safer choice, but it would disagree with the client on descending. Ranking them keeps ascending and descending exact mirrors.
- **Ties break by `-created_at`.** Most experiments are still running and have no conclusion, so that bucket is usually the largest thing on the page. Without a tiebreaker its internal order is undefined, and `LIMIT`/`OFFSET` over an unstable sort can return the same experiment twice or skip one. `-created_at` matches the list's default ordering.

I deliberately did not retrofit the tiebreaker onto the existing `duration`, `status`, and `created_by` branches. They have the same latent weakness, but that is a separate change and I would rather keep this diff reviewable.

> [!NOTE]
> No API or schema change. This only widens the set of accepted `order` values, so existing clients are unaffected.

## How did you test this code?

**What I verified manually:** the bug itself, on PostHog Cloud EU. Clicking **Result** puts `order=conclusion` in the URL and the list fails with `Invalid order field: 'conclusion'`.

**What I could not verify manually:** the fix in a running app. I do not have a local dev environment (no Docker, so no Postgres), so I have not clicked the fixed column myself and I am not claiming otherwise. The tests below are written but were **not executed locally** for the same reason. I am relying on CI for that, and I will fix anything it turns up.

To de-risk the part I could not run, I checked the piece carrying the actual design risk offline: I reimplemented both the backend sort key and the frontend sorter as plain Python and compared the orderings they produce. They match in both directions. The same check shows the `nulls_last=True` alternative diverging from the client on descending, which is what steered the approach above.

Automated tests added to `test_experiment_service.py`:

- `test_filter_experiments_queryset_orders_by_conclusion` (parameterized, ascending and descending). Catches three regressions no existing test covers: dropping `conclusion` from the allowlist, which returns the reported 400; replacing the ranking with a plain alphabetical `order_by`, which silently desyncs from the client sorter; and mis-placing the no-conclusion bucket so the two directions stop mirroring.
- `test_filter_experiments_queryset_breaks_conclusion_ties_by_recency`. Catches removal of the `-created_at` tiebreaker, which makes ordering within the large no-conclusion bucket undefined and lets pagination repeat or drop rows.

Both follow the existing `test_filter_experiments_queryset_orders_by_duration` and `..._orders_by_status` tests in the same class.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. This restores behavior the column already advertised.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this and Claude (Claude Code, Opus 5) did the code archaeology and wrote the patch. I picked the issue, reproduced it live on Cloud EU, and reviewed the reasoning behind the ranking decision before committing.

Skills invoked from this repo: `/writing-tests` and `/writing-code-comments`. The testing skill is why there are two focused tests instead of a case per conclusion value, and why each is justified by a named regression above.

Worth flagging for review: three earlier PRs attempted this (#63623, #66592, #72138). None were rejected on merit. Two were closed by the stale bot and one author left the codebase, so the fix has been sitting unowned. I read all three before starting. The substantive difference here is the ordering semantics: those PRs sorted with `nulls_last=True`, and tracing `LemonTable`'s `sortedDataSource` showed that disagrees with the client sorter when descending, which is what the offline comparison above confirmed. The `-created_at` tiebreaker is also new.

I am around to iterate on this one and will not let it go stale.
