### PR TITLE
chore(ci): ignore tool caches when listing products for lane names

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -174,10 +174,21 @@ function isTripwire(file) {
     return TRIPWIRE_MATCHERS.some((re) => re.test(file))
 }
 
+// Tool caches share the directory with the products, so a local run picks up
+// .ruff_cache and __pycache__ as products and invents a lane for each. CI never
+// sees them — a fresh checkout holds only tracked directories and this job runs
+// no Python — so this keeps a local run answering the same as CI rather than
+// fixing a live miscount. Dropping a real product would only ever widen, since
+// an unrecognized product name falls through to ALL, so the filter is safe in
+// the one direction it can be wrong.
+function isProductDirectory(name) {
+    return !name.startsWith('.') && !name.startsWith('__') && name !== 'node_modules'
+}
+
 function listProducts(repoRoot) {
     return fs
         .readdirSync(path.join(repoRoot, 'products'), { withFileTypes: true })
-        .filter((entry) => entry.isDirectory())
+        .filter((entry) => entry.isDirectory() && isProductDirectory(entry.name))
         .map((entry) => entry.name)
         .sort()
 }
@@ -275,8 +286,7 @@ function compileContractMatcher(inputs) {
     if (include.length === 0) {
         return null
     }
-    return (relativePath) =>
-        include.some((re) => re.test(relativePath)) && !exclude.some((re) => re.test(relativePath))
+    return (relativePath) => include.some((re) => re.test(relativePath)) && !exclude.some((re) => re.test(relativePath))
 }
 
 // Only products that narrow `backend:contract-check` in their own turbo.json get
@@ -763,6 +773,7 @@ module.exports = {
     buildContext,
     compileContractMatcher,
     globToRegExp,
+    isProductDirectory,
     isTripwire,
     parseCrateDependencies,
     parseCrateName,

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -174,13 +174,13 @@ function isTripwire(file) {
     return TRIPWIRE_MATCHERS.some((re) => re.test(file))
 }
 
-// Tool caches share the directory with the products, so a local run picks up
-// .ruff_cache and __pycache__ as products and invents a lane for each. CI never
-// sees them — a fresh checkout holds only tracked directories and this job runs
-// no Python — so this keeps a local run answering the same as CI rather than
-// fixing a live miscount. Dropping a real product would only ever widen, since
-// an unrecognized product name falls through to ALL, so the filter is safe in
-// the one direction it can be wrong.
+// Tool caches share the directory with the products, so a local run can pick up
+// directories such as .ruff_cache, .pytest_cache, and __pycache__ as products and
+// invent a lane for each. CI never sees them because a fresh checkout has only
+// tracked directories and this job does not run Python, so this keeps a local run
+// consistent with CI rather than fixing a live miscount. Dropping a real product
+// would only ever widen, because an unrecognized product name falls through to
+// ALL, so the filter is safe in the one direction it can be wrong.
 function isProductDirectory(name) {
     return !name.startsWith('.') && !name.startsWith('__') && name !== 'node_modules'
 }

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -14,6 +14,7 @@ const {
     computeTargets,
     compileContractMatcher,
     globToRegExp,
+    isProductDirectory,
     isTripwire,
     parseCrateDependencies,
     reverseClosure,
@@ -299,6 +300,18 @@ test('core changes expand to every leaf target in their own domain', () => {
 test('product frontend and backend changes land in separate domains', () => {
     assert.deepEqual(computeTargets(['products/alpha/frontend/Scene.tsx'], CONTEXT), ['fe:product:alpha'])
     assert.deepEqual(computeTargets(['products/beta/backend/api.py'], CONTEXT), ['py:product:beta'])
+})
+
+// ruff and pytest leave caches next to the products, and a run that treats them
+// as products invents a lane per cache. Nothing downstream rejects a nonsense
+// target name, so the only symptom is a local run disagreeing with CI.
+test('tool caches beside the products are not products', () => {
+    for (const name of ['.ruff_cache', '.pytest_cache', '__pycache__', 'node_modules']) {
+        assert.equal(isProductDirectory(name), false, name)
+    }
+    for (const name of ['surveys', 'error_tracking', 'desktop']) {
+        assert.equal(isProductDirectory(name), true, name)
+    }
 })
 
 test('a product file that is neither backend nor frontend claims both domains', () => {


### PR DESCRIPTION
## Problem

`listProducts` treats every directory under `products/` as a product, so a local run of the target script picks up the caches that sit beside them and invents a lane for each:

```
products listed locally: 87
junk entries           : [ '.ruff_cache', '__pycache__' ]
```

Nothing downstream rejects a nonsense target name, so `py:product:.ruff_cache` and `py:product:__pycache__` end up in the target set and every widened change reports two lanes more than it should.

> [!NOTE]
> **CI is not affected, so this is hardening rather than a bug fix.** A fresh checkout contains only tracked directories, both of these are untracked (`git ls-files products/.ruff_cache` is empty), and the `compute` job runs no Python — it checks out, fetches, sets up Node, and runs the script. I checked that before writing the fix, because the fix would otherwise have been justified on a false premise.

What it does cost is that a local run disagrees with CI, which matters because the script is the thing you run by hand to reason about lane behavior. Numbers I gathered locally while working on #76481 and #76483 were inflated by these two entries. The comparisons in those PRs are unaffected — both sides of every diff used the same context — but the absolute lane counts quoted there run about two high.

## Changes

Skip directories whose names start with `.` or `__`, plus `node_modules`.

```
products listed now: 85
junk remaining     : []
```

A denylist rather than a marker-file allowlist on purpose. Missing a new kind of junk leaves a harmless extra lane that overlaps consistently; excluding a real product would send all of that product's PRs to `ALL`. Given the two failure modes, the cheap one is the right one to risk.

The filter is also safe in the direction it can be wrong: an unrecognized product name falls through to `ALL`, so a product that this wrongly dropped would widen rather than narrow.

## How did you test this code?

`node --test .github/scripts/trunk-impacted-targets.test.js` — 37 pass, 1 new.

The new case asserts the four cache names are rejected and three real products accepted. It earns its place because the symptom is silent: no consumer validates target names, so the only way this surfaces is someone puzzling over a local run that disagrees with CI.

Also re-ran `buildContext` against the working tree before and after, which is where the 87 → 85 numbers above come from.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Spotted by Claude (Claude Code) while dry-running the telemetry payload in #76593 and flagged there as a follow-up; this is that follow-up.

Branched off master rather than stacked. It touches `listProducts`, while #76481 and #76483 touch the workspace and product-classification code further down the same file, so the hunks don't overlap.

Worth a reviewer knowing: four more directories under `products/` have no tracked files on master either (`deployments`, `desktop_recordings`, `discord_app`, `query_performance_ai`). Those are indistinguishable from real products by name, they don't exist in a CI checkout, and they look like leftovers from other branches in a local tree — so this filter deliberately does not try to catch them.

`/writing-tests` invoked before adding the test case.
