### PR TITLE
feat(slack_app): welcome new workspace members with an assistant DM

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -134,10 +134,11 @@ SLACK_INTEGRATION_KIND = "slack"
 # fails with ``user_not_found``.
 SLACK_PLACEHOLDER_USER_ID = "U00"
 
-# Onboarding-on-join dedupe TTL: just long enough to absorb Slack retries and
-# a near-simultaneous cross-region race during cutover. A real re-add after
-# this window should re-onboard — most likely the person forgot how it works.
-CHANNEL_ONBOARDING_DEDUPE_TTL_SECONDS = 60 * 10
+# Onboarding-on-join dedupe TTL (channel and workspace joins): just long enough
+# to absorb Slack retries and a near-simultaneous cross-region race during
+# cutover. A real re-join after this window should re-onboard — most likely the
+# person forgot how it works.
+ONBOARDING_DEDUPE_TTL_SECONDS = 60 * 10
 CHANNEL_ONBOARDING_DOCS_URL = "https://posthog.com/docs/slack-app"
 
 ROUTE_HANDLED_LOCALLY = "handled_locally"
@@ -2351,20 +2352,20 @@ def _channel_onboarding_cache_key(slack_team_id: str, channel_id: str) -> str:
     return f"slack_app:channel_onboarded:v1:{slack_team_id}:{channel_id}"
 
 
-def _claim_channel_onboarding(slack_team_id: str, channel_id: str) -> bool:
-    """Atomically claim the right to send the onboarding message.
+def _claim_once(cache_key: str) -> bool:
+    """Atomically claim a one-shot slot, e.g. the right to send an onboarding message.
 
     ``cache.add`` is the Django-blessed idempotency primitive: it returns True
     only if the key didn't already exist, so concurrent webhook deliveries
-    (Slack retries, two-region race during cutover) can't double-post.
+    (Slack retries, two-region race during cutover) can't double-post. Callers
+    release the slot with ``cache.delete`` when the claimed action fails, so
+    the next delivery gets another shot.
     """
-    return bool(
-        cache.add(
-            _channel_onboarding_cache_key(slack_team_id, channel_id),
-            True,
-            timeout=CHANNEL_ONBOARDING_DEDUPE_TTL_SECONDS,
-        )
-    )
+    return bool(cache.add(cache_key, True, timeout=ONBOARDING_DEDUPE_TTL_SECONDS))
+
+
+def _claim_channel_onboarding(slack_team_id: str, channel_id: str) -> bool:
+    return _claim_once(_channel_onboarding_cache_key(slack_team_id, channel_id))
 
 
 def _release_channel_onboarding_claim(slack_team_id: str, channel_id: str) -> None:
@@ -2458,7 +2459,7 @@ def _route_team_join(
     """
     joiner = event.get("user") if isinstance(event.get("user"), dict) else None
     slack_user_id = joiner.get("id") if joiner else None
-    if not joiner or not isinstance(slack_user_id, str) or not slack_user_id:
+    if not joiner or not isinstance(slack_user_id, str):
         return ROUTE_HANDLED_LOCALLY
     if joiner.get("is_bot") or joiner.get("is_restricted") or joiner.get("is_ultra_restricted"):
         return ROUTE_HANDLED_LOCALLY
