### PR TITLE
chore(desktop): rename inbox signal source group to "External sources"

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/SignalSourceToggles.tsx
@@ -336,10 +336,10 @@ export function SignalSourceToggles({
         </Flex>
       </Flex>
 
-      {/* External connections — data-driven from the shared source registry */}
+      {/* External sources — data-driven from the shared source registry */}
       <Flex direction="column" gap="2" className="min-w-0 flex-1">
         <Text className="font-medium text-(--gray-9) text-[13px]">
-          External connections
+          External sources
         </Text>
         <Flex direction="column" gap="3">
           {EXTERNAL_INBOX_SOURCES.map((source) => {
@@ -400,7 +400,7 @@ export function SignalSourceTogglesSkeleton() {
       </Flex>
       <Flex direction="column" gap="2" className="min-w-0 flex-1">
         <Text className="font-medium text-(--gray-9) text-[13px]">
-          External connections
+          External sources
         </Text>
         <Flex direction="column" gap="3">
           {Array.from({ length: 4 }).map((_, index) => (


### PR DESCRIPTION
## Problem

The inbox signal-sources section groups external integrations under a header that does not match its counterpart in the main PostHog app ("Connected tools" there, "External connections" here). The naming should be consistent across both surfaces.

This is a port of PostHog/code#3967, which was approved and green but can never merge: PostHog/code is now frozen behind a "block all PRs" ruleset after the monorepo migration, so the ref cannot be updated there.

## Changes

Renames the signal-sources group header (and its loading skeleton) from **External connections** to **External sources**, matching the sibling "PostHog data" group.

## How did you test this code?

I (actually the PostHog Slack agent) did not run the app or any tests for this. It is a two-string copy change in one component, ported byte-for-byte from the already-approved and fully-green PostHog/code#3967, and I verified by grep that the live header and the skeleton header are the only occurrences.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Human-driven (agent-assisted). Ported by the PostHog Slack agent at the request of the original PR's author, who is assigned as DRI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1785754752277659)*
