### PR TITLE
chore(ci): parallelize independent workflow tasks

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -828,15 +828,21 @@ jobs:
             # Shadow trial: canonical threads a setup-action app token into both
             # pnpm-install and setup-python; mint stripped here (secret not
             # available on Depot), so setup-python keeps the bot PAT.
-            - name: Install pnpm dependencies
-              uses: ./.depot/actions/pnpm-install
-              with:
-                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version: 3.13.13
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+            - parallel:
+                  - name: Install pnpm dependencies
+                    uses: ./.depot/actions/pnpm-install
+                    with:
+                        install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+                  - name: Set up Python
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    with:
+                        python-version: 3.13.13
+                        token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  - name: Install Rust
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
+                        components: cargo
             - name: Install uv
               id: setup-uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -848,11 +854,6 @@ jobs:
             - name: Install SAML dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
             - name: Install Python dependencies
@@ -965,20 +966,21 @@ jobs:
             # conflicts, dead rule globs, coverage (warn-only). No --live, so no
             # secrets — fork PRs get validated too (the --live slug check runs in
             # the fork-gated validate-product-yamls job instead).
-            - name: Lint owners.yaml files
-              run: ./bin/hogli owners:lint
-            - name: Check version specifiers
-              run: python .github/scripts/check-version-specifiers.py
-            - name: Check IDOR model coverage
-              run: python .github/scripts/check-idor-model-coverage.py
-            - name: Check DWH presentation layer stays source-agnostic
-              run: python .github/scripts/check-dwh-source-agnostic.py
-            - name: Check operator parity
-              run: python .github/scripts/check-operator-parity.py
-            - name: Check module boundaries (tach)
-              run: tach check --dependencies --interfaces
-            - name: Check product facade enforcement (import-linter)
-              run: lint-imports
+            - parallel:
+                  - name: Lint owners.yaml files
+                    run: ./bin/hogli owners:lint
+                  - name: Check version specifiers
+                    run: python .github/scripts/check-version-specifiers.py
+                  - name: Check IDOR model coverage
+                    run: python .github/scripts/check-idor-model-coverage.py
+                  - name: Check DWH presentation layer stays source-agnostic
+                    run: python .github/scripts/check-dwh-source-agnostic.py
+                  - name: Check operator parity
+                    run: python .github/scripts/check-operator-parity.py
+                  - name: Check module boundaries (tach)
+                    run: tach check --dependencies --interfaces
+                  - name: Check product facade enforcement (import-linter)
+                    run: lint-imports
             # Block deleting historical migration files (see safe-django-migrations.md).
             # GITHUB_ACTIONS=false suppresses the command's PR annotations on the shadow.
             - name: Check deleted migrations
@@ -1623,10 +1625,17 @@ jobs:
             - name: Add service hostnames to /etc/hosts
               shell: bash
               run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version: ${{ matrix.python-version }}
+            - parallel:
+                  - name: Set up Python
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    with:
+                        python-version: ${{ matrix.python-version }}
+                  - name: Install Rust
+                    if: needs.changes.outputs.backend == 'true'
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
+                        components: cargo
             - name: Install uv
               id: setup-uv-tests
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -1640,12 +1649,6 @@ jobs:
               shell: bash
               run: |
                   sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-            - name: Install Rust
-              if: needs.changes.outputs.backend == 'true'
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: cargo
             - name: Install sqlx-cli
               if: needs.changes.outputs.backend == 'true'
               uses: ./.depot/actions/setup-sqlx-cli

--- a/.github/scripts/flatten-parallel-steps-for-actionlint.awk
+++ b/.github/scripts/flatten-parallel-steps-for-actionlint.awk
@@ -1,5 +1,6 @@
 /^[ ]*- parallel:[ ]*$/ {
     parallel_indent = match($0, /[^ ]/) - 1
+    dedent = 0
     in_parallel = 1
     next
 }
@@ -17,7 +18,10 @@ in_parallel {
         next
     }
 
