### PR TITLE
fix(experiments): animate exposures header content on expand

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -286,14 +286,13 @@ export function Exposures(): JSX.Element {
                 </span>
 
                 {!isExperimentDraft && (
+                    // Transitioning visibility delays the hidden flip until the fade-out finishes
                     <div
-                        className={`flex items-center gap-3 transition-opacity duration-300 ease-in-out ${
-                            isCollapsed ? 'opacity-100' : 'opacity-0'
+                        className={`flex items-center gap-3 transition-[opacity,visibility] duration-300 ease-in-out ${
+                            isCollapsed
+                                ? 'visible opacity-100 pointer-events-auto'
+                                : 'invisible opacity-0 pointer-events-none'
                         }`}
-                        style={{
-                            visibility: isCollapsed ? 'visible' : 'hidden',
-                            pointerEvents: isCollapsed ? 'auto' : 'none',
-                        }}
                     >
                         {exposuresLoading ? (
                             <Spinner className="text-lg" />


### PR DESCRIPTION
## Problem

The exposures section header shows a summary (total exposures, variants, split) when the section is collapsed. When you collapse the section, this summary fades in nicely. But when you expand the section, the summary disappears instantly instead of fading out. The two directions don't match.

## Changes

The summary faded via an `opacity` transition, but `visibility: hidden` was set instantly, so on expand the content vanished before the fade could play. Now `visibility` transitions together with `opacity`, which makes the browser wait until the fade-out finishes before hiding the content. Also moved the inline styles to Tailwind classes.

## How did you test this code?

Not tested in a running app yet (the change was made in a light worktree without a dev stack). It's a pure CSS class change, no logic touched. Will verify the fade in both directions locally before marking ready for review.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. One decision worth noting: the fix relies on CSS transitioning `visibility` discretely (the flip to `hidden` happens at the end of the transition), which is why adding it to the transition list is enough. An alternative was keeping the element mounted and animating only opacity, but that would leave invisible content clickable without the pointer-events handling that was already there.