### PR TITLE
fix(warehouse_sources): name read access in the RevenueCat 403 error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
@@ -189,8 +189,8 @@ def _format_http_error(error: requests.HTTPError) -> str:
         )
     if status_code == 403:
         return (
-            "RevenueCat denied the request (403). Make sure the v2 secret API key "
-            "has the permissions required for this resource."
+            "RevenueCat denied the request (403). The v2 secret API key is missing read access — "
+            "give it read permission for the data you want to sync, then reconnect."
         )
     if status_code == 404:
         return "RevenueCat could not find the project (404). Double-check the project id."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
@@ -179,7 +179,7 @@ def _project_not_found_error(entered_project_id: str, accessible_ids: list[str])
     )
 
 
-def _format_http_error(error: requests.HTTPError) -> str:
+def _format_http_error(error: requests.HTTPError, forbidden_hint: str | None = None) -> str:
     response = error.response
     status_code = response.status_code if response is not None else None
     if status_code == 401:
@@ -188,10 +188,10 @@ def _format_http_error(error: requests.HTTPError) -> str:
             "from Project settings > API keys and check that it has not been revoked."
         )
     if status_code == 403:
-        return (
-            "RevenueCat denied the request (403). The v2 secret API key is missing read access. "
-            "Give it read permission for the data you want to sync, then reconnect."
-        )
+        # This formatter also serves webhook create/delete, which need write scope, so the default
+        # stays scope-neutral. Read-only callers pass a read-specific hint.
+        detail = forbidden_hint or "Make sure the v2 secret API key has the permissions this request needs."
+        return f"RevenueCat denied the request (403). {detail}"
     if status_code == 404:
         return "RevenueCat could not find the project (404). Double-check the project id."
     if status_code == 429:
@@ -215,7 +215,13 @@ def validate_credentials(api_key: str, project_id: str | None) -> tuple[bool, st
     try:
         accessible_ids = _list_accessible_project_ids(session)
     except requests.HTTPError as e:
-        return False, _format_http_error(e)
+        return False, _format_http_error(
+            e,
+            forbidden_hint=(
+                "The v2 secret API key is missing read access. Give it read permission for the data "
+                "you want to sync, then reconnect."
+            ),
+        )
     except requests.RequestException as e:
         return False, f"Could not reach RevenueCat: {e}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/revenuecat.py
@@ -189,8 +189,8 @@ def _format_http_error(error: requests.HTTPError) -> str:
         )
     if status_code == 403:
         return (
-            "RevenueCat denied the request (403). The v2 secret API key is missing read access — "
-            "give it read permission for the data you want to sync, then reconnect."
+            "RevenueCat denied the request (403). The v2 secret API key is missing read access. "
+            "Give it read permission for the data you want to sync, then reconnect."
         )
     if status_code == 404:
         return "RevenueCat could not find the project (404). Double-check the project id."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/tests/test_revenuecat.py
@@ -497,6 +497,9 @@ class TestCreateWebhook:
         assert result.success is False
         assert result.error is not None
         assert "denied" in result.error.lower()
+        # Webhook creation needs write scope, so this shared 403 message must not tell the user to
+        # grant read access (unlike the credential-check path).
+        assert "read" not in result.error.lower()
 
 
 class TestDeleteWebhook:


### PR DESCRIPTION
## Problem

When connecting a RevenueCat source, a permission failure surfaced as: "RevenueCat denied the request (403). Make sure the v2 secret API key has the permissions required for this resource." That doesn't tell the user what to actually change, so people got stuck on the setup page unable to link the source.

RevenueCat v2 secret API keys carry per-resource scopes. During credential validation a 403 means the key lacks read access to the data being synced. The mid-sync error for the same status already says this clearly. The connect-time message didn't.

## Changes

The 403 formatter is shared by credential validation and webhook create/delete, and those webhook calls need write scope, so the message can't just say "read". I added an optional `forbidden_hint` to the formatter:

- Credential validation passes a read-specific hint: the key is missing read access, so grant it read permission for the data you want to sync and reconnect.
- Webhook create/delete keep a scope-neutral default.

Copy plus one small helper parameter. No behavior, retry, or schema changes.

## How did you test this code?

Ran the full RevenueCat source test suite locally (66 passing), including a new assertion that the webhook 403 message does not tell the user to grant read access. Ran ruff check/format on the file. No manual testing against the live RevenueCat API.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Written by Claude. Found while reviewing anonymized session summaries of data warehouse onboarding, where users repeatedly failed to connect RevenueCat on a 403. First pass reworded the shared 403 message to name read access; an automated reviewer correctly pointed out that formatter is also used for webhook write operations, so I split it into a per-caller hint and added a regression test. Skills invoked: /improving-drf-endpoints, /writing-user-facing-copy, /writing-code-comments.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
