### PR TITLE
feat(cdp): migrate stateful Redis data to Valkey

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -39,6 +39,7 @@
         "migrate:cyclotron": "../rust/bin/migrate-cyclotron",
         "migrate:cyclotron-node": "../rust/bin/migrate-cyclotron-node",
         "migrate:behavioral-cohorts": "../rust/bin/migrate-behavioral-cohorts",
+        "migrate:cdp-redis-valkey": "ts-node src/cdp/scripts/migrate-cdp-redis-to-valkey.ts",
         "migrate:rust": "../rust/bin/migrate-entry all",
         "services:start": "cd .. && docker compose -f docker-compose.dev.yml up",
         "services:stop": "cd .. && docker compose -f docker-compose.dev.yml down",

--- a/nodejs/src/cdp/cdp-services.test.ts
+++ b/nodejs/src/cdp/cdp-services.test.ts
@@ -1,6 +1,6 @@
 import { RedisV2 } from '~/common/redis/redis-v2'
 
-import { createCdpReaderRedisPool } from './cdp-services'
+import { createCdpReaderRedisPool, routeSafeCdpRedis } from './cdp-services'
 
 const mockReaderPool: RedisV2 = {
     useClient: jest.fn((_opts, cb) => cb({ ping: () => Promise.resolve('PONG') } as any)),
@@ -16,6 +16,7 @@ const { createRedisV2PoolFromConfig } = require('~/common/redis/redis-v2') as {
 }
 
 const mockWriterPool = { useClient: jest.fn(), usePipeline: jest.fn() } as unknown as RedisV2
+const mockValkeyPool = { useClient: jest.fn(), usePipeline: jest.fn() } as unknown as RedisV2
 
 const baseConfig = {
     CDP_REDIS_HOST: 'cdp-writer.internal',
@@ -105,5 +106,27 @@ describe('createCdpReaderRedisPool', () => {
         const logMessage = logSpy.mock.calls[0]?.[1] as string
         expect(logMessage).not.toContain('supersecret')
         expect(logMessage).toContain('prod-redis.internal')
+    })
+})
+
+describe('routeSafeCdpRedis', () => {
+    it('keeps Redis authoritative and Valkey mirrored during the soak', () => {
+        expect(routeSafeCdpRedis(false, mockWriterPool, { writer: mockValkeyPool, reader: mockValkeyPool })).toEqual({
+            primary: mockWriterPool,
+            mirror: mockValkeyPool,
+        })
+    })
+
+    it('uses only Valkey after the safe cutover', () => {
+        expect(routeSafeCdpRedis(true, mockWriterPool, { writer: mockValkeyPool, reader: mockValkeyPool })).toEqual({
+            primary: mockValkeyPool,
+            mirror: null,
+        })
+    })
+
+    it('refuses the safe cutover without a Valkey pool', () => {
+        expect(() => routeSafeCdpRedis(true, mockWriterPool, null)).toThrow(
+            'CDP_VALKEY_SAFE_PRIMARY_ENABLED requires a configured Valkey pool'
+        )
     })
 })

--- a/nodejs/src/cdp/cdp-services.test.ts
+++ b/nodejs/src/cdp/cdp-services.test.ts
@@ -1,6 +1,6 @@
 import { RedisV2 } from '~/common/redis/redis-v2'
 