@@ -2470,11 +2471,13 @@ def _route_team_join(
     if _us_should_handle_instead(slack_team_id, [SLACK_INTEGRATION_KIND], can_defer_to_other_region, incoming_host):
         return _proxy_event_and_return_route(request, other_domain)
 
-    integration = _find_team_join_integration(workspace_result.candidates, joiner, slack_user_id)
+    integration = _find_team_join_integration(
+        workspace_result.candidates, slack_user_id, (joiner.get("profile") or {}).get("email")
+    )
     if integration is None:
         return ROUTE_HANDLED_LOCALLY
 
-    if not _claim_team_join_onboarding(slack_team_id, slack_user_id):
+    if not _claim_once(_team_join_onboarding_cache_key(slack_team_id, slack_user_id)):
         logger.info(
             "slack_app_team_join_welcome_skipped_duplicate",
             slack_team_id=slack_team_id,
@@ -2482,35 +2485,45 @@ def _route_team_join(
         )
         return ROUTE_HANDLED_LOCALLY
 
-    if not _post_team_join_welcome(SlackIntegration(integration), integration, slack_user_id):
+    if not _post_team_join_welcome(integration, slack_user_id):
         # Release the dedupe slot so the next delivery gets another shot
         # rather than being silently swallowed.
-        _release_team_join_claim(slack_team_id, slack_user_id)
+        cache.delete(_team_join_onboarding_cache_key(slack_team_id, slack_user_id))
 
     return ROUTE_HANDLED_LOCALLY
 
 
 def _find_team_join_integration(
-    candidates: list[Integration], joiner: dict[str, Any], slack_user_id: str
+    candidates: list[Integration], slack_user_id: str, profile_email: str | None
 ) -> Integration | None:
     """Pick the install to welcome the joiner from, or ``None`` to stay silent.
 
-    The joiner qualifies for an install when the assistant is enabled for its
-    team and their Slack email matches a member of the install's organization.
-    ``team_join`` carries the full user object, so the email usually comes
-    straight off the event; ``users.info`` is the fallback for hidden profiles.
+    The joiner qualifies for an install when their Slack email matches an
+    active member of the install's organization and the assistant is enabled
+    for its team. The membership check runs first: it is a local indexed
+    query, while the flag eval is a remote call that the typical joiner (a
+    coworker with no PostHog account) should never trigger. ``team_join``
+    carries the full user object, so the email usually comes straight off the
+    event; ``users.info`` is the fallback for hidden profiles.
     """
-    email = (joiner.get("profile") or {}).get("email")
-    if not isinstance(email, str) or not email:
-        email = get_slack_email_for_user(candidates[0], slack_user_id)
+    email = profile_email or get_slack_email_for_user(candidates[0], slack_user_id)
     if not email:
         return None
+    try:
+        member_org_ids = set(
+            OrganizationMembership.objects.filter(
+                organization_id__in={c.team.organization_id for c in candidates},
+                user__email__iexact=email,
+                user__is_active=True,
+            ).values_list("organization_id", flat=True)
+        )
+    except Exception:
+        # Don't propagate transient DB errors to the Slack webhook — Slack
+        # retries 5xx and would replay the event.
+        logger.warning("slack_app_team_join_membership_check_failed", slack_user_id=slack_user_id, exc_info=True)
+        return None
     for candidate in candidates:
-        if not is_slack_app_assistant_enabled(candidate.team):
-            continue
-        if OrganizationMembership.objects.filter(
-            organization_id=candidate.team.organization_id, user__email__iexact=email
-        ).exists():
+        if candidate.team.organization_id in member_org_ids and is_slack_app_assistant_enabled(candidate.team):
             return candidate
     return None
 
@@ -2519,25 +2532,11 @@ def _team_join_onboarding_cache_key(slack_team_id: str, slack_user_id: str) -> s
     return f"slack_app:team_join_welcomed:v1:{slack_team_id}:{slack_user_id}"
 
 
-def _claim_team_join_onboarding(slack_team_id: str, slack_user_id: str) -> bool:
-    """Atomically claim the right to DM this joiner — ``cache.add`` returns True
-    only for the first caller, so retries and the two-region race can't double-post."""
-    return bool(
-        cache.add(
-            _team_join_onboarding_cache_key(slack_team_id, slack_user_id),
-            True,
-            timeout=CHANNEL_ONBOARDING_DEDUPE_TTL_SECONDS,
-        )
-    )
-
-
-def _release_team_join_claim(slack_team_id: str, slack_user_id: str) -> None:
-    cache.delete(_team_join_onboarding_cache_key(slack_team_id, slack_user_id))
-
-
-def _post_team_join_welcome(slack: SlackIntegration, integration: Integration, slack_user_id: str) -> bool:
+def _post_team_join_welcome(integration: Integration, slack_user_id: str) -> bool:
     try:
-        slack.client.chat_postMessage(channel=slack_user_id, text=_ASSISTANT_MEMBER_JOIN_WELCOME)
+        SlackIntegration(integration).client.chat_postMessage(
+            channel=slack_user_id, text=_ASSISTANT_MEMBER_JOIN_WELCOME
+        )
         logger.info(
             "slack_app_team_join_welcome_posted",
             integration_id=integration.id,

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -2450,12 +2450,13 @@ def _route_team_join(
     """DM a personal welcome to a new workspace member, at most once.
 
     Slack fires ``team_join`` for every account added to the workspace —
-    including bots and single/multi-channel guests, which we skip. To avoid
-    spamming coworkers who have nothing to do with PostHog, the DM only goes
-    to joiners whose Slack email belongs to a member of an organization
-    connected to this workspace, and only when the assistant is enabled for
-    that install. The DM lands in the app's Messages tab, so replying drops
-    the joiner straight into the assistant flow.
+    including bots and single/multi-channel guests, which we skip. Every full
+    member gets the DM: it grants no access on its own — the assistant
+    resolves and authorizes the user on every interaction, offering the
+    account-linking flow when their email doesn't match — so eligibility
+    sorts itself out on first use. The ``slack-app-assistant`` flag is the
+    per-install opt-in that keeps the DM dark for workspaces that haven't
+    enabled the assistant.
     """
     joiner = event.get("user") if isinstance(event.get("user"), dict) else None
     slack_user_id = joiner.get("id") if joiner else None
@@ -2471,9 +2472,7 @@ def _route_team_join(
     if _us_should_handle_instead(slack_team_id, [SLACK_INTEGRATION_KIND], can_defer_to_other_region, incoming_host):
         return _proxy_event_and_return_route(request, other_domain)
 
-    integration = _find_team_join_integration(
-        workspace_result.candidates, slack_user_id, (joiner.get("profile") or {}).get("email")
-    )
+    integration = next((c for c in workspace_result.candidates if is_slack_app_assistant_enabled(c.team)), None)
     if integration is None:
         return ROUTE_HANDLED_LOCALLY
 
@@ -2491,41 +2490,6 @@ def _route_team_join(
         cache.delete(_team_join_onboarding_cache_key(slack_team_id, slack_user_id))
 
     return ROUTE_HANDLED_LOCALLY
-
-
-def _find_team_join_integration(
-    candidates: list[Integration], slack_user_id: str, profile_email: str | None
-) -> Integration | None:
-    """Pick the install to welcome the joiner from, or ``None`` to stay silent.
-
-    The joiner qualifies for an install when their Slack email matches an
-    active member of the install's organization and the assistant is enabled
-    for its team. The membership check runs first: it is a local indexed
-    query, while the flag eval is a remote call that the typical joiner (a
-    coworker with no PostHog account) should never trigger. ``team_join``
-    carries the full user object, so the email usually comes straight off the
-    event; ``users.info`` is the fallback for hidden profiles.
-    """
-    email = profile_email or get_slack_email_for_user(candidates[0], slack_user_id)
-    if not email:
-        return None
-    try:
-        member_org_ids = set(
-            OrganizationMembership.objects.filter(
-                organization_id__in={c.team.organization_id for c in candidates},
-                user__email__iexact=email,
-                user__is_active=True,
-            ).values_list("organization_id", flat=True)
-        )
-    except Exception:
-        # Don't propagate transient DB errors to the Slack webhook — Slack
-        # retries 5xx and would replay the event.
-        logger.warning("slack_app_team_join_membership_check_failed", slack_user_id=slack_user_id, exc_info=True)
-        return None
-    for candidate in candidates:
-        if candidate.team.organization_id in member_org_ids and is_slack_app_assistant_enabled(candidate.team):
-            return candidate
-    return None
 
 
 def _team_join_onboarding_cache_key(slack_team_id: str, slack_user_id: str) -> str:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -117,6 +117,7 @@ HANDLED_EVENT_TYPES = [
     "link_shared",
     "message",
     "member_joined_channel",
+    "team_join",
     "assistant_thread_started",
     "assistant_thread_context_changed",
     "app_home_opened",
@@ -1582,6 +1583,11 @@ _ASSISTANT_UNAVAILABLE = (
     "I can only help PostHog org members whose project has a connected repo. Make sure your Slack "
     "email matches your PostHog account and that a repo is connected, then try again."
 )
+_ASSISTANT_MEMBER_JOIN_WELCOME = (
+    ":wave: Welcome! I'm PostHog, an AI agent your team uses. DM me here to investigate issues "
+    "using your PostHog data or open PRs in your connected repos - you can also @mention me in "
+    "any channel."
+)
 
 
 def _assistant_event_fields(event: dict) -> tuple[str, str | None, str | None, str | None]:
@@ -2119,6 +2125,17 @@ def route_posthog_code_event_to_relevant_region(
             is_ext_shared_channel=is_ext_shared_channel,
         )
 
+    if event_type == "team_join":
+        return _route_team_join(
+            request,
+            event,
+            slack_team_id,
+            proxied=proxied,
+            other_domain=other_domain,
+            can_defer_to_other_region=can_defer_to_other_region,
+            incoming_host=incoming_host,
+        )
+
     # link_shared (unfurl) works with either integration kind.
     link_result = load_integrations(slack_team_id=slack_team_id, kinds=list(SLACK_INTEGRATION_KINDS))
     local_match = link_result.candidates[0] if link_result.candidates else None
@@ -2414,6 +2431,126 @@ def _post_channel_onboarding_message(slack: SlackIntegration, integration: Integ
             integration_id=integration.id,
             slack_workspace_id=integration.integration_id,
             channel_id=channel_id,
+            exc_info=True,
+        )
+        return False
+
+
+def _route_team_join(
+    request: HttpRequest,
+    event: dict[str, Any],
+    slack_team_id: str,
+    *,
+    proxied: bool,
+    other_domain: str,
+    can_defer_to_other_region: bool,
+    incoming_host: str,
+) -> str:
+    """DM a personal welcome to a new workspace member, at most once.
+
+    Slack fires ``team_join`` for every account added to the workspace —
+    including bots and single/multi-channel guests, which we skip. To avoid
+    spamming coworkers who have nothing to do with PostHog, the DM only goes
+    to joiners whose Slack email belongs to a member of an organization
+    connected to this workspace, and only when the assistant is enabled for
+    that install. The DM lands in the app's Messages tab, so replying drops
+    the joiner straight into the assistant flow.
+    """
+    joiner = event.get("user") if isinstance(event.get("user"), dict) else None
+    slack_user_id = joiner.get("id") if joiner else None
+    if not joiner or not isinstance(slack_user_id, str) or not slack_user_id:
+        return ROUTE_HANDLED_LOCALLY
+    if joiner.get("is_bot") or joiner.get("is_restricted") or joiner.get("is_ultra_restricted"):
+        return ROUTE_HANDLED_LOCALLY
+
+    workspace_result = load_integrations(slack_team_id=slack_team_id, kinds=[SLACK_INTEGRATION_KIND])
+    if not workspace_result.candidates:
+        return _route_to_other_region_or_drop(request, slack_team_id, proxied=proxied, other_domain=other_domain)
+
+    if _us_should_handle_instead(slack_team_id, [SLACK_INTEGRATION_KIND], can_defer_to_other_region, incoming_host):
+        return _proxy_event_and_return_route(request, other_domain)
+
+    integration = _find_team_join_integration(workspace_result.candidates, joiner, slack_user_id)
+    if integration is None:
+        return ROUTE_HANDLED_LOCALLY
+
+    if not _claim_team_join_onboarding(slack_team_id, slack_user_id):
+        logger.info(
+            "slack_app_team_join_welcome_skipped_duplicate",
+            slack_team_id=slack_team_id,
+            slack_user_id=slack_user_id,
+        )
+        return ROUTE_HANDLED_LOCALLY
+
+    if not _post_team_join_welcome(SlackIntegration(integration), integration, slack_user_id):
+        # Release the dedupe slot so the next delivery gets another shot
+        # rather than being silently swallowed.
+        _release_team_join_claim(slack_team_id, slack_user_id)
+
+    return ROUTE_HANDLED_LOCALLY
+
+
+def _find_team_join_integration(
+    candidates: list[Integration], joiner: dict[str, Any], slack_user_id: str
+) -> Integration | None:
+    """Pick the install to welcome the joiner from, or ``None`` to stay silent.
+
+    The joiner qualifies for an install when the assistant is enabled for its
+    team and their Slack email matches a member of the install's organization.
+    ``team_join`` carries the full user object, so the email usually comes
+    straight off the event; ``users.info`` is the fallback for hidden profiles.
+    """
+    email = (joiner.get("profile") or {}).get("email")
+    if not isinstance(email, str) or not email:
+        email = get_slack_email_for_user(candidates[0], slack_user_id)
+    if not email:
+        return None
+    for candidate in candidates:
+        if not is_slack_app_assistant_enabled(candidate.team):
+            continue
+        if OrganizationMembership.objects.filter(
+            organization_id=candidate.team.organization_id, user__email__iexact=email
+        ).exists():
+            return candidate
+    return None
+
+
+def _team_join_onboarding_cache_key(slack_team_id: str, slack_user_id: str) -> str:
+    return f"slack_app:team_join_welcomed:v1:{slack_team_id}:{slack_user_id}"
+
+
+def _claim_team_join_onboarding(slack_team_id: str, slack_user_id: str) -> bool:
+    """Atomically claim the right to DM this joiner — ``cache.add`` returns True
+    only for the first caller, so retries and the two-region race can't double-post."""
+    return bool(
+        cache.add(
+            _team_join_onboarding_cache_key(slack_team_id, slack_user_id),
+            True,
+            timeout=CHANNEL_ONBOARDING_DEDUPE_TTL_SECONDS,
+        )
+    )
+
+
+def _release_team_join_claim(slack_team_id: str, slack_user_id: str) -> None:
+    cache.delete(_team_join_onboarding_cache_key(slack_team_id, slack_user_id))
+
+
+def _post_team_join_welcome(slack: SlackIntegration, integration: Integration, slack_user_id: str) -> bool:
+    try:
+        slack.client.chat_postMessage(channel=slack_user_id, text=_ASSISTANT_MEMBER_JOIN_WELCOME)
+        logger.info(
+            "slack_app_team_join_welcome_posted",
+            integration_id=integration.id,
+            slack_workspace_id=integration.integration_id,
+            slack_user_id=slack_user_id,
+        )
+        return True
+    except Exception:
+        logger.warning(
+            "slack_app_team_join_welcome_post_failed",
+            integration_id=integration.id,
+            slack_workspace_id=integration.integration_id,
+            slack_user_id=slack_user_id,
             exc_info=True,
         )
         return False

--- a/products/slack_app/backend/tests/test_channel_onboarding_routing.py
+++ b/products/slack_app/backend/tests/test_channel_onboarding_routing.py
@@ -19,28 +19,24 @@ from products.slack_app.backend.api import (
     _team_join_onboarding_cache_key,
     route_posthog_code_event_to_relevant_region,
 )
-from products.slack_app.backend.services.slack_auth import get_cached_auth_state
+from products.slack_app.backend.services.slack_auth import get_cached_auth_state, write_auth_state_ok
+
+MEMBER_EMAIL = "dev@example.com"
 
 
-@override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
-class TestMemberJoinedChannelRouting(TestCase):
-    """Routing-level coverage for the channel onboarding flow.
+class _SlackRoutingTestBase(TestCase):
+    """Shared workspace fixtures for the routing tests below: real Postgres
+    rows for the org/team/membership/integration, with the side-effecting
+    Slack API mocked per test."""
 
-    Each test patches ``SlackIntegration`` so we can assert against the Slack
-    client without standing up a real WebClient. The Slack workspace row is
-    real Postgres state — only the side-effecting Slack API is mocked.
-    """
-
-    BOT_USER_ID = "U_BOT"
     SLACK_TEAM_ID = "T12345"
-    CHANNEL_ID = "C_NEW_CHANNEL"
 
     def setUp(self):
         cache.clear()
         self.factory = RequestFactory()
         self.organization = Organization.objects.create(name="Test Org")
         self.team = Team.objects.create(organization=self.organization, name="Test Team")
-        self.user = User.objects.create(email="dev@example.com", distinct_id="user-1")
+        self.user = User.objects.create(email=MEMBER_EMAIL, distinct_id="user-1")
         OrganizationMembership.objects.create(organization=self.organization, user=self.user)
         self.integration = Integration.objects.create(
             team=self.team,
@@ -57,12 +53,18 @@ class TestMemberJoinedChannelRouting(TestCase):
         # resolver short-circuits; ``bot_user_id=None`` keeps
         # ``get_cached_bot_user_id`` falling through to the (mocked)
         # ``auth.test`` call the onboarding flow expects.
-        from products.slack_app.backend.services.slack_auth import write_auth_state_ok
-
         write_auth_state_ok(self.integration.id, bot_user_id=None)
 
     def _request(self):
         return self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
+
+
+@override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+class TestMemberJoinedChannelRouting(_SlackRoutingTestBase):
+    """Routing-level coverage for the channel onboarding flow."""
+
+    BOT_USER_ID = "U_BOT"
+    CHANNEL_ID = "C_NEW_CHANNEL"
 
     def _event(self, *, user: str | None = None, channel: str | None = None) -> dict:
         return {
@@ -186,38 +188,11 @@ class TestMemberJoinedChannelRouting(TestCase):
 
 
 @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
-class TestTeamJoinRouting(TestCase):
-    """Routing-level coverage for the new-workspace-member welcome DM.
+class TestTeamJoinRouting(_SlackRoutingTestBase):
+    """Routing-level coverage for the new-workspace-member welcome DM, with
+    the assistant feature flag patched at the ``api`` import site."""
 
-    Same shape as the channel onboarding tests above: real Postgres rows for
-    the workspace/org/membership, mocked Slack client, and the assistant
-    feature flag patched at the ``api`` import site.
-    """
-
-    SLACK_TEAM_ID = "T12345"
     JOINER_ID = "U_NEW"
-    MEMBER_EMAIL = "dev@example.com"
-
-    def setUp(self):
-        cache.clear()
-        self.factory = RequestFactory()
-        self.organization = Organization.objects.create(name="Test Org")
-        self.team = Team.objects.create(organization=self.organization, name="Test Team")
-        self.user = User.objects.create(email=self.MEMBER_EMAIL, distinct_id="user-1")
-        OrganizationMembership.objects.create(organization=self.organization, user=self.user)
-        self.integration = Integration.objects.create(
-            team=self.team,
-            kind="slack",
-            integration_id=self.SLACK_TEAM_ID,
-            config={"scope": ",".join(sorted(REQUIRED_SLACK_SCOPES))},
-            sensitive_config={"access_token": "xoxb-test"},
-        )
-        from products.slack_app.backend.services.slack_auth import write_auth_state_ok
-
-        write_auth_state_ok(self.integration.id, bot_user_id=None)
-
-    def _request(self):
-        return self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
 
     def _event(self, *, email: str | None = MEMBER_EMAIL, **user_flags) -> dict:
         profile = {"email": email} if email is not None else {}
@@ -225,9 +200,7 @@ class TestTeamJoinRouting(TestCase):
 
     def _mock_slack(self, slack_cls_mock, *, post_ok: bool = True):
         instance = MagicMock()
-        if post_ok:
-            instance.client.chat_postMessage.return_value = {"ok": True}
-        else:
+        if not post_ok:
             instance.client.chat_postMessage.side_effect = RuntimeError("slack down")
         slack_cls_mock.return_value = instance
         return instance
@@ -262,24 +235,21 @@ class TestTeamJoinRouting(TestCase):
         slack_cls.assert_not_called()
         assert cache.get(_team_join_onboarding_cache_key(self.SLACK_TEAM_ID, self.JOINER_ID)) is None
 
-    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+    @parameterized.expand(
+        [
+            ("no_org_membership", "stranger@example.com", True),
+            ("assistant_flag_off", MEMBER_EMAIL, False),
+        ]
+    )
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled")
     @patch("products.slack_app.backend.api.SlackIntegration")
-    def test_joiner_without_org_membership_gets_no_dm(self, slack_cls, _flag):
+    def test_ineligible_joiner_gets_no_dm(self, _name, email, flag_enabled, slack_cls, flag_mock):
+        flag_mock.return_value = flag_enabled
         instance = self._mock_slack(slack_cls)
 
         result = route_posthog_code_event_to_relevant_region(
-            self._request(), self._event(email="stranger@example.com"), self.SLACK_TEAM_ID
+            self._request(), self._event(email=email), self.SLACK_TEAM_ID
         )
-
-        assert result == ROUTE_HANDLED_LOCALLY
-        instance.client.chat_postMessage.assert_not_called()
-
-    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=False)
-    @patch("products.slack_app.backend.api.SlackIntegration")
-    def test_assistant_flag_off_gets_no_dm(self, slack_cls, _flag):
-        instance = self._mock_slack(slack_cls)
-
-        result = route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
 
         assert result == ROUTE_HANDLED_LOCALLY
         instance.client.chat_postMessage.assert_not_called()

--- a/products/slack_app/backend/tests/test_channel_onboarding_routing.py
+++ b/products/slack_app/backend/tests/test_channel_onboarding_routing.py
@@ -4,6 +4,8 @@ from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 
+from parameterized import parameterized
+
 from posthog.helpers.slack_scopes import REQUIRED_SLACK_SCOPES
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization, OrganizationMembership
@@ -14,6 +16,7 @@ from products.slack_app.backend.api import (
     ROUTE_HANDLED_LOCALLY,
     ROUTE_NO_INTEGRATION,
     _channel_onboarding_cache_key,
+    _team_join_onboarding_cache_key,
     route_posthog_code_event_to_relevant_region,
 )
 from products.slack_app.backend.services.slack_auth import get_cached_auth_state
@@ -180,3 +183,123 @@ class TestMemberJoinedChannelRouting(TestCase):
         assert cached_state is not None
         assert cached_state.ok is True
         assert cached_state.bot_user_id == self.BOT_USER_ID
+
+
+@override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
+class TestTeamJoinRouting(TestCase):
+    """Routing-level coverage for the new-workspace-member welcome DM.
+
+    Same shape as the channel onboarding tests above: real Postgres rows for
+    the workspace/org/membership, mocked Slack client, and the assistant
+    feature flag patched at the ``api`` import site.
+    """
+
+    SLACK_TEAM_ID = "T12345"
+    JOINER_ID = "U_NEW"
+    MEMBER_EMAIL = "dev@example.com"
+
+    def setUp(self):
+        cache.clear()
+        self.factory = RequestFactory()
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.user = User.objects.create(email=self.MEMBER_EMAIL, distinct_id="user-1")
+        OrganizationMembership.objects.create(organization=self.organization, user=self.user)
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id=self.SLACK_TEAM_ID,
+            config={"scope": ",".join(sorted(REQUIRED_SLACK_SCOPES))},
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+        from products.slack_app.backend.services.slack_auth import write_auth_state_ok
+
+        write_auth_state_ok(self.integration.id, bot_user_id=None)
+
+    def _request(self):
+        return self.factory.post("/slack/event-callback/", HTTP_HOST="us.posthog.com")
+
+    def _event(self, *, email: str | None = MEMBER_EMAIL, **user_flags) -> dict:
+        profile = {"email": email} if email is not None else {}
+        return {"type": "team_join", "user": {"id": self.JOINER_ID, "profile": profile, **user_flags}}
+
+    def _mock_slack(self, slack_cls_mock, *, post_ok: bool = True):
+        instance = MagicMock()
+        if post_ok:
+            instance.client.chat_postMessage.return_value = {"ok": True}
+        else:
+            instance.client.chat_postMessage.side_effect = RuntimeError("slack down")
+        slack_cls_mock.return_value = instance
+        return instance
+
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    def test_org_member_join_sends_dm_and_claims_dedupe(self, slack_cls, _flag):
+        instance = self._mock_slack(slack_cls)
+
+        result = route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        instance.client.chat_postMessage.assert_called_once()
+        assert instance.client.chat_postMessage.call_args.kwargs["channel"] == self.JOINER_ID
+        assert cache.get(_team_join_onboarding_cache_key(self.SLACK_TEAM_ID, self.JOINER_ID)) is True
+
+    @parameterized.expand(
+        [
+            ("bot", {"is_bot": True}),
+            ("restricted_guest", {"is_restricted": True}),
+            ("ultra_restricted_guest", {"is_ultra_restricted": True}),
+        ]
+    )
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    def test_non_full_members_are_ignored(self, _name, user_flags, slack_cls, _flag):
+        result = route_posthog_code_event_to_relevant_region(
+            self._request(), self._event(**user_flags), self.SLACK_TEAM_ID
+        )
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        slack_cls.assert_not_called()
+        assert cache.get(_team_join_onboarding_cache_key(self.SLACK_TEAM_ID, self.JOINER_ID)) is None
+
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    def test_joiner_without_org_membership_gets_no_dm(self, slack_cls, _flag):
+        instance = self._mock_slack(slack_cls)
+
+        result = route_posthog_code_event_to_relevant_region(
+            self._request(), self._event(email="stranger@example.com"), self.SLACK_TEAM_ID
+        )
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        instance.client.chat_postMessage.assert_not_called()
+
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=False)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    def test_assistant_flag_off_gets_no_dm(self, slack_cls, _flag):
+        instance = self._mock_slack(slack_cls)
+
+        result = route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        instance.client.chat_postMessage.assert_not_called()
+
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    def test_duplicate_delivery_is_idempotent(self, slack_cls, _flag):
+        instance = self._mock_slack(slack_cls)
+
+        route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
+        route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
+
+        instance.client.chat_postMessage.assert_called_once()
+
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=True)
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    def test_post_failure_releases_dedupe_slot(self, slack_cls, _flag):
+        self._mock_slack(slack_cls, post_ok=False)
+
+        result = route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
+
+        assert result == ROUTE_HANDLED_LOCALLY
+        assert cache.get(_team_join_onboarding_cache_key(self.SLACK_TEAM_ID, self.JOINER_ID)) is None

--- a/products/slack_app/backend/tests/test_channel_onboarding_routing.py
+++ b/products/slack_app/backend/tests/test_channel_onboarding_routing.py
@@ -194,9 +194,8 @@ class TestTeamJoinRouting(_SlackRoutingTestBase):
 
     JOINER_ID = "U_NEW"
 
-    def _event(self, *, email: str | None = MEMBER_EMAIL, **user_flags) -> dict:
-        profile = {"email": email} if email is not None else {}
-        return {"type": "team_join", "user": {"id": self.JOINER_ID, "profile": profile, **user_flags}}
+    def _event(self, **user_flags) -> dict:
+        return {"type": "team_join", "user": {"id": self.JOINER_ID, **user_flags}}
 
     def _mock_slack(self, slack_cls_mock, *, post_ok: bool = True):
         instance = MagicMock()
@@ -235,21 +234,12 @@ class TestTeamJoinRouting(_SlackRoutingTestBase):
         slack_cls.assert_not_called()
         assert cache.get(_team_join_onboarding_cache_key(self.SLACK_TEAM_ID, self.JOINER_ID)) is None
 
-    @parameterized.expand(
-        [
-            ("no_org_membership", "stranger@example.com", True),
-            ("assistant_flag_off", MEMBER_EMAIL, False),
-        ]
-    )
-    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled")
+    @patch("products.slack_app.backend.api.is_slack_app_assistant_enabled", return_value=False)
     @patch("products.slack_app.backend.api.SlackIntegration")
-    def test_ineligible_joiner_gets_no_dm(self, _name, email, flag_enabled, slack_cls, flag_mock):
-        flag_mock.return_value = flag_enabled
+    def test_assistant_flag_off_gets_no_dm(self, slack_cls, _flag):
         instance = self._mock_slack(slack_cls)
 
-        result = route_posthog_code_event_to_relevant_region(
-            self._request(), self._event(email=email), self.SLACK_TEAM_ID
-        )
+        result = route_posthog_code_event_to_relevant_region(self._request(), self._event(), self.SLACK_TEAM_ID)
 
         assert result == ROUTE_HANDLED_LOCALLY
         instance.client.chat_postMessage.assert_not_called()


### PR DESCRIPTION
## Problem

New members of a Slack workspace with the PostHog app installed get no introduction to the assistant.

## Changes

Subscribes to Slack's `team_join` event and DMs a short welcome to every new full workspace member. Replying drops them straight into the existing assistant flow, which authorizes on every interaction and offers account linking when the joiner's email doesn't match a PostHog account, so the DM itself grants no access.

Gated on the `slack-app-assistant` flag (the per-install opt-in), bots and single/multi-channel guests are skipped, and it's deduped per workspace + user.

> [!NOTE]
> The Slack app manifest needs the `team_join` bot event subscription before this does anything. No new OAuth scopes needed.

## How did you test this code?

Added `TestTeamJoinRouting` (routing tests, all passing locally) covering the flag kill switch, bot/guest skips, duplicate-delivery idempotency, and dedupe release on send failure. Not tested against a live workspace since the manifest subscription isn't in place yet.

Manually tested

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, mirroring the existing `member_joined_channel` onboarding and install-welcome DM patterns. Skills invoked: `/writing-tests`. An earlier revision gated the DM on the joiner's email matching a connected org's member; we dropped that in favor of DMing every full member, since authorization already happens on first interaction.
