### PR TITLE
fix(slack_app): skip user resolution for Slack's U00 placeholder author

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -127,6 +127,12 @@ HANDLED_EVENT_TYPES = [
 # needs, so both surfaces share one kind.
 SLACK_INTEGRATION_KIND = "slack"
 
+# Slack substitutes this placeholder for the message author in ``link_shared``
+# events it cannot attribute to a real user — messages posted by apps and bots,
+# or authors whose identity is hidden. Calling ``users.info`` on it always
+# fails with ``user_not_found``.
+SLACK_PLACEHOLDER_USER_ID = "U00"
+
 # Onboarding-on-join dedupe TTL: just long enough to absorb Slack retries and
 # a near-simultaneous cross-region race during cutover. A real re-add after
 # this window should re-onboard — most likely the person forgot how it works.
@@ -356,6 +362,11 @@ def resolve_slack_user(
     post_feedback: bool = True,
 ) -> SlackUserContext | None:
     """Resolve a Slack user to a PostHog user. Posts an ephemeral error message and returns None on failure (unless post_feedback is False)."""
+    if slack_user_id == SLACK_PLACEHOLDER_USER_ID:
+        # There is no real user behind the placeholder, so there is nobody to
+        # resolve or to post feedback to.
+        return None
+
     try:
         slack_team_id = integration.integration_id
 
@@ -409,7 +420,7 @@ def resolve_slack_user(
             slack_email = dev_email
 
         if not slack_email:
-            logger.exception("slack_app_no_user_email", slack_user_id=slack_user_id)
+            logger.warning("slack_app_no_user_email", slack_user_id=slack_user_id)
             if post_feedback:
                 _post_slack_user_feedback(
                     slack,

--- a/products/slack_app/backend/tests/test_resolve_slack_user.py
+++ b/products/slack_app/backend/tests/test_resolve_slack_user.py
@@ -78,6 +78,19 @@ class TestResolveSlackUser:
         assert "email" in mock_client.chat_postMessage.call_args.kwargs["text"].lower()
 
     @patch("posthog.models.integration.WebClient")
+    def test_placeholder_user_skipped_silently(self, mock_webclient_class):
+        mock_client = MagicMock()
+        mock_webclient_class.return_value = mock_client
+
+        slack = SlackIntegration(self.integration)
+        result = resolve_slack_user(slack, self.integration, "U00", "C001", "1234.5678")
+
+        assert result is None
+        mock_client.users_info.assert_not_called()
+        mock_client.chat_postMessage.assert_not_called()
+        mock_client.chat_postEphemeral.assert_not_called()
+
+    @patch("posthog.models.integration.WebClient")
     def test_no_org_membership(self, mock_webclient_class):
         mock_client = MagicMock()
         mock_webclient_class.return_value = mock_client


### PR DESCRIPTION
## Problem

Slack sends `link_shared` events with `"user": "U00"` — its placeholder for messages it can't attribute to a real user (bot/app-posted messages). We pass that placeholder to `users.info`, which always fails with `user_not_found`, wasting a Slack API call and flooding our logs with error-level `slack_app_no_user_email` entries (one for every bot-posted message containing a PostHog link).

## Changes

Bail out of `resolve_slack_user` early and silently when the ID is `U00`. Same outcome as before (no unfurl), minus the API call and the log spam.

## How did you test this code?

Added `test_placeholder_user_skipped_silently` to `test_resolve_slack_user.py` — catches the guard being removed (would reintroduce the `users.info` call and feedback posting). 16/16 passing locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) authored this under my direction. Diagnosed from production logs: entries carry literal `slack_user_id: U00`, arrive signature-verified from Slack's user agent, and the request traces show `link_shared` events followed by `user_not_found` from `users.info`. Skills invoked: /writing-tests.
