### PR TITLE
chore(mcp): switch worker observability to logs and traces blocks

### DIFF
--- a/services/mcp/wrangler.jsonc
+++ b/services/mcp/wrangler.jsonc
@@ -41,13 +41,15 @@
         },
     ],
     "observability": {
-        "enabled": true,
-        "head_sampling_rate": 0.1,
         "logs": {
-            "enabled": true,
-            "destinations": ["posthog"],
+            "enabled": false,
             "head_sampling_rate": 0.1,
-            "persist": true, // Keep showing logs in Cloudflare dashboard
+            "invocation_logs": true,
+            "destinations": ["posthog"],
+        },
+        "traces": {
+            "enabled": false,
+            "head_sampling_rate": 0.1,
         },
     },
     "rules": [


### PR DESCRIPTION
## Problem

The MCP worker's `observability` config in `services/mcp/wrangler.jsonc` still used the older shape: a top-level `enabled` plus `head_sampling_rate`, with only a `logs` sub-block. We want the newer per-signal shape so logs and traces are configured independently, and so invocation logs are explicit rather than implied.

## Changes

Swapped the single top-level toggle for explicit `logs` and `traces` blocks. Both are set to `enabled: false` with `head_sampling_rate: 0.1`, `logs` gains `invocation_logs: true`, and the `posthog` destination stays.

```diff
     "observability": {
-        "enabled": true,
-        "head_sampling_rate": 0.1,
         "logs": {
-            "enabled": true,
+            "enabled": false,
+            "head_sampling_rate": 0.1,
+            "invocation_logs": true,
             "destinations": ["posthog"],
+        },
+        "traces": {
+            "enabled": false,
+            "head_sampling_rate": 0.1,
         },
     },
```

> [!WARNING]
> `logs.enabled` goes from `true` to `false`, which turns log delivery off. On wrangler 4.98.0 the resolution is `observability?.logs?.enabled ?? observability?.enabled === true`, so the explicit `false` wins regardless of the dropped top-level `enabled`. That is the requested config, but it is a deliberate observability change rather than a pure refactor, so it wants a second pair of eyes before merge.

The dropped `logs.persist: true` is a non-issue: `persist` defaults to `true` in the wrangler config schema, so removing it does not change behavior. Only the explicit declaration and its comment are gone.

## How did you test this code?

Config-only change, no code paths touched, and no automated test covers this file.

I validated the file against the config schema shipped with the exact wrangler version this service pins (4.98.0), using ajv plus a jsonc parser: the whole `wrangler.jsonc` validates clean, and `logs.invocation_logs`, `logs.destinations`, and the `traces` block are all real keys on that version rather than silently-ignored ones (the `Observability` definition is `additionalProperties: false`, so a typo would have failed validation). I also read wrangler's own resolution of `observability.enabled` versus `logs.enabled` to confirm the behavior described in the warning above, and the schema default for `persist`.

I did not deploy the worker or run `wrangler deploy --dry-run`, so this is schema and source-level verification, not an observed end-to-end check of log delivery.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed - internal worker config.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: a human handed over the exact `observability` JSON they wanted in place and asked for it applied verbatim, then asked for a PR. I (Claude, via the PostHog Slack app) made the edit as literally specified rather than merging it with what was already there, which is why `enabled` and `persist` disappear. I flagged both omissions in the thread and in the warning above so the reviewer can decide whether to restore them. No repo skills were invoked - the change is a single config block.

On a follow-up pass I answered the two Graphite review comments on their threads: the `logs.enabled` one is correct about the effect and left for a human to decide, the `persist` one is a false positive per the schema default. I did not change the config in response to either, since reversing `enabled` would contradict what was asked for. Both threads are left open.

I couldn't verify the requester's GitHub handle this session, so the PR is unassigned rather than assigned to a guessed account. Please assign the DRI on review.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1785755910285199)*
