### PR TITLE
fix(insights): day exclusions in funnel trends, hide for lifecycle

### DIFF
--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -37,16 +37,18 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
     const showDaysOfWeekExclusions = supportsDaysOfWeek && !smoothingActive
 
-    // Enabling smoothing hides the control, so clear daysOfWeek on that transition (never on
-    // mount): the backend rejects the combination and there'd be no UI left to remove it
+    // Anything that hides the control — smoothing turned on, or the insight switched to a kind
+    // that doesn't support day exclusions — clears daysOfWeek on that transition, otherwise it
+    // keeps filtering with no UI left to remove it. Deliberately not on mount: that would rewrite
+    // a saved insight just for opening it.
     const prevShowDaysOfWeekExclusions = useRef(showDaysOfWeekExclusions)
     useEffect(() => {
         const wasShown = prevShowDaysOfWeekExclusions.current
         prevShowDaysOfWeekExclusions.current = showDaysOfWeekExclusions
-        if (wasShown && !showDaysOfWeekExclusions && smoothingActive && dateRange?.daysOfWeek?.length) {
+        if (wasShown && !showDaysOfWeekExclusions && dateRange?.daysOfWeek?.length) {
             updateQuerySource(computeDaysOfWeekUpdate([], dateRange))
         }
-    }, [showDaysOfWeekExclusions, smoothingActive, dateRange, updateQuerySource])
+    }, [showDaysOfWeekExclusions, dateRange, updateQuerySource])
 
     const exclusions: DateFilterExclusions = {
         days: showDaysOfWeekExclusions ? excludedDaysOfWeek.map(String) : [],

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
@@ -69,7 +69,7 @@ describe('daysOfWeekFilterUtils', () => {
         [undefined, false],
         [{ kind: NodeKind.TrendsQuery }, true],
         [{ kind: NodeKind.StickinessQuery }, true],
-        [{ kind: NodeKind.LifecycleQuery }, true],
+        [{ kind: NodeKind.LifecycleQuery }, false],
         [{ kind: NodeKind.FunnelsQuery }, false],
         [{ kind: NodeKind.FunnelsQuery, funnelsFilter: { funnelVizType: FunnelVizType.Steps } }, false],
         [{ kind: NodeKind.FunnelsQuery, funnelsFilter: { funnelVizType: FunnelVizType.TimeToConvert } }, false],

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
@@ -1,13 +1,15 @@
 import { DateRange } from '~/queries/schema/schema-general'
-import { isFunnelsQuery, isLifecycleQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
+import { isFunnelsQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
 import { FunnelVizType } from '~/types'
 
 export type IsoDayOfWeek = NonNullable<DateRange['daysOfWeek']>[number]
 
-/** Mirrors backend support: trends, stickiness, lifecycle, and funnels in the trends viz only
- *  (dropping mid-sequence events from a step funnel has ambiguous semantics). */
+/** Trends, stickiness, and funnels in the trends viz only. Dropping days is ambiguous elsewhere:
+ *  mid-sequence events in a step funnel, and in lifecycle the new/returning/resurrecting/dormant
+ *  statuses are derived from adjacent intervals, so a sparse day axis both misclassifies statuses
+ *  and lands synthesized dormant buckets on deselected days. */
 export function querySupportsDaysOfWeek(querySource: Record<string, any> | null | undefined): boolean {
-    if (isTrendsQuery(querySource) || isStickinessQuery(querySource) || isLifecycleQuery(querySource)) {
+    if (isTrendsQuery(querySource) || isStickinessQuery(querySource)) {
         return true
     }
     return isFunnelsQuery(querySource) && querySource.funnelsFilter?.funnelVizType === FunnelVizType.Trends

--- a/posthog/hogql_queries/insights/funnels/funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_trends.py
@@ -473,14 +473,19 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
         )
         interval_func = get_interval_func(interval.value)
 
+        def entrance_period_start_expr() -> ast.Expr:
+            # A fresh node per call: the resolver annotates AST nodes in place, so one instance
+            # can't be shared between the select and the where
+            return ast.ArithmeticOperation(
+                left=get_start_of_interval_hogql(interval.value, team=team, source=date_from_as_hogql),
+                right=ast.Call(name=interval_func, args=[ast.Field(chain=["number"])]),
+                op=ast.ArithmeticOperationOp.Add,
+            )
+
         fill_select: list[ast.Expr] = [
             ast.Alias(
                 alias="entrance_period_start",
-                expr=ast.ArithmeticOperation(
-                    left=get_start_of_interval_hogql(interval.value, team=team, source=date_from_as_hogql),
-                    right=ast.Call(name=interval_func, args=[ast.Field(chain=["number"])]),
-                    op=ast.ArithmeticOperationOp.Add,
-                ),
+                expr=entrance_period_start_expr(),
             ),
         ]
         fill_select_from = ast.JoinExpr(
@@ -506,6 +511,8 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
             select_from=fill_select_from,
         )
 
+        fill_conditions: list[ast.Expr] = []
+
         if self.context.funnelsFilter.hideIncompleteConversionWindowPeriods:
             # Drop periods whose conversion window hasn't fully elapsed yet (relative to now), so the
             # recent tail of the trend isn't dragged down by entrants who still have time to convert.
@@ -517,19 +524,28 @@ class FunnelTrendsUDF(FunnelUDFMixin, FunnelBase):
                 args=[ast.Call(name="toDateTime", args=[ast.Constant(value=cutoff.strftime("%Y-%m-%d %H:%M:%S"))])],
             )
             period_end = ast.ArithmeticOperation(
-                left=ast.ArithmeticOperation(
-                    left=get_start_of_interval_hogql(interval.value, team=team, source=date_from_as_hogql),
-                    right=ast.Call(name=interval_func, args=[ast.Field(chain=["number"])]),
-                    op=ast.ArithmeticOperationOp.Add,
-                ),
+                left=entrance_period_start_expr(),
                 right=ast.Call(name=interval_func, args=[ast.Constant(value=1)]),
                 op=ast.ArithmeticOperationOp.Add,
             )
-            fill_query.where = ast.CompareOperation(
-                op=ast.CompareOperationOp.LtEq,
-                left=period_end,
-                right=cutoff_as_hogql,
+            fill_conditions.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.LtEq,
+                    left=period_end,
+                    right=cutoff_as_hogql,
+                )
             )
+
+        # Events on deselected days are already filtered out, so leaving their buckets in the fill
+        # plots them as a 0% conversion point rather than a gap. Only sub-day intervals can be
+        # attributed to a weekday: a week or month bucket start says nothing about the days inside it.
+        if interval.value in ("day", "hour"):
+            day_of_week_filter = date_range.day_of_week_filter_expr(entrance_period_start_expr())
+            if day_of_week_filter is not None:
+                fill_conditions.append(day_of_week_filter)
+
+        if fill_conditions:
+            fill_query.where = fill_conditions[0] if len(fill_conditions) == 1 else ast.And(exprs=fill_conditions)
 
         return fill_query
 

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py
@@ -3494,15 +3494,26 @@ class TestFunnelTrendsDaysOfWeekUDF(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            # the filter applies to every funnel event, so user_cross's Tuesday step two is
-            # dropped (entered but not converted) and user_saturday's entrance doesn't count
-            ("mondays_only", [1], (2, 1), (0, 0)),
-            ("empty_means_unfiltered", [], (2, 2), (1, 1)),
+            # The filter applies to every funnel event, so user_cross's Tuesday step two is dropped
+            # (entered but not converted). Deselected days leave the response entirely rather than
+            # plotting as a 0% conversion point.
+            ("mondays_only", [1], [("2021-06-07", 2, 1)]),
+            (
+                "empty_means_unfiltered",
+                [],
+                [
+                    ("2021-06-07", 2, 2),
+                    ("2021-06-08", 0, 0),
+                    ("2021-06-09", 0, 0),
+                    ("2021-06-10", 0, 0),
+                    ("2021-06-11", 0, 0),
+                    ("2021-06-12", 1, 1),
+                    ("2021-06-13", 0, 0),
+                ],
+            ),
         ]
     )
-    def test_days_of_week_filters_entrances_and_conversions(
-        self, _name, days_of_week, expected_monday, expected_saturday
-    ):
+    def test_days_of_week_filters_entrances_and_conversions(self, _name, days_of_week, expected_buckets):
         self._create_days_of_week_journeys()
 
         results = (
@@ -3511,15 +3522,16 @@ class TestFunnelTrendsDaysOfWeekUDF(ClickhouseTestMixin, APIBaseTest):
             .results
         )
 
-        self.assertEqual(len(results), 7)
-        monday, saturday = results[0], results[5]
         self.assertEqual(
-            (monday["reached_from_step_count"], monday["reached_to_step_count"]),
-            expected_monday,
-        )
-        self.assertEqual(
-            (saturday["reached_from_step_count"], saturday["reached_to_step_count"]),
-            expected_saturday,
+            [
+                (
+                    row["timestamp"].strftime("%Y-%m-%d"),
+                    row["reached_from_step_count"],
+                    row["reached_to_step_count"],
+                )
+                for row in results
+            ],
+            expected_buckets,
         )
 
     @parameterized.expand(
@@ -3687,11 +3699,10 @@ class TestFunnelTrendsCompareUDF(ClickhouseTestMixin, APIBaseTest):
         results = FunnelsQueryRunner(query=self._build_query(days_of_week=[1]), team=self.team).calculate().results
 
         previous_series = next(r for r in results if r["compare_label"] == "previous")
-        # Monday 2021-05-31 converts; Saturday 2021-06-05 must be filtered out of the
-        # previous period as well (index 5, conversion rate would be 100.0 unfiltered)
-        self.assertEqual(previous_series["days"][0], "2021-05-31")
-        self.assertEqual(previous_series["data"][0], 100.0)
-        self.assertEqual(previous_series["data"][5], 0.0)
+        # Monday 2021-05-31 converts, and it's the only bucket left: Saturday 2021-06-05 is
+        # filtered out of the previous period too, so it never reaches the series at all
+        self.assertEqual(previous_series["days"], ["2021-05-31"])
+        self.assertEqual(previous_series["data"], [100.0])
 
     def test_compare_with_custom_offset_shifts_previous_window(self):
         # Custom offset `-30d` puts the previous window 30 days before the current window's start


### PR DESCRIPTION
## Problem

The date picker's "exclude days" option shipped to the default insight date filter last week. Two of the insight types it offers the option on render deselected days anyway.

**Funnel trends** builds its date axis from a fill query that covers every interval in the range, and that fill had no day-of-week filter. Deselected days survived as rows with zero entrants, and `conversion_rate` is hardcoded to `0` when there are no entrants, so instead of a gap you get a hard 0% drop on every excluded day. On a conversion line that reads as a catastrophic collapse.

**Lifecycle** is worse than cosmetic. Its four statuses are derived from *adjacent* intervals: dormant is synthesized at `last_active + 1 interval`, and returning requires the previous activity to be exactly one interval earlier. Once the day axis is sparse both assumptions break. With only weekends selected, Sunday's successor is computed as Monday, so a dormant-only bar lands on a deselected day, and every Saturday shows its weekend regulars as "resurrecting" rather than "returning" because Sun to Sat is six days apart.

Only trends ever dropped the buckets, because `_filter_buckets_to_days` is a private method on `TrendsQueryRunner` rather than a shared helper.

Refs #20860

## Changes

Funnel trends: the fill query now filters to the selected days, reusing the existing `day_of_week_filter_expr` helper and the same `where` slot `hideIncompleteConversionWindowPeriods` already uses. Gated to day and hour intervals, since a week or month bucket start says nothing about the days inside it. No semantic change: `funnel_event_query.py` already gates the filter to the trends viz, and "selected-days events only" is existing tested behavior, so a Monday entrant who converts on a deselected Tuesday still counts as dropped off.

Lifecycle is removed from `querySupportsDaysOfWeek`, mirroring how step funnels are already gated out for having ambiguous semantics. The backend capability and its tests are left intact so a proper adjacency fix does not have to re-add them.

The lemon picker only cleared `daysOfWeek` when *smoothing* hid the exclusions control. With lifecycle now unsupported, switching an insight to it would hide the control and leave the filter on the query with no UI to remove it. Any hide now clears it, matching what `InsightQuillDateFilter` already did. Still not on mount, so opening a saved insight does not rewrite it.

> [!NOTE]
> A saved lifecycle insight that already has `daysOfWeek` set keeps filtering server-side until someone edits it, since the backend still honors the field. Making that airtight means having `lifecycle_query_runner` ignore it too, which I left out deliberately.

Two gaps found while auditing that this PR does not touch, both pre-existing and worth a follow-up:

| Type | Filters events | Hides deselected buckets |
| --- | --- | --- |
| Trends, day interval | yes | yes |
| Trends, week/month+ | yes | n/a, a week bucket legitimately aggregates only selected days |
| Trends, hour interval | yes | **no**, bucket drop is gated to `interval == "day"` |
| Stickiness | yes | n/a, axis is interval-count, but it is padded to the full span so you get an empty tail |
| Funnels, trends viz | yes | **fixed here** |
| Funnels, steps / time-to-convert | no, deliberately ignored | n/a |
| Lifecycle | yes | **hidden from the picker here** |

## How did you test this code?

No manual UI testing. I was not able to run the app: this box has 1 CPU and the dev stack plus a whole-repo `tsgo` pass does not fit in its memory.

Automated tests I ran locally:

- `pytest posthog/hogql_queries/insights/funnels/test/test_funnel_trends.py` in full, 71 passed including 4 snapshots. This matters because the fill query is shared by every funnel trends query, not just the day-exclusion path.
- `jest src/scenes/insights/filters/InsightDateFilter src/scenes/insights/insightVizDataLogic.test.ts`, 78 passed.
- `ruff check` and `ruff format --check` on the touched Python, `oxlint` on the touched TypeScript, both clean.
- Whole-repo `tsgo --noEmit` was OOM-killed, so I ran it against a scoped tsconfig covering the changed directory plus the ambient `.d.ts` files. Zero errors in the changed files. The only two reported were a known scoping artifact in untouched `dataThemeLogic.tsx`, whose `Window` augmentation lives in `render-query/`.

I changed two existing tests rather than adding new ones, because both encoded the bug:

- `test_days_of_week_filters_entrances_and_conversions` asserted `len(results) == 7` and indexed `results[5]` as Saturday, so it passed whether or not deselected buckets were present.
- `test_days_of_week_filters_previous_period_too` asserted `data[5] == 0.0`, which now raises IndexError.

Both now assert the exact bucket list, which is strictly stronger and is the regression this PR is about: if the day filter is dropped from the fill, deselected days reappear as 0% points. The nearby `test_days_of_week_uses_project_timezone` sums across rows, so it could not catch this.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover the exclusions yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code) wrote this after I asked it to look into why lifecycle charts looked wrong with weekdays excluded, then to audit the other insight types.

Notable decisions. Claude first proposed three options for lifecycle: hide it, port the bucket filtering, or fix the adjacency model properly. We rejected the middle one because it makes the chart look clean while leaving the dormant and returning numbers wrong and now invisible. We picked hide, matching the step-funnel precedent, and left the backend intact for the proper fix later.

For funnels it initially looked like a product decision was outstanding on what excluding a day should mean for a multi-step sequence. Reading `funnel_event_query.py:652` and `test_days_of_week_actors_match_chart` settled it: trends viz only, selected-days events only, already tested. That collapsed the funnel work to a rendering fix.

The clearing change in `InsightDateFilter.tsx` was not in the original scope. It came out of noticing that making lifecycle unsupported created a newly reachable path where the filter strands itself, which would have undercut the fix.

Skills invoked: the repo's `/writing-tests` gate, which is why this PR changes two tests instead of adding a third.
