### PR TITLE
chore(retention): run events modal tests under both base-query variants

### DIFF
--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -147,6 +147,24 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
 
         return self.calculate_with_retention_base_query_variant_comparison(query, calculate)
 
+    def run_events_query(self, interval, query, person_id=None):
+        if not query.get("retentionFilter"):
+            query["retentionFilter"] = {}
+
+        def calculate(query_for_variant):
+            runner = RetentionQueryRunner(team=self.team, query=query_for_variant)
+            events_query = runner.to_events_query(interval=interval, person_id=person_id)
+            response = execute_hogql_query(
+                query_type="RetentionEventsQuery",
+                query=events_query,
+                team=self.team,
+            )
+            # to_events_query orders by timestamp only, so rows with equal timestamps can
+            # come back in either order; sort fully so the variant comparison doesn't flake
+            return sorted(response.results)
+
+        return self.calculate_with_retention_base_query_variant_comparison(query, calculate)
+
     def test_retention_default(self):
         _create_person(team_id=self.team.pk, distinct_ids=["person1", "alias1"])
         _create_person(team_id=self.team.pk, distinct_ids=["person2"])
@@ -3449,10 +3467,9 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         """Test events query for first time ever retention"""
         self._create_first_time_ever_retention_events()
 
-        # Create RetentionQueryRunner instance
-        query = RetentionQuery(
-            dateRange={"date_from": _date(0), "date_to": _date(7)},
-            retentionFilter={
+        query = {
+            "dateRange": {"date_from": _date(0), "date_to": _date(7)},
+            "retentionFilter": {
                 "period": "Day",
                 "totalIntervals": 7,
                 "retentionType": RETENTION_FIRST_EVER_OCCURRENCE,
@@ -3463,22 +3480,14 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
                 },
                 "returningEntity": {"id": "$pageview", "name": "$pageview", "type": "events"},
             },
-        )
-
-        runner = RetentionQueryRunner(query=query, team=self.team)
+        }
 
         # Test events query for interval 1 (day 1)
-        events_query = runner.to_events_query(interval=1)
-        events_result = execute_hogql_query(
-            query_type="RetentionEventsQuery",
-            query=events_query,
-            team=self.team,
-        )
+        events = self.run_events_query(interval=1, query=query)
 
         # Should include both start and return events for people who had their first event ever on day 1
         # and performed the target action (signup)
         # Person2: first event ever was signup on day 1, returns with pageviews on day 2,4
-        events = events_result.results
         self.assertGreater(len(events), 0)
 
         # Based on the to_events_query method, event_type should be in index 5
@@ -5070,29 +5079,16 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         )
 
         # Set up the query
-        query = RetentionQuery(
-            dateRange={"date_to": _date(6, hour=6)},
-            retentionFilter={
+        query = {
+            "dateRange": {"date_to": _date(6, hour=6)},
+            "retentionFilter": {
                 "totalIntervals": 7,
                 "period": "Day",
             },
-        )
+        }
 
-        # Create the query runner
-        runner = RetentionQueryRunner(team=self.team, query=query)
-
-        # Get events query for interval 0 (day 0) and person1
-        events_query = runner.to_events_query(interval=0, person_id=person1.uuid)
-
-        # Execute the query
-        response = execute_hogql_query(
-            query_type="RetentionEventsQuery",
-            query=events_query,
-            team=self.team,
-        )
-
-        # Get the results
-        results = response.results
+        # Get events for interval 0 (day 0) and person1
+        results = self.run_events_query(interval=0, query=query, person_id=person1.uuid)
 
         # Verify we get both start and return events
         self.assertTrue(len(results) > 0, "Expected events to be returned")
@@ -5131,13 +5127,7 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             )
 
         # Test with a different interval - interval 1 should only return person2
-        events_query_day1 = runner.to_events_query(interval=1, person_id=person2.uuid)
-        response_day1 = execute_hogql_query(
-            query_type="RetentionEventsQuery",
-            query=events_query_day1,
-            team=self.team,
-        )
-        results_day1 = response_day1.results
+        results_day1 = self.run_events_query(interval=1, query=query, person_id=person2.uuid)
 
         # Verify we have events for person2 on day 1
         self.assertTrue(len(results_day1) > 0, "Expected events for day 1")


### PR DESCRIPTION
## TL;DR

The retention "view events" modal has two SQL implementations behind a rollout flag. Its tests only ran the old one. Now they run both and check the modal lists the same events either way. It does (parity holds).

## Problem

Strict-calendar retention has two base-query implementations (legacy and DWH variant) in `retention_base_query_fixed.py`, dispatched per team by the `retention-fixed-interval-base-query-dwh-variant` flag. The main results path and the persons modal already run every test under both implementations via `calculate_with_retention_base_query_variant_comparison`. The events modal (`RetentionQueryRunner.to_events_query`) did not: its two tests built the runner directly, so CI only exercised the legacy path. A variant divergence in actor qualification would silently change the event list users see when the flag flips.

**Why:** close the last flag-sensitive retention surface without legacy/variant parity coverage before rollout. Origin: [Notion issue](https://app.notion.com/p/3b189bbd191d814c922fc2637d453f20).

## Changes

- New `run_events_query` helper on `TestRetention`, mirroring `run_query`/`run_actors_query`: build the runner from the query dict, run `to_events_query`, execute, return sorted rows, all inside a calculate callable routed through the comparison mixin.
- `test_events_query` and `test_retention_first_time_ever_events_query` now use it. Their existing assertions are unchanged; the wrapper adds cross-variant equality on top.
- Rows are fully sorted before comparison because the query orders by timestamp only, so tie order is not contractual.

## How did you test this code?

Ran both tests against the dev stack. Both pass, so legacy and DWH variant return identical event lists (no divergence found). Regression this catches that no existing test did: a change to either base-query implementation that alters actor/interval qualification for the events modal now fails these tests instead of shipping silently behind the flag.

<details>
<summary>Test run</summary>

```
hogli test "posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py::TestRetention::test_events_query" "posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py::TestRetention::test_retention_first_time_ever_events_query"
2 passed
```

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude), directed by Thomas Obermueller. Skills invoked: /writing-tests, /writing-code-comments. Verified `to_events_query` reaches the flag-dispatched `build_base_query` before wiring the comparison. Kept normalization to a full-row sort only, since the query's ORDER BY covers timestamp alone; anything stronger could hide a real divergence. Neither test is snapshot-decorated, so no snapshot regeneration was needed. Note: the exclusion-audit PR #76499 touches the same file's exclusion set; diffs don't overlap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*