### PR TITLE
feat(managed-warehouse): add posthog metrics instrumentation

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -98,6 +98,7 @@ from products.managed_warehouse.backend.facade.team_state import (
     list_enabled_backfill_team_memberships,
     resolve_events_persons_tables,
 )
+from products.managed_warehouse.backend.metrics import record_duckling_backfill_workload, track_duckling_backfill
 
 logger = structlog.get_logger(__name__)
 
@@ -2369,11 +2370,12 @@ def register_persons_files_with_duckling(
     tags={"owner": JobOwners.TEAM_MANAGED_WAREHOUSE.value, **EVENTS_CONCURRENCY_TAG},
 )
 def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
-    team_id, _ = parse_partition_key_dates(context.partition_key)
+    team_id, dates = parse_partition_key_dates(context.partition_key)
     if config.dry_run:
         _run_duckling_events_backfill(context, config)
         return
 
+    mode = "monthly" if len(dates) > 1 else "daily"
     run_id = context.run.run_id
     record_backfill_started(
         team_id=team_id,
@@ -2381,24 +2383,29 @@ def duckling_events_backfill(context: AssetExecutionContext, config: DucklingBac
         partition_key=context.partition_key,
         run_id=run_id,
     )
-    try:
-        _run_duckling_events_backfill(context, config)
-    except Exception as error:
+    with track_duckling_backfill(
+        team_id=team_id,
+        dataset=ManagedWarehouseBackfillPartition.Dataset.EVENTS,
+        mode=mode,
+    ):
+        try:
+            _run_duckling_events_backfill(context, config)
+        except Exception as error:
+            record_backfill_finished(
+                team_id=team_id,
+                dataset=ManagedWarehouseBackfillPartition.Dataset.EVENTS,
+                partition_key=context.partition_key,
+                run_id=run_id,
+                error=error,
+            )
+            raise
+
         record_backfill_finished(
             team_id=team_id,
             dataset=ManagedWarehouseBackfillPartition.Dataset.EVENTS,
             partition_key=context.partition_key,
             run_id=run_id,
-            error=error,
         )
-        raise
-
-    record_backfill_finished(
-        team_id=team_id,
-        dataset=ManagedWarehouseBackfillPartition.Dataset.EVENTS,
-        partition_key=context.partition_key,
-        run_id=run_id,
-    )
 
 
 def _run_duckling_events_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
@@ -2550,6 +2557,14 @@ def _run_duckling_events_backfill(context: AssetExecutionContext, config: Duckli
                 "bucket": target.bucket,
             }
         )
+        if not config.dry_run:
+            record_duckling_backfill_workload(
+                team_id=team_id,
+                dataset=ManagedWarehouseBackfillPartition.Dataset.EVENTS,
+                mode="monthly" if len(dates) > 1 else "daily",
+                files_registered=total_registered,
+                partitions_exported=days_exported,
+            )
 
         context.log.info(
             f"Completed duckling backfill for team_id={team_id}: "
@@ -2589,24 +2604,30 @@ def duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBa
         partition_key=partition_key,
         run_id=run_id,
     )
-    try:
-        _run_duckling_persons_backfill(context, config)
-    except Exception as error:
+    mode = "full" if is_full_export_partition(partition_key) else "daily"
+    with track_duckling_backfill(
+        team_id=team_id,
+        dataset=ManagedWarehouseBackfillPartition.Dataset.PERSONS,
+        mode=mode,
+    ):
+        try:
+            _run_duckling_persons_backfill(context, config)
+        except Exception as error:
+            record_backfill_finished(
+                team_id=team_id,
+                dataset=ManagedWarehouseBackfillPartition.Dataset.PERSONS,
+                partition_key=partition_key,
+                run_id=run_id,
+                error=error,
+            )
+            raise
+
         record_backfill_finished(
             team_id=team_id,
             dataset=ManagedWarehouseBackfillPartition.Dataset.PERSONS,
             partition_key=partition_key,
             run_id=run_id,
-            error=error,
         )
-        raise
-
-    record_backfill_finished(
-        team_id=team_id,
-        dataset=ManagedWarehouseBackfillPartition.Dataset.PERSONS,
-        partition_key=partition_key,
-        run_id=run_id,
-    )
 
 
 def _run_duckling_persons_backfill(context: AssetExecutionContext, config: DucklingBackfillConfig) -> None:
@@ -2749,6 +2770,14 @@ def _run_duckling_persons_backfill(context: AssetExecutionContext, config: Duckl
                     "bucket": target.bucket,
                 }
             )
+            if not config.dry_run:
+                record_duckling_backfill_workload(
+                    team_id=team_id,
+                    dataset=ManagedWarehouseBackfillPartition.Dataset.PERSONS,
+                    mode="full",
+                    files_registered=files_registered,
+                    partitions_exported=int(bool(s3_glob)),
+                )
 
             context.log.info(
                 f"Completed duckling persons full backfill for team_id={team_id}: {files_registered} files registered"
@@ -2827,6 +2856,14 @@ def _run_duckling_persons_backfill(context: AssetExecutionContext, config: Duckl
                     "bucket": target.bucket,
                 }
             )
+            if not config.dry_run:
+                record_duckling_backfill_workload(
+                    team_id=team_id,
+                    dataset=ManagedWarehouseBackfillPartition.Dataset.PERSONS,
+                    mode="daily",
+                    files_registered=total_registered,
+                    partitions_exported=days_exported,
+                )
 
             context.log.info(
                 f"Completed duckling persons daily backfill for team_id={team_id}: "

--- a/posthog/temporal/ai_observability/test_metrics.py
+++ b/posthog/temporal/ai_observability/test_metrics.py
@@ -75,6 +75,28 @@ class TestExecutionTimeRecorder:
             assert call_args["status"] == "SKIPPED"
             assert call_args["exception"] == ""
 
+    def test_forwards_duration_and_terminal_attributes_to_recorder(self):
+        mock_meter = MagicMock()
+        mock_hist = MagicMock()
+        histogram_recorder = MagicMock()
+        mock_meter.create_histogram_timedelta.return_value = mock_hist
+
+        with (
+            patch("posthog.temporal.common.metrics.get_metric_meter", return_value=mock_meter),
+            patch("posthog.temporal.common.metrics.time.perf_counter", side_effect=[1.0, 1.25]),
+        ):
+            with ExecutionTimeRecorder(
+                "test_histogram",
+                histogram_attributes={"stage": "copy"},
+                histogram_recorder=histogram_recorder,
+            ) as recorder:
+                recorder.set_status("SKIPPED")
+
+        histogram_recorder.assert_called_once_with(
+            250.0,
+            {"stage": "copy", "status": "SKIPPED", "exception": ""},
+        )
+
 
 class TestEvalsMetricsInterceptor:
     def test_interceptor_creates_activity_interceptor(self):

--- a/posthog/temporal/common/metrics.py
+++ b/posthog/temporal/common/metrics.py
@@ -35,11 +35,13 @@ class ExecutionTimeRecorder:
         description: str | None = None,
         histogram_attributes: Attributes | None = None,
         log: bool = False,
+        histogram_recorder: typing.Callable[[float, Attributes], None] | None = None,
     ) -> None:
         self.histogram_name = histogram_name
         self.description = description
         self.histogram_attributes = histogram_attributes or {}
         self.log = log
+        self.histogram_recorder = histogram_recorder
         self._start_counter: float | None = None
         self._status_override: str | None = None
 
@@ -75,6 +77,8 @@ class ExecutionTimeRecorder:
             meter = get_metric_meter(attributes)
             hist = meter.create_histogram_timedelta(name=self.histogram_name, description=self.description, unit="ms")
             hist.record(value=delta)
+            if self.histogram_recorder is not None:
+                self.histogram_recorder(float(delta_milli_seconds), attributes)
         except Exception:
             LOGGER.exception("Failed to record execution time to histogram '%s'", self.histogram_name)
         if self.log:

--- a/products/managed_warehouse/backend/metrics.py
+++ b/products/managed_warehouse/backend/metrics.py
@@ -1,0 +1,120 @@
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+import posthoganalytics
+from posthoganalytics.metrics_capture import PostHogMetrics
+from temporalio import workflow
+
+MetricAttributes = Mapping[str, str | int | float | bool]
+
+
+def _should_record() -> bool:
+    return not (workflow.in_workflow() and workflow.unsafe.is_replaying())
+
+
+def _metrics() -> PostHogMetrics | None:
+    client = posthoganalytics.default_client
+    return client.metrics if client is not None else None
+
+
+def record_counter(
+    name: str,
+    value: int,
+    attributes: MetricAttributes,
+    *,
+    unit: str | None = None,
+) -> None:
+    if not _should_record():
+        return
+    metrics = _metrics()
+    if metrics is not None:
+        metrics.count(name, value, unit=unit, attributes=dict(attributes))
+
+
+def record_histogram(
+    name: str,
+    value: float,
+    attributes: MetricAttributes,
+    *,
+    unit: str,
+) -> None:
+    if not _should_record():
+        return
+    metrics = _metrics()
+    if metrics is not None:
+        metrics.histogram(name, value, unit=unit, attributes=dict(attributes))
+
+
+def record_gauge(
+    name: str,
+    value: float,
+    attributes: MetricAttributes,
+    *,
+    unit: str | None = None,
+) -> None:
+    if not _should_record():
+        return
+    metrics = _metrics()
+    if metrics is not None:
+        metrics.gauge(name, value, unit=unit, attributes=dict(attributes))
+
+
+@contextmanager
+def track_duckling_backfill(*, team_id: int, dataset: str, mode: str) -> Iterator[None]:
+    attributes = {"team_id": str(team_id), "dataset": dataset, "mode": mode}
+    record_counter(
+        "warehouse.duckling.backfill.started",
+        1,
+        attributes,
+    )
+    started_at = time.perf_counter()
+    status = "failed"
+    try:
+        yield
+        status = "completed"
+        record_gauge(
+            "warehouse.duckling.backfill.last.success.timestamp",
+            time.time(),
+            attributes,
+            unit="s",
+        )
+    finally:
+        terminal_attributes = {**attributes, "status": status}
+        record_counter(
+            "warehouse.duckling.backfill.finished",
+            1,
+            terminal_attributes,
+        )
+        record_histogram(
+            "warehouse.duckling.backfill.duration",
+            time.perf_counter() - started_at,
+            terminal_attributes,
+            unit="s",
+        )
+        metrics = _metrics()
+        if metrics is not None:
+            metrics.flush()
+
+
+def record_duckling_backfill_workload(
+    *,
+    team_id: int,
+    dataset: str,
+    mode: str,
+    files_registered: int,
+    partitions_exported: int,
+) -> None:
+    attributes = {"team_id": str(team_id), "dataset": dataset, "mode": mode}
+    record_histogram(
+        "warehouse.duckling.backfill.files.registered",
+        float(files_registered),
+        attributes,
+        unit="file",
+    )
+    record_histogram(
+        "warehouse.duckling.backfill.partitions.exported",
+        float(partitions_exported),
+        attributes,
+        unit="partition",
+    )

--- a/products/managed_warehouse/backend/temporal/ducklake_copy_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_copy_data_imports_workflow.py
@@ -62,6 +62,7 @@ from products.managed_warehouse.backend.temporal.metrics import (
     get_ducklake_copy_data_imports_rows_metric,
     get_ducklake_copy_data_imports_started_metric,
     get_ducklake_copy_data_imports_verification_metric,
+    record_ducklake_copy_data_imports_stage_duration,
 )
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 from products.warehouse_sources.backend.facade.pipelines import DUCKGRES_BATCH_SINK_FLAG, is_duckgres_sink_team_member
@@ -80,6 +81,7 @@ def _stage_timer(*, stage: str, team_id: int, schema_id: str | None = None) -> E
         "Execution duration of one post-gate DuckLake data import copy stage.",
         attributes,
         log=True,
+        histogram_recorder=record_ducklake_copy_data_imports_stage_duration,
     )
 
 

--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -48,6 +48,7 @@ from products.managed_warehouse.backend.temporal.metrics import (
     get_ducklake_register_data_imports_rows_metric,
     get_ducklake_register_data_imports_stale_metric,
     get_ducklake_register_data_imports_started_metric,
+    record_ducklake_register_data_imports_stage_duration,
 )
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
@@ -63,6 +64,7 @@ def _stage_timer(*, stage: str, team_id: int, schema_id: str) -> ExecutionTimeRe
         "Execution duration of one post-gate DuckLake data import registration stage.",
         {"stage": stage, "team_id": str(team_id), "schema_id": schema_id},
         log=True,
