### PR TITLE
fix(desktop): show PostHog web feedback intercept only once

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/stores/posthogWebFeedbackStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/posthogWebFeedbackStore.ts
@@ -7,19 +7,44 @@ import { persist } from "zustand/middleware";
 // to PostHog web navigates straight there instead of prompting again.
 interface PostHogWebFeedbackState {
   hasSeen: boolean;
+  // Storage is read asynchronously (Electron IPC); hasSeen exposes its default
+  // until the read settles. Readers can gate on this to avoid trusting the
+  // pre-hydration default.
+  hasHydrated: boolean;
   markSeen: () => void;
+  setHasHydrated: (hydrated: boolean) => void;
 }
 
 export const usePostHogWebFeedbackStore = create<PostHogWebFeedbackState>()(
   persist(
     (set) => ({
       hasSeen: false,
+      hasHydrated: false,
       markSeen: () => set({ hasSeen: true }),
+      setHasHydrated: (hydrated) => set({ hasHydrated: hydrated }),
     }),
     {
       name: "posthog-web-feedback-seen",
       storage: electronStorage,
       partialize: (state) => ({ hasSeen: state.hasSeen }),
+      // A markSeen() that lands before the async read returns would otherwise be
+      // undone by zustand's default merge overwriting it with the persisted
+      // value. Keep hasSeen sticky so the one-time intercept is never re-shown.
+      merge: (persisted, current) => ({
+        ...current,
+        hasSeen:
+          current.hasSeen ||
+          (persisted as Partial<PostHogWebFeedbackState>)?.hasSeen === true,
+      }),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state.setHasHydrated(true);
+          return;
+        }
+        // Failed read: fail open as unseen. Re-showing the intercept once beats
+        // never navigating; the in-session markSeen still suppresses it after.
+        usePostHogWebFeedbackStore.setState({ hasHydrated: true });
+      },
     },
   ),
 );

