### PR TITLE
chore(endpoints): remove the endpoints rollout feature flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1721,13 +1721,13 @@ snapshots:
     components-sample-data-state--wizard-installing--light:
         hash: v1.k794b7964.2052c49beff2e0a5c5c533ae05c73bacc2619a04053b4529acf93574160c3a66.sTXp62J02o4EVCFfSt9_QV7YwS6UN87FpVxkPGrmZ3o
     components-search--default--dark:
-        hash: v1.k794b7964.2143ca217d17aa04c982553503978c63645ece2137b5c8fb960ab032f00bbb37.9TgUxYSAp0acIhnmBMb9dPfmAAl1kkaUQgMkeeDz6wM
+        hash: v1.k794b7964.329848430e62c2ae6debb1cb079bd8d933d6af5f5118ca92f2d57ae45a01c2b6.AIJk0vc6yhvmiu_o3y6HHTnnMz4eT1GfcErn-94ITbc
     components-search--default--light:
-        hash: v1.k794b7964.64c572662f94f4e788566713b070a54b445de760263bc8b8aca881a2b9f597a2.am8UAt5AiGfbJ_9wiPewuFSM6TKlzAARK5bVmJm8YDI
+        hash: v1.k794b7964.bd03ec11c5490a47573146697b4dd9d1e9e0eeb9c3b282a6c4d61f1b45728356.neaCf7zZYGDFLy9BO6qBCqShufOkRTbEt_4wDYVFVuk
     components-search--product-recents-and-starred--dark:
-        hash: v1.k794b7964.29f3591d53872fdbc74f520a481e96d5eb25173806943d93e7f707c8b5458d95.6wYCSMFt1PGkDpYdUwz0f7iDtUtM0k3c12_T9H8gVvc
+        hash: v1.k794b7964.72f83a849f0cac73d1d3f07b03b882bc4cc7ec1c19f6c0c28aa2bacc3b82590a.eqQfZ61UgBEQHYME49BPEg4zP4XHN7eB2KXG3SjRf5o
     components-search--product-recents-and-starred--light:
-        hash: v1.k794b7964.5df9ac27e8f914736f6fc30fbe27aba42d686145e0f06982dfe1050b74931081.9snshG25bFXRzfMF4nFJgaB7uHRXkt-2Du2b_Qoi9Lw
+        hash: v1.k794b7964.064637c3ca7cdf4b0dfea40b5baeb3cc8908c30847204eea79fffbdb354eba19.s2UDhLxUg2786u6s2MvTxkrNxupPighJWuTZCfVkkJs
     components-search--searching--dark:
         hash: v1.k794b7964.85766b937eb3e2cb31d77d0fc3d3270ea92b5a4c51577cddc5de92649787d1ac.TQ8fgQkYMWRzITSkjwIDMOahzlPUZXGugRI2b-7Q7Rs
     components-search--searching--light:
@@ -6351,13 +6351,13 @@ snapshots:
     scenes-app-insights-side-panel-actions--saved-hog-ql-data-table--light:
         hash: v1.k794b7964.5b4c6ba0ac07ba8ea0dc4d24a980821992ee75f62b2f885972e5d332394bed34.PnQhji05di1PUTIp8bvdzvWMfEmF0FfC_K5lAZiLAEE
     scenes-app-insights-side-panel-actions--saved-trends-insight--dark:
-        hash: v1.k794b7964.9410b9410af78d41c692c7f621665f46a26d69412267fc4821d8ed5bfa15162a.7xptHHW7H8qKpVpN61v4-PFdpOqPiqZUBa_C0CRkkIw
+        hash: v1.k794b7964.322db25157e386865436b5939e7316a725b2c72d80e390c5d5f3baa7306a04a6.zfzHTZMkWbxQn3zZaERle9alV-y1iices-u1zDDwq5k
     scenes-app-insights-side-panel-actions--saved-trends-insight--light:
-        hash: v1.k794b7964.133cb880193ccc45608cb4f9c6fe26fe08000fce27a7676e6cfa9ff8f317005f.MdrxQUyv_BXf6cg_aGb8Qgh7-K14xuSIBGfWRTyFC6w
+        hash: v1.k794b7964.97ff2e1e9304f11e9b841a6f2a78ece1a557e0efcbc31c5006ce9b17638ddc3f.KFEIrF-P8x5xZoUbexHc7av7XGVJAvcTKlUjEu-9uqM
     scenes-app-insights-side-panel-actions--unsaved-insight--dark:
         hash: v1.k794b7964.5b1f322380d05a819d00b70ca105248b793bda069bd747a675d35ddfc9f36772.3OASSvV1v8eLh5esxHwFjJW0ASH2UXG3F3n6i-vJ0wE
     scenes-app-insights-side-panel-actions--unsaved-insight--light:
-        hash: v1.k794b7964.1509a0b35b8b28d5a721d77a7f1ae7e166057624f7db16331216264e581e2f6e.V-NDMPceHNP8iL5m7RVrATBNmdh4zjdetX_KW6UQg5g
+        hash: v1.k794b7964.2b3ed2b5ffec763b0f7e13af74c9e9d57df96464976ae6014512a0d7def42ad3.paLp2yPHgkf2-ncauikOAUdR87k6-KhAh-Nm4uyQ380
     scenes-app-insights-sqllinechart--sql-bar-chart-value-labels-quill--dark:
         hash: v1.k794b7964.695c5dc5ec0f91451f2b41f7d0fa7a1de0d43ee7fdc8344c6034908ed1fc9869.uGwE1r6PzWzP-kZ4-Af0RV1QNt6Iov967KI2Qh6BUHg
     scenes-app-insights-sqllinechart--sql-bar-chart-value-labels-quill--light:

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.ts
@@ -29,7 +29,6 @@ const RESOURCE_FEATURE_REQUIREMENTS: Partial<Record<AccessControlResourceType, A
 // until the user has that product rolled out or has opted in, matching the product's own nav gating.
 export const RESOURCE_ROLLOUT_FLAG_REQUIREMENTS: Partial<Record<AccessControlResourceType, string>> = {
     [AccessControlResourceType.CustomerAnalytics]: FEATURE_FLAGS.CUSTOMER_ANALYTICS,
-    [AccessControlResourceType.Endpoint]: FEATURE_FLAGS.ENDPOINTS,
     [AccessControlResourceType.McpAnalytics]: FEATURE_FLAGS.MCP_ANALYTICS,
     [AccessControlResourceType.Metrics]: FEATURE_FLAGS.METRICS,
     [AccessControlResourceType.Tracing]: FEATURE_FLAGS.TRACING,

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta<(props: StoryProps) => JSX.Element> = {
         featureFlags: [
             FEATURE_FLAGS.CUSTOMER_ANALYTICS,
             FEATURE_FLAGS.DATA_WAREHOUSE_SCENE,
-            FEATURE_FLAGS.ENDPOINTS,
             FEATURE_FLAGS.LINKS,
             FEATURE_FLAGS.LIVE_DEBUGGER,
             FEATURE_FLAGS.WEB_ANALYTICS_MARKETING,

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -296,7 +296,6 @@ export const FEATURE_FLAGS = {
     DWH_POSTGRES_CDC: 'dwh-postgres-cdc', // owner: #team-warehouse-sources
     DWH_SOURCE_METRICS: 'dwh-source-metrics', // owner: #team-warehouse-sources
     EDITOR_DRAFTS: 'editor-drafts', // owner: @EDsCODE #team-data-tools
-    ENDPOINTS: 'embedded-analytics', // owner: @sakce #team-clickhouse
     ENDPOINTS_AI_MATERIALIZATION_FIX: 'endpoints-ai-materialization-fix', // owner: @sakce #team-data-modeling, gates the AI materialization rewrite (UI button + API action + MCP tools)
     ENGINEERING_ANALYTICS: 'engineering-analytics', // owner: #team-devex
     ERROR_TRACKING_ISSUE_CORRELATION: 'error-tracking-issue-correlation', // owner: @david #team-error-tracking

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1469,7 +1469,6 @@ export const fileSystemTypes = {
         href: () => urls.endpoints(),
         iconColor: ['var(--color-product-endpoints-light)'],
         filterKey: 'endpoints',
-        flag: FEATURE_FLAGS.ENDPOINTS,
     },
     experiment: {
         name: 'Experiment',
@@ -1917,7 +1916,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         category: ProductItemCategory.TOOLS,
         href: urls.endpoints(),
         type: 'endpoints',
-        flag: FEATURE_FLAGS.ENDPOINTS,
         iconType: 'endpoints',
         iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
         sceneKey: 'EndpointsScene',
@@ -2518,7 +2516,6 @@ export const getTreeItemsMetadata = (): FileSystemImport[] => [
         iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
         href: urls.endpoints(),
         sceneKey: 'EndpointsScene',
-        flag: FEATURE_FLAGS.ENDPOINTS,
         sceneKeys: ['EndpointsScene', 'EndpointScene'],
     },
     {

--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -7,7 +7,6 @@ import { IconBook, IconChevronDown, IconDownload, IconX } from '@posthog/icons'
 import { LemonModal, Spinner } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonMenuOverlay } from 'lib/lemon-ui/LemonMenu/LemonMenu'
@@ -366,7 +365,6 @@ function SQLEditorSceneTitle(): JSX.Element | null {
         inProgressViewEdits,
         isSourceQueryLastRun,
         isMultiQuery,
-        featureFlags,
     } = useValues(sqlEditorLogic)
     const { openHistoryModal } = useActions(editorSceneLogic)
     const {
@@ -623,17 +621,13 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                                                     saveAsViewAccessDisabledReason,
                                                                 onClick: () => saveAsView(),
                                                             },
-                                                            ...(featureFlags[FEATURE_FLAGS.ENDPOINTS]
-                                                                ? [
-                                                                      {
-                                                                          label: 'Save as endpoint...',
-                                                                          disabledReason:
-                                                                              saveAsDisabledReason ??
-                                                                              saveAsEndpointAccessDisabledReason,
-                                                                          onClick: () => saveAsEndpoint(),
-                                                                      },
-                                                                  ]
-                                                                : []),
+                                                            {
+                                                                label: 'Save as endpoint...',
+                                                                disabledReason:
+                                                                    saveAsDisabledReason ??
+                                                                    saveAsEndpointAccessDisabledReason,
+                                                                onClick: () => saveAsEndpoint(),
+                                                            },
                                                         ]}
                                                     />
                                                 ),
@@ -693,17 +687,13 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                                                 saveAsDisabledReason ?? saveAsViewAccessDisabledReason,
                                                             onClick: () => saveAsView(),
                                                         },
-                                                        ...(featureFlags[FEATURE_FLAGS.ENDPOINTS]
-                                                            ? [
-                                                                  {
-                                                                      label: 'Save as endpoint...',
-                                                                      disabledReason:
-                                                                          saveAsDisabledReason ??
-                                                                          saveAsEndpointAccessDisabledReason,
-                                                                      onClick: () => saveAsEndpoint(),
-                                                                  },
-                                                              ]
-                                                            : []),
+                                                        {
+                                                            label: 'Save as endpoint...',
+                                                            disabledReason:
+                                                                saveAsDisabledReason ??
+                                                                saveAsEndpointAccessDisabledReason,
+                                                            onClick: () => saveAsEndpoint(),
+                                                        },
                                                     ]}
                                                 />
                                             ),

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -404,7 +404,6 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                 dashboardId: number | null,
                 featureFlags: import('../../../lib/logic/featureFlagLogic').FeatureFlagsSet
             ): { primary: SaveAsMenuItem; secondary: SaveAsMenuItem[] } => {
-                const endpointsEnabled = !!featureFlags[FEATURE_FLAGS.ENDPOINTS]
                 const metricsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG]
                 const saveAsInsightItem: SaveAsMenuItem = {
                     action: 'insight',
@@ -423,23 +422,16 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                     action: 'metric',
                     label: 'Save as metric',
                 }
