### PR TITLE
fix(sentry): normalize a pasted org URL into the organization slug

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -3,7 +3,7 @@ import dataclasses
 from collections.abc import Callable, Iterable, Iterator
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, cast
-from urllib.parse import quote, urljoin
+from urllib.parse import quote, urljoin, urlparse
 
 import structlog
 from dateutil import parser as dateutil_parser
@@ -77,6 +77,42 @@ class SentryResumeConfig:
     issue_id: Optional[str] = None
     tag_key: Optional[str] = None
     values_next_url: Optional[str] = None
+
+
+# Sentry exposes an org URL as `https://<org>.sentry.io/` in its UI and as
+# `https://sentry.io/organizations/<org>/...` in deep links, so users routinely paste one of
+# those into the slug field instead of the bare slug.
+_SENTRY_NON_ORG_SUBDOMAINS = {"www", "us", "de", "eu", "app"}
+
+
+def _normalize_organization_slug(organization_slug: str) -> str:
+    """Pull the org slug out of a pasted Sentry URL.
+
+    A valid Sentry org slug is lowercase alphanumeric plus hyphens, so any `/`, `:`, or `.` in the
+    value means it's a URL or host, not a slug. Extract the slug from the two shapes Sentry uses and
+    leave a bare slug untouched. Because a real slug can never contain those characters, an input we
+    rewrite here would have failed the credential check anyway, so a wrong guess can only produce the
+    same failure with a clearer target, never hijack a valid slug.
+    """
+    slug = organization_slug.strip()
+    if not any(char in slug for char in "/:."):
+        return slug
+
+    parsed = urlparse(slug if "//" in slug else f"https://{slug}")
+    segments = [segment for segment in parsed.path.split("/") if segment]
+
+    if "organizations" in segments:
+        index = segments.index("organizations")
+        if index + 1 < len(segments):
+            return segments[index + 1]
+
+    host = (parsed.hostname or "").lower()
+    if host.endswith(".sentry.io"):
+        subdomain = host.removesuffix(".sentry.io")
+        if subdomain and subdomain not in _SENTRY_NON_ORG_SUBDOMAINS:
+            return subdomain
+
+    return segments[-1] if segments else slug
 
 
 def _normalize_api_base_url(api_base_url: str | None) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -112,7 +112,10 @@ def _normalize_organization_slug(organization_slug: str) -> str:
         if subdomain and subdomain not in _SENTRY_NON_ORG_SUBDOMAINS:
             return subdomain
 
-    return segments[-1] if segments else slug
+    # Couldn't confidently identify a slug (e.g. a bare `sentry.io` or an `/organizations/` path
+    # with no slug after it), so leave the value untouched. The credential check then reports the
+    # exact thing the user typed rather than a misleading guess like the literal "organizations".
+    return slug
 
 
 def _normalize_api_base_url(api_base_url: str | None) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/source.py
@@ -22,6 +22,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.typ
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.sentry import SentrySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry import (
     SentryResumeConfig,
+    _normalize_organization_slug,
     sentry_source,
     validate_credentials as validate_sentry_credentials,
 )
@@ -46,6 +47,15 @@ class SentrySource(ResumableSource[SentrySourceConfig, SentryResumeConfig]):
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.SENTRY
+
+    def parse_config(self, job_inputs: dict) -> SentrySourceConfig:
+        # Normalize before building the config so both the credential check and the stored
+        # job_inputs use the extracted slug. Normalizing only in validate_credentials would let a
+        # pasted URL pass validation but persist as the slug, breaking every later sync.
+        organization_slug = job_inputs.get("organization_slug")
+        if isinstance(organization_slug, str):
+            job_inputs = {**job_inputs, "organization_slug": _normalize_organization_slug(organization_slug)}
+        return self._config_class.from_dict(job_inputs)
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -105,6 +105,8 @@ class TestSentryTransport:
             ("org_subdomain_with_path", "https://acme.sentry.io/issues/", "acme"),
             ("organizations_deep_link", "https://sentry.io/organizations/acme/issues/", "acme"),
             ("organizations_deep_link_no_scheme", "sentry.io/organizations/acme", "acme"),
+            # No slug to extract: return the input as-is rather than guessing the literal "organizations".
+            ("organizations_path_without_slug", "https://sentry.io/organizations/", "https://sentry.io/organizations/"),
         ]
     )
     def test_normalize_organization_slug_extracts_slug(self, _name: str, value: str, expected: str) -> None:
@@ -345,8 +347,6 @@ class TestSentrySourceValidation:
         )
 
     def test_parse_config_normalizes_pasted_org_url(self) -> None:
