### PR TITLE
fix(conversations): stop autolinking property paths in rich text editors

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/shared/markdownExtensions.ts
+++ b/frontend/src/lib/components/MarkdownEditor/shared/markdownExtensions.ts
@@ -1,6 +1,7 @@
-import { Link } from '@tiptap/extension-link'
 import { TaskItem, TaskList } from '@tiptap/extension-list'
 import StarterKit from '@tiptap/starter-kit'
+
+import { LinkExtension } from 'lib/components/RichContentEditor/LinkExtension'
 
 // Shared building blocks for the markdown editors (text card, AI prompt, etc). Each editor starts
 // from these and only layers on what makes it different — images, a placeholder, tables, and so on.
@@ -15,6 +16,12 @@ const MARKDOWN_BASE_EXTENSIONS = [
     TaskItem.configure({ nested: true }),
 ]
 
-export const MARKDOWN_BASE_EDITABLE_EXTENSIONS = [...MARKDOWN_BASE_EXTENSIONS, Link.configure({ openOnClick: false })]
+export const MARKDOWN_BASE_EDITABLE_EXTENSIONS = [
+    ...MARKDOWN_BASE_EXTENSIONS,
+    LinkExtension.configure({ openOnClick: false }),
+]
 
-export const MARKDOWN_BASE_READONLY_EXTENSIONS = [...MARKDOWN_BASE_EXTENSIONS, Link.configure({ openOnClick: true })]
+export const MARKDOWN_BASE_READONLY_EXTENSIONS = [
+    ...MARKDOWN_BASE_EXTENSIONS,
+    LinkExtension.configure({ openOnClick: true }),
+]

--- a/frontend/src/lib/components/RichContentEditor/LinkExtension.test.ts
+++ b/frontend/src/lib/components/RichContentEditor/LinkExtension.test.ts
@@ -1,0 +1,37 @@
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+
+import { LinkExtension } from './LinkExtension'
+
+describe('LinkExtension', () => {
+    function pastedHref(text: string): string | null {
+        const editor = new Editor({
+            element: document.createElement('div'),
+            extensions: [StarterKit.configure({ link: false }), LinkExtension],
+        })
+        try {
+            editor.view.pasteText(text, new Event('paste') as ClipboardEvent)
+            return editor.getHTML().match(/<a[^>]+href="([^"]+)"/)?.[1] ?? null
+        } finally {
+            editor.destroy()
+        }
+    }
+
+    it.each([
+        ['person.properties.plan', null],
+        ['event.properties.$browser', null],
+        ['person.properties.email', null],
+        ['props.name', null],
+        ['see person.properties.plan in the payload', null],
+        // Rare TLDs lose autolinking as a side effect — an explicit scheme still works
+        ['acme.solutions', null],
+        ['https://acme.solutions', 'https://acme.solutions'],
+        ['http://person.properties/path', 'http://person.properties/path'],
+        ['https://posthog.com/docs', 'https://posthog.com/docs'],
+        ['posthog.com', 'http://posthog.com'],
+        ['www.posthog.com', 'http://www.posthog.com'],
+        ['ask support@posthog.com', 'mailto:support@posthog.com'],
+    ])('pasting %j links %j', (text, expected) => {
+        expect(pastedHref(text)).toEqual(expected)
+    })
+})