-    print substr($0, 7)
+    if (!dedent) {
+        dedent = indent - parallel_indent
+    }
+    print substr($0, dedent + 1)
     next
 }
 

--- a/.github/scripts/flatten-parallel-steps-for-actionlint.awk
+++ b/.github/scripts/flatten-parallel-steps-for-actionlint.awk
@@ -1,0 +1,24 @@
+/^[ ]*- parallel:[ ]*$/ {
+    parallel_indent = match($0, /[^ ]/) - 1
+    in_parallel = 1
+    next
+}
+
+in_parallel {
+    if ($0 ~ /^[ ]*$/) {
+        print
+        next
+    }
+
+    indent = match($0, /[^ ]/) - 1
+    if (indent <= parallel_indent) {
+        in_parallel = 0
+        print
+        next
+    }
+
+    print substr($0, 7)
+    next
+}
+
+{ print }

--- a/.github/workflows/cd-metrics-agent-image.yml
+++ b/.github/workflows/cd-metrics-agent-image.yml
@@ -43,14 +43,15 @@ jobs:
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-            - name: Config render golden tests
-              run: products/metrics/agent/tests/render/run.sh
+            - parallel:
+                  - name: Config render golden tests
+                    run: products/metrics/agent/tests/render/run.sh
 
-            - name: Helm chart tests
-              run: products/metrics/agent/tests/helm/run.sh
+                  - name: Helm chart tests
+                    run: products/metrics/agent/tests/helm/run.sh
 
-            - name: Integration smoke test (exemplars survive scrape -> OTLP)
-              run: products/metrics/agent/tests/integration/run.sh
+                  - name: Integration smoke test (exemplars survive scrape -> OTLP)
+                    run: products/metrics/agent/tests/integration/run.sh
 
     # PR validation only: proves the multi-arch image builds, with no registry
     # logins, no push destinations, and a read-only token, so PR-controlled

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -214,68 +214,70 @@ jobs:
                   fi
                   echo "version=$version" >> "$GITHUB_OUTPUT"
 
-            - name: Build and push container image (base)
-              id: build
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  context: . # use local checkout (includes downloaded artifact)
-                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
-                  buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
-                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-base:master,ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) }}
-                  platforms: linux/arm64,linux/amd64
-                  build-args: |
-                      AGENT_VERSION=${{ steps.agent-version.outputs.version }}
-                      COMMIT_HASH=${{ github.sha }}
+            - parallel:
+                  - name: Build and push container image (base)
+                    id: build
+                    uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+                    with:
+                        context: . # use local checkout (includes downloaded artifact)
+                        file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-base
+                        buildx-fallback: false # the fallback is so slow it's better to just fail
+                        push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                        tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-base:master,ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-base:{0}', github.sha) }}
+                        platforms: linux/arm64,linux/amd64
+                        build-args: |
+                            AGENT_VERSION=${{ steps.agent-version.outputs.version }}
+                            COMMIT_HASH=${{ github.sha }}
 
-            - name: Build and push container image (notebook)
-              id: build-notebook
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  context: . # use local checkout (includes downloaded artifact)
-                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook
-                  buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
-                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-notebook:master,ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) }}
-                  platforms: linux/arm64,linux/amd64
-                  build-args: COMMIT_HASH=${{ github.sha }}
+                  - name: Build and push container image (notebook)
+                    id: build-notebook
+                    uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+                    with:
+                        context: . # use local checkout (includes downloaded artifact)
+                        file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-notebook
+                        buildx-fallback: false # the fallback is so slow it's better to just fail
+                        push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                        tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-notebook:master,ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-notebook:{0}', github.sha) }}
+                        platforms: linux/arm64,linux/amd64
+                        build-args: COMMIT_HASH=${{ github.sha }}
 
