### PR TITLE
fix(mysql): map datetime values to pyarrow when absent from batch schema

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -759,6 +759,16 @@ def _python_type_to_pyarrow_type(type_: type, value: Any):
 
         return pa.decimal256(DEFAULT_NUMERIC_PRECISION, DEFAULT_NUMERIC_SCALE)
 
+    # `datetime` before `date`: `datetime.datetime` subclasses `datetime.date`.
+    if issubclass(type_, datetime.datetime) and isinstance(value, datetime.datetime):
+        return pa.timestamp("us", tz="UTC") if value.tzinfo is not None else pa.timestamp("us")
+
+    if issubclass(type_, datetime.date) and isinstance(value, datetime.date):
+        return pa.date32()
+
+    if issubclass(type_, datetime.time) and isinstance(value, datetime.time):
+        return pa.time64("us")
+
     raise ValueError(f"Python type {type_} has no pyarrow mapping")
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -320,6 +320,25 @@ def test_table_from_py_list_with_null_filled_binary_column():
 
 
 @pytest.mark.parametrize(
+    "value, expected_type",
+    [
+        (datetime.datetime(2024, 1, 2, 3, 4, 5), pa.timestamp("us")),
+        (datetime.datetime(2024, 1, 2, 3, 4, 5, tzinfo=datetime.UTC), pa.timestamp("us", tz="UTC")),
+        (datetime.date(2024, 1, 2), pa.date32()),
+        (datetime.time(3, 4, 5), pa.time64("us")),
+    ],
+)
+def test_table_from_py_list_schema_missing_temporal_column(value, expected_type):
+    # A column present in the batch but absent from the provided schema is typed via
+    # `_python_type_to_pyarrow_type`; temporal values used to crash it with "no pyarrow mapping".
+    schema = pa.schema(cast(Any, [pa.field("id", pa.int64())]))
+    table = table_from_py_list([{"id": 1, "ts": value}], schema)
+
+    assert table.schema.field("ts").type == expected_type
+    assert table.column("ts").to_pylist() == [value]
+
+
+@pytest.mark.parametrize(
     "error_msg, large_type, values",
     [
         (

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -329,8 +329,8 @@ def test_table_from_py_list_with_null_filled_binary_column():
     ],
 )
 def test_table_from_py_list_schema_missing_temporal_column(value, expected_type):
-    # A column present in the batch but absent from the provided schema is typed via
-    # `_python_type_to_pyarrow_type`; temporal values used to crash it with "no pyarrow mapping".
+    # A column present in the batch but absent from the provided schema has its Arrow field
+    # inferred by `_python_type_to_pyarrow_type`, which must handle temporal values.
     schema = pa.schema(cast(Any, [pa.field("id", pa.int64())]))
     table = table_from_py_list([{"id": 1, "ts": value}], schema)
 


### PR DESCRIPTION
## Problem

The MySQL data-warehouse import surfaced this in error tracking:

> `ValueError: Python type <class 'datetime.datetime'> has no pyarrow mapping`

raised from `_python_type_to_pyarrow_type` in the shared Arrow batch helper (`pipelines/core/arrow_utils.py`), on the MySQL streaming sync path.

Here's the call path. MySQL builds an Arrow schema from `information_schema.columns` up front, then streams rows and hands each batch to `table_from_iterator(..., arrow_schema)`. Inside `_process_batch`, any column that shows up in the batch but is missing from that provided schema gets its Arrow field inferred on the fly via `_python_type_to_pyarrow_type`. That helper only mapped `int`, `float`, `str`, `bool`, `bytes`, `None`, `dict`, `list`, and `Decimal`. A `datetime` value reaching it fell straight through to the `raise ValueError(...)`, killing the sync.

The batch column data itself was fine (`pa.array([...])` infers a timestamp type for datetimes natively) - only the schema-field inference lacked the mapping. So a schema/data column divergence on a datetime column was enough to crash the whole table sync.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fc562-3a7b-7532-b371-64fe08d9e428

## Changes

This is a fixable bug, not a user/upstream error - `datetime` is a first-class Python type pyarrow supports, and it should never crash type inference. I taught `_python_type_to_pyarrow_type` the temporal types, mapping them the same way the schema path (`to_arrow_field`) and `DLT_TO_PA_TYPE_MAP` already do:

- `datetime.datetime` -> `pa.timestamp("us")` (or `tz="UTC"` when the value is timezone-aware)
- `datetime.date` -> `pa.date32()`
- `datetime.time` -> `pa.time64("us")`

`datetime` is checked before `date` since `datetime.datetime` subclasses `datetime.date`.

The fix lives in the shared helper rather than the MySQL source because the helper is the right layer: it's a generic Python-to-Arrow type map that any source's batch path can reach, and the gap it had was a first-class type it simply didn't cover.

> [!NOTE]
> Scoped strictly to the temporal types behind this error. No retry-policy or unrelated behavior changes.

## How did you test this code?

Added a parameterized regression test `test_table_from_py_list_schema_missing_temporal_column` covering `datetime`/`date`/`time` (naive and tz-aware) columns present in a batch but absent from the provided schema - the exact shape that crashed. It fails on master with the reported `no pyarrow mapping` error and passes with the fix.

I (Claude) ran:

- The new test (4 cases) - passes with the fix, fails without it (confirmed by stashing the `arrow_utils.py` change and re-running).
- The full `test_utils.py` file - 140 passed.
- `ruff check` and `ruff format` on both changed files.

I did not run a live MySQL sync.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) pulled the issue and a representative event over the PostHog MCP, traced the stack from the MySQL streaming path (`build_pipeline` -> `table_from_iterator` -> `_process_batch`) into the shared `_python_type_to_pyarrow_type`, and confirmed the crash is a missing type mapping rather than bad customer data or credentials - so it's a code fix, not a `NonRetryableErrors` addition.

Considered fixing at the MySQL layer (forcing the streaming column set to match the discovered schema) but rejected it: the helper is generic and reachable by every source's batch path, and the real defect is that a first-class Python type had no mapping. Fixing it there is smaller, lower-risk, and protects all sources.

Invoked the `/writing-tests` skill before adding the regression test.
