### PR TITLE
fix(data-warehouse): explain likely ad blocker when a source connection can't reach the server

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -253,6 +253,24 @@ function webhookResultHasNoPendingInputs(webhookResult: WebhookCreateResult | nu
     return !!webhookResult?.success && (webhookResult.pending_inputs?.length ?? 0) === 0
 }
 
+// Turn a caught request error into user-facing copy for the connect flow. A thrown fetch never
+// reaches an HTTP status, so its message is the raw "Failed to fetch" — most often an ad blocker or
+// browser extension blocking the request, which is unactionable on its own. Prefer any API-provided
+// message, then name the likely cause for a network-level failure, then fall back to a server hint.
+export function resolveConnectErrorMessage(e: any): string {
+    const apiMessage = e?.data?.message ?? e?.detail
+    if (apiMessage) {
+        return apiMessage
+    }
+    if (e?.status === undefined || e?.status === 0) {
+        return "PostHog couldn't reach the server to set up your source. This is often an ad blocker or browser extension blocking the request — try pausing it or switching networks, then try again."
+    }
+    if (e?.status >= 500) {
+        return 'PostHog could not validate your connection in time. This can happen with a very large schema or a slow or unreachable database — please check your connection details and try again.'
+    }
+    return e?.message
+}
+
 const manualLinkSourceMap: Record<ManualLinkSourceType, string> = {
     aws: 'S3',
     'google-cloud': 'Google Cloud Storage',
@@ -3301,7 +3319,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     actions.setStep(5)
                 }
             } catch (e: any) {
-                lemonToast.error(e.data?.message ?? e.message)
+                lemonToast.error(resolveConnectErrorMessage(e))
                 // Surface the failure instead of leaving it as a toast-only dead end: a captured
                 // exception keeps the stack triageable, and the event closes the connect funnel.
                 posthog.captureException(e)
@@ -3477,15 +3495,8 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 actions.setDatabaseSchemas(schemas)
                 actions.onNext()
             } catch (e: any) {
-                // A gateway timeout / 5xx has no JSON body, so e.message is the raw
-                // "Non-OK response [POST ...] (status 504: )" — meaningless to the user. Surface a
-                // friendly hint for server-side failures while keeping any API-provided message.
                 const apiMessage = e.data?.message ?? e.detail
-                const errorMessage =
-                    apiMessage ??
-                    (e.status >= 500
-                        ? 'PostHog could not validate your connection in time. This can happen with a very large schema or a slow or unreachable database — please check your connection details and try again.'
-                        : e.message)
+                const errorMessage = resolveConnectErrorMessage(e)
                 lemonToast.error(errorMessage)
 
                 // A 5xx with no body is an unexpected server failure, not a user credential

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -254,7 +254,7 @@ function webhookResultHasNoPendingInputs(webhookResult: WebhookCreateResult | nu
 }
 
 // Turn a caught request error into user-facing copy for the connect flow. A thrown fetch never
-// reaches an HTTP status, so its message is the raw "Failed to fetch" — most often an ad blocker or
+// reaches an HTTP status, so its message is the raw "Failed to fetch", most often an ad blocker or
 // browser extension blocking the request, which is unactionable on its own. Prefer any API-provided
 // message, then name the likely cause for a network-level failure, then fall back to a server hint.
 export function resolveConnectErrorMessage(e: any): string {
@@ -263,7 +263,7 @@ export function resolveConnectErrorMessage(e: any): string {
         return apiMessage
     }
     if (e?.status === undefined || e?.status === 0) {
-        return "PostHog couldn't reach the server to set up your source. This is often an ad blocker or browser extension blocking the request — try pausing it or switching networks, then try again."
+        return "PostHog couldn't reach the server to set up your source. This is often an ad blocker or browser extension blocking the request. Try pausing it or switching networks, then try again."
     }
     if (e?.status >= 500) {
         return 'PostHog could not validate your connection in time. This can happen with a very large schema or a slow or unreachable database — please check your connection details and try again.'

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -253,22 +253,21 @@ function webhookResultHasNoPendingInputs(webhookResult: WebhookCreateResult | nu
     return !!webhookResult?.success && (webhookResult.pending_inputs?.length ?? 0) === 0
 }
 
-// Turn a caught request error into user-facing copy for the connect flow. A thrown fetch never
-// reaches an HTTP status, so its message is the raw "Failed to fetch", most often an ad blocker or
-// browser extension blocking the request, which is unactionable on its own. Prefer any API-provided
-// message, then name the likely cause for a network-level failure, then fall back to a server hint.
+// A thrown fetch has no HTTP status, so its message is the raw "Failed to fetch", most often an ad
+// blocker or extension blocking the request. Name that likely cause instead of echoing it.
 export function resolveConnectErrorMessage(e: any): string {
     const apiMessage = e?.data?.message ?? e?.detail
     if (apiMessage) {
         return apiMessage
     }
-    if (e?.status === undefined || e?.status === 0) {
+    if (e?.status === undefined || e?.status === null || e?.status === 0) {
         return "PostHog couldn't reach the server to set up your source. This is often an ad blocker or browser extension blocking the request. Try pausing it or switching networks, then try again."
     }
     if (e?.status >= 500) {
         return 'PostHog could not validate your connection in time. This can happen with a very large schema or a slow or unreachable database — please check your connection details and try again.'
     }
-    return e?.message
+    // A 4xx without a message body would otherwise toast "undefined".
+    return e?.message ?? 'Something went wrong setting up your source. Please try again.'
 }
 
 const manualLinkSourceMap: Record<ManualLinkSourceType, string> = {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -72,6 +72,12 @@ describe('sourceWizardLogic', () => {
                 'Invalid credentials'
             )
         })
+
+        it('never returns undefined for a 4xx with no message body', () => {
+            const message = resolveConnectErrorMessage({ status: 400 })
+            expect(message).toBeTruthy()
+            expect(message).not.toEqual('undefined')
+        })
     })
 
     describe('getDatabaseSchemaPayload', () => {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -11,6 +11,7 @@ import {
     getDatabaseSchemaPayload,
     getErrorsForFields,
     mergeRestoredSourceFormValues,
+    resolveConnectErrorMessage,
     shouldHydrateSourceFromUrl,
     sourceWizardLogic,
 } from '../sourceWizardLogic'
@@ -56,6 +57,21 @@ describe('sourceWizardLogic', () => {
         expect(shouldHydrateSourceFromUrl(2, postgresSource, postgresSource, 'direct', 'direct')).toBe(false)
         expect(shouldHydrateSourceFromUrl(1, postgresSource, postgresSource, 'direct', 'direct')).toBe(true)
         expect(shouldHydrateSourceFromUrl(2, postgresSource, postgresSource, 'warehouse', 'direct')).toBe(true)
+    })
+
+    describe('resolveConnectErrorMessage', () => {
+        it('guides toward ad blockers when a request never reaches the server', () => {
+            // A thrown fetch has no HTTP status; without this branch the user only sees "Failed to fetch".
+            const message = resolveConnectErrorMessage({ message: 'Failed to fetch', status: undefined })
+            expect(message).toContain('ad blocker')
+            expect(message).not.toEqual('Failed to fetch')
+        })
+
+        it('prefers an API-provided message over the network hint', () => {
+            expect(resolveConnectErrorMessage({ data: { message: 'Invalid credentials' }, status: 400 })).toEqual(
+                'Invalid credentials'
+            )
+        })
     })
 
     describe('getDatabaseSchemaPayload', () => {


### PR DESCRIPTION
## Problem

Users onboarding a new data warehouse source sometimes hit a bare "Failed to fetch" toast and can't complete the connection. When `fetch` throws before getting an HTTP response (an ad blocker, a privacy extension, a flaky network, or CORS), the request never reaches a status code, so the wizard fell back to the raw error text. That message is a dead end for the user, and this class of failure can block every source in the catalog, not just one connector.

## Changes

Added a small `resolveConnectErrorMessage` helper in the new-source wizard logic and routed the `createSource` and `getDatabaseSchemas` error paths through it. Behavior:

- Prefer any API-provided message (unchanged for real credential/validation errors).
- For a network-level failure (no HTTP status), point at the likely cause: an ad blocker or browser extension blocking the request, with a clear next step.
- Keep the existing friendly copy for 5xx server errors.

This is a copy-only change. No sync behavior, schema handling, or API contracts change.

## How did you test this code?

Added two unit tests for `resolveConnectErrorMessage` (network-level failure produces the ad-blocker guidance, and an API-provided message still wins). I ran the wizard logic Jest suite and the frontend typecheck locally, both green. I did not manually reproduce an ad-blocked request in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude. The change came out of reviewing anonymized session summaries of the new-source onboarding flow, where a "Failed to fetch" error blocked a user from connecting any advertising source. The wizard surfaced the raw fetch error with no guidance, so I added the likely-cause copy for network-level failures while leaving real API errors untouched. Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
