### PR TITLE
perf(ci): keep JS-only products out of the backend merge-queue lanes

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -284,6 +284,103 @@ function listIsolatedProducts(repoRoot, products) {
     return isolated
 }
 
+// --- Nested JS workspaces ---
+
+// A product that vendors its own pnpm workspace (products/desktop is the one
+// today) has an apps/ + packages/ layout instead of the backend/ + frontend/
+// split the product rules assume. Its manifests, configs, and assets are none
+// of .py, backend/, or .tsx, so they land in the "could be either" bucket and
+// widen to every backend lane — a package.json under packages/ serializing a
+// TypeScript-only PR against all of Python.
+//
+// The workspace file is the product's own declaration of which subtrees are JS
+// packages, so it is a safer signal than an extension allowlist: a path only
+// narrows when the product itself says a JS package lives there. Anything
+// outside those subtrees (the product's root manifests, scripts/, backend/)
+// keeps the old widening behavior.
+const WORKSPACE_DECLARATION = 'pnpm-workspace.yaml'
+
+// Minimal reader for the `packages:` block of a pnpm workspace file. Only the
+// list-of-globs form is understood; anything else yields no globs, which leaves
+// the product on the old behavior rather than guessing.
+function parseWorkspacePackageGlobs(text) {
+    const globs = []
+    let inPackages = false
+    for (const rawLine of text.split('\n')) {
+        const line = rawLine.replace(/#.*$/, '').trimEnd()
+        if (!line.trim()) {
+            continue
+        }
+        if (/^packages:\s*$/.test(line)) {
+            inPackages = true
+            continue
+        }
+        if (!inPackages) {
+            continue
+        }
+        const item = line.match(/^\s+-\s+(.+)$/)
+        if (!item) {
+            break
+        }
+        globs.push(item[1].trim().replace(/^['"]|['"]$/g, ''))
+    }
+    return globs
+}
+
+function compileWorkspaceMatcher(globs) {
+    const include = []
+    const exclude = []
+    for (const glob of globs) {
+        const negated = glob.startsWith('!')
+        const matcher = globToRegExp(negated ? glob.slice(1) : glob)
+        ;(negated ? exclude : include).push(matcher)
+    }
+    if (include.length === 0) {
+        return null
+    }
+    // The globs name package directories, so a file is inside the workspace
+    // when one of its ancestor directories matches. Testing the file path
+    // itself would miss everything below the package root.
+    return (relativePath) => {
+        const segments = relativePath.split('/')
+        for (let depth = 1; depth < segments.length; depth++) {
+            const dir = segments.slice(0, depth).join('/')
+            if (include.some((re) => re.test(dir)) && !exclude.some((re) => re.test(dir))) {
+                return true
+            }
+        }
+        return false
+    }
+}
+
+function loadProductWorkspaces(repoRoot, products) {
+    const workspaces = new Map()
+    for (const product of products) {
+        const declaration = path.join(repoRoot, 'products', product, WORKSPACE_DECLARATION)
+        if (!fs.existsSync(declaration)) {
+            continue
+        }
+        let matcher
+        try {
+            matcher = compileWorkspaceMatcher(parseWorkspacePackageGlobs(fs.readFileSync(declaration, 'utf8')))
+        } catch (error) {
+            console.error(
+                `Could not read products/${product}/${WORKSPACE_DECLARATION} (${error.message}); its files keep widening to every backend lane`
+            )
+            continue
+        }
+        if (matcher) {
+            workspaces.set(product, matcher)
+        }
+    }
+    return workspaces
+}
+
+function isInProductWorkspace(product, file, productWorkspaces) {
+    const matcher = productWorkspaces.get(product)
+    return matcher ? matcher(file.slice(`products/${product}/`.length)) : false
+}
+
 // --- Contract surfaces ---
 
 const CONTRACT_TASK = 'backend:contract-check'
@@ -593,7 +690,14 @@ const feProduct = (product) => `fe:product:${product}`
 const rustCrate = (crate) => `rust:crate:${crate}`
 
 function computeTargets(changedFiles, context) {
-    const { products, isolatedProducts, rustGraph, tachGraph, contractSurfaces = new Map() } = context
+    const {
+        products,
+        isolatedProducts,
+        rustGraph,
+        tachGraph,
+        contractSurfaces = new Map(),
+        productWorkspaces = new Map(),
+    } = context
     const targets = new Set()
 
     const allPyProducts = () => {
@@ -735,11 +839,16 @@ function computeTargets(changedFiles, context) {
             }
             const isBackend = segments[2] === 'backend' || file.endsWith('.py')
             const isFrontend = segments[2] === 'frontend' || /\.tsx?$/.test(file)
+            // Only reached for a file that is neither, and only inside a
+            // package the product's own pnpm workspace declares. A .py there
+            // is still backend: the workspace says the directory holds a JS
+            // package, not that Python cannot be checked into it.
+            const isWorkspaceOnly = !isBackend && !isFrontend && isInProductWorkspace(product, file, productWorkspaces)
 
             if (isFrontend || (!isBackend && !isFrontend)) {
                 targets.add(feProduct(product))
             }
-            if (isBackend || (!isBackend && !isFrontend)) {
+            if (isBackend || (!isBackend && !isFrontend && !isWorkspaceOnly)) {
                 if (isolatedProducts.has(product)) {
                     targets.add(pyProduct(product))
                     if (touchesContractSurface(product, file, contractSurfaces)) {
@@ -853,6 +962,7 @@ function buildContext(repoRoot) {
         products,
         isolatedProducts: listIsolatedProducts(repoRoot, products),
         contractSurfaces: loadContractSurfaces(repoRoot, products),
+        productWorkspaces: loadProductWorkspaces(repoRoot, products),
         rustGraph: loadRustGraph(repoRoot),
         tachGraph: loadTachGraph(repoRoot),
     }
@@ -862,9 +972,11 @@ module.exports = {
     computeTargets,
     buildContext,
     compileContractMatcher,
+    compileWorkspaceMatcher,
     globToRegExp,
     isProductDirectory,
     isTripwire,
+    parseWorkspacePackageGlobs,
     parseCrateDependencies,
     parseCrateName,
     reverseClosure,

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -401,6 +401,63 @@ function isInProductWorkspace(product, file, productWorkspaces) {
     return WORKSPACE_OWN_FILES.includes(relativePath) || matcher(relativePath)
 }
 
+// --- Backend-detached products ---
+
+// The narrowing above stops at the layout rules: a product with a vendored
+// workspace still owns every backend lane the moment one of its files reads as
+// backend, because the product rules assume every product is a Django product
+// whose Python some other product may import. products/desktop is not one. It
+// is a standalone app imported from another repository, with no manifest.tsx,
+// no backend/, no entry in frontend/src/products.json, and its own desktop-*
+// CI. The Python it does carry is a vendored copy of that repository's own
+// tooling under tools/, which this repository's suites never load.
+//
+// Two enforced declarations say so, and both have to hold:
+//
+//   1. pytest.ini ignores the subtree, so no backend test collects a single
+//      file under it. ci-backend.yml carries the same exclusion in its path
+//      filter, but a filter tuned to over-run is not a safe source for lane
+//      assignment, while an --ignore is a statement that the suite does not
+//      cover the path at all.
+//   2. The product is absent from tach.toml, the enforced Python module graph,
+//      so no declared module may import it.
+//
+// A product satisfying both cannot fail another product's backend suite, so
+// its files claim its own lanes instead of all of them. Either condition
+// missing keeps the old widening, and so does an unreadable pytest.ini or an
+// unavailable tach graph. Both declarations are already tripwires, so a PR
+// that detaches a product cannot itself run beside anything.
+const PYTEST_CONFIG = 'pytest.ini'
+
+// Reads the --ignore paths out of pytest's addopts. Nothing matching yields an
+// empty list, which leaves every product on the old widening.
+function parsePytestIgnores(text) {
+    return [...text.matchAll(/--ignore[= ](\S+)/g)].map((match) => match[1].replace(/\/+$/, ''))
+}
+
+function loadBackendDetachedProducts(repoRoot, products, tachGraph) {
+    if (!tachGraph) {
+        return new Set()
+    }
+    let ignored
+    try {
+        ignored = new Set(parsePytestIgnores(fs.readFileSync(path.join(repoRoot, PYTEST_CONFIG), 'utf8')))
+    } catch (error) {
+        console.error(`Could not read ${PYTEST_CONFIG} (${error.message}); every product widens to all backend lanes`)
+        return new Set()
+    }
+    const detached = new Set()
+    for (const product of products) {
+        // tach spells its modules both ways across the file, so a product
+        // counts as declared under either spelling.
+        const declared = tachGraph.graph.has(product) || tachGraph.graph.has(product.replace(/_/g, '-'))
+        if (ignored.has(`products/${product}`) && !declared) {
+            detached.add(product)
+        }
+    }
+    return detached
+}
+
 // --- Contract surfaces ---
 
 const CONTRACT_TASK = 'backend:contract-check'
@@ -717,6 +774,7 @@ function computeTargets(changedFiles, context) {
         tachGraph,
         contractSurfaces = new Map(),
         productWorkspaces = new Map(),
+        backendDetachedProducts = new Set(),
     } = context
     const targets = new Set()
 
@@ -874,6 +932,10 @@ function computeTargets(changedFiles, context) {
                     if (touchesContractSurface(product, file, contractSurfaces)) {
                         changedIsolatedProducts.add(product)
                     }
+                } else if (backendDetachedProducts.has(product)) {
+                    // No backend suite covers this product and no declared
+                    // module imports it, so the lane it keeps is its own.
+                    targets.add(pyProduct(product))
                 } else {
                     allPyProducts()
                 }
@@ -978,13 +1040,15 @@ function loadTachGraph(repoRoot) {
 
 function buildContext(repoRoot) {
     const products = listProducts(repoRoot)
+    const tachGraph = loadTachGraph(repoRoot)
     return {
         products,
         isolatedProducts: listIsolatedProducts(repoRoot, products),
         contractSurfaces: loadContractSurfaces(repoRoot, products),
         productWorkspaces: loadProductWorkspaces(repoRoot, products),
+        backendDetachedProducts: loadBackendDetachedProducts(repoRoot, products, tachGraph),
         rustGraph: loadRustGraph(repoRoot),
-        tachGraph: loadTachGraph(repoRoot),
+        tachGraph,
     }
 }
 
@@ -996,6 +1060,7 @@ module.exports = {
     globToRegExp,
     isProductDirectory,
     isTripwire,
+    parsePytestIgnores,
     parseWorkspacePackageGlobs,
     parseCrateDependencies,
     parseCrateName,

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -290,8 +290,8 @@ function listIsolatedProducts(repoRoot, products) {
 // today) has an apps/ + packages/ layout instead of the backend/ + frontend/
 // split the product rules assume. Its manifests, configs, and assets are none
 // of .py, backend/, or .tsx, so they land in the "could be either" bucket and
-// widen to every backend lane — a package.json under packages/ serializing a
-// TypeScript-only PR against all of Python.
+// widen to every backend lane, which is how a package.json under packages/
+// serializes a TypeScript-only PR against all of Python.
 //
 // The workspace file is the product's own declaration of which subtrees are JS
 // packages, so it is a safer signal than an extension allowlist: a path only
@@ -299,6 +299,22 @@ function listIsolatedProducts(repoRoot, products) {
 // outside those subtrees (the product's root manifests, scripts/, backend/)
 // keeps the old widening behavior.
 const WORKSPACE_DECLARATION = 'pnpm-workspace.yaml'
+
+// pnpm's own two files at the product root. A pnpm-workspace.yaml makes that
+// directory a workspace root rather than a member of the repo-root one, so the
+// lockfile beside it resolves that workspace's packages and nothing else. The
+// repo-root lockfile is a separate file and stays a tripwire in its own right.
+// Neither of these is importable from Python, and neither is a contract
+// declaration, so without this rule they fall through the layout checks below
+// and claim every backend lane: a desktop dependency bump lands in the same
+// lane as all of Python.
+//
+// The self-gating hazard that keeps CONTRACT_DECLARATIONS widening does not
+// transfer here. turbo.json and package.json declare a Python import surface,
+// so a PR that narrows one and edits under it in the same commit would gate
+// itself against its own new contract. This pair declares no Python surface,
+// and the .py carve-out below applies whatever the globs say.
+const WORKSPACE_OWN_FILES = [WORKSPACE_DECLARATION, 'pnpm-lock.yaml']
 
 // Minimal reader for the `packages:` block of a pnpm workspace file. Only the
 // list-of-globs form is understood; anything else yields no globs, which leaves
@@ -378,7 +394,11 @@ function loadProductWorkspaces(repoRoot, products) {
 
 function isInProductWorkspace(product, file, productWorkspaces) {
     const matcher = productWorkspaces.get(product)
-    return matcher ? matcher(file.slice(`products/${product}/`.length)) : false
+    if (!matcher) {
+        return false
+    }
+    const relativePath = file.slice(`products/${product}/`.length)
+    return WORKSPACE_OWN_FILES.includes(relativePath) || matcher(relativePath)
 }
 
 // --- Contract surfaces ---

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -18,6 +18,7 @@ const {
     isProductDirectory,
     isTripwire,
     parseCrateDependencies,
+    parsePytestIgnores,
     parseWorkspacePackageGlobs,
     reverseClosure,
     ALL,
@@ -449,6 +450,37 @@ test('the vendored workspace files claim only the product lane', () => {
     assert.equal(
         computeTargets(['products/alpha/pnpm-lock.yaml'], WORKSPACE_CONTEXT).includes('py:product:alpha'),
         true
+    )
+})
+
+// delta stands in for products/desktop: an app imported from another
+// repository that pytest.ini ignores and tach.toml never declares. Its
+// vendored .py files read as backend to the layout rules, so without the
+// detachment check they claim every backend lane for suites that never run on
+// them.
+const DETACHED_CONTEXT = {
+    ...WORKSPACE_CONTEXT,
+    products: [...CONTEXT.products, 'delta'],
+    backendDetachedProducts: new Set(['delta']),
+}
+
+test('a backend-detached product keeps its own lane instead of every backend lane', () => {
+    assert.deepEqual(computeTargets(['products/delta/tools/agent/policy.py'], DETACHED_CONTEXT), ['py:product:delta'])
+    assert.deepEqual(computeTargets(['products/delta/biome.json'], DETACHED_CONTEXT), [
+        'fe:product:delta',
+        'py:product:delta',
+    ])
+    // gamma is ignored by neither declaration, so the same shapes still widen.
+    assert.equal(computeTargets(['products/gamma/tools/agent/policy.py'], DETACHED_CONTEXT).includes('py:core'), true)
+})
+
+// pytest.ini spells the list inside one long addopts line, so a reader anchored
+// to the start of a line finds nothing and silently leaves every product
+// widening.
+test('pytest ignores are read from anywhere in addopts', () => {
+    assert.deepEqual(
+        parsePytestIgnores('addopts = -p no:warnings --ignore=tools/hogli --ignore=products/desktop --reuse-db'),
+        ['tools/hogli', 'products/desktop']
     )
 })
 

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -437,6 +437,21 @@ test('files outside the declared workspace packages keep widening', () => {
     }
 })
 
+// The workspace declaration and its lockfile sit at the product root, so the
+// glob matcher alone leaves them in the "claims both domains" case and a
+// dependency bump in the vendored workspace still claims every backend lane.
+// The second assertion is the boundary: a product with no declaration keeps
+// the old widening, which a basename-only version of this rule would lose.
+test('the vendored workspace files claim only the product lane', () => {
+    for (const file of ['products/gamma/pnpm-workspace.yaml', 'products/gamma/pnpm-lock.yaml']) {
+        assert.deepEqual(computeTargets([file], WORKSPACE_CONTEXT), ['fe:product:gamma'], file)
+    }
+    assert.equal(
+        computeTargets(['products/alpha/pnpm-lock.yaml'], WORKSPACE_CONTEXT).includes('py:product:alpha'),
+        true
+    )
+})
+
 // A real pnpm-workspace.yaml carries a catalog: block right after packages:,
 // and reading past the list would turn catalog entries into package globs.
 test('workspace globs are read only from the packages block', () => {

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -13,10 +13,12 @@ const assert = require('node:assert/strict')
 const {
     computeTargets,
     compileContractMatcher,
+    compileWorkspaceMatcher,
     globToRegExp,
     isProductDirectory,
     isTripwire,
     parseCrateDependencies,
+    parseWorkspacePackageGlobs,
     reverseClosure,
     ALL,
 } = require('./trunk-impacted-targets')
@@ -42,6 +44,13 @@ const CONTEXT = {
         // Mirrors turbo-discover's dashed-name contract at the boundary.
         tachDependents: (changed) => (changed.includes('alpha') ? ['beta', 'gamma'] : []),
     },
+}
+
+// gamma vendors its own pnpm workspace; alpha and beta keep the conventional
+// backend/ + frontend/ layout, so the cases above stay on the old behavior.
+const WORKSPACE_CONTEXT = {
+    ...CONTEXT,
+    productWorkspaces: new Map([['gamma', compileWorkspaceMatcher(['apps/*', 'packages/*', 'tooling/*'])]]),
 }
 
 test('every tripwire forces ALL', () => {
@@ -393,6 +402,68 @@ test('a product file that is neither backend nor frontend claims both domains', 
     const targets = computeTargets(['products/beta/mcp/tools.yaml'], CONTEXT)
     assert.equal(targets.includes('py:product:beta'), true)
     assert.equal(targets.includes('fe:product:beta'), true)
+})
+
+// A product vendoring its own pnpm workspace has no backend/ + frontend/ split,
+// so its manifests and configs land in the "claims both domains" case above and
+// drag every backend lane along. Narrowing them is the whole point of reading
+// the workspace declaration.
+test('a file inside a declared workspace package claims only the product lane', () => {
+    for (const file of [
+        'products/gamma/packages/agent/package.json',
+        'products/gamma/apps/code/snapshots.yml',
+        'products/gamma/tooling/config/biome.json',
+        'products/gamma/apps/code/assets/icon.svg',
+    ]) {
+        assert.deepEqual(computeTargets([file], WORKSPACE_CONTEXT), ['fe:product:gamma'], file)
+    }
+})
+
+// The narrowing direction is the dangerous one: a backend lane that stops being
+// claimed lets Trunk run this PR beside a conflicting backend PR. The workspace
+// declaration says a directory holds a JS package, not that Python cannot be
+// checked into it.
+test('python inside a declared workspace package still claims the backend lanes', () => {
+    const targets = computeTargets(['products/gamma/packages/agent/scripts/codegen.py'], WORKSPACE_CONTEXT)
+    assert.equal(targets.includes('py:core'), true)
+})
+
+// Only the declared package subtrees narrow. The product root holds the files
+// that decide isolation and contract surface, and anything else under the
+// product is unclassified in the same way it was before.
+test('files outside the declared workspace packages keep widening', () => {
+    for (const file of ['products/gamma/package.json', 'products/gamma/scripts/release.mjs']) {
+        assert.equal(computeTargets([file], WORKSPACE_CONTEXT).includes('py:core'), true, file)
+    }
+})
+
+// A real pnpm-workspace.yaml carries a catalog: block right after packages:,
+// and reading past the list would turn catalog entries into package globs.
+test('workspace globs are read only from the packages block', () => {
+    assert.deepEqual(
+        parseWorkspacePackageGlobs(
+            [
+                'packages:',
+                "  - 'apps/*'",
+                '  - packages/*',
+                '  - "!packages/legacy"',
+                '',
+                'catalog:',
+                '  hono: ^1.0.0',
+            ].join('\n')
+        ),
+        ['apps/*', 'packages/*', '!packages/legacy']
+    )
+})
+
+test('a negated workspace glob excludes its subtree from the narrowing', () => {
+    const matcher = compileWorkspaceMatcher(['packages/*', '!packages/legacy'])
+    assert.equal(matcher('packages/agent/package.json'), true)
+    assert.equal(matcher('packages/legacy/package.json'), false)
+})
+
+test('a workspace declaration with no packages block yields no matcher', () => {
+    assert.equal(compileWorkspaceMatcher(parseWorkspacePackageGlobs('catalog:\n  hono: ^1.0.0\n')), null)
 })
 
 // tools/ is not one bucket. phrocs is Go with its own CI and nothing imports


### PR DESCRIPTION
## Problem

`products/desktop` is an app imported from another repository. It vendors its own pnpm workspace, so it has an `apps/` + `packages/` layout instead of the `backend/` + `frontend/` split the lane rules assume, and the product classifier keys off extension and directory:

```js
const isBackend  = segments[2] === 'backend' || file.endsWith('.py')
const isFrontend = segments[2] === 'frontend' || /\.tsx?$/.test(file)
// neither -> assume both -> allPyProducts() for a non-isolated product
```

A `package.json` under `packages/`, a `snapshots.yml` under `apps/`, an icon, a font, the two pnpm files at the product root, `postcss.config.mjs`, the 32 vendored `.py` files under `tools/`: every one of them claimed **all 82 Python lanes**. That is 889 of desktop's 4,806 tracked files, 18% of the tree, each serializing against every backend PR in the queue.

Measured against the open PRs touching `products/desktop` when this was written, 3 of 14 were widened purely by this, with a TypeScript-only footprint otherwise:

| PR | Trigger file | Lanes before |
|---|---|---|
| #76472 | `products/desktop/packages/agent/package.json` | 83 |
| #76471 | `products/desktop/apps/code/snapshots.yml` | 83 |
| #76416 | `products/desktop/packages/harness/package.json` | 83 |

Replaying the last 500 merged PRs finds two more: #76339 (a 188-file desktop resync) and #76340, both at 83 lanes for a change no Python suite runs on.

## Changes

Two rules, each keyed off a declaration the repo already enforces.

**1. A file inside a subtree the product's own `pnpm-workspace.yaml` declares as a package is frontend-only**, along with the two files pnpm itself owns at the workspace root (`pnpm-workspace.yaml`, `pnpm-lock.yaml`). The declaration is the signal rather than an extension allowlist, so a path narrows only where the product itself says a JS package lives. A `pnpm-workspace.yaml` makes its directory a workspace root rather than a member of the repo-root one (the root file excludes `products/desktop` explicitly), so the lockfile beside it resolves that workspace's packages and nothing else. The repo-root `pnpm-lock.yaml` stays a tripwire in its own right.

**2. A product with no backend surface claims its own lane instead of all of them.** Two enforced declarations have to hold together:

- `pytest.ini` ignores the subtree (`--ignore=products/desktop`), so no backend test collects a file under it. `ci-backend.yml` carries the same exclusion in its path filter, but a filter tuned to over-run is not a safe source for lane assignment, while an `--ignore` states the suite does not cover the path at all.
- The product is absent from `tach.toml`, the enforced Python module graph, so no declared module may import it.

`products/desktop` is the only product satisfying both today. It also has no `manifest.tsx`, no `backend/`, and no entry in `frontend/src/products.json`, and nothing in this repo's Python imports it. Its `.py` files are a vendored copy of the upstream repository's own tooling.

What deliberately keeps the old widening:

- **`.py` inside a declared workspace package** of a product that is *not* backend-detached. The workspace says a directory holds a JS package, not that Python cannot be checked into it.
- **`products/<p>/package.json` and `turbo.json`**, which decide isolation and contract surface, so `CONTRACT_DECLARATIONS` has to keep seeing them.
- **Anything outside the declared globs** for a product that still has a backend surface.
- **Every fallback.** No `pnpm-workspace.yaml`, an unparseable one, an unreadable `pytest.ini`, or an unavailable tach graph all leave the product exactly where it was.

> [!NOTE]
> Narrowing is the dangerous direction here: a backend lane that stops being claimed lets Trunk run two conflicting PRs in parallel. Both rules are gated on declarations that CI enforces, and `pytest.ini`, `tach.toml`, and the repo-root `pnpm-lock.yaml` are all tripwires, so a PR that changes what these rules read cannot itself run beside anything.

## How did you test this code?

`node --test .github/scripts/trunk-impacted-targets.test.js` — 45 pass, 9 new.

The new cases each guard a distinct regression rather than restating the implementation: the workspace narrowing itself; the two root pnpm files, plus the boundary that a product without a declaration keeps widening (which a basename-only rule would lose); `.py` inside a declared package still claiming backend lanes for a product that has one (the unsafe direction); files outside the declared globs still widening; the detached product keeping its own lane while a non-detached product with the same file shapes still widens; and parser cases for both readers, since `pnpm-workspace.yaml` carries a `catalog:` block right after `packages:` that a looser reader would swallow, and `pytest.ini` spells its ignores inside one long `addopts` line where a line-anchored reader finds nothing.

**Whole-tree differential against master.** Both versions run over every tracked file under `products/`, target sets diffed:

```
files compared: 20569
unchanged     : 19680
NARROWED      :   889   (all products/desktop)
WIDENED       :     0
```

No product other than desktop changes by a single file, and nothing widens anywhere. Every desktop file that claimed `py:core` under master now claims only `fe:product:desktop` / `py:product:desktop`; the count of desktop files still reaching a backend lane is zero. #76407, which genuinely touches `posthog/api/comments.py` alongside desktop files, still claims all 86 lanes.

**Against the last 500 merged PRs.** Replaying each PR's file list through both versions, two move: #76339 from 83 lanes to 1, and #76340 from 83 to 2. No PR gains a lane.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable. The rationale lives in the script's own header comments, which this PR extends.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This started as asking Claude (Claude Code) whether the existing fallback was too aggressive. It measured the open desktop PRs first, and the answer moved from "probably" to a specific number, which is what shaped the first rule. The second came from replaying the last 500 merged PRs and asking why desktop was still widening at all, which surfaced that the product has no backend surface in this repository whatsoever.

Decisions worth a reviewer's eye:

- I considered simply adding `.json`/`.yml`/asset extensions to `isFrontend`. Rejected: a product could keep a Python-consumed YAML at its root outside `backend/`, and that fix would silently narrow it. Both rules here key off a declaration instead, so neither can reach a product that has not made the statement.
- Detachment is deliberately two conditions rather than one. A pytest `--ignore` alone would narrow a product whose Python another product still imports; requiring absence from `tach.toml` closes that.
- `products/desktop/package.json` and `turbo.json` still widen, because those feed `CONTRACT_DECLARATIONS` and untangling the two is a bigger change than this should be. They are the only desktop paths left that reach beyond the product's own lanes, and rule 2 means they no longer reach the backend ones.

Earlier revisions of this description quoted 87 products and 88 lanes. That came from a local tree where six stale directories under `products/` (build artifacts left by deleted products) were read as products. The numbers here are from a clean checkout: 81 products, so 82 backend lanes.

`/writing-tests` and `/writing-code-comments` invoked before the test and comment edits.
