### PR TITLE
feat(error-tracking): fan weekly digest pages out as concurrent child workflows

### DIFF
--- a/products/error_tracking/backend/temporal/weekly_digest/__init__.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/__init__.py
@@ -2,14 +2,18 @@ from products.error_tracking.backend.temporal.weekly_digest.activities import (
     get_digest_orgs_activity,
     send_org_digest_activity,
 )
-from products.error_tracking.backend.temporal.weekly_digest.workflow import ErrorTrackingWeeklyDigestWorkflow
+from products.error_tracking.backend.temporal.weekly_digest.workflow import (
+    ErrorTrackingWeeklyDigestPageWorkflow,
+    ErrorTrackingWeeklyDigestWorkflow,
+)
 
-WORKFLOWS = [ErrorTrackingWeeklyDigestWorkflow]
+WORKFLOWS = [ErrorTrackingWeeklyDigestWorkflow, ErrorTrackingWeeklyDigestPageWorkflow]
 ACTIVITIES = [get_digest_orgs_activity, send_org_digest_activity]
 
 __all__ = [
     "ACTIVITIES",
     "WORKFLOWS",
+    "ErrorTrackingWeeklyDigestPageWorkflow",
     "ErrorTrackingWeeklyDigestWorkflow",
     "get_digest_orgs_activity",
     "send_org_digest_activity",

--- a/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -498,7 +498,7 @@ class TestErrorTrackingWeeklyDigestWorkflow:
         assert all(i.dry_run for i in inputs_seen)
 
     @pytest.mark.asyncio
-    async def test_pages_through_all_orgs_via_continue_as_new(self):
+    async def test_pages_through_all_orgs_via_child_workflows(self):
         org_ids = sorted(f"org-{i}" for i in range(25))
         cursors_seen: list[str | None] = []
         seen: list[str] = []
@@ -517,15 +517,15 @@ class TestErrorTrackingWeeklyDigestWorkflow:
         result = await self._execute(WeeklyDigestInputs(page_size=10), [_get_orgs, _send])
 
         # One discovery call per page, each carrying the previous page's last org id as
-        # the cursor; every org is processed exactly once across the continued executions.
+        # the cursor; every org is processed exactly once across the page children.
         assert cursors_seen == [None, org_ids[9], org_ids[19]]
         assert Counter(seen) == Counter(org_ids)
         assert result == WeeklyDigestResult(orgs=25, orgs_failed=0, sent=25)
 
     @pytest.mark.asyncio
-    async def test_failure_in_early_page_is_carried_to_the_final_execution(self):
-        # Exact multiple of page_size: the chain must end via the empty trailing page
-        # without dropping carried failures or totals.
+    async def test_failure_in_early_page_is_reported_by_the_parent(self):
+        # Exact multiple of page_size: the run must end via the empty trailing page
+        # without dropping failures or totals.
         org_ids = sorted(f"org-{i}" for i in range(20))
         seen: list[str] = []
 
@@ -546,6 +546,6 @@ class TestErrorTrackingWeeklyDigestWorkflow:
 
         cause = exc_info.value.__cause__
         assert cause is not None and getattr(cause, "type", None) == FAILED_ORGS_ERROR_TYPE
-        # A failure in page 1 must not stop later pages: the chain drains fully and
-        # only the final execution reports the carried failure.
+        # A failure in page 1 must not stop later pages: every page drains and the
+        # parent reports the failure once at the end.
         assert Counter(seen) == Counter(org_ids)

--- a/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -39,6 +39,7 @@ from products.error_tracking.backend.temporal.weekly_digest.types import (
 )
 from products.error_tracking.backend.temporal.weekly_digest.workflow import (
     FAILED_ORGS_ERROR_TYPE,
+    ErrorTrackingWeeklyDigestPageWorkflow,
     ErrorTrackingWeeklyDigestWorkflow,
 )
 from products.error_tracking.backend.weekly_digest import build_team_digest_data
@@ -399,7 +400,7 @@ class TestErrorTrackingWeeklyDigestWorkflow:
             async with Worker(
                 env.client,
                 task_queue=task_queue,
-                workflows=[ErrorTrackingWeeklyDigestWorkflow],
+                workflows=[ErrorTrackingWeeklyDigestWorkflow, ErrorTrackingWeeklyDigestPageWorkflow],
                 activities=activities,
                 workflow_runner=UnsandboxedWorkflowRunner(),
                 max_concurrent_activities=max_concurrent_activities,

--- a/products/error_tracking/backend/temporal/weekly_digest/types.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/types.py
@@ -15,8 +15,9 @@ class WeeklyDigestInputs:
     # Total executions per org activity: initial run + 5 retries. The final attempt sends
     # partial digests instead of deferring recipients whose teams failed to build.
     max_attempts: int = 6
-    # Orgs handled per page. Each page runs as its own child workflow so history stays
-    # bounded no matter how many orgs are discovered.
+    # Orgs handled per page. Per-org activity history lives in the page child workflows;
+    # the parent still records ~80KB per page (discovery result + child input), so it
+    # holds to roughly 600k orgs before nearing Temporal's 50MB history cap.
     page_size: int = 1000
     # Pages processed concurrently as child workflows. The global org-activity target is
     # max_concurrent_pages * max_concurrent — keep it at or below the worker fleet's

--- a/products/error_tracking/backend/temporal/weekly_digest/types.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/types.py
@@ -22,13 +22,6 @@ class WeeklyDigestInputs:
     # max_concurrent_pages * max_concurrent — keep it at or below the worker fleet's
     # activity-slot capacity (35 in prod) or the extra pages just queue.
     max_concurrent_pages: int = 3
-    # Continue-as-new carried state for the pre-fan-out workflow path — never set by
-    # callers. Still honored so an execution continued-as-new from an old deploy resumes
-    # from its cursor with its counters intact.
-    cursor: str | None = None
-    carried_orgs: int = 0
-    carried_orgs_failed: int = 0
-    carried_sent: int = 0
 
 
 @dataclasses.dataclass(frozen=True)

--- a/products/error_tracking/backend/temporal/weekly_digest/types.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/types.py
@@ -15,14 +15,16 @@ class WeeklyDigestInputs:
     # Total executions per org activity: initial run + 5 retries. The final attempt sends
     # partial digests instead of deferring recipients whose teams failed to build.
     max_attempts: int = 6
-    # Orgs handled per workflow execution. Each page runs in its own execution (chained via
-    # continue_as_new) so history stays bounded no matter how many orgs are discovered.
+    # Orgs handled per page. Each page runs as its own child workflow so history stays
+    # bounded no matter how many orgs are discovered.
     page_size: int = 1000
-    # Continue-as-new carried state — never set by callers. cursor is the last org id of
-    # the previous page (keyset paging: only this ~40-byte cursor rides between executions,
-    # never the org list, so org count can't approach the 2 MiB payload cap); the carried_*
-    # counters accumulate across the chain so the final execution can report and fail on
-    # the whole run.
+    # Pages processed concurrently as child workflows. The global org-activity target is
+    # max_concurrent_pages * max_concurrent — keep it at or below the worker fleet's
+    # activity-slot capacity (35 in prod) or the extra pages just queue.
+    max_concurrent_pages: int = 3
+    # Continue-as-new carried state for the pre-fan-out workflow path — never set by
+    # callers. Still honored so an execution continued-as-new from an old deploy resumes
+    # from its cursor with its counters intact.
     cursor: str | None = None
     carried_orgs: int = 0
     carried_orgs_failed: int = 0
@@ -37,6 +39,15 @@ class GetDigestOrgsInputs:
     # stable so an org can never be returned in two pages.
     after: str | None = None
     limit: int = 1000
+
+
+@dataclasses.dataclass(frozen=True)
+class WeeklyDigestPageInputs:
+    # ~40 bytes per org id: a 1000-org page rides well under the 2 MiB payload cap.
+    org_ids: list[str]
+    dry_run: bool = True
+    max_concurrent: int = 10
+    max_attempts: int = 6
 
 
 @dataclasses.dataclass(frozen=True)

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -83,6 +83,10 @@ async def _send_orgs(org_ids: list[str], dry_run: bool, max_concurrent: int, max
     sent = 0
     orgs_failed = 0
     for org_id, result in zip(org_ids, results):
+        # Workflow cancellation lands here as a captured CancelledError; counting it as an
+        # org failure would keep the run going instead of honoring the cancel.
+        if isinstance(result, asyncio.CancelledError):
+            raise result
         if isinstance(result, BaseException):
             orgs_failed += 1
             sent += _sent_from_error(result)
@@ -169,6 +173,10 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
         sent = 0
         for page, result in zip(pages, results):
             orgs += len(page)
+            # Same as _send_orgs: a captured CancelledError is the run being cancelled,
+            # not a failed page.
+            if isinstance(result, asyncio.CancelledError):
+                raise result
             if isinstance(result, BaseException):
                 # The child only propagates unexpected failures (per-org errors are counted
                 # inside it), so attribute the whole page.

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -17,12 +17,18 @@ with workflow.unsafe.imports_passed_through():
         SendOrgDigestInputs,
         SendOrgDigestResult,
         WeeklyDigestInputs,
+        WeeklyDigestPageInputs,
         WeeklyDigestResult,
     )
 
 WORKFLOW_NAME = "error-tracking-weekly-digest"
+PAGE_WORKFLOW_NAME = "error-tracking-weekly-digest-page"
 
 FAILED_ORGS_ERROR_TYPE = "ErrorTrackingWeeklyDigestOrgsFailed"
+
+# Gates the switch from the continue-as-new page chain to child-workflow fan-out; executions
+# whose history predates the fan-out replay the old path below.
+PAGE_FANOUT_PATCH = "weekly-digest-page-fanout-2026-08"
 
 GET_ORGS_RETRY_POLICY = common.RetryPolicy(maximum_attempts=3, initial_interval=timedelta(seconds=30))
 GET_ORGS_TIMEOUT = timedelta(minutes=5)
@@ -43,6 +49,69 @@ def _sent_from_error(error: BaseException) -> int:
     return details[0] if details and isinstance(details[0], int) else 0
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class _PageOutcome:
+    sent: int
+    orgs_failed: int
+
+
+async def _send_orgs(org_ids: list[str], dry_run: bool, max_concurrent: int, max_attempts: int) -> _PageOutcome:
+    """Run the per-org digest activities for one page, ``max_concurrent`` at a time.
+
+    Must be called from within a workflow.
+    """
+    # Keep up to max_concurrent per-org activities in flight at all times: the semaphore
+    # releases the moment one finishes, so the next org starts immediately rather than
+    # waiting for a whole wave to drain.
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def send_org(org_id: str) -> SendOrgDigestResult:
+        async with semaphore:
+            return await workflow.execute_activity(
+                send_org_digest_activity,
+                SendOrgDigestInputs(org_id=org_id, dry_run=dry_run, max_attempts=max_attempts),
+                start_to_close_timeout=SEND_ORG_START_TO_CLOSE_TIMEOUT,
+                heartbeat_timeout=SEND_ORG_HEARTBEAT_TIMEOUT,
+                retry_policy=common.RetryPolicy(
+                    # Must match SendOrgDigestInputs.max_attempts — final-attempt detection
+                    # inside the activity depends on the two agreeing.
+                    maximum_attempts=max_attempts,
+                    initial_interval=SEND_ORG_INITIAL_RETRY_INTERVAL,
+                    backoff_coefficient=2.0,
+                    maximum_interval=SEND_ORG_MAXIMUM_RETRY_INTERVAL,
+                ),
+            )
+
+    results = await asyncio.gather(*(send_org(org_id) for org_id in org_ids), return_exceptions=True)
+
+    sent = 0
+    orgs_failed = 0
+    for org_id, result in zip(org_ids, results):
+        if isinstance(result, BaseException):
+            orgs_failed += 1
+            sent += _sent_from_error(result)
+            workflow.logger.error(
+                "Error Tracking weekly digest org failed after retries",
+                extra={"org_id": org_id, "error": str(result)},
+            )
+            continue
+        sent += result.sent
+    return _PageOutcome(sent=sent, orgs_failed=orgs_failed)
+
+
+@workflow.defn(name=PAGE_WORKFLOW_NAME)
+class ErrorTrackingWeeklyDigestPageWorkflow(PostHogWorkflow):
+    """Processes one page of orgs. Returns counts instead of raising on org failures so the
+    parent can aggregate across pages and fail the run exactly once."""
+
+    inputs_cls = WeeklyDigestPageInputs
+
+    @workflow.run
+    async def run(self, inputs: WeeklyDigestPageInputs) -> WeeklyDigestResult:
+        outcome = await _send_orgs(inputs.org_ids, inputs.dry_run, inputs.max_concurrent, inputs.max_attempts)
+        return WeeklyDigestResult(orgs=len(inputs.org_ids), orgs_failed=outcome.orgs_failed, sent=outcome.sent)
+
+
 @workflow.defn(name=WORKFLOW_NAME)
 class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
     inputs_cls = WeeklyDigestInputs
@@ -53,6 +122,75 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
         if inputs is None:
             inputs = WeeklyDigestInputs()
 
+        if workflow.patched(PAGE_FANOUT_PATCH):
+            return await self._run_fanout(inputs)
+        return await self._run_paged(inputs)
+
+    async def _run_fanout(self, inputs: WeeklyDigestInputs) -> WeeklyDigestResult:
+        """Fan pages out as child workflows, ``max_concurrent_pages`` at a time.
+
+        Overlapping pages keeps activity slots busy while a page drains its slowest orgs —
+        with sequential pages, each page's tail (one slow org retrying) idles the whole
+        fleet until the next page starts.
+        """
+        window = asyncio.Semaphore(inputs.max_concurrent_pages)
+
+        async def run_page(org_ids: list[str]) -> WeeklyDigestResult:
+            async with window:
+                return await workflow.execute_child_workflow(
+                    ErrorTrackingWeeklyDigestPageWorkflow.run,
+                    WeeklyDigestPageInputs(
+                        org_ids=org_ids,
+                        dry_run=inputs.dry_run,
+                        max_concurrent=inputs.max_concurrent,
+                        max_attempts=inputs.max_attempts,
+                    ),
+                )
+
+        # inputs.cursor is normally None; it resumes a run continued-as-new from the
+        # pre-fan-out deploy, whose counters arrive via the carried_* fields below.
+        cursor = inputs.cursor
+        pages: list[list[str]] = []
+        page_tasks: list[asyncio.Task[WeeklyDigestResult]] = []
+        while True:
+            page = await workflow.execute_activity(
+                get_digest_orgs_activity,
+                GetDigestOrgsInputs(org_ids=inputs.org_ids, after=cursor, limit=inputs.page_size),
+                start_to_close_timeout=GET_ORGS_TIMEOUT,
+                retry_policy=GET_ORGS_RETRY_POLICY,
+            )
+            if not page:
+                break
+            pages.append(page)
+            page_tasks.append(asyncio.create_task(run_page(page)))
+            if len(page) < inputs.page_size:
+                break
+            cursor = page[-1]
+
+        results = await asyncio.gather(*page_tasks, return_exceptions=True)
+
+        orgs = inputs.carried_orgs
+        orgs_failed = inputs.carried_orgs_failed
+        sent = inputs.carried_sent
+        for page, result in zip(pages, results):
+            orgs += len(page)
+            if isinstance(result, BaseException):
+                # The child only propagates unexpected failures (per-org errors are counted
+                # inside it), so attribute the whole page.
+                orgs_failed += len(page)
+                workflow.logger.error(
+                    "Error Tracking weekly digest page failed",
+                    extra={"page_size": len(page), "error": str(result)},
+                )
+                continue
+            orgs_failed += result.orgs_failed
+            sent += result.sent
+
+        return self._finish(orgs=orgs, orgs_failed=orgs_failed, sent=sent, dry_run=inputs.dry_run)
+
+    async def _run_paged(self, inputs: WeeklyDigestInputs) -> WeeklyDigestResult:
+        """Pre-fan-out path: one page per execution, chained via continue_as_new. Kept only so
+        executions started before PAGE_FANOUT_PATCH replay deterministically."""
         # One keyset page per execution: only the ~40-byte cursor rides through
         # continue_as_new, so neither history nor payload size grows with org count.
         page = await workflow.execute_activity(
@@ -62,43 +200,9 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
             retry_policy=GET_ORGS_RETRY_POLICY,
         )
 
-        # Keep up to max_concurrent per-org activities in flight at all times: the semaphore
-        # releases the moment one finishes, so the next org starts immediately rather than
-        # waiting for a whole wave to drain.
-        semaphore = asyncio.Semaphore(inputs.max_concurrent)
-
-        async def send_org(org_id: str) -> SendOrgDigestResult:
-            async with semaphore:
-                return await workflow.execute_activity(
-                    send_org_digest_activity,
-                    SendOrgDigestInputs(org_id=org_id, dry_run=inputs.dry_run, max_attempts=inputs.max_attempts),
-                    start_to_close_timeout=SEND_ORG_START_TO_CLOSE_TIMEOUT,
-                    heartbeat_timeout=SEND_ORG_HEARTBEAT_TIMEOUT,
-                    retry_policy=common.RetryPolicy(
-                        # Must match SendOrgDigestInputs.max_attempts — final-attempt detection
-                        # inside the activity depends on the two agreeing.
-                        maximum_attempts=inputs.max_attempts,
-                        initial_interval=SEND_ORG_INITIAL_RETRY_INTERVAL,
-                        backoff_coefficient=2.0,
-                        maximum_interval=SEND_ORG_MAXIMUM_RETRY_INTERVAL,
-                    ),
-                )
-
-        results = await asyncio.gather(*(send_org(org_id) for org_id in page), return_exceptions=True)
-
-        sent = inputs.carried_sent
-        orgs_failed = inputs.carried_orgs_failed
-        for org_id, result in zip(page, results):
-            if isinstance(result, BaseException):
-                orgs_failed += 1
-                sent += _sent_from_error(result)
-                workflow.logger.error(
-                    "Error Tracking weekly digest org failed after retries",
-                    extra={"org_id": org_id, "error": str(result)},
-                )
-                continue
-            sent += result.sent
-
+        outcome = await _send_orgs(page, inputs.dry_run, inputs.max_concurrent, inputs.max_attempts)
+        sent = inputs.carried_sent + outcome.sent
+        orgs_failed = inputs.carried_orgs_failed + outcome.orgs_failed
         orgs = inputs.carried_orgs + len(page)
 
         # A full page may hide more orgs behind it; only a short page proves the set is
@@ -119,12 +223,15 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
                 )
             )
 
