### PR TITLE
fix(data-imports): stop requesting today's data from AWS utilization APIs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/aws_cost_explorer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/aws_cost_explorer.py
@@ -136,6 +136,17 @@ def resolve_start_date(
     return min(start, end)
 
 
+def resolve_end_date(endpoint_config: CostExplorerEndpointConfig, today: dt.date) -> dt.date:
+    """The exclusive upper bound for this run's request window.
+
+    Cost and Usage reports return a partial, `Estimated`-flagged row for the still-open current
+    day, so requesting through tomorrow captures it. Utilization reports (Reservation, Savings
+    Plans) have no such estimate: AWS rejects an `End` date that isn't strictly before today with
+    `DataUnavailableException`, so the window must stop at today instead.
+    """
+    return today + dt.timedelta(days=1) if endpoint_config.metrics else today
+
+
 def build_windows(start: dt.date, end: dt.date, window_days: int) -> list[TimeWindow]:
     """Split [start, end) into request windows. `end` is exclusive, matching `TimePeriod`."""
     windows: list[TimeWindow] = []
@@ -369,8 +380,7 @@ def get_rows(
     session = make_session(aws_secret_access_key, aws_session_token)
     credentials = Credentials(aws_access_key_id, aws_secret_access_key, aws_session_token or None)
 
-    # `End` is exclusive, so tomorrow captures today's partial (flagged estimated) too.
-    end = dt.datetime.now(dt.UTC).date() + dt.timedelta(days=1)
+    end = resolve_end_date(endpoint_config, dt.datetime.now(dt.UTC).date())
     start = resolve_start_date(
         start_date, endpoint_config, should_use_incremental_field, db_incremental_field_last_value, end
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/aws_cost_explorer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/aws_cost_explorer.py
@@ -141,8 +141,8 @@ def resolve_end_date(endpoint_config: CostExplorerEndpointConfig, today: dt.date
 
     Cost and Usage reports return a partial, `Estimated`-flagged row for the still-open current
     day, so requesting through tomorrow captures it. Utilization reports (Reservation, Savings
-    Plans) have no such estimate: AWS rejects an `End` date that isn't strictly before today with
-    `DataUnavailableException`, so the window must stop at today instead.
+    Plans) reject any range that includes the current day with `DataUnavailableException`, so
+    their window must end at `today` (exclusive), requesting only through yesterday.
     """
     return today + dt.timedelta(days=1) if endpoint_config.metrics else today
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/tests/test_aws_cost_explorer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/tests/test_aws_cost_explorer.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.aws_cost_e
     error_for_response,
     get_rows,
     normalize_results,
+    resolve_end_date,
     resolve_start_date,
     send_operation,
     validate_credentials,
@@ -148,6 +149,19 @@ class TestResolveStartDate:
 
     def test_ignores_an_unparseable_watermark(self) -> None:
         assert resolve_start_date("2024-01-01", COST_DAILY, True, "not-a-date", self.END) == dt.date(2024, 1, 1)
+
+
+class TestResolveEndDate:
+    TODAY = dt.date(2024, 6, 1)
+
+    def test_cost_and_usage_reaches_through_tomorrow_for_todays_estimated_row(self) -> None:
+        assert resolve_end_date(COST_DAILY, self.TODAY) == dt.date(2024, 6, 2)
+
+    @pytest.mark.parametrize("endpoint_config", [RESERVATION, SAVINGS_PLANS])
+    def test_utilization_endpoints_stop_at_today(self, endpoint_config: Any) -> None:
+        # AWS rejects an `End` date that isn't strictly before today for these operations with
+        # DataUnavailableException, unlike Cost and Usage which returns partial estimated data.
+        assert resolve_end_date(endpoint_config, self.TODAY) == self.TODAY
 
 
 class TestBuildPayload:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/tests/test_aws_cost_explorer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/tests/test_aws_cost_explorer.py
@@ -158,7 +158,9 @@ class TestResolveEndDate:
         assert resolve_end_date(COST_DAILY, self.TODAY) == dt.date(2024, 6, 2)
 
     @pytest.mark.parametrize("endpoint_config", [RESERVATION, SAVINGS_PLANS])
-    def test_utilization_endpoints_stop_at_today(self, endpoint_config: Any) -> None:
+    def test_utilization_endpoints_stop_at_today(
+        self, endpoint_config: aws_cost_explorer.CostExplorerEndpointConfig
+    ) -> None:
         # AWS rejects an `End` date that isn't strictly before today for these operations with
         # DataUnavailableException, unlike Cost and Usage which returns partial estimated data.
         assert resolve_end_date(endpoint_config, self.TODAY) == self.TODAY


### PR DESCRIPTION
## Problem

PostHog's error tracking surfaced a `NonRetryableException` from the AWS Cost Explorer source, wrapping `AwsCostExplorerError: AWS Cost Explorer request failed: DataUnavailableException - `. The affected sync was `savings_plans_utilization_daily`, running as an incremental sync.

`GetSavingsPlansUtilization` and `GetReservationUtilization` reject an `End` date that isn't strictly before the current day (per the [API docs](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetSavingsPlansUtilization.html)): "The `End` date must be after the `Start` date, and before the current date. Future dates can't be used as an `End` date." `GetCostAndUsage` has no such restriction, since it returns a partial `Estimated`-flagged row for the still-open current day.

`get_rows()` computed the window's exclusive `end` as tomorrow for every endpoint, based on reasoning that only applies to Cost and Usage. So every sync of `savings_plans_utilization_daily`/`reservation_utilization_daily` requested a final window that AWS always rejects, and the source already correctly classifies this as non-retryable (`DataUnavailableException` is in `get_non_retryable_errors`) - but that meant the utilization tables would never sync past their most recent window, every single run.

## Changes

Added `resolve_end_date()`, which reuses the existing `endpoint_config.metrics` signal (already used to gate `Estimated`/cost-metric handling) to decide the window's upper bound: tomorrow for Cost and Usage endpoints, today for the utilization endpoints that don't support a same-day request.

## How did you test this code?

Added `TestResolveEndDate`, parameterized over the cost-and-usage vs. utilization endpoint configs, asserting the correct exclusive end date for each. Ran the full `test_aws_cost_explorer.py` suite (55 passed), `ruff check`/`ruff format --check`, and a full-repo `mypy --cache-fine-grained .` (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via a PostHog error-tracking issue delivered by webhook, using the PostHog MCP tools to pull the stack trace and `warehouse_sources_*` sync-context properties, then confirmed the AWS API constraint via its public documentation before making the change.