-        # Guards the wiring: parse_config must run the slug normalization so a pasted URL is stored
-        # as the bare slug, not just cleaned up inside the credential check.
         config = SentrySource().parse_config({"auth_token": "token", "organization_slug": "https://acme.sentry.io/"})
 
         assert config.organization_slug == "acme"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -14,6 +14,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sen
     SentryResumeConfig,
     _custom_endpoint_rows,
     _normalize_api_base_url,
+    _normalize_organization_slug,
     _parse_next_link,
     _retention_bounded_start_param,
     _retry_wait_seconds,
@@ -94,6 +95,20 @@ class TestSentryTransport:
     def test_normalize_api_base_url(self) -> None:
         assert _normalize_api_base_url(None) == "https://sentry.io"
         assert _normalize_api_base_url("https://us.sentry.io/") == "https://us.sentry.io"
+
+    @parameterized.expand(
+        [
+            ("bare_slug", "acme", "acme"),
+            ("bare_slug_trims_whitespace", "  acme  ", "acme"),
+            ("org_subdomain_url", "https://acme.sentry.io/", "acme"),
+            ("org_subdomain_url_no_scheme", "acme.sentry.io", "acme"),
+            ("org_subdomain_with_path", "https://acme.sentry.io/issues/", "acme"),
+            ("organizations_deep_link", "https://sentry.io/organizations/acme/issues/", "acme"),
+            ("organizations_deep_link_no_scheme", "sentry.io/organizations/acme", "acme"),
+        ]
+    )
+    def test_normalize_organization_slug_extracts_slug(self, _name: str, value: str, expected: str) -> None:
+        assert _normalize_organization_slug(value) == expected
 
     def test_start_param_for_sentry_formats_datetime(self) -> None:
         value = datetime(2025, 1, 1, 10, 30, 0, tzinfo=UTC)
@@ -328,6 +343,13 @@ class TestSentrySourceValidation:
             organization_slug="acme",
             api_base_url="https://sentry.io",
         )
+
+    def test_parse_config_normalizes_pasted_org_url(self) -> None:
+        # Guards the wiring: parse_config must run the slug normalization so a pasted URL is stored
+        # as the bare slug, not just cleaned up inside the credential check.
+        config = SentrySource().parse_config({"auth_token": "token", "organization_slug": "https://acme.sentry.io/"})
+
+        assert config.organization_slug == "acme"
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.rest_api_resource")
     def test_sentry_source_builds_response(self, mock_rest_api_resource) -> None:


### PR DESCRIPTION
## Problem

When connecting Sentry as a data warehouse source, the setup wizard has an "Organization slug" field. Users routinely paste their Sentry organization URL there instead of the bare slug. The raw value was sent straight into the API path (`/api/0/organizations/<value>/projects/`), so a pasted URL like `https://<org>.sentry.io/` produced a 404 and a confusing "organization '<...>' not found" error at connect time, blocking the source from being created.

## Changes

Normalize the organization slug in `SentrySource.parse_config`, so it applies to both the create-time credential check and the value persisted to `job_inputs` (normalizing only in `validate_credentials` would let a pasted URL pass validation but store a broken slug that fails every later sync).

The helper extracts the slug from the two shapes Sentry exposes and leaves a bare slug untouched:

- `https://<org>.sentry.io/` (and without the scheme / with a path) → `<org>`
- `https://sentry.io/organizations/<org>/...` → `<org>`

A valid Sentry org slug is lowercase alphanumeric plus hyphens, so normalization only kicks in when the value contains a `/`, `:`, or `.` — characters a real slug can never contain. That means a value we rewrite would have failed the credential check anyway, so a wrong guess can only turn a guaranteed failure into a success or reproduce the same failure with a clearer target. It can never hijack a valid slug.

This is separate from #76482, which improves the wording of the 401 rejected-token message; this change addresses the 404 caused by a pasted URL.

## How did you test this code?

Added automated tests in `test_sentry.py`:

- A parameterized test over `_normalize_organization_slug` covering a bare slug, whitespace trimming, the `<org>.sentry.io` subdomain form (with and without scheme/path), and the `/organizations/<org>/` deep-link form. Catches a regression where the extraction logic silently stops handling a pasted URL and reverts to sending the raw value.
- A wiring guard that `SentrySource.parse_config` actually runs the normalization, so a refactor that drops the override (which would let a URL persist as the stored slug and break sync) fails.

Ran the full Sentry source suite locally with the repo venv (`pytest .../sentry/tests/test_sentry.py`) — 129 passed. Ran `ruff check` / `ruff format` on the three touched files. No manual/UI testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Came out of a triage of data-warehouse source-creation failures. Most failure messages were already clear and actionable or already handled in the tree, so this was the one that warranted a code fix: a pasted org URL is a common mistake we can recover from rather than reject.

Skills invoked: `/writing-tests` (kept the test at the pure-function level with a single wiring guard, each case aimed at a named regression) and `/writing-code-comments` (comments explain why normalization is safe and why it belongs in `parse_config`, not the call site).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*