-            - name: Build and push container image (pi)
-              id: build-pi
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  context: . # use local checkout (includes downloaded artifact)
-                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
-                  buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
-                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-pi:master,ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) }}
-                  platforms: linux/arm64,linux/amd64
-                  build-args: |
-                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
+                  - name: Build and push container image (streamlit)
+                    id: build-streamlit
+                    uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+                    with:
+                        context: . # use local checkout (includes downloaded artifact)
+                        file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-streamlit
+                        buildx-fallback: false # the fallback is so slow it's better to just fail
+                        push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                        tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-streamlit:master,ghcr.io/posthog/posthog-sandbox-streamlit:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-streamlit:{0}', github.sha) }}
+                        platforms: linux/arm64,linux/amd64
 
-            - name: Build and push container image (vm)
-              id: build-vm
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  context: . # use local checkout (includes downloaded artifact)
-                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-vm
-                  buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: true
-                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-vm:master,ghcr.io/posthog/posthog-sandbox-vm:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-vm:{0}', github.sha) }}
-                  platforms: linux/arm64,linux/amd64
-                  build-args: |
-                      BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
+            - parallel:
+                  - name: Build and push container image (pi)
+                    id: build-pi
+                    uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+                    with:
+                        context: . # use local checkout (includes downloaded artifact)
+                        file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-pi
+                        buildx-fallback: false # the fallback is so slow it's better to just fail
+                        push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                        tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-pi:master,ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-pi:{0}', github.sha) }}
+                        platforms: linux/arm64,linux/amd64
+                        build-args: |
+                            BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
 
-            - name: Build and push container image (streamlit)
-              id: build-streamlit
-              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
-              with:
-                  context: . # use local checkout (includes downloaded artifact)
-                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-streamlit
-                  buildx-fallback: false # the fallback is so slow it's better to just fail
-                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
-                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-streamlit:master,ghcr.io/posthog/posthog-sandbox-streamlit:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-streamlit:{0}', github.sha) }}
-                  platforms: linux/arm64,linux/amd64
+                  - name: Build and push container image (vm)
+                    id: build-vm
+                    uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+                    with:
+                        context: . # use local checkout (includes downloaded artifact)
+                        file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-vm
+                        buildx-fallback: false # the fallback is so slow it's better to just fail
+                        push: true
+                        tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-vm:master,ghcr.io/posthog/posthog-sandbox-vm:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-vm:{0}', github.sha) }}
+                        platforms: linux/arm64,linux/amd64
+                        build-args: |
+                            BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
 
     # Single required status check for branch protection. Add future sandbox
     # image jobs to `needs` here rather than reconfiguring GitHub.

--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -53,7 +53,8 @@ jobs:
                       awk -f .github/scripts/flatten-parallel-steps-for-actionlint.awk "$workflow" \
                           > "/tmp/actionlint-workflows/$(basename "$workflow")"
                   done
