### PR TITLE
fix(mysql): retry connect-time "too many connections" as a transient error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -520,6 +520,23 @@ def _is_transient_vitess_dial_timeout(e: BaseException) -> bool:
     return _VITESS_DIAL_TOKEN in args_text and _VITESS_DIAL_TIMEOUT_TOKEN in args_text
 
 
+# MySQL/MariaDB error 1040 (ER_CON_COUNT_ERROR): the server refuses a *new* connection because
+# `max_connections` is already reached. A transient capacity condition on the customer's database,
+# not a misconfiguration — a slot frees the moment another connection closes — so a fresh attempt
+# after a short backoff usually succeeds. Mirrors the Postgres source's "sorry, too many clients
+# already" / "remaining connection slots are reserved" handling, which is retried the same way and
+# likewise kept out of `get_non_retryable_errors` (see `MySQLSource.get_retryable_errors`).
+_TOO_MANY_CONNECTIONS_CODE = 1040
+
+
+def _is_transient_too_many_connections(e: BaseException) -> bool:
+    """Return True if the server refused a new connection because it's at `max_connections`."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    code = e.args[0] if e.args else None
+    return code == _TOO_MANY_CONNECTIONS_CODE
+
+
 def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
     """Open a pymysql connection, retrying a transient drop or timeout on connect.
 
@@ -543,6 +560,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
                 or _is_transient_connect_broken_pipe(e)
                 or _is_transient_packet_sequence_error(e)
                 or _is_transient_vitess_dial_timeout(e)
+                or _is_transient_too_many_connections(e)
             ):
                 raise
             structlog.get_logger().warning(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -301,7 +301,11 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         # exhausted; the streaming path's FORCE INDEX fallback does the same for a mid-query drop
         # (see `_is_bad_plan_error`). Either way, Temporal retries the whole activity next and the
         # failure is transient and self-recovering, so don't surface it as tracked exception noise.
-        return {"Lost connection to MySQL server during query"}
+        #
+        # "Too many connections" (MySQL error 1040) shares the same contract: `_connect_with_transient_retry`
+        # retries it in-process too (see `_is_transient_too_many_connections`) — a slot frees the moment
+        # another connection closes, mirroring the Postgres source's connection-limit handling.
+        return {"Lost connection to MySQL server during query", "Too many connections"}
 
     def reconcile_schema_metadata(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -34,6 +34,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _is_transient_metadata_query_reset,
     _is_transient_packet_sequence_error,
     _is_transient_tablet_unavailable,
+    _is_transient_too_many_connections,
     _is_transient_vitess_dial_timeout,
     _is_transient_vitess_reparent,
     _release_streaming_cursor,
@@ -1191,6 +1192,27 @@ class TestIsTransientVitessDialTimeout:
         assert not _is_transient_vitess_dial_timeout(ValueError("dial tcp 10.0.0.1: connection timed out"))
 
 
+class TestIsTransientTooManyConnections:
+    def test_matches_too_many_connections(self):
+        assert _is_transient_too_many_connections(pymysql.err.OperationalError(1040, "Too many connections"))
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            (2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_other_codes(self, code, message):
+        assert not _is_transient_too_many_connections(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_too_many_connections(pymysql.err.OperationalError())
+
+    def test_does_not_match_non_operational_error(self):
+        assert not _is_transient_too_many_connections(pymysql.err.InternalError(1040, "Too many connections"))
+
+
 class TestConnectTransientRetry:
     @pytest.mark.parametrize(
         "fail_count,expected_sleeps",
@@ -1332,6 +1354,21 @@ class TestConnectTransientRetry:
                 ),
                 conn,
             ],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
+
+    def test_retries_too_many_connections_then_succeeds(self, mocker):
+        sleep = mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        mock_connect = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[pymysql.err.OperationalError(1040, "Too many connections"), conn],
         )
 
         with MySQLImplementation().connect(_make_config()) as yielded:
@@ -2032,6 +2069,34 @@ class TestMySQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Transient thread-exhaustion error should remain retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "OperationalError: (1040, 'Too many connections')",
+            "Too many connections",
+        ],
+    )
+    def test_too_many_connections_stays_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Too-many-connections error should remain retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "OperationalError: (1040, 'Too many connections')",
+            "Too many connections",
+        ],
+    )
+    def test_too_many_connections_is_classified_retryable(self, source, error_msg):
+        # Already retried in-process at connect time (`_is_transient_too_many_connections`); once
+        # exhausted it re-raises for Temporal to retry the whole activity. Without this
+        # classification `_handle_import_error` logs it at `exception` on every occurrence,
+        # flooding error tracking with a self-recovering capacity condition.
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Too-many-connections error should be classified retryable: {error_msg}"
 
 
 class TestMySQLSourceValidateCredentials:


### PR DESCRIPTION
## Problem

Error tracking surfaced an unhandled `OperationalError: (1040, 'Too many connections')` from the MySQL/MariaDB data-warehouse source, raised in `_connect_with_transient_retry` when opening a new connection to the customer's database.

MySQL error 1040 (`ER_CON_COUNT_ERROR`) fires when the server has already hit `max_connections` and refuses a *new* connection. This is a transient capacity condition on the customer's database, not a misconfiguration — a slot frees the moment another connection closes — so a fresh attempt after a short backoff usually succeeds. This mirrors how the Postgres source already treats its equivalent errors ("sorry, too many clients already", "remaining connection slots are reserved", etc.): retried in-process and deliberately kept out of `get_non_retryable_errors`.

The MySQL source didn't have an equivalent predicate, so every occurrence failed the connect attempt immediately and surfaced as captured error-tracking noise, relying entirely on Temporal's outer activity retry to eventually recover.

## Changes

- Add `_is_transient_too_many_connections` in `mysql.py`, matching MySQL error code 1040, and wire it into `_connect_with_transient_retry`'s existing bounded in-process retry loop (same pattern as the existing lost-connection/reset/timeout/DNS predicates).
- Add `"Too many connections"` to `MySQLSource.get_retryable_errors()` so that if in-process retries are exhausted, the failure is still classified as an expected, self-recovering condition rather than logged as an exception on every occurrence — same contract already used for `"Lost connection to MySQL server during query"`.

## How did you test this code?

Added test coverage in `test_mysql.py`:
- `TestIsTransientTooManyConnections`: unit tests for the new predicate (matches code 1040, doesn't match other codes/error types).
- `TestConnectTransientRetry::test_retries_too_many_connections_then_succeeds`: confirms the connect retry loop recovers from a 1040 error without escaping to the caller — the actual regression this PR fixes.
- `TestMySQLSourceNonRetryableErrors::test_too_many_connections_stays_retryable` / `test_too_many_connections_is_classified_retryable`: confirm the error stays out of `get_non_retryable_errors` and is classified by `get_retryable_errors`, so the activity-level handler treats an exhausted retry as expected rather than capturing it.

Ran the full `mysql` source test suite (258 passed), `ruff check`/`ruff format --diff` (clean), and `mypy --cache-fine-grained .` repo-wide (no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification fix, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged this from a webhook-delivered PostHog error tracking issue: an `OperationalError: (1040, 'Too many connections')` from the MySQL source's `_connect_with_transient_retry`. I confirmed the failure originates in this source's code via the full stack trace, read the existing transient-connect-retry predicates in `mysql.py`, and compared against the Postgres source's `_is_connection_limit_error` handling of the equivalent connection-capacity errors to decide this should be retried in-process rather than added to `NonRetryableErrors`. I searched open PRs (by error text, module path, and the maintainer's own open PRs) and found no existing fix for this specific error.

No skills were invoked beyond `/writing-tests` before adding the regression tests.