### PR TITLE
fix(dashboards): skip tile reload on edit mode cancel without preview

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -11,6 +11,7 @@ import { DASHBOARD_WIDGET_FETCH_ERROR_MESSAGE } from '@posthog/products-dashboar
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs, now } from 'lib/dayjs'
+import * as featureFlagLib from 'lib/logic/featureFlagLogic'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { addInsightToDashboardLogic } from 'scenes/dashboard/addInsightToDashboardModalLogic'
@@ -881,6 +882,34 @@ describe('dashboardLogic', () => {
                     ])
                     .toFinishAllListeners()
                     .toNotHaveDispatchedActions(['refreshDashboardItems'])
+            })
+
+            it('discarding an unapplied filter edit above the auto-preview limit does not reload tiles', async () => {
+                // The skip-reload check relies on unpreviewed edits never reaching the URL:
+                // when the dashboard is over the auto-preview limit, filter edits stay
+                // intermittent (no URL write, no refresh) until "Apply filters" is clicked.
+                const payloadSpy = jest.spyOn(featureFlagLib, 'getFeatureFlagPayload').mockReturnValue(1)
+
+                await expectLogic(logic).toFinishAllListeners()
+                expect(logic.values.canAutoPreview).toBe(false)
+
+                await expectLogic(logic, () => {
+                    logic.actions.setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
+                    logic.actions.setDates('-14d', null)
+                }).toFinishAllListeners()
+
+                expect(router.values.searchParams[dashboardUtils.SEARCH_PARAM_FILTERS_KEY]).toBeUndefined()
+
+                await expectLogic(logic, () => {
+                    logic.actions.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)
+                })
+                    .toDispatchActions([
+                        logic.actionCreators.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges),
+                    ])
+                    .toFinishAllListeners()
+                    .toNotHaveDispatchedActions(['refreshDashboardItems'])
+
+                payloadSpy.mockRestore()
             })
 
             it('filter edit source clears layout edit mode', async () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -845,6 +845,44 @@ describe('dashboardLogic', () => {
                 restoreSpy.mockRestore()
             })
 
+            it('discarding after a previewed filter change reloads tiles', async () => {
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
+                    logic.actions.setDates('-14d', null)
+                }).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)
+                })
+                    .toDispatchActions([
+                        // anchor at the discard dispatch, so the refresh matched below is the
+                        // discard-triggered one and not an earlier (initial load / preview) one
+                        logic.actionCreators.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges),
+                        'refreshDashboardItems',
+                    ])
+                    .toFinishAllListeners()
+            })
+
+            it('discarding without a previewed filter change does not reload tiles', async () => {
+                await expectLogic(logic).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.setDashboardMode(DashboardMode.Edit, DashboardEventSource.SceneCommonButtons)
+                }).toFinishAllListeners()
+
+                await expectLogic(logic, () => {
+                    logic.actions.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges)
+                })
+                    .toDispatchActions([
+                        // anchor at the discard dispatch, so only actions after it are considered
+                        logic.actionCreators.setDashboardMode(null, DashboardEventSource.DashboardHeaderDiscardChanges),
+                    ])
+                    .toFinishAllListeners()
+                    .toNotHaveDispatchedActions(['refreshDashboardItems'])
+            })
+
             it('filter edit source clears layout edit mode', async () => {
                 await expectLogic(logic).toFinishAllListeners()
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1545,12 +1545,14 @@ export const dashboardLogic = kea<dashboardLogicType>([
                         values.dashboard?.tiles
                     ) {
                         // layout changes were discarded so need to reset to original state
-                        const restoredTiles = values.dashboard?.tiles?.map((tile) => ({
-                            ...tile,
-                            layouts: values.dashboardLayouts?.[tile.id],
-                        }))
-
-                        values.dashboard.tiles = restoredTiles
+                        // (as a new object — selectors only recompute when the reference changes)
+                        return {
+                            ...values.dashboard,
+                            tiles: values.dashboard.tiles.map((tile) => ({
+                                ...tile,
+                                layouts: values.dashboardLayouts?.[tile.id],
+                            })),
+                        }
                     }
 
                     return values.dashboard
@@ -3973,13 +3975,27 @@ export const dashboardLogic = kea<dashboardLogicType>([
             } else if (source === DashboardEventSource.DashboardHeaderDiscardChanges) {
                 // reset filters to that before previewing
                 actions.resetIntermittentFilters()
-                actions.restoreUrlStateAtEditModeEntry(values.urlSearchParamsAtEditModeEntry)
 
-                // reset tile data by reloading dashboard
-                actions.refreshDashboardItems({
-                    action: RefreshDashboardItemsAction.Preview,
-                    forceRefresh: false,
-                })
+                // Previews route filters/variables through the URL before refreshing, so tile data
+                // always matches the current URL state. Restoring the snapshot therefore only
+                // requires a reload when it actually changes that state — if no preview ran during
+                // this edit session, the data on screen is already correct.
+                const snapshot = values.urlSearchParamsAtEditModeEntry
+                const urlStateChangedSinceEditModeEntry =
+                    !equal(values.urlFilters, parseURLFilters({ [SEARCH_PARAM_FILTERS_KEY]: snapshot?.filters })) ||
+                    !equal(
+                        parseURLVariables(router.values.searchParams),
+                        parseURLVariables({ [SEARCH_PARAM_QUERY_VARIABLES_KEY]: snapshot?.variables })
+                    )
+                actions.restoreUrlStateAtEditModeEntry(snapshot)
+
+                if (urlStateChangedSinceEditModeEntry) {
+                    // reset tile data by reloading dashboard
+                    actions.refreshDashboardItems({
+                        action: RefreshDashboardItemsAction.Preview,
+                        forceRefresh: false,
+                    })
+                }
 
                 // also reset layout to that we stored in dashboardLayouts
                 // this is done in the reducer for dashboard


### PR DESCRIPTION
## TL;DR

Pressing Cancel in dashboard edit mode made every insight briefly flip into a loading state and re-fetch, even when nothing had been previewed and the data on screen was already correct. Now the reload only runs when tiles actually previewed different filters.

## Problem

Discarding edit mode unconditionally dispatched `refreshDashboardItems`, marking every tile as queued and firing one request per tile. That reload exists to restore saved-filter data after a preview overwrote tile results in place, but it also ran when no preview ever happened:

- enter edit mode, change nothing (or only layout/colors), cancel
- on dashboards above the auto-preview tile limit, change filters but never click Apply, then cancel

## Changes

- On discard, compare the URL filter/variable state against the snapshot taken at edit mode entry and skip the tile reload when they match. Previews (auto-preview and Apply) route filters through the URL before refreshing, so tile data always corresponds to the current URL state.
- The discard-time layout restore now returns a new dashboard object instead of mutating kea state in place. The mutation was only picked up because the unconditional reload touched the dashboard right after. Without it, selectors like `hasUnsavedLayoutChanges` kept stale memoized values.

## How did you test this code?

Two new kea logic tests in `dashboardLogic.test.ts`:

- discard after a previewed filter change still reloads tiles (catches over-eager skipping, which would leave preview data on screen)
- discard without a previewed change does not reload tiles (catches a regression back to the wasted reload this PR removes)

No existing test covered either path. Full `dashboardLogic` suite plus every suite that mounts `dashboardLogic` (24 suites, 420 tests) passes. I did not test manually in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc changes needed, this restores intended behavior without changing any workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), driven by Thomas Obermueller.

Authored by PostHog Code (Claude). Skills invoked: /writing-tests. Notable decisions:

- Chose comparing URL state against the edit-entry snapshot over tracking a "preview ran" flag, since both auto-preview and Apply already route filters/variables through the URL before refreshing, so equality there proves tile data is current.
- The two originally failing layout tests exposed that the in-place `values.dashboard.tiles` mutation in the `setDashboardMode` loader handler never changed the state reference, so selector memos went stale once the masking reload was skipped. Fixed by returning a new object rather than keeping the reload.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*