### PR TITLE
fix(data-imports): guide users to reconnect on a rejected Sentry token

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -920,7 +920,7 @@ def validate_credentials(
         if response.status_code == 200:
             return True, None
         if response.status_code == 401:
-            return False, "Invalid Sentry auth token"
+            return False, "Invalid Sentry auth token. Please update your token and reconnect."
         if response.status_code == 403:
             return (
                 False,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -267,6 +267,15 @@ class TestSentryTransport:
         )
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.make_tracked_session")
+    def test_validate_credentials_401_tells_user_to_reconnect(self, mock_session) -> None:
+        mock_session.return_value.get.return_value = _response(None, status_code=401)
+
+        valid, error = validate_credentials(auth_token="token", organization_slug="acme")
+
+        assert not valid
+        assert error == "Invalid Sentry auth token. Please update your token and reconnect."
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.make_tracked_session")
     def test_validate_credentials_403_names_required_scopes(self, mock_session) -> None:
         mock_session.return_value.get.return_value = _response(None, status_code=403)
 


### PR DESCRIPTION
## Problem

During data-warehouse onboarding, a user connecting Sentry as a source who supplies a token that Sentry rejects with a 401 saw only `Invalid Sentry auth token`. That reports the failure but gives no next step, so users who believe they followed the setup steps get stuck.

The sync-time failure path for the same 401 already uses friendlier, actionable wording (`Invalid Sentry auth token. Please update your token and reconnect.`). The create-time credential check did not match it.

## Changes

Align the create-time 401 message with the sync-time one so it points to a next action: update the token and reconnect.

## How did you test this code?

Added one case, `test_validate_credentials_401_tells_user_to_reconnect`, alongside the existing 403 test. It locks in the actionable 401 message so a future edit can't silently revert to the bare version; no existing test covered the 401 path. Ran it plus the neighbouring 403 test locally (`pytest ... -k "validate_credentials_401 or validate_credentials_403"`) — both pass. Ran `ruff check` and `ruff format --check` on both touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

This came out of a review of anonymized data-warehouse onboarding session summaries, where one user was blocked connecting Sentry by a terse credential error. The fix reuses the wording the sync-time path already ships, so no new copy was invented. Invoked `/writing-user-facing-copy` (sentence case, next-step guidance, no em-dash) and `/writing-tests` (added a single case that guards a real regression rather than padding coverage).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
