### PR TITLE
fix(error-tracking): raise weekly digest ClickHouse execution ceiling to 120s

### DIFF
--- a/products/error_tracking/backend/weekly_digest.py
+++ b/products/error_tracking/backend/weekly_digest.py
@@ -19,6 +19,11 @@ logger = structlog.get_logger(__name__)
 
 DIGEST_WEBHOOK_TIMEOUT_SECONDS = 10
 
+# Above HogQL's 60s default: digest scans on high-volume teams (14-day windows, plus a persons
+# join when test-account filters include person properties) legitimately run past 60s. Matches
+# the error_tracking ClickHouse profile's execution ceiling — keep the two in sync.
+DIGEST_MAX_EXECUTION_TIME_SECONDS = 120
+
 # Keep in sync with SOURCE_MAPS_DOCS_URL in sourceMapsFixWizardLogic.ts
 SOURCE_MAPS_DOCS_URL = "https://posthog.com/docs/error-tracking/upload-source-maps"
 
@@ -40,6 +45,7 @@ def query_daily_rows(team: Team) -> list:
     Missing ``$exception_issue_id`` = ingestion failure. Query errors propagate so the task retries
     instead of mistaking a failure for "no activity".
     """
+    from posthog.hogql.constants import HogQLGlobalSettings
     from posthog.hogql.query import execute_hogql_query
 
     from posthog.clickhouse.client.connection import ClickHouseUser
@@ -67,6 +73,7 @@ def query_daily_rows(team: Team) -> list:
         # Weekly batch job: Celery pinned this to the offline cluster process-wide, Temporal does not.
         workload=Workload.OFFLINE,
         ch_user=ClickHouseUser.ERROR_TRACKING,
+        settings=HogQLGlobalSettings(max_execution_time=DIGEST_MAX_EXECUTION_TIME_SECONDS),
     )
     return response.results or []
 
@@ -177,12 +184,19 @@ def get_exception_counts(team_ids: list[int] | None = None) -> list:
     """
 
     # Cross-team scan for a weekly batch job — keep it off the online cluster.
-    results = sync_execute(query, query_params, workload=Workload.OFFLINE, ch_user=ClickHouseUser.ERROR_TRACKING)
+    results = sync_execute(
+        query,
+        query_params,
+        workload=Workload.OFFLINE,
+        ch_user=ClickHouseUser.ERROR_TRACKING,
+        settings={"max_execution_time": DIGEST_MAX_EXECUTION_TIME_SECONDS},
+    )
     return results if isinstance(results, list) else []
 
 
 def get_crash_free_sessions(team: Team) -> dict:
     """Calculate crash free sessions rate for the last 7 days with previous week comparison."""
+    from posthog.hogql.constants import HogQLGlobalSettings
     from posthog.hogql.query import execute_hogql_query
 
     from posthog.clickhouse.client.connection import ClickHouseUser
@@ -214,6 +228,7 @@ def get_crash_free_sessions(team: Team) -> dict:
         # Unfiltered 14-day session scan — the heaviest query here. Must stay off the online cluster.
         workload=Workload.OFFLINE,
         ch_user=ClickHouseUser.ERROR_TRACKING,
+        settings=HogQLGlobalSettings(max_execution_time=DIGEST_MAX_EXECUTION_TIME_SECONDS),
     )
 
     if not response.results or not response.results[0]:
@@ -281,6 +296,7 @@ def _query_issue_rows(team: Team) -> list:
     tracking UI. Newness is computed in-query — embedding issue ids would make the rendered SQL grow
     with issue cardinality (ClickHouse caps query text at 1 MiB).
     """
+    from posthog.hogql.constants import HogQLGlobalSettings
     from posthog.hogql.query import execute_hogql_query
 
     from posthog.clickhouse.client.connection import ClickHouseUser
@@ -319,6 +335,7 @@ def _query_issue_rows(team: Team) -> list:
         # Weekly batch job: Celery pinned this to the offline cluster process-wide, Temporal does not.
         workload=Workload.OFFLINE,
         ch_user=ClickHouseUser.ERROR_TRACKING,
+        settings=HogQLGlobalSettings(max_execution_time=DIGEST_MAX_EXECUTION_TIME_SECONDS),
     )
     return response.results or []
 


### PR DESCRIPTION
## Problem

The weekly digest keeps failing for orgs whose digest queries run past HogQL's default 60s `max_execution_time`. Diagnosed on a production org: a team with only 15k exception events burned ~12GB and 60-71s per daily-rows query because its test-account filters include a person-property filter (`$email not_icontains ...`), which joins the persons tables onto the events scan. The query dies with `Code: 159 TIMEOUT_EXCEEDED` deterministically, so retries can't save it.

## Changes

- Set `max_execution_time=120` on all four digest query sites (`query_daily_rows`, `get_exception_counts`, `get_crash_free_sessions`, `_query_issue_rows`), matching the `error_tracking` ClickHouse profile's 120s ceiling from PostHog/posthog-cloud-infra#9757.

Query cancellation needs no change: the server-side `max_execution_time` kills the initiator, and shard-local executions get cancelled via the native protocol (the `QUERY_WAS_CANCELLED_BY_CLIENT` entries in query_log are that propagation working).

## How did you test this code?

- `hogli test products/error_tracking/backend/test/test_weekly_digest.py` - 62 passed.
- ruff check + format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - internal query settings only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored in a Claude Code session, follow-up to #76573. Diagnosis came from Metabase `system.query_log` analysis of a failing org. A companion change slowing the per-org retry backoff was considered and dropped: the apparent "retry pile-up" in query_log turned out to be normal initiator + per-shard rows from `clusterAllReplicas`, and shard cancellation already propagates correctly.