### PR TITLE
feat(skills): support disable-model-invocation skill frontmatter

### DIFF
--- a/products/desktop/apps/web/src/web-skill-bundler.ts
+++ b/products/desktop/apps/web/src/web-skill-bundler.ts
@@ -51,7 +51,11 @@ export async function bundleExportedSkill(
   // split), matching how desktop's installTeamSkill writes it to disk.
   files["SKILL.md"] = strToU8(
     serializeSkillMarkdown(
-      { name: exported.name, description: exported.description },
+      {
+        name: exported.name,
+        description: exported.description,
+        disableModelInvocation: exported.disableModelInvocation,
+      },
       exported.body,
     ),
   );

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -5622,6 +5622,7 @@ export class PostHogAPIClient {
     description: string;
     body: string;
     files?: LlmSkillFileInput[];
+    metadata?: Record<string, unknown>;
   }): Promise<LlmSkill> {
     const teamId = await this.getTeamId();
     const urlPath = `/api/environments/${teamId}/llm_skills/`;
@@ -5654,6 +5655,7 @@ export class PostHogAPIClient {
       body: string;
       description?: string;
       files?: LlmSkillFileInput[];
+      metadata?: Record<string, unknown>;
       base_version: number;
     },
   ): Promise<LlmSkill> {

--- a/products/desktop/packages/core/src/skills/teamSkillsService.test.ts
+++ b/products/desktop/packages/core/src/skills/teamSkillsService.test.ts
@@ -147,10 +147,70 @@ describe("TeamSkillsService.publishSkill", () => {
       body: "# Body",
       description: "Shepherds PRs",
       files: exported.files,
+      metadata: {},
       base_version: 2,
     });
     expect(result).toEqual({ version: 3 });
   });
+
+  it("stores disable-model-invocation in metadata on first publish", async () => {
+    const createLlmSkill = vi.fn().mockResolvedValue(makeItem({ version: 1 }));
+    const client = {
+      listLlmSkills: vi.fn().mockResolvedValue([]),
+      createLlmSkill,
+    } as unknown as PostHogAPIClient;
+
+    await makeService().publishSkill(client, {
+      ...exported,
+      disableModelInvocation: true,
+    });
+
+    expect(createLlmSkill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: { "disable-model-invocation": true },
+      }),
+    );
+  });
+
+  it.each([
+    {
+      case: "sets the key and keeps other metadata",
+      disableModelInvocation: true as const,
+      existingMetadata: { author: "dev" },
+      expected: { author: "dev", "disable-model-invocation": true },
+    },
+    {
+      case: "clears the key when the flag is gone",
+      disableModelInvocation: undefined,
+      existingMetadata: { author: "dev", "disable-model-invocation": true },
+      expected: { author: "dev" },
+    },
+  ])(
+    "republish $case",
+    async ({ disableModelInvocation, existingMetadata, expected }) => {
+      const publishLlmSkillVersion = vi
+        .fn()
+        .mockResolvedValue(makeItem({ version: 3 }));
+      const client = {
+        listLlmSkills: vi
+          .fn()
+          .mockResolvedValue([
+            makeItem({ version: 2, metadata: existingMetadata }),
+          ]),
+        publishLlmSkillVersion,
+      } as unknown as PostHogAPIClient;
+
+      await makeService().publishSkill(client, {
+        ...exported,
+        disableModelInvocation,
+      });
+
+      expect(publishLlmSkillVersion).toHaveBeenCalledWith(
+        "pr-shepherd",
+        expect.objectContaining({ metadata: expected }),
+      );
+    },
+  );
 
   it("rejects publishing without a description", async () => {
     await expect(
@@ -206,6 +266,26 @@ describe("TeamSkillsService.fetchSkillForInstall", () => {
         { path: "scripts/run.sh", content: "content of scripts/run.sh" },
       ],
     });
+  });
+
+  it("maps disable-model-invocation metadata onto the exported skill", async () => {
+    const client = {
+      getLlmSkillByName: vi.fn().mockResolvedValue({
+        name: "pr-shepherd",
+        description: "Shepherds PRs",
+        body: "# Body",
+        metadata: { "disable-model-invocation": true },
+        files: [],
+      }),
+      getLlmSkillFile: vi.fn(),
+    } as unknown as PostHogAPIClient;
+
+    const skill = await makeService().fetchSkillForInstall(
+      client,
+      "pr-shepherd",
+    );
+
+    expect(skill.disableModelInvocation).toBe(true);
   });
 });
 

