### PR TITLE
fix(desktop): restore command center task popup width

### DIFF
--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.test.tsx
@@ -1,0 +1,56 @@
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@posthog/ui/features/command-center/hooks/useAvailableTasks", () => ({
+  useAvailableTasks: () => [],
+}));
+
+vi.mock("@posthog/ui/features/folders/useFolders", () => ({
+  useFolders: () => ({
+    getRecentFolders: () => [
+      { id: "folder-1", name: "one", path: "/one" },
+      { id: "folder-2", name: "two", path: "/two" },
+    ],
+  }),
+}));
+
+import { TaskSelector } from "./TaskSelector";
+
+function renderSelector() {
+  return render(
+    <Theme>
+      <TaskSelector
+        cellIndex={0}
+        open
+        onOpenChange={() => {}}
+        onNewTerminal={() => {}}
+      >
+        <button type="button">Add task</button>
+      </TaskSelector>
+    </Theme>,
+  );
+}
+
+function expectPopupWidth(input: HTMLElement) {
+  expect(input.closest(".combobox-content")).toHaveStyle({
+    minWidth: "240px",
+  });
+}
+
+describe("TaskSelector", () => {
+  it("keeps the task popup wider than its compact trigger", () => {
+    renderSelector();
+
+    expectPopupWidth(screen.getByPlaceholderText("Search tasks..."));
+  });
+
+  it("keeps the folder popup wide after switching steps", async () => {
+    renderSelector();
+
+    await userEvent.click(screen.getByRole("button", { name: "Terminal" }));
+
+    expectPopupWidth(screen.getByPlaceholderText("Search folders..."));
+  });
+});

--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
@@ -23,6 +23,8 @@ interface TaskSelectorProps {
   children: ReactNode;
 }
 
+const CONTENT_STYLE = { minWidth: "240px" };
+
 export function TaskSelector({
   cellIndex,
   open,
@@ -97,7 +99,7 @@ export function TaskSelector({
           side="bottom"
           align="center"
           sideOffset={4}
-          className="min-w-[240px]"
+          style={CONTENT_STYLE}
         >
           {({ filtered }) => (
             <>
@@ -134,7 +136,7 @@ export function TaskSelector({
           side="bottom"
           align="center"
           sideOffset={4}
-          className="min-w-[240px]"
+          style={CONTENT_STYLE}
         >
           {({ filtered, hasMore, moreCount }) => (
             <>

--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
@@ -23,6 +23,7 @@ interface TaskSelectorProps {
   children: ReactNode;
 }
 
+// Combobox sets a trigger-derived minWidth inline, so a utility class cannot override it.
 const CONTENT_STYLE = { minWidth: "240px" };
 
 export function TaskSelector({


### PR DESCRIPTION
## Problem

The Command Center task picker collapses to the width of its compact Add task trigger, making the popup too narrow to use comfortably.

**Why:** The selector declared a 240px minimum through a CSS class, but the shared combobox applies its trigger-derived minimum width inline. The inline value wins in the cascade.

## Changes

Apply the task picker minimum width through the combobox style API so it overrides the trigger-derived default. Keep the same width for both the task and folder steps.

## How did you test this code?

- `pnpm --dir packages/ui exec vitest run src/features/command-center/components/TaskSelector.test.tsx` (2 tests passed)
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check packages/ui/src/features/command-center/components/TaskSelector.tsx packages/ui/src/features/command-center/components/TaskSelector.test.tsx`
- Added regression coverage for the task popup and folder-step popup minimum widths.
- I could not run `hogli ci:preflight --fix` because Python and Flox are unavailable in this environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change needed for this layout correction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the collapse to inline-style precedence in the shared combobox and chose a component-scoped width override to avoid changing every combobox. No repository-provided skills were invoked.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*