### PR TITLE
feat(cdp): validate valkey parity and migrate masker state

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -39,6 +39,7 @@
         "migrate:cyclotron": "../rust/bin/migrate-cyclotron",
         "migrate:cyclotron-node": "../rust/bin/migrate-cyclotron-node",
         "migrate:behavioral-cohorts": "../rust/bin/migrate-behavioral-cohorts",
+        "migrate:cdp-masker-valkey": "ts-node src/cdp/scripts/migrate-hog-masker-to-valkey.ts",
         "migrate:rust": "../rust/bin/migrate-entry all",
         "services:start": "cd .. && docker compose -f docker-compose.dev.yml up",
         "services:stop": "cd .. && docker compose -f docker-compose.dev.yml down",

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -32,7 +32,7 @@ import { HogWatcherService, HogWatcherState } from '../services/monitoring/hog-w
 import { EncryptedFields } from '../utils/encryption-utils'
 import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '../utils/hog-function-filtering'
 import { createInvocation } from '../utils/invocation-utils'
-import { mirrorCall } from '../utils/mirror-call'
+import { mirrorCall, mirrorCompare } from '../utils/mirror-call'
 import { RustVmExecutor } from './rust-vm-executor'
 import { getTransformationFunctions } from './transformation-functions'
 
@@ -433,10 +433,11 @@ export class HogTransformerService implements HogTransformer {
 
     public async fetchAndCacheHogFunctionStates(functionIds: string[]): Promise<void> {
         const timer = hogWatcherLatency.startTimer({ operation: 'getStates' })
-        const [states] = await Promise.all([
-            this.hogWatcher.getEffectiveStates(functionIds),
-            mirrorCall('hog-watcher.getEffectiveStates', () => this.hogWatcherMirror?.getEffectiveStates(functionIds)),
-        ])
+        const states = await mirrorCompare(
+            'hog-watcher.getEffectiveStates',
+            () => this.hogWatcher.getEffectiveStates(functionIds),
+            () => this.hogWatcherMirror?.getEffectiveStates(functionIds)
+        )
         timer()
 
         // Save only the state enum value to cache

--- a/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
@@ -1,0 +1,252 @@
+import IORedis, { Redis } from 'ioredis'
+import { parseArgs } from 'node:util'
+
+import { HOG_MASKER_KEY_PATTERN } from '../services/monitoring/hog-masker.constants'
+
+const KEY_PATTERN = HOG_MASKER_KEY_PATTERN
+
+type Phase = 'copy' | 'finalize' | 'verify'
+type MigrationOptions = {
+    phase: Phase
+    execute: boolean
+    writersPaused: boolean
+    scanCount: number
+    ttlToleranceMs: number
+}
+type MigrationSummary = {
+    sourceKeys: number
+    copiedKeys: number
+    skippedExpiredKeys: number
+    deletedExtraKeys: number
+    mismatchedValues: number
+    mismatchedExpiries: number
+    missingTargetKeys: number
+    extraTargetKeys: number
+}
+
+function emptySummary(): MigrationSummary {
+    return {
+        sourceKeys: 0,
+        copiedKeys: 0,
+        skippedExpiredKeys: 0,
+        deletedExtraKeys: 0,
+        mismatchedValues: 0,
+        mismatchedExpiries: 0,
+        missingTargetKeys: 0,
+        extraTargetKeys: 0,
+    }
+}
+
+function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
+    const host = process.env[`${prefix}_HOST`]
+    if (!host) {
+        throw new Error(`${prefix}_HOST is required`)
+    }
+    const port = Number(process.env[`${prefix}_PORT`] || '6379')
+    const password = process.env[`${prefix}_PASSWORD`] || undefined
+    const tls = process.env[`${prefix}_TLS`] === 'true' ? {} : undefined
+    return new IORedis({ host, port, password, tls, lazyConnect: true, maxRetriesPerRequest: 3 })
+}
+
+async function* scanBatches(redis: Redis, count: number): AsyncGenerator<string[]> {
+    let cursor = '0'
+    do {
+        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', KEY_PATTERN, 'COUNT', count)
+        cursor = nextCursor
+        if (keys.length > 0) {
+            yield keys
+        }
+    } while (cursor !== '0')
+}
+
+function sourceTimeMs([seconds, microseconds]: [string, string]): number {
+    return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
+}
+
+async function copySourceKeys(
+    source: Redis,
+    target: Redis,
+    options: MigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.scanCount)) {
+        summary.sourceKeys += keys.length
+        if (!options.execute) {
+            continue
+        }
+
+        const sourcePipeline = source.pipeline()
+        for (const key of keys) {
+            sourcePipeline.get(key)
+            sourcePipeline.pttl(key)
+        }
+        const [time, rows] = await Promise.all([source.time(), sourcePipeline.exec()])
+        if (!rows) {
+            throw new Error('Source Redis pipeline returned no results')
+        }
+
+        const nowMs = sourceTimeMs(time)
+        const targetPipeline = target.pipeline()
+        keys.forEach((key, index) => {
+            const value = rows[index * 2]?.[1] as string | null
+            const ttlMs = Number(rows[index * 2 + 1]?.[1])
+            if (value === null || ttlMs <= 0) {
+                summary.skippedExpiredKeys++
+                return
+            }
+            targetPipeline.set(key, value, 'PXAT', nowMs + ttlMs)
+            summary.copiedKeys++
+        })
+        await targetPipeline.exec()
+    }
+}
+
+async function deleteTargetExtras(
+    source: Redis,
+    target: Redis,
+    options: MigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(target, options.scanCount)) {
+        const existsPipeline = source.pipeline()
+        keys.forEach((key) => existsPipeline.exists(key))
+        const rows = await existsPipeline.exec()
+        if (!rows) {
+            throw new Error('Source Redis existence pipeline returned no results')
+        }
+        const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
+        summary.extraTargetKeys += extras.length
+        if (options.execute && extras.length > 0) {
+            summary.deletedExtraKeys += await target.del(...extras)
+        }
+    }
+}
+
+async function verifyKeys(
+    source: Redis,
+    target: Redis,
+    options: MigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.scanCount)) {
+        const sourcePipeline = source.pipeline()
+        const targetPipeline = target.pipeline()
+        for (const key of keys) {
+            sourcePipeline.get(key)
+            sourcePipeline.pttl(key)
+            targetPipeline.get(key)
+            targetPipeline.pttl(key)
+        }
+        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
+        if (!sourceRows || !targetRows) {
+            throw new Error('Verification pipeline returned no results')
+        }
+        keys.forEach((_, index) => {
+            const sourceValue = sourceRows[index * 2]?.[1] as string | null
+            const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])
+            const targetValue = targetRows[index * 2]?.[1] as string | null
+            const targetTtl = Number(targetRows[index * 2 + 1]?.[1])
+            if (sourceValue === null || sourceTtl <= 0) {
+                return
+            }
+            if (targetValue === null) {
+                summary.missingTargetKeys++
+                return
+            }
+            if (sourceValue !== targetValue) {
+                summary.mismatchedValues++
+            }
+            if (Math.abs(sourceTtl - targetTtl) > options.ttlToleranceMs) {
+                summary.mismatchedExpiries++
+            }
+        })
+    }
+    await deleteTargetExtras(source, target, { ...options, execute: false }, summary)
+}
+
+function parseOptions(): MigrationOptions {
+    const { values } = parseArgs({
+        options: {
+            phase: { type: 'string', default: 'copy' },
+            execute: { type: 'boolean', default: false },
+            'writers-paused': { type: 'boolean', default: false },
+            'scan-count': { type: 'string', default: '500' },
+            'ttl-tolerance-ms': { type: 'string', default: '2000' },
+            help: { type: 'boolean', default: false },
+        },
+    })
+    if (values.help) {
+        console.log(`Usage: migrate-hog-masker-to-valkey [options]
+
+  --phase copy       Copy source keys while Redis remains authoritative (default)
+  --phase finalize   Exact copy and remove target-only keys; requires paused writers
+  --phase verify     Compare values and expiries without writing
+  --execute          Apply changes; omitted means dry-run
+  --writers-paused   Confirm every HogMasker writer is paused
+  --scan-count N     Redis SCAN batch size (default: 500)
+  --ttl-tolerance-ms N  Allowed expiry difference during verify (default: 2000)
+
+Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
+        process.exit(0)
+    }
+    if (!['copy', 'finalize', 'verify'].includes(values.phase)) {
+        throw new Error(`Invalid --phase: ${values.phase}`)
+    }
+    const phase = values.phase as Phase
+    if (phase === 'finalize' && (!values.execute || !values['writers-paused'])) {
+        throw new Error('--phase finalize requires both --execute and --writers-paused')
+    }
+    const scanCount = Number(values['scan-count'])
+    const ttlToleranceMs = Number(values['ttl-tolerance-ms'])
+    if (!Number.isInteger(scanCount) || scanCount < 1 || !Number.isFinite(ttlToleranceMs) || ttlToleranceMs < 0) {
+        throw new Error('Scan count must be a positive integer and TTL tolerance must be non-negative')
+    }
+    return { phase, execute: values.execute, writersPaused: values['writers-paused'], scanCount, ttlToleranceMs }
+}
+
+async function main(): Promise<void> {
+    const options = parseOptions()
+    const sourceHost = process.env.CDP_REDIS_HOST
+    const targetHost = process.env.CDP_VALKEY_HOST
+    if (
+        sourceHost === targetHost &&
+        (process.env.CDP_REDIS_PORT || '6379') === (process.env.CDP_VALKEY_PORT || '6379')
+    ) {
+        throw new Error('Source Redis and target Valkey must be different endpoints')
+    }
+    const source = connectionFromEnv('CDP_REDIS')
+    const target = connectionFromEnv('CDP_VALKEY')
+    const summary = emptySummary()
+    try {
+        await Promise.all([source.connect(), target.connect()])
+        await Promise.all([source.ping(), target.ping()])
+        if (options.phase === 'copy' || options.phase === 'finalize') {
+            await copySourceKeys(source, target, options, summary)
+        }
+        if (options.phase === 'finalize') {
+            await deleteTargetExtras(source, target, options, summary)
+        }
+        if (options.phase === 'verify' || options.phase === 'finalize') {
+            await verifyKeys(source, target, options, summary)
+        }
+        console.log(
+            JSON.stringify({ phase: options.phase, dryRun: !options.execute, pattern: KEY_PATTERN, ...summary })
+        )
+        const undeletedExtraKeys = summary.extraTargetKeys - summary.deletedExtraKeys
+        if (
+            summary.mismatchedValues ||
+            summary.mismatchedExpiries ||
+            summary.missingTargetKeys ||
+            (options.phase !== 'copy' && undeletedExtraKeys > 0)
+        ) {
+            process.exitCode = 2
+        }
+    } finally {
+        await Promise.allSettled([source.quit(), target.quit()])
+    }
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+})

--- a/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.ts
@@ -11,7 +11,7 @@ import { QuotaLimiting } from '../../common/services/quota-limiting.service'
 import { CdpValkeyShadowPools } from '../cdp-services'
 import { counterRateLimited } from '../consumers/metrics'
 import { CyclotronJobInvocation, HogFunctionInvocationGlobals, LogEntry, MinimalAppMetric } from '../types'
-import { mirrorCall } from '../utils/mirror-call'
+import { mirrorCompare } from '../utils/mirror-call'
 import { HogFlowExecutorService } from './hogflows/hogflow-executor.service'
 import { HogFlowManagerService } from './hogflows/hogflow-manager.service'
 import { shouldBlockHogFlowDueToQuota } from './hogflows/hogflow-quota-limiting'
@@ -101,27 +101,29 @@ export class HogFlowInvocationPipeline {
         ).flat()
 
         const hogFlowIds = possibleInvocations.map((x) => x.hogFlow.id)
-        const [states] = await Promise.all([
-            instrumentFn('cdpConsumer.handleEachBatch.hogWatcher.getEffectiveStates', async () => {
-                return await this.deps.hogWatcher.getEffectiveStates(hogFlowIds)
-            }),
-            mirrorCall('hog-watcher.getEffectiveStates', () =>
-                this.deps.hogWatcherMirror?.getEffectiveStates(hogFlowIds)
-            ),
-        ])
+        const states = await mirrorCompare(
+            'hog-watcher.getEffectiveStates',
+            () =>
+                instrumentFn('cdpConsumer.handleEachBatch.hogWatcher.getEffectiveStates', async () => {
+                    return await this.deps.hogWatcher.getEffectiveStates(hogFlowIds)
+                }),
+            () => this.deps.hogWatcherMirror?.getEffectiveStates(hogFlowIds)
+        )
 
         const rateLimitInputs: KeyedRateLimitRequest[] = possibleInvocations.map((x) => ({
             id: x.hogFlow.id,
             cost: 1,
         }))
-        const [rateLimits] = await Promise.all([
-            instrumentFn('cdpConsumer.handleEachBatch.hogRateLimiter.rateLimitGrouped', async () => {
-                return await this.hogRateLimiter.rateLimitGrouped(rateLimitInputs)
-            }),
-            mirrorCall('hog-rate-limiter.rateLimitGrouped', () =>
-                this.hogRateLimiterMirror?.rateLimitGrouped(rateLimitInputs)
-            ),
-        ])
+        const rateLimits = await mirrorCompare(
+            'hog-rate-limiter.rateLimitGrouped',
+            () =>
+                instrumentFn('cdpConsumer.handleEachBatch.hogRateLimiter.rateLimitGrouped', async () => {
+                    return await this.hogRateLimiter.rateLimitGrouped(rateLimitInputs)
+                }),
+            () => this.hogRateLimiterMirror?.rateLimitGrouped(rateLimitInputs),
+            (primary, mirror) =>
+                primary.every(([, result], index) => result.isRateLimited === mirror[index]?.[1].isRateLimited)
+        )
         const validInvocations: CyclotronJobInvocation[] = []
 
         await Promise.all(

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -15,7 +15,7 @@ import {
     HogFunctionTypeType,
     MinimalAppMetric,
 } from '../types'
-import { mirrorCall } from '../utils/mirror-call'
+import { mirrorCompare } from '../utils/mirror-call'
 import { HogExecutorService } from './hog-executor.service'
 import { HogFunctionManagerService } from './managers/hog-function-manager.service'
 import { HogFunctionMonitoringService } from './monitoring/hog-function-monitoring.service'
@@ -103,27 +103,29 @@ export class HogFunctionInvocationPipeline {
         ).flat()
 
         const hogFunctionIds = possibleInvocations.map((x) => x.hogFunction.id)
-        const [states] = await Promise.all([
-            instrumentFn('cdpConsumer.handleEachBatch.hogWatcher.getEffectiveStates', async () => {
-                return await this.deps.hogWatcher.getEffectiveStates(hogFunctionIds)
-            }),
-            mirrorCall('hog-watcher.getEffectiveStates', () =>
-                this.deps.hogWatcherMirror?.getEffectiveStates(hogFunctionIds)
-            ),
-        ])
+        const states = await mirrorCompare(
+            'hog-watcher.getEffectiveStates',
+            () =>
+                instrumentFn('cdpConsumer.handleEachBatch.hogWatcher.getEffectiveStates', async () => {
+                    return await this.deps.hogWatcher.getEffectiveStates(hogFunctionIds)
+                }),
+            () => this.deps.hogWatcherMirror?.getEffectiveStates(hogFunctionIds)
+        )
 
         const rateLimitInputs: KeyedRateLimitRequest[] = possibleInvocations.map((x) => ({
             id: x.hogFunction.id,
             cost: 1,
         }))
-        const [rateLimits] = await Promise.all([
-            instrumentFn('cdpConsumer.handleEachBatch.hogRateLimiter.rateLimitGrouped', async () => {
-                return await this.hogRateLimiter.rateLimitGrouped(rateLimitInputs)
-            }),
-            mirrorCall('hog-rate-limiter.rateLimitGrouped', () =>
-                this.hogRateLimiterMirror?.rateLimitGrouped(rateLimitInputs)
-            ),
-        ])
+        const rateLimits = await mirrorCompare(
+            'hog-rate-limiter.rateLimitGrouped',
+            () =>
+                instrumentFn('cdpConsumer.handleEachBatch.hogRateLimiter.rateLimitGrouped', async () => {
+                    return await this.hogRateLimiter.rateLimitGrouped(rateLimitInputs)
+                }),
+            () => this.hogRateLimiterMirror?.rateLimitGrouped(rateLimitInputs),
+            (primary, mirror) =>
+                primary.every(([, result], index) => result.isRateLimited === mirror[index]?.[1].isRateLimited)
+        )
 
         const validInvocations: CyclotronJobInvocationHogFunction[] = []
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
@@ -5,7 +5,7 @@ import { RedisClient, RedisV2 } from '~/common/redis/redis-v2'
 import { logger } from '~/common/utils/logger'
 
 import { CyclotronJobInvocationHogFlow } from '../../types'
-import { mirrorCall } from '../../utils/mirror-call'
+import { mirrorCompare } from '../../utils/mirror-call'
 
 const DUPLICATE_OBSERVATION_TTL_SECONDS = 15 * 60
 
@@ -47,12 +47,12 @@ export class HogFlowDuplicateObserverService {
 
         let duplicate = false
         try {
-            const [existingId] = await Promise.all([
-                this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, setNxGet),
-                mirrorCall('hog-flow-duplicate-observer.observe', () =>
-                    this.redisMirror?.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, setNxGet)
-                ),
-            ])
+            const existingId = await mirrorCompare(
+                'hog-flow-duplicate-observer.observe',
+                () => this.redis!.useClient({ name: 'hogflow-observe', failOpen: true }, setNxGet),
+                () => this.redisMirror?.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, setNxGet),
+                (primary, mirror) => Boolean(primary) === Boolean(mirror)
+            )
             if (existingId && existingId !== invocation.id) {
                 duplicate = true
                 hogflowDuplicateInvocationDetectedTotal.inc({ workflow_id: invocation.functionId })

--- a/nodejs/src/cdp/services/monitoring/hog-masker.constants.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.constants.ts
@@ -1,0 +1,2 @@
+export const BASE_REDIS_KEY = process.env.NODE_ENV === 'test' ? '@posthog-test/hog-masker' : '@posthog/hog-masker'
+export const HOG_MASKER_KEY_PATTERN = `${BASE_REDIS_KEY}/mask/*`

--- a/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
@@ -9,9 +9,10 @@ import {
     HogFunctionMasking,
 } from '../../types'
 import { execHog } from '../../utils/hog-exec'
-import { mirrorCall } from '../../utils/mirror-call'
+import { mirrorCompare } from '../../utils/mirror-call'
+import { BASE_REDIS_KEY } from './hog-masker.constants'
 
-export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/hog-masker' : '@posthog/hog-masker'
+export { BASE_REDIS_KEY } from './hog-masker.constants'
 const REDIS_KEY_TOKENS = `${BASE_REDIS_KEY}/mask`
 
 // NOTE: These are controlled via the api so are more of a sanity fallback
@@ -30,6 +31,21 @@ type MaskContext = {
 
 type GenericHogInvocationWithMasker = CyclotronJobInvocation & {
     masker?: MaskContext
+}
+
+type MaskPipelineResult = Awaited<ReturnType<RedisV2['usePipeline']>>
+
+function allowedExecutionsForResult(result: MaskPipelineResult, index: number, masker: MaskContext): number | null {
+    const newValue: number | null = result ? result[index * 2][1] : null
+    if (newValue === null) {
+        return null
+    }
+
+    const oldValue = newValue - masker.increment
+    if (masker.threshold) {
+        return Math.floor((newValue - 1) / masker.threshold) - Math.floor((oldValue - 1) / masker.threshold)
+    }
+    return oldValue === 0 ? 1 : 0
 }
 
 function isHogFunctionInvocation(invocation: CyclotronJobInvocation): invocation is CyclotronJobInvocationHogFunction {
@@ -154,34 +170,26 @@ export class HogMaskerService {
             })
         }
 
-        const [result] = await Promise.all([
-            this.redis.usePipeline({ name: 'masker', failOpen: true }, buildPipeline),
-            mirrorCall('hog-masker.filterByMasking', () =>
-                this.redisMirror?.usePipeline({ name: 'masker-mirror', failOpen: true }, buildPipeline)
-            ),
-        ])
+        const maskContexts = Object.values(masks)
+        const result = await mirrorCompare(
+            'hog-masker.filterByMasking',
+            () => this.redis.usePipeline({ name: 'masker', failOpen: true }, buildPipeline),
+            () => this.redisMirror?.usePipeline({ name: 'masker-mirror', failOpen: true }, buildPipeline),
+            (primary, mirror) =>
+                maskContexts.every(
+                    (masker, index) =>
+                        allowedExecutionsForResult(primary, index, masker) ===
+                        allowedExecutionsForResult(mirror, index, masker)
+                )
+        )
 
-        Object.values(masks).forEach((masker, index) => {
-            const newValue: number | null = result ? result[index * 2][1] : null
-            if (newValue === null) {
+        maskContexts.forEach((masker, index) => {
+            const allowedExecutions = allowedExecutionsForResult(result, index, masker)
+            if (allowedExecutions === null) {
                 // We fail closed here as with a masking config the typical case will be not to send
                 return
             }
-
-            const oldValue = newValue - masker.increment
-
-            // Simplest case - the previous value was 0
-            masker.allowedExecutions = oldValue === 0 ? 1 : 0
-
-            if (masker.threshold) {
-                // TRICKY: We minus 1 to account for the "first" execution
-                const thresholdsPasses =
-                    Math.floor((newValue - 1) / masker.threshold) - Math.floor((oldValue - 1) / masker.threshold)
-
-                if (thresholdsPasses) {
-                    masker.allowedExecutions = thresholdsPasses
-                }
-            }
+            masker.allowedExecutions = allowedExecutions
         })
 
         return invocationsWithMasker.reduce(

--- a/nodejs/src/cdp/utils/mirror-call.test.ts
+++ b/nodejs/src/cdp/utils/mirror-call.test.ts
@@ -1,4 +1,8 @@
-import { mirrorCall } from './mirror-call'
+import { logger } from '~/common/utils/logger'
+
+import { mirrorCall, mirrorCompare } from './mirror-call'
+
+jest.mock('~/common/utils/logger', () => ({ logger: { warn: jest.fn() } }))
 
 describe('mirrorCall', () => {
     it('resolves when the call resolves in time', async () => {
@@ -25,5 +29,37 @@ describe('mirrorCall', () => {
         await mirrorCall('test.op', call, 20)
         const elapsed = Date.now() - start
         expect(elapsed).toBeLessThan(200)
+    })
+
+    it('returns the primary result when mirror results match', async () => {
+        await expect(
+            mirrorCompare(
+                'test.compare',
+                () => Promise.resolve({ state: 'healthy' }),
+                () => Promise.resolve({ state: 'healthy' })
+            )
+        ).resolves.toEqual({ state: 'healthy' })
+        expect(logger.warn).not.toHaveBeenCalledWith('🪞', '[mirror:test.compare] result mismatch')
+    })
+
+    it('reports a mismatch without changing the primary result', async () => {
+        await expect(
+            mirrorCompare(
+                'test.compare',
+                () => Promise.resolve({ state: 'healthy' }),
+                () => Promise.resolve({ state: 'degraded' })
+            )
+        ).resolves.toEqual({ state: 'healthy' })
+        expect(logger.warn).toHaveBeenCalledWith('🪞', '[mirror:test.compare] result mismatch')
+    })
+
+    it('returns the primary result when the mirror fails', async () => {
+        await expect(
+            mirrorCompare(
+                'test.compare',
+                () => Promise.resolve('primary'),
+                () => Promise.reject(new Error('boom'))
+            )
+        ).resolves.toBe('primary')
     })
 })

--- a/nodejs/src/cdp/utils/mirror-call.ts
+++ b/nodejs/src/cdp/utils/mirror-call.ts
@@ -1,8 +1,50 @@
+import { isDeepStrictEqual } from 'node:util'
+import { Counter } from 'prom-client'
+
 import { logger } from '~/common/utils/logger'
 
 import { instrumentFn } from '../../common/tracing/tracing-utils'
 
 const DEFAULT_TIMEOUT_MS = 2000
+const mismatchWarningLogged = new Set<string>()
+
+const mirrorOperationsTotal = new Counter({
+    name: 'cdp_valkey_mirror_operations_total',
+    help: 'CDP Redis-to-Valkey mirror operations by operation and outcome.',
+    labelNames: ['operation', 'outcome'],
+})
+
+type MirrorOutcome<T> = { status: 'completed'; value: T } | { status: 'skipped' } | { status: 'failed' }
+
+async function runMirrorCall<T>(
+    label: string,
+    call: () => Promise<T> | undefined,
+    timeoutMs: number
+): Promise<MirrorOutcome<T>> {
+    let timeoutId: NodeJS.Timeout | undefined
+    try {
+        const promise = call()
+        if (!promise) {
+            mirrorOperationsTotal.labels({ operation: label, outcome: 'skipped' }).inc()
+            return { status: 'skipped' }
+        }
+        const value = await Promise.race([
+            promise,
+            new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(() => reject(new Error(`mirror call timed out after ${timeoutMs}ms`)), timeoutMs)
+            }),
+        ])
+        return { status: 'completed', value }
+    } catch (err) {
+        mirrorOperationsTotal.labels({ operation: label, outcome: 'failed' }).inc()
+        logger.warn('🪞', `[mirror:${label}] failed`, { err: String(err) })
+        return { status: 'failed' }
+    } finally {
+        if (timeoutId) {
+            clearTimeout(timeoutId)
+        }
+    }
+}
 
 /**
  * Wraps a Valkey mirror call so it can never affect the primary code path.
@@ -28,27 +70,38 @@ export async function mirrorCall(
     timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<void> {
     return instrumentFn({ key: `cdp.mirror.${label}`, sendException: false }, async () => {
-        let timeoutId: NodeJS.Timeout | undefined
-        try {
-            const promise = call()
-            if (!promise) {
-                return
-            }
-            await Promise.race([
-                promise,
-                new Promise<never>((_, reject) => {
-                    timeoutId = setTimeout(
-                        () => reject(new Error(`mirror call timed out after ${timeoutMs}ms`)),
-                        timeoutMs
-                    )
-                }),
-            ])
-        } catch (err) {
-            logger.warn('🪞', `[mirror:${label}] failed`, { err: String(err) })
-        } finally {
-            if (timeoutId) {
-                clearTimeout(timeoutId)
-            }
+        const outcome = await runMirrorCall(label, call, timeoutMs)
+        if (outcome.status === 'completed') {
+            mirrorOperationsTotal.labels({ operation: label, outcome: 'completed' }).inc()
         }
     })
+}
+
+/**
+ * Runs an authoritative Redis read and its Valkey mirror in parallel, returning
+ * the Redis result while recording whether Valkey returned equivalent data.
+ */
+export async function mirrorCompare<T>(
+    label: string,
+    primaryCall: () => Promise<T>,
+    mirrorCallFactory: () => Promise<T> | undefined,
+    isEquivalent: (primary: T, mirror: T) => boolean = isDeepStrictEqual,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS
+): Promise<T> {
+    const primaryPromise = primaryCall()
+    const mirrorPromise = instrumentFn({ key: `cdp.mirror.${label}`, sendException: false }, () =>
+        runMirrorCall(label, mirrorCallFactory, timeoutMs)
+    )
+    const [primary, mirror] = await Promise.all([primaryPromise, mirrorPromise])
+
+    if (mirror.status === 'completed') {
+        const outcome = isEquivalent(primary, mirror.value) ? 'matched' : 'mismatched'
+        mirrorOperationsTotal.labels({ operation: label, outcome }).inc()
+        if (outcome === 'mismatched' && !mismatchWarningLogged.has(label)) {
+            mismatchWarningLogged.add(label)
+            logger.warn('🪞', `[mirror:${label}] result mismatch`)
+        }
+    }
+
+    return primary
 }


### PR DESCRIPTION
## Problem

The CDP Valkey mirror confirms traffic reaches the shadow store, but it did not verify equivalent read decisions. Long-lived HogMasker counters also need an explicit state migration before Valkey can become authoritative.

## Changes

- Compare Redis and Valkey results while Redis remains authoritative, with bounded outcome telemetry.
- Compare semantic rate-limit, duplicate-detection, and masking decisions instead of unstable raw counters.
- Add a dry-run-by-default HogMasker migration CLI with online copy, paused-writer finalize, target cleanup, and value/expiry verification.

**Why:** A safe primary cutover needs evidence that both stores make the same decisions and a deterministic way to preserve masking history.

## How did you test this code?

Codex ran five focused Jest suites covering 48 tests, focused ESLint, and an integration exercise against two Redis 7.2 instances. The integration copied masking values with absolute expiries, removed a target-only key during finalize, and verified the result. Repository-wide TypeScript checking was attempted but is blocked in this checkout by unbuilt workspace packages unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change. The migration CLI documents its operational arguments through `--help`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the implementation. Exact raw comparison was rejected for concurrently ordered counters; the final design compares behavior-affecting decisions. Final masking synchronization requires an explicit paused-writer acknowledgement because no online copy can promise an identical snapshot while counters are changing.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
