### PR TITLE
fix(error-tracking): isolate digest autoselect failures

### DIFF
--- a/products/error_tracking/backend/temporal/weekly_digest/activities.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/activities.py
@@ -93,7 +93,15 @@ def _send_org_digest(inputs: SendOrgDigestInputs, attempt: int) -> SendOrgDigest
     daily_rows_by_team: dict[int, list] = {}
     if any(setting_key not in (m.user.partial_notification_settings or {}) for m in memberships):
         for tid in team_ids_with_exceptions:
-            daily_rows_by_team[tid] = weekly_digest.query_daily_rows(all_org_teams[tid])
+            try:
+                daily_rows_by_team[tid] = weekly_digest.query_daily_rows(all_org_teams[tid])
+            except Exception:
+                # Auto-selection is best-effort. A project with an invalid filter (for example, one
+                # referencing a deleted cohort) must not prevent healthy projects in the org from
+                # being ranked or delivered. If a recipient already subscribes to this project,
+                # Pass 2 retries its build through the normal failed-team path below.
+                logger.exception("et_weekly_digest.autoselect_team_failed", team_id=tid, org_id=org_id)
+                continue
             summary = weekly_digest.get_exception_summary_for_team(all_org_teams[tid], daily_rows_by_team[tid])
             if summary and summary["exception_count"] > 0:
                 autoselect_counts[tid] = summary

--- a/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -24,6 +24,7 @@ from posthog.models import OrganizationMembership, Team, User
 from posthog.models.messaging import MessagingRecord
 from posthog.models.utils import uuid7
 
+from products.error_tracking.backend import weekly_digest
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueFingerprintV2,
@@ -48,6 +49,7 @@ from ee.models.rbac.access_control import AccessControl
 
 _WEBHOOK_POST = "products.error_tracking.backend.weekly_digest.requests.post"
 _BUILD_TEAM_DIGEST_DATA = "products.error_tracking.backend.weekly_digest.build_team_digest_data"
+_QUERY_DAILY_ROWS = "products.error_tracking.backend.weekly_digest.query_daily_rows"
 _IS_CLOUD = "products.error_tracking.backend.temporal.weekly_digest.activities.is_cloud"
 
 
@@ -229,6 +231,37 @@ class TestSendOrgDigest(ClickhouseTestMixin, APIBaseTest):
             "error_tracking_weekly_digest_project_enabled", {}
         )
         assert project_enabled == {str(team_b.pk): True}
+
+    def test_auto_select_skips_project_with_invalid_filter(self):
+        _create_event(distinct_id="user_a", event="$exception", team=self.team, properties={}, timestamp=_days_ago(1))
+        team_b = self._create_second_team_with_exception()
+        flush_persons_and_events()
+
+        self.user.role_at_organization = "engineering"
+        self.user.save()
+
+        original_query_daily_rows = weekly_digest.query_daily_rows
+
+        def query_or_fail(team):
+            if team.pk == self.team.pk:
+                raise Exception("Could not find cohort with ID 103523")
+            return original_query_daily_rows(team)
+
+        with (
+            patch(_QUERY_DAILY_ROWS, side_effect=query_or_fail),
+            patch(_WEBHOOK_POST) as mock_post,
+        ):
+            result = self._run()
+
+        self.user.refresh_from_db()
+        project_enabled = (self.user.partial_notification_settings or {}).get(
+            "error_tracking_weekly_digest_project_enabled", {}
+        )
+        assert project_enabled == {str(team_b.pk): True}
+        assert [section["team_name"] for section in mock_post.call_args.kwargs["json"]["digest"]["project_sections"]] == [
+            team_b.name
+        ]
+        assert result == SendOrgDigestResult(sent=1, teams_built=1)
 
     def test_auto_select_skips_the_busiest_project_the_user_cannot_access(self):
         # self.team is the busiest but private to a plain member. Enrolling them onto it would leave every

--- a/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
+++ b/products/error_tracking/backend/temporal/weekly_digest/test/test_weekly_digest_temporal.py
@@ -258,9 +258,9 @@ class TestSendOrgDigest(ClickhouseTestMixin, APIBaseTest):
             "error_tracking_weekly_digest_project_enabled", {}
         )
         assert project_enabled == {str(team_b.pk): True}
-        assert [section["team_name"] for section in mock_post.call_args.kwargs["json"]["digest"]["project_sections"]] == [
-            team_b.name
-        ]
+        assert [
+            section["team_name"] for section in mock_post.call_args.kwargs["json"]["digest"]["project_sections"]
+        ] == [team_b.name]
         assert result == SendOrgDigestResult(sent=1, teams_built=1)
 
     def test_auto_select_skips_the_busiest_project_the_user_cannot_access(self):


### PR DESCRIPTION
Fix: https://us.posthog.com/project/2/error_tracking/019fc7d0-0a8e-7532-b837-dd328bc24c11

## Problem

A project-level query failure during weekly digest auto-selection aborts the entire organization's digest. This prevents healthy subscribed projects from being delivered when another project has an invalid test-account filter.

**Why:** Weekly digests should isolate project-specific failures so one malformed project cannot block healthy projects in the same organization.

## Changes

- Catch and log per-project failures during the auto-selection pre-pass.
- Continue ranking healthy projects while leaving subscribed failed projects to the existing retry and partial-delivery path.
- Add a regression test for an invalid cohort reference.

## How did you test this code?

- Ruff passed for both changed Python files.
- Git diff validation and Python compilation passed.
- The focused regression test was attempted but could not start because PostgreSQL and ClickHouse services are not running in this task environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed because this only changes internal failure isolation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this fix using the investigating-error-issue skill. The change keeps auto-selection best-effort and relies on the existing subscribed-team retry behavior rather than adding a separate recovery path.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*