### PR TITLE
perf(ci): give unclassified top-level trees a merge-queue lane

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -195,6 +195,15 @@ const STANDALONE_TREES = new Map([
 // genuinely compile into nothing. Two trees stay off both lists: agent-os/ and
 // share/ hold only markdown today, which the prose rule already claims, and
 // anything else appearing there should widen until someone classifies it.
+//
+// .posthog-code is the entry that looks like an exception and is not. The
+// desktop app does parse .posthog-code/environments/*.toml, but it parses
+// whichever repository a user opens, and EnvironmentService's suite writes its
+// fixtures to a temp directory instead of reading this repository's copy. That
+// suite also covers a file being invalid TOML or off-schema, both of which the
+// service skips, so a config and a parser that disagree leave an environment
+// unlisted rather than failing anything. No suite here would catch the pair, so
+// sharing the desktop product's lane would serialize the two for no validation.
 const REPO_CONFIG_DIRS = [
     '.claude',
     '.codex',

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -117,6 +117,24 @@ const TRIPWIRES = [
     // bin/ appears in the backend, frontend, and E2E path filters alike.
     'bin/**',
     'patches/**',
+    // Holds the Depot-runner copies of the workflows and composite actions in
+    // .github/, so it decides what runs for everyone the same way.
+    '.depot/**',
+    // The toolchain every suite runs inside. ci-python.yml gates on
+    // .flox/env/manifest.toml for that reason.
+    '.flox/**',
+    // ClickHouse, Postgres, and Temporal configuration mounted by every
+    // docker-compose file, so it defines the services all the suites test
+    // against.
+    'docker/**',
+    // duckgres.yaml is mounted into the same stack, and intent-map.yaml steers
+    // bin/sandbox and hogli, both already tripwires.
+    'devenv/**',
+    // Lint rules that run repo-wide: a new rule fails code that merged in a
+    // parallel lane, which is the same conflict .oxlintrc.json is here for.
+    '.semgrep/**',
+    // Holds the markdownlint config, which is the same class of rule change.
+    '.config/**',
     'tsconfig.json',
     'tsconfig.*.json',
     'babel.config.js',
@@ -148,6 +166,51 @@ const TOOLS_INDEPENDENT = [
     'query-performance-ai',
     'infra-scripts',
 ]
+
+// Top-level trees that hold a lane instead of falling through to ALL, keyed by
+// directory. Every entry names the suite that would catch a conflict in it, and
+// a tree nobody has placed here still widens, so the list grows by decision
+// rather than by default.
+const STANDALONE_TREES = new Map([
+    // A cargo workspace of its own (cli/Cargo.lock, outside rust/ and outside
+    // the pnpm workspace). ci-cli.yml also builds it from services/mcp sources,
+    // so the two trees have to share a lane.
+    ['cli', ['cli', 'svc:mcp']],
+    // Go service with its own CI. ci-hog.yml ignores livestream/** explicitly,
+    // so its Hog implementation is not covered by the shared hog suite either.
+    ['livestream', ['livestream']],
+    // Another standalone cargo workspace, and nothing in the dev or CI stack
+    // builds it: the UDF binary reaches ClickHouse through its image.
+    ['funnel-udf', ['funnel-udf']],
+    // Terragrunt definitions for dashboards and alerts. No suite compiles them,
+    // and terragrunt-posthog.yaml is the only workflow that reads the tree.
+    ['terraform', ['terraform']],
+    // ci-python.yml validates the policy files through the pr-approval-agent
+    // pytest suite, which already owns that lane.
+    ['.stamphog', ['tools:pr-approval-agent']],
+])
+
+// Editor, IDE, and agent configuration. No suite reads any of it, so one shared
+// lane between the lot costs nothing and keeps the inert set to files that
+// genuinely compile into nothing. Two trees stay off both lists: agent-os/ and
+// share/ hold only markdown today, which the prose rule already claims, and
+// anything else appearing there should widen until someone classifies it.
+const REPO_CONFIG_DIRS = [
+    '.claude',
+    '.codex',
+    '.cursor',
+    '.dagster_home',
+    '.husky',
+    '.idea',
+    '.interface-design',
+    '.posthog-code',
+    '.run',
+    '.vscode',
+    '.zed',
+]
+for (const dir of REPO_CONFIG_DIRS) {
+    STANDALONE_TREES.set(dir, ['repo-config'])
+}
 
 // Supports the three forms used in TRIPWIRES: `**` spanning directories, `*`
 // within a single path segment, and literal names. The two star forms are
@@ -555,10 +618,21 @@ function computeTargets(changedFiles, context) {
         // a README under posthog/ into the backend lane.
         //
         // The exception is markdown that is a build input: `hogli build:skills`
-        // zips products/*/skills/*, and ci-agent-skills.yml gates on those paths
-        // and on .agents/. Both fall through to their directory rules below.
-        const isSkillSource = top === '.agents' || (top === 'products' && segments[2] === 'skills')
-        if (/\.mdx?$/.test(file) && !isSkillSource) {
+        // zips products/*/skills/*, ci-agent-skills.yml gates on those paths and
+        // on .agents/, and ci-python.yml runs the pr-approval-agent suite over
+        // .stamphog/. All of them fall through to their directory rules below.
+        const isBuildInput =
+            top === '.agents' || top === '.stamphog' || (top === 'products' && segments[2] === 'skills')
+
+        // The same suite reads every AGENT_APPROVALS.md wherever it sits, so the
+        // file belongs to that lane rather than to the tree holding it. On the
+        // product lane its own directory rule would give it, a policy change and
+        // a parser change would be free to merge in parallel.
+        if (segments[segments.length - 1] === 'AGENT_APPROVALS.md') {
+            targets.add('tools:pr-approval-agent')
+            continue
+        }
+        if (/\.mdx?$/.test(file) && !isBuildInput) {
             inertFiles++
             continue
         }
@@ -596,6 +670,13 @@ function computeTargets(changedFiles, context) {
         }
         if (top === '.agents') {
             targets.add('agents')
+            continue
+        }
+        const standalone = STANDALONE_TREES.get(top)
+        if (standalone) {
+            for (const target of standalone) {
+                targets.add(target)
+            }
             continue
         }
         if (top === 'tools') {

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -57,6 +57,15 @@ test('every tripwire forces ALL', () => {
         'products/alpha/manifest.tsx',
         'bin/start',
         '.test_durations',
+        // Trees that steer what every suite runs or what it runs against: the
+        // Depot copies of the workflows, the toolchain, the service configs the
+        // stack mounts, and the lint rules that run repo-wide.
+        '.depot/workflows/ci-backend.yml',
+        '.flox/env/manifest.toml',
+        'docker/clickhouse/config.d/default.xml',
+        'devenv/duckgres.yaml',
+        '.semgrep/rules/security/prefer-codegen-api.yaml',
+        '.config/.markdownlint-cli2.jsonc',
     ]
     for (const file of tripwireFiles) {
         assert.equal(isTripwire(file), true, `${file} should be a tripwire`)
@@ -72,9 +81,75 @@ test('a tripwire anywhere in the change set forces ALL even alongside narrow fil
 // target set reads to Trunk as "overlaps nothing", so the PR merges in parallel
 // with everything. A new top-level directory must widen, never narrow.
 test('an unmapped path forces ALL rather than an empty target set', () => {
-    for (const file of ['terraform/main.tf', 'some-new-toplevel/thing.go', 'common/unrecognized/x.ts']) {
+    for (const file of [
+        'some-new-toplevel/thing.go',
+        'common/unrecognized/x.ts',
+        // agent-os/ and share/ hold nothing but markdown today, so a file that
+        // is not prose there is as unclassified as a brand new tree.
+        'share/geoip.py',
+        'agent-os/generate.py',
+    ]) {
         assert.equal(computeTargets([file], CONTEXT), ALL, `${file} should force ALL`)
     }
+})
+
+// Each of these went to ALL only because no rule named the directory, which
+// serialized the PR against the whole repo for a change no suite outside its
+// own tree can see.
+test('standalone top-level trees hold a lane instead of widening', () => {
+    assert.deepEqual(computeTargets(['terraform/us/project-2/dashboards.tf'], CONTEXT), ['terraform'])
+    assert.deepEqual(computeTargets(['livestream/auth/jwt.go'], CONTEXT), ['livestream'])
+    assert.deepEqual(computeTargets(['funnel-udf/src/codec.rs'], CONTEXT), ['funnel-udf'])
+})
+
+// funnel-udf and cli are cargo workspaces of their own, outside rust/ and
+// outside its lockfile, so the crate graph must not be consulted for them.
+test('standalone cargo workspaces stay out of the rust crate lanes', () => {
+    const udf = computeTargets(['funnel-udf/src/codec.rs'], CONTEXT)
+    const rust = computeTargets(['rust/shared/src/lib.rs'], CONTEXT)
+    assert.deepEqual(
+        udf.filter((target) => rust.includes(target)),
+        []
+    )
+})
+
+// ci-cli.yml builds the CLI from services/mcp sources, so a lane of its own
+// would let an mcp change and the cli change that consumes it merge in
+// parallel.
+test('cli changes share a lane with the mcp service', () => {
+    const cli = computeTargets(['cli/src/main.rs'], CONTEXT)
+    const mcp = computeTargets(['services/mcp/src/index.ts'], CONTEXT)
+    assert.deepEqual(cli, ['cli', 'svc:mcp'])
+    assert.equal(
+        cli.some((target) => mcp.includes(target)),
+        true
+    )
+})
+
+// The pr-approval-agent suite reads both, and the policy files are markdown
+// that the prose rule would otherwise treat as inert.
+test('stamphog policy files claim the suite that validates them', () => {
+    assert.deepEqual(computeTargets(['.stamphog/policy.yml'], CONTEXT), ['tools:pr-approval-agent'])
+    assert.deepEqual(computeTargets(['.stamphog/review-guidance.md'], CONTEXT), ['tools:pr-approval-agent'])
+    // Wherever it sits, the file belongs to the suite rather than to the
+    // product tree holding it.
+    assert.deepEqual(computeTargets(['products/alpha/AGENT_APPROVALS.md'], CONTEXT), ['tools:pr-approval-agent'])
+    assert.deepEqual(
+        computeTargets(['.stamphog/policy.yml'], CONTEXT),
+        computeTargets(['tools/pr-approval-agent/policy.py'], CONTEXT)
+    )
+})
+
+// Editor and agent configuration no suite reads. One shared lane is enough:
+// these PRs are rare, and the alternative is a lane per tree for files that
+// cannot change any test's outcome.
+test('editor and agent configuration shares one lane', () => {
+    for (const file of ['.vscode/launch.json', '.zed/debug.json', '.husky/pre-commit', '.claude/settings.json']) {
+        assert.deepEqual(computeTargets([file], CONTEXT), ['repo-config'], file)
+    }
+    // Markdown in those trees is still prose, so a PR that only reorganizes an
+    // agent doc claims no lane at all.
+    assert.deepEqual(computeTargets(['.claude/agents/code-reviewer.md'], CONTEXT), ['prose'])
 })
 
 test('globs match across directories only through **', () => {
@@ -398,8 +473,11 @@ test('independent trees stay disjoint so they can share no lane', () => {
     const node = computeTargets(['nodejs/src/worker.ts'], CONTEXT)
     const service = computeTargets(['services/mcp/src/index.ts'], CONTEXT)
     const agents = computeTargets(['.agents/skills/merging-prs/SKILL.md'], CONTEXT)
+    const infra = computeTargets(['terraform/us/project-2/dashboards.tf'], CONTEXT)
+    const live = computeTargets(['livestream/auth/jwt.go'], CONTEXT)
+    const config = computeTargets(['.zed/debug.json'], CONTEXT)
 
-    const sets = [rust, node, service, agents]
+    const sets = [rust, node, service, agents, infra, live, config]
     for (let i = 0; i < sets.length; i++) {
         for (let j = i + 1; j < sets.length; j++) {
             const overlap = sets[i].filter((target) => sets[j].includes(target))


### PR DESCRIPTION
## Problem

The lane script maps a PR's changed files to Trunk targets, and anything it does not recognize falls through to `ALL`, which is the old single-lane behavior. That fallback is correct as a default, but it fires on directories nobody ever got around to classifying, not just on genuinely repo-wide changes.

Replaying the last 500 merged PRs, 63 land on `ALL`. Nine of those are there only because a top-level directory has no rule:

| Trigger | PRs at ALL |
|---|---|
| `cli/` | 3 |
| `terraform/` | 2 |
| `.depot/` | 4 (never the sole cause) |
| `.semgrep/` | 2 |
| `docker/` | 1 |
| `.stamphog/` | 1 |

A `terraform/` PR that edits a dashboard definition serialized against every backend, frontend, rust and node PR in the queue. Nothing compiles terraform.

41 directories are tracked at the top level. Before this PR, 18 of them had no rule at all.

## Changes

Every tracked top-level directory now reaches a target set by decision. The fallthrough stays exactly as it is, so a directory added tomorrow still widens until someone classifies it.

**Trees that take a lane.** New `STANDALONE_TREES` map, one entry per directory, each carrying the suite that would catch a conflict in it:

| Tree | Targets | Why it can hold a lane |
|---|---|---|
| `cli/` | `cli`, `svc:mcp` | Its own cargo workspace (`cli/Cargo.lock`, outside `rust/` and outside the pnpm workspace). `ci-cli.yml` also builds it from `services/mcp` sources, so the two trees have to share a lane. |
| `livestream/` | `livestream` | Go service with its own CI. `ci-hog.yml` ignores `livestream/**` explicitly, so its Hog implementation is not covered by the shared hog suite either. |
| `funnel-udf/` | `funnel-udf` | Another standalone cargo workspace. Nothing in the dev or CI stack builds it: the UDF binary reaches ClickHouse through its image. |
| `terraform/` | `terraform` | `terragrunt-posthog.yaml` is the only workflow that reads the tree, and no suite compiles it. |
| `.stamphog/` | `tools:pr-approval-agent` | `ci-python.yml` validates the policy files through that pytest suite, which already owns the lane. |

`.stamphog/` markdown joins the build-input exception rather than being read as prose, for the same reason `.agents/` is already there. `AGENT_APPROVALS.md` gets the same target wherever it sits: on the product lane its directory rule would otherwise give it, a policy change and a change to the parser that reads it were free to merge in parallel.

Eleven editor, IDE and agent config trees (`.vscode`, `.zed`, `.idea`, `.claude`, `.codex`, `.cursor`, `.husky`, `.run`, `.dagster_home`, `.posthog-code`, `.interface-design`) share one `repo-config` lane. No suite reads any of them. One shared lane costs nothing at this volume and keeps the inert set to files that genuinely compile into nothing. Markdown inside them is still prose.

**Trees that become explicit tripwires.** Same `ALL` result as before, but stated rather than accidental:

- `.depot/**` holds the Depot-runner copies of the workflows and composite actions in `.github/`, so it decides what runs for everyone the same way.
- `.flox/**` is the toolchain every suite runs inside. `ci-python.yml` already gates on `.flox/env/manifest.toml`.
- `docker/**` is the ClickHouse, Postgres and Temporal configuration every docker-compose file mounts, so it defines the services all the suites test against.
- `devenv/**` mounts `duckgres.yaml` into that same stack, and `intent-map.yaml` steers `bin/sandbox` and hogli, both already tripwires.
- `.semgrep/**` and `.config/**` are lint rules that run repo-wide. A new rule fails code that merged in a parallel lane, which is the same conflict `.oxlintrc.json` is already a tripwire for.

`agent-os/` and `share/` stay off both lists on purpose. Both hold only markdown today, which the prose rule already claims, and anything else appearing there should widen until someone looks at it.

> [!NOTE]
> Narrowing is the dangerous direction: a lane that stops being claimed lets Trunk run two conflicting PRs in parallel. Each new lane names a tree with its own CI and no importer inside this repo, and the one coupling that does exist (cli builds from services/mcp) is expressed by claiming both targets rather than by trusting the trees to be independent.

## How did you test this code?

`node --test .github/scripts/trunk-impacted-targets.test.js` gives 41 pass, 7 new. One existing case moved, since `terraform/main.tf` is no longer an unmapped path and `share/geoip.py` now carries that assertion.

The new cases each guard a distinct regression: the three trees that now hold a plain lane; a standalone cargo workspace staying out of the rust crate lanes (`funnel-udf` must not be resolved against `rust/`'s graph); cli overlapping `svc:mcp` rather than islanding; stamphog policy files reaching the suite that validates them, including the markdown that the prose rule would otherwise treat as inert and the `AGENT_APPROVALS.md` that sits under a product; and the config trees sharing one lane while markdown inside them stays prose. The six new tripwires join the existing tripwire table.

**Replay against the last 500 merged PRs** (2026-07-29 to 2026-08-03), master's script versus this one, same repo tree and same cached file lists for both:

| | master | this PR |
|---|---|---|
| PRs at `ALL` | 63 | **57** |
| prose only | 3 | 3 |
| narrowed | 434 | **440** |
| PR pairs with disjoint target sets | 35.8% | **37.6%** |

Six PRs move off `ALL` and no other PR's target set changes: three `cli/` (to `["cli","svc:mcp"]`), two `terraform/` (to `["terraform"]`), one `.stamphog/` (to `["tools:pr-approval-agent"]`).

Three of the nine available PRs stay at `ALL` deliberately: `.semgrep/` on 2 and `docker/` on 1. Both are the lint-rule and shared-service-config classes above, where the parallel merge is exactly what breaks. `.depot/` costs nothing either way, since all 4 of its PRs also touch `.github/`.

<details>
<summary>Adjacent gap not addressed here</summary>

`rust/.config/nextest.toml` still falls to `ALL`, because it sits outside every crate and the rust rule widens on anything it cannot resolve to one. It is rust-wide config, so the honest target is every rust crate, which the existing `rust:unresolved` handling already expands to. One PR in this corpus. Left out to keep this change to top-level directories.

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I had Claude (Claude Code, Opus 5) close out a gap I spotted while measuring lane assignment across 500 merged PRs: a chunk of the `ALL` bucket was directories nobody had classified, not changes that genuinely touch everything.

The judgment calls worth reviewing. It went through each of the 41 tracked top-level directories, checking what workflow path filters and test suites actually read the tree before deciding, rather than pattern-matching on the name. Three candidates the earlier analysis had listed as cheap wins came back as tripwires instead: `.semgrep/` and `.config/` are lint rules, where the whole point of a lane is to stop a new rule from landing beside code it rejects, and `docker/` configures the services every suite tests against. `livestream/` initially looked coupled to the hog suite until `ci-hog.yml` turned out to ignore it explicitly. `cli/` claims `svc:mcp` because `ci-cli.yml` builds it from mcp sources, which a lane of its own would have missed.

Measurement used the same cached 500-PR corpus as the earlier analysis. The first baseline run was wrong (a copied script was missing a transitive require, which silently disabled the tach graph and made master look worse than it is); the numbers above come from a fixed baseline that reproduces the earlier analysis exactly at 63 ALL and 35.8% disjoint pairs.

No repo skills were invoked; the comment and PR conventions came from `AGENTS.md`. No manual testing beyond the automated suite and the replay described above.

