### PR TITLE
chore(data-modeling): discover view tools/schema dynamically in skill

### DIFF
--- a/products/data_modeling/skills/modeling-warehouse-foundations/references/posthog-views.md
+++ b/products/data_modeling/skills/modeling-warehouse-foundations/references/posthog-views.md
@@ -25,15 +25,15 @@ These are the tools that change state. Treat this as a map, not a spec: the tool
 current set and each tool's exact inputs by inspecting the tool itself (`posthog:exec info <tool>` /
 `posthog:exec schema <tool>`) rather than trusting an enumerated list here.
 
-| Tool                                       | Purpose                                                                                                                                                     |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `posthog:view-create`                      | Create (or upsert) a view from HogQL. Same `name` → updates the existing view.                                                                              |
-| `posthog:view-update`                      | Change name / query / description / sync frequency. Editing the query re-infers columns and needs the current `edited_history_id` (optimistic concurrency). |
-| `posthog:view-materialize`                 | Turn a virtual view into a materialized table + a sync schedule. Rate-limited.                                                                              |
-| `posthog:view-run` / `view-run-history`    | Trigger a materialization refresh now (must already be materialized) / read recent run statuses to debug failures.                                          |
-| `posthog:view-unmaterialize`               | Drop the physical table + schedule; keep the view definition as virtual.                                                                                    |
-| `posthog:view-delete`                      | Soft-delete a view. Refused if other views depend on it, or if it's owned by a managed viewset (e.g. `revenue_analytics_*`).                                |
-| `posthog:saved-query-column-annotations-*` | Attach human/agent-readable descriptions to the view and its columns (discoverability).                                                                     |
+| Tool                                            | Purpose                                                                                                                                                     |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `posthog:view-create`                           | Create (or upsert) a view from HogQL. Same `name` → updates the existing view.                                                                              |
+| `posthog:view-update`                           | Change name / query / description / sync frequency. Editing the query re-infers columns and needs the current `edited_history_id` (optimistic concurrency). |
+| `posthog:view-materialize`                      | Turn a virtual view into a materialized table + a sync schedule. Rate-limited.                                                                              |
+| `posthog:view-run` / `posthog:view-run-history` | Trigger a materialization refresh now (must already be materialized) / read recent run statuses to debug failures.                                          |
+| `posthog:view-unmaterialize`                    | Drop the physical table + schedule; keep the view definition as virtual.                                                                                    |
+| `posthog:view-delete`                           | Soft-delete a view. Refused if other views depend on it, or if it's owned by a managed viewset (e.g. `revenue_analytics_*`).                                |
+| `posthog:saved-query-column-annotations-*`      | Attach human/agent-readable descriptions to the view and its columns (discoverability).                                                                     |
 
 ## The workflow
 

--- a/products/data_modeling/skills/modeling-warehouse-foundations/references/posthog-views.md
+++ b/products/data_modeling/skills/modeling-warehouse-foundations/references/posthog-views.md
@@ -2,21 +2,38 @@
 
 A **view** (a.k.a. saved query) is a named HogQL `SELECT` stored in the project. By default it is
 **virtual** — it re-runs every time something reads it. **Materializing** it computes it once into a
-physical table on a schedule, so reads are fast and cheap. Both are managed over MCP with the `view-*` tools.
+physical table on a schedule, so reads are fast and cheap. Views are written and managed over MCP with the
+`view-*` tools; their inventory is read back through `information_schema` (below).
 
-## The tools
+## Reading what exists
 
-| Tool                                       | Purpose                                                                                                                                                                                      |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `posthog:view-create`                      | Create (or upsert) a view from HogQL. Same `name` → updates the existing view.                                                                                                               |
-| `posthog:view-get` / `posthog:view-list`   | Read one / list all views with status, materialization flag, last run, latest error.                                                                                                         |
-| `posthog:view-update`                      | Change name / query / description / `sync_frequency`. Editing the query re-infers columns and needs the current `edited_history_id` (optimistic concurrency — get it from `view-get` first). |
-| `posthog:view-materialize`                 | Turn a virtual view into a materialized table + a sync schedule (defaults to every 24h). Rate-limited.                                                                                       |
-| `posthog:view-run`                         | Trigger a materialization refresh now (view must already be materialized).                                                                                                                   |
-| `posthog:view-run-history`                 | Recent materialization run statuses (debug failures).                                                                                                                                        |
-| `posthog:view-unmaterialize`               | Drop the physical table + schedule; keep the view definition as virtual.                                                                                                                     |
-| `posthog:view-delete`                      | Soft-delete a view. Refused if other views depend on it, or if it's owned by a managed viewset (e.g. `revenue_analytics_*`).                                                                 |
-| `posthog:saved-query-column-annotations-*` | Attach human/agent-readable descriptions to the view and its columns (discoverability).                                                                                                      |
+To list views, inspect their columns, or check materialization status, query `information_schema` with
+`posthog:execute-sql` rather than a per-view tool — it stays correct as the toolset changes and is the same
+discovery path the rest of these skills use:
+
+```sql
+SELECT table_name FROM system.information_schema.tables WHERE table_name ILIKE '%my_view%'
+-- columns: system.information_schema.columns; accepted joins: system.information_schema.relationships
+```
+
+The one thing `information_schema` can't give you is the `edited_history_id` concurrency token — fetch that
+with `posthog:view-get` right before a `view-update` that changes the query.
+
+## The write tools
+
+These are the tools that change state. Treat this as a map, not a spec: the toolset evolves, so confirm the
+current set and each tool's exact inputs by inspecting the tool itself (`posthog:exec info <tool>` /
+`posthog:exec schema <tool>`) rather than trusting an enumerated list here.
+
+| Tool                                       | Purpose                                                                                                                                                     |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `posthog:view-create`                      | Create (or upsert) a view from HogQL. Same `name` → updates the existing view.                                                                              |
+| `posthog:view-update`                      | Change name / query / description / sync frequency. Editing the query re-infers columns and needs the current `edited_history_id` (optimistic concurrency). |
+| `posthog:view-materialize`                 | Turn a virtual view into a materialized table + a sync schedule. Rate-limited.                                                                              |
+| `posthog:view-run` / `view-run-history`    | Trigger a materialization refresh now (must already be materialized) / read recent run statuses to debug failures.                                          |
+| `posthog:view-unmaterialize`               | Drop the physical table + schedule; keep the view definition as virtual.                                                                                    |
+| `posthog:view-delete`                      | Soft-delete a view. Refused if other views depend on it, or if it's owned by a managed viewset (e.g. `revenue_analytics_*`).                                |
+| `posthog:saved-query-column-annotations-*` | Attach human/agent-readable descriptions to the view and its columns (discoverability).                                                                     |
 
 ## The workflow
 