-                const extraItems = [
-                    ...(endpointsEnabled ? [saveAsEndpointItem] : []),
-                    ...(metricsEnabled ? [saveAsMetricItem] : []),
-                ]
+                const extraItems = [saveAsEndpointItem, ...(metricsEnabled ? [saveAsMetricItem] : [])]
 
                 if (editorSource === 'metric' && metricsEnabled) {
                     return {
                         primary: saveAsMetricItem,
-                        secondary: [
-                            saveAsInsightItem,
-                            saveAsViewItem,
-                            ...(endpointsEnabled ? [saveAsEndpointItem] : []),
-                        ],
+                        secondary: [saveAsInsightItem, saveAsViewItem, saveAsEndpointItem],
                     }
                 }
 
-                if (editorSource === 'endpoint' && endpointsEnabled) {
+                if (editorSource === 'endpoint') {
                     return {
                         primary: saveAsEndpointItem,
                         secondary: [saveAsInsightItem, saveAsViewItem, ...(metricsEnabled ? [saveAsMetricItem] : [])],

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -178,19 +178,17 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
                 Manage with Terraform
             </ButtonPrimitive>
 
-            {featureFlags[FEATURE_FLAGS.ENDPOINTS] ? (
-                <ButtonPrimitive
-                    onClick={openCreateFromInsightModal}
-                    menuItem
-                    disabledReasons={{
-                        'You must save the insight first before creating an endpoint from it': !isSavedInsight,
-                        ...(createEndpointAccessReason ? { [createEndpointAccessReason]: true } : {}),
-                    }}
-                >
-                    <IconEndpoints />
-                    Create endpoint
-                </ButtonPrimitive>
-            ) : null}
+            <ButtonPrimitive
+                onClick={openCreateFromInsightModal}
+                menuItem
+                disabledReasons={{
+                    'You must save the insight first before creating an endpoint from it': !isSavedInsight,
+                    ...(createEndpointAccessReason ? { [createEndpointAccessReason]: true } : {}),
+                }}
+            >
+                <IconEndpoints />
+                Create endpoint
+            </ButtonPrimitive>
 
             {featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG] ? (
                 <CreateMetricFromInsightButton isSavedInsight={isSavedInsight} insightShortId={insight?.short_id} />

--- a/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
@@ -147,9 +147,7 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
     const showFileMenu = true // file ops (project tree, terraform) always available
     const showEditMenu = true // duplicate always available
     const showCreateEndpoint =
-        featureFlags[FEATURE_FLAGS.ENDPOINTS] &&
-        isSavedInsight &&
-        !getAccessControlDisabledReason(AccessControlResourceType.Endpoint, AccessControlLevel.Editor)
+        isSavedInsight && !getAccessControlDisabledReason(AccessControlResourceType.Endpoint, AccessControlLevel.Editor)
     const showCreateMetric = !!featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG] && isSavedInsight
     const showAddToNotebook = isSavedInsight
     const showCreateMenu =

--- a/products/endpoints/manifest.tsx
+++ b/products/endpoints/manifest.tsx
@@ -1,6 +1,5 @@
 import { combineUrl } from 'kea-router'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { urls } from 'scenes/urls'
 
 import { FileSystemIconType, ProductItemCategory, ProductKey } from '~/queries/schema/schema-general'
@@ -79,7 +78,6 @@ export const manifest: ProductManifest = {
             href: () => urls.endpoints(),
             iconColor: ['var(--color-product-endpoints-light)'],
             filterKey: 'endpoints',
-            flag: FEATURE_FLAGS.ENDPOINTS,
         },
     },
     treeItemsProducts: [
@@ -89,7 +87,6 @@ export const manifest: ProductManifest = {
             category: ProductItemCategory.TOOLS,
             href: urls.endpoints(),
             type: 'endpoints',
-            flag: FEATURE_FLAGS.ENDPOINTS,
             iconType: 'endpoints',
             iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
             sceneKey: 'EndpointsScene',
@@ -103,7 +100,6 @@ export const manifest: ProductManifest = {
             iconColor: ['var(--color-product-endpoints-light)'] as FileSystemIconColor,
             href: urls.endpoints(),
             sceneKey: 'EndpointsScene',
-            flag: FEATURE_FLAGS.ENDPOINTS,
             sceneKeys: ['EndpointsScene', 'EndpointScene'],
         },
     ],


### PR DESCRIPTION
## Problem

Endpoints is fully rolled out, so the `embedded-analytics` flag (`FEATURE_FLAGS.ENDPOINTS`) is no longer doing any useful gating. Leaving it in place just means the product's nav entries and entry points are conditional on a flag that is always on, which is dead weight and a trap for anyone reading the code later.

## Changes

Removed `FEATURE_FLAGS.ENDPOINTS` and every gate behind it:

- `products/endpoints/manifest.tsx`: dropped `flag` from the filesystem type, product tree item, and metadata tree item, so Endpoints shows in the nav unconditionally (regenerated `frontend/src/products.tsx`).
- `resourcesAccessControlLogic.ts`: removed the Endpoint entry from the rollout-flag map, so the access control row always renders.
- SQL editor (`SQLEditor.tsx`, `editorSceneLogic.tsx`): "Save as endpoint" is always in the save-as menu. Access-level `disabledReason` handling is unchanged.
- Insight menus (`InsightPanelActions.tsx`, `InsightSceneMenuBar.tsx`): "Create endpoint" is always offered, still subject to the existing saved-insight and editor-access checks.

Access control still governs who can actually create or edit endpoints. This only removes the rollout gate.

> [!NOTE]
> The `embedded-analytics` flag itself should be deleted in PostHog once this ships.

`ENDPOINTS_AI_MATERIALIZATION_FIX` is a separate flag and is untouched.

## How did you test this code?

I (Claude, via the PostHog Slack app) did not test this manually. Automated checks I actually ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in any touched file. Pre-existing unrelated errors remain from the nested `@posthog/quill` workspace not being built in this environment.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) — clean.
- `jest src/layout/navigation-3000/sidepanel/panels/access_control/resourcesAccessControlLogic.test.ts` — 7/7 passing.
- Confirmed zero remaining references to `FEATURE_FLAGS.ENDPOINTS` or `embedded-analytics` in the repo.

No new tests. This is a pure removal of conditionals, and there is no regression a new test would catch that the existing suites plus typecheck do not.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change: the flag was internal rollout plumbing, not documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude through the PostHog Slack app, from a request to drop the Endpoints rollout gate now that the product is fully out.

Approach: found the flag's canonical definition in `frontend/src/lib/constants.tsx`, traced all call sites, and confirmed there was no backend gating on `embedded-analytics` at all, it was frontend-only. Each site was then unwrapped rather than defaulted to `true`, so no conditional survives. `frontend/src/products.tsx` is codegen output, so it was regenerated with `pnpm build:products` rather than hand-edited. The `--color-product-embedded-analytics-*` CSS vars in `base.scss` share the old name but are not flag references, so they were left alone.

No repo skills were invoked. The one judgment call worth flagging: `editorSceneLogic`'s `editorSource === 'endpoint'` branch was previously gated on the flag, which meant an endpoint-sourced editor session silently fell through to the generic insight branch when the flag was off. That branch is now reachable whenever the source is an endpoint, which is the intended behavior but is a real behavior change, so it is worth a look during review.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GNDPDNEN/p1785764017147999)*
