### PR TITLE
fix(onboarding): load browser snippet once

### DIFF
--- a/docs/onboarding/product-analytics/_snippets/js-snippet-builder.ts
+++ b/docs/onboarding/product-analytics/_snippets/js-snippet-builder.ts
@@ -4,10 +4,15 @@ export type SnippetOption = {
     comment?: string
 }
 
-export function snippetFunctions(methods: string[], arrayJs = '/static/array.js'): string {
+export const DEFAULT_SNIPPET_METHODS =
+    'init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep'.split(
+        ' '
+    )
+
+export function snippetFunctions(methods: readonly string[], arrayJs = '/static/array.js'): string {
     const snippetMethods = methods.join(' ')
 
-    return `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"${arrayJs}",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="${snippetMethods}".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);`
+    return `!function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}p||((p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"${arrayJs}",p.onerror=function(){p=null},(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r));var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="${snippetMethods}".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);`
 }
 
 export interface BuildJsHtmlSnippetConfig {

--- a/docs/onboarding/product-analytics/astro.tsx
+++ b/docs/onboarding/product-analytics/astro.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getAstroSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -42,7 +43,7 @@ export const getAstroSteps = (ctx: OnboardingComponentsContext): StepDefinition[
                                     // src/components/posthog.astro
                                     ---
                                     <script is:inline>
-                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                         posthog.init('<ph_project_token>', {
                                             api_host: '<ph_client_api_host>',
                                             defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/bubble.tsx
+++ b/docs/onboarding/product-analytics/bubble.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getBubbleSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -22,7 +23,7 @@ export const getBubbleSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 file: 'HTML',
                                 code: dedent`
                                     <script>
-                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                         posthog.init('<ph_project_token>', {
                                             api_host: '<ph_client_api_host>',
                                             defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/flutter.tsx
+++ b/docs/onboarding/product-analytics/flutter.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -122,7 +123,7 @@ export const getFlutterSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                             <head>
                                               ...
                                               <script>
-                                                !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                                ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                                 posthog.init('<ph_project_token>', {
                                                     api_host: '<ph_client_api_host>',
                                                     defaults: '${SDK_DEFAULTS_DATE}',

--- a/docs/onboarding/product-analytics/framer.tsx
+++ b/docs/onboarding/product-analytics/framer.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getFramerSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -22,7 +23,7 @@ export const getFramerSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 file: 'HTML',
                                 code: dedent`
                                     <script>
-                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                         posthog.init('<ph_project_token>', {
                                             api_host: '<ph_client_api_host>',
                                             defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/google-tag-manager.tsx
+++ b/docs/onboarding/product-analytics/google-tag-manager.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getGoogleTagManagerSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -30,7 +31,7 @@ export const getGoogleTagManagerSteps = (ctx: OnboardingComponentsContext): Step
                                 file: 'Custom HTML Tag',
                                 code: dedent`
                                     <script>
-                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                         posthog.init('<ph_project_token>', {
                                             api_host: '<ph_client_api_host>',
                                             defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/retool.tsx
+++ b/docs/onboarding/product-analytics/retool.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getRetoolSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -30,7 +31,7 @@ export const getRetoolSteps = (ctx: OnboardingComponentsContext): StepDefinition
                                 file: 'Head section',
                                 code: dedent`
                                 <script>
-                                    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                    ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                     posthog.init('<ph_project_token>', {
                                         api_host: '<ph_client_api_host>',
                                         defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/shopify.tsx
+++ b/docs/onboarding/product-analytics/shopify.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getShopifySteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -32,7 +33,7 @@ export const getShopifySteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 file: 'theme.liquid',
                                 code: dedent`
                                 <script>
-                                    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                    ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                     posthog.init('<ph_project_token>', {
                                         api_host: '<ph_client_api_host>',
                                         defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/webflow.tsx
+++ b/docs/onboarding/product-analytics/webflow.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getWebflowSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -22,7 +23,7 @@ export const getWebflowSteps = (ctx: OnboardingComponentsContext): StepDefinitio
                                 file: 'HTML',
                                 code: dedent`
                                     <script>
-                                        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                        ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                         posthog.init('<ph_project_token>', {
                                             api_host: '<ph_client_api_host>',
                                             defaults: '${SDK_DEFAULTS_DATE}'

--- a/docs/onboarding/product-analytics/wordpress.tsx
+++ b/docs/onboarding/product-analytics/wordpress.tsx
@@ -1,6 +1,7 @@
 import { OnboardingComponentsContext, createInstallation } from 'scenes/onboarding/shared/OnboardingDocsContentWrapper'
 
 import { StepDefinition } from '../steps'
+import { DEFAULT_SNIPPET_METHODS, snippetFunctions } from './_snippets/js-snippet-builder'
 import { SDK_DEFAULTS_DATE } from './_snippets/sdkDefaults'
 
 export const getWordpressSteps = (ctx: OnboardingComponentsContext): StepDefinition[] => {
@@ -24,7 +25,7 @@ export const getWordpressSteps = (ctx: OnboardingComponentsContext): StepDefinit
                                 file: 'HTML',
                                 code: dedent`
                                 <script>
-                                    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group identify setPersonProperties setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags resetGroups onFeatureFlags addFeatureFlagsHandler onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+                                    ${snippetFunctions(DEFAULT_SNIPPET_METHODS)}
                                     posthog.init('<ph_project_token>', {
                                         api_host: '<ph_client_api_host>',
                                         defaults: '${SDK_DEFAULTS_DATE}'

--- a/frontend/src/lib/components/JSSnippet.test.ts
+++ b/frontend/src/lib/components/JSSnippet.test.ts
@@ -1,0 +1,62 @@
+import { runInNewContext } from 'node:vm'
+
+import { snippetFunctions } from '@posthog/shared-onboarding/product-analytics'
+
+type SnippetConfig = { api_host: string }
+type InitQueueEntry = [token: string, config: SnippetConfig, name: string]
+
+type SnippetStub = unknown[] & {
+    _i: InitQueueEntry[]
+    init: (token: string, config: SnippetConfig, name?: string) => void
+}
+
+type ScriptElement = {
+    async?: boolean
+    crossOrigin?: string
+    onerror?: () => void
+    src?: string
+    type?: string
+}
+
+describe('JavaScript snippet', () => {
+    it('queues every init while loading array.js once and retries after a load failure', () => {
+        const insertedScripts: ScriptElement[] = []
+        const snippetWindow: { posthog?: SnippetStub } = {}
+        const snippetDocument = {
+            createElement: (): ScriptElement => ({}),
+            getElementsByTagName: () => [
+                {
+                    parentNode: {
+                        insertBefore: (script: ScriptElement): void => {
+                            insertedScripts.push(script)
+                        },
+                    },
+                },
+            ],
+        }
+
+        runInNewContext(snippetFunctions(['capture']), { document: snippetDocument, window: snippetWindow })
+
+        const posthog = snippetWindow.posthog
+        expect(posthog).not.toBeUndefined()
+        if (!posthog) {
+            return
+        }
+
+        const config = { api_host: 'https://us.i.posthog.com' }
+        posthog.init('phc_first', config)
+        posthog.init('phc_second', config, 'project2')
+
+        expect(insertedScripts).toHaveLength(1)
+        expect(posthog._i).toHaveLength(2)
+        expect(posthog._i[0][0]).toBe('phc_first')
+        expect(posthog._i[1][0]).toBe('phc_second')
+        expect(posthog._i[1][2]).toBe('project2')
+
+        insertedScripts[0].onerror?.()
+        posthog.init('phc_third', config, 'project3')
+
+        expect(insertedScripts).toHaveLength(2)
+        expect(posthog._i).toHaveLength(3)
+    })
+})


### PR DESCRIPTION
## Problem

Calling the browser snippet's `posthog.init()` more than once before `array.js` finishes loading inserts another copy of the script each time. Duplicate tags can therefore download and execute the SDK more than once, even though all initialization calls already share the same queue.

This complements the SDK-side duplicate-loader protection in [posthog-js#4341](https://github.com/PostHog/posthog-js/pull/4341).

## Changes

- Load `array.js` once while preserving every queued initialization.
- Clear the in-flight script reference after a load error so a later `init()` can retry.
- Move the shared onboarding method list into the snippet builder.
- Generate the Astro, Bubble, Flutter, Framer, Google Tag Manager, Retool, Shopify, Webflow, and WordPress snippets from the shared implementation instead of copied bootstrap code.
- Add a focused regression test for queueing, single-flight loading, and retry behavior.

The closure variable `p` tracks the inserted `array.js` script and prevents another `init()` from inserting a duplicate while that script is loading. If the load fails, leaving `p` set would permanently block later initialization attempts. The `onerror` handler clears only that reference, allowing a later `init()` to try loading the SDK again while preserving the existing queue. It does not retry automatically or discard queued calls.

## How did you test this code?

- `bin/hogli test frontend/src/lib/components/JSSnippet.test.ts`
- `pnpm --filter=@posthog/frontend fix`
- `pnpm --filter=@posthog/frontend typescript:check`
- `bin/hogli ci:preflight --fix`
- `git diff --check`

The new Jest test catches the regression where multiple queued `init()` calls insert multiple `array.js` scripts. It also verifies that all initializations remain queued and that a failed load can be retried.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The affected onboarding snippets are updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the Pi coding agent with the `/karpathy-guidelines`, `/writing-tests`, `/writing-user-facing-copy`, `/pr`, and `/autoreview` skills. The implementation keeps script insertion single-flight without changing the existing initialization queue contract, and centralizes the copied onboarding bootstraps so they stay aligned with the canonical snippet builder.
