### PR TITLE
feat(cli): adopt bundler-emitted debug ids as chunk ids under --no-release-bind

### DIFF
--- a/cli/.sampo/changesets/cli-debug-id-adoption.md
+++ b/cli/.sampo/changesets/cli-debug-id-adoption.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: minor
+---
+
+With `--no-release-bind`, `inject` now adopts a bundler-emitted ECMA-426 debug id (`//# debugId=` comment or the sourcemap's `debugId` field) as the chunk id instead of deriving its own, so one id identifies the chunk across the toolchain. The sourcemap's `debugId` field is preserved on save, and hermes uploads still accept maps that carry only a `debugId`.

--- a/cli/.sampo/changesets/cli-experimental-release-injection.md
+++ b/cli/.sampo/changesets/cli-experimental-release-injection.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: minor
+---
+
+Add experimental `--no-release-bind` (env `POSTHOG_NO_RELEASE_BIND`) to `inject`/`upload`/`process`: derive content-addressed chunk ids that stay stable across rebuilds, and inject the release id into each JS chunk as `_posthogReleaseId` so the SDK reports it per event, instead of stamping it onto the uploaded symbol sets. The release is still created — it just isn't bound to any chunk. Off by default; the existing paths are unchanged.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2815,6 +2815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,6 +3589,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,7 +50,7 @@ serde_yaml = "0.9"
 colored = "3.0"
 regex = "1.12"
 tracing = "0.1.41"
-uuid = { version = "1.16.0", features = ["v7"] }
+uuid = { version = "1.16.0", features = ["v5", "v7"] }
 thiserror = "2.0.12"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 posthog-rs = { version = "0.15.0", default-features = false, features = ["error-tracking"] }

--- a/cli/src/sourcemaps/constant.rs
+++ b/cli/src/sourcemaps/constant.rs
@@ -1,3 +1,18 @@
+// Chunk-id-only injection. `e._posthogChunkIds[stack] = chunkId` on the global.
 pub const CODE_SNIPPET_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{},n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();"#;
+
+// Chunk-id + release injection. Sets `e._posthogReleaseId` to the release row's id
+// (first-wins, so the first loaded chunk pins the release) alongside the chunk-id map.
+// The SDK only reads it when it is a non-empty string, so the placeholder is filled with
+// a JSON-encoded string literal that carries its own quotes.
+pub const CODE_SNIPPET_WITH_RELEASE_TEMPLATE: &str = r#"!function(){try{var e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof globalThis?globalThis:"undefined"!=typeof self?self:{};e._posthogReleaseId=e._posthogReleaseId||__POSTHOG_RELEASE_ID__;var n=(new e.Error).stack;n&&(e._posthogChunkIds=e._posthogChunkIds||{},e._posthogChunkIds[n]="__POSTHOG_CHUNK_ID__")}catch(e){}}();"#;
+
 pub const CHUNKID_COMMENT_PREFIX: &str = "\n//# chunkId=__POSTHOG_CHUNK_ID__";
 pub const CHUNKID_PLACEHOLDER: &str = "__POSTHOG_CHUNK_ID__";
+pub const RELEASE_ID_PLACEHOLDER: &str = "__POSTHOG_RELEASE_ID__";
+
+// Fixed namespace for deriving deterministic (content-addressed) chunk ids via UUIDv5.
+// Same minified bytes in, same chunk id out — across machines and rebuilds — so re-uploads
+// dedupe and symbol sets stay stable without a per-build random id.
+pub const CHUNK_ID_NAMESPACE: uuid::Uuid =
+    uuid::Uuid::from_u128(0x0e9b3c7a5d1f42a8b6c4e2d0f8a17593);

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -31,8 +31,13 @@ fn build_code_snippet(chunk_id: &str, release_id: Option<&str>) -> Result<String
 pub struct SourceMapContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub release_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", alias = "debugId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub chunk_id: Option<String>,
+    /// Bundler-emitted ECMA-426 debug id. Kept separate from `chunk_id` so a bundler-stamped
+    /// map isn't mistaken for one we already processed (which would skip the mapping
+    /// adjustment on inject). Preserved on save for interop.
+    #[serde(rename = "debugId", skip_serializing_if = "Option::is_none")]
+    pub debug_id: Option<String>,
     #[serde(flatten)]
     pub fields: BTreeMap<String, Value>,
 }
@@ -102,6 +107,10 @@ impl SourceMapFile {
         self.inner.content.chunk_id.clone()
     }
 
