### PR TITLE
feat(product-analytics): paths v2 plumbing polish

### DIFF
--- a/ee/hogai/context/insight/test/test_query_executor.py
+++ b/ee/hogai/context/insight/test/test_query_executor.py
@@ -26,6 +26,8 @@ from posthog.schema import (
     LifecycleQuery,
     PathsFilter,
     PathsQuery,
+    PathsV2Filter,
+    PathsV2Query,
     RetentionFilter,
     RetentionQuery,
     StickinessQuery,
@@ -197,6 +199,31 @@ class TestAssistantQueryExecutor(NonAtomicBaseTest):
         self.assertIsInstance(result, str)
         self.assertTrue(used_fallback)
         # Should NOT capture NotImplementedError
+        mock_capture.assert_not_called()
+
+    @patch("ee.hogai.context.insight.query_executor.capture_exception")
+    @patch("ee.hogai.context.insight.query_executor.process_query_dict")
+    async def test_paths_v2_query_degrades_to_json_fallback(self, mock_process_query, mock_capture):
+        # The assistant has no PathsV2Query formatter yet, so a journeys insight must degrade to
+        # the raw-JSON fallback instead of erroring.
+        results = {
+            "steps": [
+                {
+                    "stepIndex": 0,
+                    "rows": [{"item": {"event": "$pageview", "label": "/home"}, "count": 2}],
+                    "otherCount": 0,
+                    "dropOffCount": 1,
+                }
+            ],
+            "edges": [],
+            "prefixes": [],
+        }
+        mock_process_query.return_value = {"results": results}
+
+        result = await execute_and_format_query(self.team, PathsV2Query(pathsV2Filter=PathsV2Filter()), user=self.user)
+
+        self.assertIn('"stepIndex":0', result)
+        self.assertIn("/home", result)
         mock_capture.assert_not_called()
 
     @patch("ee.hogai.context.insight.query_executor.process_query_dict")

--- a/ee/hogai/context/insight/test/test_query_executor.py
+++ b/ee/hogai/context/insight/test/test_query_executor.py
@@ -203,7 +203,7 @@ class TestAssistantQueryExecutor(NonAtomicBaseTest):
 
     @patch("ee.hogai.context.insight.query_executor.capture_exception")
     @patch("ee.hogai.context.insight.query_executor.process_query_dict")
-    async def test_paths_v2_query_degrades_to_json_fallback(self, mock_process_query, mock_capture):
+    async def test_paths_v2_query_degrades_to_json_fallback(self, mock_process_query: Mock, mock_capture: Mock) -> None:
         # The assistant has no PathsV2Query formatter yet, so a journeys insight must degrade to
         # the raw-JSON fallback instead of erroring.
         results = {
@@ -222,7 +222,7 @@ class TestAssistantQueryExecutor(NonAtomicBaseTest):
 
         result = await execute_and_format_query(self.team, PathsV2Query(pathsV2Filter=PathsV2Filter()), user=self.user)
 
-        self.assertIn('"stepIndex":0', result)
+        self.assertIn("stepIndex", result)
         self.assertIn("/home", result)
         mock_capture.assert_not_called()
 

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -45,6 +45,7 @@ import {
     Node,
     NodeKind,
     PathsQuery,
+    PathsV2Query,
     RetentionQuery,
     StickinessQuery,
     TrendsFormulaNode,
@@ -67,6 +68,7 @@ import {
     isInsightVizNode,
     isLifecycleQuery,
     isPathsQuery,
+    isPathsV2Query,
     isRetentionQuery,
     isTrendsQuery,
     hasBreakdownFilter,
@@ -79,6 +81,8 @@ import {
     IntervalType,
     UserBasicType,
 } from '~/types'
+
+import { journeysSummaryParts } from 'products/product_analytics/frontend/insights/journeys/journeysSummary'
 
 import { PropertyKeyInfo } from '../../PropertyKeyInfo'
 import { TZLabel } from '../../TZLabel'
@@ -301,6 +305,25 @@ function PathsSummary({ query }: { query: PathsQuery }): JSX.Element {
     )
 }
 
+function PathsV2Summary({ query }: { query: PathsV2Query }): JSX.Element {
+    // Sync format with summarizeJourneys in journeysSummary.ts
+    const { sources, anchor } = journeysSummaryParts(query.pathsV2Filter)
+    return (
+        <div className="SeriesDisplay">
+            <div>
+                <div>
+                    Journeys based on <b>{sources}</b>
+                </div>
+                {anchor && (
+                    <div>
+                        {anchor.verb} at <b>{anchor.label}</b>
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
 function RetentionSummary({ query }: { query: RetentionQuery }): JSX.Element {
     const { aggregationLabel } = useValues(mathsLogic)
 
@@ -374,6 +397,8 @@ export function SeriesSummary({
                     {isTrendsQuery(query) && <FormulaSummary query={query} />}
                     {isPathsQuery(query) ? (
                         <PathsSummary query={query} />
+                    ) : isPathsV2Query(query) ? (
+                        <PathsV2Summary query={query} />
                     ) : isRetentionQuery(query) ? (
                         <RetentionSummary query={query} />
                     ) : isInsightQueryWithSeries(query) ? (

--- a/frontend/src/scenes/insights/summarizeInsight.test.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.test.ts
@@ -17,6 +17,8 @@ import {
     LifecycleQuery,
     NodeKind,
     PathsQuery,
+    PathsV2AnchorType,
+    PathsV2Query,
     RetentionQuery,
     StickinessQuery,
     TrendsQuery,
@@ -433,6 +435,49 @@ describe('summarizing insights', () => {
 
             expect(result).toEqual('User paths based on page views starting at /landing-page and ending at /basket')
         })
+
+        it.each([
+            ['absent step sources (runner default)', undefined, 'Journeys based on page views'],
+            [
+                'a matching preset',
+                { stepSources: [{ event: '$screen', namingProperty: '$screen_name' }] },
+                'Journeys based on screen views',
+            ],
+            [
+                'custom step sources',
+                { stepSources: [{ event: '$pageview', namingProperty: '$pathname' }, { event: 'purchase' }] },
+                'Journeys based on $pageview and purchase',
+            ],
+            [
+                'a start anchor',
+                {
+                    anchor: {
+                        type: PathsV2AnchorType.Start,
+                        item: { event: '$pageview', label: '/landing-page' },
+                    },
+                },
+                'Journeys based on page views starting at /landing-page',
+            ],
+            [
+                'an end anchor with an empty label',
+                {
+                    anchor: { type: PathsV2AnchorType.End, item: { event: '$pageview', label: '' } },
+                },
+                'Journeys based on page views ending at (empty)',
+            ],
+        ] as [string, PathsV2Query['pathsV2Filter'], string][])(
+            'summarizes a Journeys insight with %s',
+            (_name, pathsV2Filter, expected) => {
+                const query: PathsV2Query = { kind: NodeKind.PathsV2Query, pathsV2Filter }
+
+                const result = summarizeInsight(
+                    { kind: NodeKind.InsightVizNode, source: query } as InsightVizNode,
+                    summaryContext
+                )
+
+                expect(result).toEqual(expected)
+            }
+        )
 
         it('summarizes a Stickiness insight with a user-based series and an organization-based one', () => {
             const query: StickinessQuery = {

--- a/frontend/src/scenes/insights/summarizeInsight.test.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.test.ts
@@ -446,7 +446,7 @@ describe('summarizing insights', () => {
             [
                 'custom step sources',
                 { stepSources: [{ event: '$pageview', namingProperty: '$pathname' }, { event: 'purchase' }] },
-                'Journeys based on $pageview and purchase',
+                'Journeys based on Pageview and purchase',
             ],
             [
                 'a start anchor',

--- a/frontend/src/scenes/insights/summarizeInsight.ts
+++ b/frontend/src/scenes/insights/summarizeInsight.ts
@@ -44,7 +44,7 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { CORE_FILTER_DEFINITIONS_BY_GROUP } from '~/taxonomy/taxonomy'
 import { BreakdownKeyType, BreakdownType, EntityFilter, FilterType, FunnelVizType, StepOrderValue } from '~/types'
 
-import { presetForStepSources } from 'products/product_analytics/frontend/insights/journeys/stepSourcePresets'
+import { summarizeJourneys } from 'products/product_analytics/frontend/insights/journeys/journeysSummary'
 
 function summarizeSingularBreakdown(
     breakdown: BreakdownKeyType | undefined,
@@ -224,9 +224,7 @@ export function summarizeInsightQuery(query: InsightQueryNode, context: SummaryC
         }
         return summary
     } else if (isPathsV2Query(query)) {
-        // A placeholder until the dedicated journeys summary lands with the insight-platform polish
-        const preset = presetForStepSources(query.pathsV2Filter?.stepSources ?? undefined)
-        return preset ? `User journeys based on ${preset.label.toLowerCase()}` : 'User journeys'
+        return summarizeJourneys(query.pathsV2Filter)
     } else if (isStickinessQuery(query)) {
         return capitalizeFirstLetter(
             query.series

--- a/products/notebooks/backend/query_validation.py
+++ b/products/notebooks/backend/query_validation.py
@@ -1,8 +1,8 @@
-from typing import Any, get_args
+from typing import Any
 
 import structlog
 
-from posthog.schema import InsightVizNode
+from posthog.schema_enums import InsightNodeKind
 
 logger = structlog.get_logger(__name__)
 
@@ -23,16 +23,10 @@ _VALID_TOP_LEVEL_QUERY_KINDS = frozenset(
 )
 
 
-def _insight_viz_source_kinds() -> frozenset[str]:
-    # Derived from the generated Pydantic schema so new insight kinds are accepted here the
-    # moment they join InsightVizNode.source, instead of drifting behind a hardcoded copy.
-    annotation = InsightVizNode.model_fields["source"].annotation
-    source_types = get_args(annotation) or (annotation,)
-    kinds = (source_type.model_fields["kind"].default for source_type in source_types)
-    return frozenset(str(getattr(kind, "value", kind)) for kind in kinds)
-
-
-_VALID_INSIGHT_VIZ_SOURCE_KINDS = _insight_viz_source_kinds()
+# InsightNodeKind is generated from the same schema union as InsightVizNode.source, so new
+# insight kinds are accepted here the moment they join the union instead of drifting behind a
+# hardcoded copy.
+_VALID_INSIGHT_VIZ_SOURCE_KINDS = frozenset(kind.value for kind in InsightNodeKind)
 _INSIGHT_VIZ_SOURCE_KINDS_SENTENCE = ", ".join(sorted(_VALID_INSIGHT_VIZ_SOURCE_KINDS))
 
 

--- a/products/notebooks/backend/query_validation.py
+++ b/products/notebooks/backend/query_validation.py
@@ -1,6 +1,8 @@
-from typing import Any
+from typing import Any, get_args
 
 import structlog
+
+from posthog.schema import InsightVizNode
 
 logger = structlog.get_logger(__name__)
 
@@ -20,20 +22,18 @@ _VALID_TOP_LEVEL_QUERY_KINDS = frozenset(
     }
 )
 
-# Source kinds that an InsightVizNode is actually allowed to wrap (matches the Pydantic
-# schema at posthog/schema.py — InsightVizNode.source).
-_VALID_INSIGHT_VIZ_SOURCE_KINDS = frozenset(
-    {
-        "TrendsQuery",
-        "FunnelsQuery",
-        "RetentionQuery",
-        "PathsQuery",
-        "StickinessQuery",
-        "LifecycleQuery",
-        "WebStatsTableQuery",
-        "WebOverviewQuery",
-    }
-)
+
+def _insight_viz_source_kinds() -> frozenset[str]:
+    # Derived from the generated Pydantic schema so new insight kinds are accepted here the
+    # moment they join InsightVizNode.source, instead of drifting behind a hardcoded copy.
+    annotation = InsightVizNode.model_fields["source"].annotation
+    source_types = get_args(annotation) or (annotation,)
+    kinds = (source_type.model_fields["kind"].default for source_type in source_types)
+    return frozenset(str(getattr(kind, "value", kind)) for kind in kinds)
+
+
+_VALID_INSIGHT_VIZ_SOURCE_KINDS = _insight_viz_source_kinds()
+_INSIGHT_VIZ_SOURCE_KINDS_SENTENCE = ", ".join(sorted(_VALID_INSIGHT_VIZ_SOURCE_KINDS))
 
 
 class InvalidNotebookQueryError(ValueError):
@@ -108,8 +108,7 @@ def _normalize_insight_viz_node(query: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(source, dict):
         raise InvalidNotebookQueryError(
             "ph-query node has an InsightVizNode without a `source`. "
-            "InsightVizNode.source must be a TrendsQuery, FunnelsQuery, RetentionQuery, "
-            "PathsQuery, StickinessQuery, LifecycleQuery, WebStatsTableQuery, or WebOverviewQuery."
+            f"InsightVizNode.source must be one of: {_INSIGHT_VIZ_SOURCE_KINDS_SENTENCE}."
         )
 
     source_kind = source.get("kind")
@@ -136,8 +135,7 @@ def _normalize_insight_viz_node(query: dict[str, Any]) -> dict[str, Any]:
     if source_kind not in _VALID_INSIGHT_VIZ_SOURCE_KINDS:
         raise InvalidNotebookQueryError(
             f"ph-query node has an InsightVizNode wrapping `{source_kind}`, which is not "
-            "a valid insight source. InsightVizNode.source must be one of: "
-            f"{', '.join(sorted(_VALID_INSIGHT_VIZ_SOURCE_KINDS))}."
+            f"a valid insight source. InsightVizNode.source must be one of: {_INSIGHT_VIZ_SOURCE_KINDS_SENTENCE}."
         )
 
     return query

--- a/products/notebooks/backend/test/test_query_validation.py
+++ b/products/notebooks/backend/test/test_query_validation.py
@@ -50,9 +50,17 @@ class TestNormalizeNotebookQueryNodes:
         doc = _wrap(VALID_DATA_VIZ)
         assert _extract_query(normalize_notebook_query_nodes(doc)) == VALID_DATA_VIZ
 
-    def test_passes_through_valid_insight_viz_node(self) -> None:
-        doc = _wrap(VALID_INSIGHT_VIZ)
-        assert _extract_query(normalize_notebook_query_nodes(doc)) == VALID_INSIGHT_VIZ
+    @parameterized.expand(
+        [
+            ("trends", VALID_INSIGHT_VIZ),
+            # The accepted kinds are derived from the schema, so a source kind newer than this
+            # file (PathsV2Query) must pass without an allowlist edit.
+            ("paths_v2", {"kind": "InsightVizNode", "source": {"kind": "PathsV2Query", "pathsV2Filter": {}}}),
+        ]
+    )
+    def test_passes_through_valid_insight_viz_node(self, _name: str, query: dict) -> None:
+        doc = _wrap(query)
+        assert _extract_query(normalize_notebook_query_nodes(doc)) == query
 
     def test_unwraps_insight_viz_node_wrapping_data_visualization_node(self) -> None:
         # The exact bug observed in notebook wUll: AI agent wrapped a SQL chart in an

--- a/products/notebooks/backend/test/test_query_validation.py
+++ b/products/notebooks/backend/test/test_query_validation.py
@@ -58,7 +58,7 @@ class TestNormalizeNotebookQueryNodes:
             ("paths_v2", {"kind": "InsightVizNode", "source": {"kind": "PathsV2Query", "pathsV2Filter": {}}}),
         ]
     )
-    def test_passes_through_valid_insight_viz_node(self, _name: str, query: dict) -> None:
+    def test_passes_through_valid_insight_viz_node(self, _name: str, query: dict[str, Any]) -> None:
         doc = _wrap(query)
         assert _extract_query(normalize_notebook_query_nodes(doc)) == query
 

--- a/products/product_analytics/backend/hogql_queries/paths_v2/paths_v2_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/paths_v2_query_runner.py
@@ -267,14 +267,22 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
         # Fixed seconds via the funnels realization (month means 31 days), never calendar INTERVAL
         # arithmetic, so a journey's gap G always equals the emitted funnel's conversion window.
         return parse_expr(
-            f"toIntervalSecond({conversion_window_to_seconds(self.gap_interval, self.gap_interval_unit)})"
+            "toIntervalSecond({seconds})",
+            placeholders={
+                "seconds": ast.Constant(value=conversion_window_to_seconds(self.gap_interval, self.gap_interval_unit))
+            },
         )
 
     def _window_interval_expr(self) -> ast.Expr:
         # Window W realized the same fixed-seconds way as the gap, so it always equals the emitted
         # funnel's conversion window.
         return parse_expr(
-            f"toIntervalSecond({conversion_window_to_seconds(self.window_interval, self.window_interval_unit)})"
+            "toIntervalSecond({seconds})",
+            placeholders={
+                "seconds": ast.Constant(
+                    value=conversion_window_to_seconds(self.window_interval, self.window_interval_unit)
+                )
+            },
         )
 
     def _split_interval_expr(self) -> ast.Expr:
@@ -289,12 +297,12 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
         """The per-actor event tuples in the order the grid reads them. Ascending time everywhere except
         an end anchor, which sorts descending so the anchor (each actor's latest anchor event) lands at
         step 0 and the grid reads backward in time toward it."""
-        events = "groupArray(tuple(timestamp, path_item))"
+        events = parse_expr("groupArray(tuple(timestamp, path_item))")
         if self.is_anchored and self.anchor is not None and self.anchor.type == PathsV2AnchorType.END:
             # arrayReverse(arraySort(...)), not arrayReverseSort: HogQL aliases arrayReverseSort to the
             # ascending arraySort, which would silently keep forward order.
-            return parse_expr(f"arrayReverse(arraySort(x -> x.1, {events}))")
-        return parse_expr(f"arraySort(x -> x.1, {events})")
+            return parse_expr("arrayReverse(arraySort(x -> x.1, {events}))", placeholders={"events": events})
+        return parse_expr("arraySort(x -> x.1, {events})", placeholders={"events": events})
 
     def _event_base_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         """One row per in-range event matching a step source and no excluded item:

--- a/products/product_analytics/backend/hogql_queries/paths_v2/test/test_paths_v2_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/test/test_paths_v2_query_runner.py
@@ -26,6 +26,7 @@ from posthog.hogql.query import execute_hogql_query
 
 from posthog.test.test_journeys import journeys_for
 
+from products.product_analytics.backend.hogql_queries.paths_v2.path_item import resolve_step_sources
 from products.product_analytics.backend.hogql_queries.paths_v2.paths_v2_query_runner import PathsV2QueryRunner
 
 DATE_RANGE = DateRange(date_from="2023-03-01", date_to="2023-03-31")
@@ -94,6 +95,14 @@ class TestPathsV2FilterConstraints(SimpleTestCase):
         self.assertIsNone(paths_filter.anchor)
         self.assertIsNone(paths_filter.excludedItems)
         self.assertIsNone(paths_filter.localPathCleaningFilters)
+
+    def test_absent_step_sources_resolve_to_pageviews_preset(self) -> None:
+        # Saved queries may omit stepSources; the frontend preset picker mirrors this default,
+        # so a backend change here would silently relabel them.
+        self.assertEqual(
+            resolve_step_sources(PathsV2Query()),
+            [PathsV2StepSource(event="$pageview", namingProperty="$pathname")],
+        )
 
 
 class TestPathsV2Validation(ClickhouseTestMixin, APIBaseTest):

--- a/products/product_analytics/backend/models/insight.py
+++ b/products/product_analytics/backend/models/insight.py
@@ -29,6 +29,7 @@ _ANALYTICS_INSIGHT_QUERY_KINDS = frozenset(
         "FunnelsQuery",
         "RetentionQuery",
         "PathsQuery",
+        "PathsV2Query",
         "StickinessQuery",
         "LifecycleQuery",
         "CalendarHeatmapQuery",

--- a/products/product_analytics/frontend/insights/journeys/journeysSummary.ts
+++ b/products/product_analytics/frontend/insights/journeys/journeysSummary.ts
@@ -1,0 +1,38 @@
+import { PathsV2AnchorType, PathsV2Filter } from '~/queries/schema/schema-general'
+
+import { journeyItemLabel } from './journeyGridModel'
+import { STEP_SOURCE_PRESETS, presetForStepSources } from './stepSourcePresets'
+
+export interface JourneysSummaryParts {
+    /** Step sources as a phrase: the preset label ("page views"), or the picked event names. */
+    sources: string
+    /** Anchored-mode phrase pieces; null in open mode. */
+    anchor: { verb: 'starting' | 'ending'; label: string } | null
+}
+
+export function journeysSummaryParts(filter: PathsV2Filter | null | undefined): JourneysSummaryParts {
+    const stepSources = filter?.stepSources
+    const preset = presetForStepSources(stepSources ?? undefined)
+    const sources = preset
+        ? preset.label.toLowerCase()
+        : stepSources && stepSources.length > 0
+          ? stepSources.map((source) => source.event).join(' and ')
+          : // An empty list is rejected server-side; showing the runner's default beats an empty phrase.
+            STEP_SOURCE_PRESETS.pageViews.label.toLowerCase()
+    const anchor = filter?.anchor
+    return {
+        sources,
+        anchor: anchor
+            ? {
+                  verb: anchor.type === PathsV2AnchorType.End ? 'ending' : 'starting',
+                  label: journeyItemLabel(anchor.item),
+              }
+            : null,
+    }
+}
+
+/** One-line journeys summary; doubles as the auto-generated insight name. Sync format with PathsV2Summary in InsightDetails. */
+export function summarizeJourneys(filter: PathsV2Filter | null | undefined): string {
+    const { sources, anchor } = journeysSummaryParts(filter)
+    return `Journeys based on ${sources}${anchor ? ` ${anchor.verb} at ${anchor.label}` : ''}`
+}

--- a/products/product_analytics/frontend/insights/journeys/journeysSummary.ts
+++ b/products/product_analytics/frontend/insights/journeys/journeysSummary.ts
@@ -1,24 +1,28 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
 import { PathsV2AnchorType, PathsV2Filter } from '~/queries/schema/schema-general'
+import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 
 import { journeyItemLabel } from './journeyGridModel'
-import { STEP_SOURCE_PRESETS, presetForStepSources } from './stepSourcePresets'
+import { presetForStepSources } from './stepSourcePresets'
 
-export interface JourneysSummaryParts {
-    /** Step sources as a phrase: the preset label ("page views"), or the picked event names. */
+function eventLabel(event: string): string {
+    return getCoreFilterDefinition(event, TaxonomicFilterGroupType.Events)?.label ?? event
+}
+
+export function journeysSummaryParts(filter: PathsV2Filter | null | undefined): {
+    /** Step sources as a phrase: the preset label ("page views"), or the picked events' labels. */
     sources: string
     /** Anchored-mode phrase pieces; null in open mode. */
     anchor: { verb: 'starting' | 'ending'; label: string } | null
-}
-
-export function journeysSummaryParts(filter: PathsV2Filter | null | undefined): JourneysSummaryParts {
-    const stepSources = filter?.stepSources
-    const preset = presetForStepSources(stepSources ?? undefined)
+} {
+    // An empty source list is rejected server-side; treating it like the absent default keeps the
+    // pageviews fallback encoded in one place (presetForStepSources).
+    const stepSources = filter?.stepSources?.length ? filter.stepSources : undefined
+    const preset = presetForStepSources(stepSources)
     const sources = preset
         ? preset.label.toLowerCase()
-        : stepSources && stepSources.length > 0
-          ? stepSources.map((source) => source.event).join(' and ')
-          : // An empty list is rejected server-side; showing the runner's default beats an empty phrase.
-            STEP_SOURCE_PRESETS.pageViews.label.toLowerCase()
+        : (stepSources ?? []).map((source) => eventLabel(source.event)).join(' and ')
     const anchor = filter?.anchor
     return {
         sources,

--- a/products/slack_app/backend/slack_link_unfurl.py
+++ b/products/slack_app/backend/slack_link_unfurl.py
@@ -32,6 +32,7 @@ _QUERY_KIND_TO_SHORT_NAME: dict[str, str] = {
     "FunnelCorrelationQuery": "Funnel correlation",
     "RetentionQuery": "Retention",
     "PathsQuery": "Paths",
+    "PathsV2Query": "Journeys",
     "StickinessQuery": "Stickiness",
     "LifecycleQuery": "Lifecycle",
     "WebStatsTableQuery": "Web analytics",

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -74,6 +74,14 @@ class TestInsightResourceLabel:
         )
         assert _insight_resource_label(insight) == "Trends insight"
 
+    def test_insight_viz_journeys(self):
+        # Guards the user-facing name: without the map entry this would leak "PathsV2 insight".
+        insight = Insight(
+            team_id=1,
+            query={"kind": "InsightVizNode", "source": {"kind": "PathsV2Query"}},
+        )
+        assert _insight_resource_label(insight) == "Journeys insight"
+
     def test_data_viz_sql(self):
         insight = Insight(
             team_id=1,

--- a/products/slack_app/backend/tests/test_link_unfurl.py
+++ b/products/slack_app/backend/tests/test_link_unfurl.py
@@ -74,7 +74,7 @@ class TestInsightResourceLabel:
         )
         assert _insight_resource_label(insight) == "Trends insight"
 
-    def test_insight_viz_journeys(self):
+    def test_insight_viz_journeys(self) -> None:
         # Guards the user-facing name: without the map entry this would leak "PathsV2 insight".
         insight = Insight(
             team_id=1,


### PR DESCRIPTION
## TL;DR

Eli5: the journeys chart is built, but the platform around it had loose ends. This PR gives journeys insights a proper text summary (used for auto-generated names, insight headers, and dashboard card details), fixes notebooks rejecting journeys insights, makes Slack link previews say "Journeys insight", and verifies the AI assistant handles the new query kind without erroring. Slice 7, the last slice of the paths v2 stack.

## Problem

Slice 7 (plumbing polish) of the paths v2 build. Refs #37285.

The journey grid, editor, drill-downs, and view-as-funnel exist in slices 1 to 6, but the insight-platform edges were deferred here: the summary text was a placeholder, shared surfaces that key on insight kind had not been verified against `PathsV2Query`, and the rollout decision made "the AI assistant degrades gracefully on the unknown kind" a beta gate that was still unchecked.

## Changes

- **Journeys summary.** New `summarizeJourneys` / `journeysSummaryParts` in the journeys product feed both `summarizeInsight` (auto-generated insight names, header) and a new `PathsV2Summary` block in `InsightDetails` (dashboard card details). Copy: "Journeys based on page views", plus "starting at /home" or "ending at /checkout" in anchored mode; preset label when the step sources match a preset, taxonomy-humanized event labels otherwise ("Pageview and purchase", never "$pageview").
- **Notebooks accepted no journeys insights (bug found by this slice's verification).** The ph-query validator's `InsightVizNode` source allowlist was a hardcoded copy of the schema union that predates `PathsV2Query`, so saving a notebook embedding a journeys insight returned 400. The allowlist now derives from the generated `InsightNodeKind` enum, so future insight kinds pass the moment they join the union.
- **Slack link unfurls** labeled journeys links with the internal name ("PathsV2 insight"); they now say "Journeys insight".
- **`Insight.get_analytics_query_metadata`** kind set gains `PathsV2Query` (it mirrors a frontend gate that already includes it).
- **Assistant beta gate.** Verified live that both assistant entry points (query executor, attached-insight context) degrade to the raw-JSON fallback on `PathsV2Query` instead of erroring, and pinned that with a test. The real results formatter stays out by design (it is a GA gate, not a beta gate).
- **Defaults.** The backend's default step sources (mirrored by the frontend preset picker) are now pinned by a test; the summary placeholder comment is gone.

Everything stays dark behind the `paths-v2` flag (verified at 0% rollout, no conditions, untouched).

## How did you test this code?

Automated (each group names the regression it guards):

- `summarizeInsight.test.ts`: 5 parameterized journeys cases (default preset, matching preset, custom sources with humanized labels, start anchor, end anchor with empty label). Guards the summary dispatch and phrasing; nothing covered `PathsV2Query` summaries before. 30/30 pass.
- `test_query_validation.py`: parameterized pass-through case for an `InsightVizNode` wrapping `PathsV2Query`. Guards the exact 400 this slice fixed. 20/20 pass.
- `test_link_unfurl.py`: journeys label case. Guards the user-facing name, which otherwise silently falls back to "PathsV2 insight". 5/5 pass.
- `test_paths_v2_query_runner.py`: pins `resolve_step_sources` on an empty query to the pageviews preset. A backend default change would silently relabel saved queries that omit `stepSources`. 9/9 pass.
- `test_query_executor.py`: pins that `execute_and_format_query` on a `PathsV2Query` returns the JSON fallback without raising or capturing an exception. Guards the beta gate against future executor refactors. Passes.

Live, against the local dev stack (Postgres, ClickHouse, Kafka, real backend process): saved a journeys insight over the API (201) and read it back, attached it to a dashboard with a date filter and refreshed from the dashboard (200 with results), executed the query directly through `/query` (200), saved and re-read a notebook embedding it (400 before the validator fix, 201 after), and ran both assistant entry points against the real stack (no raise, fallback output). Repo-wide mypy: no issues. Frontend `typescript:check`: clean. `hogli ci:preflight --fix`: 0 failures. All re-run after the review-fix commit.

Not done: no browser walkthrough (headless session; the flag is at 0%).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change: the feature is dark behind the `paths-v2` flag; docs land with rollout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by a PostHog Code session executing slice 7 of the paths v2 build playbook (Notion), stacked on slice 6's branch per the merge-free stacking rules. Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-code-comments, /code-review.

After opening the PR I (the agent) ran an 8-angle review pass over the slice diff and pushed a follow-up commit fixing what it found: the summary leaked raw event codes like "$pageview" into user-facing derived names (now humanized via the taxonomy), the notebook allowlist derivation reflected over `InsightVizNode`'s annotation shape (fragile against schema regeneration and it pulled the large generated schema module into the validator's import path; now reads the small generated `InsightNodeKind` enum), the pageviews default was encoded a third time in an empty-list fallback (now routed through `presetForStepSources`), an exported type had no importers, a test was coupled to JSON separator details, and new tests were missing strict-typing annotations.

Decisions worth a reviewer's eye:

- The notebook fix derives the allowlist from generated schema output rather than adding one string, so the drift class that caused the bug is gone rather than patched. The error messages render from the derived set too.
- The assistant's `_NAMING_GUIDANCE` map (AI insight auto-naming) deliberately gets no `PathsV2Query` entry: it degrades to generic guidance, and kind-specific AI treatment is scoped to the GA-gate formatter work.
- The two build sessions before this one reported the assistant hard-failing on the unknown kind. On this stack's tip I could not reproduce a hard failure anywhere (executor, attached-insight context, insight search, dashboard reading, notebook artifacts): every path degrades by construction, live-verified above. The pinning test keeps it that way.
- Pre-existing, left alone: `_ANALYTICS_INSIGHT_QUERY_KINDS` in the insight model has drifted from the frontend gate its comment claims to mirror (it has `CalendarHeatmapQuery`, lacks the web analytics kinds). Realigning it changes metadata behavior for other insight types, so it deserves its own PR; this one only adds `PathsV2Query`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