@@ -38,7 +55,8 @@ physical table on a schedule, so reads are fast and cheap. Both are managed over
 3. **Create it:** `posthog:view-create {"name": "monthly_events", "query": {"kind": "HogQLQuery", "query": "..."}}`.
    (Inspect the exact input shape once with `posthog:exec info view-create` / `schema view-create query`.)
    Names are lowercase snake_case, unique, and become the table name you query later.
-4. **Verify:** `view-get` the new view; confirm columns inferred as expected and there's no `latest_error`.
+4. **Verify:** confirm the inferred columns via `system.information_schema.columns` (use `view-get` if you
+   need to see a `latest_error`).
 5. **Materialize only if it earns it** (see below), then set an appropriate `sync_frequency`.
 
 ## Virtual vs materialized — when to materialize
@@ -53,10 +71,11 @@ Materialize when **at least one** holds:
 Leave it **virtual** when the query is cheap, ad-hoc, or needs up-to-the-second freshness. Materialized reads
 are stale up to one `sync_frequency` interval.
 
-`sync_frequency` accepts: `15min`, `30min`, `1hour`, `6hour`, `12hour`, `24hour`, `7day`, `30day`, `never`.
-Match it to how fast the data changes and how fresh readers need it — a daily-rebuilt country dimension is
-fine at `24hour` or `7day`; a near-real-time funnel might want `1hour`. Materialization runs get extra
-compute but still time out after ~1 hour, so materialize a bounded query, not an unbounded full-history scan.
+Set `sync_frequency` to match how fast the data changes and how fresh readers need it — a daily-rebuilt
+country dimension is fine at a daily or weekly cadence; a near-real-time funnel wants an hourly one. The tool
+takes a fixed set of interval values, so read the accepted ones from the `view-materialize` (or `view-update`)
+schema — `posthog:exec schema view-materialize` — rather than assuming. Materialization runs get extra compute
+but still time out after ~1 hour, so materialize a bounded query, not an unbounded full-history scan.
 
 ## Nesting
 


### PR DESCRIPTION
## Problem

Follow-up to review on [#75458](https://github.com/PostHog/posthog/pull/75458).
@sakce left three non-blocking notes on `posthog-views.md`, all the same theme: the skill hard-codes things that live on our side and will drift.

- The exhaustive `view-*` tool table becomes wrong the moment we change the toolset.
- Listing/reading views should go through `information_schema` via `execute-sql`, not per-view tools.
- The enumerated `sync_frequency` values are a server-side set that can change.

sakce asked an agent to check how we handle this elsewhere. It's an established pattern already used inside this same skill set (revenue and governance references read `system.information_schema.tables`/`.metrics` via `execute-sql`), and `querying-posthog-data` documents `information_schema` as the discovery path.

## Changes

One file, `modeling-warehouse-foundations/references/posthog-views.md`:

- **Reading what exists** now uses `system.information_schema` (`tables`/`columns`/`relationships`) via `execute-sql`; `view-get` is kept only for the `edited_history_id` concurrency token, which `information_schema` can't provide.
- The tool table is reframed as a map, not a spec, with a note to confirm the current tools and their inputs by inspecting the tool itself (`posthog:exec info`/`schema`).
- The `sync_frequency` enumeration is replaced with a pointer to the `view-materialize` schema for the accepted values.

## How did you test this code?

Docs/skill content only — no code, migrations, or endpoints.
`oxfmt --check` passes on the changed markdown.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude at Anna's direction to address @sakce's review comments on #75458.
Verified the "read from information_schema / discover tools dynamically" convention against existing skills before applying, per sakce's request.
Stacked on `posthog-code/data-modeling-skills` because that branch is managed as the run's base; fast-forwarding it to this commit or merging this PR folds the change in.
