### PR TITLE
fix(mysql): stop retrying syncs against a dropped/renamed database

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -187,7 +187,7 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # retry connects with the same database name and fails identically. Match the
             # locale-independent error code (the database name is volatile and the message text is
             # translated on non-English servers).
-            "(1049,": "The database configured for this source no longer exists (MySQL error 1049). It may have been renamed or dropped — update the database name in your source settings, or restore it, then resync.",
+            "(1049,": "The database configured for this source no longer exists (MySQL error 1049). It may have been renamed or dropped. Update the database name in your source settings, or restore it, then resync.",
             "sqlstate 42S02": None,  # Table not found error
             # MySQL/MariaDB error 1146 (ER_NO_SUCH_TABLE): a table the sync reads no longer exists
             # in the source — it was renamed or dropped after the schema was set up. The streaming

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -179,6 +179,15 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # source — so the user fixes credentials instead of the generic "check connection
             # details" message sending them to check the host/port.
             "Access denied for user": "Invalid user or password",
+            # MySQL/MariaDB error 1049 (ER_BAD_DB_ERROR): the configured database doesn't exist on
+            # the server — it was renamed or dropped after the source was set up, or the connection
+            # was reconfigured to point at a different server. `validate_credentials` already
+            # catches this at create time via `_VALIDATE_CONNECTION_HINTS`, but that hint only fires
+            # on the create-time probe; a database dropped later only surfaces here, mid-sync. Every
+            # retry connects with the same database name and fails identically. Match the
+            # locale-independent error code (the database name is volatile and the message text is
+            # translated on non-English servers).
+            "(1049,": "The database configured for this source no longer exists (MySQL error 1049). It may have been renamed or dropped — update the database name in your source settings, or restore it, then resync.",
             "sqlstate 42S02": None,  # Table not found error
             # MySQL/MariaDB error 1146 (ER_NO_SUCH_TABLE): a table the sync reads no longer exists
             # in the source — it was renamed or dropped after the schema was set up. The streaming

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1864,6 +1864,21 @@ class TestMySQLSourceNonRetryableErrors:
         [
             # Raw pymysql str(error) form the import/sync path classifies (`_handle_import_error`
             # matches `str(error)`, which has no class-name prefix).
+            str(pymysql.err.OperationalError(1049, "Unknown database 'wealth_insights'")),
+            # Temporal-wrapped / refresh-schemas form that prepends the exception class name.
+            "OperationalError: (1049, \"Unknown database 'wealth_insights'\")",
+        ],
+    )
+    def test_unknown_database_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Unknown-database error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw pymysql str(error) form the import/sync path classifies (`_handle_import_error`
+            # matches `str(error)`, which has no class-name prefix).
             str(
                 pymysql.err.OperationalError(
                     1356, "View 'defaultdb.wealth_view' references invalid table(s) or column(s)"


### PR DESCRIPTION
## Problem

Error tracking surfaced a MySQL sync repeatedly raising `OperationalError(1049, "Unknown database '<name>'")` – the database configured for the source no longer existed on the server. The stack trace confirms the error originates in `MySQLImplementation._stream_with_optional_force_index` / `get_rows`, i.e. the streaming sync itself, not just a logged/serialized reference.

This is a customer/upstream configuration issue (the database was renamed or dropped after the source was set up) – there's nothing PostHog can do but stop retrying and tell the user to fix it.

MySQL error 1049 is already given a friendly message at source-creation time via `_VALIDATE_CONNECTION_HINTS` in `validate_credentials`, but that path only runs once, at create time. The ongoing sync path consults `get_non_retryable_errors` instead, which didn't have an entry for 1049, so once a database was dropped/renamed after setup the sync kept retrying indefinitely and reporting the same error to error tracking on every attempt.

## Changes

- Added a `"(1049,"` entry to `MySQLSource.get_non_retryable_errors()`, matching the same locale-independent-error-code convention already used for other MySQL error codes in this dict (`(1146,`, `(1356,`, `(1142,`, `(1038,`).

## How did you test this code?

Added `test_unknown_database_is_non_retryable` to `TestMySQLSourceNonRetryableErrors` in `test_mysql.py`, parameterized over the raw `pymysql` error form and the Temporal-wrapped/refresh-schemas form – mirrors the existing tests for the other MySQL-error-code entries (e.g. `test_table_not_found_is_non_retryable`). This guards the regression: without the new dict entry, a dropped/renamed database keeps retrying forever instead of surfacing a friendly, stoppable error.

Ran the full `TestMySQLSourceNonRetryableErrors` class plus the rest of `test_mysql.py`: all 35 tests pass. Also ran `ruff check` / `ruff format --check` on both changed files – clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue `019fc698-3ab9-7ec2-b144-cf7c2887249c`): confirmed the stack trace, exception type, and 17 occurrences across 17 users in a short window, all under `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py`. Compared against the Stripe source's `get_non_retryable_errors` pattern and this source's existing per-error-code entries to keep the fix consistent in shape and comment style. Searched open PRs (by search terms and by the source maintainer's own open PRs) and found no existing PR addressing this specific error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*