### PR TITLE
refactor(cdp): require Valkey mirrors

### DIFF
--- a/nodejs/src/cdp/cdp-services.test.ts
+++ b/nodejs/src/cdp/cdp-services.test.ts
@@ -1,6 +1,6 @@
 import { RedisV2 } from '~/common/redis/redis-v2'
 
-import { createCdpReaderRedisPool } from './cdp-services'
+import { createCdpReaderRedisPool, createCdpValkeyShadowPools } from './cdp-services'
 
 const mockReaderPool: RedisV2 = {
     useClient: jest.fn((_opts, cb) => cb({ ping: () => Promise.resolve('PONG') } as any)),
@@ -105,5 +105,36 @@ describe('createCdpReaderRedisPool', () => {
         const logMessage = logSpy.mock.calls[0]?.[1] as string
         expect(logMessage).not.toContain('supersecret')
         expect(logMessage).toContain('prod-redis.internal')
+    })
+})
+
+describe('createCdpValkeyShadowPools', () => {
+    const valkeyConfig = {
+        CDP_VALKEY_HOST: 'cdp-valkey.internal',
+        CDP_VALKEY_PORT: 6379,
+        CDP_VALKEY_PASSWORD: 'secret',
+        CDP_VALKEY_READER_HOST: '',
+        CDP_VALKEY_READER_PORT: 6379,
+        CDP_VALKEY_TLS: true,
+        REDIS_POOL_MIN_SIZE: 1,
+        REDIS_POOL_MAX_SIZE: 4,
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('creates pools whenever a Valkey host is configured', () => {
+        const result = createCdpValkeyShadowPools(valkeyConfig, 'test-valkey')
+
+        expect(result).toEqual({ writer: mockReaderPool, reader: mockReaderPool })
+        expect(createRedisV2PoolFromConfig).toHaveBeenCalledTimes(1)
+    })
+
+    it('stays disabled when no Valkey host is configured', () => {
+        const result = createCdpValkeyShadowPools({ ...valkeyConfig, CDP_VALKEY_HOST: '' }, 'test-valkey')
+
+        expect(result).toBeNull()
+        expect(createRedisV2PoolFromConfig).not.toHaveBeenCalled()
     })
 })

--- a/nodejs/src/cdp/cdp-services.test.ts
+++ b/nodejs/src/cdp/cdp-services.test.ts
@@ -132,9 +132,9 @@ describe('createCdpValkeyShadowPools', () => {
     })
 
     it('requires a Valkey host', () => {
-        expect(() =>
-            createCdpValkeyShadowPools({ ...valkeyConfig, CDP_VALKEY_HOST: '' }, 'test-valkey')
-        ).toThrow('[test-valkey] CDP_VALKEY_HOST is required for CDP services')
+        expect(() => createCdpValkeyShadowPools({ ...valkeyConfig, CDP_VALKEY_HOST: '' }, 'test-valkey')).toThrow(
+            '[test-valkey] CDP_VALKEY_HOST is required for CDP services'
+        )
         expect(createRedisV2PoolFromConfig).not.toHaveBeenCalled()
     })
 })

--- a/nodejs/src/cdp/cdp-services.test.ts
+++ b/nodejs/src/cdp/cdp-services.test.ts
@@ -131,10 +131,10 @@ describe('createCdpValkeyShadowPools', () => {
         expect(createRedisV2PoolFromConfig).toHaveBeenCalledTimes(1)
     })
 
