### PR TITLE
fix(data-imports): stop AWS Cost Explorer utilization syncs from requesting today's date

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/aws_cost_explorer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/aws_cost_explorer.py
@@ -369,8 +369,11 @@ def get_rows(
     session = make_session(aws_secret_access_key, aws_session_token)
     credentials = Credentials(aws_access_key_id, aws_secret_access_key, aws_session_token or None)
 
-    # `End` is exclusive, so tomorrow captures today's partial (flagged estimated) too.
-    end = dt.datetime.now(dt.UTC).date() + dt.timedelta(days=1)
+    # `End` is exclusive. Cost-and-usage operations report today's partial figures (flagged
+    # estimated), so their window reaches into tomorrow; the utilization operations have no
+    # data for the current, still-in-progress day and reject a window that includes it.
+    today = dt.datetime.now(dt.UTC).date()
+    end = today + dt.timedelta(days=1) if endpoint_config.includes_current_day else today
     start = resolve_start_date(
         start_date, endpoint_config, should_use_incremental_field, db_incremental_field_last_value, end
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/settings.py
@@ -47,6 +47,10 @@ class CostExplorerEndpointConfig:
     # Response sub-structures to flatten into the row, as (member name, column prefix) pairs.
     # An empty prefix keeps the sub-structure's own field names.
     nested_keys: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    # Only cost-and-usage operations return a flagged-`Estimated` figure for the current,
+    # still-in-progress day. The utilization operations have no such concept and reject a
+    # request whose window includes today with DataUnavailableException.
+    includes_current_day: bool = False
 
 
 AWS_COST_EXPLORER_ENDPOINTS: dict[str, CostExplorerEndpointConfig] = {
@@ -61,6 +65,7 @@ AWS_COST_EXPLORER_ENDPOINTS: dict[str, CostExplorerEndpointConfig] = {
         group_by=("SERVICE", "LINKED_ACCOUNT"),
         window_days=92,
         restatement_lookback_days=7,
+        includes_current_day=True,
     ),
     "cost_and_usage_monthly": CostExplorerEndpointConfig(
         name="cost_and_usage_monthly",
@@ -73,6 +78,7 @@ AWS_COST_EXPLORER_ENDPOINTS: dict[str, CostExplorerEndpointConfig] = {
         group_by=("SERVICE", "LINKED_ACCOUNT"),
         window_days=366,
         restatement_lookback_days=45,
+        includes_current_day=True,
     ),
     "reservation_utilization_daily": CostExplorerEndpointConfig(
         name="reservation_utilization_daily",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/tests/test_aws_cost_explorer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/aws_cost_explorer/tests/test_aws_cost_explorer.py
@@ -510,6 +510,16 @@ class TestGetRows:
 
         assert send.call_args_list[0][0][3]["TimePeriod"]["End"] == "2024-03-04"
 
+    @pytest.mark.parametrize("endpoint", ["reservation_utilization_daily", "savings_plans_utilization_daily"])
+    def test_utilization_endpoints_stop_at_today_because_aws_has_no_data_for_it_yet(self, endpoint: str) -> None:
+        # Unlike cost-and-usage, AWS rejects a utilization request whose window reaches into
+        # the current, still-in-progress day with DataUnavailableException.
+        manager = FakeResumeManager()
+
+        _, send = self._run([{}], manager, endpoint=endpoint)
+
+        assert send.call_args_list[0][0][3]["TimePeriod"]["End"] == "2024-03-03"
+
     def test_wide_ranges_are_split_into_windows_walked_oldest_first(self) -> None:
         manager = FakeResumeManager()
 


### PR DESCRIPTION
## Problem

Error tracking surfaced [`AwsCostExplorerError`](https://us.posthog.com/project/2/error_tracking/019fc6da-85d0-7101-94ec-bf9c1831107b): `AWS Cost Explorer request failed: DataUnavailableException`, raised from the `savings_plans_utilization_daily` schema on an incremental sync.

AWS's `GetSavingsPlansUtilization` and `GetReservationUtilization` operations reject any request window that reaches into the current, still-in-progress day with `DataUnavailableException` - only `GetCostAndUsage` supports a partial/estimated figure for today. The sync builds its request window with an exclusive end date of "tomorrow" for every AWS Cost Explorer endpoint, so every incremental run of the two utilization schemas asked AWS for a window it can never answer, and the sync would fail every time (not a flaky/transient condition) after exhausting its non-retryable-error retry budget.

## Changes

- Added `includes_current_day` to `CostExplorerEndpointConfig`, set only on the two `GetCostAndUsage` endpoints (which do return an estimated figure for today).
- `get_rows` now caps the window's exclusive end date at today for endpoints without that flag, instead of tomorrow, so the two utilization endpoints stop requesting a date range AWS will always refuse.

`DataUnavailableException` is already mapped to a user-facing message in `get_non_retryable_errors`, which is still correct for the (much rarer) case of a genuinely new account with no Cost Explorer data yet - that mapping stays as-is.

## How did you test this code?

Added a parametrized regression test (`test_utilization_endpoints_stop_at_today_because_aws_has_no_data_for_it_yet`) covering both `reservation_utilization_daily` and `savings_plans_utilization_daily`, asserting the request window's end date is today rather than tomorrow - this would have caught the bug, since before the fix both endpoints always requested through tomorrow just like the cost-and-usage endpoints.

Ran the full `aws_cost_explorer` unit test suite (54 passed), `ruff check`/`ruff format --check`, and `mypy --cache-fine-grained .` repo-wide - all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal sync-window fix, no user-facing behavior or config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I triaged this directly from a PostHog error-tracking webhook: pulled the issue's stack trace and a representative event's `warehouse_sources_*` properties via the PostHog MCP error-tracking tools to confirm the exact source/schema/sync-type combination reproducing it, then read the AWS Cost Explorer source connector to find where the request window is built. Confirmed the root cause (utilization operations don't support current-day data) via public AWS API documentation before making the change, rather than guessing. No repo skills were invoked for this change beyond `/writing-tests` while shaping the regression test.

Decision: fixed the source connector's window computation (root cause) rather than only relying on the existing `NonRetryableErrors` classification, since the failure is deterministic given the current code (not a flaky/transient condition) and the existing non-retryable message is misleading for this case.