### PR TITLE
chore(experiments): add a throwaway flag branch for cleanup dogfood

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -309,6 +309,7 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_SOURCE_MAPS_BANNER: 'error-tracking-source-maps-banner', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
+    EXPERIMENT_CLEANUP_E2E_DUMMY: 'experiment-cleanup-e2e-dummy', // owner: @jurajmajerik #team-experiments multivariate=control,test, throwaway dogfood flag validating the flag-cleanup PR flow end to end
     EXPERIMENT_FLAG_CLEANUP_PR: 'experiment-flag-cleanup-pr', // owner: @jurajmajerik #team-experiments
     EXPERIMENT_RECORDINGS_TAB: 'experiment-recordings-tab', // owner: @mp-hog #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -13,6 +13,7 @@ import { MemberMultiSelect } from 'lib/components/MemberMultiSelect'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -23,6 +24,7 @@ import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/Le
 import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { pluralize } from 'lib/utils/strings'
 import stringWithWBR from 'lib/utils/stringWithWBR'
@@ -66,6 +68,12 @@ import { Holdouts } from './Holdouts'
 import { SharedMetrics } from './SharedMetrics/SharedMetrics'
 
 const HedgehogExperiment = pngHoggie(experimentPng)
+
+// Renders nothing on purpose: throwaway code that exists only so the experiment-cleanup-e2e-dummy
+// flag has references in the repo for the flag-cleanup PR flow to remove.
+const CleanupDummyExperiment = (): JSX.Element | null => {
+    return null
+}
 
 export const scene: SceneExport = {
     component: Experiments,
@@ -560,6 +568,9 @@ const ExperimentsTable = ({
 export function Experiments(): JSX.Element {
     const { tab } = useValues(experimentsLogic)
     const { setExperimentsTab, loadExperiments } = useActions(experimentsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const cleanupDummyTestVariant = featureFlags[FEATURE_FLAGS.EXPERIMENT_CLEANUP_E2E_DUMMY] === 'test'
 
     const [duplicateModalExperiment, setDuplicateModalExperiment] = useState<Experiment | null>(null)
     const [copyToProjectModalExperiment, setCopyToProjectModalExperiment] = useState<Experiment | null>(null)
@@ -639,6 +650,7 @@ export function Experiments(): JSX.Element {
                     ) : undefined
                 }
             />
+            {cleanupDummyTestVariant && <CleanupDummyExperiment />}
             <LemonTabs
                 activeKey={tab}
                 onChange={(newKey) => setExperimentsTab(newKey)}


### PR DESCRIPTION
## Problem

We want to test the experiment flag cleanup flow end to end: end an experiment, pick the repository in the modal, and get a draft PR that removes the flag code. That needs real flag code in the repo tied to a real experiment.

## Changes

A throwaway branch on the new `experiment-cleanup-e2e-dummy` flag: a component that renders nothing, mounted on the experiments list only for the test variant. Users never see anything. The matching experiment runs on our own project (dogfood only).

When the experiment ends with a cleanup PR requested, that PR should remove exactly this code. That removal is the point of this change; nothing here is meant to stay.

## How did you test this code?

It is a flag constant plus a variant-gated component that returns null; CI covers it. The real verification is the cleanup PR that should later remove it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, throwaway dogfood code.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. The flag constant follows the existing dogfood A/A flag pattern in constants.tsx. An earlier version rendered a small banner to the test variant; changed to a null-rendering component so real users can never see anything.
