### PR TITLE
chore(insights): verify retention aggregation legacy/variant parity

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -275,8 +275,11 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
     def _can_single_scan(self) -> bool:
         # Events-only, non-property-aggregating series read the same `events` source on both arms, so the
         # start and return timestamp arrays can be computed in one pass. Property aggregation stays on the
-        # UNION because collapsing it into the single scan is known to diverge from legacy results; the
-        # UNION shape itself matches legacy (covered by the aggregation tests in
+        # UNION only because this builder does not collect the (interval, value, timestamp) tuple arrays
+        # (_start_event_data / _return_event_data) that _get_intervals_from_base_exprs reads in
+        # aggregation mode, so routing it through the single scan fails to resolve those fields.
+        # Collecting them inline, the way build_base_query_legacy does on one scan, is a legitimate perf
+        # follow-up; the UNION shape matches legacy results (compared by the aggregation tests in
         # test_retention_query_runner.py). A data-warehouse entity is a genuinely different source and
         # cannot collapse here.
         return (

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -5876,6 +5876,168 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         # Interval 0: (50 + 30) / 2 = 40 — avg of return events after start events per user
         self.assertEqual(day0_values[0]["aggregation_value"], 40)
 
+    def test_retention_aggregation_first_ever_occurrence_different_events(self):
+        create_person(team=self.team, distinct_ids=["user1"])
+        create_person(team=self.team, distinct_ids=["user2"])
+
+        # user1's first-ever signup predates the window, so user1 joins no cohort even
+        # though it signs up again inside the window and its purchases carry revenue.
+        _create_events(self.team, [("user1", _date(-2)), ("user1", _date(0, hour=10))], event="signed_up")
+        _create_events(
+            self.team,
+            [
+                ("user1", _date(0, hour=12), {"revenue": 50}),
+                ("user1", _date(1), {"revenue": 100}),
+            ],
+            event="purchased",
+        )
+        # user2's first-ever signup is inside the window; the same-interval purchase counts
+        # because it happens after the signup, and the day-4 purchase lands in interval 3.
+        _create_events(self.team, [("user2", _date(1, hour=9))], event="signed_up")
+        _create_events(
+            self.team,
+            [
+                ("user2", _date(1, hour=11), {"revenue": 8}),
+                ("user2", _date(4), {"revenue": 2}),
+            ],
+            event="purchased",
+        )
+
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": _date(0, hour=0), "date_to": _date(6)},
+                "retentionFilter": {
+                    "totalIntervals": 7,
+                    "retentionType": RETENTION_FIRST_EVER_OCCURRENCE,
+                    "targetEntity": {"id": "signed_up", "type": "events"},
+                    "returningEntity": {"id": "purchased", "type": "events"},
+                    "aggregationType": "sum",
+                    "aggregationProperty": "revenue",
+                },
+            }
+        )
+
+        self.assertEqual(
+            pluck(result, "values", "aggregation_value"),
+            pad(
+                [
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [8, 0, 0, 2, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0],
+                    [0, 0],
+                    [0],
+                ]
+            ),
+        )
+        self.assertEqual(pluck(result, "values", "count")[1], [1, 0, 0, 1, 0, 0, 0])
+
+    def test_retention_aggregation_with_event_value_breakdown(self):
+        create_person(team=self.team, distinct_ids=["user1"])
+        create_person(team=self.team, distinct_ids=["user2"])
+
+        # user1 starts on Chrome and returns on Firefox: the Firefox revenue must count
+        # toward the Firefox day-1 cohort, not toward user1's Chrome day-0 cohort.
+        _create_events(
+            self.team,
+            [
+                ("user1", _date(0), {"revenue": 10, "$browser": "Chrome"}),
+                ("user1", _date(1), {"revenue": 20, "$browser": "Firefox"}),
+                ("user1", _date(2), {"revenue": 30, "$browser": "Chrome"}),
+                ("user2", _date(0), {"revenue": 40, "$browser": "Firefox"}),
+                ("user2", _date(1), {"revenue": 50, "$browser": "Firefox"}),
+            ],
+        )
+
+        flush_persons_and_events()
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": _date(0, hour=0), "date_to": _date(6)},
+                "retentionFilter": {
+                    "totalIntervals": 7,
+                    "aggregationType": "sum",
+                    "aggregationProperty": "revenue",
+                },
+                "breakdownFilter": {"breakdowns": [{"type": "event", "property": "$browser"}]},
+            }
+        )
+
+        chrome_results = [r for r in result if r["breakdown_value"] == "Chrome"]
+        firefox_results = [r for r in result if r["breakdown_value"] == "Firefox"]
+
+        self.assertEqual(
+            pluck(chrome_results, "values", "aggregation_value"),
+            pad(
+                [
+                    [10, 0, 30, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0],
+                    [30, 0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0],
+                    [0, 0],
+                    [0],
+                ]
+            ),
+        )
+        self.assertEqual(
+            pluck(firefox_results, "values", "aggregation_value"),
+            pad(
+                [
+                    [40, 50, 0, 0, 0, 0, 0],
+                    [70, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0],
+                    [0, 0, 0],
+                    [0, 0],
+                    [0],
+                ]
+            ),
+        )
+
+    def test_retention_aggregation_ignores_minimum_occurrences(self):
+        create_person(team=self.team, distinct_ids=["user1"])
+        create_person(team=self.team, distinct_ids=["user2"])
+
+        _create_events(
+            self.team,
+            [
+                ("user1", _date(0), {"revenue": 10}),
+                ("user1", _date(1), {"revenue": 20}),
+                ("user2", _date(0), {"revenue": 40}),
+                ("user2", _date(2, hour=4), {"revenue": 9}),
+                ("user2", _date(2, hour=6), {"revenue": 1}),
+            ],
+        )
+
+        flush_persons_and_events()
+
+        date_range = {"date_from": _date(0, hour=0), "date_to": _date(6)}
+        aggregation_filter = {
+            "totalIntervals": 7,
+            "aggregationType": "sum",
+            "aggregationProperty": "revenue",
+        }
+
+        without_threshold = self.run_query(query={"dateRange": date_range, "retentionFilter": aggregation_filter})
+        with_threshold = self.run_query(
+            query={
+                "dateRange": date_range,
+                "retentionFilter": {**aggregation_filter, "minimumOccurrences": 3},
+            }
+        )
+
+        # Property aggregation ignores the minimum-occurrences threshold on both base-query
+        # implementations: user2's two day-2 events stay counted even though 2 < 3.
+        self.assertEqual(with_threshold, without_threshold)
+        self.assertEqual(
+            pluck(without_threshold, "values", "aggregation_value")[0],
+            [50, 20, 10, 0, 0, 0, 0],
+        )
+
     def test_retention_aggregation_person_property_sum(self):
         """Aggregating on a person property reads person.properties, not event.properties."""
         create_person(team=self.team, distinct_ids=["high_value"], properties={"account_value": 100})


