### PR TITLE
feat(slack): default the Slack bot to Opus 5

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -31,6 +31,11 @@ _SLACK_RECOVERY_STRATEGY_CANCELLED = "cancelled_resume"
 _THREAD_CONTEXT_TAG = "slack_thread_context"
 _THREAD_CONTEXT_UPDATE_TAG = "slack_thread_context_update"
 _INITIATOR_PLACEHOLDER = "<original user message was here>"
+# Default the Slack bot to Opus 5 when neither the user nor the workspace has
+# pinned a model, instead of letting the agent server fall back to its own
+# default. Kept together as a valid (runtime_adapter, model) pair.
+_SLACK_DEFAULT_RUNTIME_ADAPTER = "claude"
+_SLACK_DEFAULT_MODEL = "claude-opus-5"
 _SLACK_DELIVERY_CONSTRAINTS = """Slack delivery constraints:
 - Local sandbox paths such as /tmp/workspace/... are not visible to Slack users.
 - Do not say a file, report, PDF, spreadsheet, document, or other artifact is attached, uploaded, or shared unless a tool explicitly confirms that delivery.
@@ -636,6 +641,12 @@ def create_posthog_code_task_for_repo_activity(
 
     ai_prefs = resolve_ai_preferences(integration, slack_user_id)
 
+    # `resolve_ai_preferences` guarantees runtime_adapter and model are set together,
+    # so falling back on both keeps the pair consistent — an explicit override wins,
+    # otherwise the Slack bot defaults to Opus 5.
+    runtime_adapter = ai_prefs.runtime_adapter or _SLACK_DEFAULT_RUNTIME_ADAPTER
+    model = ai_prefs.model or _SLACK_DEFAULT_MODEL
+
     # File into the creator's personal "#me" channel so the task surfaces in PostHog Desktop's
     # Spaces feed, which is strictly channel-scoped — a NULL-channel task shows up in no space.
     personal_channel_id: uuid.UUID | None = None
@@ -664,8 +675,8 @@ def create_posthog_code_task_for_repo_activity(
             start_workflow=False,
             posthog_mcp_scopes="full",
             initial_permission_mode="bypassPermissions",
-            runtime_adapter=ai_prefs.runtime_adapter,
-            model=ai_prefs.model,
+            runtime_adapter=runtime_adapter,
+            model=model,
             reasoning_effort=ai_prefs.reasoning_effort,
             channel_id=personal_channel_id,
         )

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -414,8 +414,8 @@ def _header_blocks() -> list[dict]:
 def _active_model_blocks(effective: AIPreferences, source: PreferenceSource) -> list[dict]:
     """Headline that shows which model is actually running, and why.
 
-    When nothing is set the agent-server picks its own default — we don't
-    know which one, so don't lie. Just say so and let the user override.
+    When nothing is set the Slack bot defaults to Opus 5 (pinned in the task
+    creation activity); the user can still override it here.
     """
     header = _section_title(
         "🤖 AI model",
@@ -430,7 +430,7 @@ def _active_model_blocks(effective: AIPreferences, source: PreferenceSource) -> 
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": "Inheriting PostHog Desktop's default — pick personal or workspace settings to override.",
+                    "text": "Defaulting to Opus 5. Pick personal or workspace settings to override.",
                 },
             },
             source_blurb,


### PR DESCRIPTION
## Problem

The interactive `@PostHog` Slack bot didn't pin a model. When neither the user nor the workspace had set an AI-preference override, the task was created with `model=None`, so it inherited whatever default the agent server picked rather than a model we control.

## Changes

- Pin the Slack bot's default to `claude-opus-5` when no user/workspace override exists. Because `resolve_ai_preferences` guarantees `runtime_adapter` and `model` are set together, the fallback applies to both, keeping the pair consistent — an explicit override still wins.
- Update the Slack Home tab copy, which previously said the model was inherited from the agent server's default.

## How did you test this code?

Ran `ruff check` and `ruff format --check` on both changed files (clean) and verified they parse. No behavior change to `resolve_ai_preferences` itself, so existing `test_slack_settings.py` coverage still applies; no test asserted on the old Home tab string.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: switch the Slack bot to Opus 5. Traced the model-resolution chain (Slack mention activity → `resolve_ai_preferences` → task creation → agent server default) and found there was no PostHog-side pin for the interactive path — it fell back to the agent server's `opus` alias. Pinned the default in the Slack task-creation activity rather than changing the shared agent-server default, to keep the change Slack-scoped. Invoked `/writing-user-facing-copy` before editing the Home tab string.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785748001252459?thread_ts=1785748001.252459&cid=C09SK2PAGKF)*
