### PR TITLE
perf(desktop): move terminal scrollback off synchronous localStorage

### DIFF
--- a/products/desktop/apps/code/src/renderer/main.tsx
+++ b/products/desktop/apps/code/src/renderer/main.tsx
@@ -21,6 +21,7 @@ import { preloadHighlighter } from "@pierre/diffs";
 import { boot } from "@posthog/di/contribution";
 import { assertHostCapabilities } from "@posthog/di/hostCapabilities";
 import { ServiceProvider } from "@posthog/di/react";
+import { hydrateTerminalScrollback } from "@posthog/ui/features/terminal/terminalScrollback";
 import App from "@posthog/ui/shell/App";
 import { logger } from "@posthog/ui/shell/logger";
 import { initializePostHog } from "@posthog/ui/shell/posthogAnalyticsImpl";
@@ -31,6 +32,8 @@ import "@renderer/desktop-services";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "@posthog/ui/styles/globals.css";
+
+void hydrateTerminalScrollback();
 
 void preloadHighlighter({
   themes: ["github-dark", "github-light"],

--- a/products/desktop/packages/ui/src/features/terminal/ShellTerminal.test.tsx
+++ b/products/desktop/packages/ui/src/features/terminal/ShellTerminal.test.tsx
@@ -1,0 +1,60 @@
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { renderSpy } = vi.hoisted(() => ({ renderSpy: vi.fn() }));
+
+vi.mock("./Terminal", () => ({
+  Terminal: (props: Record<string, unknown>) => {
+    renderSpy(props);
+    return null;
+  },
+}));
+
+vi.mock("@posthog/ui/features/terminal/terminalScrollback", () => ({
+  removeScrollback: vi.fn(),
+  removeScrollbackForTask: vi.fn(),
+}));
+
+import { ShellTerminal } from "./ShellTerminal";
+import { useTerminalStore } from "./terminalStore";
+
+describe("ShellTerminal", () => {
+  beforeEach(() => {
+    renderSpy.mockClear();
+    useTerminalStore.setState({ terminalStates: {} });
+  });
+
+  it("does not pass scrollback through React props", () => {
+    render(<ShellTerminal stateKey="task-1-shell" cwd="/repo" />);
+
+    expect(renderSpy).toHaveBeenCalled();
+    expect(renderSpy.mock.calls[0][0]).not.toHaveProperty("initialState");
+    expect(renderSpy.mock.calls[0][0]).toMatchObject({
+      persistenceKey: "task-1-shell",
+      cwd: "/repo",
+    });
+  });
+
+  it("does not re-render when unrelated terminal state changes", () => {
+    render(<ShellTerminal stateKey="task-1-shell" cwd="/repo" />);
+    const initialRenders = renderSpy.mock.calls.length;
+
+    act(() => {
+      useTerminalStore.getState().setProcessName("task-2-shell", "vim");
+      useTerminalStore.getState().setSessionId("task-2-shell", "other-session");
+    });
+
+    expect(renderSpy.mock.calls.length).toBe(initialRenders);
+  });
+
+  it("does not re-render when its own process name changes", () => {
+    render(<ShellTerminal stateKey="task-1-shell" cwd="/repo" />);
+    const initialRenders = renderSpy.mock.calls.length;
+
+    act(() => {
+      useTerminalStore.getState().setProcessName("task-1-shell", "vim");
+    });
+
+    expect(renderSpy.mock.calls.length).toBe(initialRenders);
+  });
+});

--- a/products/desktop/packages/ui/src/features/terminal/ShellTerminal.tsx
+++ b/products/desktop/packages/ui/src/features/terminal/ShellTerminal.tsx
@@ -12,25 +12,24 @@ interface ShellTerminalProps {
 export function ShellTerminal({ cwd, stateKey, taskId }: ShellTerminalProps) {
   const persistenceKey = stateKey || cwd || "default";
 
-  const savedState = useTerminalStore(
-    (state) => state.terminalStates[persistenceKey],
+  const savedSessionId = useTerminalStore(
+    (state) => state.terminalStates[persistenceKey]?.sessionId,
   );
 
   const sessionId = useMemo(() => {
-    if (savedState?.sessionId) {
-      return savedState.sessionId;
+    if (savedSessionId) {
+      return savedSessionId;
     }
     const newId = `shell-${Date.now()}-${secureRandomString(7)}`;
     useTerminalStore.getState().setSessionId(persistenceKey, newId);
     return newId;
-  }, [savedState?.sessionId, persistenceKey]);
+  }, [savedSessionId, persistenceKey]);
 
   return (
     <Terminal
       sessionId={sessionId}
       persistenceKey={persistenceKey}
       cwd={cwd}
-      initialState={savedState?.serializedState ?? undefined}
       taskId={taskId}
     />
   );

--- a/products/desktop/packages/ui/src/features/terminal/Terminal.tsx
+++ b/products/desktop/packages/ui/src/features/terminal/Terminal.tsx
@@ -16,7 +16,6 @@ export interface TerminalProps {
   sessionId: string;
   persistenceKey: string;
   cwd?: string;
-  initialState?: string;
   taskId?: string;
   command?: string;
   onReady?: () => void;
@@ -27,7 +26,6 @@ export function Terminal({
   sessionId,
   persistenceKey,
   cwd,
-  initialState,
   taskId,
   command,
   onReady,
@@ -49,12 +47,11 @@ export function Terminal({
         sessionId,
         persistenceKey,
         cwd,
-        initialState,
         taskId,
         command,
       });
     }
-  }, [sessionId, persistenceKey, cwd, initialState, taskId, command]);
+  }, [sessionId, persistenceKey, cwd, taskId, command]);
 
   // Attach/detach from DOM
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/terminal/TerminalManager.test.ts
+++ b/products/desktop/packages/ui/src/features/terminal/TerminalManager.test.ts
@@ -10,6 +10,11 @@ const mocks = vi.hoisted(() => {
   const logInfo = vi.fn();
   const logError = vi.fn();
   const logWarn = vi.fn();
+  const serialize = vi.fn(() => "serialized-terminal-state");
+  const getScrollback = vi.fn(() => undefined as string | undefined);
+  const setScrollback = vi.fn();
+  const isScrollbackReady = vi.fn(() => true);
+  const whenScrollbackReady = vi.fn(() => Promise.resolve());
 
   class MockTerminal {
     cols = 80;
@@ -58,6 +63,11 @@ const mocks = vi.hoisted(() => {
     logInfo,
     logError,
     logWarn,
+    serialize,
+    getScrollback,
+    setScrollback,
+    isScrollbackReady,
+    whenScrollbackReady,
     MockTerminal,
     terminalInstances,
   };
@@ -96,8 +106,17 @@ vi.mock("@xterm/addon-fit", () => ({
 
 vi.mock("@xterm/addon-serialize", () => ({
   SerializeAddon: class {
-    serialize = vi.fn(() => "serialized-terminal-state");
+    serialize = mocks.serialize;
   },
+}));
+
+vi.mock("@posthog/ui/features/terminal/terminalScrollback", () => ({
+  getScrollback: mocks.getScrollback,
+  setScrollback: mocks.setScrollback,
+  isScrollbackReady: mocks.isScrollbackReady,
+  whenScrollbackReady: mocks.whenScrollbackReady,
+  SERIALIZE_SCROLLBACK_LINES: 400,
+  TERMINAL_SCROLLBACK_LINES: 1000,
 }));
 
 vi.mock("@xterm/addon-web-links", () => ({
@@ -129,6 +148,11 @@ describe("TerminalManager shell recovery", () => {
     mocks.openExternal.mockReset();
     mocks.logInfo.mockReset();
     mocks.logError.mockReset();
+    mocks.isScrollbackReady.mockReset().mockReturnValue(true);
+    mocks.whenScrollbackReady.mockReset().mockResolvedValue(undefined);
+    mocks.serialize.mockReset().mockReturnValue("serialized-terminal-state");
+    mocks.getScrollback.mockReset().mockReturnValue(undefined);
+    mocks.setScrollback.mockReset();
     mocks.terminalInstances.length = 0;
 
     mocks.check.mockResolvedValue(true);
@@ -186,6 +210,11 @@ describe("TerminalManager.destroyForTask", () => {
     mocks.create.mockReset().mockResolvedValue(undefined);
     mocks.write.mockReset().mockResolvedValue(undefined);
     mocks.resize.mockReset().mockResolvedValue(undefined);
+    mocks.isScrollbackReady.mockReset().mockReturnValue(true);
+    mocks.whenScrollbackReady.mockReset().mockResolvedValue(undefined);
+    mocks.serialize.mockReset().mockReturnValue("serialized-terminal-state");
+    mocks.getScrollback.mockReset().mockReturnValue(undefined);
+    mocks.setScrollback.mockReset();
     mocks.terminalInstances.length = 0;
     vi.stubGlobal(
       "ResizeObserver",
@@ -275,6 +304,11 @@ describe("TerminalManager custom key handling", () => {
     mocks.create.mockReset().mockResolvedValue(undefined);
     mocks.write.mockReset().mockResolvedValue(undefined);
     mocks.resize.mockReset().mockResolvedValue(undefined);
+    mocks.isScrollbackReady.mockReset().mockReturnValue(true);
+    mocks.whenScrollbackReady.mockReset().mockResolvedValue(undefined);
+    mocks.serialize.mockReset().mockReturnValue("serialized-terminal-state");
+    mocks.getScrollback.mockReset().mockReturnValue(undefined);
+    mocks.setScrollback.mockReset();
     mocks.terminalInstances.length = 0;
   });
 
@@ -326,5 +360,147 @@ describe("TerminalManager custom key handling", () => {
     expect(result).toBe(false);
     expect(event.stopPropagation).not.toHaveBeenCalled();
     expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalManager scrollback persistence", () => {
+  const sessionId = "shell-scrollback-test";
+  const persistenceKey = "task-1-shell";
+
+  beforeEach(() => {
+    mocks.check.mockReset().mockResolvedValue(true);
+    mocks.create.mockReset().mockResolvedValue(undefined);
+    mocks.createCommand.mockReset().mockResolvedValue(undefined);
+    mocks.write.mockReset().mockResolvedValue(undefined);
+    mocks.resize.mockReset().mockResolvedValue(undefined);
+    mocks.setScrollback.mockReset();
+    mocks.getScrollback.mockReset().mockReturnValue(undefined);
+    mocks.serialize.mockReset().mockReturnValue("serialized-terminal-state");
+    mocks.isScrollbackReady.mockReset().mockReturnValue(true);
+    mocks.whenScrollbackReady.mockReset().mockResolvedValue(undefined);
+    mocks.terminalInstances.length = 0;
+  });
+
+  afterEach(() => {
+    terminalManager.destroy(sessionId);
+    vi.useRealTimers();
+  });
+
+  it("bounds the xterm scrollback buffer", () => {
+    terminalManager.create({ sessionId, persistenceKey, cwd: "/repo" });
+
+    expect(mocks.terminalInstances[0].options.scrollback).toBe(1000);
+  });
+
+  it("restores saved scrollback on create", () => {
+    mocks.getScrollback.mockReturnValue("restored-scrollback");
+
+    terminalManager.create({ sessionId, persistenceKey, cwd: "/repo" });
+
+    expect(mocks.getScrollback).toHaveBeenCalledWith(persistenceKey);
+    expect(mocks.terminalInstances[0].write).toHaveBeenCalledWith(
+      "restored-scrollback",
+    );
+  });
+
+  it("writes restored scrollback before live output when hydration is still pending", async () => {
+    let releaseHydration!: () => void;
+    mocks.isScrollbackReady.mockReturnValue(false);
+    mocks.whenScrollbackReady.mockReturnValue(
+      new Promise<void>((resolve) => {
+        releaseHydration = resolve;
+      }),
+    );
+    mocks.getScrollback.mockReturnValue("restored-scrollback");
+
+    terminalManager.create({ sessionId, persistenceKey, cwd: "/repo" });
+    const term = mocks.terminalInstances[0];
+
+    terminalManager.writeData(sessionId, "live-output");
+    await vi.waitFor(() => {
+      expect(term.write).not.toHaveBeenCalled();
+    });
+
+    releaseHydration();
+    await vi.waitFor(() => {
+      expect(term.write).toHaveBeenCalledTimes(2);
+    });
+
+    expect(term.write.mock.calls.map((call) => call[0])).toEqual([
+      "restored-scrollback",
+      "live-output",
+    ]);
+  });
+
+  it("persists a bounded serialization after the debounce", () => {
+    vi.useFakeTimers();
+    terminalManager.create({ sessionId, persistenceKey, cwd: "/repo" });
+
+    mocks.terminalInstances[0].emitData("a");
+    expect(mocks.setScrollback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+
+    expect(mocks.serialize).toHaveBeenCalledWith({ scrollback: 400 });
+    expect(mocks.setScrollback).toHaveBeenCalledWith(
+      persistenceKey,
+      "serialized-terminal-state",
+    );
+  });
+
+  it("skips the serialize walk when nothing changed since the last save", () => {
+    vi.useFakeTimers();
+    terminalManager.create({ sessionId, persistenceKey, cwd: "/repo" });
+
+    mocks.terminalInstances[0].emitData("a");
+    vi.advanceTimersByTime(1000);
+    expect(mocks.serialize).toHaveBeenCalledTimes(1);
+
+    terminalManager.detach(sessionId);
+    vi.advanceTimersByTime(1000);
+
+    expect(mocks.serialize).toHaveBeenCalledTimes(1);
+  });
+
+  it("never persists scrollback for a command session", () => {
+    vi.useFakeTimers();
+    terminalManager.create({
+      sessionId,
+      persistenceKey,
+      cwd: "/repo",
+      command: "pnpm test",
+    });
+
+    mocks.terminalInstances[0].emitData("a");
+    vi.advanceTimersByTime(5000);
+
+    expect(mocks.getScrollback).not.toHaveBeenCalled();
+    expect(mocks.setScrollback).not.toHaveBeenCalled();
+  });
+
+  it("persists on detach", () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    terminalManager.create({ sessionId, persistenceKey, cwd: "/repo" });
+    terminalManager.attach(sessionId, element);
+
+    mocks.terminalInstances[0].emitData("a");
+    mocks.setScrollback.mockClear();
+
+    terminalManager.detach(sessionId);
+
+    expect(mocks.setScrollback).toHaveBeenCalledWith(
+      persistenceKey,
+      "serialized-terminal-state",
+    );
+    element.remove();
+    vi.unstubAllGlobals();
   });
 });

--- a/products/desktop/packages/ui/src/features/terminal/TerminalManager.ts
+++ b/products/desktop/packages/ui/src/features/terminal/TerminalManager.ts
@@ -5,6 +5,14 @@ import {
   SHELL_CLIENT,
   type ShellClient,
 } from "@posthog/ui/features/terminal/shellClient";
+import {
+  getScrollback,
+  isScrollbackReady,
+  SERIALIZE_SCROLLBACK_LINES,
+  setScrollback,
+  TERMINAL_SCROLLBACK_LINES,
+  whenScrollbackReady,
+} from "@posthog/ui/features/terminal/terminalScrollback";
 import { logger } from "@posthog/ui/shell/logger";
 import { isMac } from "@posthog/ui/utils/platform";
 import { FitAddon } from "@xterm/addon-fit";
@@ -49,6 +57,8 @@ export interface TerminalInstance {
   cleanups: Array<() => void>;
   resizeObserver: ResizeObserver | null;
   saveTimeout: number | null;
+  needsSave: boolean;
+  restorePending: boolean;
   persistenceKey: string;
   cwd?: string;
   taskId?: string;
@@ -60,7 +70,6 @@ export interface CreateOptions {
   sessionId: string;
   persistenceKey: string;
   cwd?: string;
-  initialState?: string;
   taskId?: string;
   command?: string;
 }
@@ -71,16 +80,10 @@ type ExitPayload = {
   persistenceKey: string;
   exitCode?: number;
 };
-type StateChangePayload = {
-  sessionId: string;
-  persistenceKey: string;
-  serializedState: string;
-};
 
 type EventPayloadMap = {
   ready: ReadyPayload;
   exit: ExitPayload;
-  stateChange: StateChangePayload;
 };
 
 type EventType = keyof EventPayloadMap;
@@ -184,8 +187,7 @@ class TerminalManagerImpl {
   }
 
   create(options: CreateOptions): TerminalInstance {
-    const { sessionId, persistenceKey, cwd, initialState, taskId, command } =
-      options;
+    const { sessionId, persistenceKey, cwd, taskId, command } = options;
 
     const existing = this.instances.get(sessionId);
     if (existing) {
@@ -200,6 +202,7 @@ class TerminalManagerImpl {
       cursorStyle: "block",
       cursorWidth: 8,
       allowProposedApi: true,
+      scrollback: TERMINAL_SCROLLBACK_LINES,
     });
 
     const { fit, serialize } = loadAddons(term);
@@ -219,6 +222,8 @@ class TerminalManagerImpl {
       cleanups: [],
       resizeObserver: null,
       saveTimeout: null,
+      needsSave: false,
+      restorePending: false,
       persistenceKey,
       cwd,
       taskId,
@@ -226,8 +231,19 @@ class TerminalManagerImpl {
       recoveryPromise: null,
     };
 
-    if (initialState) {
-      term.write(initialState);
+    if (!command) {
+      if (isScrollbackReady()) {
+        this.writeRestoredScrollback(instance);
+      } else {
+        // Hold buffered pty output back until the restored scrollback has been
+        // written, otherwise it would land after the live output.
+        instance.restorePending = true;
+        void whenScrollbackReady().then(() => {
+          instance.restorePending = false;
+          this.writeRestoredScrollback(instance);
+          this.flushWrite(instance);
+        });
+      }
     }
 
     // Setup user input handler
@@ -240,7 +256,8 @@ class TerminalManagerImpl {
             retryData: data,
           });
         });
-      this.scheduleSave(sessionId, instance);
+      instance.needsSave = true;
+      this.scheduleSave(instance);
     });
     instance.cleanups.push(() => disposable.dispose());
 
@@ -324,23 +341,31 @@ class TerminalManagerImpl {
     if (instance.flushHandle === null) {
       instance.flushHandle = requestAnimationFrame(() => {
         instance.flushHandle = null;
-        this.flushWrite(sessionId, instance);
+        this.flushWrite(instance);
       });
     }
   }
 
-  private flushWrite(sessionId: string, instance: TerminalInstance): void {
+  private writeRestoredScrollback(instance: TerminalInstance): void {
+    const restored = getScrollback(instance.persistenceKey);
+    if (restored) {
+      instance.term.write(restored);
+    }
+  }
+
+  private flushWrite(instance: TerminalInstance): void {
     if (instance.flushHandle !== null) {
       cancelAnimationFrame(instance.flushHandle);
       instance.flushHandle = null;
     }
-    if (instance.writeBuffer.length === 0) {
+    if (instance.restorePending || instance.writeBuffer.length === 0) {
       return;
     }
     const data = instance.writeBuffer;
     instance.writeBuffer = "";
     instance.term.write(data);
-    this.scheduleSave(sessionId, instance);
+    instance.needsSave = true;
+    this.scheduleSave(instance);
   }
 
   handleExit(sessionId: string, exitCode?: number): void {
@@ -426,19 +451,32 @@ class TerminalManagerImpl {
     return instance.recoveryPromise;
   }
 
-  private scheduleSave(sessionId: string, instance: TerminalInstance): void {
+  private scheduleSave(instance: TerminalInstance): void {
+    if (instance.command) {
+      return;
+    }
+
     if (instance.saveTimeout) {
       clearTimeout(instance.saveTimeout);
     }
 
     instance.saveTimeout = window.setTimeout(() => {
-      const serialized = instance.serializeAddon.serialize();
-      this.emit("stateChange", {
-        sessionId,
-        persistenceKey: instance.persistenceKey,
-        serializedState: serialized,
-      });
-    }, 500);
+      instance.saveTimeout = null;
+      this.saveScrollback(instance);
+    }, 1000);
+  }
+
+  private saveScrollback(instance: TerminalInstance): void {
+    if (instance.command || !instance.needsSave) {
+      return;
+    }
+    instance.needsSave = false;
+    setScrollback(
+      instance.persistenceKey,
+      instance.serializeAddon.serialize({
+        scrollback: SERIALIZE_SCROLLBACK_LINES,
+      }),
+    );
   }
 
   // The WebGL renderer must be loaded after term.open() — it needs the canvas
@@ -531,14 +569,13 @@ class TerminalManagerImpl {
     this.disconnectResizeObserver(instance);
 
     // Drain buffered output so the serialized snapshot reflects the latest data.
-    this.flushWrite(sessionId, instance);
+    this.flushWrite(instance);
 
-    const serialized = instance.serializeAddon.serialize();
-    this.emit("stateChange", {
-      sessionId,
-      persistenceKey: instance.persistenceKey,
-      serializedState: serialized,
-    });
+    if (instance.saveTimeout) {
+      clearTimeout(instance.saveTimeout);
+      instance.saveTimeout = null;
+    }
+    this.saveScrollback(instance);
 
     if (instance.terminalElement) {
       getParkingContainer().appendChild(instance.terminalElement);
@@ -624,7 +661,9 @@ class TerminalManagerImpl {
     if (!instance) {
       return null;
     }
-    return instance.serializeAddon.serialize();
+    return instance.serializeAddon.serialize({
+      scrollback: SERIALIZE_SCROLLBACK_LINES,
+    });
   }
 
   setTheme(isDarkMode: boolean): void {

--- a/products/desktop/packages/ui/src/features/terminal/terminalScrollback.test.ts
+++ b/products/desktop/packages/ui/src/features/terminal/terminalScrollback.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { logError } = vi.hoisted(() => ({ logError: vi.fn() }));
+
+vi.mock("@posthog/ui/shell/logger", () => ({
+  logger: {
+    scope: () => ({ info: vi.fn(), warn: vi.fn(), error: logError }),
+  },
+}));
+
+import {
+  clearScrollback,
+  flushScrollback,
+  getScrollback,
+  hydrateTerminalScrollback,
+  isScrollbackReady,
+  registerScrollbackBackend,
+  removeScrollback,
+  removeScrollbackForTask,
+  type ScrollbackBackend,
+  setScrollback,
+} from "./terminalScrollback";
+
+const MAX_ENTRY_BYTES = 128 * 1024;
+const MAX_ENTRIES = 32;
+const FLUSH_INTERVAL_MS = 3000;
+
+function createFakeBackend(initial: Record<string, string> = {}) {
+  const entries = new Map(Object.entries(initial));
+  return {
+    entries,
+    loadAll: vi.fn(async () => Object.fromEntries(entries)),
+    save: vi.fn(async (key: string, value: string) => {
+      entries.set(key, value);
+    }),
+    remove: vi.fn(async (keys: string[]) => {
+      for (const key of keys) entries.delete(key);
+    }),
+    clear: vi.fn(async () => {
+      entries.clear();
+    }),
+  } satisfies ScrollbackBackend & { entries: Map<string, string> };
+}
+
+let backend: ReturnType<typeof createFakeBackend>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  logError.mockClear();
+  localStorage.clear();
+  backend = createFakeBackend();
+  registerScrollbackBackend(backend);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("setScrollback", () => {
+  it("keeps the tail when a value exceeds the byte cap", async () => {
+    const value = `${"a".repeat(MAX_ENTRY_BYTES)}TAIL`;
+
+    setScrollback("key", value);
+
+    expect(getScrollback("key")).toHaveLength(MAX_ENTRY_BYTES);
+    expect(getScrollback("key")?.endsWith("TAIL")).toBe(true);
+
+    await flushScrollback();
+    expect(backend.entries.get("key")).toHaveLength(MAX_ENTRY_BYTES);
+  });
+
+  it("coalesces repeated writes within one flush window into a single save", async () => {
+    setScrollback("key", "one");
+    setScrollback("key", "two");
+    setScrollback("key", "three");
+
+    expect(backend.save).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(FLUSH_INTERVAL_MS);
+
+    expect(backend.save).toHaveBeenCalledTimes(1);
+    expect(backend.save).toHaveBeenCalledWith("key", "three");
+  });
+
+  it("evicts least recently used entries past the cap", async () => {
+    for (let i = 0; i < MAX_ENTRIES + 2; i++) {
+      setScrollback(`key-${i}`, `value-${i}`);
+    }
+
+    await flushScrollback();
+
+    expect(getScrollback("key-0")).toBeUndefined();
+    expect(getScrollback("key-1")).toBeUndefined();
+    expect(getScrollback("key-2")).toBe("value-2");
+    expect(backend.remove).toHaveBeenCalledWith(["key-0", "key-1"]);
+    expect(backend.entries.has("key-0")).toBe(false);
+  });
+
+  it("treats a read as a recency touch", async () => {
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      setScrollback(`key-${i}`, `value-${i}`);
+    }
+    getScrollback("key-0");
+    setScrollback("key-new", "value-new");
+
+    await flushScrollback();
+
+    expect(getScrollback("key-0")).toBe("value-0");
+    expect(getScrollback("key-1")).toBeUndefined();
+  });
+
+  it("swallows and logs a rejecting backend", async () => {
+    backend.save.mockRejectedValueOnce(new Error("disk full"));
+
+    setScrollback("key", "value");
+    await expect(flushScrollback()).resolves.toBeUndefined();
+
+    expect(logError).toHaveBeenCalled();
+  });
+});
+
+describe("removal", () => {
+  it("removes a single key from cache and backend", async () => {
+    setScrollback("key", "value");
+    await flushScrollback();
+
+    removeScrollback("key");
+
+    expect(getScrollback("key")).toBeUndefined();
+    expect(backend.remove).toHaveBeenCalledWith(["key"]);
+  });
+
+  it("removes only keys belonging to the task", async () => {
+    setScrollback("task-1", "a");
+    setScrollback("task-1-shell", "b");
+    setScrollback("task-10-shell", "c");
+    setScrollback("task-2-shell", "d");
+    await flushScrollback();
+
+    removeScrollbackForTask("task-1");
+
+    expect(getScrollback("task-1")).toBeUndefined();
+    expect(getScrollback("task-1-shell")).toBeUndefined();
+    expect(getScrollback("task-10-shell")).toBe("c");
+    expect(getScrollback("task-2-shell")).toBe("d");
+  });
+});
+
+describe("clearScrollback", () => {
+  it("empties the cache and the backend", async () => {
+    setScrollback("key", "value");
+    await flushScrollback();
+
+    await clearScrollback();
+
+    expect(getScrollback("key")).toBeUndefined();
+    expect(backend.clear).toHaveBeenCalled();
+  });
+});
+
+describe("hydrateTerminalScrollback", () => {
+  it("loads persisted entries and only reads the backend once", async () => {
+    registerScrollbackBackend(createFakeBackend({ key: "restored" }));
+
+    await hydrateTerminalScrollback();
+    await hydrateTerminalScrollback();
+
+    expect(getScrollback("key")).toBe("restored");
+  });
+
+  it("migrates the legacy localStorage store and removes it", async () => {
+    localStorage.setItem(
+      "terminal-store",
+      JSON.stringify({
+        state: {
+          terminalStates: {
+            "task-1-shell": { serializedState: "legacy", sessionId: null },
+            "action-abc-0": { serializedState: "action-noise" },
+            "task-2-shell": { serializedState: null },
+          },
+        },
+      }),
+    );
+
+    await hydrateTerminalScrollback();
+
+    expect(getScrollback("task-1-shell")).toBe("legacy");
+    expect(getScrollback("action-abc-0")).toBeUndefined();
+    expect(getScrollback("task-2-shell")).toBeUndefined();
+    expect(localStorage.getItem("terminal-store")).toBeNull();
+  });
+
+  it("does not let the legacy store overwrite already-persisted entries", async () => {
+    registerScrollbackBackend(createFakeBackend({ "task-1-shell": "current" }));
+    localStorage.setItem(
+      "terminal-store",
+      JSON.stringify({
+        state: {
+          terminalStates: { "task-1-shell": { serializedState: "legacy" } },
+        },
+      }),
+    );
+
+    await hydrateTerminalScrollback();
+
+    expect(getScrollback("task-1-shell")).toBe("current");
+  });
+
+  it("reports ready only once an in-flight hydration settles", async () => {
+    let releaseLoad!: (entries: Record<string, string>) => void;
+    const slow = createFakeBackend();
+    slow.loadAll.mockReturnValue(
+      new Promise((resolve) => {
+        releaseLoad = resolve;
+      }),
+    );
+    registerScrollbackBackend(slow);
+
+    expect(isScrollbackReady()).toBe(true);
+
+    const pending = hydrateTerminalScrollback();
+    expect(isScrollbackReady()).toBe(false);
+
+    releaseLoad({ key: "restored" });
+    await pending;
+
+    expect(isScrollbackReady()).toBe(true);
+    expect(getScrollback("key")).toBe("restored");
+  });
+
+  it("reports ready even when hydration fails", async () => {
+    const broken = createFakeBackend();
+    broken.loadAll.mockRejectedValue(new Error("no indexeddb"));
+    registerScrollbackBackend(broken);
+
+    await hydrateTerminalScrollback();
+
+    expect(isScrollbackReady()).toBe(true);
+    expect(logError).toHaveBeenCalled();
+  });
+
+  it("flushes pending writes when the window is hidden", async () => {
+    await hydrateTerminalScrollback();
+    setScrollback("key", "value");
+    expect(backend.save).not.toHaveBeenCalled();
+
+    window.dispatchEvent(new Event("pagehide"));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(backend.save).toHaveBeenCalledWith("key", "value");
+  });
+
+  it("logs and continues when the legacy store is malformed", async () => {
+    localStorage.setItem("terminal-store", "{not json");
+
+    await hydrateTerminalScrollback();
+
+    expect(logError).toHaveBeenCalled();
+    expect(localStorage.getItem("terminal-store")).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/terminal/terminalScrollback.ts
+++ b/products/desktop/packages/ui/src/features/terminal/terminalScrollback.ts
@@ -1,0 +1,322 @@
+import { logger } from "@posthog/ui/shell/logger";
+
+const log = logger.scope("terminal-scrollback");
+
+export interface ScrollbackBackend {
+  loadAll(): Promise<Record<string, string>>;
+  save(key: string, value: string): Promise<void>;
+  remove(keys: string[]): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export const TERMINAL_SCROLLBACK_LINES = 1000;
+export const SERIALIZE_SCROLLBACK_LINES = 400;
+
+const MAX_ENTRY_BYTES = 128 * 1024;
+const MAX_ENTRIES = 32;
+const FLUSH_INTERVAL_MS = 3000;
+const LEGACY_STORE_KEY = "terminal-store";
+const ACTION_KEY_PREFIX = "action-";
+
+const DB_NAME = "posthog-terminal";
+const DB_VERSION = 1;
+const STORE_NAME = "scrollback";
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error("IndexedDB open blocked"));
+  });
+}
+
+export function createIndexedDbScrollbackBackend(): ScrollbackBackend {
+  let dbPromise: Promise<IDBDatabase> | null = null;
+
+  const getDb = (): Promise<IDBDatabase> => {
+    if (!dbPromise) {
+      dbPromise = openDatabase().catch((error) => {
+        dbPromise = null;
+        throw error;
+      });
+    }
+    return dbPromise;
+  };
+
+  const withStore = async <T>(
+    mode: IDBTransactionMode,
+    run: (store: IDBObjectStore) => Promise<T>,
+  ): Promise<T> => {
+    const db = await getDb();
+    const transaction = db.transaction(STORE_NAME, mode);
+    const result = await run(transaction.objectStore(STORE_NAME));
+    await new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => resolve();
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error);
+    });
+    return result;
+  };
+
+  return {
+    async loadAll() {
+      try {
+        return await withStore("readonly", async (store) => {
+          const [keys, values] = await Promise.all([
+            requestToPromise(store.getAllKeys()),
+            requestToPromise(store.getAll()),
+          ]);
+          const entries: Record<string, string> = {};
+          keys.forEach((key, index) => {
+            const value = values[index];
+            if (typeof key === "string" && typeof value === "string") {
+              entries[key] = value;
+            }
+          });
+          return entries;
+        });
+      } catch (error) {
+        log.error("Failed to load scrollback", error);
+        return {};
+      }
+    },
+
+    async save(key, value) {
+      try {
+        await withStore("readwrite", async (store) => {
+          store.put(value, key);
+        });
+      } catch (error) {
+        log.error("Failed to save scrollback", { key, error });
+      }
+    },
+
+    async remove(keys) {
+      if (keys.length === 0) return;
+      try {
+        await withStore("readwrite", async (store) => {
+          for (const key of keys) {
+            store.delete(key);
+          }
+        });
+      } catch (error) {
+        log.error("Failed to remove scrollback", error);
+      }
+    },
+
+    async clear() {
+      try {
+        await withStore("readwrite", async (store) => {
+          store.clear();
+        });
+      } catch (error) {
+        log.error("Failed to clear scrollback", error);
+      }
+    },
+  };
+}
+
+let backend: ScrollbackBackend = createIndexedDbScrollbackBackend();
+let cache = new Map<string, string>();
+const dirty = new Set<string>();
+let flushHandle: ReturnType<typeof setTimeout> | null = null;
+let hydrated: Promise<void> | null = null;
+let hydrationComplete = false;
+
+export function registerScrollbackBackend(next: ScrollbackBackend): void {
+  backend = next;
+  cache = new Map();
+  dirty.clear();
+  hydrated = null;
+  hydrationComplete = false;
+  if (flushHandle !== null) {
+    clearTimeout(flushHandle);
+    flushHandle = null;
+  }
+}
+
+// Hosts that never hydrate simply run without persistence, so an unstarted
+// hydration must not block terminals from writing.
+export function isScrollbackReady(): boolean {
+  return hydrated === null || hydrationComplete;
+}
+
+export function whenScrollbackReady(): Promise<void> {
+  return hydrated ?? Promise.resolve();
+}
+
+function isTaskKey(key: string, taskId: string): boolean {
+  return key === taskId || key.startsWith(`${taskId}-`);
+}
+
+function evictOverflow(): string[] {
+  const overflow = cache.size - MAX_ENTRIES;
+  if (overflow <= 0) return [];
+
+  const evicted: string[] = [];
+  for (const key of cache.keys()) {
+    if (evicted.length >= overflow) break;
+    evicted.push(key);
+  }
+  for (const key of evicted) {
+    cache.delete(key);
+    dirty.delete(key);
+  }
+  return evicted;
+}
+
+export async function flushScrollback(): Promise<void> {
+  if (flushHandle !== null) {
+    clearTimeout(flushHandle);
+    flushHandle = null;
+  }
+
+  const pending = [...dirty];
+  dirty.clear();
+
+  const evicted = evictOverflow();
+  const writes = pending
+    .filter((key) => cache.has(key))
+    .map((key) => backend.save(key, cache.get(key) as string));
+
+  try {
+    await Promise.all(writes);
+    if (evicted.length > 0) {
+      await backend.remove(evicted);
+    }
+  } catch (error) {
+    log.error("Failed to flush scrollback", error);
+  }
+}
+
+function scheduleFlush(): void {
+  if (flushHandle !== null) return;
+  flushHandle = setTimeout(() => {
+    flushHandle = null;
+    void flushScrollback();
+  }, FLUSH_INTERVAL_MS);
+}
+
+export function getScrollback(key: string): string | undefined {
+  const value = cache.get(key);
+  if (value === undefined) return undefined;
+  cache.delete(key);
+  cache.set(key, value);
+  return value;
+}
+
+export function setScrollback(key: string, value: string): void {
+  const bounded =
+    value.length > MAX_ENTRY_BYTES ? value.slice(-MAX_ENTRY_BYTES) : value;
+  cache.delete(key);
+  cache.set(key, bounded);
+  dirty.add(key);
+  scheduleFlush();
+}
+
+export function removeScrollback(key: string): void {
+  cache.delete(key);
+  dirty.delete(key);
+  void backend.remove([key]);
+}
+
+export function removeScrollbackForTask(taskId: string): void {
+  const keys = [...cache.keys()].filter((key) => isTaskKey(key, taskId));
+  if (keys.length === 0) return;
+  for (const key of keys) {
+    cache.delete(key);
+    dirty.delete(key);
+  }
+  void backend.remove(keys);
+}
+
+export function clearScrollback(): Promise<void> {
+  cache.clear();
+  dirty.clear();
+  if (flushHandle !== null) {
+    clearTimeout(flushHandle);
+    flushHandle = null;
+  }
+  return backend.clear();
+}
+
+function migrateLegacyTerminalStore(): void {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(LEGACY_STORE_KEY);
+  } catch (error) {
+    log.error("Failed to read legacy terminal store", error);
+    return;
+  }
+  if (!raw) return;
+
+  try {
+    const parsed = JSON.parse(raw) as {
+      state?: {
+        terminalStates?: Record<string, { serializedState?: unknown }>;
+      };
+    };
+    const states = parsed.state?.terminalStates ?? {};
+
+    for (const [key, value] of Object.entries(states)) {
+      if (key.startsWith(ACTION_KEY_PREFIX)) continue;
+      if (cache.has(key)) continue;
+      if (typeof value?.serializedState !== "string") continue;
+      setScrollback(key, value.serializedState);
+    }
+  } catch (error) {
+    log.error("Failed to migrate legacy terminal store", error);
+  }
+
+  try {
+    localStorage.removeItem(LEGACY_STORE_KEY);
+  } catch (error) {
+    log.error("Failed to remove legacy terminal store", error);
+  }
+}
+
+export function hydrateTerminalScrollback(): Promise<void> {
+  if (hydrated) return hydrated;
+
+  // The flush is throttled, so a quit inside the window would drop the most
+  // recent scrollback without this.
+  window.addEventListener("pagehide", () => {
+    void flushScrollback();
+  });
+
+  hydrated = (async () => {
+    const entries = await backend.loadAll();
+    for (const [key, value] of Object.entries(entries)) {
+      if (!cache.has(key)) {
+        cache.set(key, value);
+      }
+    }
+    migrateLegacyTerminalStore();
+
+    const evicted = evictOverflow();
+    if (evicted.length > 0) {
+      await backend.remove(evicted);
+    }
+  })()
+    .catch((error) => {
+      log.error("Failed to hydrate scrollback", error);
+    })
+    .finally(() => {
+      hydrationComplete = true;
+    });
+
+  return hydrated;
+}

--- a/products/desktop/packages/ui/src/features/terminal/terminalStore.test.ts
+++ b/products/desktop/packages/ui/src/features/terminal/terminalStore.test.ts
@@ -1,59 +1,58 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { managerOn } = vi.hoisted(() => ({
-  managerOn: vi.fn(() => vi.fn()),
+const { removeScrollback, removeScrollbackForTask } = vi.hoisted(() => ({
+  removeScrollback: vi.fn(),
+  removeScrollbackForTask: vi.fn(),
 }));
 
-vi.mock("./TerminalManager", () => ({
-  terminalManager: {
-    on: managerOn,
-  },
+vi.mock("@posthog/ui/features/terminal/terminalScrollback", () => ({
+  removeScrollback,
+  removeScrollbackForTask,
 }));
 
-import { clearPersistedSessionIds, useTerminalStore } from "./terminalStore";
+import { useTerminalStore } from "./terminalStore";
 
-describe("terminalStore persistence", () => {
+describe("terminalStore", () => {
   beforeEach(() => {
     localStorage.clear();
-    managerOn.mockClear();
-    useTerminalStore.setState({
-      terminalStates: {},
+    removeScrollback.mockClear();
+    removeScrollbackForTask.mockClear();
+    useTerminalStore.setState({ terminalStates: {} });
+  });
+
+  it("keeps session and process state out of localStorage", () => {
+    useTerminalStore.getState().setSessionId("task-1-shell", "shell-session");
+    useTerminalStore.getState().setProcessName("task-1-shell", "vim");
+
+    expect(localStorage.getItem("terminal-store")).toBeNull();
+    expect(localStorage.length).toBe(0);
+    expect(useTerminalStore.getState().terminalStates["task-1-shell"]).toEqual({
+      sessionId: "shell-session",
+      processName: "vim",
     });
   });
 
-  it("does not persist process-local shell session ids", () => {
-    useTerminalStore
-      .getState()
-      .setSerializedState("task-1-shell", "scrollback");
-    useTerminalStore
-      .getState()
-      .setSessionId("task-1-shell", "shell-stale-session");
+  it("drops scrollback when a terminal state is cleared", () => {
+    useTerminalStore.getState().setSessionId("task-1-shell", "shell-session");
 
-    const persisted = JSON.parse(localStorage.getItem("terminal-store") ?? "");
+    useTerminalStore.getState().clearTerminalState("task-1-shell");
 
-    expect(persisted.state.terminalStates["task-1-shell"]).toEqual({
-      serializedState: "scrollback",
-      sessionId: null,
-    });
-  });
-
-  it("clears session ids from old persisted terminal state", () => {
+    expect(removeScrollback).toHaveBeenCalledWith("task-1-shell");
     expect(
-      clearPersistedSessionIds({
-        terminalStates: {
-          "task-1-shell": {
-            serializedState: "scrollback",
-            sessionId: "shell-stale-session",
-          },
-        },
-      }),
-    ).toEqual({
-      terminalStates: {
-        "task-1-shell": {
-          serializedState: "scrollback",
-          sessionId: null,
-        },
-      },
-    });
+      useTerminalStore.getState().terminalStates["task-1-shell"],
+    ).toBeUndefined();
+  });
+
+  it("drops scrollback for every terminal belonging to a task", () => {
+    useTerminalStore.getState().setSessionId("task-1", "a");
+    useTerminalStore.getState().setSessionId("task-1-shell", "b");
+    useTerminalStore.getState().setSessionId("task-2-shell", "c");
+
+    useTerminalStore.getState().clearTerminalStatesForTask("task-1");
+
+    expect(removeScrollbackForTask).toHaveBeenCalledWith("task-1");
+    expect(Object.keys(useTerminalStore.getState().terminalStates)).toEqual([
+      "task-2-shell",
+    ]);
   });
 });

--- a/products/desktop/packages/ui/src/features/terminal/terminalStore.ts
+++ b/products/desktop/packages/ui/src/features/terminal/terminalStore.ts
@@ -1,150 +1,70 @@
+import {
+  removeScrollback,
+  removeScrollbackForTask,
+} from "@posthog/ui/features/terminal/terminalScrollback";
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
-import { terminalManager } from "./TerminalManager";
 
 export interface TerminalState {
-  serializedState: string | null;
   sessionId: string | null;
   processName: string | null;
 }
 
 interface TerminalStoreState {
   terminalStates: Record<string, TerminalState>;
-  getTerminalState: (key: string) => TerminalState | undefined;
-  setSerializedState: (key: string, state: string) => void;
   setSessionId: (key: string, sessionId: string) => void;
   setProcessName: (key: string, processName: string | null) => void;
   clearTerminalState: (key: string) => void;
   clearTerminalStatesForTask: (taskId: string) => void;
 }
 
-type PersistedTerminalStoreState = {
-  terminalStates: Record<
-    string,
-    {
-      serializedState: string | null;
-      sessionId: null;
-    }
-  >;
-};
+export const useTerminalStore = create<TerminalStoreState>()((set) => ({
+  terminalStates: {},
 
-const DEFAULT_TERMINAL_STATE: TerminalState = {
-  serializedState: null,
-  sessionId: null,
-  processName: null,
-};
-
-export function clearPersistedSessionIds(persistedState: unknown) {
-  if (!persistedState || typeof persistedState !== "object") {
-    return persistedState;
-  }
-
-  const state = persistedState as {
-    terminalStates?: Record<string, Partial<TerminalState>>;
-  };
-
-  if (!state.terminalStates || typeof state.terminalStates !== "object") {
-    return persistedState;
-  }
-
-  return {
-    ...state,
-    terminalStates: Object.fromEntries(
-      Object.entries(state.terminalStates).map(([key, value]) => [
-        key,
-        {
-          ...value,
-          sessionId: null,
+  setSessionId: (key: string, sessionId: string) => {
+    set((prev) => ({
+      terminalStates: {
+        ...prev.terminalStates,
+        [key]: {
+          ...prev.terminalStates[key],
+          processName: prev.terminalStates[key]?.processName ?? null,
+          sessionId,
         },
-      ]),
-    ),
-  };
-}
-
-export const useTerminalStore = create<TerminalStoreState>()(
-  persist(
-    (set, get) => ({
-      terminalStates: {},
-
-      getTerminalState: (key: string) => {
-        return get().terminalStates[key] || DEFAULT_TERMINAL_STATE;
       },
+    }));
+  },
 
-      setSerializedState: (key: string, state: string) => {
-        set((prev) => ({
-          terminalStates: {
-            ...prev.terminalStates,
-            [key]: {
-              ...prev.terminalStates[key],
-              serializedState: state,
-            },
-          },
-        }));
+  setProcessName: (key: string, processName: string | null) => {
+    set((prev) => ({
+      terminalStates: {
+        ...prev.terminalStates,
+        [key]: {
+          ...prev.terminalStates[key],
+          sessionId: prev.terminalStates[key]?.sessionId ?? null,
+          processName,
+        },
       },
+    }));
+  },
 
-      setSessionId: (key: string, sessionId: string) => {
-        set((prev) => ({
-          terminalStates: {
-            ...prev.terminalStates,
-            [key]: {
-              ...prev.terminalStates[key],
-              sessionId,
-            },
-          },
-        }));
-      },
+  clearTerminalState: (key: string) => {
+    removeScrollback(key);
+    set((prev) => {
+      const newStates = { ...prev.terminalStates };
+      delete newStates[key];
+      return { terminalStates: newStates };
+    });
+  },
 
-      setProcessName: (key: string, processName: string | null) => {
-        set((prev) => ({
-          terminalStates: {
-            ...prev.terminalStates,
-            [key]: {
-              ...prev.terminalStates[key],
-              processName,
-            },
-          },
-        }));
-      },
-
-      clearTerminalState: (key: string) => {
-        set((prev) => {
-          const newStates = { ...prev.terminalStates };
+  clearTerminalStatesForTask: (taskId: string) => {
+    removeScrollbackForTask(taskId);
+    set((prev) => {
+      const newStates = { ...prev.terminalStates };
+      for (const key of Object.keys(newStates)) {
+        if (key === taskId || key.startsWith(`${taskId}-`)) {
           delete newStates[key];
-          return { terminalStates: newStates };
-        });
-      },
-
-      clearTerminalStatesForTask: (taskId: string) => {
-        set((prev) => {
-          const newStates = { ...prev.terminalStates };
-          for (const key of Object.keys(newStates)) {
-            if (key === taskId || key.startsWith(`${taskId}-`)) {
-              delete newStates[key];
-            }
-          }
-          return { terminalStates: newStates };
-        });
-      },
-    }),
-    {
-      name: "terminal-store",
-      version: 1,
-      migrate: (persistedState) =>
-        clearPersistedSessionIds(persistedState) as PersistedTerminalStoreState,
-      partialize: (state): PersistedTerminalStoreState => ({
-        terminalStates: Object.fromEntries(
-          Object.entries(state.terminalStates).map(([k, v]) => [
-            k,
-            { serializedState: v.serializedState, sessionId: null },
-          ]),
-        ),
-      }),
-    },
-  ),
-);
-
-terminalManager.on("stateChange", ({ persistenceKey, serializedState }) => {
-  useTerminalStore
-    .getState()
-    .setSerializedState(persistenceKey, serializedState);
-});
+        }
+      }
+      return { terminalStates: newStates };
+    });
+  },
+}));

--- a/products/desktop/packages/ui/src/utils/clearStorage.ts
+++ b/products/desktop/packages/ui/src/utils/clearStorage.ts
@@ -3,6 +3,7 @@ import {
   HOST_TRPC_CLIENT,
   type HostTrpcClient,
 } from "@posthog/host-router/client";
+import { clearScrollback } from "@posthog/ui/features/terminal/terminalScrollback";
 import { logger } from "@posthog/ui/shell/logger";
 
 const log = logger.scope("clear-storage");
@@ -19,6 +20,7 @@ export function clearApplicationStorage(): void {
   Promise.allSettled([
     client.folders.clearAllData.mutate(),
     client.secureStore.clear.query(),
+    clearScrollback(),
   ]).then((results) => {
     const rejected = results.filter(
       (result): result is PromiseRejectedResult => result.status === "rejected",


### PR DESCRIPTION
## Problem

The desktop terminal tab is laggy and freezes constantly.

The cause isn't xterm.js rendering or React re-renders on the output path — those are already well optimised (WebGL renderer with DOM fallback, rAF-coalesced `term.write()`, parked instances). It's **scrollback persistence blocking the renderer's main thread**.

`terminalStore.ts` was the only persisted zustand store in `packages/ui` **not** passing `storage: electronStorage` — every other one does (`settingsStore`, `commandCenterStore`, `draftStore`, `gitInteractionStore`, and 8 more). So it silently fell back to zustand's default: **synchronous `localStorage`** — while holding by far the largest payload in the app, the full serialized xterm scrollback for every terminal key ever created.

Every ~500ms of terminal use, on the main thread:

1. `scheduleSave()` fires a debounce armed by **every keystroke** *and* **every rAF of pty output**.
2. `serializeAddon.serialize()` walks the entire 1000-line scrollback, rebuilding it as a string with all SGR escape codes.
3. zustand `persist` runs `partialize` over **all** terminal states, `JSON.stringify`s the lot, and does a **synchronous `localStorage.setItem`** of potentially multiple MB.

`detach()` did the same full serialize + stringify + sync write on **every tab switch**.

Two things made it degrade over time rather than merely be slow:

- **`action-*` keys leaked forever.** `ActionTerminal` persists scrollback under `action-<actionId>-<generation>`, but never passes it back in, so it is **never read**. And `clearTerminalStatesForTask` only matches keys equal to or prefixed by the taskId — these start with `action-`, so they are **never pruned**. Every action re-run permanently added a multi-KB blob.
- Past the **5MB localStorage quota**, every write threw `QuotaExceededError` while *still* paying the full serialize + stringify cost, and persistence silently stopped working.

## Fix

Scrollback moves to a non-reactive module (`terminalScrollback.ts`) backed by IndexedDB: commits happen off the main thread, writes are per-key, and the quota is orders of magnitude larger. Writes are coalesced on a 3s flush, capped at 128KB per entry, and LRU-evicted past 32 terminals. Existing `localStorage` state is migrated on first launch (skipping `action-*`) and the legacy key removed, which reclaims the quota affected users are currently pinned against.

Since `partialize` only ever emitted `serializedState`, nothing is left worth persisting — `persist` is removed from `terminalStore` entirely (`sessionId` was already force-nulled on write, and `processName` is re-polled within 500ms of mount).

Also in scope, because it falls directly out of the above:

- Command/action sessions no longer persist scrollback at all, killing the `action-*` leak at the source.
- `ShellTerminal` selects a scalar `sessionId` instead of the whole state object, so saves no longer re-render the terminal tree twice a second. `initialState` is gone from the React tree — `TerminalManager` is now the sole reader/writer of scrollback.
- A `needsSave` flag means a timer firing with no new bytes skips the serialize walk entirely.
- Buffered pty output is held back until restored scrollback has been written, so async boot hydration can't interleave restore *after* live output.
- Explicit `scrollback: 1000` on the xterm constructor, so a future default change can't silently inflate the payload.

### Why not `electronStorage`

Routing these blobs through the existing `electronStorage` would be **worse**: `secureStore.setItem` AES-encrypts into `rendererStore`, an `electron-store` that **synchronously atomic-rewrites the entire `renderer-storage.json`** on every `set` — on the same main process that pumps pty data for every terminal. Each save would structured-clone MBs over IPC, encrypt, then sync-rewrite a file that now also contains every terminal's scrollback, making every settings/draft/git write slow too.

IndexedDB is available in both the Electron renderer and browser hosts, so `packages/ui` stays host-agnostic with no new host wiring. The injectable backend seam exists only so jsdom tests (which have no IDB) can swap in an in-memory fake.

## Out of scope

Two real but independent issues, deliberately left for follow-ups:

- `shell.router.ts` `subscribeFiltered` — each terminal subscribes to the **entire** pty data stream and filters by sessionId in the main process, so with N terminals every chunk is pushed through N async iterators. There's also no batching between `node-pty`'s `onData` and the per-chunk Electron IPC `event.reply`.
- The `ResizeObserver` in `attach()` calls `fitAddon.fit()` (forcing layout) and fires a `shell.resize` mutation on every tick, unthrottled — so a panel drag spams the main process.

## Testing

- `pnpm typecheck` — clean (9/9 tasks)
- `biome check` — clean on all touched files
- `@posthog/ui` — **2527/2527 pass**, including 30 terminal tests (18 new)

New/updated coverage: byte-cap truncation keeps the tail; N writes in one flush window produce one `save` per key; LRU eviction; hydration idempotency and the ready/pending gate; legacy migration imports non-`action-` keys and removes the legacy key; malformed legacy store is logged and survived; a rejecting backend is swallowed; bounded `serialize({ scrollback: 400 })`; no save for command sessions; restore-before-live-output ordering; `detach()` saves; and `ShellTerminal` doesn't re-render on unrelated or own-`processName` store changes.

## Not verified

I did not run the app and stress a terminal by hand. Worth doing before merge: launch, confirm the `terminal-store` key is gone from Local Storage and `posthog-terminal` appears under IndexedDB, then profile while streaming heavy output (`yes | head -c 50000000`) across ~6 terminals.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*