-                  ./.bin/actionlint -format '{{json .}}' /tmp/actionlint-workflows/* > actionlint.json
+                  ./.bin/actionlint -config-file .github/actionlint.yaml \
+                      -format '{{json .}}' /tmp/actionlint-workflows/* > actionlint.json
 
             - name: Summarize findings
               if: always()

--- a/.github/workflows/ci-actionlint.yml
+++ b/.github/workflows/ci-actionlint.yml
@@ -47,7 +47,13 @@ jobs:
                   SHELLCHECK_OPTS: --severity=error
               run: |
                   set -euo pipefail
-                  ./.bin/actionlint -format '{{json .}}' > actionlint.json
+                  mkdir -p /tmp/actionlint-workflows
+                  for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
+                      [ -e "$workflow" ] || continue
+                      awk -f .github/scripts/flatten-parallel-steps-for-actionlint.awk "$workflow" \
+                          > "/tmp/actionlint-workflows/$(basename "$workflow")"
+                  done
+                  ./.bin/actionlint -format '{{json .}}' /tmp/actionlint-workflows/* > actionlint.json
 
             - name: Summarize findings
               if: always()

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -823,17 +823,24 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY }}
                   skip-token-revoke: true
 
-            - name: Install pnpm dependencies
-              uses: ./.github/actions/pnpm-install
-              with:
-                  install-command: pnpm install --frozen-lockfile --filter=@posthog/root
-                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            - parallel:
+                  - name: Install pnpm dependencies
+                    uses: ./.github/actions/pnpm-install
+                    with:
+                        install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+                        token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version: 3.13.13
-                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+                  - name: Set up Python
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    with:
+                        python-version: 3.13.13
+                        token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+
+                  - name: Install Rust
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
+                        components: cargo
 
             - name: Install uv
               id: setup-uv
@@ -847,12 +854,6 @@ jobs:
             - name: Install SAML dependencies
               if: steps.setup-uv.outputs.cache-hit != 'true'
               run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-
-            - name: Install Rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: cargo
 
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
@@ -1181,26 +1182,27 @@ jobs:
             # conflicts, dead rule globs, coverage (warn-only). No --live, so no
             # secrets — fork PRs get validated too (the --live slug check runs in
             # the fork-gated validate-product-yamls job instead).
-            - name: Lint owners.yaml files
-              run: ./bin/hogli owners:lint
+            - parallel:
+                  - name: Lint owners.yaml files
+                    run: ./bin/hogli owners:lint
 
-            - name: Check version specifiers
-              run: python .github/scripts/check-version-specifiers.py
+                  - name: Check version specifiers
+                    run: python .github/scripts/check-version-specifiers.py
 
-            - name: Check IDOR model coverage
-              run: python .github/scripts/check-idor-model-coverage.py
+                  - name: Check IDOR model coverage
+                    run: python .github/scripts/check-idor-model-coverage.py
 
-            - name: Check DWH presentation layer stays source-agnostic
-              run: python .github/scripts/check-dwh-source-agnostic.py
+                  - name: Check DWH presentation layer stays source-agnostic
+                    run: python .github/scripts/check-dwh-source-agnostic.py
 
-            - name: Check operator parity
-              run: python .github/scripts/check-operator-parity.py
+                  - name: Check operator parity
+                    run: python .github/scripts/check-operator-parity.py
 
-            - name: Check module boundaries (tach)
-              run: tach check --dependencies --interfaces
+                  - name: Check module boundaries (tach)
+                    run: tach check --dependencies --interfaces
 
-            - name: Check product facade enforcement (import-linter)
-              run: lint-imports
+                  - name: Check product facade enforcement (import-linter)
+                    run: lint-imports
 
             # Deterministic = a static check above failed after setup completed.
             # A retry can't fix it, so this signals the cancellation gate to stop the run.
@@ -2563,11 +2565,19 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}
                   skip-token-revoke: true
 
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version: ${{ matrix.python-version }}
-                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+            - parallel:
+                  - name: Set up Python
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    with:
+                        python-version: ${{ matrix.python-version }}
+                        token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+
+                  - name: Install Rust
+                    if: needs.changes.outputs.backend == 'true'
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
+                        components: cargo
 
             - name: Install uv
               id: setup-uv-tests
@@ -2583,13 +2593,6 @@ jobs:
               shell: bash
               run: |
                   sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
-
-            - name: Install Rust
-              if: needs.changes.outputs.backend == 'true'
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: cargo
 
             - name: Install sqlx-cli
               if: needs.changes.outputs.backend == 'true'

--- a/.github/workflows/ci-deltalite-python.yml
+++ b/.github/workflows/ci-deltalite-python.yml
@@ -49,11 +49,17 @@ jobs:
                   sparse-checkout-cone-mode: false
                   clean: false
 
-            - name: Install rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: clippy,rustfmt
+            - parallel:
+                  - name: Install rust
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
+                        components: clippy,rustfmt
+
+                  - name: Set up Python
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    with:
+                        python-version: '3.13'
 
             - name: Cache Rust dependencies
               uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
@@ -61,10 +67,6 @@ jobs:
                   shared-key: 'v1-deltalite-python'
                   workspaces: rust
                   save-if: ${{ github.ref == 'refs/heads/master' }}
-
-            - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-              with:
-                  python-version: '3.13'
 
             - name: Install uv
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -660,19 +660,20 @@ jobs:
                   path: .typegen
                   key: ${{ runner.os }}-typegen-${{ hashFiles('pnpm-lock.yaml') }}
 
-            - name: Run typescript check (tsgo)
-              run: pnpm --filter=@posthog/frontend typescript:check
+            - parallel:
+                  - name: Run typescript check (tsgo)
+                    run: pnpm --filter=@posthog/frontend typescript:check
 
-            - name: Check if schema.json and validators.js are up to date
-              run: pnpm --filter=@posthog/frontend schema:build:json && git diff --exit-code
+                  - name: Check if schema.json and validators.js are up to date
+                    run: pnpm --filter=@posthog/frontend schema:build:json && git diff --exit-code
 
-            - name: Check if mobile replay "schema.json" is up to date
-              run: pnpm --filter=@posthog/frontend mobile-replay:schema:build:json && git diff --exit-code
-              env:
-                  NODE_OPTIONS: --max-old-space-size=8192
+                  - name: Check if mobile replay "schema.json" is up to date
+                    run: pnpm --filter=@posthog/frontend mobile-replay:schema:build:json && git diff --exit-code
+                    env:
+                        NODE_OPTIONS: --max-old-space-size=8192
 
-            - name: Validate SetupTaskId completions
-              run: node bin/validate-setup-tasks.mjs
+                  - name: Validate SetupTaskId completions
+                    run: node bin/validate-setup-tasks.mjs
 
     jest:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -169,21 +169,22 @@ jobs:
             - name: Prepare Node.js workspace
               run: bin/turbo --filter=@posthog/nodejs prepare
 
-            - name: Check formatting with prettier
-              run: pnpm --filter=@posthog/nodejs format:check
+            - parallel:
+                  - name: Check formatting with prettier
+                    run: pnpm --filter=@posthog/nodejs format:check
 
-            - name: Lint with ESLint
-              run: pnpm --filter=@posthog/nodejs lint
+                  - name: Lint with ESLint
+                    run: pnpm --filter=@posthog/nodejs lint
 
-            # Guards the cdp/ingestion separation: fails on new lane->lane or shared->lane
-            # imports. Presence-checked so branches without the guard yet are unaffected.
-            - name: Check ingestion boundaries
-              run: |
-                  if [ -f nodejs/bin/check-ingestion-boundaries.mjs ]; then
-                      node nodejs/bin/check-ingestion-boundaries.mjs
-                  else
-                      echo "Ingestion boundary guard not present on this branch; skipping."
-                  fi
+                  # Guards the cdp/ingestion separation: fails on new lane->lane or shared->lane
+                  # imports. Presence-checked so branches without the guard yet are unaffected.
+                  - name: Check ingestion boundaries
+                    run: |
+                        if [ -f nodejs/bin/check-ingestion-boundaries.mjs ]; then
+                            node nodejs/bin/check-ingestion-boundaries.mjs
+                        else
+                            echo "Ingestion boundary guard not present on this branch; skipping."
+                        fi
 
     build:
         if: needs.changes.outputs.nodejs == 'true'

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -136,26 +136,10 @@ jobs:
               run: |
                   ./bin/download-mmdb
 
-            - name: Check for syntax errors, import sort, and code style violations
-              shell: bash
-              run: |
-                  ruff check .
-
-            - name: Check formatting
-              shell: bash
-              run: |
-                  ruff format --check --diff .
-
             - name: Add ty Problem Matcher
               shell: bash
               run: |
                   echo "::add-matcher::.github/ty-problem-matcher.json"
-
-            - name: Check ty type checking
-              shell: bash
-              run: |
-                  echo "📊 Feedback welcome in #team-devex"
-                  uv run ty check
 
             - name: Add mypy Problem Matcher
               shell: bash
@@ -170,12 +154,59 @@ jobs:
                   restore-keys: |
                       mypy-cache-${{ runner.os }}-3.12-mypy2-
 
-            - name: Check static typing
-              shell: bash -e {0}
-              env:
-                  MYPY_NUM_WORKERS: 2
+            - name: Check if "schema.py" is up to date
+              shell: bash
               run: |
-                  mypy --version && mypy --cache-fine-grained .
+                  npm run schema:build:python && git diff --exit-code
+
+            - parallel:
+                  - name: Check for syntax errors, import sort, and code style violations
+                    shell: bash
+                    run: ruff check .
+
+                  - name: Check formatting
+                    shell: bash
+                    run: ruff format --check --diff .
+
+                  - name: Check ty type checking
+                    shell: bash
+                    run: |
+                        echo "📊 Feedback welcome in #team-devex"
+                        uv run ty check
+
+                  - name: Check static typing
+                    shell: bash -e {0}
+                    env:
+                        MYPY_NUM_WORKERS: 2
+                    run: mypy --version && mypy --cache-fine-grained .
+
+                  - name: Check hogli manifest completeness
+                    shell: bash
+                    run: ./bin/hogli meta:check
+
+                  - name: Run hogli framework tests
+                    shell: bash
+                    run: pytest tools/hogli/tests -v --junitxml=junit-hogli.xml
+
+                  - name: Run hogli extension tests
+                    shell: bash
+                    run: pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
+
+                  - name: Run owners resolver tests
+                    shell: bash
+                    run: pytest tools/owners/tests -v --junitxml=junit-owners.xml
+
+                  - name: Run query-performance-ai tests
+                    shell: bash
+                    run: pytest tools/query-performance-ai/query_performance_ai -v --junitxml=junit-query-performance-ai.xml
+
+                  - name: Run pr-approval-agent (stamphog) tests
+                    shell: bash
+                    run: pytest tools/pr-approval-agent -v --junitxml=junit-pr-approval-agent.xml
+
+                  - name: Run dependency detection script tests
+                    shell: bash
+                    run: pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
 
             - name: Save mypy cache
               if: github.ref == 'refs/heads/master'
@@ -183,41 +214,6 @@ jobs:
               with:
                   path: .mypy_cache
                   key: mypy-cache-${{ runner.os }}-3.12-mypy2-${{ hashFiles('**/pyproject.toml', '**/mypy.ini') }}
