### PR TITLE
fix(desktop): isolate test skill installs

### DIFF
--- a/products/desktop/packages/agent/src/server/agent-server.test.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.test.ts
@@ -421,6 +421,7 @@ describe("AgentServer HTTP Mode", () => {
       port,
       jwtPublicKey: TEST_PUBLIC_KEY,
       repositoryPath: repo.path,
+      skillInstallRoot: join(repo.path, ".posthog", "test-skill-installs"),
       apiUrl: "http://localhost:8000",
       apiKey: "test-api-key",
       projectId: 1,
@@ -2379,6 +2380,18 @@ describe("AgentServer HTTP Mode", () => {
       expect(sentMeta?.localSkillContext).toContain("LOCAL_SKILL_MARKER");
       expect(sentMeta?.localSkillContext).toContain("with context");
       expect(sentMeta?.localSkillName).toBe("local-test-skill");
+      await expect(
+        readFile(
+          join(
+            repo.path,
+            ".posthog",
+            "test-skill-installs",
+            "local-test-skill",
+            "SKILL.md",
+          ),
+          "utf-8",
+        ),
+      ).resolves.toBe(skillDefinition);
     }, 20000);
 
     it("lists co-installed dependency skills with their paths in the skill context", async () => {

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -3184,6 +3184,10 @@ export class AgentServer {
   }
 
   private getSkillInstallDirectories(skillName: string): string[] {
+    if (this.config.skillInstallRoot) {
+      return [join(this.config.skillInstallRoot, skillName)];
+    }
+
     const home = process.env.HOME ?? "/tmp";
     return [
       join("/scripts", "plugins", "posthog", "skills", skillName),

--- a/products/desktop/packages/agent/src/server/types.ts
+++ b/products/desktop/packages/agent/src/server/types.ts
@@ -16,6 +16,7 @@ export interface AgentServerConfig {
   agentStateDir?: string;
   repositoryPath?: string;
   repoReadyFile?: string;
+  skillInstallRoot?: string;
   apiUrl: string;
   apiKey: string;
   projectId: number;


### PR DESCRIPTION
## Problem

Agent-server tests install bundled skills into user-global agent skill directories. Test fixtures can then be discovered by unrelated agents.

## Changes

- Add an optional isolated skill-install root to `AgentServer`.
- Configure the HTTP server test helper to install bundles under its temporary repository.
- Verify the bundled local-skill fixture is installed in that isolated root.

## How did you test this code?

- `pnpm exec biome check packages/agent/src/server/agent-server.ts packages/agent/src/server/agent-server.test.ts packages/agent/src/server/types.ts`
- `pnpm --filter @posthog/agent typecheck`
- `pnpm --filter @posthog/agent test src/server/agent-server.test.ts` — 154 tests passed.

The extended bundle-install test guards against test fixtures being copied to global skill directories instead of the temporary test repository.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update required. This is test isolation for an internal runtime configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. I used the `/writing-tests` skill before extending the existing regression test. The branch is based directly on `master`.
