### PR TITLE
fix(error-tracking): use merge-aware issue queries

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4722,10 +4722,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
-        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
-        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
+    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
+    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -6037,7 +6037,7 @@ snapshots:
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--dark:
         hash: v1.k794b7964.feb19120fcb35db2a44666c4e20b7728f8b9bb5d0c1bc38d41b7698f5722c181.Hw40iUldn70Z33rYE-zitkjrvytX-vhUGY03V3ycXNk
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--light:
-        hash: v1.k794b7964.9d7dfffb7317f37caea4ad6a4492ab88a74944025164c8985ae09d4598998dce.LTVbWdIGOWozyPbgjbbSanV3cqEaLuHls5Da2LEvzRw
+        hash: v1.k794b7964.c6dcb51165a484e751646e0567ffaa1612e4d6e8ee78120efb3e6cf569d9f796.OoO5GBNS10hRMccIEjdNLgWnwG649BGZ2Ch_mF89vy0
     scenes-app-experiments--experiment-with-multiple-metrics--dark:
         hash: v1.k794b7964.c2b2dfac0dcf77fefa7bfcd55ad0022ee6a8f461f3c03d74448bab270ba7dd7b.DgmRBGi8wUsgVlPWENMllouOKXKtCawcdVWsU6Srd5U
     scenes-app-experiments--experiment-with-multiple-metrics--light:
@@ -6367,7 +6367,7 @@ snapshots:
     scenes-app-inbox-scene--self-driving-onboarding--light:
         hash: v1.k794b7964.8ef3184a453d8082e2e3b7ae2716c4f40ea8c99c1b5f8a579c5bbc138985ad09.LjMg91MLj3APANRgr6pCKk697oexyrwWR0kgBpE6s4s
     scenes-app-inbox-scene--self-driving-paused--dark:
-        hash: v1.k794b7964.bd2bee28eee6668bfd9f1e5c00191e38189bc27ac734c8adf8ddc55da8381b1b.HFfADdkZDnQv2BGCHc-yzXZ4Z0Rpk-xn9cn7uRUXIyg
+        hash: v1.k794b7964.92028573740590e09775ef9658859d39cdd27586aa87d58a0f0e640939e567de.MZizHJ2RxoNKJZSls9oD4rbqLflKx5MCcfUQ4yP2gXQ
     scenes-app-inbox-scene--self-driving-paused--light:
         hash: v1.k794b7964.54f6835c7d4a343bd6c9efef4189805b8dc5ea3347380b5d772ce55abaad79be.P7Ramt_0TgHAl4YgBsBumQ1QVxkb2ds9GsTaxbNAKRQ
     scenes-app-inbox-signalsourcespanel--armed-but-tools-off--dark:
@@ -7367,9 +7367,9 @@ snapshots:
     scenes-app-settings-user--settings-user-danger-zone--light:
         hash: v1.k794b7964.96846d7823357e89a9d91350f6f435373fe287f713250b59ccce2dbd31b6f69c.kl21kygOhH1SlNOJ6VekMMlGUuyNg5Ka7NXFoHcG6M0
     scenes-app-settings-user--settings-user-navigation--dark:
-        hash: v1.k794b7964.341940b9fa0d928eede78d3bfb88639fc3fab5aacf27f214fb16c7db2c242bbe.3N930aBs8a33duFvtnHC7-3ha1YW0D0Dy3_XSjl8rFM
+        hash: v1.k794b7964.f1c0834efdf1ebf264e46ba2ef25c79266051f51ee4ddc70c939b1bfbedab033.1D-CrzTr7y6mQww6EZRG8VmOtNYW7cMvJ2t3RFc2E10
     scenes-app-settings-user--settings-user-navigation--light:
-        hash: v1.k794b7964.1720a78a3826f4c22f8768ef9f089b1f72b851db6993c9260245fd81db4c1c58.wjIskRgUABczrhV39b1Wxc8fqHRarlnkDmus1xn3Mnk
+        hash: v1.k794b7964.81ca37a8d9427140b54c07c9c68d8b77001e956e6cf6f4fa66a4420d2adc0d02.VOWpKzNBO_d-f7SkK0G7tFxwGKj4TaRH-9n3BztTszI
     scenes-app-settings-user--settings-user-notifications--dark:
         hash: v1.k794b7964.a09a57f1c0bbcebf82942edebeba7772b2f684ba235bcef3a816aec2beb4cbce.AtQZhdZeeMVvpcmyBhPvprSMZawliTZaIFE5G8M_MVg
     scenes-app-settings-user--settings-user-notifications--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4722,10 +4722,10 @@ snapshots:
         hash: v1.k794b7964.ea754a4783f7653247f127337c407a8cdd4a9c6bc3f1b908d8d00dd1a090b966.KQ3yKnRzi4l3ZeYVThZdmo4L6mAbxtNa2uQh7y-kGWA
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues--tile-filters-read-only--light:
         hash: v1.k794b7964.b2ca2efc52a9ccf56953159c66d3c8766acd1d3a17379d5faec45a4715ae24a9.fK76p7ZVcgvFJNcKJ5Ixy3YnBm_BcBSFnoytLS2jZdU
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark
-    :   hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
-    ? products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light
-    :   hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--dark:
+        hash: v1.k794b7964.ee9bd78f705c05a89b8dffa7ce394b1af07b75a9597fd220c94d177b49def5bd.Ii4is9m845vi1gNJRW-Pdw93hMfdAEL_0UIj6lAOTvw
+    products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--before-exception-ingestion--light:
+        hash: v1.k794b7964.b71412d69902241f7ec02efa87c138362522d5c7227c36a71e7f0dc0627d2a38.xiUrsbrXCMYmKv85SCzax7k6HNDzZsfKE5ZBhZBFPsI
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--dark:
         hash: v1.k794b7964.b1e0f5f542426e34dec73826f3135902a392c0c13dade4fec14037c615186b13.kbxxijyDI1SdvgdKwkRnIRLLgmsine5AYvOcD79DYsY
     products-dashboards-dashboard-widgets-widget-types-error-tracking-top-issues-widget-settings--default--light:
@@ -6037,7 +6037,7 @@ snapshots:
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--dark:
         hash: v1.k794b7964.feb19120fcb35db2a44666c4e20b7728f8b9bb5d0c1bc38d41b7698f5722c181.Hw40iUldn70Z33rYE-zitkjrvytX-vhUGY03V3ycXNk
     scenes-app-experiments--experiment-with-multi-step-funnel-metric--light:
-        hash: v1.k794b7964.c6dcb51165a484e751646e0567ffaa1612e4d6e8ee78120efb3e6cf569d9f796.OoO5GBNS10hRMccIEjdNLgWnwG649BGZ2Ch_mF89vy0
+        hash: v1.k794b7964.9d7dfffb7317f37caea4ad6a4492ab88a74944025164c8985ae09d4598998dce.LTVbWdIGOWozyPbgjbbSanV3cqEaLuHls5Da2LEvzRw
     scenes-app-experiments--experiment-with-multiple-metrics--dark:
         hash: v1.k794b7964.c2b2dfac0dcf77fefa7bfcd55ad0022ee6a8f461f3c03d74448bab270ba7dd7b.DgmRBGi8wUsgVlPWENMllouOKXKtCawcdVWsU6Srd5U
     scenes-app-experiments--experiment-with-multiple-metrics--light:
@@ -6367,7 +6367,7 @@ snapshots:
     scenes-app-inbox-scene--self-driving-onboarding--light:
         hash: v1.k794b7964.8ef3184a453d8082e2e3b7ae2716c4f40ea8c99c1b5f8a579c5bbc138985ad09.LjMg91MLj3APANRgr6pCKk697oexyrwWR0kgBpE6s4s
     scenes-app-inbox-scene--self-driving-paused--dark:
-        hash: v1.k794b7964.92028573740590e09775ef9658859d39cdd27586aa87d58a0f0e640939e567de.MZizHJ2RxoNKJZSls9oD4rbqLflKx5MCcfUQ4yP2gXQ
+        hash: v1.k794b7964.bd2bee28eee6668bfd9f1e5c00191e38189bc27ac734c8adf8ddc55da8381b1b.HFfADdkZDnQv2BGCHc-yzXZ4Z0Rpk-xn9cn7uRUXIyg
     scenes-app-inbox-scene--self-driving-paused--light:
         hash: v1.k794b7964.54f6835c7d4a343bd6c9efef4189805b8dc5ea3347380b5d772ce55abaad79be.P7Ramt_0TgHAl4YgBsBumQ1QVxkb2ds9GsTaxbNAKRQ
     scenes-app-inbox-signalsourcespanel--armed-but-tools-off--dark:
@@ -7367,9 +7367,9 @@ snapshots:
     scenes-app-settings-user--settings-user-danger-zone--light:
         hash: v1.k794b7964.96846d7823357e89a9d91350f6f435373fe287f713250b59ccce2dbd31b6f69c.kl21kygOhH1SlNOJ6VekMMlGUuyNg5Ka7NXFoHcG6M0
     scenes-app-settings-user--settings-user-navigation--dark:
-        hash: v1.k794b7964.f1c0834efdf1ebf264e46ba2ef25c79266051f51ee4ddc70c939b1bfbedab033.1D-CrzTr7y6mQww6EZRG8VmOtNYW7cMvJ2t3RFc2E10
+        hash: v1.k794b7964.341940b9fa0d928eede78d3bfb88639fc3fab5aacf27f214fb16c7db2c242bbe.3N930aBs8a33duFvtnHC7-3ha1YW0D0Dy3_XSjl8rFM
     scenes-app-settings-user--settings-user-navigation--light:
-        hash: v1.k794b7964.81ca37a8d9427140b54c07c9c68d8b77001e956e6cf6f4fa66a4420d2adc0d02.VOWpKzNBO_d-f7SkK0G7tFxwGKj4TaRH-9n3BztTszI
+        hash: v1.k794b7964.1720a78a3826f4c22f8768ef9f089b1f72b851db6993c9260245fd81db4c1c58.wjIskRgUABczrhV39b1Wxc8fqHRarlnkDmus1xn3Mnk
     scenes-app-settings-user--settings-user-notifications--dark:
         hash: v1.k794b7964.a09a57f1c0bbcebf82942edebeba7772b2f684ba235bcef3a816aec2beb4cbce.AtQZhdZeeMVvpcmyBhPvprSMZawliTZaIFE5G8M_MVg
     scenes-app-settings-user--settings-user-notifications--light:

--- a/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
@@ -9,7 +9,8 @@ import { BehavioralFilterKey } from 'scenes/cohorts/CohortFilters/types'
 import { createCohortFormData } from 'scenes/cohorts/cohortUtils'
 
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
-import { BehavioralEventType, CohortType, FilterLogicalOperator, PropertyFilterType, PropertyOperator } from '~/types'
+import { escapeHogQLString } from '~/queries/utils'
+import { BehavioralEventType, CohortType, FilterLogicalOperator, PropertyFilterType } from '~/types'
 
 import type {
     ErrorTrackingIssueAssignee,
@@ -323,10 +324,8 @@ function createCohortParams(name: string, description: string, issueId: string):
                                 event_type: TaxonomicFilterGroupType.Events,
                                 event_filters: [
                                     {
-                                        key: '$exception_issue_id',
-                                        type: PropertyFilterType.Event,
-                                        value: [issueId],
-                                        operator: PropertyOperator.Exact,
+                                        key: `issue_id = ${escapeHogQLString(issueId)}`,
+                                        type: PropertyFilterType.HogQL,
                                     },
                                 ],
                                 explicit_datetime: '-30d',

--- a/products/error_tracking/frontend/queries.test.ts
+++ b/products/error_tracking/frontend/queries.test.ts
@@ -94,6 +94,18 @@ describe('queries', () => {
             })
 
             expect(actual.source.tags).toEqual({ productKey: ProductKey.ERROR_TRACKING })
+            expect(actual.source).toMatchObject({
+                series: [
+                    {
+                        properties: [
+                            {
+                                key: "issue_id = 'issue-id'",
+                                type: 'hogql',
+                            },
+                        ],
+                    },
+                ],
+            })
         })
     })
 })