-
-            - name: Check if "schema.py" is up to date
-              shell: bash
-              run: |
-                  npm run schema:build:python && git diff --exit-code
-
-            - name: Check hogli manifest completeness
-              shell: bash
-              run: |
-                  ./bin/hogli meta:check
-
-            - name: Run hogli framework tests
-              shell: bash
-              run: |
-                  pytest tools/hogli/tests -v --junitxml=junit-hogli.xml
-
-            - name: Run hogli extension tests
-              shell: bash
-              run: |
-                  pytest tools/hogli-commands/hogli_commands/tests -v --junitxml=junit-hogli-commands.xml
-
-            - name: Run owners resolver tests
-              shell: bash
-              run: |
-                  pytest tools/owners/tests -v --junitxml=junit-owners.xml
-
-            - name: Run query-performance-ai tests
-              shell: bash
-              run: |
-                  pytest tools/query-performance-ai/query_performance_ai -v --junitxml=junit-query-performance-ai.xml
-
-            - name: Run pr-approval-agent (stamphog) tests
-              shell: bash
-              run: |
-                  pytest tools/pr-approval-agent -v --junitxml=junit-pr-approval-agent.xml
 
             - name: Upload test results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -230,11 +226,6 @@ jobs:
                       junit-owners.xml
                       junit-query-performance-ai.xml
                       junit-pr-approval-agent.xml