-    it('stays disabled when no Valkey host is configured', () => {
-        const result = createCdpValkeyShadowPools({ ...valkeyConfig, CDP_VALKEY_HOST: '' }, 'test-valkey')
-
-        expect(result).toBeNull()
+    it('requires a Valkey host', () => {
+        expect(() =>
+            createCdpValkeyShadowPools({ ...valkeyConfig, CDP_VALKEY_HOST: '' }, 'test-valkey')
+        ).toThrow('[test-valkey] CDP_VALKEY_HOST is required for CDP services')
         expect(createRedisV2PoolFromConfig).not.toHaveBeenCalled()
     })
 })

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -67,7 +67,7 @@ export interface CdpCoreServices {
     redis: RedisV2
     /**
      * Shadow Valkey pools used for dual-write/read load testing. Null when
-     * CDP_VALKEY_DUAL_ENABLED is false or CDP_VALKEY_HOST is unset. Consumers
+     * CDP_VALKEY_HOST is unset. Consumers
      * that build their own redis-backed services (e.g. CdpEventsConsumer's
      * HogRateLimiterService) read this to construct mirror instances bound
      * to the shadow Valkey.
@@ -125,7 +125,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_VALKEY_PASSWORD'
         | 'CDP_VALKEY_READER_HOST'
         | 'CDP_VALKEY_READER_PORT'
-        | 'CDP_VALKEY_DUAL_ENABLED'
         | 'CDP_VALKEY_TLS'
         | 'CDP_WATCHER_HOG_COST_TIMING_LOWER_MS'
         | 'CDP_WATCHER_HOG_COST_TIMING_UPPER_MS'
@@ -245,7 +244,7 @@ export function createCdpReaderRedisPool(
 
 /**
  * Creates writer + reader pools for the shadow Valkey instance used in dual-write/read mode.
- * Returns null when CDP_VALKEY_DUAL_ENABLED is false or CDP_VALKEY_HOST is unset, in which
+ * Returns null when CDP_VALKEY_HOST is unset, in which
  * case the shadow path is disabled and behavior is identical to today.
  *
  * The reader falls back to the writer pool when CDP_VALKEY_READER_HOST is unset.
@@ -258,14 +257,13 @@ export function createCdpValkeyShadowPools(
         | 'CDP_VALKEY_PASSWORD'
         | 'CDP_VALKEY_READER_HOST'
         | 'CDP_VALKEY_READER_PORT'
-        | 'CDP_VALKEY_DUAL_ENABLED'
         | 'CDP_VALKEY_TLS'
         | 'REDIS_POOL_MIN_SIZE'
         | 'REDIS_POOL_MAX_SIZE'
     >,
     name: string
 ): CdpValkeyShadowPools | null {
-    if (!config.CDP_VALKEY_DUAL_ENABLED || !config.CDP_VALKEY_HOST) {
+    if (!config.CDP_VALKEY_HOST) {
         return null
     }
 

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -65,24 +65,13 @@ export interface CdpValkeyShadowPools {
 
 export interface CdpCoreServices {
     redis: RedisV2
-    /**
-     * Shadow Valkey pools used for dual-write/read load testing. Null when
-     * CDP_VALKEY_HOST is unset. Consumers
-     * that build their own redis-backed services (e.g. CdpEventsConsumer's
-     * HogRateLimiterService) read this to construct mirror instances bound
-     * to the shadow Valkey.
-     */
-    valkeyShadow: CdpValkeyShadowPools | null
+    /** Shadow Valkey pools used for dual-write/read load testing. */
+    valkeyShadow: CdpValkeyShadowPools
     hogFunctionManager: HogFunctionManagerService
     hogFlowManager: HogFlowManagerService
     hogWatcher: HogWatcherService
-    /**
-     * Mirror HogWatcherService bound to the shadow Valkey pool. Null when
-     * shadow mode is disabled. Use at call sites alongside `hogWatcher` (via
-     * `mirrorCall`) to load-test the new infrastructure. Constructed with
-     * `sendEvents: false` so it never emits duplicate billable team events.
-     */
-    hogWatcherMirror: HogWatcherService | null
+    /** Mirror bound to Valkey. `sendEvents` is disabled to avoid duplicate billable events. */
+    hogWatcherMirror: HogWatcherService
     hogExecutor: HogExecutorService
     /** Rebuilds the templated/resolved input bundle for a hog function — used by the rerun path to re-derive `inputs` after they're stripped from the persisted payload. */
     hogInputsService: HogInputsService
@@ -244,8 +233,6 @@ export function createCdpReaderRedisPool(
 
 /**
  * Creates writer + reader pools for the shadow Valkey instance used in dual-write/read mode.
- * Returns null when CDP_VALKEY_HOST is unset, in which
- * case the shadow path is disabled and behavior is identical to today.
  *
  * The reader falls back to the writer pool when CDP_VALKEY_READER_HOST is unset.
  */
@@ -262,9 +249,9 @@ export function createCdpValkeyShadowPools(
         | 'REDIS_POOL_MAX_SIZE'
     >,
     name: string
-): CdpValkeyShadowPools | null {
+): CdpValkeyShadowPools {
     if (!config.CDP_VALKEY_HOST) {
-        return null
+        throw new Error(`[${name}] CDP_VALKEY_HOST is required for CDP services`)
     }
 
     logger.info(
@@ -383,14 +370,12 @@ export function createCdpCoreServices(
     // so it never emits duplicate billable team events on state transitions; the
     // Prom counter `cdp_hog_function_state_change` may double-emit when both pools
     // detect the same transition — rare, accepted during dual-write mode.
-    const hogWatcherMirror: HogWatcherService | null = valkeyShadow
-        ? new HogWatcherService(
-              deps.teamManager,
-              { ...hogWatcherConfig, sendEvents: false },
-              valkeyShadow.writer,
-              valkeyShadow.reader
-          )
-        : null
+    const hogWatcherMirror = new HogWatcherService(
+        deps.teamManager,
+        { ...hogWatcherConfig, sendEvents: false },
+        valkeyShadow.writer,
+        valkeyShadow.reader
+    )
 
     const trackingCodeSigner = new EmailTrackingCodeSigner(config.ENCRYPTION_SALT_KEYS, config.CDP_EMAIL_TRACKING_URL)
     const teamWorkflowsConfigService = new TeamWorkflowsConfigService(deps.postgres)
@@ -467,7 +452,7 @@ export function createCdpCoreServices(
     // and EmailValidationService degrades to the local cache + DNS.
     const emailValidationService = new EmailValidationService(deps.emailValidationValkey)
     // Observer mirrors writes to Valkey (load-only); only the primary path drives metrics.
-    const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(redis, valkeyShadow?.writer ?? null)
+    const hogFlowDuplicateObserver = new HogFlowDuplicateObserverService(redis, valkeyShadow.writer)
     const hogFlowExecutor = new HogFlowExecutorService(
         hogFlowFunctionsService,
         recipientPreferencesService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -69,8 +69,8 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_REDIS_READER_HOST: string
     CDP_REDIS_READER_PORT: number
 
-    // Shadow Valkey pool for dual-write/read load testing. When CDP_VALKEY_DUAL_ENABLED
-    // is true and CDP_VALKEY_HOST is set, every Redis call also runs against this pool;
+    // Shadow Valkey pool for dual-write/read load testing. When CDP_VALKEY_HOST
+    // is set, every Redis call also runs against this pool;
     // shadow results are discarded, errors/timeouts logged + counted but never affect
     // the primary code path.
     CDP_VALKEY_HOST: string
@@ -78,7 +78,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_VALKEY_PASSWORD: string
     CDP_VALKEY_READER_HOST: string
     CDP_VALKEY_READER_PORT: number
-    CDP_VALKEY_DUAL_ENABLED: boolean
     // AWS ElastiCache Valkey Serverless requires TLS; toggle off only for local non-TLS test setups.
     CDP_VALKEY_TLS: boolean
 
@@ -242,7 +241,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_VALKEY_PASSWORD: '',
         CDP_VALKEY_READER_HOST: '',
         CDP_VALKEY_READER_PORT: 6379,
-        CDP_VALKEY_DUAL_ENABLED: false,
         CDP_VALKEY_TLS: false,
 
         SES_RATE_LIMITER_VALKEY_HOST: '',

--- a/nodejs/src/cdp/consumers/cdp-base.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-base.consumer.ts
@@ -53,7 +53,7 @@ export interface TeamIDWithConfig {
 
 export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = CdpConsumerBaseConfig> {
     redis: RedisV2
-    valkeyShadow: CdpValkeyShadowPools | null
+    valkeyShadow: CdpValkeyShadowPools
     isStopping = false
 
     hogExecutor: HogExecutorService
@@ -61,7 +61,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
     hogFlowExecutor: HogFlowExecutorService
     hogMasker: HogMaskerService
     hogWatcher: HogWatcherService
-    hogWatcherMirror: HogWatcherService | null
+    hogWatcherMirror: HogWatcherService
 
     groupsManager: GroupsManagerService
     hogFlowManager: HogFlowManagerService
@@ -109,7 +109,7 @@ export abstract class CdpConsumerBase<TConfig extends CdpConsumerBaseConfig = Cd
         this.outputs = services.outputs
 
         // Base-only services
-        this.hogMasker = new HogMaskerService(services.redis, services.valkeyShadow?.writer ?? null)
+        this.hogMasker = new HogMaskerService(services.redis, services.valkeyShadow.writer)
         this.personsManager = new PersonsManagerService(deps.teamManager, deps.personRepository, config.SITE_URL)
         this.groupsManager = new GroupsManagerService(deps.teamManager, deps.groupRepository)
         this.pluginDestinationExecutorService = new LegacyPluginExecutorService(deps.postgres, deps.geoipService)

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker.consumer.ts
@@ -205,9 +205,7 @@ export class CdpCyclotronWorker<
         try {
             await Promise.all([
                 this.hogWatcher.observeResults(invocationResults),
-                mirrorCall('hog-watcher.observeResults', () =>
-                    this.hogWatcherMirror?.observeResults(invocationResults)
-                ),
+                mirrorCall('hog-watcher.observeResults', () => this.hogWatcherMirror.observeResults(invocationResults)),
             ])
         } catch (err: any) {
             captureException(err)

--- a/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.test.ts
+++ b/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.test.ts
@@ -77,12 +77,12 @@ describe('HogFlowInvocationPipeline', () => {
             hogFlowManager,
             hogFlowExecutor,
             hogWatcher,
-            hogWatcherMirror: null,
+            hogWatcherMirror: hogWatcher,
             hogMasker,
             hogFunctionMonitoringService,
             quotaLimiting,
             redis: {} as any,
-            valkeyShadow: null,
+            valkeyShadow: { writer: {} as any, reader: {} as any },
         })
 
         rateLimitGroupedMock = (pipeline as any).hogRateLimiter.rateLimitGrouped as jest.Mock

--- a/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-flow-invocation-pipeline.service.ts
@@ -29,12 +29,12 @@ export interface HogFlowInvocationPipelineDeps {
     hogFlowManager: HogFlowManagerService
     hogFlowExecutor: HogFlowExecutorService
     hogWatcher: HogWatcherService
-    hogWatcherMirror: HogWatcherService | null
+    hogWatcherMirror: HogWatcherService
     hogMasker: HogMaskerService
     hogFunctionMonitoringService: HogFunctionMonitoringService
     quotaLimiting: QuotaLimiting
     redis: RedisV2
-    valkeyShadow: CdpValkeyShadowPools | null
+    valkeyShadow: CdpValkeyShadowPools
 }
 
 /**
@@ -45,7 +45,7 @@ export interface HogFlowInvocationPipelineDeps {
  */
 export class HogFlowInvocationPipeline {
     private hogRateLimiter: KeyedRateLimiterService
-    private hogRateLimiterMirror: KeyedRateLimiterService | null
+    private hogRateLimiterMirror: KeyedRateLimiterService
 
     constructor(
         private config: HogFlowInvocationPipelineConfig,
@@ -58,9 +58,7 @@ export class HogFlowInvocationPipeline {
             ttlSeconds: config.CDP_RATE_LIMITER_TTL,
         }
         this.hogRateLimiter = new KeyedRateLimiterService(rateLimiterConfig, deps.redis)
-        this.hogRateLimiterMirror = deps.valkeyShadow
-            ? new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
-            : null
+        this.hogRateLimiterMirror = new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
     }
 
     @instrumented('cdpConsumer.handleEachBatch.queueMatchingFlows')
@@ -107,7 +105,7 @@ export class HogFlowInvocationPipeline {
                 instrumentFn('cdpConsumer.handleEachBatch.hogWatcher.getEffectiveStates', async () => {
                     return await this.deps.hogWatcher.getEffectiveStates(hogFlowIds)
                 }),
-            () => this.deps.hogWatcherMirror?.getEffectiveStates(hogFlowIds)
+            () => this.deps.hogWatcherMirror.getEffectiveStates(hogFlowIds)
         )
 
         const rateLimitInputs: KeyedRateLimitRequest[] = possibleInvocations.map((x) => ({
@@ -120,7 +118,7 @@ export class HogFlowInvocationPipeline {
                 instrumentFn('cdpConsumer.handleEachBatch.hogRateLimiter.rateLimitGrouped', async () => {
                     return await this.hogRateLimiter.rateLimitGrouped(rateLimitInputs)
                 }),
-            () => this.hogRateLimiterMirror?.rateLimitGrouped(rateLimitInputs)
+            () => this.hogRateLimiterMirror.rateLimitGrouped(rateLimitInputs)
         )
         const validInvocations: CyclotronJobInvocation[] = []
 

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.test.ts
@@ -92,12 +92,12 @@ describe('HogFunctionInvocationPipeline', () => {
             hogFunctionManager,
             hogExecutor,
             hogWatcher,
-            hogWatcherMirror: null,
+            hogWatcherMirror: hogWatcher,
             hogMasker,
             hogFunctionMonitoringService,
             quotaLimiting,
             redis: {} as any,
-            valkeyShadow: null,
+            valkeyShadow: { writer: {} as any, reader: {} as any },
         })
 
         rateLimitGroupedMock = (pipeline as any).hogRateLimiter.rateLimitGrouped as jest.Mock

--- a/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
+++ b/nodejs/src/cdp/services/hog-function-invocation-pipeline.service.ts
@@ -33,12 +33,12 @@ export interface HogFunctionInvocationPipelineDeps {
     hogFunctionManager: HogFunctionManagerService
     hogExecutor: HogExecutorService
     hogWatcher: HogWatcherService
-    hogWatcherMirror: HogWatcherService | null
+    hogWatcherMirror: HogWatcherService
     hogMasker: HogMaskerService
     hogFunctionMonitoringService: HogFunctionMonitoringService
     quotaLimiting: QuotaLimiting
     redis: RedisV2
-    valkeyShadow: CdpValkeyShadowPools | null
+    valkeyShadow: CdpValkeyShadowPools
 }
 
 export interface BuildHogFunctionInvocationsOptions {
@@ -54,7 +54,7 @@ export interface BuildHogFunctionInvocationsOptions {
  */
 export class HogFunctionInvocationPipeline {
     private hogRateLimiter: KeyedRateLimiterService
-    private hogRateLimiterMirror: KeyedRateLimiterService | null
+    private hogRateLimiterMirror: KeyedRateLimiterService
 
     constructor(
         private config: HogFunctionInvocationPipelineConfig,
@@ -67,9 +67,7 @@ export class HogFunctionInvocationPipeline {
             ttlSeconds: config.CDP_RATE_LIMITER_TTL,
         }
         this.hogRateLimiter = new KeyedRateLimiterService(rateLimiterConfig, deps.redis)
-        this.hogRateLimiterMirror = deps.valkeyShadow
-            ? new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
-            : null
+        this.hogRateLimiterMirror = new KeyedRateLimiterService(rateLimiterConfig, deps.valkeyShadow.writer)
     }
 
     @instrumented('cdpConsumer.handleEachBatch.queueMatchingFunctions')
@@ -109,7 +107,7 @@ export class HogFunctionInvocationPipeline {
                 instrumentFn('cdpConsumer.handleEachBatch.hogWatcher.getEffectiveStates', async () => {
                     return await this.deps.hogWatcher.getEffectiveStates(hogFunctionIds)
                 }),
-            () => this.deps.hogWatcherMirror?.getEffectiveStates(hogFunctionIds)
+            () => this.deps.hogWatcherMirror.getEffectiveStates(hogFunctionIds)
         )
 
         const rateLimitInputs: KeyedRateLimitRequest[] = possibleInvocations.map((x) => ({
@@ -122,7 +120,7 @@ export class HogFunctionInvocationPipeline {
                 instrumentFn('cdpConsumer.handleEachBatch.hogRateLimiter.rateLimitGrouped', async () => {
                     return await this.hogRateLimiter.rateLimitGrouped(rateLimitInputs)
                 }),
-            () => this.hogRateLimiterMirror?.rateLimitGrouped(rateLimitInputs)
+            () => this.hogRateLimiterMirror.rateLimitGrouped(rateLimitInputs)
         )
 
         const validInvocations: CyclotronJobInvocationHogFunction[] = []

--- a/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.test.ts
@@ -58,21 +58,15 @@ describe('HogFlowDuplicateObserverService', () => {
     const readKey = async (key: string): Promise<string | null> =>
         (await redis.useClient({ name: 'read' }, (client) => client.get(key))) ?? null
 
-    it('is a no-op when redis is null', async () => {
-        const observer = new HogFlowDuplicateObserverService(null)
-        await observer.observe(buildInvocation(), buildAction('action-1'))
-        // Nothing to assert beyond not throwing — verifies the early return.
-    })
-
     it('is a no-op when invocation has no eventUuid', async () => {
-        const observer = new HogFlowDuplicateObserverService(redis)
+        const observer = new HogFlowDuplicateObserverService(redis, redis)
         await observer.observe(buildInvocation({ eventUuid: null }), buildAction('action-1'))
         const keys = await redis.useClient({ name: 'keys' }, (client) => client.keys(`${KEY_PREFIX}*`))
         expect(keys ?? []).toHaveLength(0)
     })
 
     it('writes the key on first observation and does not flag a duplicate', async () => {
-        const observer = new HogFlowDuplicateObserverService(redis)
+        const observer = new HogFlowDuplicateObserverService(redis, redis)
         await observer.observe(buildInvocation({ id: 'inv-A' }), buildAction('action-1'))
 
         const stored = await readKey('hogflow:observe:workflow-1:event-1:action-1')
@@ -81,7 +75,7 @@ describe('HogFlowDuplicateObserverService', () => {
     })
 
     it('does not flag a duplicate when the same invocation re-observes', async () => {
-        const observer = new HogFlowDuplicateObserverService(redis)
+        const observer = new HogFlowDuplicateObserverService(redis, redis)
         const inv = buildInvocation({ id: 'inv-A' })
         await observer.observe(inv, buildAction('action-1'))
         await observer.observe(inv, buildAction('action-1'))
@@ -90,7 +84,7 @@ describe('HogFlowDuplicateObserverService', () => {
     })
 
     it('flags a duplicate when a different invocation hits the same key', async () => {
-        const observer = new HogFlowDuplicateObserverService(redis)
+        const observer = new HogFlowDuplicateObserverService(redis, redis)
         await observer.observe(buildInvocation({ id: 'inv-A' }), buildAction('action-1'))
         await observer.observe(buildInvocation({ id: 'inv-B' }), buildAction('action-1'))
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-duplicate-observer.service.ts
@@ -17,14 +17,14 @@ const hogflowDuplicateInvocationDetectedTotal = new Counter({
 
 /**
  * Detects duplicate workflow invocations via a Redis SET-NX key per
- * (workflow, event, action). When `redisMirror` is set, every observation also
- * fires against the mirror in parallel — load is realised on the mirror; only
+ * (workflow, event, action). Every observation also fires against the mirror
+ * in parallel — load is realised on the mirror; only
  * the primary drives the duplicate-detected metric.
  */
 export class HogFlowDuplicateObserverService {
     constructor(
-        private readonly redis: RedisV2 | null,
-        private readonly redisMirror: RedisV2 | null = null
+        private readonly redis: RedisV2,
+        private readonly redisMirror: RedisV2
     ) {}
 
     public async observe(
@@ -32,7 +32,7 @@ export class HogFlowDuplicateObserverService {
         currentAction: HogFlowAction
     ): Promise<{ duplicate: boolean }> {
         const eventUuid = invocation.state?.event?.uuid
-        if (!this.redis || !eventUuid) {
+        if (!eventUuid) {
             return { duplicate: false }
         }
         const key = `hogflow:observe:${invocation.functionId}:${eventUuid}:${currentAction.id}`
@@ -49,8 +49,8 @@ export class HogFlowDuplicateObserverService {
         try {
             const existingId = await mirrorCallWithPrimary(
                 'hog-flow-duplicate-observer.observe',
-                () => this.redis!.useClient({ name: 'hogflow-observe', failOpen: true }, setNxGet),
-                () => this.redisMirror?.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, setNxGet)
+                () => this.redis.useClient({ name: 'hogflow-observe', failOpen: true }, setNxGet),
+                () => this.redisMirror.useClient({ name: 'hogflow-observe-mirror', failOpen: true }, setNxGet)
             )
             if (existingId && existingId !== invocation.id) {
                 duplicate = true

--- a/nodejs/src/cdp/services/monitoring/hog-masker.service.test.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.service.test.ts
@@ -38,7 +38,7 @@ describe('HogMasker', () => {
             })
             await deleteKeysWithPrefix(redis, BASE_REDIS_KEY)
 
-            masker = new HogMaskerService(redis)
+            masker = new HogMaskerService(redis, redis)
         })
 
         const advanceTime = (ms: number) => {

--- a/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-masker.service.ts
@@ -94,7 +94,7 @@ function getTtl(invocation: CyclotronJobInvocation, maskingConfig: HogFunctionMa
 export class HogMaskerService {
     constructor(
         private redis: RedisV2,
-        private redisMirror: RedisV2 | null = null
+        private redisMirror: RedisV2
     ) {}
 
     public async filterByMasking<T extends CyclotronJobInvocation>(
@@ -157,7 +157,7 @@ export class HogMaskerService {
         const result = await mirrorCallWithPrimary(
             'hog-masker.filterByMasking',
             () => this.redis.usePipeline({ name: 'masker', failOpen: true }, buildPipeline),
-            () => this.redisMirror?.usePipeline({ name: 'masker-mirror', failOpen: true }, buildPipeline)
+            () => this.redisMirror.usePipeline({ name: 'masker-mirror', failOpen: true }, buildPipeline)
         )
 
         Object.values(masks).forEach((masker, index) => {

--- a/nodejs/src/cdp/utils/mirror-call.test.ts
+++ b/nodejs/src/cdp/utils/mirror-call.test.ts
@@ -7,13 +7,6 @@ describe('mirrorCall', () => {
         expect(call).toHaveBeenCalledTimes(1)
     })
 
-    it('short-circuits when the call factory returns undefined (mirror unconfigured)', async () => {
-        const call = jest.fn().mockReturnValue(undefined)
-        await mirrorCall('test.op', call, 50)
-        expect(call).toHaveBeenCalledTimes(1)
-        // Resolving with no work — verified by virtue of the test not hanging.
-    })
-
     it('catches and logs errors instead of throwing', async () => {
         const call = jest.fn().mockRejectedValue(new Error('boom'))
         await expect(mirrorCall('test.op', call, 50)).resolves.toBeUndefined()

--- a/nodejs/src/cdp/utils/mirror-call.ts
+++ b/nodejs/src/cdp/utils/mirror-call.ts
@@ -18,22 +18,16 @@ const DEFAULT_TIMEOUT_MS = 2000
  * - Wrapped in `instrumentFn` so latency / errors surface in tracing under
  *   the `cdp.mirror.<label>` key.
  *
- * The `call` arg returns `Promise<unknown> | undefined` so the common pattern
- * of `() => this.fooMirror?.bar(args)` works directly: when the mirror is null
- * the inner expression evaluates to undefined and the helper short-circuits.
  */
 export async function mirrorCall(
     label: string,
-    call: () => Promise<unknown> | undefined,
+    call: () => Promise<unknown>,
     timeoutMs: number = DEFAULT_TIMEOUT_MS
 ): Promise<void> {
     return instrumentFn({ key: `cdp.mirror.${label}`, sendException: false }, async () => {
         let timeoutId: NodeJS.Timeout | undefined
         try {
             const promise = call()
-            if (!promise) {
-                return
-            }
             await Promise.race([
                 promise,
                 new Promise<never>((_, reject) => {
@@ -57,7 +51,7 @@ export async function mirrorCall(
 export async function mirrorCallWithPrimary<T>(
     label: string,
     primaryCall: () => Promise<T>,
-    mirrorCallFactory: () => Promise<unknown> | undefined,
+    mirrorCallFactory: () => Promise<unknown>,
     timeoutMs?: number
 ): Promise<T> {
     const [primary] = await Promise.all([primaryCall(), mirrorCall(label, mirrorCallFactory, timeoutMs)])


### PR DESCRIPTION
## Problem

CDP's Redis-to-Valkey mirror is controlled by optional dependencies and a separate enable flag, so configured Valkey infrastructure can remain unused.

> [!NOTE]
> This PR is stacked on [#76661](https://github.com/PostHog/posthog/pull/76661), which removes CDP Redis, Valkey, and HogWatcher infrastructure from ingestion. Review and merge #76661 first.

## Changes

- Remove `CDP_VALKEY_DUAL_ENABLED`.
- Require `CDP_VALKEY_HOST` for CDP service construction.
- Make CDP Valkey pools and all mirror consumers non-nullable.

**Why:** Configured Valkey should always be used by CDP services. The preceding ingestion PR establishes that CDP is the only remaining owner of this infrastructure.

## How did you test this code?

- `git diff --check`
- Updated focused tests for required Valkey configuration and non-nullable mirror dependencies.
- Full TypeScript and Jest validation runs in CI.

## Docs update

No user-facing documentation change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex stacked this Valkey hardening on the ingestion infrastructure cleanup to keep the incremental diff CDP-only. No skills were invoked.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*