--- a/products/error_tracking/frontend/queries.test.ts
+++ b/products/error_tracking/frontend/queries.test.ts
@@ -73,6 +73,7 @@ describe('queries', () => {
             const where = (actual.where ?? []).join(' ')
             expect(where).toContain("'fp_with_\\'quote'")
             expect(where).toContain("'%O\\'Brien%'")
+            expect(where).toContain('isNotNull(issue_id)')
         })
 
         it('tags issue breakdown insight queries as error tracking', () => {
@@ -93,6 +94,18 @@ describe('queries', () => {
             })
 
             expect(actual.source.tags).toEqual({ productKey: ProductKey.ERROR_TRACKING })
+            expect(actual.source).toMatchObject({
+                series: [
+                    {
+                        properties: [
+                            {
+                                key: "issue_id = 'issue-id'",
+                                type: 'hogql',
+                            },
+                        ],
+                    },
+                ],
+            })
         })
     })
 })

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -18,7 +18,6 @@ import {
     ChartDisplayType,
     PropertyFilterType,
     PropertyGroupFilter,
-    PropertyOperator,
     UniversalFiltersGroup,
 } from '~/types'
 
@@ -269,10 +268,8 @@ export const errorTrackingIssueBreakdownQuery = ({
                     math: BaseMathType.TotalCount,
                     properties: [
                         {
-                            key: '$exception_issue_id',
-                            type: PropertyFilterType.Event,
-                            value: issueId,
-                            operator: PropertyOperator.Exact,
+                            key: `issue_id = ${escapeHogQLString(issueId)}`,
+                            type: PropertyFilterType.HogQL,
                         },
                         ...properties,
                     ],

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -18,7 +18,6 @@ import {
     ChartDisplayType,
     PropertyFilterType,
     PropertyGroupFilter,
-    PropertyOperator,
     UniversalFiltersGroup,
 } from '~/types'
 
@@ -154,7 +153,7 @@ export const errorTrackingIssueEventsQuery = ({
     const group = filterGroup.values[0] as UniversalFiltersGroup
     const properties = [...group.values] as AnyPropertyFilter[]
 
-    let where_string = `properties.$exception_fingerprint in [${fingerprints.map((f) => escapeHogQLString(f)).join(', ')}] AND isNotNull(properties.$exception_issue_id)`
+    let where_string = `properties.$exception_fingerprint in [${fingerprints.map((f) => escapeHogQLString(f)).join(', ')}] AND isNotNull(issue_id)`
     if (searchQuery) {
         // This is an ugly hack for the fact I don't think we support nested property filters in
         // the eventsquery
@@ -269,10 +268,8 @@ export const errorTrackingIssueBreakdownQuery = ({
                     math: BaseMathType.TotalCount,
                     properties: [
                         {
-                            key: '$exception_issue_id',
-                            type: PropertyFilterType.Event,
-                            value: issueId,
-                            operator: PropertyOperator.Exact,
+                            key: `issue_id = ${escapeHogQLString(issueId)}`,
+                            type: PropertyFilterType.HogQL,
                         },
                         ...properties,
                     ],

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/assignmentRuleModalLogic.ts
@@ -185,7 +185,7 @@ export const assignmentRuleModalLogic = kea<assignmentRuleModalLogicType>([
                     const query: Record<string, any> = {
                         kind: NodeKind.EventsQuery,
                         event: '$exception',
-                        select: ['count()', 'count(distinct properties.$exception_issue_id)'],
+                        select: ['count()', 'count(distinct issue_id)'],
                         after: values.dateRange,
                         tags: { productKey: ProductKey.ERROR_TRACKING },
                     }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/codeOwnersModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/assignment_rules/codeOwnersModalLogic.ts
@@ -259,7 +259,7 @@ export const codeOwnersModalLogic = kea<codeOwnersModalLogicType>([
                             const response = (await api.query({
                                 kind: NodeKind.EventsQuery,
                                 event: '$exception',
-                                select: ['count()', 'count(distinct properties.$exception_issue_id)'],
+                                select: ['count()', 'count(distinct issue_id)'],
                                 after: values.dateRange,
                                 fixedProperties: [{ type: filters.type, values: properties }],
                                 tags: { productKey: ProductKey.ERROR_TRACKING },

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/groupingRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/grouping_rules/groupingRuleModalLogic.ts
@@ -183,7 +183,7 @@ export const groupingRuleModalLogic = kea<groupingRuleModalLogicType>([
                     const query: Record<string, any> = {
                         kind: NodeKind.EventsQuery,
                         event: '$exception',
-                        select: ['count()', 'count(distinct properties.$exception_issue_id)'],
+                        select: ['count()', 'count(distinct issue_id)'],
                         after: values.dateRange,
                         tags: { productKey: ProductKey.ERROR_TRACKING },
                     }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/suppressionRuleModalLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/suppressionRuleModalLogic.ts
@@ -194,7 +194,7 @@ export const suppressionRuleModalLogic = kea<suppressionRuleModalLogicType>([
                     const query: Record<string, any> = {
                         kind: NodeKind.EventsQuery,
                         event: '$exception',
-                        select: ['count()', 'count(distinct properties.$exception_issue_id)'],
+                        select: ['count()', 'count(distinct issue_id)'],
                         after: values.dateRange,
                         tags: { productKey: ProductKey.ERROR_TRACKING },
                     }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -28,7 +28,8 @@ import { urls } from 'scenes/urls'
 
 import { SceneMenuBar, SceneMenuBarItem, SceneMenuBarMenu } from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, ReplayTabs } from '~/types'
+import { escapeHogQLString } from '~/queries/utils'
+import { FilterLogicalOperator, PropertyFilterType, ReplayTabs } from '~/types'
 
 import { useAttachedContext } from 'products/posthog_ai/frontend/api/logics'
 
@@ -130,10 +131,8 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                                     type: FilterLogicalOperator.And,
                                                                     values: [
                                                                         {
-                                                                            key: '$exception_issue_id',
-                                                                            type: PropertyFilterType.Event,
-                                                                            operator: PropertyOperator.Exact,
-                                                                            value: [issue.id],
+                                                                            key: `issue_id = ${escapeHogQLString(issue.id)}`,
+                                                                            type: PropertyFilterType.HogQL,
                                                                         },
                                                                     ],
                                                                 },
@@ -181,10 +180,8 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                                     type: FilterLogicalOperator.And,
                                                                     values: [
                                                                         {
-                                                                            key: '$exception_issue_id',
-                                                                            type: PropertyFilterType.Event,
-                                                                            operator: PropertyOperator.Exact,
-                                                                            value: [issue.id],
+                                                                            key: `issue_id = ${escapeHogQLString(issue.id)}`,
+                                                                            type: PropertyFilterType.HogQL,
                                                                         },
                                                                     ],
                                                                 },

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -28,8 +28,7 @@ import { urls } from 'scenes/urls'
 
 import { SceneMenuBar, SceneMenuBarItem, SceneMenuBarMenu } from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { escapeHogQLString } from '~/queries/utils'
-import { FilterLogicalOperator, PropertyFilterType, ReplayTabs } from '~/types'
+import { ReplayTabs } from '~/types'
 
 import { useAttachedContext } from 'products/posthog_ai/frontend/api/logics'
 
@@ -47,7 +46,7 @@ import { IssueStatusButton } from '../../components/IssueStatusButton'
 import { ErrorTrackingSetupPrompt } from '../../components/SetupPrompt/SetupPrompt'
 import { StyleVariables } from '../../components/StyleVariables'
 import { useErrorTagRenderer } from '../../hooks/use-error-tag-renderer'
-import { getIssueReplayDateRange } from '../../utils'
+import { getIssueReplayDateRange, getIssueReplayFilterGroup } from '../../utils'
 import {
     ErrorTrackingIssueSceneCategory,
     errorTrackingIssueSceneConfigurationLogic,
@@ -124,20 +123,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                 onClick={() => {
                                                     const url = urls.replay(ReplayTabs.Home, {
                                                         ...getIssueReplayDateRange(issue.first_seen, lastSeen),
-                                                        filter_group: {
-                                                            type: FilterLogicalOperator.And,
-                                                            values: [
-                                                                {
-                                                                    type: FilterLogicalOperator.And,
-                                                                    values: [
-                                                                        {
-                                                                            key: `issue_id = ${escapeHogQLString(issue.id)}`,
-                                                                            type: PropertyFilterType.HogQL,
-                                                                        },
-                                                                    ],
-                                                                },
-                                                            ],
-                                                        },
+                                                        filter_group: getIssueReplayFilterGroup(issue.id),
                                                     })
                                                     newInternalTab(url)
                                                 }}
@@ -173,20 +159,7 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                 <ViewRecordingsPlaylistButton
                                                     filters={{
                                                         ...getIssueReplayDateRange(issue.first_seen, lastSeen),
-                                                        filter_group: {
-                                                            type: FilterLogicalOperator.And,
-                                                            values: [
-                                                                {
-                                                                    type: FilterLogicalOperator.And,
-                                                                    values: [
-                                                                        {
-                                                                            key: `issue_id = ${escapeHogQLString(issue.id)}`,
-                                                                            type: PropertyFilterType.HogQL,
-                                                                        },
-                                                                    ],
-                                                                },
-                                                            ],
-                                                        },
+                                                        filter_group: getIssueReplayFilterGroup(issue.id),
                                                     }}
                                                     size="small"
                                                     type="secondary"

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -29,7 +29,8 @@ import { urls } from 'scenes/urls'
 
 import { SceneMenuBar, SceneMenuBarItem, SceneMenuBarMenu } from '~/layout/scenes/components/SceneMenuBar'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, ReplayTabs } from '~/types'
+import { escapeHogQLString } from '~/queries/utils'
+import { FilterLogicalOperator, PropertyFilterType, ReplayTabs } from '~/types'
 
 import { useAttachedContext } from 'products/posthog_ai/frontend/api/logics'
 
@@ -133,10 +134,8 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                                     type: FilterLogicalOperator.And,
                                                                     values: [
                                                                         {
-                                                                            key: '$exception_issue_id',
-                                                                            type: PropertyFilterType.Event,
-                                                                            operator: PropertyOperator.Exact,
-                                                                            value: [issue.id],
+                                                                            key: `issue_id = ${escapeHogQLString(issue.id)}`,
+                                                                            type: PropertyFilterType.HogQL,
                                                                         },
                                                                     ],
                                                                 },
@@ -185,10 +184,8 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                                                                     type: FilterLogicalOperator.And,
                                                                     values: [
                                                                         {
-                                                                            key: '$exception_issue_id',
-                                                                            type: PropertyFilterType.Event,
-                                                                            operator: PropertyOperator.Exact,
-                                                                            value: [issue.id],
+                                                                            key: `issue_id = ${escapeHogQLString(issue.id)}`,
+                                                                            type: PropertyFilterType.HogQL,
                                                                         },
                                                                     ],
                                                                 },

--- a/products/error_tracking/frontend/utils.test.ts
+++ b/products/error_tracking/frontend/utils.test.ts
@@ -1,8 +1,15 @@
 import { Dayjs, dayjs } from 'lib/dayjs'
 
 import { ErrorTrackingIssue, ErrorTrackingIssueAggregations } from '~/queries/schema/schema-general'
+import { FilterLogicalOperator, PropertyFilterType } from '~/types'
 
-import { generateDateRangeLabel, getIssueReplayDateRange, mergeIssues, sourceDisplay } from './utils'
+import {
+    generateDateRangeLabel,
+    getIssueReplayDateRange,
+    getIssueReplayFilterGroup,
+    mergeIssues,
+    sourceDisplay,
+} from './utils'
 
 function wrapVolumeBuckets(
     initialDate: Dayjs,
@@ -198,6 +205,32 @@ describe('getIssueReplayDateRange', () => {
         expect(getIssueReplayDateRange(firstSeen, dayjs('2023-12-31T00:00:00.000Z')).date_to).toEqual(
             '2024-01-01T13:00:00.000Z'
         )
+    })
+})
+
+describe('getIssueReplayFilterGroup', () => {
+    it('scopes the merge-aware issue field to exception events', () => {
+        expect(getIssueReplayFilterGroup("issue-'quoted'")).toEqual({
+            type: FilterLogicalOperator.And,
+            values: [
+                {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            id: '$exception',
+                            name: '$exception',
+                            type: 'events',
+                            properties: [
+                                {
+                                    key: "issue_id = 'issue-\\'quoted\\''",
+                                    type: PropertyFilterType.HogQL,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        })
     })
 })
 

--- a/products/error_tracking/frontend/utils.ts
+++ b/products/error_tracking/frontend/utils.ts
@@ -10,7 +10,14 @@ import { componentsToDayJs, dateStringToComponents, dateStringToDayJs, isStringD
 import { Params } from 'scenes/sceneTypes'
 
 import { DateRange, ErrorTrackingIssue } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import { escapeHogQLString } from '~/queries/utils'
+import {
+    AccessControlLevel,
+    AccessControlResourceType,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    type UniversalFiltersGroup,
+} from '~/types'
 
 /** Reason error tracking write actions are disabled, or null when the user has editor access. */
 export function errorTrackingEditAccessDisabledReason(): string | null {
@@ -112,6 +119,30 @@ export function getIssueReplayDateRange(firstSeen: string, lastSeen: Dayjs | nul
     return {
         date_from: from.subtract(1, 'hour').toISOString(),
         date_to: to.add(1, 'hour').toISOString(),
+    }
+}
+
+export function getIssueReplayFilterGroup(issueId: string): UniversalFiltersGroup {
+    return {
+        type: FilterLogicalOperator.And,
+        values: [
+            {
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
+                        id: '$exception',
+                        name: '$exception',
+                        type: 'events',
+                        properties: [
+                            {
+                                key: `issue_id = ${escapeHogQLString(issueId)}`,
+                                type: PropertyFilterType.HogQL,
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
     }
 }
 


### PR DESCRIPTION
## Problem

Error tracking UI queries grouped and filtered on the ingest-time `$exception_issue_id` property. That can split merged issues or omit events that should follow the current issue.

**Why:** Issue analytics should reflect the current grouping after merge operations.

## Changes

- Use the virtual `issue_id` field for issue event lists, breakdowns, recording filters, cohorts, and rule previews.
- Keep raw event-property access only where the captured payload itself is required.
- Add focused query-builder regression coverage.

## How did you test this code?

- `pnpm exec jest --runInBand --runTestsByPath ../products/error_tracking/frontend/queries.test.ts`
- `pnpm --filter=@posthog/frontend fix`
- `pnpm --filter=@posthog/frontend typescript:check` passed once after building workspace dependencies. A final repeat was killed by the VM memory limit.
- The query tests guard against reverting event eligibility and issue-specific breakdown filters to the ingest-time property.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this corrects internal query semantics without changing the user-facing workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this through PostHog Code. The repository `/writing-tests` skill was used to keep regression coverage focused on observable query output. Raw property references used for ingestion health and captured payload rendering were deliberately left unchanged.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