-
-            - name: Run dependency detection script tests
-              shell: bash
-              run: |
-                  pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
 
             - name: Upload test results for dependency detection
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -141,6 +141,12 @@ jobs:
               run: |
                   echo "::add-matcher::.github/ty-problem-matcher.json"
 
+            - name: Check ty type checking
+              shell: bash
+              run: |
+                  echo "📊 Feedback welcome in #team-devex"
+                  uv run ty check
+
             - name: Add mypy Problem Matcher
               shell: bash
               run: |
@@ -153,6 +159,19 @@ jobs:
                   key: mypy-cache-${{ runner.os }}-3.12-mypy2-${{ hashFiles('**/pyproject.toml', '**/mypy.ini') }}
                   restore-keys: |
                       mypy-cache-${{ runner.os }}-3.12-mypy2-
+
+            - name: Check static typing
+              shell: bash -e {0}
+              env:
+                  MYPY_NUM_WORKERS: 2
+              run: mypy --version && mypy --cache-fine-grained .
+
+            - name: Save mypy cache
+              if: github.ref == 'refs/heads/master'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: .mypy_cache
+                  key: mypy-cache-${{ runner.os }}-3.12-mypy2-${{ hashFiles('**/pyproject.toml', '**/mypy.ini') }}
 
             - name: Check if "schema.py" is up to date
               shell: bash
