### PR TITLE
fix(clickhouse): route API-key async queries to the offline cluster

### DIFF
--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -355,14 +355,16 @@ def sync_execute(
     if workload == Workload.DEFAULT and (is_api_key_auth or tags.kind == "celery"):
         workload = Workload.OFFLINE
 
-    # Make sure we always have process_query_task on the online cluster.
+    # Make sure we always have app traffic through process_query_task on the online cluster.
+    # API-key traffic stays offline here too, so an async query lands on the same cluster its
+    # synchronous counterpart would.
     # Workload.LOGS is exempt: it pins queries to the dedicated logs cluster, which is the
     # only place the logs tables exist, so overriding it would send the query to a cluster
     # that cannot answer it.
     tags_id: str = tags.id or ""
     if tags_id == "posthog.tasks.tasks.process_query_task":
         if workload != Workload.LOGS:
-            workload = Workload.ONLINE
+            workload = Workload.OFFLINE if is_api_key_auth else Workload.ONLINE
         ch_user = ClickHouseUser.API if is_api_key_auth else ClickHouseUser.APP
 
     if tags.workload == Workload.ENDPOINTS and workload != Workload.LOGS:

--- a/posthog/clickhouse/client/test/test_execute.py
+++ b/posthog/clickhouse/client/test/test_execute.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute import sync_execute
 from posthog.clickhouse.client.limit import RateLimit, get_llm_analytics_rate_limiter
-from posthog.clickhouse.query_tagging import Product, tags_context
+from posthog.clickhouse.query_tagging import AccessMethod, Product, tags_context
 
 
 @pytest.fixture
@@ -26,22 +26,29 @@ def llm_analytics_slots():
 
 
 @pytest.mark.parametrize(
-    "workload,expected_workload",
+    "workload,access_method,expected_workload,expected_ch_user",
     [
-        (Workload.DEFAULT, Workload.ONLINE),
-        (Workload.OFFLINE, Workload.ONLINE),
-        (Workload.LOGS, Workload.LOGS),
+        (Workload.DEFAULT, None, Workload.ONLINE, ClickHouseUser.APP),
+        (Workload.OFFLINE, None, Workload.ONLINE, ClickHouseUser.APP),
+        (Workload.LOGS, None, Workload.LOGS, ClickHouseUser.APP),
+        (Workload.DEFAULT, AccessMethod.OAUTH, Workload.ONLINE, ClickHouseUser.APP),
+        (Workload.DEFAULT, AccessMethod.PERSONAL_API_KEY, Workload.OFFLINE, ClickHouseUser.API),
+        (Workload.ONLINE, AccessMethod.PROJECT_SECRET_API_KEY, Workload.OFFLINE, ClickHouseUser.API),
+        (Workload.LOGS, AccessMethod.PERSONAL_API_KEY, Workload.LOGS, ClickHouseUser.API),
     ],
 )
-def test_process_query_task_workload_routing(client_from_pool, workload, expected_workload):
-    # The async query worker forces queries onto the online cluster, but must not override
+def test_process_query_task_workload_routing(
+    client_from_pool, workload, access_method, expected_workload, expected_ch_user
+):
+    # The async query worker forces app traffic onto the online cluster while API-key traffic
+    # keeps the offline routing it gets when run synchronously. Neither may override
     # cluster-pinned workloads: LOGS-workload tables only exist on the logs cluster.
-    with tags_context(kind="celery", id="posthog.tasks.tasks.process_query_task"):
+    with tags_context(kind="celery", id="posthog.tasks.tasks.process_query_task", access_method=access_method):
         sync_execute("SELECT 1", workload=workload, flush=False)
 
     called_workload, _, _, called_ch_user = client_from_pool.call_args[0]
     assert called_workload == expected_workload
-    assert called_ch_user == ClickHouseUser.APP
+    assert called_ch_user == expected_ch_user
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`sync_execute` has a rule that programmatic API-key traffic (personal API key, project secret API key, legacy team secret token) runs on the offline ClickHouse cluster, so it does not compete with interactive app traffic:

https://github.com/PostHog/posthog/blob/master/posthog/clickhouse/client/execute.py#L353-L356

Three lines later, an unconditional override pins every `process_query_task` query back to the online cluster:

https://github.com/PostHog/posthog/blob/master/posthog/clickhouse/client/execute.py#L358-L366

`process_query_task` is the Celery worker behind async queries, and the request's tag context travels with it (`enqueue_process_query_task` snapshots the tags, the task replays them), so `access_method` is intact inside the worker. That is exactly why the `ch_user` line right below already picks `ClickHouseUser.API`. Only the workload was being forced.

The result: the same API-key query hit a different cluster depending on whether it ran synchronously or asynchronously. Async API traffic landed on the online nodes.

## Changes

Keep the online pin for app and session traffic only. API-key traffic keeps the offline routing it already gets when run synchronously.

```diff
     tags_id: str = tags.id or ""
     if tags_id == "posthog.tasks.tasks.process_query_task":
         if workload != Workload.LOGS:
-            workload = Workload.ONLINE
+            workload = Workload.OFFLINE if is_api_key_auth else Workload.ONLINE
         ch_user = ClickHouseUser.API if is_api_key_auth else ClickHouseUser.APP
```

`is_api_key_auth` comes from `is_api_key_access_method`, which deliberately excludes OAuth and sharing tokens, so user-consented and public-read traffic stays online. The `LOGS` exemption is untouched, since those tables only exist on the logs cluster. The `ENDPOINTS` tag branch runs after this and still wins.

> [!NOTE]
> `CLICKHOUSE_OFFLINE_CLUSTER_HOST` is unset in EU, dev, and tests, where `OFFLINE` collapses back to the same host. This only changes routing where a separate offline cluster exists.

## How did you test this code?

Extended the existing parameterized `test_process_query_task_workload_routing` with an `access_method` dimension rather than adding a new test. The regression it now catches, which no existing case did: if the unconditional `ONLINE` pin is reinstated, API-key async queries silently return to the online cluster. Every previous case asserted `ch_user == APP`, so none exercised the API-key path at all. New cases cover personal API key, project secret key over an explicit `workload=ONLINE`, OAuth staying online, and the `LOGS` pin holding under API-key auth.

Ran locally:

- `pytest posthog/clickhouse/client/test/test_execute.py` — 17 passed
- `pytest posthog/clickhouse/client/test/` — 46 passed, plus 60 errors that are all `OperationalError` from Postgres not running in my local setup, unrelated to this change
- `ruff check` and `ruff format --check` on both files — clean

Worth confirming after deploy: in `system.query_log`, rows whose `log_comment` carries `id = 'posthog.tasks.tasks.process_query_task'` and an API-key `access_method` should report `workload = 'OFFLINE'`, while session and OAuth rows stay `ONLINE`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I had Claude (Claude Code, Opus 5) trace the routing. My starting hypothesis was that the bug lived somewhere in the Celery worker setup, but the trace landed on `sync_execute` instead: `task_prerun` in `posthog/celery.py` already tags `kind="celery"` and flips the process-global default workload to `OFFLINE`, so generic Celery tasks were fine. The single leak was this `process_query_task` carve-out, which post-dates the API-key rule and overrides it.

Two options were on the table. Dropping the ONLINE pin entirely would have sent app UI async refreshes offline too, which is a latency regression for interactive users, so I rejected it and kept the pin scoped to non-API-key traffic. Skills invoked: `/writing-tests`, which is why this extends the existing parameterized test instead of adding a fourth near-duplicate test function.
