### PR TITLE
chore: remove sales and marketing alert checkbox from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,6 @@
 ## Automatic notifications
 
 - [ ] Publish to changelog?
-- [ ] Alert Sales and Marketing teams?
 
 ## Docs update
 

--- a/.github/workflows/ci-storybook-update-test-timing.yml
+++ b/.github/workflows/ci-storybook-update-test-timing.yml
@@ -207,7 +207,6 @@ jobs:
                   ## Automatic notifications
 
                   - [ ] Publish to changelog?
-                  - [ ] Alert Sales and Marketing teams?
 
                   ## Docs update
 


### PR DESCRIPTION
## Problem

The *Alert Sales and Marketing teams?* checkbox under **Automatic notifications** fed a digest into the `#coming-soon` Slack channel. That channel is archived, so ticking the box does nothing. [PostHog/posthog.com#19186](https://github.com/PostHog/posthog.com/pull/19186) cleared the channel out of the handbook and flagged this checkbox as the remaining loose end.

## Changes

Drop the checkbox from `.github/pull_request_template.md`, and from the body the Storybook timing-refresh workflow generates for its automated PRs. *Publish to changelog?* stays.

Companion handbook change: [PostHog/posthog.com#19188](https://github.com/PostHog/posthog.com/pull/19188).

## How did you test this code?

Markdown and YAML only, no automated tests apply. I grepped the repo to confirm those were the only two occurrences and that no workflow or script reads the checkbox.

## Docs update

The handbook pages that documented the checkbox are updated in the companion posthog.com PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) removed the checkbox here and updated the handbook copy in the companion PR, switching each "these checkboxes" sentence to the single remaining one rather than just deleting the phrase.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