--- a/frontend/src/lib/components/RichContentEditor/LinkExtension.ts
+++ b/frontend/src/lib/components/RichContentEditor/LinkExtension.ts
@@ -1,0 +1,74 @@
+import { PasteRule, PasteRuleMatch } from '@tiptap/core'
+import { Link, LinkOptions } from '@tiptap/extension-link'
+
+/**
+ * TLDs we're willing to autolink when the text carries no scheme. Deliberately narrow: plenty of
+ * gTLDs double as property names (`.properties`, `.email`, `.name`, `.id`), so linkify reads a path
+ * like `person.properties.plan` as a domain and hyperlinks it. Anything missing from this list still
+ * becomes a link with an explicit `https://`, a `www.` prefix, or the link button.
+ *
+ * Country codes that read as property names are left out on purpose: id, is, as, to, on, by, do, re, am, so.
+ */
+const AUTOLINK_TLDS = new Set(
+    `ai app biz blog cc cloud co com dev edu fm gov info int io mil net news online org shop site store tech tv wiki xyz
+     ae ar at au be br ca ch cl cn cz de dk eg es eu fi fr gg gr hk hu ie il in it jp ke kr ly me mx my ng nl no nz ph
+     pl pt ro ru sa se sg sh th tr tw ua uk us vn za`.split(/\s+/)
+)
+
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i
+/** A dot followed by more identifier characters — i.e. the match ended mid-word. */
+const CONTINUES_WORD_RE = /^\.[\w$]/
+const IDENTIFIER_CHAR_RE = /[\w$]/
+
+/** Whether an autolink candidate looks like a URL rather than a dotted property path. */
+function shouldAutoLink(candidate: string): boolean {
+    if (SCHEME_RE.test(candidate)) {
+        return true
+    }
+    // Strip userinfo (emails) and everything after the host, the way TipTap's own default does
+    const hostname = candidate
+        .split('@')
+        .slice(-1)[0]
+        .split(/[/?#:]/)[0]
+        .toLowerCase()
+    if (hostname.startsWith('www.')) {
+        return true
+    }
+    return AUTOLINK_TLDS.has(hostname.split('.').slice(-1)[0])
+}
+
+/**
+ * linkify stops at the last segment that looks like a TLD, so `person.properties.plan` matches only
+ * `person.properties`. A pasted URL fills its whole word, so ignore matches that are butted up
+ * against more identifier characters.
+ */
+function coversWholeWord(text: string, match: PasteRuleMatch): boolean {
+    const charBefore = text[match.index - 1]
+    if (charBefore && (IDENTIFIER_CHAR_RE.test(charBefore) || charBefore === '.')) {
+        return false
+    }
+    return !CONTINUES_WORD_RE.test(text.slice(match.index + match.text.length))
+}
+
+/**
+ * `@tiptap/extension-link`, minus the autolinking of code that only looks like a domain. Use this
+ * everywhere instead of importing `Link` directly, so every editor behaves the same.
+ */
+export const LinkExtension = Link.extend({
+    addOptions(): LinkOptions {
+        return { ...this.parent?.(), shouldAutoLink } as LinkOptions
+    },
+
+    addPasteRules() {
+        return (this.parent?.() ?? []).map((rule) => {
+            const { find } = rule
+            if (typeof find !== 'function') {
+                return rule
+            }
+            return new PasteRule({
+                handler: rule.handler,
+                find: (text, event) => find(text, event)?.filter((match) => coversWholeWord(text, match)),
+            })
+        })
+    },
+})

--- a/frontend/src/lib/components/RichContentEditor/LinkExtension.ts
+++ b/frontend/src/lib/components/RichContentEditor/LinkExtension.ts
@@ -22,6 +22,8 @@ const IDENTIFIER_CHAR_RE = /[\w$]/
 
 /** Whether an autolink candidate looks like a URL rather than a dotted property path. */
 function shouldAutoLink(candidate: string): boolean {
+    // An explicit scheme means the author meant a URL. TipTap runs its own `isAllowedUri` protocol
+    // check before this, so `javascript:` and friends never get here.
     if (SCHEME_RE.test(candidate)) {
         return true
     }

--- a/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
+++ b/frontend/src/scenes/product-tours/editor/StepContentEditor.tsx
@@ -3,7 +3,6 @@ import './StepContentEditor.scss'
 import { JSONContent } from '@tiptap/core'
 import { Color } from '@tiptap/extension-color'
 import { Image } from '@tiptap/extension-image'
-import { Link } from '@tiptap/extension-link'
 import { Placeholder } from '@tiptap/extension-placeholder'
 import { TextAlign } from '@tiptap/extension-text-align'
 import { TextStyle } from '@tiptap/extension-text-style'
@@ -18,6 +17,7 @@ import { IconCode, IconImage, IconList, IconVideoCamera } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonInput, LemonMenu, LemonModal } from '@posthog/lemon-ui'
 
 import { ResizableElement } from 'lib/components/ResizeElement/ResizeElement'
+import { LinkExtension } from 'lib/components/RichContentEditor/LinkExtension'
 import { useUploadFiles } from 'lib/hooks/useUploadFiles'
 import { IconBold, IconItalic, IconLink } from 'lib/lemon-ui/icons'
 import { LemonFileInput } from 'lib/lemon-ui/LemonFileInput'
@@ -126,7 +126,7 @@ export function StepContentEditor({
                   }),
                   TextStyle,
                   Color,
-                  Link.configure({
+                  LinkExtension.configure({
                       openOnClick: false,
                       HTMLAttributes: {
                           class: 'step-content-link',

--- a/frontend/src/scenes/product-tours/editor/generateStepHtml.test.ts
+++ b/frontend/src/scenes/product-tours/editor/generateStepHtml.test.ts
@@ -65,7 +65,7 @@ jest.mock('@tiptap/html', () => ({
 jest.mock('@tiptap/starter-kit', () => ({ __esModule: true, default: { configure: () => ({}) } }))
 jest.mock('@tiptap/extension-code-block-lowlight', () => ({ __esModule: true, default: { configure: () => ({}) } }))
 jest.mock('@tiptap/extension-image', () => ({ Image: { configure: () => ({}) } }))
-jest.mock('@tiptap/extension-link', () => ({ Link: { configure: () => ({}) } }))
+jest.mock('lib/components/RichContentEditor/LinkExtension', () => ({ LinkExtension: { configure: () => ({}) } }))
 jest.mock('@tiptap/extension-underline', () => ({ Underline: {} }))
 jest.mock('./EmbedExtension', () => ({ EmbedExtension: {} }))
 

--- a/frontend/src/scenes/product-tours/editor/generateStepHtml.ts
+++ b/frontend/src/scenes/product-tours/editor/generateStepHtml.ts
@@ -2,7 +2,6 @@ import type { JSONContent } from '@tiptap/core'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import { Color } from '@tiptap/extension-color'
 import { Image } from '@tiptap/extension-image'
-import { Link } from '@tiptap/extension-link'
 import { TextAlign } from '@tiptap/extension-text-align'
 import { TextStyle } from '@tiptap/extension-text-style'
 import { Underline } from '@tiptap/extension-underline'
@@ -11,6 +10,8 @@ import StarterKit from '@tiptap/starter-kit'
 import { toHtml } from 'hast-util-to-html'
 import { decode } from 'he'
 import { common, createLowlight } from 'lowlight'
+
+import { LinkExtension } from 'lib/components/RichContentEditor/LinkExtension'
 
 import { ProductTourStep, ProductTourStepTranslation } from '~/types'
 
@@ -56,7 +57,7 @@ const htmlExtensions = [
     }),
     TextStyle,
     Color,
-    Link.configure({
+    LinkExtension.configure({
         openOnClick: false,
         HTMLAttributes: {
             class: 'ph-tour-link',

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -4,7 +4,6 @@ import { JSONContent, TextSerializer } from '@tiptap/core'
 import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight'
 import ExtensionDocument from '@tiptap/extension-document'
 import { Image } from '@tiptap/extension-image'
-import { Link } from '@tiptap/extension-link'
 import { Underline } from '@tiptap/extension-underline'
 import { Placeholder } from '@tiptap/extensions'
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
@@ -28,6 +27,7 @@ import { EmojiPickerPopover } from 'lib/components/EmojiPicker/EmojiPickerPopove
 import { useRichContentEditor } from 'lib/components/RichContentEditor'
 import { CommandEnterExtension } from 'lib/components/RichContentEditor/CommandEnterExtension'
 import { EmojiSuggestionExtension } from 'lib/components/RichContentEditor/EmojiSuggestionExtension'
+import { LinkExtension } from 'lib/components/RichContentEditor/LinkExtension'
 import { MentionsExtension } from 'lib/components/RichContentEditor/MentionsExtension'
 import { RichContentNodeMention } from 'lib/components/RichContentEditor/RichContentNodeMention'
 import { RichContentEditorType, RichContentNodeType, TTEditor } from 'lib/components/RichContentEditor/types'
@@ -177,7 +177,7 @@ const ImageExtension = Image.configure({
     allowBase64: false,
 })
 
-const LinkExtension = Link.configure({
+const SupportLinkExtension = LinkExtension.configure({
     openOnClick: false, // Don't open links when clicking in editor
     HTMLAttributes: {
         class: 'SupportEditor__link',
@@ -260,7 +260,7 @@ export const SUPPORT_EXTENSIONS = [
     }),
     Underline, // Cmd+U
     ImageExtension,
-    LinkExtension,
+    SupportLinkExtension,
     LinkOnPasteExtension,
     SupportCodeBlockExtension,
 ]
@@ -277,7 +277,7 @@ export const SUPPORT_PREVIEW_EXTENSIONS = [
     }),
     Underline,
     ImageExtension,
-    LinkExtension,
+    SupportLinkExtension,
     SupportCodeBlockExtension,
 ]
 


### PR DESCRIPTION
## Problem

Pasting a dotted property path into one of our rich text editors turns part of it into a link. Paste `person.properties.plan` into a support reply and you get a hyperlink on `person.properties`.

The cause is that `.properties` is a real gTLD, so linkify reads the first two segments as a domain and TipTap's paste rule marks them up. Same story for `props.name`, `person.properties.email`, and anything else whose last segment happens to be a delegated TLD. There is a whole family of these, and support conversations are full of property paths.

## Changes

New shared `LinkExtension` that wraps `@tiptap/extension-link` with two guards:

- **Common TLDs only for scheme-less text.** `posthog.com` and `docs.posthog.com` still autolink. `person.properties`, `props.name` and `acme.solutions` do not. Anything left out still becomes a link with an explicit `https://`, a `www.` prefix, or the link button.
- **No partial-word matches on paste.** linkify stops at the last segment that looks like a TLD, so a match butted up against more identifier characters gets thrown away.

Every editor that configured `Link` directly now goes through it: the support editor, the markdown editors behind text cards and AI prompts, and the product tour step editor plus its HTML generator. There was no shared factory before, so each site had its own `Link.configure` call and the same bug.

> [!NOTE]
> The tradeoff is that domains on rare TLDs no longer autolink from bare text. That felt like the right side to err on for editors people use to discuss code, and the link button still works.

## How did you test this code?

New Jest suite at `frontend/src/lib/components/RichContentEditor/LinkExtension.test.ts` drives a real TipTap editor through `view.pasteText` and asserts the resulting `href`. It covers the reported case and its siblings, plus the URLs that must keep working (explicit scheme, bare common-TLD domain, `www.`, email). The regression it catches: no existing test pasted anything into these editors, so nothing noticed a property path being hyperlinked.

I also ran the surrounding suites (support editor, markdown editors, rich content editor, product tours editor), 84 passing, and the frontend typecheck, which reports no errors in the changed files. I did not exercise this by hand in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover autolinking behavior, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude) from a Slack report of the paste behavior.

Worth knowing about the path not taken. I first tried fixing only the partial-match case, since linking a substring of a word is unambiguously wrong and needs no judgement call. That turned out to be a half fix: `person.properties.email` matches a valid TLD end to end, so it survived. The other extreme, GitHub's rule of only autolinking explicit `https://` and `www.`, kills `posthog.com` everywhere in the app. The common-TLD allowlist is the middle ground, and it is a plain `Set` that is easy to extend when someone hits a domain it misses.

The allowlist deliberately omits two-letter country codes that read as property names (`id`, `is`, `as`, `to`, `on`, `by`, `do`, `re`, `am`, `so`) so `person.id` stays plain text.

One pre-existing quirk I noticed and left alone: TipTap does not autolink a scheme-less URL that has a path (`posthog.com/docs`) on paste, with or without this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1785754770547939)*