--- a/products/desktop/packages/core/src/skills/teamSkillsService.ts
+++ b/products/desktop/packages/core/src/skills/teamSkillsService.ts
@@ -176,11 +176,7 @@ export class TeamSkillsService {
   }
 }
 
-/**
- * Reflects the flag into the API metadata dict: set on manual-only, removed
- * otherwise, so a republished skill that dropped the frontmatter stops being
- * manual-only. Other metadata keys pass through untouched.
- */
+// Clearing the key keeps a republish that dropped the frontmatter from staying manual-only.
 function withDisableModelInvocation(
   metadata: Record<string, unknown> | undefined,
   disableModelInvocation: boolean | undefined,

--- a/products/desktop/packages/core/src/skills/teamSkillsService.ts
+++ b/products/desktop/packages/core/src/skills/teamSkillsService.ts
@@ -2,7 +2,10 @@ import type {
   LlmSkillListItem,
   PostHogAPIClient,
 } from "@posthog/api-client/posthog-client";
-import type { ExportedSkill } from "@posthog/shared";
+import {
+  DISABLE_MODEL_INVOCATION_METADATA_KEY,
+  type ExportedSkill,
+} from "@posthog/shared";
 import { inject, injectable } from "inversify";
 import { SKILLS_WORKSPACE_CLIENT } from "./identifiers";
 
@@ -127,6 +130,10 @@ export class TeamSkillsService {
           body: exported.body,
           description: exported.description,
           files: exported.files,
+          metadata: withDisableModelInvocation(
+            existing.metadata,
+            exported.disableModelInvocation,
+          ),
           base_version: existing.latest_version ?? existing.version,
         })
       : await client.createLlmSkill({
@@ -134,6 +141,9 @@ export class TeamSkillsService {
           description: exported.description,
           body: exported.body,
           files: exported.files,
+          ...(exported.disableModelInvocation
+            ? { metadata: { [DISABLE_MODEL_INVOCATION_METADATA_KEY]: true } }
+            : {}),
         });
 
     return { version: published.version };
@@ -158,9 +168,28 @@ export class TeamSkillsService {
       name: detail.name,
       description: detail.description,
       body: detail.body,
+      ...(detail.metadata?.[DISABLE_MODEL_INVOCATION_METADATA_KEY] === true
+        ? { disableModelInvocation: true }
+        : {}),
       files,
     };
   }
