### PR TITLE
perf(ci): give non-isolated product declarations a per-product lane

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -577,9 +577,13 @@ function loadContractSurfaces(repoRoot, products) {
 // exactly when the dependents most need to be tested alongside it.
 const CONTRACT_DECLARATIONS = ['turbo.json', 'package.json']
 
+function isContractDeclaration(product, file) {
+    return CONTRACT_DECLARATIONS.includes(file.slice(`products/${product}/`.length))
+}
+
 function touchesContractSurface(product, file, contractSurfaces) {
     const relativePath = file.slice(`products/${product}/`.length)
-    if (CONTRACT_DECLARATIONS.includes(relativePath)) {
+    if (isContractDeclaration(product, file)) {
         return true
     }
     const matcher = contractSurfaces.get(product)
@@ -791,7 +795,7 @@ function computeTargets(changedFiles, context) {
         }
     }
 
-    const changedIsolatedProducts = new Set()
+    const cascadeSeeds = new Set()
     let inertFiles = 0
 
     for (const file of changedFiles) {
@@ -930,12 +934,24 @@ function computeTargets(changedFiles, context) {
                 if (isolatedProducts.has(product)) {
                     targets.add(pyProduct(product))
                     if (touchesContractSurface(product, file, contractSurfaces)) {
-                        changedIsolatedProducts.add(product)
+                        cascadeSeeds.add(product)
                     }
                 } else if (backendDetachedProducts.has(product)) {
                     // No backend suite covers this product and no declared
-                    // module imports it, so the lane it keeps is its own.
+                    // module imports it, so the lane it keeps is its own. This
+                    // case comes first because it also answers the declaration
+                    // case below: a product absent from the module graph has no
+                    // importers for the cascade to name.
                     targets.add(pyProduct(product))
+                } else if (isContractDeclaration(product, file)) {
+                    // A non-isolated product's backend code has no declared
+                    // boundary, so it keeps widening below. Its declarations
+                    // are a different kind of file: they configure this
+                    // product's own tasks, including the backend:test command
+                    // most of them carry, and every importer that a change to
+                    // them can reach is named by the cascade instead.
+                    targets.add(pyProduct(product))
+                    cascadeSeeds.add(product)
                 } else {
                     allPyProducts()
                 }
@@ -956,11 +972,12 @@ function computeTargets(changedFiles, context) {
     // backend target. Only 14 of the products declare a contract check, so
     // widening on each of them would collapse every cascade to the full set.
     //
-    // The seeds are the products whose contract surface changed, and the
-    // dependents are one hop deep. See the two numbered narrowings at the top
-    // of this file for what that gives up.
-    if (changedIsolatedProducts.size > 0) {
-        const dependents = tachDependentProducts([...changedIsolatedProducts], tachGraph)
+    // The seeds are the products whose contract surface changed, plus any
+    // product whose own declarations changed, and the dependents are one hop
+    // deep. See the two numbered narrowings at the top of this file for what
+    // that gives up.
+    if (cascadeSeeds.size > 0) {
+        const dependents = tachDependentProducts([...cascadeSeeds], tachGraph)
         if (dependents === null) {
             allPyProducts()
         } else {

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -364,6 +364,41 @@ test('a non-isolated product change widens to every backend target', () => {
     }
 })
 
+// 63 of the products are non-isolated, and their package.json carries the
+// backend:test command rather than being a bare JS manifest. It still claims a
+// backend lane, just this product's own plus its importers, instead of dragging
+// in every other product's.
+test("a non-isolated product's declarations claim its own lane, not every backend lane", () => {
+    for (const file of ['products/gamma/package.json', 'products/gamma/turbo.json']) {
+        assert.deepEqual(computeTargets([file], CONTEXT), ['fe:product:gamma', 'py:product:gamma'], file)
+    }
+})
+
+test("a non-isolated product's declarations still seed the dependent cascade", () => {
+    const context = {
+        ...CONTEXT,
+        tachGraph: { graph: new Map(), tachDependents: (changed) => (changed.includes('gamma') ? ['alpha'] : []) },
+    }
+    assert.deepEqual(computeTargets(['products/gamma/package.json'], context), [
+        'fe:product:gamma',
+        'py:product:alpha',
+        'py:product:gamma',
+    ])
+})
+
+// The narrowing is scoped to the declarations. Backend code in a non-isolated
+// product has no declared boundary, which is the whole reason it widens.
+test('a non-isolated product keeps widening on everything that is not a declaration', () => {
+    for (const file of ['products/gamma/backend/api.py', 'products/gamma/mcp/tools.yaml']) {
+        assert.equal(computeTargets([file], CONTEXT).includes('py:product:alpha'), true, file)
+    }
+})
+
+test('an unavailable tach graph widens a declaration change too', () => {
+    const noTach = { ...CONTEXT, tachGraph: null }
+    assert.equal(computeTargets(['products/gamma/package.json'], noTach).includes('py:core'), true)
+})
+
 test('an unavailable tach graph widens backend changes instead of narrowing', () => {
     const noTach = { ...CONTEXT, tachGraph: null }
     const targets = computeTargets(['products/alpha/backend/api.py'], noTach)
@@ -432,10 +467,12 @@ test('python inside a declared workspace package still claims the backend lanes'
 // Only the declared package subtrees narrow. The product root holds the files
 // that decide isolation and contract surface, and anything else under the
 // product is unclassified in the same way it was before.
-test('files outside the declared workspace packages keep widening', () => {
-    for (const file of ['products/gamma/package.json', 'products/gamma/scripts/release.mjs']) {
-        assert.equal(computeTargets([file], WORKSPACE_CONTEXT).includes('py:core'), true, file)
-    }
+test('files outside the declared workspace packages keep their backend claim', () => {
+    // The root declarations get the narrower per-product treatment below rather
+    // than the workspace one, so what matters here is that they still claim a
+    // backend lane instead of being read as a JS manifest.
+    assert.equal(computeTargets(['products/gamma/package.json'], WORKSPACE_CONTEXT).includes('py:product:gamma'), true)
+    assert.equal(computeTargets(['products/gamma/scripts/release.mjs'], WORKSPACE_CONTEXT).includes('py:core'), true)
 })
 
 // The workspace declaration and its lockfile sit at the product root, so the


### PR DESCRIPTION
> [!NOTE]
> Stacked on #76481. Review that one first; this PR's diff is against it, not master.

## Problem

`products/<p>/package.json` and `products/<p>/turbo.json` claim **all 87 backend lanes** for the 63 non-isolated products. A non-isolated product widens on any file the frontend rules don't claim, and neither of those is `.tsx`.

The 15 isolated products already get the narrow treatment for the same two files — their own lane plus the tach dependent cascade:

```
products/error_tracking/package.json  ->  8 lanes   (isolated)
products/endpoints/package.json       ->  3 lanes   (isolated)
products/actions/package.json         -> 89 lanes   (non-isolated)
products/desktop/package.json         -> 89 lanes   (non-isolated)
```

Nothing about the file justifies the difference. Isolation governs whether a product's *backend code* can be tested alone; these two files aren't backend code.

## Changes

A non-isolated product's `CONTRACT_DECLARATIONS` (`turbo.json`, `package.json`) now claim `py:product:<p>` and seed the dependent cascade, instead of `allPyProducts()`. Everything else in a non-isolated product widens exactly as before.

Renamed `changedIsolatedProducts` to `cascadeSeeds`, since the set is no longer isolated-only.

**Why these two files and nothing else.** I checked what they actually contain before narrowing them. 69 of 78 products keep their backend test command right there:

```json
"scripts": {
    "backend:test": "pytest -c ../../pytest.ini --rootdir ../.. backend/ -v --tb=short"
}
```

So they are not bare JS manifests, and this PR deliberately does **not** treat them as frontend-only — they keep a backend claim. What changes is the blast radius: the product's own lane plus every importer the tach cascade names, rather than every product in the repo. The cascade is the same mechanism the isolated products rely on, and `tach check` runs in CI so the graph can't drift.

> [!WARNING]
> This extends to non-isolated products a trust we previously reserved for isolated ones, for these two files. If the tach graph is unavailable the code still falls back to `allPyProducts()`, and there's a test for that, but the policy call is worth a reviewer's opinion rather than mine.

## How did you test this code?

`node --test .github/scripts/trunk-impacted-targets.test.js` — 46 pass, 4 new.

The new cases cover the narrowing, the cascade seeding, that non-declaration files in the same product still widen, and that an unavailable tach graph widens a declaration change. I also updated one case from #76481 whose expectation this supersedes: it asserted the product root still reached `py:core`, and now asserts it still claims a backend lane (`py:product:gamma`) — the property it was actually guarding, which is that the workspace narrowing doesn't swallow the product root.

**Whole-tree differential against #76481's head**, all 20,555 tracked files under `products/`:

```
unchanged : 20488
NARROWED  :    67   (only basenames: package.json, turbo.json)
WIDENED   :     0
```

Every narrowed file is a product-root declaration, 89 lanes down to 2-13. Spot checks: `products/desktop/package.json` → `['fe:product:desktop', 'py:product:desktop']`; `products/actions/package.json` → 13 lanes including its 11 tach dependents; `products/actions/backend/api.py` still → 88 lanes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable. The rationale lives in the script's own header comments.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #76481. I asked Claude (Claude Code) whether the same idea extended to every `package.json` in the repo outside the root; the answer was no, and finding out why is what produced this narrower change.

Two rejected approaches worth recording:

- **Treating a nested `package.json` as a JS manifest and dropping its backend claim.** Rejected on the `backend:test` evidence above. Repo-wide the case doesn't exist anyway: of 137 `package.json` files, 52 already claim no Python lane, 16 are the isolated products, and the only non-product ones that widen are `common/hogql_parser`, `common/hogvm/typescript`, and `common/plugin_transpiler`, which are genuinely Python-coupled.
- **"No `backend:*` script means no Python effect."** Only 9 products qualify, and the rule inverts on deletion: removing `backend:test` would classify as frontend-only precisely when the change is most backend-relevant.

`/writing-tests` invoked before adding the test cases.