### PR DESCRIPTION
## TL;DR

The retention code claims property aggregation (sum/avg over a property) has a "known legacy/variant discrepancy". We traced the claim to its origin: no discrepancy ever existed. The two aggregation tests were excluded from the legacy-vs-variant comparison because they are SQL-snapshot tests and running each query twice broke the snapshot bookkeeping, nothing more. This PR replaces the misleading comment with the real reason aggregation stays on the UNION shape, and adds three tests for aggregation combinations nothing covered. Follow-up to #76499, which re-enabled the two excluded tests.

## Problem

`_can_single_scan()` keeps property aggregation on the two-pass UNION citing a "known legacy/variant discrepancy" (wording introduced in #65731). The claim was never written down anywhere, left aggregation parity looking like an unverified hole in the `retention-fixed-interval-base-query-dwh-variant` rollout, and blocked treating the single-scan extension as a plain perf follow-up.

What the archaeology found (full trail in the linked Notion issue):

- The two aggregation tests sat on the comparison-harness exclusion list since #57119 for snapshot bookkeeping. They are the file's only `@snapshot_clickhouse_queries` aggregation tests, the harness runs each query twice, and the second run had no recorded `.1` snapshot, which broke the Django test matrix. A commit on that PR's branch (031a0e440) says exactly this and nothing about result differences. All 7 excluded `TestRetention` tests were the class's snapshot tests.
- The non-snapshot aggregation tests (avg, multiple-events-per-day, cohort-size, interval-0 trio, person-property) have run the comparison green since the harness landed.
- Both excluded tests pass with the comparison forced on at the harness commit itself (1dc283df9, reproduced in an isolated worktree with a fresh database). Parity held at exclusion time.
- Forcing aggregation through the single scan today fails HogQL resolution (`Unable to resolve field: _start_event_data`) because the single-scan builder never collects the aggregation tuple arrays. It cannot silently diverge; it is simply not implemented.

## Changes

- Rewrite the `_can_single_scan` comment: aggregation stays on the UNION because the single-scan builder does not collect the `(interval, value, timestamp)` tuple arrays the aggregation combine step reads, and collecting them inline (the way `build_base_query_legacy` already does on one scan) is a legitimate perf follow-up.
- Add three aggregation tests, each through the comparison harness, for shapes with zero prior coverage on either implementation (see test plan for the regression each catches).

Probed but deliberately not committed (throwaway comparison probes, all parity-green): first-time-matching-filters with same and with different entities, cohort breakdown, entity-level property filters, action entities, avg with event breakdown.

> [!WARNING]
> Found while probing, not fixed here: cumulative (rolling) retention combined with property aggregation crashes with `ResolutionError: Field retention_value not found on query with alias actor_activity` on BOTH implementations. `_build_cumulative_actors_query` does not propagate `retention_value`, but `_outer_retention_query` selects `sum(actor_activity.retention_value)` in aggregation mode. Pre-existing and orthogonal to the variant rollout; tracked separately.

## How did you test this code?

I'm an agent (PostHog Code); automated tests only.

- Ran 10 throwaway parity probes through `calculate_with_retention_base_query_variant_comparison` covering aggregation combined with first-time retention types, event-value breakdown, cohort breakdown, minimumOccurrences, cumulative, entity property filters, and action entities: 9 parity-green, cumulative crashed identically on both paths (the pre-existing bug above).
- The three committed tests each catch a regression no existing test does:
  - `test_retention_aggregation_first_ever_occurrence_different_events`: no existing test runs aggregation with any first-time retention type on either path; catches the anchoring logic (recently touched by #74218) miscombining with aggregation tuples, e.g. an out-of-window first-ever actor leaking revenue into a cohort.
  - `test_retention_aggregation_with_event_value_breakdown`: the only existing aggregation+breakdown test uses person properties (constant per actor) and asserts counts only; this one has an actor starting on Chrome and returning on Firefox, so mis-partitioning revenue across per-value cohorts fails it.
  - `test_retention_aggregation_ignores_minimum_occurrences`: an inline comment asserts both implementations ignore the threshold under aggregation, but nothing enforced it; one side starting to respect it is precisely the silent-numbers-change rollout risk.
- Verified the two historically excluded tests pass with the comparison forced on at the harness commit itself (1dc283df9), in an isolated worktree with its own Postgres and ClickHouse databases. The run regenerates the two missing variant SQL snapshots, which is exactly the bookkeeping gap the exclusions papered over.
- The three new tests pass on this branch (2 first try; the first-ever test needed its `count` expectation widened to the 7-value rows first-time cohorts emit, the comparison itself was green throughout).
- `hogli ci:preflight --fix`: staleness, ruff lint, and ruff format green; mypy advisory only (a comment plus tests in the file's untyped idiom).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: a code comment and tests only, no behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Archaeology + parity-verification task for the `retention-fixed-interval-base-query-dwh-variant` rollout, follow-up to the exclusion audit in #76499. Skills invoked: `/writing-tests`, `/writing-code-comments`. Method: traced the discrepancy claim through #57097, #57102, #57119 (branch commit 031a0e440 documents the snapshot-bookkeeping exclusion reason), #64530 and #65731; reproduced the two tests with comparison forced on at the harness commit in a git worktree with a pinned older uv and a fresh Postgres database; probed 10 untested aggregation shapes with a throwaway comparison suite and kept the 3 that pass the test-value gate. Decisions: stacked on #76499 instead of conflicting with its comment rewording; left the cumulative+aggregation crash unfixed because it is a runner bug above the legacy/variant split and needs its own change; did not extend single-scan to aggregation here (perf follow-up, now unblocked).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
