### PR TITLE
fix(desktop): restore session drag to command center

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -209,6 +209,29 @@ describe("ChannelItemRow", () => {
     expect(screen.queryByRole("img", { name: "Pinned" })).toBeNull();
   });
 
+  it("makes tasks draggable into the Command Center", () => {
+    renderRow(item());
+    const setData = vi.fn();
+    const dataTransfer = { setData, effectAllowed: "none" };
+
+    fireEvent.dragStart(screen.getByRole("button"), { dataTransfer });
+
+    expect(setData).toHaveBeenCalledWith("text/x-task-id", "task-1");
+    expect(dataTransfer.effectAllowed).toBe("copy");
+  });
+
+  it("does not make canvases draggable into the Command Center", () => {
+    renderRow(
+      item({
+        key: "canvas:canvas-1",
+        kind: "canvas",
+        id: "canvas-1",
+      }),
+    );
+
+    expect(screen.getByRole("button")).not.toHaveAttribute("draggable", "true");
+  });
+
   // The hover card and right-click render the same item list from one
   // definition, so both are asserted against the same expectations.
   const MENU_ITEMS = [

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -53,7 +53,7 @@ import {
   taskDot,
 } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
 import { SidebarItem } from "@posthog/ui/features/sidebar/components/SidebarItem";
-import { type ReactNode, useCallback, useState } from "react";
+import { type DragEvent, type ReactNode, useCallback, useState } from "react";
 
 /**
  * What a row can do. One object per channel rather than closures per item, so
@@ -204,6 +204,15 @@ export function ChannelItemRow({
   const closeCard = useCallback(() => setCardOpen(false), []);
   const statusLabel = runStatusLabel(item.rawStatus);
   const author = authorLabel(item);
+  const handleDragStart = useCallback(
+    (event: DragEvent) => {
+      if (item.kind !== "task") return;
+
+      event.dataTransfer.setData("text/x-task-id", item.id);
+      event.dataTransfer.effectAllowed = "copy";
+    },
+    [item.id, item.kind],
+  );
   // The row's leading mark is always the task-list state vocabulary. Canvases
   // have no live run, so they use the quiet dot and move their glyph to the
   // right-side identity stack — except while one is being deleted, which is the
@@ -270,6 +279,8 @@ export function ChannelItemRow({
               // A non-string label opts out of SidebarItem's truncation tooltip.
               label={<span>{item.title}</span>}
               isActive={isActive}
+              draggable={item.kind === "task"}
+              onDragStart={handleDragStart}
               onClick={() => actions.open(item)}
               endContent={
                 <span className={TRAILING_CLASS}>


### PR DESCRIPTION
## Problem

Sessions in the rewritten left sidebar cannot be dragged into Command Center cells because the new task row no longer emits the existing drag payload.

**Why:** Drag and drop is the fastest way to compose a Command Center layout, and the sidebar rewrite unintentionally removed that workflow.

## Changes

Make task rows draggable and restore the `text/x-task-id` payload consumed by Command Center cells. Canvas rows remain non-draggable.

## How did you test this code?

- `pnpm --dir packages/ui exec vitest run src/features/canvas/components/ChannelItemRow.test.tsx` (27 tests passed)
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check packages/ui/src/features/canvas/components/ChannelItemRow.tsx packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx`
- Added regression coverage for the task drag payload and for canvases remaining non-draggable.
- I could not run `hogli ci:preflight --fix` because Python and Flox are unavailable in this environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change needed for restoring existing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the regression to the migrated desktop sidebar, ported the fix to `products/desktop`, and added focused component coverage. No repository-provided skills were invoked.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*