### PR TITLE
feat(cdp): add masker valkey copy and check CLI

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -39,6 +39,7 @@
         "migrate:cyclotron": "../rust/bin/migrate-cyclotron",
         "migrate:cyclotron-node": "../rust/bin/migrate-cyclotron-node",
         "migrate:behavioral-cohorts": "../rust/bin/migrate-behavioral-cohorts",
+        "migrate:cdp-masker-valkey": "ts-node src/cdp/scripts/migrate-hog-masker-to-valkey.ts",
         "migrate:rust": "../rust/bin/migrate-entry all",
         "services:start": "cd .. && docker compose -f docker-compose.dev.yml up",
         "services:stop": "cd .. && docker compose -f docker-compose.dev.yml down",

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
@@ -1,6 +1,12 @@
 import IORedis, { Redis } from 'ioredis'
 
-import { MaskerMigrationOptions, migrationHasMismatches, runMaskerMigration } from './hog-masker-valkey-migration'
+import {
+    MaskerMigrationOptions,
+    copyMaskerKeys,
+    emptyMigrationSummary,
+    migrationHasMismatches,
+    runMaskerMigration,
+} from './hog-masker-valkey-migration'
 
 const KEY_PATTERN = '@posthog-test/hog-masker/mask/*'
 const SOURCE_KEY = '@posthog-test/hog-masker/mask/function/hash'
@@ -55,6 +61,22 @@ describe('HogMasker Valkey migration', () => {
         expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 1 })
         await expect(target.get(SOURCE_KEY)).resolves.toBe('42')
         expect(Math.abs(sourceTtl - targetTtl)).toBeLessThan(500)
+    })
+
+    it('fails the migration and does not count copies when a target write fails', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+        const failingPipeline = {
+            set: jest.fn(),
+            exec: jest.fn().mockResolvedValue([[new Error('write rejected'), null]]),
+        }
+        failingPipeline.set.mockReturnValue(failingPipeline)
+        jest.spyOn(target, 'pipeline').mockReturnValueOnce(failingPipeline as any)
+        const summary = emptyMigrationSummary()
+
+        await expect(copyMaskerKeys(source, target, options(), summary)).rejects.toThrow(
+            'Target Valkey write pipeline failed: write rejected'
+        )
+        expect(summary.copiedKeys).toBe(0)
     })
 
     it('finalizes an identical target and removes target-only keys', async () => {

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
@@ -21,6 +21,8 @@ describe('HogMasker Valkey migration', () => {
     })
 
     beforeAll(async () => {
+        // This suite runs against the local Redis test container; production connections come from CDP_* env vars.
+        // nosemgrep: trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport
         const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
         source = new IORedis(redisUrl, { db: 14 })
         target = new IORedis(redisUrl, { db: 15 })

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
@@ -52,7 +52,7 @@ describe('HogMasker Valkey migration', () => {
         await expect(target.get(SOURCE_KEY)).resolves.toBeNull()
     })
 
-    it('copies values while preserving the absolute expiry', async () => {
+    it('copies values while preserving the remaining expiry', async () => {
         await source.set(SOURCE_KEY, '42', 'PX', 60_000)
 
         const summary = await runMaskerMigration(source, target, options())

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
@@ -1,0 +1,89 @@
+import IORedis, { Redis } from 'ioredis'
+
+import { MaskerMigrationOptions, migrationHasMismatches, runMaskerMigration } from './hog-masker-valkey-migration'
+
+const KEY_PATTERN = '@posthog-test/hog-masker/mask/*'
+const SOURCE_KEY = '@posthog-test/hog-masker/mask/function/hash'
+const EXTRA_KEY = '@posthog-test/hog-masker/mask/extra/hash'
+
+describe('HogMasker Valkey migration', () => {
+    let source: Redis
+    let target: Redis
+
+    const options = (overrides: Partial<MaskerMigrationOptions> = {}): MaskerMigrationOptions => ({
+        phase: 'copy',
+        execute: true,
+        writersPaused: false,
+        scanCount: 10,
+        ttlToleranceMs: 500,
+        keyPattern: KEY_PATTERN,
+        ...overrides,
+    })
+
+    beforeAll(async () => {
+        const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
+        source = new IORedis(redisUrl, { db: 14 })
+        target = new IORedis(redisUrl, { db: 15 })
+        await Promise.all([source.ping(), target.ping()])
+    })
+
+    beforeEach(async () => {
+        await Promise.all([source.flushdb(), target.flushdb()])
+    })
+
+    afterAll(async () => {
+        await Promise.all([source.quit(), target.quit()])
+    })
+
+    it('keeps dry-run copy read-only', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+
+        const summary = await runMaskerMigration(source, target, options({ execute: false }))
+
+        expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 0 })
+        await expect(target.get(SOURCE_KEY)).resolves.toBeNull()
+    })
+
+    it('copies values while preserving the absolute expiry', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+
+        const summary = await runMaskerMigration(source, target, options())
+        const [sourceTtl, targetTtl] = await Promise.all([source.pttl(SOURCE_KEY), target.pttl(SOURCE_KEY)])
+
+        expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 1 })
+        await expect(target.get(SOURCE_KEY)).resolves.toBe('42')
+        expect(Math.abs(sourceTtl - targetTtl)).toBeLessThan(500)
+    })
+
+    it('finalizes an identical target and removes target-only keys', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+        await target.set(EXTRA_KEY, '1', 'PX', 60_000)
+
+        const summary = await runMaskerMigration(source, target, options({ phase: 'finalize', writersPaused: true }))
+
+        expect(summary).toMatchObject({ copiedKeys: 1, deletedExtraKeys: 1, missingTargetKeys: 0 })
+        expect(migrationHasMismatches(summary)).toBe(false)
+        await expect(target.get(EXTRA_KEY)).resolves.toBeNull()
+    })
+
+    it('detects missing, different, and differently expiring target keys', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+        await target.set(SOURCE_KEY, '7', 'PX', 30_000)
+        await target.set(EXTRA_KEY, '1', 'PX', 60_000)
+
+        const summary = await runMaskerMigration(
+            source,
+            target,
+            options({ phase: 'verify', execute: false, ttlToleranceMs: 100 })
+        )
+
+        expect(summary).toMatchObject({ mismatchedValues: 1, mismatchedExpiries: 1, extraTargetKeys: 1 })
+        expect(migrationHasMismatches(summary)).toBe(true)
+    })
+
+    it('refuses to finalize without paused writers', async () => {
+        await expect(
+            runMaskerMigration(source, target, options({ phase: 'finalize', writersPaused: false }))
+        ).rejects.toThrow('Finalization requires execute=true and writersPaused=true')
+    })
+})

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.test.ts
@@ -1,16 +1,17 @@
 import IORedis, { Redis } from 'ioredis'
 
+import { MASK_KEY_PREFIX } from '../services/monitoring/hog-masker.keys'
 import {
+    DEFAULT_KEY_PATTERN,
     MaskerMigrationOptions,
-    copyMaskerKeys,
-    emptyMigrationSummary,
-    migrationHasMismatches,
+    migrationHasDrift,
     runMaskerMigration,
 } from './hog-masker-valkey-migration'
 