@@ -167,18 +186,6 @@ jobs:
                   - name: Check formatting
                     shell: bash
                     run: ruff format --check --diff .
-
-                  - name: Check ty type checking
-                    shell: bash
-                    run: |
-                        echo "📊 Feedback welcome in #team-devex"
-                        uv run ty check
-
-                  - name: Check static typing
-                    shell: bash -e {0}
-                    env:
-                        MYPY_NUM_WORKERS: 2
-                    run: mypy --version && mypy --cache-fine-grained .
 
                   - name: Check hogli manifest completeness
                     shell: bash
@@ -207,13 +214,6 @@ jobs:
                   - name: Run dependency detection script tests
                     shell: bash
                     run: pytest bin/test/test_find_python_dependencies.py -v --junitxml=junit-dependency-detection.xml
-
-            - name: Save mypy cache
-              if: github.ref == 'refs/heads/master'
-              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: .mypy_cache
-                  key: mypy-cache-${{ runner.os }}-3.12-mypy2-${{ hashFiles('**/pyproject.toml', '**/mypy.ini') }}
 
             - name: Upload test results
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -247,19 +247,20 @@ jobs:
                   sparse-checkout-cone-mode: false
                   clean: false
 
-            - name: Install system OpenSSL
-              run: |
-                  sudo rm -f /etc/apt/sources.list.d/*twingate*
-                  sudo apt-get update
-                  sudo apt-get install -y libssl-dev pkg-config
+            - parallel:
+                  - name: Install system OpenSSL
+                    run: |
+                        sudo rm -f /etc/apt/sources.list.d/*twingate*
+                        sudo apt-get update
+                        sudo apt-get install -y libssl-dev pkg-config
 
-            - name: Install protoc
-              uses: ./.github/actions/setup-protoc
+                  - name: Install protoc
+                    uses: ./.github/actions/setup-protoc
 
-            - name: Install rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
+                  - name: Install rust
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
 
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
@@ -695,20 +696,21 @@ jobs:
                   sparse-checkout-cone-mode: false
                   clean: false
 
-            - name: Install system OpenSSL
-              run: |
-                  sudo rm -f /etc/apt/sources.list.d/*twingate*
-                  sudo apt-get update
-                  sudo apt-get install -y libssl-dev pkg-config
+            - parallel:
+                  - name: Install system OpenSSL
+                    run: |
+                        sudo rm -f /etc/apt/sources.list.d/*twingate*
+                        sudo apt-get update
+                        sudo apt-get install -y libssl-dev pkg-config
 
-            - name: Install protoc
-              uses: ./.github/actions/setup-protoc
+                  - name: Install protoc
+                    uses: ./.github/actions/setup-protoc
 
-            - name: Install rust
-              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
-              with:
-                  toolchain: 1.91.1
-                  components: clippy,rustfmt
+                  - name: Install rust
+                    uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+                    with:
+                        toolchain: 1.91.1
+                        components: clippy,rustfmt
 
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"

--- a/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_workflow_lint.py
@@ -108,6 +108,33 @@ class TestReadWorkflows:
         assert job.is_reusable_call
         assert job.uses == "./.github/workflows/other.yml"
 
+    def test_flattens_parallel_steps(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "wf.yml",
+            """
+            name: My
+            on: [pull_request]
+            jobs:
+              build:
+                timeout-minutes: 5
+                runs-on: depot-ubuntu-latest
+                steps:
+                  - run: echo before
+                  - parallel:
+                      - id: cache
+                        uses: actions/cache/save@v5
+                      - run: echo nested
+            """,
+        )
+        wf = next(read_workflows(tmp_path))
+        [job] = wf.jobs
+        assert [(step.id_, step.uses, step.run) for step in job.steps] == [
+            (None, None, "echo before"),
+            ("cache", "actions/cache/save@v5", None),
+            (None, None, "echo nested"),
+        ]
+
     def test_parse_error_raises_typed(self, tmp_path: Path) -> None:
         bad = tmp_path / "wf.yml"
         bad.write_text("name: x\non: [\njobs: {}\n")

--- a/tools/hogli-commands/hogli_commands/workflow_lint/model.py
+++ b/tools/hogli-commands/hogli_commands/workflow_lint/model.py
@@ -12,6 +12,8 @@ Quirks hidden here:
 - Reusable workflow calls (jobs with `uses:` at the job level) have no steps
   and no `timeout-minutes` — surfaced as `is_reusable_call` so checks can skip
   cleanly.
+- Parallel task groups are flattened so policy checks inspect their nested
+  steps exactly like ordinary sequential steps.
 """
 
 from __future__ import annotations
@@ -134,7 +136,16 @@ def _build_job(name: str, raw: object) -> Job | None:
     raw_steps = raw.get("steps")
     steps: list[Step] = []
     if isinstance(raw_steps, list):
-        for idx, step_raw in enumerate(raw_steps):
+        flattened_steps = [
+            nested_step
+            for step_raw in raw_steps
+            for nested_step in (
+                step_raw.get("parallel", [])
+                if isinstance(step_raw, dict) and isinstance(step_raw.get("parallel"), list)
+                else [step_raw]
+            )
+        ]
+        for idx, step_raw in enumerate(flattened_steps):
             step = _build_step(idx, step_raw)
             if step is not None:
                 steps.append(step)


### PR DESCRIPTION
## Problem

Independent setup, validation, test, and image-build steps currently run serially on Depot runners. This adds avoidable wall-clock time to CI and deployment workflows even when the tasks do not share state.

## Changes

- run independent frontend, backend, Python, Node.js, Rust, DeltaLite, and metrics-agent tasks in parallel
- build independent sandbox images concurrently while preserving the base-image dependency boundary
- keep actionlint and custom workflow policy checks effective by flattening parallel groups for actionlint and traversing nested tasks in the custom parser

Before:

```mermaid
flowchart LR
    A[setup] --> B[check one] --> C[check two] --> D[check three]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B,C,D phBlue;
```

After:

```mermaid
flowchart LR
    A[setup] --> B[parallel task group]
    B --> C[next dependency boundary]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,C phYellow;
    class B phBlue;
```

## How did you test this code?

- ran actionlint v1.7.12 against all workflows after compatibility flattening
- ran all 99 workflow-lint tests; the new case prevents nested parallel tasks from escaping policy checks
- ran hogli lint:workflows across all workflows
- ran git diff --check

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change is needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the workflow changes after reviewing the parallel-task pattern in PostHog/burrow#22. It invoked /writing-tests and /writing-code-comments for the workflow parser coverage and documentation. Stateful database operations, generated-file prerequisites, cache publication, artifact upload, and dependent sandbox image builds remain ordered.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*