+        return self._finish(orgs=orgs, orgs_failed=orgs_failed, sent=sent, dry_run=inputs.dry_run)
+
+    def _finish(self, orgs: int, orgs_failed: int, sent: int, dry_run: bool) -> WeeklyDigestResult:
         if not orgs:
             workflow.logger.info("No orgs for Error Tracking weekly digest")
 
         workflow.logger.info(
             "Error Tracking weekly digest run complete",
-            extra={"orgs": orgs, "orgs_failed": orgs_failed, "sent": sent, "dry_run": inputs.dry_run},
+            extra={"orgs": orgs, "orgs_failed": orgs_failed, "sent": sent, "dry_run": dry_run},
         )
 
         if orgs_failed:

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -138,6 +138,10 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
                         max_attempts=inputs.max_attempts,
                     ),
                     id=f"{workflow.info().workflow_id}-page-{page_number}",
+                    # Explicitly the default: terminating the parent must stop all page
+                    # children too, so killing the parent is a reliable stop-everything
+                    # switch and no abandoned child keeps sending digests.
+                    parent_close_policy=workflow.ParentClosePolicy.TERMINATE,
                 )
 
         cursor: str | None = None

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -26,10 +26,6 @@ PAGE_WORKFLOW_NAME = "error-tracking-weekly-digest-page"
 
 FAILED_ORGS_ERROR_TYPE = "ErrorTrackingWeeklyDigestOrgsFailed"
 