+    pub fn get_debug_id(&self) -> Option<String> {
+        self.inner.content.debug_id.clone()
+    }
+
     pub fn get_release_id(&self) -> Option<String> {
         self.inner.content.release_id.clone()
     }
@@ -151,6 +160,7 @@ impl SourceMapFile {
         let mut old_content = std::mem::replace(&mut self.inner.content, new_content);
         self.inner.content.chunk_id = old_content.chunk_id.take();
         self.inner.content.release_id = old_content.release_id.take();
+        self.inner.content.debug_id = old_content.debug_id.take();
         // Preserve extension fields (e.g. x_org_dartlang_dart2js for Flutter/Dart minified name mapping)
         // Skip "sections" since that's specific to index sourcemaps which we flatten above
         for (key, value) in old_content.fields {
@@ -188,6 +198,11 @@ impl MinifiedSourceFile {
 
     pub fn get_chunk_id(&self) -> Option<String> {
         let patterns = ["//# chunkId="];
+        self.get_comment_value(&patterns)
+    }
+
+    pub fn get_debug_id(&self) -> Option<String> {
+        let patterns = ["//# debugId="];
         self.get_comment_value(&patterns)
     }
 
@@ -364,7 +379,10 @@ fn trailing_sourcemap_reference_range(content: &str) -> Option<std::ops::Range<u
 
     for (line_start, line_end, line) in lines.into_iter().rev() {
         let trimmed_line = line.trim();
-        if trimmed_line.is_empty() || trimmed_line.starts_with("//# chunkId=") {
+        if trimmed_line.is_empty()
+            || trimmed_line.starts_with("//# chunkId=")
+            || trimmed_line.starts_with("//# debugId=")
+        {
             continue;
         }
         if trimmed_line.starts_with("//# sourceMappingURL=")
@@ -382,8 +400,11 @@ impl TryInto<SymbolSetUpload> for SourceMapFile {
     type Error = anyhow::Error;
 
     fn try_into(self) -> Result<SymbolSetUpload> {
+        // Hermes maps built with other tooling may carry only a debug id; accept it as the
+        // chunk id so those uploads keep working.
         let chunk_id = self
             .get_chunk_id()
+            .or_else(|| self.get_debug_id())
             .ok_or_else(|| anyhow!("Chunk ID not found"))?;
 
         let release_id = self.get_release_id();
@@ -540,6 +561,47 @@ mod tests {
             ],
         }));
         assert!(!sm.is_empty());
+    }
+
+    #[test]
+    fn debug_id_is_not_conflated_with_chunk_id_and_round_trips() {
+        let sm = content_from(json!({
+            "version": 3,
+            "mappings": "AAAA",
+            "sources": ["a.ts"],
+            "names": [],
+            "debugId": "11111111-2222-4333-8444-555555555555",
+        }));
+
+        assert_eq!(
+            sm.debug_id.as_deref(),
+            Some("11111111-2222-4333-8444-555555555555")
+        );
+        assert!(sm.chunk_id.is_none());
+
+        let out = serde_json::to_value(&sm).expect("Failed to serialize");
+        assert_eq!(out["debugId"], "11111111-2222-4333-8444-555555555555");
+        assert!(out.get("chunk_id").is_none());
+    }
+
+    #[test]
+    fn hermes_upload_accepts_map_with_only_debug_id() {
+        let file = SourceMapFile {
+            inner: SourceFile::new(
+                PathBuf::from("bundle.js.map"),
+                content_from(json!({
+                    "version": 3,
+                    "mappings": "AAAA",
+                    "sources": ["a.ts"],
+                    "names": [],
+                    "debugId": "11111111-2222-4333-8444-555555555555",
+                    "x_hermes_function_offsets": {},
+                })),
+            ),
+        };
+
+        let upload: SymbolSetUpload = file.try_into().expect("Failed to convert to upload");
+        assert_eq!(upload.chunk_id, "11111111-2222-4333-8444-555555555555");
     }
 
     #[test]

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -8,9 +8,24 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use crate::{
     api::symbol_sets::SymbolSetUpload,
-    sourcemaps::constant::{CHUNKID_COMMENT_PREFIX, CHUNKID_PLACEHOLDER, CODE_SNIPPET_TEMPLATE},
+    sourcemaps::constant::{
+        CHUNKID_COMMENT_PREFIX, CHUNKID_PLACEHOLDER, CODE_SNIPPET_TEMPLATE,
+        CODE_SNIPPET_WITH_RELEASE_TEMPLATE, RELEASE_ID_PLACEHOLDER,
+    },
     utils::files::SourceFile,
 };
+
+/// Build the injected IIFE for a chunk. When a release id is present we use the release-carrying
+/// template and fill its placeholder with a JSON-encoded string literal, so quotes/backslashes in
+/// the value can't break out of the snippet.
+fn build_code_snippet(chunk_id: &str, release_id: Option<&str>) -> Result<String> {
+    let Some(release_id) = release_id else {
+        return Ok(CODE_SNIPPET_TEMPLATE.replace(CHUNKID_PLACEHOLDER, chunk_id));
+    };
+    Ok(CODE_SNIPPET_WITH_RELEASE_TEMPLATE
+        .replace(CHUNKID_PLACEHOLDER, chunk_id)
+        .replace(RELEASE_ID_PLACEHOLDER, &serde_json::to_string(release_id)?))
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SourceMapContent {
@@ -176,12 +191,12 @@ impl MinifiedSourceFile {
         self.get_comment_value(&patterns)
     }
 
-    pub fn set_chunk_id(&mut self, chunk_id: &str) -> Result<SourceMap> {
+    pub fn set_chunk_id(&mut self, chunk_id: &str, release_id: Option<&str>) -> Result<SourceMap> {
         let (new_source_content, source_adjustment) = {
             // Update source content with chunk ID
             let source_content = &self.inner.content;
             let mut magic_source = MagicString::new(source_content);
-            let code_snippet = CODE_SNIPPET_TEMPLATE.replace(CHUNKID_PLACEHOLDER, chunk_id);
+            let code_snippet = build_code_snippet(chunk_id, release_id)?;
             magic_source
                 .prepend(&code_snippet)
                 .map_err(|err| anyhow!("Failed to prepend code snippet: {err}"))?;

--- a/cli/src/sourcemaps/hermes/clone.rs
+++ b/cli/src/sourcemaps/hermes/clone.rs
@@ -63,8 +63,12 @@ pub fn clone(args: &CloneArgs) -> Result<()> {
         minified_map.save()?;
     }
 
-    // Copy metadata from source map to composed map
-    if let Some(chunk_id) = minified_map.get_chunk_id() {
+    // Copy metadata from source map to composed map; a map carrying only a debug id
+    // contributes it as the chunk id.
+    if let Some(chunk_id) = minified_map
+        .get_chunk_id()
+        .or_else(|| minified_map.get_debug_id())
+    {
         composed_map.set_chunk_id(Some(chunk_id));
     }
 

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -55,7 +55,7 @@ pub fn upload(args: &Args) -> Result<()> {
     let mut uploads: Vec<SymbolSetUpload> = Vec::new();
     let mut empty_skipped = 0usize;
     for mut map in maps.into_iter() {
-        if map.get_chunk_id().is_none() {
+        if map.get_chunk_id().is_none() && map.get_debug_id().is_none() {
             warn!("Skipping map {}, no chunk ID", map.inner.path.display());
             continue;
         }

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -117,12 +117,29 @@ pub fn inject_pairs(
         // Chunk ids are content-addressed and stable, so a chunk that already carries one is
         // already injected — leave it untouched (idempotent re-injection).
         if pair.get_chunk_id().is_none() {
-            let chunk_id = stable_chunk_id(&pair.source.inner.content);
+            let chunk_id = adopted_debug_id(pair)
+                .unwrap_or_else(|| stable_chunk_id(&pair.source.inner.content));
             pair.add_chunk_id(chunk_id, release_id)?;
         }
     }
 
     Ok(pairs)
+}
+
+/// A bundler-emitted ECMA-426 debug id is already content-derived, so adopt it as the chunk id
+/// instead of deriving our own. Non-UUID values are refused: the id flows into upload rows and
+/// SDK events, and a malformed one is worse than a derived one.
+fn adopted_debug_id(pair: &SourcePair) -> Option<String> {
+    let debug_id = pair.get_debug_id()?;
+    if uuid::Uuid::parse_str(&debug_id).is_err() {
+        warn!(
+            "ignoring malformed debug id {:?} on {} — falling back to a content-derived chunk id",
+            debug_id,
+            pair.source.inner.path.display()
+        );
+        return None;
+    }
+    Some(debug_id)
 }
 
 /// Legacy injection: a random per-build chunk id and the created release id stamped into the

--- a/cli/src/sourcemaps/inject.rs
+++ b/cli/src/sourcemaps/inject.rs
@@ -7,6 +7,7 @@ use crate::{
     api::releases::{Release, ReleaseBuilder},
     sourcemaps::{
         args::{FileSelectionArgs, ReleaseArgs},
+        constant::CHUNK_ID_NAMESPACE,
         content::SourceMapFile,
         source_pairs::{read_pairs, SourcePair},
     },
@@ -26,6 +27,23 @@ pub struct InjectArgs {
 
     #[clap(flatten)]
     pub release: ReleaseArgs,
+
+    /// EXPERIMENTAL: don't bind the injected chunks to a server-side release. The release is still
+    /// created, but instead of stamping its id into the sourcemap (which binds the uploaded symbol
+    /// set to it), this injects the id into each chunk as `_posthogReleaseId` so the SDK emits it
+    /// on every exception, and derives content-addressed chunk ids that are stable across rebuilds.
+    /// When unset (the default), inject behaves exactly as before. Also settable via
+    /// `POSTHOG_NO_RELEASE_BIND`.
+    #[arg(
+        long,
+        env = "POSTHOG_NO_RELEASE_BIND",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value = "false",
+        default_missing_value = "true",
+    )]
+    pub no_release_bind: bool,
 }
 
 impl InjectArgs {
@@ -43,6 +61,7 @@ pub fn inject_impl(
         file_selection,
         public_path_prefix,
         release,
+        no_release_bind,
     } = args;
 
     info!("injecting selection: {}", file_selection);
@@ -57,16 +76,28 @@ pub fn inject_impl(
         bail!("no source files found");
     }
 
-    let created_release_id = if let Some(r) = existing_release {
-        Some(r.id.to_string())
+    if *no_release_bind {
+        // The release id travels inside each chunk for the SDK to emit, rather than being stamped
+        // into the sourcemap — so the release exists, but nothing binds a symbol set to it.
+        let release_id = resolve_release_id(release.clone(), existing_release)?;
+        if release_id.is_none() {
+            warn!(
+                "no release could be resolved, injecting chunk ids only — events will carry no release"
+            );
+        }
+        pairs = inject_pairs(pairs, release_id.as_deref())?;
     } else {
-        let cwd = std::env::current_dir()?;
-        get_release_for_maps(&cwd, release.clone(), pairs.iter().map(|p| &p.sourcemap))?
-            .as_ref()
-            .map(|r| r.id.to_string())
-    };
-
-    pairs = inject_pairs(pairs, created_release_id)?;
+        // Legacy path: fetch or create a release over the API and stamp its id into the sourcemap.
+        let created_release_id = if let Some(r) = existing_release {
+            Some(r.id.to_string())
+        } else {
+            let cwd = std::env::current_dir()?;
+            get_release_for_maps(&cwd, release.clone(), pairs.iter().map(|p| &p.sourcemap))?
+                .as_ref()
+                .map(|r| r.id.to_string())
+        };
+        pairs = inject_pairs_legacy(pairs, created_release_id)?;
+    }
 
     // Write the source and sourcemaps back to disk
     for pair in &pairs {
@@ -76,7 +107,27 @@ pub fn inject_impl(
     Ok(())
 }
 
+/// Experimental injection: content-addressed chunk ids plus an optional `_posthogReleaseId`
+/// payload.
 pub fn inject_pairs(
+    mut pairs: Vec<SourcePair>,
+    release_id: Option<&str>,
+) -> Result<Vec<SourcePair>> {
+    for pair in &mut pairs {
+        // Chunk ids are content-addressed and stable, so a chunk that already carries one is
+        // already injected — leave it untouched (idempotent re-injection).
+        if pair.get_chunk_id().is_none() {
+            let chunk_id = stable_chunk_id(&pair.source.inner.content);
+            pair.add_chunk_id(chunk_id, release_id)?;
+        }
+    }
+
+    Ok(pairs)
+}
+
+/// Legacy injection: a random per-build chunk id and the created release id stamped into the
+/// sourcemap. Regenerates the chunk id whenever the release id changes or is missing.
+pub fn inject_pairs_legacy(
     mut pairs: Vec<SourcePair>,
     created_release_id: Option<String>,
 ) -> Result<Vec<SourcePair>> {
@@ -90,12 +141,42 @@ pub fn inject_pairs(
             if let Some(previous_chunk_id) = pair.get_chunk_id() {
                 pair.update_chunk_id(previous_chunk_id, chunk_id)?;
             } else {
-                pair.add_chunk_id(chunk_id)?;
+                pair.add_chunk_id(chunk_id, None)?;
             }
         }
     }
 
     Ok(pairs)
+}
+
+/// Deterministically derive a chunk id from the minified source bytes (UUIDv5). Identical
+/// source produces an identical id on every machine and rebuild, so uploads dedupe and symbol
+/// sets stay stable — no per-build random id.
+fn stable_chunk_id(source_content: &str) -> String {
+    uuid::Uuid::new_v5(&CHUNK_ID_NAMESPACE, source_content.as_bytes()).to_string()
+}
+
+/// Resolve the release row whose id gets injected into the chunks. Reuses the release already
+/// fetched upstream (the `process` command) when there is one; otherwise resolves name/version
+/// from flags and git/CI metadata and fetches or creates the row. Returns `None` only when there
+/// isn't enough information to identify a release at all.
+fn resolve_release_id(
+    release: ReleaseArgs,
+    existing_release: Option<&Release>,
+) -> Result<Option<String>> {
+    if let Some(r) = existing_release {
+        return Ok(Some(r.id.to_string()));
+    }
+
+    let cwd = std::env::current_dir()?;
+    let release_args_were_provided =
+        release.name.is_some() || release.version.is_some() || release.build.is_some();
+    let mut builder: ReleaseBuilder = release.into();
+    add_git_info_to_release_builder(&cwd, &mut builder, release_args_were_provided)?;
+    if !builder.can_create() {
+        return Ok(None);
+    }
+    Ok(Some(builder.fetch_or_create()?.id.to_string()))
 }
 
 pub fn get_release_for_maps<'a>(

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -47,6 +47,22 @@ pub struct ProcessArgs {
 
     #[clap(flatten)]
     pub upload_concurrency: UploadConcurrencyArgs,
+
+    /// EXPERIMENTAL: don't bind the chunks to a server-side release. The release is still created,
+    /// but its id is injected into each chunk as `_posthogReleaseId` (alongside content-addressed
+    /// chunk ids) rather than stamped onto the uploaded symbol sets, so the SDK reports the release
+    /// per event. When unset (the default), process behaves exactly as before.
+    /// Also settable via `POSTHOG_NO_RELEASE_BIND`.
+    #[arg(
+        long,
+        env = "POSTHOG_NO_RELEASE_BIND",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value = "false",
+        default_missing_value = "true",
+    )]
+    pub no_release_bind: bool,
 }
 
 impl ProcessArgs {
@@ -63,6 +79,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             file_selection: args.file_selection.clone(),
             release: args.release.clone(),
             public_path_prefix: args.public_path_prefix.clone(),
+            no_release_bind: args.no_release_bind,
         };
         let upload_args = upload::Args {
             file_selection: args.file_selection,
@@ -73,6 +90,7 @@ impl From<ProcessArgs> for (InjectArgs, upload::Args) {
             release: args.release,
             conflict: args.conflict,
             upload_concurrency: args.upload_concurrency,
+            no_release_bind: args.no_release_bind,
         };
 
         (inject_args, upload_args)

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -60,6 +60,21 @@ pub struct Args {
     /// DEPRECATED - this flag is a no-op. Use top-level `--skip-ssl-verification` instead.
     #[arg(long)]
     pub skip_ssl_verification: bool,
+
+    /// EXPERIMENTAL: don't bind the uploaded symbol sets to a release. The chunks carry the release
+    /// id in their injected snippet instead, so the release is resolved per event rather than per
+    /// symbol set. When unset (the default), upload behaves exactly as before. Also settable via
+    /// `POSTHOG_NO_RELEASE_BIND`.
+    #[arg(
+        long,
+        env = "POSTHOG_NO_RELEASE_BIND",
+        value_parser = clap::builder::BoolishValueParser::new(),
+        num_args = 0..=1,
+        require_equals = true,
+        default_value = "false",
+        default_missing_value = "true",
+    )]
+    pub no_release_bind: bool,
 }
 
 pub fn upload_cmd(args: &Args) -> Result<()> {
@@ -86,8 +101,13 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
         .collect::<Vec<_>>();
     info!("Found {} chunks to upload", pairs.len());
 
-    // Reuse the pre-resolved release if available, otherwise fetch or create one
-    let created_release_id = if let Some(r) = existing_release {
+    // Reuse the pre-resolved release if available, otherwise fetch or create one. Skipped entirely
+    // under `--no-release-bind`: inject already put the release id inside the chunks, and resolving
+    // one here would only serve to stamp it onto the symbol sets, which is the binding we're
+    // avoiding.
+    let created_release_id = if args.no_release_bind {
+        None
+    } else if let Some(r) = existing_release {
         Some(r.id.to_string())
     } else {
         let cwd = std::env::current_dir()?;

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -25,6 +25,24 @@ impl SourcePair {
         self.source.get_chunk_id()
     }
 
+    /// Debug id already present in the pair, if any. The chunk's comment is authoritative
+    /// (sourcemaps can be shared across chunks); the sourcemap's field is only a fallback.
+    pub fn get_debug_id(&self) -> Option<String> {
+        let source_debug_id = self.source.get_debug_id();
+        let sourcemap_debug_id = self.sourcemap.get_debug_id();
+        if let (Some(source_id), Some(map_id)) = (&source_debug_id, &sourcemap_debug_id) {
+            if source_id != map_id {
+                warn!(
+                    "debug id mismatch for {}: chunk has {}, sourcemap has {} — using the chunk's",
+                    self.source.inner.path.display(),
+                    source_id,
+                    map_id
+                );
+            }
+        }
+        source_debug_id.or(sourcemap_debug_id)
+    }
+
     pub fn has_release_id(&self) -> bool {
         self.sourcemap.has_release_id()
     }

--- a/cli/src/sourcemaps/source_pairs.rs
+++ b/cli/src/sourcemaps/source_pairs.rs
@@ -49,16 +49,16 @@ impl SourcePair {
         new_chunk_id: String,
     ) -> Result<()> {
         self.remove_chunk_id(previous_chunk_id)?;
-        self.add_chunk_id(new_chunk_id)?;
+        self.add_chunk_id(new_chunk_id, None)?;
         Ok(())
     }
 
-    pub fn add_chunk_id(&mut self, chunk_id: String) -> Result<()> {
+    pub fn add_chunk_id(&mut self, chunk_id: String, release_id: Option<&str>) -> Result<()> {
         if self.has_chunk_id() {
             return Err(anyhow!("Chunk ID already set"));
         }
 
-        let adjustment = self.source.set_chunk_id(&chunk_id)?;
+        let adjustment = self.source.set_chunk_id(&chunk_id, release_id)?;
         // In cases where sourcemaps are shared across multiple chunks,
         // we should only apply the adjustment if the sourcemap doesn't
         // have a chunk ID set (since otherwise, it's already been adjusted)

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -1,14 +1,15 @@
 use posthog_cli::{
     sourcemaps::{
-        content::SourceMapContent,
+        content::{MinifiedSourceFile, SourceMapContent, SourceMapFile},
         inject::{inject_pairs, inject_pairs_legacy},
         plain::inject::is_javascript_file,
         source_pairs::SourcePair,
     },
-    utils::files::FileSelection,
+    utils::files::{FileSelection, SourceFile},
 };
 
 use anyhow::Result;
+use serde_json::json;
 
 use std::{
     fs,
@@ -338,6 +339,113 @@ fn test_upload_set() {
     // Verify that the upload set uses the source's chunk ID, not the sourcemap's
     assert_eq!(upload_set.chunk_id, source_chunk_id);
     assert_ne!(upload_set.chunk_id, sourcemap_chunk_id);
+}
+
+const BUNDLER_DEBUG_ID: &str = "11111111-2222-4333-8444-555555555555";
+
+fn make_pair(source_content: &str, map_json: serde_json::Value) -> SourcePair {
+    SourcePair {
+        source: MinifiedSourceFile {
+            inner: SourceFile::new(PathBuf::from("chunk.js"), source_content.to_string()),
+        },
+        sourcemap: SourceMapFile {
+            inner: SourceFile::new(
+                PathBuf::from("chunk.js.map"),
+                serde_json::from_value(map_json).expect("Failed to build SourceMapContent"),
+            ),
+        },
+    }
+}
+
+fn map_with_debug_id(debug_id: Option<&str>) -> serde_json::Value {
+    let mut map = json!({
+        "version": 3,
+        "file": "chunk.js",
+        "sources": ["src/index.js"],
+        "sourcesContent": ["console.log(1)\n"],
+        "names": [],
+        "mappings": "AAAA",
+    });
+    if let Some(debug_id) = debug_id {
+        map["debugId"] = json!(debug_id);
+    }
+    map
+}
+
+#[test]
+fn test_inject_adopts_bundler_debug_id() {
+    // The bundler already stamped a debug id into the chunk and its map. Inject must adopt it
+    // as the chunk id and still apply the mapping adjustment for the prepended snippet — the
+    // old `alias = "debugId"` conflation made the map look already-processed and skipped it.
+    let pair = make_pair(
+        &format!(
+            "console.log(1);\n//# debugId={BUNDLER_DEBUG_ID}\n//# sourceMappingURL=chunk.js.map\n"
+        ),
+        map_with_debug_id(Some(BUNDLER_DEBUG_ID)),
+    );
+
+    let injected = inject_pairs(vec![pair], None).expect("Failed to inject pairs");
+    let pair = injected.first().unwrap();
+
+    assert_eq!(
+        pair.source.get_chunk_id().as_deref(),
+        Some(BUNDLER_DEBUG_ID)
+    );
+    assert!(pair
+        .source
+        .inner
+        .content
+        .contains(&format!("=\"{BUNDLER_DEBUG_ID}\"")));
+    let map = &pair.sourcemap.inner.content;
+    assert_eq!(map.chunk_id.as_deref(), Some(BUNDLER_DEBUG_ID));
+    assert_eq!(map.debug_id.as_deref(), Some(BUNDLER_DEBUG_ID));
+    assert_ne!(
+        map.fields.get("mappings").and_then(|v| v.as_str()),
+        Some("AAAA"),
+        "mapping adjustment for the prepended snippet was not applied"
+    );
+}
+
+#[test]
+fn test_inject_ignores_malformed_debug_id() {
+    // Adopted ids flow into upload rows and SDK events; a bundler emitting a non-UUID debug id
+    // must not poison them — fall back to the content-derived chunk id.
+    let pair = make_pair(
+        "console.log(1);\n//# debugId=not-a-uuid\n//# sourceMappingURL=chunk.js.map\n",
+        map_with_debug_id(None),
+    );
+
+    let injected = inject_pairs(vec![pair], None).expect("Failed to inject pairs");
+    let chunk_id = injected.first().unwrap().source.get_chunk_id().unwrap();
+
+    assert_ne!(chunk_id, "not-a-uuid");
+    assert!(uuid::Uuid::parse_str(&chunk_id).is_ok());
+}
+
+#[test]
+fn test_inject_prefers_chunk_debug_id_over_sourcemap() {
+    // Sourcemaps can be shared across chunks, so the chunk's own debug id must win when the two
+    // disagree — flipping the precedence would stamp one chunk's id onto its siblings.
+    let map_debug_id = "99999999-8888-4777-8666-555555555555";
+    let pair = make_pair(
+        &format!(
+            "console.log(1);\n//# debugId={BUNDLER_DEBUG_ID}\n//# sourceMappingURL=chunk.js.map\n"
+        ),
+        map_with_debug_id(Some(map_debug_id)),
+    );
+
+    let injected = inject_pairs(vec![pair], None).expect("Failed to inject pairs");
+    let pair = injected.first().unwrap();
+
+    assert_eq!(
+        pair.source.get_chunk_id().as_deref(),
+        Some(BUNDLER_DEBUG_ID)
+    );
+    assert_eq!(
+        pair.sourcemap.inner.content.debug_id.as_deref(),
+        Some(map_debug_id),
+        "the map's own debugId field must be preserved, not overwritten"
+    );
 }
 
 #[test]

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -1,6 +1,8 @@
 use posthog_cli::{
     sourcemaps::{
-        content::SourceMapContent, inject::inject_pairs, plain::inject::is_javascript_file,
+        content::SourceMapContent,
+        inject::{inject_pairs, inject_pairs_legacy},
+        plain::inject::is_javascript_file,
         source_pairs::SourcePair,
     },
     utils::files::FileSelection,
@@ -129,7 +131,7 @@ fn test_pair_inject() {
     let current_pair = pairs.first_mut().expect("Failed to get first pair");
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     assert_file_eq(
@@ -152,7 +154,7 @@ fn test_index_inject() {
     let current_pair = pairs.first_mut().expect("Failed to get first pair");
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     let bytes = serde_json::to_string(&current_pair.sourcemap.inner.content).unwrap();
@@ -177,7 +179,7 @@ fn test_index_inject_retains_extension_fields() {
 
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     // Extension field should be retained after flattening
@@ -206,7 +208,7 @@ fn test_pair_remove() {
     let current_pair = pairs.first_mut().expect("Failed to get first pair");
     let chunk_id = "00000-00000-00000";
     current_pair
-        .add_chunk_id(chunk_id.to_string())
+        .add_chunk_id(chunk_id.to_string(), None)
         .expect("Failed to set chunk ID");
 
     current_pair
@@ -222,12 +224,55 @@ fn test_pair_remove() {
 }
 
 #[test]
-fn test_reinject_without_new_release() {
+fn test_reinject_is_idempotent() {
+    // A chunk that already carries a content-addressed id must survive re-injection untouched.
+    // Regenerating the id on every build would orphan the already-uploaded symbol set.
     let case_path = get_case_path("reinject");
     let pairs =
         read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
     assert_eq!(pairs.len(), 1);
+    let source_before = pairs.first().unwrap().source.inner.content.clone();
+
     let injected_pairs = inject_pairs(pairs, None).expect("Failed to inject pairs");
+    let first_pair = injected_pairs.first().expect("Failed to get first pair");
+
+    assert_eq!(first_pair.source.get_chunk_id().as_deref(), Some("0"));
+    assert_eq!(first_pair.source.inner.content, source_before);
+}
+
+#[test]
+fn test_inject_with_release_embeds_id_in_source() {
+    // Injecting with a release must embed its id into the JS chunk itself — that global is the
+    // SDK's only source of the release — and must leave the release out of the sourcemap, so
+    // nothing binds the uploaded symbol set to it. The SDK ignores the global unless it is a
+    // non-empty string, so it has to be emitted as a quoted string literal.
+    let case_path = get_case_path("inject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    assert_eq!(pairs.len(), 1);
+    let release_id = "0199f7c2-1c4e-7c3a-9f8b-2d6e4a1b7c05";
+
+    let injected_pairs = inject_pairs(pairs, Some(release_id)).expect("Failed to inject pairs");
+    let first_pair = injected_pairs.first().expect("Failed to get first pair");
+
+    let source = &first_pair.source.inner.content;
+    assert!(
+        source.contains(&format!(r#"_posthogReleaseId||"{release_id}""#)),
+        "source: {source}"
+    );
+    assert!(first_pair.source.get_chunk_id().is_some());
+    assert!(first_pair.sourcemap.get_release_id().is_none());
+}
+
+#[test]
+fn test_legacy_reinject_without_new_release() {
+    // Legacy path: with no release, an existing chunk carrying a stale release id is regenerated
+    // and the release id is cleared from the sourcemap.
+    let case_path = get_case_path("reinject");
+    let pairs =
+        read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
+    assert_eq!(pairs.len(), 1);
+    let injected_pairs = inject_pairs_legacy(pairs, None).expect("Failed to inject pairs");
     let first_pair = injected_pairs.first().expect("Failed to get first pair");
     assert_ne!(&first_pair.source.get_chunk_id().unwrap(), "0");
     assert_eq!(
@@ -238,14 +283,15 @@ fn test_reinject_without_new_release() {
 }
 
 #[test]
-fn test_reinject_with_new_release() {
+fn test_legacy_reinject_with_new_release() {
+    // Legacy path: a new release id regenerates the chunk id and is stamped into the sourcemap.
     let case_path = get_case_path("reinject");
     let pairs =
         read_pairs(vec![case_path.clone()], vec![], vec![], &None).expect("Failed to read pairs");
     assert_eq!(pairs.len(), 1);
     let release_id = uuid::Uuid::now_v7().to_string();
     let injected_pairs =
-        inject_pairs(pairs, Some(release_id.clone())).expect("Failed to inject pairs");
+        inject_pairs_legacy(pairs, Some(release_id.clone())).expect("Failed to inject pairs");
     let first_pair = injected_pairs.first().expect("Failed to get first pair");
     assert_ne!(&first_pair.source.get_chunk_id().unwrap(), "0");
     assert_eq!(


### PR DESCRIPTION
## Problem

Bundlers increasingly stamp ECMA-426 debug ids into chunks (`//# debugId=`) and sourcemaps (`debugId` field). Under `--no-release-bind` (#75562) the CLI derives its own chunk id, so one artifact ends up with two identifiers. There's also a latent bug: a serde alias made a debug-id-carrying sourcemap look already processed, which skipped the mapping adjustment on inject and renamed `debugId` away on save.

## Changes

Stacked on #75562.

- `SourceMapContent` gets a dedicated `debug_id` field; the alias on `chunk_id` is gone and the field round-trips on save.
- Under `--no-release-bind`, inject adopts an existing debug id as the chunk id. Chunk comment wins over map field, non-UUID values fall back to the derived id.
- Hermes flows still accept maps carrying only a `debugId`.
- Legacy inject path unchanged.

> [!NOTE]
> Companion plugin PR (PostHog/posthog-js#4401) must release after this ships.

## How did you test this code?

`cargo test` (172 passing), clippy clean. New tests: adoption with the mapping adjustment actually applied (the alias bug), malformed-id fallback, chunk-over-map precedence, `debugId` round-trip, hermes maps with only a debug id. Also verified end to end against a real bundle with debug ids: inject adopts the id everywhere and a second run is byte-identical.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Pending until the experimental flag graduates.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code; skills: /writing-tests, /writing-code-comments. Adoption stays gated to `--no-release-bind` because the legacy path regenerates chunk ids per release by design. Rejected reusing the serde alias: it destroys provenance at parse time, loses the field on round-trip, and risks duplicate-field parse errors.