-const KEY_PATTERN = '@posthog-test/hog-masker/mask/*'
-const SOURCE_KEY = '@posthog-test/hog-masker/mask/function/hash'
-const EXTRA_KEY = '@posthog-test/hog-masker/mask/extra/hash'
+const SOURCE_KEY = `${MASK_KEY_PREFIX}function/hash`
+const MISSING_KEY = `${MASK_KEY_PREFIX}function/missing`
+const EXPIRY_KEY = `${MASK_KEY_PREFIX}function/expiry`
+const TARGET_ONLY_KEY = `${MASK_KEY_PREFIX}function/target-only`
 
 describe('HogMasker Valkey migration', () => {
     let source: Redis
@@ -19,10 +20,12 @@ describe('HogMasker Valkey migration', () => {
     const options = (overrides: Partial<MaskerMigrationOptions> = {}): MaskerMigrationOptions => ({
         phase: 'copy',
         execute: true,
-        writersPaused: false,
+        keyPattern: DEFAULT_KEY_PATTERN,
         scanCount: 10,
+        limit: null,
+        sleepMsBetweenBatches: 0,
         ttlToleranceMs: 500,
-        keyPattern: KEY_PATTERN,
+        sampleKeysPerBucket: 5,
         ...overrides,
     })
 
@@ -43,71 +46,78 @@ describe('HogMasker Valkey migration', () => {
         await Promise.all([source.quit(), target.quit()])
     })
 
-    it('keeps dry-run copy read-only', async () => {
+    it('refuses a key pattern outside the masker prefix', async () => {
+        await expect(runMaskerMigration(source, target, options({ keyPattern: '*' }))).rejects.toThrow(
+            `Key pattern must start with ${MASK_KEY_PREFIX}`
+        )
+    })
+
+    it('reports the copy it would make without writing anything', async () => {
         await source.set(SOURCE_KEY, '42', 'PX', 60_000)
 
         const summary = await runMaskerMigration(source, target, options({ execute: false }))
 
-        expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 0 })
+        expect(summary).toMatchObject({ dryRun: true, scannedSourceKeys: 1, missingFromTarget: 1, copiedKeys: 0 })
         await expect(target.get(SOURCE_KEY)).resolves.toBeNull()
     })
 
-    it('copies values while preserving the remaining expiry', async () => {
+    it('copies missing keys while preserving the remaining expiry', async () => {
         await source.set(SOURCE_KEY, '42', 'PX', 60_000)
 
         const summary = await runMaskerMigration(source, target, options())
         const [sourceTtl, targetTtl] = await Promise.all([source.pttl(SOURCE_KEY), target.pttl(SOURCE_KEY)])
 
-        expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 1 })
+        expect(summary).toMatchObject({ scannedSourceKeys: 1, missingFromTarget: 1, copiedKeys: 1 })
         await expect(target.get(SOURCE_KEY)).resolves.toBe('42')
         expect(Math.abs(sourceTtl - targetTtl)).toBeLessThan(500)
     })
 
-    it('fails the migration and does not count copies when a target write fails', async () => {
-        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
-        const failingPipeline = {
-            set: jest.fn(),
-            exec: jest.fn().mockResolvedValue([[new Error('write rejected'), null]]),
-        }
-        failingPipeline.set.mockReturnValue(failingPipeline)
-        jest.spyOn(target, 'pipeline').mockReturnValueOnce(failingPipeline as any)
-        const summary = emptyMigrationSummary()
-
-        await expect(copyMaskerKeys(source, target, options(), summary)).rejects.toThrow(
-            'Target Valkey write pipeline failed: write rejected'
-        )
-        expect(summary.copiedKeys).toBe(0)
-    })
-
-    it('finalizes an identical target and removes target-only keys', async () => {
-        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
-        await target.set(EXTRA_KEY, '1', 'PX', 60_000)
-
-        const summary = await runMaskerMigration(source, target, options({ phase: 'finalize', writersPaused: true }))
-
-        expect(summary).toMatchObject({ copiedKeys: 1, deletedExtraKeys: 1, missingTargetKeys: 0 })
-        expect(migrationHasMismatches(summary)).toBe(false)
-        await expect(target.get(EXTRA_KEY)).resolves.toBeNull()
-    })
-
-    it('detects missing, different, and differently expiring target keys', async () => {
+    it('leaves a counter the target already holds untouched', async () => {
         await source.set(SOURCE_KEY, '42', 'PX', 60_000)
         await target.set(SOURCE_KEY, '7', 'PX', 30_000)
-        await target.set(EXTRA_KEY, '1', 'PX', 60_000)
+
+        const summary = await runMaskerMigration(source, target, options())
+
+        expect(summary).toMatchObject({ presentInTarget: 1, missingFromTarget: 0, copiedKeys: 0 })
+        await expect(target.get(SOURCE_KEY)).resolves.toBe('7')
+        expect(await target.pttl(SOURCE_KEY)).toBeLessThanOrEqual(30_000)
+    })
+
+    it('stops at the limit and marks the counts as a sample', async () => {
+        for (let index = 0; index < 25; index++) {
+            await source.set(`${MASK_KEY_PREFIX}function/${index}`, '1', 'PX', 60_000)
+        }
+
+        const summary = await runMaskerMigration(source, target, options({ phase: 'stats', execute: false, limit: 5 }))
+
+        expect(summary).toMatchObject({ scannedSourceKeys: 5, missingFromTarget: 5, limitReached: true })
+        expect(summary.sourceTtlBuckets.under1h).toBe(5)
+    })
+
+    it('reports drift in both directions without deleting anything', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+        await target.set(SOURCE_KEY, '7', 'PX', 60_000)
+        await source.set(MISSING_KEY, '1', 'PX', 60_000)
+        await source.set(EXPIRY_KEY, '1', 'PX', 60_000)
+        await target.set(EXPIRY_KEY, '1', 'PX', 30_000)
+        await target.set(TARGET_ONLY_KEY, '1', 'PX', 60_000)
 
         const summary = await runMaskerMigration(
             source,
             target,
-            options({ phase: 'verify', execute: false, ttlToleranceMs: 100 })
+            options({ phase: 'check', execute: false, ttlToleranceMs: 100 })
         )
 
-        expect(summary).toMatchObject({ mismatchedValues: 1, mismatchedExpiries: 1, extraTargetKeys: 1 })
-        expect(migrationHasMismatches(summary)).toBe(true)
-    })
-
-    it('refuses to finalize without paused writers', async () => {
-        await expect(
-            runMaskerMigration(source, target, options({ phase: 'finalize', writersPaused: false }))
-        ).rejects.toThrow('Finalization requires execute=true and writersPaused=true')
+        expect(summary).toMatchObject({
+            scannedSourceKeys: 3,
+            scannedTargetKeys: 3,
+            missingFromTarget: 1,
+            valueDrift: 1,
+            targetBehindSource: 1,
+            expiryDrift: 1,
+            targetOnlyKeys: 1,
+        })
+        expect(migrationHasDrift(summary)).toBe(true)
+        await expect(target.exists(TARGET_ONLY_KEY)).resolves.toBe(1)
     })
 })

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
@@ -46,14 +46,7 @@ async function* scanBatches(redis: Redis, keyPattern: string, count: number): As
     } while (cursor !== '0')
 }
 
-function sourceTimeMs([seconds, microseconds]: [string, string]): number {
-    return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
-}
-
-function successfulPipelineRows(
-    rows: [Error | null, unknown][] | null,
-    operation: string
-): [Error | null, unknown][] {
+function successfulPipelineRows(rows: [Error | null, unknown][] | null, operation: string): [Error | null, unknown][] {
     if (!rows) {
         throw new Error(`${operation} returned no results`)
     }
@@ -81,10 +74,8 @@ export async function copyMaskerKeys(
             sourcePipeline.get(key)
             sourcePipeline.pttl(key)
         }
-        const [time, pipelineRows] = await Promise.all([source.time(), sourcePipeline.exec()])
-        const rows = successfulPipelineRows(pipelineRows, 'Source Redis read pipeline')
+        const rows = successfulPipelineRows(await sourcePipeline.exec(), 'Source Redis read pipeline')
 
-        const nowMs = sourceTimeMs(time)
         const targetPipeline = target.pipeline()
         let pendingCopies = 0
         keys.forEach((key, index) => {
@@ -94,7 +85,7 @@ export async function copyMaskerKeys(
                 summary.skippedExpiredKeys++
                 return
             }
-            targetPipeline.set(key, value, 'PXAT', nowMs + ttlMs)
+            targetPipeline.set(key, value, 'PX', ttlMs)
             pendingCopies++
         })
         if (pendingCopies > 0) {

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
@@ -50,6 +50,20 @@ function sourceTimeMs([seconds, microseconds]: [string, string]): number {
     return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
 }
 
+function successfulPipelineRows(
+    rows: [Error | null, unknown][] | null,
+    operation: string
+): [Error | null, unknown][] {
+    if (!rows) {
+        throw new Error(`${operation} returned no results`)
+    }
+    const failed = rows.find(([error]) => error)
+    if (failed?.[0]) {
+        throw new Error(`${operation} failed: ${failed[0].message}`)
+    }
+    return rows
+}
+
 export async function copyMaskerKeys(
     source: Redis,
     target: Redis,
@@ -67,13 +81,12 @@ export async function copyMaskerKeys(
             sourcePipeline.get(key)
             sourcePipeline.pttl(key)
         }
-        const [time, rows] = await Promise.all([source.time(), sourcePipeline.exec()])
-        if (!rows) {
-            throw new Error('Source Redis pipeline returned no results')
-        }
+        const [time, pipelineRows] = await Promise.all([source.time(), sourcePipeline.exec()])
+        const rows = successfulPipelineRows(pipelineRows, 'Source Redis read pipeline')
 
         const nowMs = sourceTimeMs(time)
         const targetPipeline = target.pipeline()
+        let pendingCopies = 0
         keys.forEach((key, index) => {
             const value = rows[index * 2]?.[1] as string | null
             const ttlMs = Number(rows[index * 2 + 1]?.[1])
@@ -82,9 +95,12 @@ export async function copyMaskerKeys(
                 return
             }
             targetPipeline.set(key, value, 'PXAT', nowMs + ttlMs)
-            summary.copiedKeys++
+            pendingCopies++
         })
-        await targetPipeline.exec()
+        if (pendingCopies > 0) {
+            successfulPipelineRows(await targetPipeline.exec(), 'Target Valkey write pipeline')
+            summary.copiedKeys += pendingCopies
+        }
     }
 }
 
@@ -97,10 +113,7 @@ export async function deleteTargetExtras(
     for await (const keys of scanBatches(target, options.keyPattern, options.scanCount)) {
         const existsPipeline = source.pipeline()
         keys.forEach((key) => existsPipeline.exists(key))
-        const rows = await existsPipeline.exec()
-        if (!rows) {
-            throw new Error('Source Redis existence pipeline returned no results')
-        }
+        const rows = successfulPipelineRows(await existsPipeline.exec(), 'Source Redis existence pipeline')
         const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
         summary.extraTargetKeys += extras.length
         if (options.execute && extras.length > 0) {
@@ -124,10 +137,12 @@ export async function verifyMaskerKeys(
             targetPipeline.get(key)
             targetPipeline.pttl(key)
         }
-        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
-        if (!sourceRows || !targetRows) {
-            throw new Error('Verification pipeline returned no results')
-        }
+        const [sourcePipelineRows, targetPipelineRows] = await Promise.all([
+            sourcePipeline.exec(),
+            targetPipeline.exec(),
+        ])
+        const sourceRows = successfulPipelineRows(sourcePipelineRows, 'Source Redis verification pipeline')
+        const targetRows = successfulPipelineRows(targetPipelineRows, 'Target Valkey verification pipeline')
         keys.forEach((_, index) => {
             const sourceValue = sourceRows[index * 2]?.[1] as string | null
             const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
@@ -1,0 +1,183 @@
+import { Redis } from 'ioredis'
+
+export type MigrationPhase = 'copy' | 'finalize' | 'verify'
+
+export type MaskerMigrationOptions = {
+    phase: MigrationPhase
+    execute: boolean
+    writersPaused: boolean
+    scanCount: number
+    ttlToleranceMs: number
+    keyPattern: string
+}
+
+export type MigrationSummary = {
+    sourceKeys: number
+    copiedKeys: number
+    skippedExpiredKeys: number
+    deletedExtraKeys: number
+    mismatchedValues: number
+    mismatchedExpiries: number
+    missingTargetKeys: number
+    extraTargetKeys: number
+}
+
+export function emptyMigrationSummary(): MigrationSummary {
+    return {
+        sourceKeys: 0,
+        copiedKeys: 0,
+        skippedExpiredKeys: 0,
+        deletedExtraKeys: 0,
+        mismatchedValues: 0,
+        mismatchedExpiries: 0,
+        missingTargetKeys: 0,
+        extraTargetKeys: 0,
+    }
+}
+
+async function* scanBatches(redis: Redis, keyPattern: string, count: number): AsyncGenerator<string[]> {
+    let cursor = '0'
+    do {
+        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', keyPattern, 'COUNT', count)
+        cursor = nextCursor
+        if (keys.length > 0) {
+            yield keys
+        }
+    } while (cursor !== '0')
+}
+
+function sourceTimeMs([seconds, microseconds]: [string, string]): number {
+    return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
+}
+
+export async function copyMaskerKeys(
+    source: Redis,
+    target: Redis,
+    options: MaskerMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.keyPattern, options.scanCount)) {
+        summary.sourceKeys += keys.length
+        if (!options.execute) {
+            continue
+        }
+
+        const sourcePipeline = source.pipeline()
+        for (const key of keys) {
+            sourcePipeline.get(key)
+            sourcePipeline.pttl(key)
+        }
+        const [time, rows] = await Promise.all([source.time(), sourcePipeline.exec()])
+        if (!rows) {
+            throw new Error('Source Redis pipeline returned no results')
+        }
+
+        const nowMs = sourceTimeMs(time)
+        const targetPipeline = target.pipeline()
+        keys.forEach((key, index) => {
+            const value = rows[index * 2]?.[1] as string | null
+            const ttlMs = Number(rows[index * 2 + 1]?.[1])
+            if (value === null || ttlMs <= 0) {
+                summary.skippedExpiredKeys++
+                return
+            }
+            targetPipeline.set(key, value, 'PXAT', nowMs + ttlMs)
+            summary.copiedKeys++
+        })
+        await targetPipeline.exec()
+    }
+}
+
+export async function deleteTargetExtras(
+    source: Redis,
+    target: Redis,
+    options: MaskerMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(target, options.keyPattern, options.scanCount)) {
+        const existsPipeline = source.pipeline()
+        keys.forEach((key) => existsPipeline.exists(key))
+        const rows = await existsPipeline.exec()
+        if (!rows) {
+            throw new Error('Source Redis existence pipeline returned no results')
+        }
+        const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
+        summary.extraTargetKeys += extras.length
+        if (options.execute && extras.length > 0) {
+            summary.deletedExtraKeys += await target.del(...extras)
+        }
+    }
+}
+
+export async function verifyMaskerKeys(
+    source: Redis,
+    target: Redis,
+    options: MaskerMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.keyPattern, options.scanCount)) {
+        const sourcePipeline = source.pipeline()
+        const targetPipeline = target.pipeline()
+        for (const key of keys) {
+            sourcePipeline.get(key)
+            sourcePipeline.pttl(key)
+            targetPipeline.get(key)
+            targetPipeline.pttl(key)
+        }
+        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
+        if (!sourceRows || !targetRows) {
+            throw new Error('Verification pipeline returned no results')
+        }
+        keys.forEach((_, index) => {
+            const sourceValue = sourceRows[index * 2]?.[1] as string | null
+            const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])
+            const targetValue = targetRows[index * 2]?.[1] as string | null
+            const targetTtl = Number(targetRows[index * 2 + 1]?.[1])
+            if (sourceValue === null || sourceTtl <= 0) {
+                return
+            }
+            if (targetValue === null) {
+                summary.missingTargetKeys++
+                return
+            }
+            if (sourceValue !== targetValue) {
+                summary.mismatchedValues++
+            }
+            if (Math.abs(sourceTtl - targetTtl) > options.ttlToleranceMs) {
+                summary.mismatchedExpiries++
+            }
+        })
+    }
+    await deleteTargetExtras(source, target, { ...options, execute: false }, summary)
+}
+
+export function migrationHasMismatches(summary: MigrationSummary): boolean {
+    return Boolean(
+        summary.mismatchedValues ||
+            summary.mismatchedExpiries ||
+            summary.missingTargetKeys ||
+            summary.extraTargetKeys - summary.deletedExtraKeys > 0
+    )
+}
+
+export async function runMaskerMigration(
+    source: Redis,
+    target: Redis,
+    options: MaskerMigrationOptions
+): Promise<MigrationSummary> {
+    if (options.phase === 'finalize' && (!options.execute || !options.writersPaused)) {
+        throw new Error('Finalization requires execute=true and writersPaused=true')
+    }
+
+    const summary = emptyMigrationSummary()
+    if (options.phase === 'copy' || options.phase === 'finalize') {
+        await copyMaskerKeys(source, target, options, summary)
+    }
+    if (options.phase === 'finalize') {
+        await deleteTargetExtras(source, target, options, summary)
+    }
+    if (options.phase === 'verify' || options.phase === 'finalize') {
+        await verifyMaskerKeys(source, target, options, summary)
+    }
+    return summary
+}

--- a/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
+++ b/nodejs/src/cdp/scripts/hog-masker-valkey-migration.ts
@@ -1,47 +1,138 @@
 import { Redis } from 'ioredis'
 
-export type MigrationPhase = 'copy' | 'finalize' | 'verify'
+import { MASK_KEY_PREFIX } from '../services/monitoring/hog-masker.keys'
+
+export const DEFAULT_KEY_PATTERN = `${MASK_KEY_PREFIX}*`
+
+export type MigrationPhase = 'stats' | 'copy' | 'check'
 
 export type MaskerMigrationOptions = {
     phase: MigrationPhase
+    /** Only read by the copy phase; stats and check never write. */
     execute: boolean
-    writersPaused: boolean
-    scanCount: number
-    ttlToleranceMs: number
     keyPattern: string
+    scanCount: number
+    /** Stop after this many scanned keys, so a run can be sized to fit a pod session. */
+    limit: number | null
+    sleepMsBetweenBatches: number
+    ttlToleranceMs: number
+    sampleKeysPerBucket: number
+}
+
+export type TtlBucket = 'under1h' | 'under1d' | 'under7d' | 'under30d' | 'under1y' | 'over1y' | 'noExpiry'
+
+const TTL_BUCKET_UPPER_BOUNDS_MS: [Exclude<TtlBucket, 'noExpiry' | 'over1y'>, number][] = [
+    ['under1h', 60 * 60 * 1000],
+    ['under1d', 24 * 60 * 60 * 1000],
+    ['under7d', 7 * 24 * 60 * 60 * 1000],
+    ['under30d', 30 * 24 * 60 * 60 * 1000],
+    ['under1y', 365 * 24 * 60 * 60 * 1000],
+]
+
+export type MigrationSamples = {
+    missingFromTarget: string[]
+    valueDrift: string[]
+    expiryDrift: string[]
+    targetOnly: string[]
 }
 
 export type MigrationSummary = {
-    sourceKeys: number
+    phase: MigrationPhase
+    dryRun: boolean
+    scannedSourceKeys: number
+    scannedTargetKeys: number
+    /** True when --limit cut the scan short, so the counts are a sample rather than a total. */
+    limitReached: boolean
+    presentInTarget: number
+    missingFromTarget: number
     copiedKeys: number
+    /** Keys SCAN returned that had already expired by the time we read them. */
     skippedExpiredKeys: number
-    deletedExtraKeys: number
-    mismatchedValues: number
-    mismatchedExpiries: number
-    missingTargetKeys: number
-    extraTargetKeys: number
+    valueDrift: number
+    targetBehindSource: number
+    targetAheadOfSource: number
+    expiryDrift: number
+    targetOnlyKeys: number
+    sourceTtlBuckets: Record<TtlBucket, number>
+    samples: MigrationSamples
 }
 
-export function emptyMigrationSummary(): MigrationSummary {
+export function emptyMigrationSummary(phase: MigrationPhase, dryRun: boolean): MigrationSummary {
     return {
-        sourceKeys: 0,
+        phase,
+        dryRun,
+        scannedSourceKeys: 0,
+        scannedTargetKeys: 0,
+        limitReached: false,
+        presentInTarget: 0,
+        missingFromTarget: 0,
         copiedKeys: 0,
         skippedExpiredKeys: 0,
-        deletedExtraKeys: 0,
-        mismatchedValues: 0,
-        mismatchedExpiries: 0,
-        missingTargetKeys: 0,
-        extraTargetKeys: 0,
+        valueDrift: 0,
+        targetBehindSource: 0,
+        targetAheadOfSource: 0,
+        expiryDrift: 0,
+        targetOnlyKeys: 0,
+        sourceTtlBuckets: {
+            under1h: 0,
+            under1d: 0,
+            under7d: 0,
+            under30d: 0,
+            under1y: 0,
+            over1y: 0,
+            noExpiry: 0,
+        },
+        samples: { missingFromTarget: [], valueDrift: [], expiryDrift: [], targetOnly: [] },
     }
 }
 
-async function* scanBatches(redis: Redis, keyPattern: string, count: number): AsyncGenerator<string[]> {
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function recordSample(samples: string[], key: string, sampleKeysPerBucket: number): void {
+    if (samples.length < sampleKeysPerBucket) {
+        samples.push(key)
+    }
+}
+
+function recordTtlBucket(buckets: Record<TtlBucket, number>, ttlMs: number): void {
+    if (ttlMs < 0) {
+        buckets.noExpiry++
+        return
+    }
+    const bucket = TTL_BUCKET_UPPER_BOUNDS_MS.find(([, upperBoundMs]) => ttlMs < upperBoundMs)
+    buckets[bucket ? bucket[0] : 'over1y']++
+}
+
+/**
+ * Yields SCAN batches, stopping once `limit` keys have been seen. Batches are trimmed to the
+ * limit so callers can treat every yielded key as in scope.
+ */
+async function* scanBatches(
+    redis: Redis,
+    options: MaskerMigrationOptions,
+    onLimitReached: () => void
+): AsyncGenerator<string[]> {
     let cursor = '0'
+    let seen = 0
     do {
-        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', keyPattern, 'COUNT', count)
+        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', options.keyPattern, 'COUNT', options.scanCount)
         cursor = nextCursor
-        if (keys.length > 0) {
-            yield keys
+        if (keys.length === 0) {
+            continue
+        }
+        const batch = options.limit === null ? keys : keys.slice(0, options.limit - seen)
+        seen += batch.length
+        if (batch.length > 0) {
+            yield batch
+        }
+        if (options.limit !== null && seen >= options.limit) {
+            onLimitReached()
+            return
+        }
+        if (options.sleepMsBetweenBatches > 0) {
+            await sleep(options.sleepMsBetweenBatches)
         }
     } while (cursor !== '0')
 }
@@ -57,69 +148,146 @@ function successfulPipelineRows(rows: [Error | null, unknown][] | null, operatio
     return rows
 }
 
-export async function copyMaskerKeys(
+function readValueAndTtl(rows: [Error | null, unknown][], index: number): { value: string | null; ttlMs: number } {
+    return { value: (rows[index * 2]?.[1] ?? null) as string | null, ttlMs: Number(rows[index * 2 + 1]?.[1]) }
+}
+
+/**
+ * Source-side census: how many masking keys exist, how many the target already holds, and how
+ * long the rest have left. Cheaper than checkMaskerKeys because it never reads values.
+ */
+export async function collectMaskerStats(
     source: Redis,
     target: Redis,
     options: MaskerMigrationOptions,
     summary: MigrationSummary
 ): Promise<void> {
-    for await (const keys of scanBatches(source, options.keyPattern, options.scanCount)) {
-        summary.sourceKeys += keys.length
-        if (!options.execute) {
-            continue
-        }
+    for await (const keys of scanBatches(source, options, () => (summary.limitReached = true))) {
+        summary.scannedSourceKeys += keys.length
 
         const sourcePipeline = source.pipeline()
-        for (const key of keys) {
-            sourcePipeline.get(key)
-            sourcePipeline.pttl(key)
-        }
-        const rows = successfulPipelineRows(await sourcePipeline.exec(), 'Source Redis read pipeline')
-
         const targetPipeline = target.pipeline()
-        let pendingCopies = 0
+        for (const key of keys) {
+            sourcePipeline.pttl(key)
+            targetPipeline.exists(key)
+        }
+        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
+        const ttls = successfulPipelineRows(sourceRows, 'Source Redis expiry pipeline')
+        const exists = successfulPipelineRows(targetRows, 'Target Valkey existence pipeline')
+
         keys.forEach((key, index) => {
-            const value = rows[index * 2]?.[1] as string | null
-            const ttlMs = Number(rows[index * 2 + 1]?.[1])
-            if (value === null || ttlMs <= 0) {
+            const ttlMs = Number(ttls[index]?.[1])
+            // -2 means the key expired between SCAN returning it and this read.
+            if (ttlMs === -2) {
                 summary.skippedExpiredKeys++
                 return
             }
-            targetPipeline.set(key, value, 'PX', ttlMs)
-            pendingCopies++
+            recordTtlBucket(summary.sourceTtlBuckets, ttlMs)
+            if (Number(exists[index]?.[1]) === 1) {
+                summary.presentInTarget++
+                return
+            }
+            summary.missingFromTarget++
+            recordSample(summary.samples.missingFromTarget, key, options.sampleKeysPerBucket)
         })
-        if (pendingCopies > 0) {
-            successfulPipelineRows(await targetPipeline.exec(), 'Target Valkey write pipeline')
-            summary.copiedKeys += pendingCopies
-        }
     }
 }
 
-export async function deleteTargetExtras(
+/**
+ * Creates the keys the target does not have yet, with SET NX so a counter the mirror is already
+ * maintaining is never clobbered. That is what makes this safe to run repeatedly against live
+ * writers, and why no writer pause is needed.
+ */
+export async function copyMissingMaskerKeys(
     source: Redis,
     target: Redis,
     options: MaskerMigrationOptions,
     summary: MigrationSummary
 ): Promise<void> {
-    for await (const keys of scanBatches(target, options.keyPattern, options.scanCount)) {
+    for await (const keys of scanBatches(source, options, () => (summary.limitReached = true))) {
+        summary.scannedSourceKeys += keys.length
+
+        const existsPipeline = target.pipeline()
+        keys.forEach((key) => existsPipeline.exists(key))
+        const exists = successfulPipelineRows(await existsPipeline.exec(), 'Target Valkey existence pipeline')
+        const missing = keys.filter((_, index) => Number(exists[index]?.[1]) === 0)
+        summary.presentInTarget += keys.length - missing.length
+        if (missing.length === 0) {
+            continue
+        }
+
+        const readPipeline = source.pipeline()
+        for (const key of missing) {
+            readPipeline.get(key)
+            readPipeline.pttl(key)
+        }
+        const rows = successfulPipelineRows(await readPipeline.exec(), 'Source Redis read pipeline')
+
+        const writes: { key: string; value: string; ttlMs: number }[] = []
+        missing.forEach((key, index) => {
+            const { value, ttlMs } = readValueAndTtl(rows, index)
+            if (value === null || ttlMs === -2) {
+                summary.skippedExpiredKeys++
+                return
+            }
+            recordTtlBucket(summary.sourceTtlBuckets, ttlMs)
+            recordSample(summary.samples.missingFromTarget, key, options.sampleKeysPerBucket)
+            writes.push({ key, value, ttlMs })
+        })
+        summary.missingFromTarget += writes.length
+        if (!options.execute || writes.length === 0) {
+            continue
+        }
+
+        const writePipeline = target.pipeline()
+        for (const { key, value, ttlMs } of writes) {
+            if (ttlMs >= 0) {
+                writePipeline.set(key, value, 'PX', ttlMs, 'NX')
+            } else {
+                writePipeline.set(key, value, 'NX')
+            }
+        }
+        const writeRows = successfulPipelineRows(await writePipeline.exec(), 'Target Valkey write pipeline')
+        // SET NX replies null when the mirror won the race and created the key, so this counts real writes.
+        summary.copiedKeys += writeRows.filter(([, reply]) => reply === 'OK').length
+    }
+}
+
+/** Counts keys the target holds that the source no longer has. Never deletes anything. */
+async function countTargetOnlyKeys(
+    source: Redis,
+    target: Redis,
+    options: MaskerMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(target, options, () => (summary.limitReached = true))) {
+        summary.scannedTargetKeys += keys.length
         const existsPipeline = source.pipeline()
         keys.forEach((key) => existsPipeline.exists(key))
-        const rows = successfulPipelineRows(await existsPipeline.exec(), 'Source Redis existence pipeline')
-        const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
-        summary.extraTargetKeys += extras.length
-        if (options.execute && extras.length > 0) {
-            summary.deletedExtraKeys += await target.del(...extras)
-        }
+        const exists = successfulPipelineRows(await existsPipeline.exec(), 'Source Redis existence pipeline')
+        keys.forEach((key, index) => {
+            if (Number(exists[index]?.[1]) !== 0) {
+                return
+            }
+            summary.targetOnlyKeys++
+            recordSample(summary.samples.targetOnly, key, options.sampleKeysPerBucket)
+        })
     }
 }
 
-export async function verifyMaskerKeys(
+/**
+ * Compares values and expiries in both directions and reports what differs. Read-only, so it
+ * stays a reporting tool rather than a gate: finding drift never stops anything.
+ */
+export async function checkMaskerKeys(
     source: Redis,
     target: Redis,
     options: MaskerMigrationOptions,
     summary: MigrationSummary
 ): Promise<void> {
-    for await (const keys of scanBatches(source, options.keyPattern, options.scanCount)) {
+    for await (const keys of scanBatches(source, options, () => (summary.limitReached = true))) {
+        summary.scannedSourceKeys += keys.length
+
         const sourcePipeline = source.pipeline()
         const targetPipeline = target.pipeline()
         for (const key of keys) {
@@ -128,42 +296,50 @@ export async function verifyMaskerKeys(
             targetPipeline.get(key)
             targetPipeline.pttl(key)
         }
-        const [sourcePipelineRows, targetPipelineRows] = await Promise.all([
-            sourcePipeline.exec(),
-            targetPipeline.exec(),
-        ])
-        const sourceRows = successfulPipelineRows(sourcePipelineRows, 'Source Redis verification pipeline')
-        const targetRows = successfulPipelineRows(targetPipelineRows, 'Target Valkey verification pipeline')
-        keys.forEach((_, index) => {
-            const sourceValue = sourceRows[index * 2]?.[1] as string | null
-            const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])
-            const targetValue = targetRows[index * 2]?.[1] as string | null
-            const targetTtl = Number(targetRows[index * 2 + 1]?.[1])
-            if (sourceValue === null || sourceTtl <= 0) {
+        const [sourceRowsRaw, targetRowsRaw] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
+        const sourceRows = successfulPipelineRows(sourceRowsRaw, 'Source Redis verification pipeline')
+        const targetRows = successfulPipelineRows(targetRowsRaw, 'Target Valkey verification pipeline')
+
+        keys.forEach((key, index) => {
+            const sourceEntry = readValueAndTtl(sourceRows, index)
+            const targetEntry = readValueAndTtl(targetRows, index)
+            if (sourceEntry.value === null) {
+                summary.skippedExpiredKeys++
                 return
             }
-            if (targetValue === null) {
-                summary.missingTargetKeys++
+            recordTtlBucket(summary.sourceTtlBuckets, sourceEntry.ttlMs)
+            if (targetEntry.value === null) {
+                summary.missingFromTarget++
+                recordSample(summary.samples.missingFromTarget, key, options.sampleKeysPerBucket)
                 return
             }
-            if (sourceValue !== targetValue) {
-                summary.mismatchedValues++
+            summary.presentInTarget++
+
+            if (sourceEntry.value !== targetEntry.value) {
+                summary.valueDrift++
+                recordSample(summary.samples.valueDrift, key, options.sampleKeysPerBucket)
+                const sourceCount = Number(sourceEntry.value)
+                const targetCount = Number(targetEntry.value)
+                if (Number.isFinite(sourceCount) && Number.isFinite(targetCount)) {
+                    if (targetCount < sourceCount) {
+                        summary.targetBehindSource++
+                    } else {
+                        summary.targetAheadOfSource++
+                    }
+                }
             }
-            if (Math.abs(sourceTtl - targetTtl) > options.ttlToleranceMs) {
-                summary.mismatchedExpiries++
+            if (Math.abs(sourceEntry.ttlMs - targetEntry.ttlMs) > options.ttlToleranceMs) {
+                summary.expiryDrift++
+                recordSample(summary.samples.expiryDrift, key, options.sampleKeysPerBucket)
             }
         })
     }
-    await deleteTargetExtras(source, target, { ...options, execute: false }, summary)
+
+    await countTargetOnlyKeys(source, target, options, summary)
 }
 
-export function migrationHasMismatches(summary: MigrationSummary): boolean {
-    return Boolean(
-        summary.mismatchedValues ||
-            summary.mismatchedExpiries ||
-            summary.missingTargetKeys ||
-            summary.extraTargetKeys - summary.deletedExtraKeys > 0
-    )
+export function migrationHasDrift(summary: MigrationSummary): boolean {
+    return Boolean(summary.missingFromTarget || summary.valueDrift || summary.expiryDrift || summary.targetOnlyKeys)
 }
 
 export async function runMaskerMigration(
@@ -171,19 +347,70 @@ export async function runMaskerMigration(
     target: Redis,
     options: MaskerMigrationOptions
 ): Promise<MigrationSummary> {
-    if (options.phase === 'finalize' && (!options.execute || !options.writersPaused)) {
-        throw new Error('Finalization requires execute=true and writersPaused=true')
+    if (!options.keyPattern.startsWith(MASK_KEY_PREFIX)) {
+        throw new Error(`Key pattern must start with ${MASK_KEY_PREFIX}, got: ${options.keyPattern}`)
     }
 
-    const summary = emptyMigrationSummary()
-    if (options.phase === 'copy' || options.phase === 'finalize') {
-        await copyMaskerKeys(source, target, options, summary)
+    const summary = emptyMigrationSummary(options.phase, options.phase !== 'copy' || !options.execute)
+    if (options.phase === 'stats') {
+        await collectMaskerStats(source, target, options, summary)
     }
-    if (options.phase === 'finalize') {
-        await deleteTargetExtras(source, target, options, summary)
+    if (options.phase === 'copy') {
+        await copyMissingMaskerKeys(source, target, options, summary)
     }
-    if (options.phase === 'verify' || options.phase === 'finalize') {
-        await verifyMaskerKeys(source, target, options, summary)
+    if (options.phase === 'check') {
+        await checkMaskerKeys(source, target, options, summary)
     }
     return summary
+}
+
+function formatTtlBuckets(buckets: Record<TtlBucket, number>): string {
+    return Object.entries(buckets)
+        .filter(([, count]) => count > 0)
+        .map(([bucket, count]) => `${bucket}=${count}`)
+        .join(' ')
+}
+
+function formatSamples(label: string, keys: string[]): string[] {
+    return keys.length > 0 ? [`  ${label} samples:`, ...keys.map((key) => `    ${key}`)] : []
+}
+
+export function formatMigrationSummary(summary: MigrationSummary, keyPattern: string): string {
+    const lines = [
+        `phase=${summary.phase} ${summary.dryRun ? '(read-only)' : '(writing)'} pattern=${keyPattern}`,
+        `  source keys scanned:  ${summary.scannedSourceKeys}${summary.limitReached ? ' (limit reached, so these are a sample not a total)' : ''}`,
+        `  already in target:    ${summary.presentInTarget}`,
+        `  missing from target:  ${summary.missingFromTarget}`,
+    ]
+    if (summary.phase === 'copy') {
+        lines.push(
+            summary.dryRun
+                ? `  would copy:           ${summary.missingFromTarget}`
+                : `  copied:               ${summary.copiedKeys}`
+        )
+    }
+    if (summary.skippedExpiredKeys > 0) {
+        lines.push(`  expired mid-scan:     ${summary.skippedExpiredKeys}`)
+    }
+    if (summary.phase === 'check') {
+        lines.push(
+            `  value drift:          ${summary.valueDrift} (target behind ${summary.targetBehindSource}, ahead ${summary.targetAheadOfSource})`,
+            `  expiry drift:         ${summary.expiryDrift}`,
+            `  target keys scanned:  ${summary.scannedTargetKeys}`,
+            `  target-only keys:     ${summary.targetOnlyKeys}`
+        )
+    }
+    const ttlBuckets = formatTtlBuckets(summary.sourceTtlBuckets)
+    if (ttlBuckets) {
+        // Copy only reads expiries for the keys it is about to write, so the buckets describe those.
+        const label = summary.phase === 'copy' ? 'missing, by lifetime' : 'source lifetimes'
+        lines.push(`  ${label.padEnd(20)}  ${ttlBuckets}`)
+    }
+    lines.push(
+        ...formatSamples('missing from target', summary.samples.missingFromTarget),
+        ...formatSamples('value drift', summary.samples.valueDrift),
+        ...formatSamples('expiry drift', summary.samples.expiryDrift),
+        ...formatSamples('target-only', summary.samples.targetOnly)
+    )
+    return lines.join('\n')
 }

--- a/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
@@ -1,39 +1,14 @@
 import IORedis, { Redis } from 'ioredis'
 import { parseArgs } from 'node:util'
 
+import {
+    MaskerMigrationOptions,
+    MigrationPhase,
+    migrationHasMismatches,
+    runMaskerMigration,
+} from './hog-masker-valkey-migration'
+
 const KEY_PATTERN = '@posthog/hog-masker/mask/*'
-
-type Phase = 'copy' | 'finalize' | 'verify'
-type MigrationOptions = {
-    phase: Phase
-    execute: boolean
-    writersPaused: boolean
-    scanCount: number
-    ttlToleranceMs: number
-}
-type MigrationSummary = {
-    sourceKeys: number
-    copiedKeys: number
-    skippedExpiredKeys: number
-    deletedExtraKeys: number
-    mismatchedValues: number
-    mismatchedExpiries: number
-    missingTargetKeys: number
-    extraTargetKeys: number
-}
-
-function emptySummary(): MigrationSummary {
-    return {
-        sourceKeys: 0,
-        copiedKeys: 0,
-        skippedExpiredKeys: 0,
-        deletedExtraKeys: 0,
-        mismatchedValues: 0,
-        mismatchedExpiries: 0,
-        missingTargetKeys: 0,
-        extraTargetKeys: 0,
-    }
-}
 
 function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
     const host = process.env[`${prefix}_HOST`]
@@ -46,123 +21,7 @@ function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
     return new IORedis({ host, port, password, tls, lazyConnect: true, maxRetriesPerRequest: 3 })
 }
 
-async function* scanBatches(redis: Redis, count: number): AsyncGenerator<string[]> {
-    let cursor = '0'
-    do {
-        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', KEY_PATTERN, 'COUNT', count)
-        cursor = nextCursor
-        if (keys.length > 0) {
-            yield keys
-        }
-    } while (cursor !== '0')
-}
-
-function sourceTimeMs([seconds, microseconds]: [string, string]): number {
-    return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
-}
-
-async function copySourceKeys(
-    source: Redis,
-    target: Redis,
-    options: MigrationOptions,
-    summary: MigrationSummary
-): Promise<void> {
-    for await (const keys of scanBatches(source, options.scanCount)) {
-        summary.sourceKeys += keys.length
-        if (!options.execute) {
-            continue
-        }
-
-        const sourcePipeline = source.pipeline()
-        for (const key of keys) {
-            sourcePipeline.get(key)
-            sourcePipeline.pttl(key)
-        }
-        const [time, rows] = await Promise.all([source.time(), sourcePipeline.exec()])
-        if (!rows) {
-            throw new Error('Source Redis pipeline returned no results')
-        }
-
-        const nowMs = sourceTimeMs(time)
-        const targetPipeline = target.pipeline()
-        keys.forEach((key, index) => {
-            const value = rows[index * 2]?.[1] as string | null
-            const ttlMs = Number(rows[index * 2 + 1]?.[1])
-            if (value === null || ttlMs <= 0) {
-                summary.skippedExpiredKeys++
-                return
-            }
-            targetPipeline.set(key, value, 'PXAT', nowMs + ttlMs)
-            summary.copiedKeys++
-        })
-        await targetPipeline.exec()
-    }
-}
-
-async function deleteTargetExtras(
-    source: Redis,
-    target: Redis,
-    options: MigrationOptions,
-    summary: MigrationSummary
-): Promise<void> {
-    for await (const keys of scanBatches(target, options.scanCount)) {
-        const existsPipeline = source.pipeline()
-        keys.forEach((key) => existsPipeline.exists(key))
-        const rows = await existsPipeline.exec()
-        if (!rows) {
-            throw new Error('Source Redis existence pipeline returned no results')
-        }
-        const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
-        summary.extraTargetKeys += extras.length
-        if (options.execute && extras.length > 0) {
-            summary.deletedExtraKeys += await target.del(...extras)
-        }
-    }
-}
-
-async function verifyKeys(
-    source: Redis,
-    target: Redis,
-    options: MigrationOptions,
-    summary: MigrationSummary
-): Promise<void> {
-    for await (const keys of scanBatches(source, options.scanCount)) {
-        const sourcePipeline = source.pipeline()
-        const targetPipeline = target.pipeline()
-        for (const key of keys) {
-            sourcePipeline.get(key)
-            sourcePipeline.pttl(key)
-            targetPipeline.get(key)
-            targetPipeline.pttl(key)
-        }
-        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
-        if (!sourceRows || !targetRows) {
-            throw new Error('Verification pipeline returned no results')
-        }
-        keys.forEach((_, index) => {
-            const sourceValue = sourceRows[index * 2]?.[1] as string | null
-            const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])
-            const targetValue = targetRows[index * 2]?.[1] as string | null
-            const targetTtl = Number(targetRows[index * 2 + 1]?.[1])
-            if (sourceValue === null || sourceTtl <= 0) {
-                return
-            }
-            if (targetValue === null) {
-                summary.missingTargetKeys++
-                return
-            }
-            if (sourceValue !== targetValue) {
-                summary.mismatchedValues++
-            }
-            if (Math.abs(sourceTtl - targetTtl) > options.ttlToleranceMs) {
-                summary.mismatchedExpiries++
-            }
-        })
-    }
-    await deleteTargetExtras(source, target, { ...options, execute: false }, summary)
-}
-
-function parseOptions(): MigrationOptions {
+function parseOptions(): MaskerMigrationOptions {
     const { values } = parseArgs({
         options: {
             phase: { type: 'string', default: 'copy' },
@@ -190,16 +49,19 @@ Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
     if (!['copy', 'finalize', 'verify'].includes(values.phase)) {
         throw new Error(`Invalid --phase: ${values.phase}`)
     }
-    const phase = values.phase as Phase
-    if (phase === 'finalize' && (!values.execute || !values['writers-paused'])) {
-        throw new Error('--phase finalize requires both --execute and --writers-paused')
-    }
     const scanCount = Number(values['scan-count'])
     const ttlToleranceMs = Number(values['ttl-tolerance-ms'])
     if (!Number.isInteger(scanCount) || scanCount < 1 || !Number.isFinite(ttlToleranceMs) || ttlToleranceMs < 0) {
         throw new Error('Scan count must be a positive integer and TTL tolerance must be non-negative')
     }
-    return { phase, execute: values.execute, writersPaused: values['writers-paused'], scanCount, ttlToleranceMs }
+    return {
+        phase: values.phase as MigrationPhase,
+        execute: values.execute,
+        writersPaused: values['writers-paused'],
+        scanCount,
+        ttlToleranceMs,
+        keyPattern: KEY_PATTERN,
+    }
 }
 
 async function main(): Promise<void> {
@@ -214,29 +76,14 @@ async function main(): Promise<void> {
     }
     const source = connectionFromEnv('CDP_REDIS')
     const target = connectionFromEnv('CDP_VALKEY')
-    const summary = emptySummary()
     try {
         await Promise.all([source.connect(), target.connect()])
         await Promise.all([source.ping(), target.ping()])
-        if (options.phase === 'copy' || options.phase === 'finalize') {
-            await copySourceKeys(source, target, options, summary)
-        }
-        if (options.phase === 'finalize') {
-            await deleteTargetExtras(source, target, options, summary)
-        }
-        if (options.phase === 'verify' || options.phase === 'finalize') {
-            await verifyKeys(source, target, options, summary)
-        }
+        const summary = await runMaskerMigration(source, target, options)
         console.log(
-            JSON.stringify({ phase: options.phase, dryRun: !options.execute, pattern: KEY_PATTERN, ...summary })
+            JSON.stringify({ phase: options.phase, dryRun: !options.execute, pattern: options.keyPattern, ...summary })
         )
-        const undeletedExtraKeys = summary.extraTargetKeys - summary.deletedExtraKeys
-        if (
-            summary.mismatchedValues ||
-            summary.mismatchedExpiries ||
-            summary.missingTargetKeys ||
-            (options.phase !== 'copy' && undeletedExtraKeys > 0)
-        ) {
+        if (migrationHasMismatches(summary)) {
             process.exitCode = 2
         }
     } finally {

--- a/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
@@ -1,0 +1,250 @@
+import IORedis, { Redis } from 'ioredis'
+import { parseArgs } from 'node:util'
+
+const KEY_PATTERN = '@posthog/hog-masker/mask/*'
+
+type Phase = 'copy' | 'finalize' | 'verify'
+type MigrationOptions = {
+    phase: Phase
+    execute: boolean
+    writersPaused: boolean
+    scanCount: number
+    ttlToleranceMs: number
+}
+type MigrationSummary = {
+    sourceKeys: number
+    copiedKeys: number
+    skippedExpiredKeys: number
+    deletedExtraKeys: number
+    mismatchedValues: number
+    mismatchedExpiries: number
+    missingTargetKeys: number
+    extraTargetKeys: number
+}
+
+function emptySummary(): MigrationSummary {
+    return {
+        sourceKeys: 0,
+        copiedKeys: 0,
+        skippedExpiredKeys: 0,
+        deletedExtraKeys: 0,
+        mismatchedValues: 0,
+        mismatchedExpiries: 0,
+        missingTargetKeys: 0,
+        extraTargetKeys: 0,
+    }
+}
+
+function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
+    const host = process.env[`${prefix}_HOST`]
+    if (!host) {
+        throw new Error(`${prefix}_HOST is required`)
+    }
+    const port = Number(process.env[`${prefix}_PORT`] || '6379')
+    const password = process.env[`${prefix}_PASSWORD`] || undefined
+    const tls = process.env[`${prefix}_TLS`] === 'true' ? {} : undefined
+    return new IORedis({ host, port, password, tls, lazyConnect: true, maxRetriesPerRequest: 3 })
+}
+
+async function* scanBatches(redis: Redis, count: number): AsyncGenerator<string[]> {
+    let cursor = '0'
+    do {
+        const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', KEY_PATTERN, 'COUNT', count)
+        cursor = nextCursor
+        if (keys.length > 0) {
+            yield keys
+        }
+    } while (cursor !== '0')
+}
+
+function sourceTimeMs([seconds, microseconds]: [string, string]): number {
+    return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
+}
+
+async function copySourceKeys(
+    source: Redis,
+    target: Redis,
+    options: MigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.scanCount)) {
+        summary.sourceKeys += keys.length
+        if (!options.execute) {
+            continue
+        }
+
+        const sourcePipeline = source.pipeline()
+        for (const key of keys) {
+            sourcePipeline.get(key)
+            sourcePipeline.pttl(key)
+        }
+        const [time, rows] = await Promise.all([source.time(), sourcePipeline.exec()])
+        if (!rows) {
+            throw new Error('Source Redis pipeline returned no results')
+        }
+
+        const nowMs = sourceTimeMs(time)
+        const targetPipeline = target.pipeline()
+        keys.forEach((key, index) => {
+            const value = rows[index * 2]?.[1] as string | null
+            const ttlMs = Number(rows[index * 2 + 1]?.[1])
+            if (value === null || ttlMs <= 0) {
+                summary.skippedExpiredKeys++
+                return
+            }
+            targetPipeline.set(key, value, 'PXAT', nowMs + ttlMs)
+            summary.copiedKeys++
+        })
+        await targetPipeline.exec()
+    }
+}
+
+async function deleteTargetExtras(
+    source: Redis,
+    target: Redis,
+    options: MigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(target, options.scanCount)) {
+        const existsPipeline = source.pipeline()
+        keys.forEach((key) => existsPipeline.exists(key))
+        const rows = await existsPipeline.exec()
+        if (!rows) {
+            throw new Error('Source Redis existence pipeline returned no results')
+        }
+        const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
+        summary.extraTargetKeys += extras.length
+        if (options.execute && extras.length > 0) {
+            summary.deletedExtraKeys += await target.del(...extras)
+        }
+    }
+}
+
+async function verifyKeys(
+    source: Redis,
+    target: Redis,
+    options: MigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.scanCount)) {
+        const sourcePipeline = source.pipeline()
+        const targetPipeline = target.pipeline()
+        for (const key of keys) {
+            sourcePipeline.get(key)
+            sourcePipeline.pttl(key)
+            targetPipeline.get(key)
+            targetPipeline.pttl(key)
+        }
+        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
+        if (!sourceRows || !targetRows) {
+            throw new Error('Verification pipeline returned no results')
+        }
+        keys.forEach((_, index) => {
+            const sourceValue = sourceRows[index * 2]?.[1] as string | null
+            const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])
+            const targetValue = targetRows[index * 2]?.[1] as string | null
+            const targetTtl = Number(targetRows[index * 2 + 1]?.[1])
+            if (sourceValue === null || sourceTtl <= 0) {
+                return
+            }
+            if (targetValue === null) {
+                summary.missingTargetKeys++
+                return
+            }
+            if (sourceValue !== targetValue) {
+                summary.mismatchedValues++
+            }
+            if (Math.abs(sourceTtl - targetTtl) > options.ttlToleranceMs) {
+                summary.mismatchedExpiries++
+            }
+        })
+    }
+    await deleteTargetExtras(source, target, { ...options, execute: false }, summary)
+}
+
+function parseOptions(): MigrationOptions {
+    const { values } = parseArgs({
+        options: {
+            phase: { type: 'string', default: 'copy' },
+            execute: { type: 'boolean', default: false },
+            'writers-paused': { type: 'boolean', default: false },
+            'scan-count': { type: 'string', default: '500' },
+            'ttl-tolerance-ms': { type: 'string', default: '2000' },
+            help: { type: 'boolean', default: false },
+        },
+    })
+    if (values.help) {
+        console.log(`Usage: migrate-hog-masker-to-valkey [options]
+
+  --phase copy       Copy source keys while Redis remains authoritative (default)
+  --phase finalize   Exact copy and remove target-only keys; requires paused writers
+  --phase verify     Compare values and expiries without writing
+  --execute          Apply changes; omitted means dry-run
+  --writers-paused   Confirm every HogMasker writer is paused
+  --scan-count N     Redis SCAN batch size (default: 500)
+  --ttl-tolerance-ms N  Allowed expiry difference during verify (default: 2000)
+
+Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
+        process.exit(0)
+    }
+    if (!['copy', 'finalize', 'verify'].includes(values.phase)) {
+        throw new Error(`Invalid --phase: ${values.phase}`)
+    }
+    const phase = values.phase as Phase
+    if (phase === 'finalize' && (!values.execute || !values['writers-paused'])) {
+        throw new Error('--phase finalize requires both --execute and --writers-paused')
+    }
+    const scanCount = Number(values['scan-count'])
+    const ttlToleranceMs = Number(values['ttl-tolerance-ms'])
+    if (!Number.isInteger(scanCount) || scanCount < 1 || !Number.isFinite(ttlToleranceMs) || ttlToleranceMs < 0) {
+        throw new Error('Scan count must be a positive integer and TTL tolerance must be non-negative')
+    }
+    return { phase, execute: values.execute, writersPaused: values['writers-paused'], scanCount, ttlToleranceMs }
+}
+
+async function main(): Promise<void> {
+    const options = parseOptions()
+    const sourceHost = process.env.CDP_REDIS_HOST
+    const targetHost = process.env.CDP_VALKEY_HOST
+    if (
+        sourceHost === targetHost &&
+        (process.env.CDP_REDIS_PORT || '6379') === (process.env.CDP_VALKEY_PORT || '6379')
+    ) {
+        throw new Error('Source Redis and target Valkey must be different endpoints')
+    }
+    const source = connectionFromEnv('CDP_REDIS')
+    const target = connectionFromEnv('CDP_VALKEY')
+    const summary = emptySummary()
+    try {
+        await Promise.all([source.connect(), target.connect()])
+        await Promise.all([source.ping(), target.ping()])
+        if (options.phase === 'copy' || options.phase === 'finalize') {
+            await copySourceKeys(source, target, options, summary)
+        }
+        if (options.phase === 'finalize') {
+            await deleteTargetExtras(source, target, options, summary)
+        }
+        if (options.phase === 'verify' || options.phase === 'finalize') {
+            await verifyKeys(source, target, options, summary)
+        }
+        console.log(
+            JSON.stringify({ phase: options.phase, dryRun: !options.execute, pattern: KEY_PATTERN, ...summary })
+        )
+        const undeletedExtraKeys = summary.extraTargetKeys - summary.deletedExtraKeys
+        if (
+            summary.mismatchedValues ||
+            summary.mismatchedExpiries ||
+            summary.missingTargetKeys ||
+            (options.phase !== 'copy' && undeletedExtraKeys > 0)
+        ) {
+            process.exitCode = 2
+        }
+    } finally {
+        await Promise.allSettled([source.quit(), target.quit()])
+    }
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+})

--- a/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
@@ -10,11 +10,16 @@ import {
 
 const KEY_PATTERN = '@posthog/hog-masker/mask/*'
 
-function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
+function requiredHost(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): string {
     const host = process.env[`${prefix}_HOST`]
     if (!host) {
         throw new Error(`${prefix}_HOST is required`)
     }
+    return host
+}
+
+function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
+    const host = requiredHost(prefix)
     const port = Number(process.env[`${prefix}_PORT`] || '6379')
     const password = process.env[`${prefix}_PASSWORD`] || undefined
     const tls = process.env[`${prefix}_TLS`] === 'true' ? {} : undefined
@@ -66,8 +71,9 @@ Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
 
 async function main(): Promise<void> {
     const options = parseOptions()
-    const sourceHost = process.env.CDP_REDIS_HOST
-    const targetHost = process.env.CDP_VALKEY_HOST
+    // Resolve hosts before comparing them, so a missing host reports itself rather than looking like a duplicate endpoint.
+    const sourceHost = requiredHost('CDP_REDIS')
+    const targetHost = requiredHost('CDP_VALKEY')
     if (
         sourceHost === targetHost &&
         (process.env.CDP_REDIS_PORT || '6379') === (process.env.CDP_VALKEY_PORT || '6379')

--- a/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
@@ -1,99 +1,203 @@
-import IORedis, { Redis } from 'ioredis'
+import IORedis, { Redis, RedisOptions } from 'ioredis'
 import { parseArgs } from 'node:util'
 
+import { stringToBoolean } from '~/common/utils/env-utils'
+
+import { getDefaultCdpConfig } from '../config'
 import {
+    DEFAULT_KEY_PATTERN,
     MaskerMigrationOptions,
     MigrationPhase,
-    migrationHasMismatches,
+    formatMigrationSummary,
+    migrationHasDrift,
     runMaskerMigration,
 } from './hog-masker-valkey-migration'
 
-const KEY_PATTERN = '@posthog/hog-masker/mask/*'
+const PHASES: MigrationPhase[] = ['stats', 'copy', 'check']
 
-function requiredHost(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): string {
-    const host = process.env[`${prefix}_HOST`]
-    if (!host) {
-        throw new Error(`${prefix}_HOST is required`)
+const USAGE = `Usage: node dist/cdp/scripts/migrate-hog-masker-to-valkey.js [options]
+
+Copies HogMasker counters from the CDP Redis to the shadow Valkey. Counters are created with
+SET NX, so a key the mirror is already maintaining is never overwritten and writers can keep
+running throughout. Nothing here pauses or blocks CDP.
+
+Phases:
+  --phase stats   Count masking keys, how many the target already has, and their remaining
+                  time to live (default). Read-only.
+  --phase copy    Create the keys the target is missing. Reports what it would do unless
+                  --execute is passed.
+  --phase check   Compare values and expiries in both directions and report drift. Read-only,
+                  and exits 2 when it finds any, so it can be scripted.
+
+Options:
+  --execute               Apply a copy. Rejected for the read-only phases.
+  --pattern <glob>        Narrow the scan, e.g. to one hog function. Must start with the
+                          masker key prefix (default: ${DEFAULT_KEY_PATTERN})
+  --limit <n>             Stop after n scanned keys. Use this to size a run to a pod session.
+  --scan-count <n>        SCAN batch size (default: 500)
+  --sleep-ms <n>          Pause between batches to keep load off the source (default: 0)
+  --ttl-tolerance-ms <n>  Expiry difference --phase check tolerates (default: 2000)
+  --samples <n>           Example keys to print per drift bucket (default: 5)
+  --json                  Print the summary as JSON instead of text
+
+Connections are read from the same environment the CDP services use, so this works as-is
+inside a running CDP pod:
+  source  CDP_REDIS_HOST, CDP_REDIS_PORT, CDP_REDIS_PASSWORD (or REDIS_URL)
+  target  CDP_VALKEY_HOST, CDP_VALKEY_PORT, CDP_VALKEY_PASSWORD, CDP_VALKEY_TLS`
+
+const cdpDefaults = getDefaultCdpConfig()
+
+type Endpoint = {
+    label: string
+    /** Host or full URL, matching what the CDP services hand to ioredis. */
+    connection: string
+    options: RedisOptions
+}
+
+function envString(key: string, fallback: string): string {
+    return process.env[key] ?? fallback
+}
+
+function envNumber(key: string, fallback: number): number {
+    const raw = process.env[key]
+    if (raw === undefined || raw === '') {
+        return fallback
     }
-    return host
+    const value = Number(raw)
+    if (!Number.isFinite(value)) {
+        throw new Error(`${key} must be a number, got: ${raw}`)
+    }
+    return value
 }
 
-function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
-    const host = requiredHost(prefix)
-    const port = Number(process.env[`${prefix}_PORT`] || '6379')
-    const password = process.env[`${prefix}_PASSWORD`] || undefined
-    const tls = process.env[`${prefix}_TLS`] === 'true' ? {} : undefined
-    return new IORedis({ host, port, password, tls, lazyConnect: true, maxRetriesPerRequest: 3 })
+function sourceEndpoint(): Endpoint {
+    const password = envString('CDP_REDIS_PASSWORD', cdpDefaults.CDP_REDIS_PASSWORD) || undefined
+    const host = envString('CDP_REDIS_HOST', cdpDefaults.CDP_REDIS_HOST)
+    if (host) {
+        return {
+            label: 'source Redis',
+            connection: host,
+            options: { port: envNumber('CDP_REDIS_PORT', cdpDefaults.CDP_REDIS_PORT), password },
+        }
+    }
+    // Same fallback order as createCdpCoreServices, so a pod without CDP_REDIS_HOST still resolves.
+    const url = process.env.REDIS_URL
+    if (!url) {
+        throw new Error('Set CDP_REDIS_HOST or REDIS_URL to point at the source Redis')
+    }
+    return { label: 'source Redis', connection: url, options: {} }
 }
 
-function parseOptions(): MaskerMigrationOptions {
+function targetEndpoint(): Endpoint {
+    const host = envString('CDP_VALKEY_HOST', cdpDefaults.CDP_VALKEY_HOST)
+    if (!host) {
+        throw new Error('Set CDP_VALKEY_HOST to point at the target Valkey')
+    }
+    return {
+        label: 'target Valkey',
+        connection: host,
+        options: {
+            port: envNumber('CDP_VALKEY_PORT', cdpDefaults.CDP_VALKEY_PORT),
+            password: envString('CDP_VALKEY_PASSWORD', cdpDefaults.CDP_VALKEY_PASSWORD) || undefined,
+            tls: stringToBoolean(envString('CDP_VALKEY_TLS', String(cdpDefaults.CDP_VALKEY_TLS))) ? {} : undefined,
+        },
+    }
+}
+
+/** Host and port only — a password can be embedded in a REDIS_URL and must not reach the logs. */
+function describeEndpoint(endpoint: Endpoint): string {
+    try {
+        return new URL(endpoint.connection).host
+    } catch {
+        return `${endpoint.connection}:${endpoint.options.port ?? 6379}`
+    }
+}
+
+function connect(endpoint: Endpoint): Redis {
+    return new IORedis(endpoint.connection, { ...endpoint.options, lazyConnect: true, maxRetriesPerRequest: 3 })
+}
+
+function positiveInteger(name: string, raw: string): number {
+    const value = Number(raw)
+    if (!Number.isInteger(value) || value < 1) {
+        throw new Error(`${name} must be a positive integer, got: ${raw}`)
+    }
+    return value
+}
+
+function nonNegativeInteger(name: string, raw: string): number {
+    const value = Number(raw)
+    if (!Number.isInteger(value) || value < 0) {
+        throw new Error(`${name} must be zero or a positive integer, got: ${raw}`)
+    }
+    return value
+}
+
+function parseOptions(): { options: MaskerMigrationOptions; json: boolean } {
     const { values } = parseArgs({
         options: {
-            phase: { type: 'string', default: 'copy' },
+            phase: { type: 'string', default: 'stats' },
             execute: { type: 'boolean', default: false },
-            'writers-paused': { type: 'boolean', default: false },
+            pattern: { type: 'string', default: DEFAULT_KEY_PATTERN },
+            limit: { type: 'string' },
             'scan-count': { type: 'string', default: '500' },
+            'sleep-ms': { type: 'string', default: '0' },
             'ttl-tolerance-ms': { type: 'string', default: '2000' },
+            samples: { type: 'string', default: '5' },
+            json: { type: 'boolean', default: false },
             help: { type: 'boolean', default: false },
         },
     })
     if (values.help) {
-        console.log(`Usage: migrate-hog-masker-to-valkey [options]
-
-  --phase copy       Copy source keys while Redis remains authoritative (default)
-  --phase finalize   Exact copy and remove target-only keys; requires paused writers
-  --phase verify     Compare values and expiries without writing
-  --execute          Apply changes; omitted means dry-run
-  --writers-paused   Confirm every HogMasker writer is paused
-  --scan-count N     Redis SCAN batch size (default: 500)
-  --ttl-tolerance-ms N  Allowed expiry difference during verify (default: 2000)
-
-Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
+        console.log(USAGE)
         process.exit(0)
     }
-    if (!['copy', 'finalize', 'verify'].includes(values.phase)) {
-        throw new Error(`Invalid --phase: ${values.phase}`)
+    if (!PHASES.includes(values.phase as MigrationPhase)) {
+        throw new Error(`Invalid --phase: ${values.phase}. Expected one of ${PHASES.join(', ')}`)
     }
-    const scanCount = Number(values['scan-count'])
-    const ttlToleranceMs = Number(values['ttl-tolerance-ms'])
-    if (!Number.isInteger(scanCount) || scanCount < 1 || !Number.isFinite(ttlToleranceMs) || ttlToleranceMs < 0) {
-        throw new Error('Scan count must be a positive integer and TTL tolerance must be non-negative')
+    const phase = values.phase as MigrationPhase
+    if (values.execute && phase !== 'copy') {
+        throw new Error(`--execute only applies to --phase copy; --phase ${phase} never writes`)
     }
     return {
-        phase: values.phase as MigrationPhase,
-        execute: values.execute,
-        writersPaused: values['writers-paused'],
-        scanCount,
-        ttlToleranceMs,
-        keyPattern: KEY_PATTERN,
+        json: values.json,
+        options: {
+            phase,
+            execute: values.execute,
+            keyPattern: values.pattern,
+            scanCount: positiveInteger('--scan-count', values['scan-count']),
+            limit: values.limit === undefined ? null : positiveInteger('--limit', values.limit),
+            sleepMsBetweenBatches: nonNegativeInteger('--sleep-ms', values['sleep-ms']),
+            ttlToleranceMs: nonNegativeInteger('--ttl-tolerance-ms', values['ttl-tolerance-ms']),
+            sampleKeysPerBucket: nonNegativeInteger('--samples', values.samples),
+        },
     }
 }
 
 async function main(): Promise<void> {
-    const options = parseOptions()
-    // Resolve hosts before comparing them, so a missing host reports itself rather than looking like a duplicate endpoint.
-    const sourceHost = requiredHost('CDP_REDIS')
-    const targetHost = requiredHost('CDP_VALKEY')
-    if (
-        sourceHost === targetHost &&
-        (process.env.CDP_REDIS_PORT || '6379') === (process.env.CDP_VALKEY_PORT || '6379')
-    ) {
-        throw new Error('Source Redis and target Valkey must be different endpoints')
+    const { options, json } = parseOptions()
+    const source = sourceEndpoint()
+    const target = targetEndpoint()
+    if (describeEndpoint(source) === describeEndpoint(target)) {
+        throw new Error('Source Redis and target Valkey resolve to the same endpoint')
     }
-    const source = connectionFromEnv('CDP_REDIS')
-    const target = connectionFromEnv('CDP_VALKEY')
+
+    const sourceClient = connect(source)
+    const targetClient = connect(target)
     try {
-        await Promise.all([source.connect(), target.connect()])
-        await Promise.all([source.ping(), target.ping()])
-        const summary = await runMaskerMigration(source, target, options)
-        console.log(
-            JSON.stringify({ phase: options.phase, dryRun: !options.execute, pattern: options.keyPattern, ...summary })
-        )
-        if (migrationHasMismatches(summary)) {
+        await Promise.all([sourceClient.connect(), targetClient.connect()])
+        await Promise.all([sourceClient.ping(), targetClient.ping()])
+        if (!json) {
+            console.log(`${source.label} ${describeEndpoint(source)} -> ${target.label} ${describeEndpoint(target)}`)
+        }
+
+        const summary = await runMaskerMigration(sourceClient, targetClient, options)
+        console.log(json ? JSON.stringify(summary) : formatMigrationSummary(summary, options.keyPattern))
+        if (options.phase === 'check' && migrationHasDrift(summary)) {
             process.exitCode = 2
         }
     } finally {
-        await Promise.allSettled([source.quit(), target.quit()])
+        await Promise.allSettled([sourceClient.quit(), targetClient.quit()])
     }
 }
 

--- a/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-hog-masker-to-valkey.ts
@@ -15,7 +15,8 @@ import {
 
 const PHASES: MigrationPhase[] = ['stats', 'copy', 'check']
 
-const USAGE = `Usage: node dist/cdp/scripts/migrate-hog-masker-to-valkey.js [options]
+// The image ships dist rather than src, and an exec lands in /code, so that is the path to document.
+const USAGE = `Usage: node nodejs/dist/cdp/scripts/migrate-hog-masker-to-valkey.js [options]
 
 Copies HogMasker counters from the CDP Redis to the shadow Valkey. Counters are created with
 SET NX, so a key the mirror is already maintaining is never overwritten and writers can keep

--- a/nodejs/src/cdp/services/monitoring/hog-masker.keys.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.keys.ts
@@ -1,0 +1,7 @@
+/**
+ * Split out from hog-masker.service so operational tooling can address the masker's keys
+ * without pulling the service's runtime graph (hogvm, redis pools) in behind it.
+ */
+export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/hog-masker' : '@posthog/hog-masker'
+
+export const MASK_KEY_PREFIX = `${BASE_REDIS_KEY}/mask/`

--- a/nodejs/src/cdp/services/monitoring/hog-masker.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.service.test.ts
@@ -9,7 +9,8 @@ import { HOG_FLOW_MASK_EXAMPLES, HOG_MASK_EXAMPLES } from '../../_tests/examples
 import { createExampleInvocation, createHogExecutionGlobals, createHogFunction } from '../../_tests/fixtures'
 import { createExampleHogFlowInvocation } from '../../_tests/fixtures-hogflows'
 import { CyclotronJobInvocationHogFunction, HogFunctionType } from '../../types'
-import { BASE_REDIS_KEY, HogMaskerService } from './hog-masker.service'
+import { BASE_REDIS_KEY } from './hog-masker.keys'
+import { HogMaskerService } from './hog-masker.service'
 
 const mockNow: jest.SpyInstance = jest.spyOn(Date, 'now')
 

--- a/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
@@ -10,9 +10,7 @@ import {
 } from '../../types'
 import { execHog } from '../../utils/hog-exec'
 import { mirrorCall } from '../../utils/mirror-call'
-
-export const BASE_REDIS_KEY = process.env.NODE_ENV == 'test' ? '@posthog-test/hog-masker' : '@posthog/hog-masker'
-const REDIS_KEY_TOKENS = `${BASE_REDIS_KEY}/mask`
+import { MASK_KEY_PREFIX } from './hog-masker.keys'
 
 // NOTE: These are controlled via the api so are more of a sanity fallback
 const MASKER_MAX_TTL_HOG_FUNCTION = 60 * 60 * 24
@@ -148,9 +146,9 @@ export class HogMaskerService {
 
         const buildPipeline = (pipeline: RedisClientPipeline): void => {
             Object.values(masks).forEach(({ hogFunctionId, hash, increment, ttl }) => {
-                pipeline.incrby(`${REDIS_KEY_TOKENS}/${hogFunctionId}/${hash}`, increment)
+                pipeline.incrby(`${MASK_KEY_PREFIX}${hogFunctionId}/${hash}`, increment)
                 // @ts-expect-error - NX is not typed in ioredis
-                pipeline.expire(`${REDIS_KEY_TOKENS}/${hogFunctionId}/${hash}`, ttl, 'NX')
+                pipeline.expire(`${MASK_KEY_PREFIX}${hogFunctionId}/${hash}`, ttl, 'NX')
             })
         }
 


### PR DESCRIPTION
## Problem

Long-lived HogMasker counters do not move to Valkey through the mirror soak alone. The mirror
starts every counter it touches from zero, so any masking key created before the soak began is
either absent from Valkey or sitting at a lower count than Redis. Cutting over on that state
would let masked invocations fire again.

The first version of this CLI answered that with a finalize phase that demanded every writer be
paused. That does not hold up. Masking counters are `INCRBY` plus `EXPIRE NX`, and the mirror
already writes both sides, so an exact frozen snapshot buys nothing a create-if-absent copy
cannot get while CDP keeps running.

## Changes

A dry-run-by-default CLI with three phases, none of which pause or gate anything.

- `--phase stats` counts masking keys, how many the target already holds, and how long the rest
  have left to live. Read-only.
- `--phase copy` creates only the keys the target is missing, with `SET NX`. A counter the mirror
  is already maintaining is never overwritten, so the copy is safe against live writers and safe
  to re-run. Without `--execute` it reports the writes it would make.
- `--phase check` compares values and expiries in both directions and reports missing keys, value
  drift, expiry drift, and target-only keys. Read-only, deletes nothing, exits 2 when it finds
  drift so it can be scripted.

`--limit` and `--pattern` scope a run to a sample or a single hog function, and `--sleep-ms`
throttles the scan. Connections resolve from the same `CDP_REDIS_*` and `CDP_VALKEY_*` variables
the CDP services read, so the CLI runs as-is from a shell inside a CDP pod. The image ships
`dist`, so that invocation is `node nodejs/dist/cdp/scripts/migrate-hog-masker-to-valkey.js` from `/code`.

The masker's key prefix moved into `hog-masker.keys.ts` so the tooling addresses exactly the keys
the service writes, without importing the service's runtime graph.

> [!NOTE]
> Copying only what is missing leaves the counters the mirror already created sitting below
> Redis. For masking without a threshold that changes nothing, since only "does the key exist"
> decides the outcome. For threshold masking it can allow an occasional extra execution. The
> check phase reports that population as `target behind`, so the size of it is measurable before
> anyone decides whether it is worth a follow-up.

## How did you test this code?

Six Redis-backed tests in `hog-masker-valkey-migration.test.ts`, all passing locally. Each one
guards a specific regression: the pattern guard stops a scan escaping the masker prefix; the
dry-run test stops `--execute` defaulting on; the expiry test stops a copy resetting a TTL; the
NX test stops a copy clobbering a live mirrored counter; the limit test stops an exploratory run
scanning a whole keyspace; the check test stops drift reporting acquiring a write path.

The 19 existing `hog-masker.service.test.ts` tests also pass, covering the key-constant move.

I also ran the CLI end to end against a local Redis and Valkey with seeded masking keys, and
confirmed each phase's output, that a second `--execute` copies nothing, that a pre-existing
target counter and a three-year expiry both survive, and that the phase, pattern, and
`--execute` guards reject bad input.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change. The CLI documents itself through `--help`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code rewrote this on top of the earlier Codex version after we talked through why the
paused-writer finalize step did not add up. The reasoning that killed it: the masker's own
`EXPIRE NX` means a counter's window is anchored to its first increment and never extended, and
the mirror writes both sides, so a create-if-absent copy converges without a freeze. Deleting
target-only keys went with it, since that is the one operation that genuinely needs a quiet
keyspace.

Skills invoked: `/writing-tests`. The test suite shrank by one case as a result, because moving
the key prefix into a shared module made the drift-guard test it replaced unnecessary.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