+}
+
+/**
+ * Reflects the flag into the API metadata dict: set on manual-only, removed
+ * otherwise, so a republished skill that dropped the frontmatter stops being
+ * manual-only. Other metadata keys pass through untouched.
+ */
+function withDisableModelInvocation(
+  metadata: Record<string, unknown> | undefined,
+  disableModelInvocation: boolean | undefined,
+): Record<string, unknown> {
+  const { [DISABLE_MODEL_INVOCATION_METADATA_KEY]: _removed, ...rest } =
+    metadata ?? {};
+  return disableModelInvocation
+    ? { ...rest, [DISABLE_MODEL_INVOCATION_METADATA_KEY]: true }
+    : rest;
 }
 
 function toTeamSkillInfo(item: LlmSkillListItem): TeamSkillInfo {

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -337,6 +337,7 @@ export type {
   UploadableSkillSource,
 } from "./skills";
 export {
+  DISABLE_MODEL_INVOCATION_METADATA_KEY,
   SKILL_EXISTS_MARKER,
   serializeSkillMarkdown,
   stripFrontmatter,

--- a/products/desktop/packages/shared/src/skills.ts
+++ b/products/desktop/packages/shared/src/skills.ts
@@ -11,6 +11,12 @@ export interface SkillInfo {
   editable: boolean;
   /** Size of SKILL.md in bytes (context-cost signal). */
   skillMdBytes: number;
+  /**
+   * Frontmatter `disable-model-invocation: true`: the agent never invokes the
+   * skill on its own — only an explicit user invocation (slash command or
+   * composer skill tag) runs it.
+   */
+  disableModelInvocation?: boolean;
 }
 
 export interface SkillFileEntry {
@@ -44,13 +50,18 @@ export interface ExportedSkill {
  * sandbox, so it must not drift between hosts.
  */
 export function serializeSkillMarkdown(
-  meta: { name: string; description: string },
+  meta: {
+    name: string;
+    description: string;
+    disableModelInvocation?: boolean;
+  },
   body: string,
 ): string {
   const frontmatter = [
     "---",
     `name: ${serializeSkillScalar(meta.name)}`,
     `description: ${serializeSkillScalar(meta.description)}`,
+    ...(meta.disableModelInvocation ? ["disable-model-invocation: true"] : []),
     "---",
   ].join("\n");
 

--- a/products/desktop/packages/shared/src/skills.ts
+++ b/products/desktop/packages/shared/src/skills.ts
@@ -37,7 +37,15 @@ export interface ExportedSkill {
   description: string;
   body: string;
   files: ExportedSkillFile[];
+  /** Frontmatter `disable-model-invocation: true`, carried so reconstruction keeps it. */
+  disableModelInvocation?: boolean;
 }
+
+/**
+ * Where `disableModelInvocation` rides in the team-skills API's metadata dict.
+ * Named after the frontmatter key so the stored value reads the same everywhere.
+ */
+export const DISABLE_MODEL_INVOCATION_METADATA_KEY = "disable-model-invocation";
 
 /**
  * Serializes a SKILL.md file from frontmatter metadata plus a markdown body.

--- a/products/desktop/packages/shared/src/skills.ts
+++ b/products/desktop/packages/shared/src/skills.ts
@@ -11,11 +11,7 @@ export interface SkillInfo {
   editable: boolean;
   /** Size of SKILL.md in bytes (context-cost signal). */
   skillMdBytes: number;
-  /**
-   * Frontmatter `disable-model-invocation: true`: the agent never invokes the
-   * skill on its own — only an explicit user invocation (slash command or
-   * composer skill tag) runs it.
-   */
+  /** Frontmatter `disable-model-invocation: true`: only an explicit user invocation runs the skill, never the agent on its own. */
   disableModelInvocation?: boolean;
 }
 
@@ -37,14 +33,9 @@ export interface ExportedSkill {
   description: string;
   body: string;
   files: ExportedSkillFile[];
-  /** Frontmatter `disable-model-invocation: true`, carried so reconstruction keeps it. */
   disableModelInvocation?: boolean;
 }
 
-/**
- * Where `disableModelInvocation` rides in the team-skills API's metadata dict.
- * Named after the frontmatter key so the stored value reads the same everywhere.
- */
 export const DISABLE_MODEL_INVOCATION_METADATA_KEY = "disable-model-invocation";
 
 /**

--- a/products/desktop/packages/ui/src/features/skills/SkillCard.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillCard.tsx
@@ -92,6 +92,13 @@ export function SkillCard({
               {skill.repoName}
             </Badge>
           )}
+          {skill.disableModelInvocation && (
+            <Tooltip content="The agent won't use this skill on its own — only when you invoke it">
+              <Badge size="1" variant="soft" color="gray" className="shrink-0">
+                Manual
+              </Badge>
+            </Tooltip>
+          )}
         </>
       }
     />

--- a/products/desktop/packages/ui/src/features/skills/SkillCard.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillCard.tsx
@@ -93,7 +93,7 @@ export function SkillCard({
             </Badge>
           )}
           {skill.disableModelInvocation && (
-            <Tooltip content="The agent won't use this skill on its own — only when you invoke it">
+            <Tooltip content="The agent won't use this skill on its own. It runs only when you invoke it">
               <Badge size="1" variant="soft" color="gray" className="shrink-0">
                 Manual
               </Badge>

--- a/products/desktop/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -288,7 +288,7 @@ export function SkillDetailPanel({
             </Badge>
           )}
           {skill.disableModelInvocation && (
-            <Tooltip content="The agent won't use this skill on its own — only when you invoke it">
+            <Tooltip content="The agent won't use this skill on its own. It runs only when you invoke it">
               <Badge size="1" variant="soft" color="gray">
                 <HandTap size={10} className="text-gray-9" />
                 Manual-only

--- a/products/desktop/packages/ui/src/features/skills/SkillDetailPanel.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillDetailPanel.tsx
@@ -3,6 +3,7 @@ import {
   DownloadSimple,
   FilePlus,
   Folder,
+  HandTap,
   LockSimple,
   PencilSimple,
   Trash,
@@ -285,6 +286,14 @@ export function SkillDetailPanel({
               <LockSimple size={10} className="text-gray-9" />
               Read-only
             </Badge>
+          )}
+          {skill.disableModelInvocation && (
+            <Tooltip content="The agent won't use this skill on its own — only when you invoke it">
+              <Badge size="1" variant="soft" color="gray">
+                <HandTap size={10} className="text-gray-9" />
+                Manual-only
+              </Badge>
+            </Tooltip>
           )}
           {skill.source === "codex" && (
             <Button

--- a/products/desktop/packages/ui/src/features/skills/SkillManifestEditor.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillManifestEditor.tsx
@@ -1,6 +1,14 @@
 import type { SkillInfo } from "@posthog/shared";
 import { toast } from "@posthog/ui/primitives/toast";
-import { Box, Button, Flex, Text, TextArea, TextField } from "@radix-ui/themes";
+import {
+  Box,
+  Button,
+  Flex,
+  Switch,
+  Text,
+  TextArea,
+  TextField,
+} from "@radix-ui/themes";
 import { useRef, useState } from "react";
 import { SkillCodeEditor } from "./SkillCodeEditor";
 import { skillErrorDescription } from "./skillErrors";
@@ -25,6 +33,9 @@ export function SkillManifestEditor({
 }: SkillManifestEditorProps) {
   const [name, setName] = useState(skill.name);
   const [description, setDescription] = useState(skill.description);
+  const [disableModelInvocation, setDisableModelInvocation] = useState(
+    skill.disableModelInvocation ?? false,
+  );
   // Captured at mount: background refetches must not reset in-flight edits.
   const [mountedBody] = useState(initialBody);
   const bodyRef = useRef(mountedBody);
@@ -37,6 +48,7 @@ export function SkillManifestEditor({
         name,
         description,
         body: bodyRef.current,
+        disableModelInvocation,
       });
       onSaved();
     } catch (error) {
@@ -72,6 +84,22 @@ export function SkillManifestEditor({
             placeholder="When should an agent use this skill?"
           />
         </Box>
+        <Flex align="center" justify="between" gap="2">
+          <Box>
+            <Text className="block text-[12px] text-gray-12">
+              Manual invocation only
+            </Text>
+            <Text className="block text-[11px] text-gray-10">
+              The agent won't use this skill on its own — only when you invoke
+              it
+            </Text>
+          </Box>
+          <Switch
+            size="1"
+            checked={disableModelInvocation}
+            onCheckedChange={setDisableModelInvocation}
+          />
+        </Flex>
       </Flex>
 
       <Box className="min-h-0 flex-1 border-t border-t-(--gray-5)">

--- a/products/desktop/packages/ui/src/features/skills/SkillManifestEditor.tsx
+++ b/products/desktop/packages/ui/src/features/skills/SkillManifestEditor.tsx
@@ -90,8 +90,8 @@ export function SkillManifestEditor({
               Manual invocation only
             </Text>
             <Text className="block text-[11px] text-gray-10">
-              The agent won't use this skill on its own — only when you invoke
-              it
+              The agent won't use this skill on its own. It runs only when you
+              invoke it
             </Text>
           </Box>
           <Switch

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.test.ts
@@ -1,5 +1,43 @@
 import { describe, expect, it } from "vitest";
-import { parseSkillDependencies } from "./parse-skill-frontmatter";
+import {
+  parseSkillDependencies,
+  parseSkillFrontmatter,
+} from "./parse-skill-frontmatter";
+
+describe("parseSkillFrontmatter disable-model-invocation", () => {
+  it.each([
+    ["absent", `---\nname: a\ndescription: d\n---\nbody`, false],
+    [
+      "true",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: true\n---\nbody`,
+      true,
+    ],
+    [
+      "capitalized True",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: True\n---\nbody`,
+      true,
+    ],
+    [
+      "quoted true",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: "true"\n---\nbody`,
+      true,
+    ],
+    [
+      "false",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: false\n---\nbody`,
+      false,
+    ],
+    [
+      "non-boolean value",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: maybe\n---\nbody`,
+      false,
+    ],
+  ])("parses %s", (_label, content, expected) => {
+    expect(parseSkillFrontmatter(content)?.disableModelInvocation).toBe(
+      expected,
+    );
+  });
+});
 
 describe("parseSkillDependencies", () => {
   it.each([

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.test.ts
@@ -47,6 +47,11 @@ describe("parseSkillFrontmatter disable-model-invocation", () => {
       `---\nname: a\ndescription: d\ndisable-model-invocation: false # keep automatic\n---\nbody`,
       false,
     ],
+    [
+      "quoted string that only starts with true",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: "true # manual only"\n---\nbody`,
+      false,
+    ],
   ])("parses %s", (_label, content, expected) => {
     expect(parseSkillFrontmatter(content)?.disableModelInvocation).toBe(
       expected,

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.test.ts
@@ -32,6 +32,21 @@ describe("parseSkillFrontmatter disable-model-invocation", () => {
       `---\nname: a\ndescription: d\ndisable-model-invocation: maybe\n---\nbody`,
       false,
     ],
+    [
+      "true with trailing comment",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: true  # manual only\n---\nbody`,
+      true,
+    ],
+    [
+      "quoted true with trailing comment",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: "true" # manual only\n---\nbody`,
+      true,
+    ],
+    [
+      "false with trailing comment",
+      `---\nname: a\ndescription: d\ndisable-model-invocation: false # keep automatic\n---\nbody`,
+      false,
+    ],
   ])("parses %s", (_label, content, expected) => {
     expect(parseSkillFrontmatter(content)?.disableModelInvocation).toBe(
       expected,

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
@@ -28,13 +28,7 @@ export function parseSkillFrontmatter(content: string): {
 
 /** YAML 1.2 core-schema booleans: `true`/`True`/`TRUE` (quoted forms too). */
 function parseYamlBoolean(value: string | null): boolean {
-  if (value === null) return false;
-  // extractYamlValue's plain-scalar path keeps trailing `# ...` comments
-  // (YAML only treats `#` as a comment after whitespace), so strip one here —
-  // otherwise `true  # manual only` misparses to false and a later manifest
-  // save would silently drop the field from disk.
-  const withoutComment = value.replace(/\s+#.*$/, "").trim();
-  return unquoteYamlScalar(withoutComment).toLowerCase() === "true";
+  return value !== null && value.toLowerCase() === "true";
 }
 
 /**
@@ -116,7 +110,8 @@ function extractYamlValue(yaml: string, key: string): string | null {
       return collectIndentedLines(lines, i + 1).join("\n");
     }
 
-    // Quoted string (single or double)
+    // Quoted string (single or double). Quoted content is literal in YAML —
+    // a `#` inside never starts a comment, so no comment stripping here.
     if (
       (rawValue.startsWith("'") && rawValue.endsWith("'")) ||
       (rawValue.startsWith('"') && rawValue.endsWith('"'))
@@ -124,8 +119,10 @@ function extractYamlValue(yaml: string, key: string): string | null {
       return rawValue.slice(1, -1);
     }
 
-    // Plain scalar
-    return rawValue;
+    // Plain scalar: a `#` preceded by whitespace starts a trailing comment.
+    // Stripping it may uncover a quoted scalar (`"true" # manual only`).
+    const withoutComment = rawValue.replace(/\s+#.*$/, "").trim();
+    return unquoteYamlScalar(withoutComment);
   }
 
   return null;

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
@@ -1,15 +1,17 @@
 /**
  * Parses YAML frontmatter from a SKILL.md file.
- * Extracts `name` and `description` fields.
+ * Extracts `name`, `description`, and `disable-model-invocation` fields.
  *
  * Handles:
  * - Simple values: `name: my-skill`
  * - Quoted strings: `description: 'Some text'` or `description: "Some text"`
  * - Multi-line folded: `description: >-\n  line1\n  line2`
  */
-export function parseSkillFrontmatter(
-  content: string,
-): { name: string; description: string } | null {
+export function parseSkillFrontmatter(content: string): {
+  name: string;
+  description: string;
+  disableModelInvocation: boolean;
+} | null {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return null;
 
@@ -18,7 +20,15 @@ export function parseSkillFrontmatter(
   if (!name) return null;
 
   const description = extractYamlValue(yaml, "description") ?? "";
-  return { name, description };
+  const disableModelInvocation = parseYamlBoolean(
+    extractYamlValue(yaml, "disable-model-invocation"),
+  );
+  return { name, description, disableModelInvocation };
+}
+
+/** YAML 1.2 core-schema booleans: `true`/`True`/`TRUE` (quoted forms too). */
+function parseYamlBoolean(value: string | null): boolean {
+  return value !== null && value.toLowerCase() === "true";
 }
 
 /**

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
@@ -28,7 +28,13 @@ export function parseSkillFrontmatter(content: string): {
 
 /** YAML 1.2 core-schema booleans: `true`/`True`/`TRUE` (quoted forms too). */
 function parseYamlBoolean(value: string | null): boolean {
-  return value !== null && value.toLowerCase() === "true";
+  if (value === null) return false;
+  // extractYamlValue's plain-scalar path keeps trailing `# ...` comments
+  // (YAML only treats `#` as a comment after whitespace), so strip one here —
+  // otherwise `true  # manual only` misparses to false and a later manifest
+  // save would silently drop the field from disk.
+  const withoutComment = value.replace(/\s+#.*$/, "").trim();
+  return unquoteYamlScalar(withoutComment).toLowerCase() === "true";
 }
 
 /**

--- a/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/parse-skill-frontmatter.ts
@@ -26,7 +26,7 @@ export function parseSkillFrontmatter(content: string): {
   return { name, description, disableModelInvocation };
 }
 
-/** YAML 1.2 core-schema booleans: `true`/`True`/`TRUE` (quoted forms too). */
+// YAML 1.2 core schema: only `true` (any casing) is boolean true, never `yes`/`on`.
 function parseYamlBoolean(value: string | null): boolean {
   return value !== null && value.toLowerCase() === "true";
 }
@@ -110,8 +110,8 @@ function extractYamlValue(yaml: string, key: string): string | null {
       return collectIndentedLines(lines, i + 1).join("\n");
     }
 
-    // Quoted string (single or double). Quoted content is literal in YAML —
-    // a `#` inside never starts a comment, so no comment stripping here.
+    // Quoted string (single or double): a `#` inside quotes is literal in
+    // YAML, so no comment stripping here.
     if (
       (rawValue.startsWith("'") && rawValue.endsWith("'")) ||
       (rawValue.startsWith('"') && rawValue.endsWith('"'))

--- a/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
@@ -17,6 +17,9 @@ export const skillInfo = z.object({
   repoName: z.string().optional(),
   editable: z.boolean(),
   skillMdBytes: z.number(),
+  // Frontmatter `disable-model-invocation: true`: only explicit user
+  // invocation runs the skill; the agent never picks it on its own.
+  disableModelInvocation: z.boolean().optional(),
 });
 
 export const listSkillsOutput = z.array(skillInfo);
@@ -59,6 +62,7 @@ export const saveSkillManifestInput = z.object({
   name: z.string(),
   description: z.string(),
   body: z.string(),
+  disableModelInvocation: z.boolean().optional(),
 });
 
 export const saveSkillFileInput = z.object({

--- a/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
@@ -17,8 +17,6 @@ export const skillInfo = z.object({
   repoName: z.string().optional(),
   editable: z.boolean(),
   skillMdBytes: z.number(),
-  // Frontmatter `disable-model-invocation: true`: only explicit user
-  // invocation runs the skill; the agent never picks it on its own.
   disableModelInvocation: z.boolean().optional(),
 });
 

--- a/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/schemas.ts
@@ -102,6 +102,7 @@ export const exportSkillOutput = z.object({
   description: z.string(),
   body: z.string(),
   files: z.array(exportedSkillFile),
+  disableModelInvocation: z.boolean().optional(),
   /** Files excluded from the export (binary or oversized). */
   skipped: z.array(z.string()),
 }) satisfies z.ZodType<SharedExportedSkill & { skipped: string[] }>;
@@ -116,6 +117,7 @@ export const installTeamSkillInput = z.object({
   description: z.string(),
   body: z.string(),
   files: z.array(exportedSkillFile),
+  disableModelInvocation: z.boolean().optional(),
   overwrite: z.boolean().optional(),
 }) satisfies z.ZodType<SharedExportedSkill & { overwrite?: boolean }>;
 

--- a/products/desktop/packages/workspace-server/src/services/skills/skill-discovery.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skill-discovery.ts
@@ -176,7 +176,7 @@ export async function readSkillMetadataFromDir(
   if (skillNames.length === 0) return [];
 
   const results = await Promise.all(
-    skillNames.map(async (skillName) => {
+    skillNames.map(async (skillName): Promise<SkillInfo | null> => {
       const skillPath = path.join(skillsDir, skillName);
       try {
         const content = await fs.promises.readFile(
@@ -192,6 +192,9 @@ export async function readSkillMetadataFromDir(
           ...(repoName ? { repoName } : {}),
           editable: isEditableSource(source),
           skillMdBytes: Buffer.byteLength(content, "utf-8"),
+          ...(frontmatter?.disableModelInvocation
+            ? { disableModelInvocation: true }
+            : {}),
         } satisfies SkillInfo;
       } catch {
         return null;

--- a/products/desktop/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skills.test.ts
@@ -312,6 +312,18 @@ describe("exportSkill", () => {
     });
   });
 
+  it("carries disable-model-invocation out of the frontmatter", async () => {
+    const skillPath = await createSkill(
+      repoSkillsDir,
+      "manual-only",
+      "---\nname: manual-only\ndescription: Manual\ndisable-model-invocation: true\n---\n\n# Body",
+    );
+
+    const exported = await makeService().exportSkill(skillPath);
+
+    expect(exported.disableModelInvocation).toBe(true);
+  });
+
   it("refuses to export non-writable skills", async () => {
     await createSkill(path.join(pluginPath, "skills"), "bundled-skill");
 
@@ -349,6 +361,18 @@ describe("installTeamSkill", () => {
     expect(manifest).toContain("# Team body");
     const guide = await service.readSkillFile(target, "references/guide.md");
     expect(guide).toBe("guide");
+  });
+
+  it("writes disable-model-invocation back into the frontmatter", async () => {
+    const service = makeService();
+    const { path: target } = await service.installTeamSkill({
+      ...input,
+      name: "manual-team-skill",
+      disableModelInvocation: true,
+    });
+
+    const manifest = await service.readSkillFile(target, "SKILL.md");
+    expect(manifest).toContain("disable-model-invocation: true");
   });
 
   it("rejects invalid names and unsafe file paths", async () => {

--- a/products/desktop/packages/workspace-server/src/services/skills/skills.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skills.test.ts
@@ -85,6 +85,24 @@ describe("listSkills", () => {
     expect(repoSkill?.editable).toBe(true);
     expect(bundledSkill?.editable).toBe(false);
   });
+
+  it("surfaces disable-model-invocation from frontmatter", async () => {
+    await createSkill(
+      repoSkillsDir,
+      "manual-skill",
+      `---\nname: manual-skill\ndescription: d\ndisable-model-invocation: true\n---\nbody`,
+    );
+    await createSkill(repoSkillsDir, "auto-skill");
+
+    const skills = await makeService().listSkills();
+
+    expect(
+      skills.find((s) => s.name === "manual-skill")?.disableModelInvocation,
+    ).toBe(true);
+    expect(
+      skills.find((s) => s.name === "auto-skill")?.disableModelInvocation,
+    ).toBeUndefined();
+  });
 });
 
 describe("getSkillContents", () => {
@@ -680,6 +698,35 @@ describe("skill mutations", () => {
     });
     const content = await service.readSkillFile(skillPath, "SKILL.md");
     expect(content).toContain("# Alpha");
+  });
+
+  it("writes and clears disable-model-invocation through manifest saves", async () => {
+    const skillPath = await createSkill(repoSkillsDir, "alpha");
+    const service = makeService();
+
+    await service.saveSkillManifest(skillPath, {
+      name: "alpha",
+      description: "d",
+      body: "body",
+      disableModelInvocation: true,
+    });
+    let skills = await service.listSkills();
+    expect(
+      skills.find((s) => s.path === skillPath)?.disableModelInvocation,
+    ).toBe(true);
+
+    await service.saveSkillManifest(skillPath, {
+      name: "alpha",
+      description: "d",
+      body: "body",
+      disableModelInvocation: false,
+    });
+    skills = await service.listSkills();
+    expect(
+      skills.find((s) => s.path === skillPath)?.disableModelInvocation,
+    ).toBeUndefined();
+    const content = await service.readSkillFile(skillPath, "SKILL.md");
+    expect(content).not.toContain("disable-model-invocation");
   });
 
   it("rejects manifest saves without a name", async () => {

--- a/products/desktop/packages/workspace-server/src/services/skills/skills.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skills.ts
@@ -133,11 +133,20 @@ export class SkillsService {
 
   async saveSkillManifest(
     skillPath: string,
-    manifest: { name: string; description: string; body: string },
+    manifest: {
+      name: string;
+      description: string;
+      body: string;
+      disableModelInvocation?: boolean;
+    },
   ): Promise<void> {
     const skillDir = await this.resolveWritableSkillDir(skillPath);
     const content = serializeSkillMarkdown(
-      { name: manifest.name.trim(), description: manifest.description.trim() },
+      {
+        name: manifest.name.trim(),
+        description: manifest.description.trim(),
+        disableModelInvocation: manifest.disableModelInvocation ?? false,
+      },
       manifest.body,
     );
     // The writer and parser must agree, or the skill vanishes from the list.

--- a/products/desktop/packages/workspace-server/src/services/skills/skills.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/skills.ts
@@ -277,6 +277,9 @@ export class SkillsService {
       name,
       description,
       body,
+      ...(frontmatter?.disableModelInvocation
+        ? { disableModelInvocation: true }
+        : {}),
       files: results.filter(
         (r): r is { path: string; content: string } => r.content !== null,
       ),
@@ -312,7 +315,11 @@ export class SkillsService {
       await fs.promises.writeFile(
         path.join(staging, "SKILL.md"),
         serializeSkillMarkdown(
-          { name, description: input.description },
+          {
+            name,
+            description: input.description,
+            disableModelInvocation: input.disableModelInvocation,
+          },
           input.body,
         ),
         "utf-8",

--- a/products/desktop/packages/workspace-server/src/services/skills/write-skill-frontmatter.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/skills/write-skill-frontmatter.test.ts
@@ -28,9 +28,39 @@ describe("serializeSkillMarkdown", () => {
 
       const parsed = parseSkillFrontmatter(content);
 
-      expect(parsed).toEqual({ name, description });
+      expect(parsed).toEqual({
+        name,
+        description,
+        disableModelInvocation: false,
+      });
     },
   );
+
+  it("emits disable-model-invocation and round-trips it", () => {
+    const content = serializeSkillMarkdown(
+      { name: "my-skill", description: "d", disableModelInvocation: true },
+      "The body",
+    );
+
+    expect(content).toBe(
+      "---\nname: my-skill\ndescription: d\ndisable-model-invocation: true\n---\n\nThe body\n",
+    );
+    expect(parseSkillFrontmatter(content)).toEqual({
+      name: "my-skill",
+      description: "d",
+      disableModelInvocation: true,
+    });
+  });
+
+  it("omits disable-model-invocation when false", () => {
+    const content = serializeSkillMarkdown(
+      { name: "my-skill", description: "d", disableModelInvocation: false },
+      "The body",
+    );
+
+    expect(content).not.toContain("disable-model-invocation");
+    expect(parseSkillFrontmatter(content)?.disableModelInvocation).toBe(false);
+  });
 
   it("appends the body after the frontmatter with a trailing newline", () => {
     const content = serializeSkillMarkdown(


### PR DESCRIPTION
Ports PostHog/code#3776 into the monorepo (PostHog/code `main` is frozen after the desktop import; open PRs there are remade here). Commits preserve the original authorship.

## Problem

Claude Code skills support `disable-model-invocation: true` in SKILL.md frontmatter: the agent never invokes the skill on its own — only an explicit user invocation (slash command or composer skill tag) runs it. The bundled agent CLI already honors the field at runtime (both locally and in cloud sandboxes, since skill bundles ship SKILL.md verbatim), but PostHog Desktop was blind to it: the field wasn't parsed, wasn't shown anywhere in the skills UI, and — worse — editing a skill in the manifest editor silently stripped it from the file.

## Changes

- `parseSkillFrontmatter` now extracts `disable-model-invocation`, exposed as an optional `disableModelInvocation` on `SkillInfo`.
- `serializeSkillMarkdown` (the shared SKILL.md serialization contract) emits the field, so manifest saves round-trip it instead of dropping it.
- Skills UI: a "Manual-only" badge on the skill card and detail panel, and a "Manual invocation only" toggle in the manifest editor.

Not covered: team skill publish/install — the team-skills API only stores name/description/body, so the flag doesn't survive that round trip yet.

Related (different feature, no overlap): PostHog/code#3735 adds always-on skills.

## How did you test this code?

- New unit tests for frontmatter parsing, serialization round-trip, and manifest save/clear of the flag (`pnpm --filter @posthog/workspace-server exec vitest run src/services/skills`: 111 passed).
- `pnpm --filter @posthog/ui exec vitest run src/features/skills` passed.
- `pnpm typecheck` for shared, workspace-server, host-router, ui, and web; Biome check on changed files.
- After the port: from `products/desktop/`, `pnpm install --frozen-lockfile`, `pnpm typecheck` (24/24 clean), workspace-server skills tests (124), UI skills tests and the full `@posthog/shared` suite (780) all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR is a mechanical port of PostHog/code#3776 (author: haacked) into `products/desktop/`, done with Claude Code following the repo's /porting-code-prs skill: `git am -3 --directory=products/desktop/` over the source patch series, preserving the original commits and authorship. It applied without conflicts; no source changes beyond the path relocation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
