### PR TITLE
fix: change code to desktop on overview page

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -273,7 +273,7 @@ export function Billing(): JSX.Element {
                                 <LemonButton
                                     icon={<IconDocument />}
                                     size="small"
-                                    to="https://posthog.com/docs/posthog-code"
+                                    to="https://posthog.com/docs/posthog-desktop"
                                     tooltip="Read the docs"
                                 />
                             </div>

--- a/frontend/src/scenes/billing/BillingProduct.stories.tsx
+++ b/frontend/src/scenes/billing/BillingProduct.stories.tsx
@@ -55,7 +55,7 @@ const makePostHogCodeUsageBilling = ({
         description: 'AI coding agents for automating PostHog work.',
         usage_key: POSTHOG_CODE_USAGE_PRODUCT_KEY,
         icon_key: 'IconTerminal',
-        docs_url: 'https://posthog.com/docs/posthog-code',
+        docs_url: 'https://posthog.com/docs/posthog-desktop',
         subscribed: true,
         type: POSTHOG_CODE_USAGE_PRODUCT_KEY,
         current_amount_usd: currentLimitUsd > STARTUP_PROGRAM_BILLING_LIMIT_MAX ? '3750.00' : '25.00',

--- a/frontend/src/scenes/billing/billingLimitConfig.ts
+++ b/frontend/src/scenes/billing/billingLimitConfig.ts
@@ -33,7 +33,7 @@ type BillingLimitConfigResolver = (context: BillingLimitConfigContext) => Partia
 
 // Mirrors the caps the billing service enforces for startup-program customers, so the form
 // rejects out-of-range limits before the API does. The billing API product names are too
-// verbose for copy (e.g. "PostHog Code (usage-based)").
+// verbose for copy (e.g. "PostHog Desktop (usage-based)").
 const startupProgramCapResolver = (productName: string): BillingLimitConfigResolver => {
     return ({ billing, customLimitUsd, billingLimitNextPeriod }) => {
         if (!billing?.startup_program_label) {
@@ -58,7 +58,7 @@ const startupProgramCapResolver = (productName: string): BillingLimitConfigResol
 }
 
 const BILLING_LIMIT_CONFIG_BY_PRODUCT: Record<string, BillingLimitConfigResolver> = {
-    [POSTHOG_CODE_USAGE_PRODUCT_KEY]: startupProgramCapResolver('Code'),
+    [POSTHOG_CODE_USAGE_PRODUCT_KEY]: startupProgramCapResolver('Desktop'),
     [REPLAY_VISION_PRODUCT_KEY]: startupProgramCapResolver('Replay vision'),
 }
 


### PR DESCRIPTION
## Problem

<img width="1199" height="352" alt="image" src="https://github.com/user-attachments/assets/ca5cd196-2f1c-4a94-a884-62655adf3d15" />
changes this to posthog-desktop. and updates the read docs button link

## Changes

small change to update docs and name on billing overview page.

## How did you test this code?

just a link change

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->