-# Gates the switch from the continue-as-new page chain to child-workflow fan-out; executions
-# whose history predates the fan-out replay the old path below.
-PAGE_FANOUT_PATCH = "weekly-digest-page-fanout-2026-08"
-
 GET_ORGS_RETRY_POLICY = common.RetryPolicy(maximum_attempts=3, initial_interval=timedelta(seconds=30))
 GET_ORGS_TIMEOUT = timedelta(minutes=5)
 
@@ -114,6 +110,13 @@ class ErrorTrackingWeeklyDigestPageWorkflow(PostHogWorkflow):
 
 @workflow.defn(name=WORKFLOW_NAME)
 class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
+    """Fans pages of orgs out as child workflows, ``max_concurrent_pages`` at a time.
+
+    Overlapping pages keeps activity slots busy while a page drains its slowest orgs —
+    with sequential pages, each page's tail (one slow org retrying) idles the whole
+    fleet until the next page starts.
+    """
+
     inputs_cls = WeeklyDigestInputs
     inputs_optional = True
 
@@ -122,17 +125,6 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
         if inputs is None:
             inputs = WeeklyDigestInputs()
 
-        if workflow.patched(PAGE_FANOUT_PATCH):
-            return await self._run_fanout(inputs)
-        return await self._run_paged(inputs)
-
-    async def _run_fanout(self, inputs: WeeklyDigestInputs) -> WeeklyDigestResult:
-        """Fan pages out as child workflows, ``max_concurrent_pages`` at a time.
-
-        Overlapping pages keeps activity slots busy while a page drains its slowest orgs —
-        with sequential pages, each page's tail (one slow org retrying) idles the whole
-        fleet until the next page starts.
-        """
         window = asyncio.Semaphore(inputs.max_concurrent_pages)
 
         async def run_page(org_ids: list[str], page_number: int) -> WeeklyDigestResult:
@@ -148,9 +140,7 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
                     id=f"{workflow.info().workflow_id}-page-{page_number}",
                 )
 
-        # inputs.cursor is normally None; it resumes a run continued-as-new from the
-        # pre-fan-out deploy, whose counters arrive via the carried_* fields below.
-        cursor = inputs.cursor
+        cursor: str | None = None
         pages: list[list[str]] = []
         page_tasks: list[asyncio.Task[WeeklyDigestResult]] = []
         while True:
@@ -170,9 +160,9 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
 
         results = await asyncio.gather(*page_tasks, return_exceptions=True)
 
-        orgs = inputs.carried_orgs
-        orgs_failed = inputs.carried_orgs_failed
-        sent = inputs.carried_sent
+        orgs = 0
+        orgs_failed = 0
+        sent = 0
         for page, result in zip(pages, results):
             orgs += len(page)
             if isinstance(result, BaseException):
@@ -187,52 +177,12 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
             orgs_failed += result.orgs_failed
             sent += result.sent
 
-        return self._finish(orgs=orgs, orgs_failed=orgs_failed, sent=sent, dry_run=inputs.dry_run)
-
-    async def _run_paged(self, inputs: WeeklyDigestInputs) -> WeeklyDigestResult:
-        """Pre-fan-out path: one page per execution, chained via continue_as_new. Kept only so
-        executions started before PAGE_FANOUT_PATCH replay deterministically."""
-        # One keyset page per execution: only the ~40-byte cursor rides through
-        # continue_as_new, so neither history nor payload size grows with org count.
-        page = await workflow.execute_activity(
-            get_digest_orgs_activity,
-            GetDigestOrgsInputs(org_ids=inputs.org_ids, after=inputs.cursor, limit=inputs.page_size),
-            start_to_close_timeout=GET_ORGS_TIMEOUT,
-            retry_policy=GET_ORGS_RETRY_POLICY,
-        )
-
-        outcome = await _send_orgs(page, inputs.dry_run, inputs.max_concurrent, inputs.max_attempts)
-        sent = inputs.carried_sent + outcome.sent
-        orgs_failed = inputs.carried_orgs_failed + outcome.orgs_failed
-        orgs = inputs.carried_orgs + len(page)
-
-        # A full page may hide more orgs behind it; only a short page proves the set is
-        # drained. An exact-multiple total costs one extra execution that gets an empty
-        # page and finishes with the carried totals.
-        if page and len(page) == inputs.page_size:
-            workflow.logger.info(
-                "Error Tracking weekly digest page complete, continuing as new",
-                extra={"orgs_so_far": orgs, "cursor": page[-1], "orgs_failed": orgs_failed, "sent": sent},
-            )
-            workflow.continue_as_new(
-                dataclasses.replace(
-                    inputs,
-                    cursor=page[-1],
-                    carried_orgs=orgs,
-                    carried_orgs_failed=orgs_failed,
-                    carried_sent=sent,
-                )
-            )
-
-        return self._finish(orgs=orgs, orgs_failed=orgs_failed, sent=sent, dry_run=inputs.dry_run)
-
-    def _finish(self, orgs: int, orgs_failed: int, sent: int, dry_run: bool) -> WeeklyDigestResult:
         if not orgs:
             workflow.logger.info("No orgs for Error Tracking weekly digest")
 
         workflow.logger.info(
             "Error Tracking weekly digest run complete",
-            extra={"orgs": orgs, "orgs_failed": orgs_failed, "sent": sent, "dry_run": dry_run},
+            extra={"orgs": orgs, "orgs_failed": orgs_failed, "sent": sent, "dry_run": inputs.dry_run},
         )
 
         if orgs_failed:

--- a/products/error_tracking/backend/temporal/weekly_digest/workflow.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/workflow.py
@@ -135,7 +135,7 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
         """
         window = asyncio.Semaphore(inputs.max_concurrent_pages)
 
-        async def run_page(org_ids: list[str]) -> WeeklyDigestResult:
+        async def run_page(org_ids: list[str], page_number: int) -> WeeklyDigestResult:
             async with window:
                 return await workflow.execute_child_workflow(
                     ErrorTrackingWeeklyDigestPageWorkflow.run,
@@ -145,6 +145,7 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
                         max_concurrent=inputs.max_concurrent,
                         max_attempts=inputs.max_attempts,
                     ),
+                    id=f"{workflow.info().workflow_id}-page-{page_number}",
                 )
 
         # inputs.cursor is normally None; it resumes a run continued-as-new from the
@@ -162,7 +163,7 @@ class ErrorTrackingWeeklyDigestWorkflow(PostHogWorkflow):
             if not page:
                 break
             pages.append(page)
-            page_tasks.append(asyncio.create_task(run_page(page)))
+            page_tasks.append(asyncio.create_task(run_page(page, page_number=len(pages))))
             if len(page) < inputs.page_size:
                 break
             cursor = page[-1]


### PR DESCRIPTION
Our entire weekly digest is still too slow.

Current flow does pagination with 1000 orgs per workflow and then starts a new workflow in a "continued as new" strategy. That has two major problems:
1. When the workflow starts, it does one initial query for all orgs inside of it - it is pretty slow. During that time literally nothing happens. Everything is blocked by this query.
2. We have to wait until EVERY activity finishes within a workflow to start a new one. This means that 1 team which is slow or fails for whatever reason blocks everything until it eventually fails


This PR adds another layer of concurrency. Instead of spawning next workflows sequentially, we now have a master workflow, which spawns workflows per page which then spawn activities which handle each org.

| Parent workflow and it's children in a list view |
|--------|
| <img width="515" height="510" alt="CleanShot 2026-08-03 at 15 59 20" src="https://github.com/user-attachments/assets/4fa3daba-922f-4b4a-bb06-7a36cad09835" /> |


 | Parent workflow and it's children in parent detail view |
|--------|
| <img width="1691" height="769" alt="CleanShot 2026-08-03 at 15 59 53" src="https://github.com/user-attachments/assets/24de4ac1-e206-477b-b651-a22df257d0b0" /> |