--- a/products/desktop/packages/ui/src/features/canvas/stores/posthogWebFeedbackStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/posthogWebFeedbackStore.ts
@@ -1,0 +1,25 @@
+import { electronStorage } from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// Tracks whether the "Before you head to PostHog web" feedback intercept has
+// already run once. After the user submits, skips, or dismisses it, going back
+// to PostHog web navigates straight there instead of prompting again.
+interface PostHogWebFeedbackState {
+  hasSeen: boolean;
+  markSeen: () => void;
+}
+
+export const usePostHogWebFeedbackStore = create<PostHogWebFeedbackState>()(
+  persist(
+    (set) => ({
+      hasSeen: false,
+      markSeen: () => set({ hasSeen: true }),
+    }),
+    {
+      name: "posthog-web-feedback-seen",
+      storage: electronStorage,
+      partialize: (state) => ({ hasSeen: state.hasSeen }),
+    },
+  ),
+);

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -33,6 +33,7 @@ import {
 import { useCanvasDeepLink } from "@posthog/ui/features/canvas/hooks/useCanvasDeepLink";
 import { useChannelDeepLink } from "@posthog/ui/features/canvas/hooks/useChannelDeepLink";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
+import { usePostHogWebFeedbackStore } from "@posthog/ui/features/canvas/stores/posthogWebFeedbackStore";
 import { CommandMenu } from "@posthog/ui/features/command/CommandMenu";
 import { CommandSearchBar } from "@posthog/ui/features/command/CommandSearchBar";
 import { GlobalFilePicker } from "@posthog/ui/features/command/GlobalFilePicker";
@@ -156,18 +157,36 @@ function RootLayout() {
     currentProjectId ? `/project/${currentProjectId}` : "/",
   );
 
+  // The "PostHog web" intercept is a one-time prompt: once it has been
+  // submitted, skipped, or dismissed, going back to PostHog web navigates
+  // straight there without asking again.
+  const posthogWebFeedbackSeen = usePostHogWebFeedbackStore((s) => s.hasSeen);
+  const markPostHogWebFeedbackSeen = usePostHogWebFeedbackStore(
+    (s) => s.markSeen,
+  );
+
+  const openPostHogWeb = () => {
+    if (posthogWebUrl) void openUrlInBrowser(posthogWebUrl);
+  };
+
   // "PostHog Web" opens the feedback modal first and performs its navigation
   // only once the modal is submitted or skipped.
   const handleFeedbackFinished = () => {
     const finishedMode = feedbackMode;
     setFeedbackMode(null);
-    if (finishedMode === "posthog-web" && posthogWebUrl) {
-      void openUrlInBrowser(posthogWebUrl);
+    if (finishedMode === "posthog-web") {
+      markPostHogWebFeedbackSeen();
+      openPostHogWeb();
     }
   };
 
   const handleOpenPostHogWeb = () => {
     track(ANALYTICS_EVENTS.POSTHOG_WEB_OPENED);
+    // The intercept only runs the first time; afterwards go straight to web.
+    if (posthogWebFeedbackSeen) {
+      openPostHogWeb();
+      return;
+    }
     setFeedbackMode("posthog-web");
   };
   const {

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -158,6 +158,9 @@ function RootLayout() {
   );
 
   const posthogWebFeedbackSeen = usePostHogWebFeedbackStore((s) => s.hasSeen);
+  const posthogWebFeedbackHydrated = usePostHogWebFeedbackStore(
+    (s) => s.hasHydrated,
+  );
   const markPostHogWebFeedbackSeen = usePostHogWebFeedbackStore(
     (s) => s.markSeen,
   );
@@ -175,7 +178,9 @@ function RootLayout() {
 
   const handleOpenPostHogWeb = () => {
     track(ANALYTICS_EVENTS.POSTHOG_WEB_OPENED);
-    if (posthogWebFeedbackSeen && posthogWebUrl) {
+    // Only skip the intercept once the persisted flag has hydrated, so a stale
+    // pre-hydration default can't wrongly re-show it.
+    if (posthogWebFeedbackHydrated && posthogWebFeedbackSeen && posthogWebUrl) {
       void openUrlInBrowser(posthogWebUrl);
       return;
     }

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -157,34 +157,26 @@ function RootLayout() {
     currentProjectId ? `/project/${currentProjectId}` : "/",
   );
 
-  // The "PostHog web" intercept is a one-time prompt: once it has been
-  // submitted, skipped, or dismissed, going back to PostHog web navigates
-  // straight there without asking again.
   const posthogWebFeedbackSeen = usePostHogWebFeedbackStore((s) => s.hasSeen);
   const markPostHogWebFeedbackSeen = usePostHogWebFeedbackStore(
     (s) => s.markSeen,
   );
-
-  const openPostHogWeb = () => {
-    if (posthogWebUrl) void openUrlInBrowser(posthogWebUrl);
-  };
 
   // "PostHog Web" opens the feedback modal first and performs its navigation
   // only once the modal is submitted or skipped.
   const handleFeedbackFinished = () => {
     const finishedMode = feedbackMode;
     setFeedbackMode(null);
-    if (finishedMode === "posthog-web") {
+    if (finishedMode === "posthog-web" && posthogWebUrl) {
       markPostHogWebFeedbackSeen();
-      openPostHogWeb();
+      void openUrlInBrowser(posthogWebUrl);
     }
   };
 
   const handleOpenPostHogWeb = () => {
     track(ANALYTICS_EVENTS.POSTHOG_WEB_OPENED);
-    // The intercept only runs the first time; afterwards go straight to web.
-    if (posthogWebFeedbackSeen) {
-      openPostHogWeb();
+    if (posthogWebFeedbackSeen && posthogWebUrl) {
+      void openUrlInBrowser(posthogWebUrl);
       return;
     }
     setFeedbackMode("posthog-web");


### PR DESCRIPTION
## Problem

The "Before you head to PostHog web" feedback prompt in the desktop app's Spaces/Channels world fired every single time the user clicked "PostHog web". Once you've answered (or skipped) it, being asked again on every navigation is annoying. Raised in a Slack thread.

## Changes

Make the prompt a one-time intercept. A small persisted store records that it has run; once the user submits, skips, or dismisses it, later clicks on "PostHog web" navigate straight there without showing the modal again.

- New `posthogWebFeedbackStore` (zustand + persisted via `electronStorage`, same pattern as `billingAnnouncementStore`).
- `handleOpenPostHogWeb` skips the modal when already seen; `handleFeedbackFinished` marks it seen on submit/skip/dismiss.

## How did you test this code?

Typechecked the `@posthog/ui` package (the changed files compile clean; remaining errors in the run are pre-existing unbuilt-dependency errors unrelated to this change) and ran Biome on the two touched files. I did not run the desktop app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The dismiss path already routed Esc/outside-click/Skip/Send through one `onFinished` handler, so the one-time gate only needed to hook that handler plus the open handler, backed by a persisted flag. No skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785740131534379?thread_ts=1785740131.534379&cid=C09G8Q32R6F)*