-import { createCdpReaderRedisPool, routeSafeCdpRedis } from './cdp-services'
+import { createCdpReaderRedisPool, routeSafeCdpRedis, routeStatefulCdpRedis } from './cdp-services'
 
 const mockReaderPool: RedisV2 = {
     useClient: jest.fn((_opts, cb) => cb({ ping: () => Promise.resolve('PONG') } as any)),
@@ -127,6 +127,42 @@ describe('routeSafeCdpRedis', () => {
     it('refuses the safe cutover without a Valkey pool', () => {
         expect(() => routeSafeCdpRedis(true, mockWriterPool, null)).toThrow(
             'CDP_VALKEY_SAFE_PRIMARY_ENABLED requires a configured Valkey pool'
+        )
+    })
+})
+
+describe('routeStatefulCdpRedis', () => {
+    it('uses Redis with Valkey mirrors before migration', () => {
+        expect(
+            routeStatefulCdpRedis(false, mockWriterPool, mockReaderPool, {
+                writer: mockValkeyPool,
+                reader: mockValkeyPool,
+            })
+        ).toEqual({
+            primary: mockWriterPool,
+            primaryReader: mockReaderPool,
+            mirror: mockValkeyPool,
+            mirrorReader: mockValkeyPool,
+        })
+    })
+
+    it('uses only Valkey after migration', () => {
+        expect(
+            routeStatefulCdpRedis(true, mockWriterPool, mockReaderPool, {
+                writer: mockValkeyPool,
+                reader: mockValkeyPool,
+            })
+        ).toEqual({
+            primary: mockValkeyPool,
+            primaryReader: mockValkeyPool,
+            mirror: null,
+            mirrorReader: null,
+        })
+    })
+
+    it('refuses stateful cutover without a Valkey pool', () => {
+        expect(() => routeStatefulCdpRedis(true, mockWriterPool, mockReaderPool, null)).toThrow(
+            'CDP_VALKEY_STATEFUL_PRIMARY_ENABLED requires a configured Valkey pool'
         )
     })
 })

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -77,8 +77,35 @@ export function routeSafeCdpRedis(
     return { primary: valkey.writer, mirror: null }
 }
 
+export function routeStatefulCdpRedis(
+    primaryEnabled: boolean,
+    redis: RedisV2,
+    redisReader: RedisV2,
+    valkey: CdpValkeyShadowPools | null
+): {
+    primary: RedisV2
+    primaryReader: RedisV2
+    mirror: RedisV2 | null
+    mirrorReader: RedisV2 | null
+} {
+    if (!primaryEnabled) {
+        return {
+            primary: redis,
+            primaryReader: redisReader,
+            mirror: valkey?.writer ?? null,
+            mirrorReader: valkey?.reader ?? null,
+        }
+    }
+    if (!valkey) {
+        throw new Error('CDP_VALKEY_STATEFUL_PRIMARY_ENABLED requires a configured Valkey pool')
+    }
+    return { primary: valkey.writer, primaryReader: valkey.reader, mirror: null, mirrorReader: null }
+}
+
 export interface CdpCoreServices {
     redis: RedisV2
+    statefulRedis: RedisV2
+    statefulRedisMirror: RedisV2 | null
     /**
      * Shadow Valkey pools used for dual-write/read load testing. Null when
      * CDP_VALKEY_DUAL_ENABLED is false or CDP_VALKEY_HOST is unset. Consumers
@@ -141,6 +168,7 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_VALKEY_READER_PORT'
         | 'CDP_VALKEY_DUAL_ENABLED'
         | 'CDP_VALKEY_SAFE_PRIMARY_ENABLED'
+        | 'CDP_VALKEY_STATEFUL_PRIMARY_ENABLED'
         | 'CDP_VALKEY_TLS'
         | 'CDP_WATCHER_HOG_COST_TIMING_LOWER_MS'
         | 'CDP_WATCHER_HOG_COST_TIMING_UPPER_MS'
@@ -275,13 +303,19 @@ export function createCdpValkeyShadowPools(
         | 'CDP_VALKEY_READER_PORT'
         | 'CDP_VALKEY_DUAL_ENABLED'
         | 'CDP_VALKEY_SAFE_PRIMARY_ENABLED'
+        | 'CDP_VALKEY_STATEFUL_PRIMARY_ENABLED'
         | 'CDP_VALKEY_TLS'
         | 'REDIS_POOL_MIN_SIZE'
         | 'REDIS_POOL_MAX_SIZE'
     >,
     name: string
 ): CdpValkeyShadowPools | null {
-    if ((!config.CDP_VALKEY_DUAL_ENABLED && !config.CDP_VALKEY_SAFE_PRIMARY_ENABLED) || !config.CDP_VALKEY_HOST) {
+    if (
+        (!config.CDP_VALKEY_DUAL_ENABLED &&
+            !config.CDP_VALKEY_SAFE_PRIMARY_ENABLED &&
+            !config.CDP_VALKEY_STATEFUL_PRIMARY_ENABLED) ||
+        !config.CDP_VALKEY_HOST
+    ) {
         return null
     }
 
@@ -289,6 +323,12 @@ export function createCdpValkeyShadowPools(
         logger.warn(
             '⚠️',
             `[${name}] Valkey is authoritative for safe CDP keys; enable only after the dual-write TTL soak and parity checks`
+        )
+    }
+    if (config.CDP_VALKEY_STATEFUL_PRIMARY_ENABLED) {
+        logger.warn(
+            '⚠️',
+            `[${name}] Valkey is authoritative for stateful CDP keys; enable only after migration finalization and verification`
         )
     }
 
@@ -385,6 +425,12 @@ export function createCdpCoreServices(
         redis,
         valkeyShadow
     )
+    const stateful = routeStatefulCdpRedis(
+        config.CDP_VALKEY_STATEFUL_PRIMARY_ENABLED,
+        redis,
+        redisReader,
+        valkeyShadow
+    )
 
     const hogFunctionManager = new HogFunctionManagerService(deps.postgres, deps.pubSub, deps.encryptedFields)
     const hogFlowManager = new HogFlowManagerService(deps.postgres, deps.pubSub, deps.encryptedFields)
@@ -407,18 +453,23 @@ export function createCdpCoreServices(
         observeResultsBufferMaxResults: config.CDP_WATCHER_OBSERVE_RESULTS_BUFFER_MAX_RESULTS,
     }
 
-    const hogWatcher = new HogWatcherService(deps.teamManager, hogWatcherConfig, redis, redisReader)
+    const hogWatcher = new HogWatcherService(
+        deps.teamManager,
+        hogWatcherConfig,
+        stateful.primary,
+        stateful.primaryReader
+    )
 
     // Mirror HogWatcherService bound to the shadow Valkey pool. `sendEvents: false`
     // so it never emits duplicate billable team events on state transitions; the
     // Prom counter `cdp_hog_function_state_change` may double-emit when both pools
     // detect the same transition — rare, accepted during dual-write mode.
-    const hogWatcherMirror: HogWatcherService | null = valkeyShadow
+    const hogWatcherMirror: HogWatcherService | null = stateful.mirror
         ? new HogWatcherService(
               deps.teamManager,
               { ...hogWatcherConfig, sendEvents: false },
-              valkeyShadow.writer,
-              valkeyShadow.reader
+              stateful.mirror,
+              stateful.mirrorReader ?? stateful.mirror
           )
         : null
 
@@ -523,6 +574,8 @@ export function createCdpCoreServices(
 
     return {
         redis,
+        statefulRedis: stateful.primary,
+        statefulRedisMirror: stateful.mirror,
         valkeyShadow,
         hogFunctionManager,
         hogFlowManager,

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -63,6 +63,20 @@ export interface CdpValkeyShadowPools {
     reader: RedisV2
 }
 
+export function routeSafeCdpRedis(
+    primaryEnabled: boolean,
+    redis: RedisV2,
+    valkey: CdpValkeyShadowPools | null
+): { primary: RedisV2; mirror: RedisV2 | null } {
+    if (!primaryEnabled) {
+        return { primary: redis, mirror: valkey?.writer ?? null }
+    }
+    if (!valkey) {
+        throw new Error('CDP_VALKEY_SAFE_PRIMARY_ENABLED requires a configured Valkey pool')
+    }
+    return { primary: valkey.writer, mirror: null }
+}
+
 export interface CdpCoreServices {
     redis: RedisV2
     /**
@@ -126,6 +140,7 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_VALKEY_READER_HOST'
         | 'CDP_VALKEY_READER_PORT'
         | 'CDP_VALKEY_DUAL_ENABLED'
+        | 'CDP_VALKEY_SAFE_PRIMARY_ENABLED'
         | 'CDP_VALKEY_TLS'
         | 'CDP_WATCHER_HOG_COST_TIMING_LOWER_MS'
         | 'CDP_WATCHER_HOG_COST_TIMING_UPPER_MS'
@@ -259,14 +274,22 @@ export function createCdpValkeyShadowPools(
         | 'CDP_VALKEY_READER_HOST'
         | 'CDP_VALKEY_READER_PORT'
         | 'CDP_VALKEY_DUAL_ENABLED'
+        | 'CDP_VALKEY_SAFE_PRIMARY_ENABLED'
         | 'CDP_VALKEY_TLS'
         | 'REDIS_POOL_MIN_SIZE'
         | 'REDIS_POOL_MAX_SIZE'
     >,
     name: string
 ): CdpValkeyShadowPools | null {
-    if (!config.CDP_VALKEY_DUAL_ENABLED || !config.CDP_VALKEY_HOST) {
+    if ((!config.CDP_VALKEY_DUAL_ENABLED && !config.CDP_VALKEY_SAFE_PRIMARY_ENABLED) || !config.CDP_VALKEY_HOST) {
         return null
+    }
+
+    if (config.CDP_VALKEY_SAFE_PRIMARY_ENABLED) {
+        logger.warn(
+            '⚠️',
+            `[${name}] Valkey is authoritative for safe CDP keys; enable only after the dual-write TTL soak and parity checks`
+        )
     }
 
     logger.info(
@@ -357,6 +380,11 @@ export function createCdpCoreServices(
 
     const redisReader = createCdpReaderRedisPool(config, redis, redisName)
     const valkeyShadow = createCdpValkeyShadowPools(config, redisName)
+    const { primary: safePrimary, mirror: safeMirror } = routeSafeCdpRedis(
+        config.CDP_VALKEY_SAFE_PRIMARY_ENABLED,
+        redis,
+        valkeyShadow
+    )
 
     const hogFunctionManager = new HogFunctionManagerService(deps.postgres, deps.pubSub, deps.encryptedFields)
     const hogFlowManager = new HogFlowManagerService(deps.postgres, deps.pubSub, deps.encryptedFields)
@@ -436,9 +464,9 @@ export function createCdpCoreServices(
             backoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             backoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
         },
-        redis,
+        safePrimary,
         messageAssetsService,
-        valkeyShadow?.writer ?? null
+        safeMirror
     )
 
     const hogExecutor = new HogExecutorService(
@@ -470,7 +498,7 @@ export function createCdpCoreServices(
     // and EmailValidationService degrades to the local cache + DNS.
     const emailValidationService = new EmailValidationService(deps.emailValidationValkey)
     // Observer mirrors writes to Valkey (load-only); only the primary path drives metrics.
-    const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(redis, valkeyShadow?.writer ?? null)
+    const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(safePrimary, safeMirror)
     const hogFlowExecutor = new HogFlowExecutorService(
         hogFlowFunctionsService,
         recipientPreferencesService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -82,6 +82,9 @@ export type CdpConfig = ClickhouseConfig & {
     // WARNING: Enable only after the dual-write soak has exceeded the safe key TTLs and parity is healthy.
     // Moves only short-lived/replaceable CDP state (rate limits, duplicate observations, APNS JWTs) to Valkey.
     CDP_VALKEY_SAFE_PRIMARY_ENABLED: boolean
+    // WARNING: Enable only after the CDP state migration has finalized and verified successfully.
+    // Moves HogWatcher and HogMasker state, including non-expiring and multi-year keys, to Valkey.
+    CDP_VALKEY_STATEFUL_PRIMARY_ENABLED: boolean
     // AWS ElastiCache Valkey Serverless requires TLS; toggle off only for local non-TLS test setups.
     CDP_VALKEY_TLS: boolean
 
@@ -247,6 +250,7 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_VALKEY_READER_PORT: 6379,
         CDP_VALKEY_DUAL_ENABLED: false,
         CDP_VALKEY_SAFE_PRIMARY_ENABLED: false,
+        CDP_VALKEY_STATEFUL_PRIMARY_ENABLED: false,
         CDP_VALKEY_TLS: false,
 
         SES_RATE_LIMITER_VALKEY_HOST: '',

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -79,6 +79,9 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_VALKEY_READER_HOST: string
     CDP_VALKEY_READER_PORT: number
     CDP_VALKEY_DUAL_ENABLED: boolean
+    // WARNING: Enable only after the dual-write soak has exceeded the safe key TTLs and parity is healthy.
+    // Moves only short-lived/replaceable CDP state (rate limits, duplicate observations, APNS JWTs) to Valkey.
+    CDP_VALKEY_SAFE_PRIMARY_ENABLED: boolean
     // AWS ElastiCache Valkey Serverless requires TLS; toggle off only for local non-TLS test setups.
     CDP_VALKEY_TLS: boolean
 
@@ -243,6 +246,7 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_VALKEY_READER_HOST: '',
         CDP_VALKEY_READER_PORT: 6379,
         CDP_VALKEY_DUAL_ENABLED: false,
+        CDP_VALKEY_SAFE_PRIMARY_ENABLED: false,
         CDP_VALKEY_TLS: false,
 
         SES_RATE_LIMITER_VALKEY_HOST: '',

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -109,7 +109,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
         this.outputs = services.outputs
 
         // Base-only services
-        this.hogMasker = new HogMaskerService(services.redis, services.valkeyShadow?.writer ?? null)
+        this.hogMasker = new HogMaskerService(services.statefulRedis, services.statefulRedisMirror)
         this.personsManager = new PersonsManagerService(deps.teamManager, deps.personRepository, config.SITE_URL)
         this.groupsManager = new GroupsManagerService(deps.teamManager, deps.groupRepository)
         this.pluginDestinationExecutorService = new LegacyPluginExecutorService(deps.postgres, deps.geoipService)

--- a/nodejs/src/cdp/scripts/cdp-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/cdp-valkey-migration.test.ts
@@ -1,6 +1,11 @@
 import IORedis, { Redis } from 'ioredis'
 
-import { CdpMigrationOptions, migrationHasMismatches, runCdpMigration } from './cdp-valkey-migration'
+import {
+    CdpMigrationOptions,
+    keyPatternsForGroups,
+    migrationHasMismatches,
+    runCdpMigration,
+} from './cdp-valkey-migration'
 
 const KEY_PATTERNS = ['@posthog-test/hog-masker/mask/*', '@posthog-test/hog-watcher-2/*']
 const SOURCE_KEY = '@posthog-test/hog-masker/mask/function/hash'
@@ -16,6 +21,7 @@ describe('CDP Valkey migration', () => {
         phase: 'copy',
         execute: true,
         writersPaused: false,
+        requireWritersPaused: true,
         scanCount: 10,
         ttlToleranceMs: 500,
         keyPatterns: KEY_PATTERNS,
@@ -86,7 +92,33 @@ describe('CDP Valkey migration', () => {
     it('refuses to finalize without paused writers', async () => {
         await expect(
             runCdpMigration(source, target, options({ phase: 'finalize', writersPaused: false }))
-        ).rejects.toThrow('Finalization requires execute=true and writersPaused=true')
+        ).rejects.toThrow('Finalization for the selected key groups requires writersPaused=true')
+    })
+
+    it('allows a one-shot live finalization for watcher-only state', async () => {
+        await source.set(WATCHER_STATE_KEY, '12')
+
+        const summary = await runCdpMigration(
+            source,
+            target,
+            options({
+                phase: 'finalize',
+                keyPatterns: keyPatternsForGroups(['hog-watcher']).map((pattern) => pattern.replace('@posthog/', '@posthog-test/')),
+                requireWritersPaused: false,
+            })
+        )
+
+        expect(migrationHasMismatches(summary)).toBe(false)
+        await expect(target.get(WATCHER_STATE_KEY)).resolves.toBe('12')
+    })
+
+    it('selects masker and watcher key groups independently', () => {
+        expect(keyPatternsForGroups(['hog-masker'])).toEqual(['@posthog/hog-masker/mask/*'])
+        expect(keyPatternsForGroups(['hog-watcher'])).toEqual([
+            '@posthog/hog-watcher-2/state/*',
+            '@posthog/hog-watcher-2/tokens/*',
+            '@posthog/hog-watcher-2/state-lock/*',
+        ])
     })
 
     it('copies non-expiring watcher state', async () => {

--- a/nodejs/src/cdp/scripts/cdp-valkey-migration.test.ts
+++ b/nodejs/src/cdp/scripts/cdp-valkey-migration.test.ts
@@ -1,0 +1,115 @@
+import IORedis, { Redis } from 'ioredis'
+
+import { CdpMigrationOptions, migrationHasMismatches, runCdpMigration } from './cdp-valkey-migration'
+
+const KEY_PATTERNS = ['@posthog-test/hog-masker/mask/*', '@posthog-test/hog-watcher-2/*']
+const SOURCE_KEY = '@posthog-test/hog-masker/mask/function/hash'
+const EXTRA_KEY = '@posthog-test/hog-masker/mask/extra/hash'
+const WATCHER_STATE_KEY = '@posthog-test/hog-watcher-2/state/function'
+const WATCHER_TOKENS_KEY = '@posthog-test/hog-watcher-2/tokens/function'
+
+describe('CDP Valkey migration', () => {
+    let source: Redis
+    let target: Redis
+
+    const options = (overrides: Partial<CdpMigrationOptions> = {}): CdpMigrationOptions => ({
+        phase: 'copy',
+        execute: true,
+        writersPaused: false,
+        scanCount: 10,
+        ttlToleranceMs: 500,
+        keyPatterns: KEY_PATTERNS,
+        ...overrides,
+    })
+
+    beforeAll(async () => {
+        const redisUrl = process.env.REDIS_URL || 'redis://127.0.0.1:6379'
+        source = new IORedis(redisUrl, { db: 14 })
+        target = new IORedis(redisUrl, { db: 15 })
+        await Promise.all([source.ping(), target.ping()])
+    })
+
+    beforeEach(async () => {
+        await Promise.all([source.flushdb(), target.flushdb()])
+    })
+
+    afterAll(async () => {
+        await Promise.all([source.quit(), target.quit()])
+    })
+
+    it('keeps dry-run copy read-only', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+
+        const summary = await runCdpMigration(source, target, options({ execute: false }))
+
+        expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 0 })
+        await expect(target.get(SOURCE_KEY)).resolves.toBeNull()
+    })
+
+    it('copies values while preserving the absolute expiry', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+
+        const summary = await runCdpMigration(source, target, options())
+        const [sourceTtl, targetTtl] = await Promise.all([source.pttl(SOURCE_KEY), target.pttl(SOURCE_KEY)])
+
+        expect(summary).toMatchObject({ sourceKeys: 1, copiedKeys: 1 })
+        await expect(target.get(SOURCE_KEY)).resolves.toBe('42')
+        expect(Math.abs(sourceTtl - targetTtl)).toBeLessThan(500)
+    })
+
+    it('finalizes an identical target and removes target-only keys', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+        await target.set(EXTRA_KEY, '1', 'PX', 60_000)
+
+        const summary = await runCdpMigration(source, target, options({ phase: 'finalize', writersPaused: true }))
+
+        expect(summary).toMatchObject({ copiedKeys: 1, deletedExtraKeys: 1, missingTargetKeys: 0 })
+        expect(migrationHasMismatches(summary)).toBe(false)
+        await expect(target.get(EXTRA_KEY)).resolves.toBeNull()
+    })
+
+    it('detects missing, different, and differently expiring target keys', async () => {
+        await source.set(SOURCE_KEY, '42', 'PX', 60_000)
+        await target.set(SOURCE_KEY, '7', 'PX', 30_000)
+        await target.set(EXTRA_KEY, '1', 'PX', 60_000)
+
+        const summary = await runCdpMigration(
+            source,
+            target,
+            options({ phase: 'verify', execute: false, ttlToleranceMs: 100 })
+        )
+
+        expect(summary).toMatchObject({ mismatchedValues: 1, mismatchedExpiries: 1, extraTargetKeys: 1 })
+        expect(migrationHasMismatches(summary)).toBe(true)
+    })
+
+    it('refuses to finalize without paused writers', async () => {
+        await expect(
+            runCdpMigration(source, target, options({ phase: 'finalize', writersPaused: false }))
+        ).rejects.toThrow('Finalization requires execute=true and writersPaused=true')
+    })
+
+    it('copies non-expiring watcher state', async () => {
+        await source.set(WATCHER_STATE_KEY, '12')
+
+        const summary = await runCdpMigration(source, target, options())
+
+        expect(summary).toMatchObject({ copiedKeys: 1, skippedExpiredKeys: 0 })
+        await expect(target.get(WATCHER_STATE_KEY)).resolves.toBe('12')
+        await expect(target.pttl(WATCHER_STATE_KEY)).resolves.toBe(-1)
+    })
+
+    it('copies watcher hash values with their absolute expiry', async () => {
+        await source.hset(WATCHER_TOKENS_KEY, { pool: '42', ts: '1234' })
+        await source.pexpire(WATCHER_TOKENS_KEY, 60_000)
+
+        await runCdpMigration(source, target, options())
+        const [sourceTtl, targetTtl] = await Promise.all([
+            source.pttl(WATCHER_TOKENS_KEY),
+            target.pttl(WATCHER_TOKENS_KEY),
+        ])
+
+        await expect(target.hgetall(WATCHER_TOKENS_KEY)).resolves.toEqual({ pool: '42', ts: '1234' })
+        expect(Math.abs(sourceTtl - targetTtl)).toBeLessThan(500)
+    })
+})

--- a/nodejs/src/cdp/scripts/cdp-valkey-migration.ts
+++ b/nodejs/src/cdp/scripts/cdp-valkey-migration.ts
@@ -1,0 +1,200 @@
+import { Redis } from 'ioredis'
+
+type DumpBufferPipeline = ReturnType<Redis['pipeline']> & {
+    dumpBuffer(key: string): ReturnType<Redis['pipeline']>
+}
+
+export type MigrationPhase = 'copy' | 'finalize' | 'verify'
+
+export type CdpMigrationOptions = {
+    phase: MigrationPhase
+    execute: boolean
+    writersPaused: boolean
+    scanCount: number
+    ttlToleranceMs: number
+    keyPatterns: string[]
+}
+
+export type MigrationSummary = {
+    sourceKeys: number
+    copiedKeys: number
+    skippedExpiredKeys: number
+    deletedExtraKeys: number
+    mismatchedValues: number
+    mismatchedExpiries: number
+    missingTargetKeys: number
+    extraTargetKeys: number
+}
+
+export function emptyMigrationSummary(): MigrationSummary {
+    return {
+        sourceKeys: 0,
+        copiedKeys: 0,
+        skippedExpiredKeys: 0,
+        deletedExtraKeys: 0,
+        mismatchedValues: 0,
+        mismatchedExpiries: 0,
+        missingTargetKeys: 0,
+        extraTargetKeys: 0,
+    }
+}
+
+async function* scanBatches(redis: Redis, keyPatterns: string[], count: number): AsyncGenerator<string[]> {
+    for (const keyPattern of keyPatterns) {
+        let cursor = '0'
+        do {
+            const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', keyPattern, 'COUNT', count)
+            cursor = nextCursor
+            if (keys.length > 0) {
+                yield keys
+            }
+        } while (cursor !== '0')
+    }
+}
+
+function sourceTimeMs([seconds, microseconds]: [string, string]): number {
+    return Number(seconds) * 1000 + Math.floor(Number(microseconds) / 1000)
+}
+
+export async function copyCdpKeys(
+    source: Redis,
+    target: Redis,
+    options: CdpMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.keyPatterns, options.scanCount)) {
+        summary.sourceKeys += keys.length
+        if (!options.execute) {
+            continue
+        }
+
+        const sourcePipeline = source.pipeline() as DumpBufferPipeline
+        for (const key of keys) {
+            sourcePipeline.dumpBuffer(key)
+            sourcePipeline.pttl(key)
+        }
+        const [time, rows] = await Promise.all([source.time(), sourcePipeline.exec()])
+        if (!rows) {
+            throw new Error('Source Redis pipeline returned no results')
+        }
+
+        const nowMs = sourceTimeMs(time)
+        const targetPipeline = target.pipeline()
+        keys.forEach((key, index) => {
+            const value = rows[index * 2]?.[1] as Buffer | null
+            const ttlMs = Number(rows[index * 2 + 1]?.[1])
+            if (value === null || ttlMs === -2) {
+                summary.skippedExpiredKeys++
+                return
+            }
+            if (ttlMs === -1) {
+                targetPipeline.restore(key, 0, value, 'REPLACE')
+            } else if (ttlMs > 0) {
+                targetPipeline.restore(key, nowMs + ttlMs, value, 'ABSTTL', 'REPLACE')
+            } else {
+                summary.skippedExpiredKeys++
+                return
+            }
+            summary.copiedKeys++
+        })
+        await targetPipeline.exec()
+    }
+}
+
+export async function deleteTargetExtras(
+    source: Redis,
+    target: Redis,
+    options: CdpMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(target, options.keyPatterns, options.scanCount)) {
+        const existsPipeline = source.pipeline()
+        keys.forEach((key) => existsPipeline.exists(key))
+        const rows = await existsPipeline.exec()
+        if (!rows) {
+            throw new Error('Source Redis existence pipeline returned no results')
+        }
+        const extras = keys.filter((_, index) => Number(rows[index]?.[1]) === 0)
+        summary.extraTargetKeys += extras.length
+        if (options.execute && extras.length > 0) {
+            summary.deletedExtraKeys += await target.del(...extras)
+        }
+    }
+}
+
+export async function verifyCdpKeys(
+    source: Redis,
+    target: Redis,
+    options: CdpMigrationOptions,
+    summary: MigrationSummary
+): Promise<void> {
+    for await (const keys of scanBatches(source, options.keyPatterns, options.scanCount)) {
+        const sourcePipeline = source.pipeline() as DumpBufferPipeline
+        const targetPipeline = target.pipeline() as DumpBufferPipeline
+        for (const key of keys) {
+            sourcePipeline.dumpBuffer(key)
+            sourcePipeline.pttl(key)
+            targetPipeline.dumpBuffer(key)
+            targetPipeline.pttl(key)
+        }
+        const [sourceRows, targetRows] = await Promise.all([sourcePipeline.exec(), targetPipeline.exec()])
+        if (!sourceRows || !targetRows) {
+            throw new Error('Verification pipeline returned no results')
+        }
+        keys.forEach((_, index) => {
+            const sourceValue = sourceRows[index * 2]?.[1] as Buffer | null
+            const sourceTtl = Number(sourceRows[index * 2 + 1]?.[1])
+            const targetValue = targetRows[index * 2]?.[1] as Buffer | null
+            const targetTtl = Number(targetRows[index * 2 + 1]?.[1])
+            if (sourceValue === null || sourceTtl === -2) {
+                return
+            }
+            if (targetValue === null) {
+                summary.missingTargetKeys++
+                return
+            }
+            if (!sourceValue.equals(targetValue)) {
+                summary.mismatchedValues++
+            }
+            const expiryMismatch =
+                sourceTtl === -1 || targetTtl === -1
+                    ? sourceTtl !== targetTtl
+                    : Math.abs(sourceTtl - targetTtl) > options.ttlToleranceMs
+            if (expiryMismatch) {
+                summary.mismatchedExpiries++
+            }
+        })
+    }
+    await deleteTargetExtras(source, target, { ...options, execute: false }, summary)
+}
+
+export function migrationHasMismatches(summary: MigrationSummary): boolean {
+    return Boolean(
+        summary.mismatchedValues ||
+            summary.mismatchedExpiries ||
+            summary.missingTargetKeys ||
+            summary.extraTargetKeys - summary.deletedExtraKeys > 0
+    )
+}
+
+export async function runCdpMigration(
+    source: Redis,
+    target: Redis,
+    options: CdpMigrationOptions
+): Promise<MigrationSummary> {
+    if (options.phase === 'finalize' && (!options.execute || !options.writersPaused)) {
+        throw new Error('Finalization requires execute=true and writersPaused=true')
+    }
+
+    const summary = emptyMigrationSummary()
+    if (options.phase === 'copy' || options.phase === 'finalize') {
+        await copyCdpKeys(source, target, options, summary)
+    }
+    if (options.phase === 'finalize') {
+        await deleteTargetExtras(source, target, options, summary)
+    }
+    if (options.phase === 'verify' || options.phase === 'finalize') {
+        await verifyCdpKeys(source, target, options, summary)
+    }
+    return summary
+}

--- a/nodejs/src/cdp/scripts/cdp-valkey-migration.ts
+++ b/nodejs/src/cdp/scripts/cdp-valkey-migration.ts
@@ -6,10 +6,26 @@ type DumpBufferPipeline = ReturnType<Redis['pipeline']> & {
 
 export type MigrationPhase = 'copy' | 'finalize' | 'verify'
 
+export const CDP_MIGRATION_KEY_GROUPS = {
+    'hog-masker': ['@posthog/hog-masker/mask/*'],
+    'hog-watcher': [
+        '@posthog/hog-watcher-2/state/*',
+        '@posthog/hog-watcher-2/tokens/*',
+        '@posthog/hog-watcher-2/state-lock/*',
+    ],
+} as const
+
+export type CdpMigrationKeyGroup = keyof typeof CDP_MIGRATION_KEY_GROUPS
+
+export function keyPatternsForGroups(groups: CdpMigrationKeyGroup[]): string[] {
+    return [...new Set(groups.flatMap((group) => CDP_MIGRATION_KEY_GROUPS[group]))]
+}
+
 export type CdpMigrationOptions = {
     phase: MigrationPhase
     execute: boolean
     writersPaused: boolean
+    requireWritersPaused: boolean
     scanCount: number
     ttlToleranceMs: number
     keyPatterns: string[]
@@ -182,8 +198,11 @@ export async function runCdpMigration(
     target: Redis,
     options: CdpMigrationOptions
 ): Promise<MigrationSummary> {
-    if (options.phase === 'finalize' && (!options.execute || !options.writersPaused)) {
-        throw new Error('Finalization requires execute=true and writersPaused=true')
+    if (options.phase === 'finalize' && !options.execute) {
+        throw new Error('Finalization requires execute=true')
+    }
+    if (options.phase === 'finalize' && options.requireWritersPaused && !options.writersPaused) {
+        throw new Error('Finalization for the selected key groups requires writersPaused=true')
     }
 
     const summary = emptyMigrationSummary()

--- a/nodejs/src/cdp/scripts/migrate-cdp-redis-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-cdp-redis-to-valkey.ts
@@ -1,0 +1,102 @@
+import IORedis, { Redis } from 'ioredis'
+import { parseArgs } from 'node:util'
+
+import {
+    CdpMigrationOptions,
+    MigrationPhase,
+    migrationHasMismatches,
+    runCdpMigration,
+} from './cdp-valkey-migration'
+
+const KEY_PATTERNS = [
+    '@posthog/hog-masker/mask/*',
+    '@posthog/hog-watcher-2/state/*',
+    '@posthog/hog-watcher-2/tokens/*',
+    '@posthog/hog-watcher-2/state-lock/*',
+]
+
+function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
+    const host = process.env[`${prefix}_HOST`]
+    if (!host) {
+        throw new Error(`${prefix}_HOST is required`)
+    }
+    const port = Number(process.env[`${prefix}_PORT`] || '6379')
+    const password = process.env[`${prefix}_PASSWORD`] || undefined
+    const tls = process.env[`${prefix}_TLS`] === 'true' ? {} : undefined
+    return new IORedis({ host, port, password, tls, lazyConnect: true, maxRetriesPerRequest: 3 })
+}
+
+function parseOptions(): CdpMigrationOptions {
+    const { values } = parseArgs({
+        options: {
+            phase: { type: 'string', default: 'copy' },
+            execute: { type: 'boolean', default: false },
+            'writers-paused': { type: 'boolean', default: false },
+            'scan-count': { type: 'string', default: '500' },
+            'ttl-tolerance-ms': { type: 'string', default: '2000' },
+            help: { type: 'boolean', default: false },
+        },
+    })
+    if (values.help) {
+        console.log(`Usage: migrate-cdp-redis-to-valkey [options]
+
+  --phase copy       Copy source keys while Redis remains authoritative (default)
+  --phase finalize   Exact copy and remove target-only keys; requires paused writers
+  --phase verify     Compare values and expiries without writing
+  --execute          Apply changes; omitted means dry-run
+  --writers-paused   Confirm every HogMasker and HogWatcher writer is paused
+  --scan-count N     Redis SCAN batch size (default: 500)
+  --ttl-tolerance-ms N  Allowed expiry difference during verify (default: 2000)
+
+Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
+        process.exit(0)
+    }
+    if (!['copy', 'finalize', 'verify'].includes(values.phase)) {
+        throw new Error(`Invalid --phase: ${values.phase}`)
+    }
+    const scanCount = Number(values['scan-count'])
+    const ttlToleranceMs = Number(values['ttl-tolerance-ms'])
+    if (!Number.isInteger(scanCount) || scanCount < 1 || !Number.isFinite(ttlToleranceMs) || ttlToleranceMs < 0) {
+        throw new Error('Scan count must be a positive integer and TTL tolerance must be non-negative')
+    }
+    return {
+        phase: values.phase as MigrationPhase,
+        execute: values.execute,
+        writersPaused: values['writers-paused'],
+        scanCount,
+        ttlToleranceMs,
+        keyPatterns: KEY_PATTERNS,
+    }
+}
+
+async function main(): Promise<void> {
+    const options = parseOptions()
+    const sourceHost = process.env.CDP_REDIS_HOST
+    const targetHost = process.env.CDP_VALKEY_HOST
+    if (
+        sourceHost === targetHost &&
+        (process.env.CDP_REDIS_PORT || '6379') === (process.env.CDP_VALKEY_PORT || '6379')
+    ) {
+        throw new Error('Source Redis and target Valkey must be different endpoints')
+    }
+    const source = connectionFromEnv('CDP_REDIS')
+    const target = connectionFromEnv('CDP_VALKEY')
+    try {
+        await Promise.all([source.connect(), target.connect()])
+        await Promise.all([source.ping(), target.ping()])
+        const summary = await runCdpMigration(source, target, options)
+        console.log(
+            JSON.stringify({ phase: options.phase, dryRun: !options.execute, patterns: options.keyPatterns, ...summary })
+        )
+        if (migrationHasMismatches(summary)) {
+            process.exitCode = 2
+        }
+    } finally {
+        await Promise.allSettled([source.quit(), target.quit()])
+    }
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+})

--- a/nodejs/src/cdp/scripts/migrate-cdp-redis-to-valkey.ts
+++ b/nodejs/src/cdp/scripts/migrate-cdp-redis-to-valkey.ts
@@ -2,18 +2,14 @@ import IORedis, { Redis } from 'ioredis'
 import { parseArgs } from 'node:util'
 
 import {
+    CDP_MIGRATION_KEY_GROUPS,
     CdpMigrationOptions,
+    CdpMigrationKeyGroup,
     MigrationPhase,
+    keyPatternsForGroups,
     migrationHasMismatches,
     runCdpMigration,
 } from './cdp-valkey-migration'
-
-const KEY_PATTERNS = [
-    '@posthog/hog-masker/mask/*',
-    '@posthog/hog-watcher-2/state/*',
-    '@posthog/hog-watcher-2/tokens/*',
-    '@posthog/hog-watcher-2/state-lock/*',
-]
 
 function connectionFromEnv(prefix: 'CDP_REDIS' | 'CDP_VALKEY'): Redis {
     const host = process.env[`${prefix}_HOST`]
@@ -30,6 +26,7 @@ function parseOptions(): CdpMigrationOptions {
     const { values } = parseArgs({
         options: {
             phase: { type: 'string', default: 'copy' },
+            group: { type: 'string', multiple: true, default: ['all'] },
             execute: { type: 'boolean', default: false },
             'writers-paused': { type: 'boolean', default: false },
             'scan-count': { type: 'string', default: '500' },
@@ -41,19 +38,40 @@ function parseOptions(): CdpMigrationOptions {
         console.log(`Usage: migrate-cdp-redis-to-valkey [options]
 
   --phase copy       Copy source keys while Redis remains authoritative (default)
-  --phase finalize   Exact copy and remove target-only keys; requires paused writers
+  --phase finalize   Exact copy, remove target-only keys, and verify
   --phase verify     Compare values and expiries without writing
+  --group NAME       Key group to migrate: hog-watcher, hog-masker, or all (default)
+                     May be repeated to select multiple groups
   --execute          Apply changes; omitted means dry-run
-  --writers-paused   Confirm every HogMasker and HogWatcher writer is paused
+  --writers-paused   Confirm writers are paused (required when hog-masker is selected)
   --scan-count N     Redis SCAN batch size (default: 500)
   --ttl-tolerance-ms N  Allowed expiry difference during verify (default: 2000)
 
-Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
+Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).
+
+Examples:
+  --group hog-watcher --phase verify
+      Check watcher parity without writing.
+  --group hog-watcher --phase finalize --execute
+      One-shot live watcher migration; watcher state is operational and recoverable.
+  --group hog-masker --phase finalize --execute --writers-paused
+      Finalize sensitive masker history after pausing all writers.`)
         process.exit(0)
     }
     if (!['copy', 'finalize', 'verify'].includes(values.phase)) {
         throw new Error(`Invalid --phase: ${values.phase}`)
     }
+    const requestedGroups = values.group ?? ['all']
+    const availableGroups = Object.keys(CDP_MIGRATION_KEY_GROUPS) as CdpMigrationKeyGroup[]
+    const invalidGroups = requestedGroups.filter(
+        (group): group is string => group !== 'all' && !availableGroups.includes(group as CdpMigrationKeyGroup)
+    )
+    if (invalidGroups.length > 0) {
+        throw new Error(`Invalid --group: ${invalidGroups.join(', ')}`)
+    }
+    const groups = requestedGroups.includes('all')
+        ? availableGroups
+        : [...new Set(requestedGroups as CdpMigrationKeyGroup[])]
     const scanCount = Number(values['scan-count'])
     const ttlToleranceMs = Number(values['ttl-tolerance-ms'])
     if (!Number.isInteger(scanCount) || scanCount < 1 || !Number.isFinite(ttlToleranceMs) || ttlToleranceMs < 0) {
@@ -63,9 +81,10 @@ Connections come from CDP_REDIS_* (source) and CDP_VALKEY_* (target).`)
         phase: values.phase as MigrationPhase,
         execute: values.execute,
         writersPaused: values['writers-paused'],
+        requireWritersPaused: groups.includes('hog-masker'),
         scanCount,
         ttlToleranceMs,
-        keyPatterns: KEY_PATTERNS,
+        keyPatterns: keyPatternsForGroups(groups),
     }
 }
 

--- a/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.ts
@@ -8,7 +8,7 @@ import { captureException } from '~/common/utils/posthog'
 import { RedisV2 } from '../../common/redis/redis-v2'
 import { KeyedRateLimitRequest, KeyedRateLimiterService } from '../../common/services/keyed-rate-limiter.service'
 import { QuotaLimiting } from '../../common/services/quota-limiting.service'
-import { CdpValkeyShadowPools } from '../cdp-services'
+import { CdpValkeyShadowPools, routeSafeCdpRedis } from '../cdp-services'
 import { counterRateLimited } from '../consumers/metrics'
 import { CyclotronJobInvocation, HogFunctionInvocationGlobals, LogEntry, MinimalAppMetric } from '../types'
 import { mirrorCompare } from '../utils/mirror-call'
@@ -23,6 +23,7 @@ export interface HogFlowInvocationPipelineConfig {
     CDP_RATE_LIMITER_BUCKET_SIZE: number
     CDP_RATE_LIMITER_REFILL_RATE: number
     CDP_RATE_LIMITER_TTL: number
+    CDP_VALKEY_SAFE_PRIMARY_ENABLED: boolean
 }
 
 export interface HogFlowInvocationPipelineDeps {
@@ -57,10 +58,13 @@ export class HogFlowInvocationPipeline {
             refillRate: config.CDP_RATE_LIMITER_REFILL_RATE,
             ttlSeconds: config.CDP_RATE_LIMITER_TTL,
         }
-        this.hogRateLimiter = new KeyedRateLimiterService(rateLimiterConfig, deps.redis)
-        this.hogRateLimiterMirror = deps.valkeyShadow
-            ? new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
-            : null
+        const { primary, mirror } = routeSafeCdpRedis(
+            config.CDP_VALKEY_SAFE_PRIMARY_ENABLED,
+            deps.redis,
+            deps.valkeyShadow
+        )
+        this.hogRateLimiter = new KeyedRateLimiterService(rateLimiterConfig, primary)
+        this.hogRateLimiterMirror = mirror ? new KeyedRateLimiterService(rateLimiterConfig, mirror) : null
     }
 
     @instrumented('cdpConsumer.handleEachBatch.queueMatchingFlows')

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -5,7 +5,7 @@ import { captureException } from '~/common/utils/posthog'
 import { RedisV2 } from '../../common/redis/redis-v2'
 import { KeyedRateLimitRequest, KeyedRateLimiterService } from '../../common/services/keyed-rate-limiter.service'
 import { QuotaLimiting } from '../../common/services/quota-limiting.service'
-import { CdpValkeyShadowPools } from '../cdp-services'
+import { CdpValkeyShadowPools, routeSafeCdpRedis } from '../cdp-services'
 import { counterHogFunctionStateOnEvent, counterRateLimited } from '../consumers/metrics'
 import { shouldBlockInvocationDueToQuota } from '../consumers/quota-limiting-helper'
 import {
@@ -26,6 +26,7 @@ export interface HogFunctionInvocationPipelineConfig {
     CDP_RATE_LIMITER_BUCKET_SIZE: number
     CDP_RATE_LIMITER_REFILL_RATE: number
     CDP_RATE_LIMITER_TTL: number
+    CDP_VALKEY_SAFE_PRIMARY_ENABLED: boolean
     CDP_OVERFLOW_QUEUE_ENABLED: boolean
 }
 
@@ -66,10 +67,13 @@ export class HogFunctionInvocationPipeline {
             refillRate: config.CDP_RATE_LIMITER_REFILL_RATE,
             ttlSeconds: config.CDP_RATE_LIMITER_TTL,
         }
-        this.hogRateLimiter = new KeyedRateLimiterService(rateLimiterConfig, deps.redis)
-        this.hogRateLimiterMirror = deps.valkeyShadow
-            ? new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
-            : null
+        const { primary, mirror } = routeSafeCdpRedis(
+            config.CDP_VALKEY_SAFE_PRIMARY_ENABLED,
+            deps.redis,
+            deps.valkeyShadow
+        )
+        this.hogRateLimiter = new KeyedRateLimiterService(rateLimiterConfig, primary)
+        this.hogRateLimiterMirror = mirror ? new KeyedRateLimiterService(rateLimiterConfig, mirror) : null
     }
 
     @instrumented('cdpConsumer.handleEachBatch.queueMatchingFunctions')


### PR DESCRIPTION
## Problem

HogWatcher contains non-expiring state and HogMasker can retain suppression history for years, so those families cannot safely switch to Valkey without an exact migration.

## Changes

- Add a dry-run-first migration CLI for masker and watcher key families.
- Allow `hog-watcher`, `hog-masker`, repeated groups, or `all` to be migrated independently.
- Preserve arbitrary Redis value types, absolute expiries, and non-expiring keys with `DUMP`/`RESTORE`.
- Support online copy, target-only cleanup, and value/expiry verification; watcher-only migration may finalize live, while masker finalization requires paused writers.
- Add `CDP_VALKEY_STATEFUL_PRIMARY_ENABLED`, guarded by Valkey configuration and an explicit startup warning.

> [!WARNING]
> Do not enable the stateful-primary switch until the selected migrations have completed `finalize` and verification reports no mismatches. HogMasker finalization requires paused writers; HogWatcher can finalize live.

**Why:** Masking history and manually forced watcher states must remain exact through the cutover.

Stacked on [#76595](https://github.com/PostHog/posthog/pull/76595). HogTransformer remains deferred.

## How did you test this code?

Nine Redis-backed migration tests cover dry-run safety, independent group selection, live watcher finalization, string and hash copying, expiring and non-expiring keys, final cleanup, mismatch detection, and masker writer-pause enforcement. The CLI help path, ESLint, and diff checks also pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change. Operational usage is available through `pnpm --dir nodejs run migrate:cdp-redis-valkey --help`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The migration covers `@posthog/hog-masker/mask/*` plus HogWatcher state, token, and lock prefixes. The CLI can target either family independently. Running it never changes the deployment's primary-store setting.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
