### PR TITLE
fix(warehouse): reuse managed staging S3 secret

### DIFF
--- a/products/managed_warehouse/backend/storage.py
+++ b/products/managed_warehouse/backend/storage.py
@@ -509,6 +509,7 @@ def get_deltalake_storage_options(
 
 
 STAGING_PREFIX = "__posthog_staging"
+_STAGING_READ_SECRET_NAME = "posthog_staging_delta_https"
 
 
 def compute_staging_uri(source_uri: str, catalog_bucket: str) -> str:
@@ -680,20 +681,23 @@ def setup_duckgres_session(
 
 
 def create_staging_read_secret(conn: psycopg.Connection, catalog_bucket: str) -> None:
-    """Pin HTTPS for delta-kernel reads of the staging tree on this session.
+    """Ensure delta-kernel staging reads use scoped HTTPS credentials.
 
-    On cache-proxy-enabled duckgres clusters the org's ambient S3 secret carries
-    USE_SSL false so httpfs traffic flows through the logging proxy — but
-    delta_scan's delta-kernel object store ignores DuckDB's proxy and dials the
-    plain-HTTP S3 endpoint directly, which worker egress silently drops (10
-    retries, ~58s, then failure — on every attempt). This longer-SCOPE session
-    secret wins prefix resolution for the staging tree only and forces direct
-    HTTPS (allowed egress) using the worker's own ambient credentials; the
-    region also resolves from the worker's chain. Session-scoped on purpose:
-    duckgres wipes non-persistent secrets at the next session create.
+    Duckgres activation creates this secret with the worker's temporary S3
+    credentials. Replacing it with a credential-chain secret would discard
+    credentials that are intentionally unavailable through DuckDB's provider
+    chain. Older deployments do not create the managed secret, so they retain
+    the existing credential-chain fallback.
     """
+    secret_exists = conn.execute(
+        "SELECT EXISTS (SELECT 1 FROM duckdb_secrets() WHERE name = %s)",
+        (_STAGING_READ_SECRET_NAME,),
+    ).fetchone()
+    if secret_exists is not None and secret_exists[0] is True:
+        return
+
     conn.execute(
-        "CREATE OR REPLACE SECRET posthog_staging_delta_https ("
+        f"CREATE OR REPLACE SECRET {_STAGING_READ_SECRET_NAME} ("
         "TYPE S3, PROVIDER credential_chain, USE_SSL true, "
         f"SCOPE 's3://{catalog_bucket}/{STAGING_PREFIX}')"
     )

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_copy_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_copy_data_imports_workflow.py
@@ -625,10 +625,8 @@ def test_copy_data_imports_to_ducklake_activity_via_duckgres(monkeypatch):
     assert any("CREATE OR REPLACE TABLE" in str(call) for call in execute_calls)
     assert any("delta_scan" in str(call) for call in execute_calls)
 
-    # delta-kernel ignores DuckDB's proxy transport and dials the org secret's
-    # plain-HTTP endpoint directly, which worker egress silently drops (~58s
-    # failure per attempt). The session must pin an HTTPS credential-chain
-    # secret over the staging tree BEFORE any delta_scan runs.
+    # Older deployments rely on the client fallback to create the scoped HTTPS
+    # secret before delta_scan runs.
     secret_idx = next(
         i for i, call in enumerate(execute_calls) if "CREATE OR REPLACE SECRET posthog_staging_delta_https" in str(call)
     )

--- a/products/managed_warehouse/backend/tests/test_storage.py
+++ b/products/managed_warehouse/backend/tests/test_storage.py
@@ -8,6 +8,7 @@ from products.managed_warehouse.backend.storage import (
     _DELTA_LOG_VERSION_RE,
     DuckLakeStorageConfig,
     _collect_delta_log_keys,
+    create_staging_read_secret,
     normalize_endpoint,
 )
 
@@ -26,6 +27,30 @@ class TestNormalizeEndpoint:
     )
     def test_normalize_endpoint(self, input_endpoint, expected):
         assert normalize_endpoint(input_endpoint) == expected
+
+
+class TestCreateStagingReadSecret:
+    @parameterized.expand(
+        [
+            ("managed_secret_exists", True, 1),
+            ("managed_secret_is_absent", False, 2),
+        ]
+    )
+    def test_preserves_managed_secret_with_legacy_fallback(
+        self, _name: str, managed_secret_exists: bool, expected_execute_count: int
+    ) -> None:
+        conn = MagicMock()
+        conn.execute.return_value.fetchone.return_value = (managed_secret_exists,)
+
+        create_staging_read_secret(conn, "catalog-bucket")
+
+        assert "duckdb_secrets()" in str(conn.execute.call_args_list[0])
+        assert conn.execute.call_count == expected_execute_count
+        if not managed_secret_exists:
+            secret_sql = str(conn.execute.call_args_list[1])
+            assert "PROVIDER credential_chain" in secret_sql
+            assert "USE_SSL true" in secret_sql
+            assert "SCOPE 's3://catalog-bucket/__posthog_staging'" in secret_sql
 
 
 class TestDuckLakeStorageConfigLocalSetup:


### PR DESCRIPTION
## Problem

Managed workers receive temporary object-storage credentials during session activation. The client then unconditionally replaces the managed staging secret with credential-chain configuration, discarding credentials that are not exposed through that chain.

## Changes

- Reuse the scoped staging secret when session activation already created it.
- Keep the credential-chain path as a fallback when the managed secret is absent.
- Cover both managed-secret reuse and legacy fallback behavior.

## How did you test this code?

- `bin/hogli test products/managed_warehouse/backend/tests/test_storage.py` (36 passed)
- The combined storage and workflow run completed all 73 selected tests; an unrelated local database teardown then failed because a replicated test table was read-only.
- `uv run mypy --cache-fine-grained .` (no issues in 17,384 files)
- `bin/hogli ci:preflight --fix` (no failures)

The new regression coverage catches replacement of a valid managed secret while confirming that deployments without one still create the existing credential-chain fallback.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. This only changes internal credential selection and preserves the existing fallback behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop authored and validated the patch under human direction. Session link is unavailable from this environment. I invoked `/writing-tests`, `/writing-code-comments`, and `/github:yeet`.

I chose an existence check before secret creation so activated credentials remain authoritative, while older deployments keep their current credential-chain behavior.