### PR TITLE
fix(mcp): fit the instructions payload into Codex's namespace cap

### DIFF
--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -34,12 +34,18 @@ export class InstructionsBuilder {
     }
 
     build(state: ResolvedState): string {
-        const supportsInstructions = state.clientProfile.capabilities.supportsInstructions
+        const { supportsInstructions, instructionsBudgetBytes } = state.clientProfile.capabilities
         if (!supportsInstructions) {
             return ''
         }
 
         const ctx = this.buildContext(state)
+        // A budgeted payload only carries the tool-domain index, so it applies to both
+        // modes: in tools mode the per-tool descriptions already cover the rest, and in
+        // single-exec mode the exec `command` description does.
+        if (instructionsBudgetBytes !== undefined) {
+            return this.formatter.buildBoundedExecInstructions(ctx, instructionsBudgetBytes)
+        }
         if (state.useSingleExec) {
             return this.formatter.buildExecInstructions(ctx)
         }
@@ -105,21 +111,22 @@ export class InstructionsBuilder {
     }
 
     buildExecCommandReference(state: ResolvedState): string {
-        const supportsInstructions = state.clientProfile.capabilities.supportsInstructions
+        const { supportsInstructions, instructionsBudgetBytes } = state.clientProfile.capabilities
         // Claude web/desktop report `supportsInstructions` but never surface the
         // `instructions` payload to the model, so its env-context (tool domains,
         // project metadata, group types) would be lost. Keep it on the exec command
         // description for those chat hosts only — Cowork surfaces instructions
-        // normally and gets env-context through them. (Codex, which reports
-        // `supportsInstructions: false`, already gets the full env-context via the
-        // un-stripped path.)
+        // normally and gets env-context through them.
         const keepEnvContext = state.clientProfile.isClaudeChatHost()
         const ctx = this.buildContext(state)
         if (keepEnvContext) {
             return this.formatter.buildClaudeExecCommandReference(ctx)
         }
+        // A budgeted `instructions` payload (Codex) spends its whole budget on the
+        // tool-domain index and carries no env-context, so this description has to keep
+        // it. This parameter description is the one surface these clients read in full.
         return this.formatter.buildExecCommandReference(ctx, {
-            stripEnvContext: supportsInstructions,
+            stripEnvContext: supportsInstructions && instructionsBudgetBytes === undefined,
         })
     }
 

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -35,8 +35,8 @@
  *   them. Cowork surfaces instructions normally, so it is deliberately excluded.
  *
  * - `capabilities` is a feature-flag-style object describing protocol
- *   features the client actually implements (e.g. `supportsInstructions` —
- *   Codex ignores the `instructions` field returned from `initialize`).
+ *   features the client actually implements (e.g. `instructionsBudgetBytes` —
+ *   Codex truncates the `instructions` field returned from `initialize`).
  */
 
 function normalizeClientName(s: string): string {
@@ -203,14 +203,24 @@ export const ANTHROPIC_UI_HOST_USER_AGENT_FRAGMENTS = ANTHROPIC_USER_AGENT_FRAGM
 
 export type ClientCapabilities = {
     // MCP `initialize` response includes an `instructions` field that most
-    // clients inject into the model's system prompt. Codex discards it, so
-    // we skip sending it (saving the payload cost) for those sessions.
+    // clients inject into the model's system prompt. A client that ignores it
+    // gets no payload at all, saving the transfer cost.
     supportsInstructions: boolean
+    // Set when the client truncates `instructions` instead of passing it through
+    // whole. The payload is then rendered to fit the budget and everything that
+    // doesn't fit stays on the exec `command` description, which is not capped.
+    instructionsBudgetBytes?: number
 }
 
 export const DEFAULT_CLIENT_CAPABILITIES: ClientCapabilities = {
     supportsInstructions: true,
 }
+
+/** Codex surfaces `instructions` as the *namespace description* of the MCP server's
+ *  tool namespace, and bounds that description at 1000 bytes
+ *  (`MAX_MCP_NAMESPACE_DESCRIPTION_BYTES` in codex-rs/core/src/tools/handlers/mcp.rs),
+ *  cutting the rest mid-string. */
+export const CODEX_INSTRUCTIONS_BUDGET_BYTES = 1000
 
 type CapabilityOverride = {
     // Matched against the self-reported `clientInfo.name`.
@@ -226,7 +236,10 @@ const CLIENT_CAPABILITY_OVERRIDES: readonly CapabilityOverride[] = [
     {
         fragments: ['codex'],
         userAgentFragments: ['codex'],
-        capabilities: { supportsInstructions: false },
+        capabilities: {
+            supportsInstructions: true,
+            instructionsBudgetBytes: CODEX_INSTRUCTIONS_BUDGET_BYTES,
+        },
     },
 ]
 

--- a/services/mcp/src/lib/instructions-formatter.ts
+++ b/services/mcp/src/lib/instructions-formatter.ts
@@ -3,6 +3,7 @@ import {
     buildDefinedGroupsBlock,
     buildQueryToolsBlock,
     buildToolDomainsBlock,
+    buildToolDomainsBounded,
     buildToolDomainsCompact,
     type QueryToolInfo,
     type ToolInfo,
@@ -31,6 +32,12 @@ import SCHEMA_WORKFLOW from '@/templates/sections/schema-workflow.md'
 import TOOL_SEARCH from '@/templates/sections/tool-search.md'
 import URL_PATTERNS from '@/templates/sections/url-patterns.md'
 import { type ExecHelpEntry, LEARN_COMMAND_LINE } from '@/tools/exec-help'
+
+/** Squeeze the runs of blank lines left behind by placeholders a caller deliberately
+ *  resolved to nothing, so a budgeted payload doesn't spend bytes on whitespace. */
+function collapseBlankLines(text: string): string {
+    return text.replace(/\n{3,}/g, '\n\n')
+}
 
 export interface InstructionsContext {
     guidelines: string
@@ -80,6 +87,31 @@ export class InstructionsFormatter {
      *  description (`buildExecCommandReference`) — this is just env + tool index. */
     buildExecInstructions(ctx: InstructionsContext): string {
         return this.compose([COMPACT_INSTRUCTIONS], ctx, { compact: true })
+    }
+
+    /** Build an `instructions` payload that fits `maxBytes` for clients that truncate
+     *  the field (Codex caps it at 1000 bytes). Env context is dropped rather than
+     *  squeezed: it survives on the exec `command` description, whereas the tool-domain
+     *  index has no other home in these sessions, so it gets the whole budget and
+     *  degrades its own precision to fit (see `ToolDomainExtractor.toCompactBounded`). */
+    buildBoundedExecInstructions(ctx: InstructionsContext, maxBytes: number): string {
+        const render = (toolDomains: string): string =>
+            collapseBlankLines(
+                this.compose(
+                    [COMPACT_INSTRUCTIONS],
+                    { guidelines: ctx.guidelines },
+                    {
+                        compact: true,
+                        toolDomains,
+                    }
+                )
+            )
+        // Measure the scaffold by rendering a one-byte stand-in rather than an empty
+        // string: `formatPrompt` trims the result, so an empty index would also swallow
+        // the newlines that separate it from the heading and understate the cost.
+        const scaffoldBytes = Buffer.byteLength(render('x'), 'utf8') - 1
+        const domains = ctx.tools ? buildToolDomainsBounded(ctx.tools, Math.max(0, maxBytes - scaffoldBytes)) : ''
+        return render(domains)
     }
 
     /** Build the top-level description of the `posthog:exec` tool. */
@@ -231,7 +263,13 @@ export class InstructionsFormatter {
     private compose(
         sections: string[],
         ctx: InstructionsContext,
-        opts: { compact: boolean; compactToolDomains?: boolean; extraCommands?: string }
+        opts: {
+            compact: boolean
+            compactToolDomains?: boolean
+            extraCommands?: string
+            /** Pre-rendered index, used when the caller sizes it itself. */
+            toolDomains?: string
+        }
     ): string {
         const renderToolDomains =
             opts.compact || opts.compactToolDomains ? buildToolDomainsCompact : buildToolDomainsBlock
@@ -242,7 +280,7 @@ export class InstructionsFormatter {
             guidelines: ctx.guidelines.trim(),
             defined_groups: buildDefinedGroupsBlock(ctx.groupTypes),
             metadata: ctx.metadata?.trim() ?? '',
-            tool_domains: ctx.tools ? renderToolDomains(ctx.tools) : '',
+            tool_domains: opts.toolDomains ?? (ctx.tools ? renderToolDomains(ctx.tools) : ''),
             query_tools: ctx.queryTools ? buildQueryToolsBlock(ctx.queryTools) : '',
             entity_schema_discovery: ENTITY_SCHEMA_DISCOVERY.trim(),
             extra_commands: opts.extraCommands ?? '',

--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -96,6 +96,19 @@ interface ToolItem {
  * All query-* tools collapse to a single "query" domain (`search query-` lists
  * them); their typed catalog is documented separately in the prompt.
  */
+const SEPARATOR = '|'
+/** ASCII so the marker itself costs the same in bytes as in characters, which keeps
+ *  the budget arithmetic exact for clients that cap the payload in bytes. */
+const OVERFLOW_MARKER = '|...'
+
+function fitsInBytes(text: string, maxBytes: number): boolean {
+    return Buffer.byteLength(text, 'utf8') <= maxBytes
+}
+
+function dedupeSorted(values: string[]): string[] {
+    return [...new Set(values)].sort()
+}
+
 export class ToolDomainExtractor {
     /** A family at or below this many tools stays one domain; above it, split
      *  into sub-family roots. ~25 keeps flat CRUD families (e.g. experiment) whole
@@ -179,6 +192,85 @@ export class ToolDomainExtractor {
 
     toCompact(): string {
         return this.getDomains().join('|')
+    }
+
+    /** Render the compact index within `maxBytes`, degrading precision instead of
+     *  coverage: families collapse to their shared prefix, then the longest domains
+     *  shed trailing segments one at a time. Every rendered domain stays a valid
+     *  `search` prefix at a segment boundary, so a shortened domain still finds the
+     *  tools it stands for. Domains are only dropped (marked with a trailing `...`)
+     *  when even one-segment roots overflow the budget. */
+    toCompactBounded(maxBytes: number): string {
+        const plain = this.getDomains()
+        if (fitsInBytes(plain.join(SEPARATOR), maxBytes)) {
+            return plain.join(SEPARATOR)
+        }
+        let domains = ToolDomainExtractor.foldFamilies(plain)
+        while (!fitsInBytes(domains.join(SEPARATOR), maxBytes)) {
+            const shortened = ToolDomainExtractor.shortenLongest(domains)
+            if (!shortened) {
+                break
+            }
+            domains = shortened
+        }
+        if (fitsInBytes(domains.join(SEPARATOR), maxBytes)) {
+            return domains.join(SEPARATOR)
+        }
+        while (domains.length > 1 && !fitsInBytes(domains.join(SEPARATOR) + OVERFLOW_MARKER, maxBytes)) {
+            domains = ToolDomainExtractor.dropLongest(domains)
+        }
+        return domains.join(SEPARATOR) + OVERFLOW_MARKER
+    }
+
+    /** Collapse each root family to the segment prefix its members share, so the
+     *  21 `experiment-*` sub-domains render as `experiment` and the three
+     *  `external-data-*` ones as `external-data`. */
+    private static foldFamilies(domains: string[]): string[] {
+        const byRoot = new Map<string, string[][]>()
+        for (const domain of domains) {
+            const segments = domain.split('-')
+            const root = segments[0] ?? domain
+            byRoot.set(root, [...(byRoot.get(root) ?? []), segments])
+        }
+        const folded: string[] = []
+        for (const family of byRoot.values()) {
+            folded.push(ToolDomainExtractor.sharedPrefix(family).join('-'))
+        }
+        return dedupeSorted(folded)
+    }
+
+    private static sharedPrefix(family: string[][]): string[] {
+        const first = family[0] ?? []
+        let length = 1
+        while (length < first.length && family.every((segments) => segments[length] === first[length])) {
+            length++
+        }
+        return first.slice(0, length)
+    }
+
+    /** Drop the last segment of the longest multi-segment domain. Returns null once
+     *  every domain is a single segment and precision can't be traded any further. */
+    private static shortenLongest(domains: string[]): string[] | null {
+        const target = ToolDomainExtractor.longest(domains, (domain) => domain.includes('-'))
+        if (!target) {
+            return null
+        }
+        const shortened = target.split('-').slice(0, -1).join('-')
+        return dedupeSorted(domains.map((domain) => (domain === target ? shortened : domain)))
+    }
+
+    private static dropLongest(domains: string[]): string[] {
+        const target = ToolDomainExtractor.longest(domains, () => true)
+        return domains.filter((domain) => domain !== target)
+    }
+
+    /** Longest match, breaking ties on the last name alphabetically so the rendered
+     *  index is stable for a given tool set. */
+    private static longest(domains: string[], eligible: (domain: string) => boolean): string | undefined {
+        return domains
+            .filter(eligible)
+            .sort((a, b) => a.length - b.length || a.localeCompare(b))
+            .pop()
     }
 
     /** Reduce a group sharing a `depth`-segment prefix to one or more domains,
@@ -270,6 +362,10 @@ export function buildToolDomainsBlock(tools: ToolInfo[]): string {
 
 export function buildToolDomainsCompact(tools: ToolInfo[]): string {
     return new ToolDomainExtractor(tools).toCompact()
+}
+
+export function buildToolDomainsBounded(tools: ToolInfo[], maxBytes: number): string {
+    return new ToolDomainExtractor(tools).toCompactBounded(maxBytes)
 }
 
 export interface QueryToolInfo {

--- a/services/mcp/tests/hono/instructions.test.ts
+++ b/services/mcp/tests/hono/instructions.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { InstructionsBuilder } from '@/hono/instructions'
+import type { ResolvedState } from '@/hono/request-state-resolver'
+import { CODEX_INSTRUCTIONS_BUDGET_BYTES } from '@/lib/client-detection'
+import type { ClientCapabilities } from '@/lib/client-detection'
+import { getToolDefinitions } from '@/tools/toolDefinitions'
+
+describe('InstructionsBuilder', () => {
+    const metadataMarker = 'CURRENT PROJECT: Acme (timezone America/New_York)'
+
+    const makeState = (capabilities: ClientCapabilities): ResolvedState =>
+        ({
+            useSingleExec: true,
+            metadata: metadataMarker,
+            groupTypes: [{ group_type: 'organization', group_type_index: 0, name_singular: null, name_plural: null }],
+            allTools: Object.keys(getToolDefinitions()).map((name) => ({ name })),
+            clientProfile: {
+                capabilities,
+                isClaudeChatHost: () => false,
+            },
+        }) as unknown as ResolvedState
+
+    // Codex truncates `instructions` at 1000 bytes, so a budgeted client has to get the
+    // bounded payload here and its env-context on the exec `command` description instead.
+    // Wiring this to the unbounded builder would ship a payload Codex cuts mid-domain,
+    // which is how the tool-domain index went missing for those sessions.
+    it('splits the payload for a budgeted client', () => {
+        const builder = new InstructionsBuilder('')
+        const state = makeState({
+            supportsInstructions: true,
+            instructionsBudgetBytes: CODEX_INSTRUCTIONS_BUDGET_BYTES,
+        })
+
+        const instructions = builder.build(state)
+        const commandReference = builder.buildExecCommandReference(state)
+
+        expect(Buffer.byteLength(instructions, 'utf8')).toBeLessThanOrEqual(CODEX_INSTRUCTIONS_BUDGET_BYTES)
+        expect(instructions.split('|')).toContain('skill')
+        expect(instructions).not.toContain(metadataMarker)
+        expect(commandReference).toContain(metadataMarker)
+        expect(commandReference).toContain('Defined group types: organization')
+    })
+
+    it('keeps the full payload and strips env-context from the command for an unbudgeted client', () => {
+        const builder = new InstructionsBuilder('')
+        const state = makeState({ supportsInstructions: true })
+
+        const instructions = builder.build(state)
+        const commandReference = builder.buildExecCommandReference(state)
+
+        expect(Buffer.byteLength(instructions, 'utf8')).toBeGreaterThan(CODEX_INSTRUCTIONS_BUDGET_BYTES)
+        expect(instructions).toContain(metadataMarker)
+        expect(commandReference).not.toContain(metadataMarker)
+    })
+})

--- a/services/mcp/tests/hono/request-state-resolver.test.ts
+++ b/services/mcp/tests/hono/request-state-resolver.test.ts
@@ -80,6 +80,7 @@ vi.mock('@/hono/request-context', () => {
 
 import type { RedisLike } from '@/hono/cache/RedisCache'
 import { RequestStateResolver } from '@/hono/request-state-resolver'
+import { CODEX_INSTRUCTIONS_BUDGET_BYTES } from '@/lib/client-detection'
 import { resolveFeatureFlagOverrides } from '@/lib/posthog/flags'
 import type { RequestProperties } from '@/lib/request-properties'
 import type { Env } from '@/tools/types'
@@ -193,7 +194,7 @@ describe('RequestStateResolver MCP client contexts', () => {
         expect(result.requestContext.mcpClientName).toBe('Claude Desktop')
         expect(result.sessionContext?.mcpClientName).toBe('codex')
         expect(result.clientProfile.clientName).toBe('codex')
-        expect(result.clientProfile.capabilities.supportsInstructions).toBe(false)
+        expect(result.clientProfile.capabilities.instructionsBudgetBytes).toBe(CODEX_INSTRUCTIONS_BUDGET_BYTES)
     })
 
     it('uses explicit mode when cached session client props would resolve differently', async () => {

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -15,6 +15,7 @@ import { InstructionsBuilder } from '@/hono/instructions'
 import type { ResolvedState } from '@/hono/request-state-resolver'
 import { ToolCatalog } from '@/hono/tool-catalog'
 import { ToolExecutor } from '@/hono/tool-executor'
+import { CODEX_INSTRUCTIONS_BUDGET_BYTES } from '@/lib/client-detection'
 import { buildToolDomainsCompact } from '@/lib/instructions'
 import { RENDER_UI_RESOURCE_URI, URI_MAP } from '@/resources/ui-apps.generated'
 import { getToolDefinition } from '@/tools/toolDefinitions'
@@ -187,32 +188,35 @@ describe('ToolExecutor', () => {
         })
 
         // Env-context (active project metadata + tool-domain index) must reach the model
-        // on the exec `command` for clients that don't otherwise receive the `instructions`
-        // payload: Codex reports `supportsInstructions: false` so never gets it, and Claude
-        // web/desktop report `true` but silently ignore it. Claude Code and Cowork strip
-        // it here because it arrives via `instructions` instead.
+        // on the exec `command` for clients that don't receive it through the `instructions`
+        // payload: Codex truncates that payload so it only carries the tool-domain index,
+        // and Claude web/desktop report support but silently ignore it. Claude Code and
+        // Cowork strip it here because it arrives via `instructions` instead.
         it.each([
             {
                 label: 'Claude web/desktop (ignores instructions)',
-                supportsInstructions: true,
+                capabilities: { supportsInstructions: true },
                 isClaudeChatHost: true,
                 expectEnv: true,
             },
             {
-                label: 'Codex (supportsInstructions: false)',
-                supportsInstructions: false,
+                label: 'Codex (budgeted instructions)',
+                capabilities: {
+                    supportsInstructions: true,
+                    instructionsBudgetBytes: CODEX_INSTRUCTIONS_BUDGET_BYTES,
+                },
                 isClaudeChatHost: false,
                 expectEnv: true,
             },
             {
                 label: 'Claude Code / Cowork (consume instructions)',
-                supportsInstructions: true,
+                capabilities: { supportsInstructions: true },
                 isClaudeChatHost: false,
                 expectEnv: false,
             },
         ])(
             'injects project metadata into the exec command for $label → $expectEnv',
-            async ({ supportsInstructions, isClaudeChatHost, expectEnv }) => {
+            async ({ capabilities, isClaudeChatHost, expectEnv }) => {
                 const tools = catalog
                     .getPreBuiltEntries()
                     .slice(0, 5)
@@ -223,7 +227,7 @@ describe('ToolExecutor', () => {
                     useSingleExec: true,
                     metadata: metadataMarker,
                     clientProfile: {
-                        capabilities: { supportsInstructions },
+                        capabilities,
                         isCliModeEnabled: vi.fn(() => true),
                         isClaudeUiHost: vi.fn(() => false),
                         isInlineExecUiHost: vi.fn(() => false),

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -4,6 +4,7 @@ import {
     ANTHROPIC_CLIENT_NAME_FRAGMENTS,
     ANTHROPIC_UI_HOST_USER_AGENT_FRAGMENTS,
     ANTHROPIC_UI_HOST_VENDOR_FRAGMENTS,
+    CODEX_INSTRUCTIONS_BUDGET_BYTES,
     CODING_AGENT_CLIENT_NAME_FRAGMENTS,
     DEFAULT_CLIENT_CAPABILITIES,
     MCPClientProfile,
@@ -465,24 +466,28 @@ describe('MCPClientProfile', () => {
         })
     })
 
-    describe('capabilities.supportsInstructions', () => {
+    describe('capabilities.instructionsBudgetBytes', () => {
         it.each([['codex'], ['Codex'], ['CODEX'], ['codex-cli'], ['Codex CLI'], ['codex/1.2.3'], ['openai-codex']])(
-            'is false for Codex variant %s',
+            'is budgeted for Codex variant %s',
             (clientName) => {
-                expect(new MCPClientProfile({ clientName }).capabilities.supportsInstructions).toBe(false)
+                const capabilities = new MCPClientProfile({ clientName }).capabilities
+                expect(capabilities.supportsInstructions).toBe(true)
+                expect(capabilities.instructionsBudgetBytes).toBe(CODEX_INSTRUCTIONS_BUDGET_BYTES)
             }
         )
 
-        it('is false for the name-less Codex surface of openai-mcp (User-Agent only)', () => {
+        it('is budgeted for the name-less Codex surface of openai-mcp (User-Agent only)', () => {
             expect(
-                new MCPClientProfile({ userAgent: 'openai-mcp/1.0.0 (Codex)' }).capabilities.supportsInstructions
-            ).toBe(false)
+                new MCPClientProfile({ userAgent: 'openai-mcp/1.0.0 (Codex)' }).capabilities.instructionsBudgetBytes
+            ).toBe(CODEX_INSTRUCTIONS_BUDGET_BYTES)
         })
 
         it.each([['openai-mcp/1.0.0'], ['openai-mcp/1.0.0 (ChatGPT)']])(
-            'stays true for the non-Codex openai-mcp user-agent %s',
+            'stays unbudgeted for the non-Codex openai-mcp user-agent %s',
             (userAgent) => {
-                expect(new MCPClientProfile({ userAgent }).capabilities.supportsInstructions).toBe(true)
+                const capabilities = new MCPClientProfile({ userAgent }).capabilities
+                expect(capabilities.supportsInstructions).toBe(true)
+                expect(capabilities.instructionsBudgetBytes).toBeUndefined()
             }
         )
 
@@ -495,12 +500,12 @@ describe('MCPClientProfile', () => {
             ['mcp-inspector'],
             ['windsurf'],
             ['zed'],
-        ])('is true for non-Codex client %s', (clientName) => {
-            expect(new MCPClientProfile({ clientName }).capabilities.supportsInstructions).toBe(true)
+        ])('is unbudgeted for non-Codex client %s', (clientName) => {
+            expect(new MCPClientProfile({ clientName }).capabilities.instructionsBudgetBytes).toBeUndefined()
         })
 
-        it.each([[undefined], [''], ['   ']])('defaults to true for %s', (clientName) => {
-            expect(new MCPClientProfile({ clientName }).capabilities.supportsInstructions).toBe(true)
+        it.each([[undefined], [''], ['   ']])('defaults to unbudgeted for %s', (clientName) => {
+            expect(new MCPClientProfile({ clientName }).capabilities.instructionsBudgetBytes).toBeUndefined()
         })
     })
 
@@ -528,7 +533,8 @@ describe('MCPClientProfile', () => {
 })
 
 describe('DEFAULT_CLIENT_CAPABILITIES', () => {
-    it('has supportsInstructions=true by default', () => {
+    it('has supportsInstructions=true and no budget by default', () => {
         expect(DEFAULT_CLIENT_CAPABILITIES.supportsInstructions).toBe(true)
+        expect(DEFAULT_CLIENT_CAPABILITIES.instructionsBudgetBytes).toBeUndefined()
     })
 })

--- a/services/mcp/tests/unit/instructions-formatter.test.ts
+++ b/services/mcp/tests/unit/instructions-formatter.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import type { GroupType } from '@/api/client'
 import { buildToolDomainsCompact, type QueryToolInfo } from '@/lib/instructions'
+import { CODEX_INSTRUCTIONS_BUDGET_BYTES } from '@/lib/client-detection'
 import { InstructionsFormatter, type InstructionsContext } from '@/lib/instructions-formatter'
+import { getToolDefinitions } from '@/tools/toolDefinitions'
 
 const realisticGroupTypes: GroupType[] = [
     { group_type: 'organization', group_type_index: 0, name_singular: null, name_plural: null },
@@ -359,43 +361,65 @@ describe('InstructionsFormatter', () => {
         })
     })
 
-    // Mirrors the single-exec wiring in `src/mcp.ts`. When the client honors the MCP
-    // `instructions` field, env-context moves out of the `command` description and into
-    // `instructions`: tool domains (including the `query` domain), user preferences
+    // Codex truncates `instructions` at 1000 bytes, so the payload it receives has to fit
+    // the shipped catalog inside that budget. This guards the growth direction: adding
+    // tools (or prose to the compact template) must degrade the domain index instead of
+    // pushing the payload over the cap, where Codex would cut it mid-domain.
+    describe('buildBoundedExecInstructions', () => {
+        it('fits the shipped tool catalog into the Codex budget', () => {
+            const tools = Object.entries(getToolDefinitions()).map(([name, definition]) => ({
+                name,
+                category: definition.category,
+            }))
+            const payload = new InstructionsFormatter().buildBoundedExecInstructions(
+                { ...fullCtx, tools },
+                CODEX_INSTRUCTIONS_BUDGET_BYTES
+            )
+
+            expect(Buffer.byteLength(payload, 'utf8')).toBeLessThanOrEqual(CODEX_INSTRUCTIONS_BUDGET_BYTES)
+            expect(payload).toContain('Prioritize skills over tools')
+            expect(payload.split('|')).toContain('skill')
+        })
+    })
+
+    // Mirrors the single-exec wiring in `src/hono/instructions.ts`. When the client honors
+    // the MCP `instructions` field, env-context moves out of the `command` description and
+    // into `instructions`: tool domains (including the `query` domain), user preferences
     // (timezone/name via `{metadata}`), and defined group types. The query-tool catalog
-    // stays on the `command` description. Codex (no `instructions` support) keeps today's
-    // behavior: empty `instructions`, everything inlined in the `command` description.
+    // stays on the `command` description. A client that truncates `instructions` (Codex)
+    // gets the tool-domain index there and keeps env-context on the `command` description.
     describe('exec mode wiring', () => {
         it.each([
-            { name: 'supportsInstructions=true (Claude Code etc.)', supportsInstructions: true },
-            { name: 'supportsInstructions=false (Codex)', supportsInstructions: false },
-        ])('$name: splits product context between instructions and commandReference', ({ supportsInstructions }) => {
+            { name: 'unbudgeted instructions (Claude Code etc.)', budgeted: false },
+            { name: 'budgeted instructions (Codex)', budgeted: true },
+        ])('$name: splits product context between instructions and commandReference', ({ budgeted }) => {
             const formatter = new InstructionsFormatter()
-            const instructions = supportsInstructions ? formatter.buildExecInstructions(fullCtx) : ''
+            const instructions = budgeted
+                ? formatter.buildBoundedExecInstructions(fullCtx, 1000)
+                : formatter.buildExecInstructions(fullCtx)
             const commandReference = formatter.buildExecCommandReference(fullCtx, {
-                stripEnvContext: supportsInstructions,
+                stripEnvContext: !budgeted,
             })
 
             expect(commandReference).toContain('SCHEMA DRILL-DOWN RULE')
             expect(commandReference).toContain('### Basic functionality')
             // the query catalog always lives on the command reference, both modes
             expect(commandReference).toContain('- `query-trends` — time series')
+            // queries surface in instructions only as the `query` tool domain
+            expect(instructions).toContain('dashboard|execute-sql|feature-flag|query')
+            expect(instructions).not.toContain('- `query-trends` — time series')
+            expect(commandReference).not.toContain('dashboard|execute-sql')
 
-            if (supportsInstructions) {
-                // queries surface in instructions only as the `query` tool domain
-                expect(instructions).toContain('dashboard|execute-sql|feature-flag|query')
-                expect(instructions).not.toContain('- `query-trends` — time series')
+            if (budgeted) {
+                expect(instructions).not.toContain("The user's name is Jane Doe")
+                expect(instructions).not.toContain('Defined group types: organization')
+                expect(commandReference).toContain("The user's name is Jane Doe")
+                expect(commandReference).toContain('Defined group types: organization')
+            } else {
                 expect(instructions).toContain("The user's name is Jane Doe")
                 expect(instructions).toContain('Defined group types: organization')
                 expect(commandReference).not.toContain("The user's name is Jane Doe")
                 expect(commandReference).not.toContain('Defined group types: organization')
-                expect(commandReference).not.toContain('dashboard|execute-sql')
-            } else {
-                expect(instructions).toBe('')
-                expect(commandReference).toContain('- `query-trends` — time series')
-                expect(commandReference).toContain("The user's name is Jane Doe")
-                expect(commandReference).not.toContain('dashboard|execute-sql')
-                expect(commandReference).toContain('Defined group types: organization')
             }
         })
     })

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -6,6 +6,7 @@ import {
     buildDefinedGroupsBlock,
     buildQueryToolsBlock,
     buildToolDomainsBlock,
+    buildToolDomainsBounded,
     buildToolDomainsCompact,
     QueryToolCatalog,
     type QueryToolInfo,
@@ -170,6 +171,48 @@ describe('buildToolDomainsCompact', () => {
 
     it('returns an empty string for an empty array', () => {
         expect(buildToolDomainsCompact([])).toBe('')
+    })
+})
+
+describe('buildToolDomainsBounded', () => {
+    // A family wide enough that the plain index overflows a small budget, plus a
+    // singleton and a query wrapper, so folding, shortening and the `query` domain are
+    // all exercised from one fixture.
+    const tools = [
+        ...['activity', 'archive', 'calculate', 'holdouts', 'timeseries', 'unarchive'].map((sub) => ({
+            name: `experiment-${sub}-get`,
+            category: 'Experiments',
+        })),
+        { name: 'external-data-sources-get', category: 'Warehouse' },
+        { name: 'external-data-schemas-get', category: 'Warehouse' },
+        { name: 'session-recording-get', category: 'Replay' },
+        { name: 'skill-get', category: 'Skills' },
+        { name: 'query-trends', category: 'Query wrappers' },
+    ]
+    const plain = buildToolDomainsCompact(tools)
+
+    it('renders the full index unchanged when it already fits', () => {
+        expect(buildToolDomainsBounded(tools, plain.length)).toBe(plain)
+    })
+
+    it.each([[plain.length - 1], [60], [40], [20]])(
+        'fits %i bytes with searchable prefixes of the full index',
+        (maxBytes) => {
+            const rendered = buildToolDomainsBounded(tools, maxBytes)
+
+            expect(Buffer.byteLength(rendered, 'utf8')).toBeLessThanOrEqual(maxBytes)
+            // Precision may be traded away, but a rendered domain the model can't find
+            // anything with is worse than a missing one: each must still prefix a real
+            // domain at a segment boundary.
+            for (const domain of rendered.split('|').filter((entry) => entry !== '...')) {
+                expect(plain.split('|').some((full) => full === domain || full.startsWith(`${domain}-`))).toBe(true)
+            }
+        }
+    )
+
+    it('marks the index as partial once domains have to be dropped', () => {
+        expect(buildToolDomainsBounded(tools, 20)).toContain('|...')
+        expect(buildToolDomainsBounded(tools, plain.length)).not.toContain('|...')
     })
 })
 


### PR DESCRIPTION
## Problem

Codex does read the MCP `instructions` field, but not the way we assumed. It stores the server's `instructions` and surfaces it as the *namespace description* of the server's tool namespace (`rmcp_client.rs` sets `namespace_description` from `initialize_result.instructions`, `core/src/tools/handlers/mcp.rs` puts it on the tool spec), and it bounds that description at 1000 bytes (`MAX_MCP_NAMESPACE_DESCRIPTION_BYTES`, added upstream in "Bound MCP namespace descriptions").

Our compact single-exec payload is about 2.7KB, so it would be cut mid-string. Meanwhile our client profile had Codex on `supportsInstructions: false`, meaning we sent nothing at all, so those sessions never received the tool-domain index and had no hint that domains like `skill` exist. Agents on Codex guess at what the server offers instead of searching the right prefix.

## Changes

Codex now gets a *budgeted* `instructions` payload: the skills-first line plus the tool-domain index, rendered to fit its cap. Everything else (project metadata, group types) stays on the exec `command` parameter description, which Codex reads in full and which has no cap.

- New `instructionsBudgetBytes` client capability, set to 1000 for Codex, replacing the `supportsInstructions: false` override.
- `ToolDomainExtractor.toCompactBounded(maxBytes)` renders the index within a byte budget by trading precision, not coverage:
  1. full index if it already fits,
  2. fold each family to its shared prefix (`experiment-activity|experiment-archive|...` becomes `experiment`),
  3. shed a trailing segment from the longest domain, repeatedly,
  4. only then drop domains, with a trailing `...` so the model knows the list is partial.

  Every rendered domain stays a valid `search` prefix at a segment boundary, so a shortened domain still finds the tools it stands for.
- For budgeted clients, the exec command description keeps env-context instead of stripping it.

With the full tool catalog the Codex payload lands at 999 bytes and keeps all 86 domain roots, `skill` included. Scoped sessions have fewer tools and land on an earlier, more precise rung.

> [!NOTE]
> No change for any other client: unbudgeted clients still get the full compact payload with env-context, and the exec command description is untouched for them.

## How did you test this code?

Automated only, no manual client testing:

- `pnpm exec vitest run --project unit` (2452 passed) and `--config vitest.hono.config.mts` (338 passed).
- New `buildToolDomainsBounded` cases in `tests/unit/instructions.test.ts`: catches a bounded render that overflows its budget, and one that emits a token which prefixes no real domain (which would send the model searching for nothing).
- New `tests/unit/instructions-formatter.test.ts` case asserting the *shipped* catalog fits 1000 bytes with `skill` present: catches catalog growth or added template prose pushing the payload back over Codex's cap.
- New `tests/hono/instructions.test.ts`: catches the wiring regression where a budgeted client is handed the unbounded builder, or loses env-context on the command description.
- Updated the existing Codex rows in the client-detection, tool-executor and formatter suites to the new capability shape rather than adding parallel cases.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover the per-client instructions plumbing; the behavior is documented in the capability's own doc comments.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Slack app) from a Slack thread asking whether Codex uses MCP instructions these days. I cloned openai/codex and traced `initialize_result.instructions` through to the tool spec, which is where the 1000-byte namespace-description cap turned up, then measured our rendered payloads against it.

Two approaches were rejected along the way. Flipping `supportsInstructions` to true on its own would have been worse than the status quo: it moves env-context out of the command description into a payload Codex then truncates. A single hard truncation of the domain list was also rejected because it drops the alphabetical tail (`warehouse`, `web-analytics`, `workflows`), so the ladder trades precision first and only drops domains as a last resort.

Skills invoked: `/writing-tests`, `/writing-code-comments`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785146589975769?thread_ts=1785146589.975769&cid=C09SK2PAGKF)*
