### PR TITLE
fix(desktop): update Command Center icon

### DIFF
--- a/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
+++ b/products/desktop/packages/ui/src/features/command/CommandMenu.tsx
@@ -4,6 +4,7 @@ import {
   ChartLine,
   EnvelopeSimple,
   GitDiffIcon,
+  SquaresFourIcon,
 } from "@phosphor-icons/react";
 import { workspaceIdSet } from "@posthog/core/command-center/eligibility";
 import { resolveService } from "@posthog/di/container";
@@ -75,7 +76,6 @@ import {
   FileTextIcon,
   GearIcon,
   HomeIcon,
-  LightningBoltIcon,
   MagnifyingGlassIcon,
   MoonIcon,
   ReloadIcon,
@@ -277,8 +277,8 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
       {
         id: "command-center",
         label: "Command center",
-        keywords: "lightning grid tasks parallel dashboard",
-        icon: <LightningBoltIcon className="h-3 w-3 text-gray-11" />,
+        keywords: "grid tasks parallel dashboard",
+        icon: <SquaresFourIcon className="h-3 w-3 text-gray-11" />,
         action: "open-command-center",
         onRun: () => {
           closeSettingsDialog();

--- a/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/CustomizeSidebarDialog.tsx
@@ -4,8 +4,8 @@ import {
   Bell,
   DotsSixVertical,
   EnvelopeSimple,
-  Lightning,
   SlidersHorizontal,
+  SquaresFourIcon,
 } from "@phosphor-icons/react";
 import { LOOPS_FLAG, PROJECT_BLUEBIRD_FLAG } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
@@ -29,7 +29,7 @@ const ITEM_ICONS: Record<
   React.ComponentType<{ size?: number | string }>
 > = {
   inbox: EnvelopeSimple,
-  "command-center": Lightning,
+  "command-center": SquaresFourIcon,
   activity: Bell,
   configure: SlidersHorizontal,
   loops: LoopIcon,

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/CommandCenterItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/CommandCenterItem.tsx
@@ -1,4 +1,4 @@
-import { Lightning } from "@phosphor-icons/react";
+import { SquaresFourIcon } from "@phosphor-icons/react";
 import { CountBadge } from "@posthog/ui/primitives/CountBadge";
 import { SidebarItem } from "../SidebarItem";
 
@@ -23,7 +23,9 @@ export function CommandCenterItem({
   return (
     <SidebarItem
       depth={depth}
-      icon={<Lightning size={16} weight={isActive ? "fill" : "regular"} />}
+      icon={
+        <SquaresFourIcon size={16} weight={isActive ? "fill" : "regular"} />
+      }
       label="Command Center"
       isActive={isActive}
       onClick={onClick}


### PR DESCRIPTION
## Problem

Command Center uses a lightning bolt in several navigation surfaces, which does not represent its multi-panel workspace clearly.

**Why:** A four-square grid better communicates the feature layout and keeps its visual identity consistent across navigation.

## Changes

- Replace Command Center lightning icons with the existing four-square icon in the sidebar, customizer, and command palette
- Align these surfaces with the browser tab existing Command Center icon

## How did you test this code?

- `pnpm dlx @biomejs/biome@2.2.4 check` on all three changed files
- `git diff --check`
- No new tests: this is a presentation-only icon substitution with no behavior change

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested icon update after reviewing `products/desktop/AGENTS.md` and existing Command Center icon usage. No repo-provided or public skills were invoked.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*