### PR TITLE
fix(ci): stop a comment in tach.toml from truncating a module's deps

### DIFF
--- a/.github/scripts/turbo-discover-cascade.test.js
+++ b/.github/scripts/turbo-discover-cascade.test.js
@@ -207,6 +207,26 @@ layer = "modules"
     assert.deepEqual(dependents, [])
 })
 
+// tach.toml annotates facade-only edges with prose that names the tach block
+// enforcing them, so a depends_on list can carry a `]` inside a comment. The
+// scan for the list's closing bracket used to stop there and drop every entry
+// below it, and the fail-closed check could not see it because that check
+// discarded comments too.
+test('a comment inside depends_on does not truncate the list', () => {
+    const toml = `
+[[modules]]
+path = "products.a"
+depends_on = [
+    "products.b",
+    # Facade-only (enforced by c's [[interfaces]] block): a queues c's work.
+    "products.c",
+    "products.d", # direct import
+]
+layer = "modules"
+`
+    assert.deepEqual(parseTachModules(toml).get('a'), ['b', 'c', 'd'])
+})
+
 test('fail closed: a depends_on entry that is not a double-quoted string throws instead of silently dropping the edge', () => {
     const toml = `
 [[modules]]

--- a/.github/scripts/turbo-discover.js
+++ b/.github/scripts/turbo-discover.js
@@ -244,20 +244,47 @@ const moduleToProduct = (module) => module.replace(/_/g, '-')
 // aren't products.* so they fall out of the startsWith filter for free. See
 // tachDependents for why routing through them would be wrong, not just
 // inconvenient.
+// TOML comments run to the end of the line, and a `#` inside a double-quoted
+// string does not start one. Comments have to go before the block scan below,
+// because a comment inside a depends_on list can carry a `]`: tach.toml
+// documents a facade-only edge as "enforced by stamphog's [[interfaces]]
+// block", and that bracket ends the non-greedy scan early, dropping every
+// entry after it.
+function stripTomlComments(tomlText) {
+    let out = ''
+    let inString = false
+    for (let index = 0; index < tomlText.length; index++) {
+        const char = tomlText[index]
+        if (char === '"' && tomlText[index - 1] !== '\\') {
+            inString = !inString
+        }
+        if (!inString && char === '#') {
+            while (index < tomlText.length && tomlText[index] !== '\n') {
+                index++
+            }
+            out += '\n'
+            continue
+        }
+        out += char
+    }
+    return out
+}
+
 function parseTachModules(tomlText) {
     const graph = new Map()
     // Each `[[modules]]` block holds exactly one `path` and one `depends_on`
     // before the next block starts — split on the marker and take the first
-    // match of each within a block. depends_on entries are plain quoted
-    // strings with no nested brackets, so a non-greedy scan to the first `]`
-    // is safe even across multi-line lists or lists split across shared lines.
+    // match of each within a block. With comments stripped, depends_on entries
+    // are plain quoted strings with no nested brackets, so a non-greedy scan to
+    // the first `]` is safe even across multi-line lists or lists split across
+    // shared lines.
     //
     // Only double-quoted strings are supported. Other valid TOML (single-quoted
     // literals, inline tables) would be dropped by the regexes without error,
     // silently shrinking the cascade — so any entry the regexes can't represent
     // throws instead, which loadTachModuleGraph turns into "test all products".
     // A false trip over-tests; a silent drop under-tests, so err on throwing.
-    const blocks = tomlText.split('[[modules]]').slice(1)
+    const blocks = stripTomlComments(tomlText).split('[[modules]]').slice(1)
     for (const block of blocks) {
         const pathMatch = block.match(/path\s*=\s*"([^"]+)"/)
         if (!pathMatch) {
@@ -273,7 +300,9 @@ function parseTachModules(tomlText) {
             }
             continue
         }
-        const leftover = dependsMatch[1].replace(/"[^"]*"/g, '').replace(/#[^\n]*/g, '')
+        // Comments are already gone, so anything left beside the quoted entries
+        // is an entry shape these regexes cannot represent.
+        const leftover = dependsMatch[1].replace(/"[^"]*"/g, '')
         if (/[^\s,]/.test(leftover)) {
             throw new Error(
                 `unsupported \`depends_on\` entry for ${pathMatch[1]} in tach.toml (expected double-quoted strings): ${leftover.trim().slice(0, 80)}`


### PR DESCRIPTION
## Problem

`parseTachModules` finds the end of a `depends_on` list with a non-greedy `\[([\s\S]*?)\]`, so it stops at the first `]` in the block. A comment inside the list can carry one. `products.review_hog` has exactly that:

```toml
[[modules]]
path = "products.review_hog"
depends_on = [
    "ee",
    "posthog",
    "products.engineering_analytics",
    "products.signals",
    "products.skills",
    # Facade-only (enforced by stamphog's [[interfaces]] block): the inbox trigger queues
    # hosted Stamphog reviews and registers the toggle resolver hook.
    "products.stamphog",
    "products.tasks",
]
```

The scan ends inside `[[interfaces]]`, so the parser returns `["engineering_analytics", "signals", "skills"]` and drops stamphog and tasks.

It is silent, which is the part that matters. The fail-closed check right below is meant to throw on anything the regexes cannot represent, but it strips `#` comments before looking, so a list truncated *by* a comment looks perfectly well-formed.

Two consumers read that graph and both lost the same edges:

- **turbo-discover** skipped review_hog's test suite when stamphog or tasks changed.
- **The Trunk merge queue** left `py:product:review_hog` out of the lane set for those changes, so a stamphog facade rename and a review_hog call site could merge in parallel without ever being tested together. That is the exact conflict the lanes exist to prevent.

Replaying the last 500 merged PRs through the target script, 10 should have claimed `py:product:review_hog` and did not, all of them touching `products/tasks`.

## Changes

Strip TOML comments before the block scan, tracking double-quoted strings so a `#` inside one is left alone. With comments gone the non-greedy scan is correct again, and the fail-closed check can go back to seeing the raw list (it no longer needs to strip comments itself, which is what blinded it).

review_hog is the only module affected today. I verified that by diffing the parser's output against a line-based reference parse of the real `tach.toml`:

```
before: 1 of 69 modules differs (review_hog: missing stamphog, tasks)
after : 0 of 69 modules differ
```

After the fix, `tachDependents(['stamphog'])` returns `['review-hog']` and `tachDependents(['tasks'])` gains `review-hog` alongside the nine products it already named.

> [!NOTE]
> This only ever adds edges, so both consumers move in the safe direction: more test suites run, more lanes claimed. No product loses coverage.

## How did you test this code?

`node --test` on all three suites that read this parser: `turbo-discover-cascade.test.js` (11 pass, 1 new), `turbo-discover-staleness.test.js` (10 pass), `trunk-impacted-targets.test.js` (36 pass).

The new case covers the regression no existing test caught: a `depends_on` list whose comment contains `]`, asserting all three entries survive. Against the current parser it returns only the first entry, so it fails without the fix. The two existing fail-closed tests still pass, which is what keeps the `leftover` change honest.

I also ran the real `tach.toml` through both versions and diffed all 69 product modules against an independent line-based parse (numbers above), and replayed the last 500 merged PRs through `trunk-impacted-targets.js` with each version to get the 10-PR figure.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable. The reasoning lives in the parser's own comments.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude (Claude Code) while I had it checking whether the merge-queue lane rules could lean harder on the tach graph (#76481). Before answering that, it validated the graph the rules already trust, comparing `parseTachModules` output against an independent parse of `tach.toml`, and this was the one module where they disagreed.

Worth a reviewer's eye: I kept the fix to comment stripping rather than swapping in a real TOML parser. `.github/scripts` has no dependencies and runs on bare node in CI, and the existing throw-on-anything-unusual contract already covers the shapes a hand-rolled reader cannot represent. A parser would be the right call if these blocks ever grow inline tables.

`/writing-tests` and `/writing-code-comments` invoked before the test and comment edits.
