### PR TITLE
fix(toolbar): disable global exception autocapture

### DIFF
--- a/frontend/src/toolbar/toolbarPosthogJS.ts
+++ b/frontend/src/toolbar/toolbarPosthogJS.ts
@@ -20,6 +20,8 @@ const initResult = posthog.init(
             featureFlags: {},
         },
         autocapture: false,
+        // The toolbar runs on customer pages and must not install global exception handlers.
+        capture_exceptions: false,
         capture_pageview: false,
         capture_pageleave: false,
         disable_surveys: true,


### PR DESCRIPTION
## Problem

The toolbar's internal posthog-js instance runs inside customer pages. If exception autocapture is enabled through remote configuration, that instance can install global error and unhandled-rejection handlers and capture host-page exceptions that are unrelated to the toolbar.

## Changes

I explicitly disabled exception autocapture for `ph_toolbar_internal`. Intentional toolbar errors can still be reported through `captureToolbarException`.

## How did you test this code?

- Ran `./bin/hogli test frontend/src/toolbar/index.test.ts`: 8 tests passed.
- Verified the changed file with oxfmt and `git diff --check`.
- Attempted the full frontend TypeScript check, but the worktree was missing built internal Quill and HogVM packages. The resulting module-resolution errors were unrelated to this config-only change.

No new test was added. The existing toolbar suite imports and initializes the real internal posthog-js instance, while a new mock-only assertion of the config object would duplicate the implementation without testing additional behavior.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this only changes the toolbar's internal telemetry configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed Pi to make this targeted configuration change in a dedicated worktree. The agent used the `/karpathy-guidelines`, `/writing-tests`, `/pr`, and `/autoreview` skills. We kept the patch to the explicit opt-out and rejected a mock-only test because it would only mirror the configuration object.
