### PR TITLE
chore(ci): revert Trunk pause docs and gate desktop Trunk uploads

### DIFF
--- a/.github/workflows/desktop-test.yml
+++ b/.github/workflows/desktop-test.yml
@@ -25,6 +25,9 @@ concurrency:
     group: desktop-test-${{ github.head_ref || github.ref }}
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+    RUNS_ON_INTERNAL_PR: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+
 jobs:
     changes:
         runs-on: ubuntu-latest
@@ -127,13 +130,23 @@ jobs:
               run: node scripts/rebuild-better-sqlite3-node.mjs
 
             - name: Run tests
+              id: run-tests
+              # continue-on-error so the quarantine gate below is the verdict — it passes when
+              # every failure is an already-quarantined flake, fails otherwise.
+              continue-on-error: true
               run: pnpm test
 
-            - name: Upload test results to Trunk
-              # Run even when tests fail so flaky/failed results are still reported,
-              # but never let an upload problem fail the job.
-              if: ${{ !cancelled() }}
+            # Best-effort Trunk upload (continue-on-error); the "Fail on test failure" step below is
+            # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
+            # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
+            # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
+            # known flakes; otherwise any real failure reds the job (quarantining needs upload on too).
+            - name: Quarantine gate
+              id: quarantine_gate
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   # Scope to each package root. A bare **/junit.xml glob descends into
@@ -141,7 +154,17 @@ jobs:
                   # every report many times over.
                   junit-paths: 'products/desktop/apps/*/junit.xml,products/desktop/packages/*/junit.xml'
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  previous-step-outcome: ${{ steps.run-tests.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
+
+            # Verdict: red a real failure the gate didn't clear as a quarantined flake. != 'success'
+            # also covers the skipped gate on fork/Dependabot.
+            - name: Fail on test failure
+              if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' && (vars.TRUNK_QUARANTINE_ENABLED != 'true' || steps.quarantine_gate.outcome != 'success') }}
+              shell: bash
+              run: exit 1
 
     integration-test:
         needs: changes
@@ -221,24 +244,39 @@ jobs:
               run: pnpm --filter code exec playwright install --with-deps chromium
 
             - name: Run E2E smoke tests
+              id: run-e2e
+              # continue-on-error so the quarantine gate below is the verdict — it passes when
+              # every failure is an already-quarantined flake, fails otherwise.
+              continue-on-error: true
               run: pnpm --filter code run test:e2e
               env:
                   CI: true
 
-            - name: Upload test results to Trunk
-              # Run even when E2E tests fail so flaky/failed results are still
-              # reported, but never let an upload problem fail the job.
-              if: ${{ !cancelled() }}
+            # Best-effort Trunk upload (continue-on-error); the "Fail on E2E failure" step below is
+            # the verdict, so a Trunk outage can't red a passing job. Internal PRs only (needs the
+            # secret); cli-version pinned, not 'latest' (skips the release redirect).
+            # TRUNK_UPLOAD_ENABLED is the master kill-switch: when it is not 'true' this gate
+            # skips, so nothing uploads and no known flakes are quarantined. TRUNK_QUARANTINE_ENABLED
+            # splits the two — it defaults off, so set it to 'true' to let the verdict step below mask
+            # known flakes; otherwise any real failure reds the job (quarantining needs upload on too).
+            - name: Quarantine gate
+              id: quarantine_gate
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: 'products/desktop/apps/code/tests/e2e/junit.xml'
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  previous-step-outcome: ${{ steps.run-e2e.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 
             - name: Upload Playwright report
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              if: failure()
+              # Keys off the step outcome, not failure(): the test step is continue-on-error, so a
+              # failing suite no longer reds the job on its own and failure() would never fire here.
+              if: ${{ !cancelled() && steps.run-e2e.outcome == 'failure' }}
               with:
                   name: playwright-report
                   path: products/desktop/apps/code/playwright-report/
@@ -248,27 +286,41 @@ jobs:
             # no Electron packaging. Reuses the cached Chromium above. Runs even if the
             # desktop suite failed so both hosts report independently.
             - name: Run web E2E smoke tests
+              id: run-web-e2e
               if: ${{ !cancelled() }}
+              continue-on-error: true
               run: pnpm run test:e2e:web
               env:
                   CI: true
 
-            - name: Upload web test results to Trunk
-              if: ${{ !cancelled() }}
+            - name: Quarantine gate (web)
+              id: quarantine_gate_web
               continue-on-error: true
+              if: ${{ !cancelled() && env.RUNS_ON_INTERNAL_PR == 'true' && github.repository == 'PostHog/posthog' && github.actor != 'dependabot[bot]' && vars.TRUNK_UPLOAD_ENABLED == 'true' }}
               uses: trunk-io/analytics-uploader@385f1ccdf345b4532dc4b6c665dd432b702b8e28 # v2.1.2
               with:
                   junit-paths: 'products/desktop/apps/web/tests/e2e/junit.xml'
                   org-slug: posthog-inc
+                  cli-version: '0.13.7'
+                  quarantine: true
+                  previous-step-outcome: ${{ steps.run-web-e2e.outcome }}
                   token: ${{ secrets.TRUNK_API_TOKEN }}
 
             - name: Upload web Playwright report
               uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-              if: failure()
+              if: ${{ !cancelled() && steps.run-web-e2e.outcome == 'failure' }}
               with:
                   name: web-playwright-report
                   path: products/desktop/apps/web/playwright-report/
                   retention-days: 7
+
+            # Verdict: red a real failure neither gate cleared as a quarantined flake. != 'success'
+            # also covers a skipped gate on fork/Dependabot. Both hosts report independently, so
+            # either one failing is enough to red the job.
+            - name: Fail on E2E failure
+              if: ${{ !cancelled() && ((steps.run-e2e.outcome == 'failure' && (vars.TRUNK_QUARANTINE_ENABLED != 'true' || steps.quarantine_gate.outcome != 'success')) || (steps.run-web-e2e.outcome == 'failure' && (vars.TRUNK_QUARANTINE_ENABLED != 'true' || steps.quarantine_gate_web.outcome != 'success'))) }}
+              shell: bash
+              run: exit 1
 
     e2e:
         # Live-model e2e for the @posthog/agent adapters (claude + codex). Runs only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Guarding it inside the workflow is worse: skipping the gate job cascades to the 
 #### Stacked PRs
 
 Restacking force-pushes every branch, and each push triggers a full CI fan-out.
-If the Trunk merge queue is re-enabled (it is paused, see below), never restack while any branch in the stack is sitting in it: the force-push removes the PR from the queue.
+Never restack while any branch in the stack is sitting in the merge queue — the force-push removes it from the queue.
 Pushing a deep stack at once can exceed GitHub's per-repo dispatch cap (500 workflow runs / 10s).
 The overflow fails as `startup_failure` and takes unrelated runs in the same window down too.
 Draft status doesn't help, since runs are dispatched before draft/skip logic applies.
@@ -115,15 +115,14 @@ In environments without hooks (no `node_modules`), run `hogli ci:preflight --fix
 
 ### Merging PRs
 
-Merges into `master` currently go through `gh pr merge <number> --squash`.
-Squash is the only merge method the repo allows, so `--merge` and `--rebase` are rejected.
+All merges into `master` go through the Trunk merge queue.
+Never run `gh pr merge` or click the GitHub merge button — both are blocked by branch ruleset.
 
-**The Trunk merge queue is paused.** Its ruleset is disabled, so `/trunk merge` and `/trunk cancel` comments and the `trunk-merge-queue-submit` label are no-ops: no `Trunk Merge Queue (master)` check run appears and the bot never replies. Don't reach for them.
-
-- Branch protection on `master` is unchanged and still enforced: an approving review, code owner review, the required status checks, and signed commits. `gh pr merge` refuses until all of those pass.
-- Shortly after a force-push or a label change, GitHub's mergeability cache can be stale and the first attempt fails with "the base branch policy prohibits the merge". Retrying a moment later works.
-- [`.agents/skills/merging-prs/SKILL.md`](./.agents/skills/merging-prs/SKILL.md) is still written for the Trunk flow, so it's stale pending a follow-up. Its preflight and CI failure-handling advice still applies; its enqueue and queue-watching steps don't.
-- If Trunk is re-enabled, the old flow was: enqueue with `gh pr comment <number> --body "/trunk merge"`, watch the `Trunk Merge Queue (master)` check run on the head commit rather than the PR's own checks, and never force-push while the PR sits in the queue.
+- Enqueue: `gh pr comment <number> --body "/trunk merge"`. Cancel: `gh pr comment <number> --body "/trunk cancel"`.
+- After enqueueing, babysit the PR until it merges or fails — follow [`.agents/skills/merging-prs/SKILL.md`](./.agents/skills/merging-prs/SKILL.md) for the preflight, watch, and failure-handling loop.
+- Queue progress is the `Trunk Merge Queue (master)` check run on the PR's head commit. The PR's own checks don't reflect the queue's testing — it runs CI on a `trunk-merge/**` branch.
+- On failure the Trunk bot comments with links to the failing workflows; fix, push, and re-enqueue.
+- Never force-push a branch while it is in the queue — it removes the PR from the queue.
 
 ### Public open source repo guidance
 
@@ -234,7 +233,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 
 **Invoke when in the area:**
 
-- `/merging-prs` — merging a PR, or babysitting one through CI (written for the Trunk queue, so partly stale while it's paused)
+- `/merging-prs` — merging a PR, or babysitting one through the Trunk merge queue
 - `/implementing-mcp-tools` — adding/modifying endpoints or `tools.yaml`
 - `/modifying-taxonomic-filter` — any TaxonomicFilter change
 - `/sending-notifications` — adding notification support


### PR DESCRIPTION
## Problem

Two things, both tied to re-enabling Trunk.

**1. The docs describe the pause.** #75873 rewrote the `### Merging PRs` section of `AGENTS.md` (symlinked as `CLAUDE.md`) to describe the interim path, `gh pr merge <number> --squash`, with the Trunk instructions demoted to a single "if Trunk is re-enabled" line. We're re-enabling the queue, so that guidance is about to be wrong in the other direction: agents would reach for `gh pr merge`, which the branch ruleset blocks once the Trunk ruleset enforces again.

**2. The desktop test jobs bypass the Trunk kill-switch.** `desktop-test.yml` came in with the PostHog/code monorepo import (#72483) and uploads to Trunk from three steps, none of which check `TRUNK_UPLOAD_ENABLED`. Every other CI workflow gates on it. So while the org variable sits at `false` and the rest of CI uploads nothing, desktop has been uploading on every run.

## Changes

**Docs:** straight revert of #75873 (`git revert 1057b672e4d`, clean on master). Restores three spots: the merging section, the stacked-PR force-push warning, and the `/merging-prs` line in the mandatory skill list.

```diff
-Merges into `master` currently go through `gh pr merge <number> --squash`.
-Squash is the only merge method the repo allows, so `--merge` and `--rebase` are rejected.
+All merges into `master` go through the Trunk merge queue.
+Never run `gh pr merge` or click the GitHub merge button — both are blocked by branch ruleset.
```

`.agents/skills/merging-prs/SKILL.md` needs nothing. #75873 deliberately left it alone and only flagged it stale inline, so reverting drops the stale note and the skill is already written for the Trunk flow.

**Desktop CI:** brings all three uploads onto the standard gate + quarantine pattern used across the other workflows.

| Job | Step | Gate | Verdict |
|---|---|---|---|
| `unit-test` | `pnpm test` | `Quarantine gate` | `Fail on test failure` |
| `integration-test` | desktop E2E | `Quarantine gate` | `Fail on E2E failure` |
| `integration-test` | web E2E | `Quarantine gate (web)` | same step, either host reds the job |

Each test step becomes `continue-on-error` with an `id`, the uploader picks up `quarantine: true`, `previous-step-outcome`, and a pinned `cli-version`, and a verdict step reds the job on any failure the gate didn't clear. Also adds the `RUNS_ON_INTERNAL_PR` env var the gate reads, which this workflow didn't define.

> [!WARNING]
> One non-obvious consequence. Making the test steps `continue-on-error` means a failing suite no longer reds the job on its own, so the two `if: failure()` Playwright report uploads would silently stop firing exactly when you need the report. Both now key off `steps.<id>.outcome == 'failure'` instead.

## How did you test this code?

No behavior to exercise locally, this is workflow YAML plus markdown.

- `bin/hogli lint:workflows` passes, 7 checks across 123 workflows.
- `actionlint .github/workflows/desktop-test.yml` clean (installed it for this).
- `hogli ci:preflight --strict` passes via the pre-push hook.
- I audited every `analytics-uploader` step in `.github/workflows/` and confirmed the three desktop ones were ungated before this change and gated after.

I did not run the desktop suite itself. The quarantine path can only really be exercised once `TRUNK_UPLOAD_ENABLED` is `true` and Trunk has current flake data.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable, the docs change here is the agent instruction file itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (Claude Code) to find the PR documenting the pause and revert it ahead of the re-enable, then to close the desktop gate gap once we spotted it. It reverted the commit rather than hand-editing the section back, so `AGENTS.md` returns to a byte-identical known-good state.

Two things worth a reviewer's eye:

- The clean revert also drops a detail from #75873 that isn't Trunk-specific: the stale mergeability cache after a force-push or label change. I let it go rather than hand-picking lines out of the revert, since it only bites on the `gh pr merge` path we're leaving. Say the word if you'd rather keep it.
- I initially flagged `ci-storybook.yml` as having the same gap. It doesn't: its `trunk-upload` job gates on `TRUNK_UPLOAD_ENABLED` at the job level, so both uploader steps are already covered. Re-audited with the YAML parsed properly, and all 18 uploader steps in `.github/workflows/` are gated with this PR's changes.

No skills invoked. `/authoring-ci-workflows` covers this area and would have been the right call for the workflow half; I leaned on the existing in-repo pattern from `ci-llm-gateway.yml` and `ci-backend.yml` instead and verified with the linters.