+        histogram_recorder=record_ducklake_register_data_imports_stage_duration,
     )
 
 

--- a/products/managed_warehouse/backend/temporal/metrics.py
+++ b/products/managed_warehouse/backend/temporal/metrics.py
@@ -1,5 +1,150 @@
+from typing import Self
+
 from temporalio import activity, workflow
-from temporalio.common import MetricCounter, MetricGaugeFloat, MetricHistogramFloat, MetricMeter
+from temporalio.common import MetricAttributes, MetricCounter, MetricGaugeFloat, MetricHistogramFloat, MetricMeter
+
+from products.managed_warehouse.backend.metrics import record_counter, record_gauge, record_histogram
+
+
+def _temporal_context_active() -> bool:
+    return activity.in_activity() or workflow.in_workflow()
+
+
+def _posthog_metric_name(temporal_metric_name: str) -> str:
+    normalized_name = temporal_metric_name.removesuffix("_seconds")
+    return f"warehouse.{normalized_name.replace('_', '.')}"
+
+
+class _CounterTwin(MetricCounter):
+    def __init__(self, temporal_metric: MetricCounter, attributes: MetricAttributes) -> None:
+        self._temporal_metric = temporal_metric
+        self._attributes = dict(attributes)
+
+    @property
+    def name(self) -> str:
+        return self._temporal_metric.name
+
+    @property
+    def description(self) -> str | None:
+        return self._temporal_metric.description
+
+    @property
+    def unit(self) -> str | None:
+        return self._temporal_metric.unit
+
+    def with_additional_attributes(self, additional_attributes: MetricAttributes) -> Self:
+        return type(self)(
+            self._temporal_metric.with_additional_attributes(additional_attributes),
+            {**self._attributes, **additional_attributes},
+        )
+
+    def add(self, value: int, additional_attributes: MetricAttributes | None = None) -> None:
+        self._temporal_metric.add(value, additional_attributes)
+        if _temporal_context_active():
+            record_counter(
+                _posthog_metric_name(self.name),
+                value,
+                {**self._attributes, **(additional_attributes or {})},
+                unit=self.unit,
+            )
+
+
+class _HistogramTwin(MetricHistogramFloat):
+    def __init__(self, temporal_metric: MetricHistogramFloat, attributes: MetricAttributes) -> None:
+        self._temporal_metric = temporal_metric
+        self._attributes = dict(attributes)
+
+    @property
+    def name(self) -> str:
+        return self._temporal_metric.name
+
+    @property
+    def description(self) -> str | None:
+        return self._temporal_metric.description
+
+    @property
+    def unit(self) -> str | None:
+        return self._temporal_metric.unit
+
+    def with_additional_attributes(self, additional_attributes: MetricAttributes) -> Self:
+        return type(self)(
+            self._temporal_metric.with_additional_attributes(additional_attributes),
+            {**self._attributes, **additional_attributes},
+        )
+
+    def record(self, value: float, additional_attributes: MetricAttributes | None = None) -> None:
+        self._temporal_metric.record(value, additional_attributes)
+        if _temporal_context_active():
+            record_histogram(
+                _posthog_metric_name(self.name),
+                value,
+                {**self._attributes, **(additional_attributes or {})},
+                unit=self.unit or "1",
+            )
+
+
+class _GaugeTwin(MetricGaugeFloat):
+    def __init__(self, temporal_metric: MetricGaugeFloat, attributes: MetricAttributes) -> None:
+        self._temporal_metric = temporal_metric
+        self._attributes = dict(attributes)
+
+    @property
+    def name(self) -> str:
+        return self._temporal_metric.name
+
+    @property
+    def description(self) -> str | None:
+        return self._temporal_metric.description
+
+    @property
+    def unit(self) -> str | None:
+        return self._temporal_metric.unit
+
+    def with_additional_attributes(self, additional_attributes: MetricAttributes) -> Self:
+        return type(self)(
+            self._temporal_metric.with_additional_attributes(additional_attributes),
+            {**self._attributes, **additional_attributes},
+        )
+
+    def set(self, value: float, additional_attributes: MetricAttributes | None = None) -> None:
+        self._temporal_metric.set(value, additional_attributes)
+        if _temporal_context_active():
+            record_gauge(
+                _posthog_metric_name(self.name),
+                value,
+                {**self._attributes, **(additional_attributes or {})},
+                unit=self.unit,
+            )
+
+
+def _counter_twin(metric: MetricCounter, attributes: MetricAttributes) -> MetricCounter:
+    return _CounterTwin(metric, attributes)
+
+
+def _histogram_twin(metric: MetricHistogramFloat, attributes: MetricAttributes) -> MetricHistogramFloat:
+    return _HistogramTwin(metric, attributes)
+
+
+def _gauge_twin(metric: MetricGaugeFloat, attributes: MetricAttributes) -> MetricGaugeFloat:
+    return _GaugeTwin(metric, attributes)
+
+
+def record_ducklake_copy_data_imports_stage_duration(value: float, attributes: MetricAttributes) -> None:
+    record_histogram(
+        "warehouse.ducklake.copy.data.imports.stage.duration",
+        value,
+        attributes,
+        unit="ms",
+    )
+
+
+def record_ducklake_register_data_imports_stage_duration(value: float, attributes: MetricAttributes) -> None:
+    record_histogram(
+        "warehouse.ducklake.register.data.imports.stage.duration",
+        value,
+        attributes,
+        unit="ms",
+    )
 
 
 def _activity_meter() -> MetricMeter:
@@ -18,210 +163,244 @@ def _copy_data_imports_attributes(team_id: int, schema_id: str | None = None) ->
 
 
 def get_ducklake_copy_data_modeling_finished_metric(status: str) -> MetricCounter:
-    return (
+    attributes = {"status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes({"status": status})
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_copy_data_modeling_finished",
             "Number of DuckLake data modeling copy workflows finished, including failures.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_modeling_verification_metric(check: str, status: str) -> MetricCounter:
-    return (
+    attributes = {"check": check, "status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes({"check": check, "status": status})
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_copy_data_modeling_verification",
             "Number of DuckLake data modeling verification checks executed grouped by status.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_finished_metric(*, team_id: int, status: str) -> MetricCounter:
-    return (
+    attributes = {**_copy_data_imports_attributes(team_id), "status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes({**_copy_data_imports_attributes(team_id), "status": status})
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_copy_data_imports_finished",
             "Number of DuckLake data import copy workflows finished after passing the feature flag gate.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_started_metric(*, team_id: int) -> MetricCounter:
-    return (
+    attributes = _copy_data_imports_attributes(team_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_copy_data_imports_attributes(team_id))
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_copy_data_imports_started",
             "Number of DuckLake data import copy workflows that passed the feature flag gate.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_duration_metric(*, team_id: int, status: str) -> MetricHistogramFloat:
-    return (
+    attributes = {**_copy_data_imports_attributes(team_id), "status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes({**_copy_data_imports_attributes(team_id), "status": status})
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_copy_data_imports_duration_seconds",
             "End-to-end duration of DuckLake data import copy workflows after passing the feature flag gate.",
             "s",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_last_success_metric(*, team_id: int, schema_id: str) -> MetricGaugeFloat:
-    return (
+    attributes = _copy_data_imports_attributes(team_id, schema_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_copy_data_imports_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_gauge_float(
             "ducklake_copy_data_imports_last_success_timestamp_seconds",
             "Unix timestamp of the last successful DuckLake data import copy for a schema.",
             "s",
         )
     )
+    return _gauge_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_verification_metric(
     *, team_id: int, schema_id: str, check_name: str, status: str
 ) -> MetricCounter:
-    return (
+    attributes = {**_copy_data_imports_attributes(team_id, schema_id), "check": check_name, "status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(
-            {**_copy_data_imports_attributes(team_id, schema_id), "check": check_name, "status": status}
-        )
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_copy_data_imports_verification",
             "Number of DuckLake data import verification checks completed.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_files_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
-    return (
+    attributes = _copy_data_imports_attributes(team_id, schema_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_copy_data_imports_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_copy_data_imports_data_files_copied",
             "Number of Delta data files in a successful DuckLake data import copy.",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_rows_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
-    return (
+    attributes = _copy_data_imports_attributes(team_id, schema_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_copy_data_imports_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_copy_data_imports_rows_copied",
             "Number of rows in a successful DuckLake data import copy.",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_copy_data_imports_bytes_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
-    return (
+    attributes = _copy_data_imports_attributes(team_id, schema_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_copy_data_imports_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_copy_data_imports_data_bytes_copied",
             "Number of Delta data file bytes in a successful DuckLake data import copy.",
             "By",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_finished_metric(*, team_id: int, schema_id: str, status: str) -> MetricCounter:
-    return (
+    attributes = {**_registration_attributes(team_id, schema_id), "status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes({**_registration_attributes(team_id, schema_id), "status": status})
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_register_data_imports_finished",
             "Number of DuckLake prepared data import registration workflows finished, including failures.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_duration_metric(
     *, team_id: int, schema_id: str, status: str
 ) -> MetricHistogramFloat:
-    return (
+    attributes = {**_registration_attributes(team_id, schema_id), "status": status}
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes({**_registration_attributes(team_id, schema_id), "status": status})
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_register_data_imports_duration_seconds",
             "End-to-end duration of DuckLake prepared data import registration workflows that passed the feature flag gate.",
             "s",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_started_metric(*, team_id: int, schema_id: str) -> MetricCounter:
-    return (
+    attributes = _registration_attributes(team_id, schema_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_register_data_imports_started",
             "Number of DuckLake prepared data import registration workflows that passed the feature flag gate.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_last_success_metric(*, team_id: int, schema_id: str) -> MetricGaugeFloat:
-    return (
+    attributes = _registration_attributes(team_id, schema_id)
+    metric = (
         workflow.metric_meter()
-        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_gauge_float(
             "ducklake_register_data_imports_last_success_timestamp_seconds",
             "Unix timestamp of the last successful DuckLake prepared data import registration workflow.",
             "s",
         )
     )
+    return _gauge_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_stale_metric(*, team_id: int, schema_id: str, stage: str) -> MetricCounter:
-    return (
+    attributes = {**_registration_attributes(team_id, schema_id), "stage": stage}
+    metric = (
         _activity_meter()
-        .with_additional_attributes({**_registration_attributes(team_id, schema_id), "stage": stage})
+        .with_additional_attributes(attributes)
         .create_counter(
             "ducklake_register_data_imports_stale",
             "Number of post-gate DuckLake registrations skipped because their prepared generation became stale.",
         )
     )
+    return _counter_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_files_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
-    return (
+    attributes = _registration_attributes(team_id, schema_id)
+    metric = (
         _activity_meter()
-        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_register_data_imports_files_registered",
             "Number of Parquet files in a successful DuckLake data import registration.",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_rows_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
-    return (
+    attributes = _registration_attributes(team_id, schema_id)
+    metric = (
         _activity_meter()
-        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_register_data_imports_rows_registered",
             "Number of rows in a successful DuckLake data import registration.",
         )
     )
+    return _histogram_twin(metric, attributes)
 
 
 def get_ducklake_register_data_imports_bytes_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
-    return (
+    attributes = _registration_attributes(team_id, schema_id)
+    metric = (
         _activity_meter()
-        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .with_additional_attributes(attributes)
         .create_histogram_float(
             "ducklake_register_data_imports_bytes_copied",
             "Number of prepared Parquet bytes copied by a successful DuckLake data import registration.",
             "By",
         )
     )
+    return _histogram_twin(metric, attributes)

--- a/products/managed_warehouse/backend/tests/test_metrics.py
+++ b/products/managed_warehouse/backend/tests/test_metrics.py
@@ -1,0 +1,189 @@
+import pytest
+from unittest.mock import MagicMock, call, patch
+
+from parameterized import parameterized
+
+from products.managed_warehouse.backend.metrics import (
+    record_counter,
+    record_duckling_backfill_workload,
+    track_duckling_backfill,
+)
+from products.managed_warehouse.backend.temporal import metrics as temporal_metrics
+
+
+class TestTemporalMetricTwins:
+    @parameterized.expand(
+        [
+            (
+                "counter",
+                "get_ducklake_copy_data_imports_started_metric",
+                {"team_id": 7},
+                "create_counter",
+                "add",
+                "count",
+                1,
+                "ducklake_copy_data_imports_started",
+                "warehouse.ducklake.copy.data.imports.started",
+                None,
+                {"team_id": "7"},
+            ),
+            (
+                "histogram",
+                "get_ducklake_register_data_imports_duration_metric",
+                {"team_id": 7, "schema_id": "schema-1", "status": "completed"},
+                "create_histogram_float",
+                "record",
+                "histogram",
+                4.5,
+                "ducklake_register_data_imports_duration_seconds",
+                "warehouse.ducklake.register.data.imports.duration",
+                "s",
+                {"team_id": "7", "schema_id": "schema-1", "status": "completed"},
+            ),
+            (
+                "gauge",
+                "get_ducklake_copy_data_imports_last_success_metric",
+                {"team_id": 7, "schema_id": "schema-1"},
+                "create_gauge_float",
+                "set",
+                "gauge",
+                123.0,
+                "ducklake_copy_data_imports_last_success_timestamp_seconds",
+                "warehouse.ducklake.copy.data.imports.last.success.timestamp",
+                "s",
+                {"team_id": "7", "schema_id": "schema-1"},
+            ),
+        ]
+    )
+    def test_records_temporal_and_posthog_metrics(
+        self,
+        _name: str,
+        getter_name: str,
+        getter_kwargs: dict[str, object],
+        create_method: str,
+        record_method: str,
+        posthog_method: str,
+        value: float,
+        temporal_name: str,
+        posthog_name: str,
+        unit: str | None,
+        attributes: dict[str, str],
+    ) -> None:
+        meter = MagicMock()
+        temporal_metric = getattr(meter.with_additional_attributes.return_value, create_method).return_value
+        temporal_metric.name = temporal_name
+        temporal_metric.description = "description"
+        temporal_metric.unit = unit
+        client = MagicMock()
+
+        with (
+            patch.object(temporal_metrics.workflow, "metric_meter", return_value=meter),
+            patch.object(temporal_metrics.workflow, "in_workflow", return_value=True),
+            patch("products.managed_warehouse.backend.metrics.workflow.unsafe.is_replaying", return_value=False),
+            patch("products.managed_warehouse.backend.metrics.posthoganalytics.default_client", client),
+        ):
+            metric = getattr(temporal_metrics, getter_name)(**getter_kwargs)
+            getattr(metric, record_method)(value)
+
+        getattr(temporal_metric, record_method).assert_called_once_with(value, None)
+        getattr(client.metrics, posthog_method).assert_called_once_with(
+            posthog_name,
+            value,
+            unit=unit,
+            attributes=attributes,
+        )
+
+
+class TestDucklingBackfillMetrics:
+    @parameterized.expand([("completed", False), ("failed", True)])
+    def test_records_terminal_status(self, expected_status: str, fails: bool) -> None:
+        client = MagicMock()
+        perf_counter_values = [10.0, 12.5]
+
+        with (
+            patch("products.managed_warehouse.backend.metrics.posthoganalytics.default_client", client),
+            patch("products.managed_warehouse.backend.metrics.workflow.in_workflow", return_value=False),
+            patch("products.managed_warehouse.backend.metrics.time.perf_counter", side_effect=perf_counter_values),
+            patch("products.managed_warehouse.backend.metrics.time.time", return_value=123.0),
+        ):
+            if fails:
+                with pytest.raises(RuntimeError, match="backfill failed"):
+                    with track_duckling_backfill(team_id=7, dataset="events", mode="daily"):
+                        raise RuntimeError("backfill failed")
+            else:
+                with track_duckling_backfill(team_id=7, dataset="events", mode="daily"):
+                    pass
+
+        base_attributes = {"team_id": "7", "dataset": "events", "mode": "daily"}
+        client.metrics.count.assert_has_calls(
+            [
+                call("warehouse.duckling.backfill.started", 1, unit=None, attributes=base_attributes),
+                call(
+                    "warehouse.duckling.backfill.finished",
+                    1,
+                    unit=None,
+                    attributes={**base_attributes, "status": expected_status},
+                ),
+            ]
+        )
+        client.metrics.histogram.assert_called_once_with(
+            "warehouse.duckling.backfill.duration",
+            2.5,
+            unit="s",
+            attributes={**base_attributes, "status": expected_status},
+        )
+        if fails:
+            client.metrics.gauge.assert_not_called()
+        else:
+            client.metrics.gauge.assert_called_once_with(
+                "warehouse.duckling.backfill.last.success.timestamp",
+                123.0,
+                unit="s",
+                attributes=base_attributes,
+            )
+        client.metrics.flush.assert_called_once_with()
+
+    def test_records_successful_workload(self) -> None:
+        client = MagicMock()
+
+        with (
+            patch("products.managed_warehouse.backend.metrics.posthoganalytics.default_client", client),
+            patch("products.managed_warehouse.backend.metrics.workflow.in_workflow", return_value=False),
+        ):
+            record_duckling_backfill_workload(
+                team_id=7,
+                dataset="persons",
+                mode="full",
+                files_registered=12,
+                partitions_exported=3,
+            )
+
+        attributes = {"team_id": "7", "dataset": "persons", "mode": "full"}
+        client.metrics.histogram.assert_has_calls(
+            [
+                call(
+                    "warehouse.duckling.backfill.files.registered",
+                    12.0,
+                    unit="file",
+                    attributes=attributes,
+                ),
+                call(
+                    "warehouse.duckling.backfill.partitions.exported",
+                    3.0,
+                    unit="partition",
+                    attributes=attributes,
+                ),
+            ]
+        )
+
+    def test_does_not_record_workflow_replays(self) -> None:
+        client = MagicMock()
+
+        with (
+            patch("products.managed_warehouse.backend.metrics.posthoganalytics.default_client", client),
+            patch("products.managed_warehouse.backend.metrics.workflow.in_workflow", return_value=True),
+            patch("products.managed_warehouse.backend.metrics.workflow.unsafe.is_replaying", return_value=True),
+        ):
+            record_counter("warehouse.ducklake.copy.started", 1, {"status": "completed"})
+
+        client.metrics.count.assert_not_called()


### PR DESCRIPTION
## Problem

DuckLake copy and registration workflows already expose operational metrics through Temporal, and the Dagster backfills persist run status. These signals are not available in PostHog Metrics, which makes it harder to query the same workflow health alongside product metrics.

This PR is stacked on #76379 because that PR adds the copy data import metrics mirrored here.

## Changes

- Mirror the existing DuckLake copy and registration counters, gauges, and histograms into `posthoganalytics.default_client.metrics` while preserving the Temporal metrics used by Grafana.
- Add PostHog Metrics stage-duration observations with the same stage, status, team, and schema attributes.
- Instrument Dagster event and person backfills with started and finished counts, terminal status, duration, last-success timestamps, registered files, and exported partitions.
- Suppress workflow replay emissions and flush metrics at the end of short-lived Dagster backfill runs.

Before:

```mermaid
flowchart LR
    Run["Copy, registration, or backfill run"] --> Existing["Temporal metrics or backfill status"]
    Existing --> Grafana["Grafana and status views"]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Run phYellow;
    class Existing phBlue;
    class Grafana phGray;
```

After:

```mermaid
flowchart LR
    Run["Copy, registration, or backfill run"] --> Existing["Temporal metrics or backfill status"]
    Run --> Product["PostHog Metrics"]
    Existing --> Grafana["Grafana and status views"]
    Product --> MetricsUI["Metrics UI and queries"]

    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Run phYellow;
    class Existing phBlue;
    class Product phRed;
    class Grafana,MetricsUI phGray;
```

## How did you test this code?

- `pytest -q products/managed_warehouse/backend/tests/test_metrics.py posthog/temporal/ai_observability/test_metrics.py` – 17 passed. These cases catch dropped Temporal-to-PostHog mirroring, replay double-counting, incorrect backfill terminal status, and lost stage/status duration attributes.
- Ran the copy, registration, and Dagster backfill test files – 38 database-independent cases passed; 23 database-backed cases could not start because the local Postgres and Dagster test services were not running.
- `mypy --cache-fine-grained .` – no issues in 17,386 source files.
- `hogli ci:preflight --fix --against origin/feat/ducklake-copy-imports-metrics` – clean.
- Pre-commit Python lint, format, and `ty check` hooks passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed because this adds internal instrumentation without changing user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex Desktop authored the implementation under human direction. I used the `/instrumenting-first-party-metrics`, `/writing-tests`, `/running-ci-preflight`, and GitHub `/yeet` skills.

I chose the supported Python SDK metrics API from the pinned `posthoganalytics` version, kept the existing Temporal metrics intact, and made workflow emissions replay-safe. The PR is stacked on #76379 so the copy data import metric definitions are present.