### PR TITLE
ci: add antlr toolchain for parser source builds

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1131,14 +1131,17 @@ jobs:
                   components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
+            # Before the master checkout (ref: master, clean: false) removes this
+            # composite and its installer script from the workspace; the /usr install
+            # it performs survives the checkout.
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: master
                   clean: false
-            - name: Set up ANTLR C++ runtime
-              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies for master
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -877,7 +877,6 @@ jobs:
               uses: ./.depot/actions/setup-sqlx-cli
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Add service hostnames to /etc/hosts
@@ -980,7 +979,6 @@ jobs:
                   version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1046,7 +1044,6 @@ jobs:
                   version: '0.11.28'
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1131,9 +1128,9 @@ jobs:
                   components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
-            # Before the master checkout (ref: master, clean: false) removes this
-            # composite and its installer script from the workspace; the /usr install
-            # it performs survives the checkout.
+            # Must run before the master checkout below removes this composite and
+            # its installer script from the workspace; the /usr install it performs
+            # survives the checkout.
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
             # First running migrations from master, to simulate the real-world scenario
@@ -1142,7 +1139,6 @@ jobs:
               with:
                   ref: master
                   clean: false
-
             - name: Install python dependencies for master
               run: |
                   UV_PROJECT_ENVIRONMENT=.venv-master uv sync --frozen --dev
@@ -1730,7 +1726,6 @@ jobs:
                   version: 1.0
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -875,6 +875,9 @@ jobs:
               run: sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install -y libxml2-dev libxmlsec1-dev libxmlsec1-openssl
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Add service hostnames to /etc/hosts
@@ -975,6 +978,9 @@ jobs:
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1038,6 +1044,9 @@ jobs:
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.28'
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1128,6 +1137,9 @@ jobs:
               with:
                   ref: master
                   clean: false
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies for master
               run: |
                   UV_PROJECT_ENVIRONMENT=.venv-master uv sync --frozen --dev
@@ -1713,6 +1725,9 @@ jobs:
               with:
                   packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
                   version: 1.0
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1110,14 +1110,17 @@ jobs:
                   components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
+            # Before the master checkout (ref: master, clean: false) removes this
+            # composite and its installer script from the workspace; the /usr install
+            # it performs survives the checkout.
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: master
                   clean: false
-            - name: Set up ANTLR C++ runtime
-              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies for master
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -855,6 +855,9 @@ jobs:
                   components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Add service hostnames to /etc/hosts
@@ -955,6 +958,9 @@ jobs:
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1017,6 +1023,9 @@ jobs:
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
               with:
                   version: '0.11.28'
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1107,6 +1116,9 @@ jobs:
               with:
                   ref: master
                   clean: false
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies for master
               run: |
                   UV_PROJECT_ENVIRONMENT=.venv-master uv sync --frozen --dev
@@ -1668,6 +1680,9 @@ jobs:
               with:
                   packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
                   version: 1.0
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -857,7 +857,6 @@ jobs:
               uses: ./.depot/actions/setup-sqlx-cli
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Add service hostnames to /etc/hosts
@@ -960,7 +959,6 @@ jobs:
                   version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Bootstrap scaffold product
@@ -1025,7 +1023,6 @@ jobs:
                   version: '0.11.28'
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
             - name: Validate changed product.yaml owners
@@ -1110,9 +1107,9 @@ jobs:
                   components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
-            # Before the master checkout (ref: master, clean: false) removes this
-            # composite and its installer script from the workspace; the /usr install
-            # it performs survives the checkout.
+            # Must run before the master checkout below removes this composite and
+            # its installer script from the workspace; the /usr install it performs
+            # survives the checkout.
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
             # First running migrations from master, to simulate the real-world scenario
@@ -1121,7 +1118,6 @@ jobs:
               with:
                   ref: master
                   clean: false
-
             - name: Install python dependencies for master
               run: |
                   UV_PROJECT_ENVIRONMENT=.venv-master uv sync --frozen --dev
@@ -1685,7 +1681,6 @@ jobs:
                   version: 1.0
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.github/actions/setup-antlr-runtime/action.yml
+++ b/.github/actions/setup-antlr-runtime/action.yml
@@ -1,0 +1,36 @@
+name: Set up ANTLR C++ runtime
+description: >-
+    Restore or build the static ANTLR C++ runtime that compiling hogql-parser from
+    source requires, and install it system-wide. Cheap (cache restore) when warm.
+
+runs:
+    using: composite
+    steps:
+        - name: Restore ANTLR static runtime
+          id: antlr-cache
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ~/.antlr4-static
+              # Content-addressed on the installer script, which pins the ANTLR
+              # version and md5, so one canonical key serves every ref.
+              key: antlr4-static-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bin/install-antlr4-cpp-runtime') }}
+
+        - name: Build ANTLR static runtime
+          if: steps.antlr-cache.outputs.cache-hit != 'true'
+          shell: bash
+          run: ANTLR_INSTALL_PREFIX="$HOME/.antlr4-static" bin/install-antlr4-cpp-runtime
+
+        - name: Save ANTLR static runtime
+          if: github.ref == 'refs/heads/master' && steps.antlr-cache.outputs.cache-hit != 'true'
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ~/.antlr4-static
+              key: antlr4-static-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bin/install-antlr4-cpp-runtime') }}
+
+        - name: Install ANTLR static runtime system-wide
+          shell: bash
+          # hogql-parser's setup.py searches /usr/include and /usr/lib (see
+          # common/hogql_parser/setup.py), so the staged artifacts move there.
+          run: |
+              sudo cp -r "$HOME/.antlr4-static/include/antlr4-runtime" /usr/include/
+              sudo cp "$HOME/.antlr4-static/lib/libantlr4-runtime.a" /usr/lib/

--- a/.github/actions/setup-antlr-runtime/action.yml
+++ b/.github/actions/setup-antlr-runtime/action.yml
@@ -12,7 +12,7 @@ runs:
           with:
               path: ~/.antlr4-static
               # Content-addressed on the installer script, which pins the ANTLR
-              # version and md5, so one canonical key serves every ref.
+              # version and md5, so every ref shares one key.
               key: antlr4-static-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bin/install-antlr4-cpp-runtime') }}
 
         - name: Build ANTLR static runtime
@@ -25,7 +25,7 @@ runs:
           uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
           with:
               path: ~/.antlr4-static
-              key: antlr4-static-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('bin/install-antlr4-cpp-runtime') }}
+              key: ${{ steps.antlr-cache.outputs.cache-primary-key }}
 
         - name: Install ANTLR static runtime system-wide
           shell: bash

--- a/.github/workflows/build-deltalite.yml
+++ b/.github/workflows/build-deltalite.yml
@@ -231,6 +231,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Update deltalite in requirements
               shell: bash
               env:

--- a/.github/workflows/build-hogql-parser-rs.yml
+++ b/.github/workflows/build-hogql-parser-rs.yml
@@ -217,6 +217,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Update hogql-parser-rs in requirements
               shell: bash
               env:

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -207,6 +207,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Update hogql-parser in requirements
               shell: bash
               env:

--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -80,6 +80,9 @@ jobs:
                   enable-cache: true
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 

--- a/.github/workflows/ci-agent-skills.yml
+++ b/.github/workflows/ci-agent-skills.yml
@@ -105,6 +105,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -231,6 +234,9 @@ jobs:
                   enable-cache: true
                   cache-dependency-glob: uv.lock
                   save-cache: false
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-ai.yml
+++ b/.github/workflows/ci-ai.yml
@@ -107,6 +107,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               shell: bash
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -876,6 +876,9 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -1162,6 +1165,9 @@ jobs:
               with:
                   version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -1299,6 +1305,9 @@ jobs:
               with:
                   version: '0.11.28'
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -1423,6 +1432,9 @@ jobs:
               with:
                   ref: master
                   clean: false
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies for master
               run: |
@@ -2101,6 +2113,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -2713,6 +2728,9 @@ jobs:
               with:
                   packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
                   version: 1.0
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install Python dependencies
               shell: bash

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1426,9 +1426,9 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
-            # Before the master checkout (ref: master, clean: false) removes this
-            # composite and its installer script from the workspace; the /usr install
-            # it performs survives the checkout.
+            # Must run before the master checkout below removes this composite and
+            # its installer script from the workspace; the /usr install it performs
+            # survives the checkout.
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
 

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1426,15 +1426,18 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
+            # Before the master checkout (ref: master, clean: false) removes this
+            # composite and its installer script from the workspace; the /usr install
+            # it performs survives the checkout.
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: master
                   clean: false
-
-            - name: Set up ANTLR C++ runtime
-              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies for master
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1401,15 +1401,18 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
+            # Before the master checkout (ref: master, clean: false) removes this
+            # composite and its installer script from the workspace; the /usr install
+            # it performs survives the checkout.
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   ref: master
                   clean: false
-
-            - name: Set up ANTLR C++ runtime
-              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies for master
               run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -857,6 +857,9 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -1143,6 +1146,9 @@ jobs:
               with:
                   version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -1276,6 +1282,9 @@ jobs:
               with:
                   version: '0.11.28'
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -1398,6 +1407,9 @@ jobs:
               with:
                   ref: master
                   clean: false
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies for master
               run: |
@@ -2024,6 +2036,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -2615,6 +2630,9 @@ jobs:
               with:
                   packages: libegl1 libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 x11-utils libxcb-cursor0 libopengl0
                   version: 1.0
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install Python dependencies
               shell: bash

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1401,9 +1401,9 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
-            # Before the master checkout (ref: master, clean: false) removes this
-            # composite and its installer script from the workspace; the /usr install
-            # it performs survives the checkout.
+            # Must run before the master checkout below removes this composite and
+            # its installer script from the workspace; the /usr install it performs
+            # survives the checkout.
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
 

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -82,6 +82,9 @@ jobs:
                   enable-cache: true
                   cache-dependency-glob: uv.lock
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -94,6 +94,9 @@ jobs:
                   enable-cache: true
                   cache-dependency-glob: uv.lock
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -355,6 +355,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               shell: bash
               run: |

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -342,6 +342,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               shell: bash
               run: |

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -632,6 +632,9 @@ jobs:
                   pnpm --filter=@posthog/plugin-transpiler... install --frozen-lockfile
                   bin/turbo --filter=@posthog/plugin-transpiler build
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -619,6 +619,9 @@ jobs:
                   pnpm --filter=@posthog/plugin-transpiler... install --frozen-lockfile
                   bin/turbo --filter=@posthog/plugin-transpiler build
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -104,6 +104,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -212,6 +215,9 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-hog.yml
+++ b/.github/workflows/ci-hog.yml
@@ -217,7 +217,6 @@ jobs:
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
             - name: Set up ANTLR C++ runtime
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/ci-lint-workflows.yml
+++ b/.github/workflows/ci-lint-workflows.yml
@@ -36,6 +36,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -166,6 +166,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -386,6 +389,9 @@ jobs:
               shell: bash
               run: |
                   sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install Python dependencies
               shell: bash

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -166,6 +166,9 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
@@ -374,6 +377,9 @@ jobs:
               shell: bash
               run: |
                   sudo rm -f /etc/apt/sources.list.d/*twingate* && sudo apt-get update && sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install Python dependencies
               shell: bash

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -368,6 +368,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -642,6 +645,9 @@ jobs:
                   sudo rm -f /etc/apt/sources.list.d/*twingate*
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies
               run: |

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -345,6 +345,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
@@ -619,6 +622,9 @@ jobs:
                   sudo rm -f /etc/apt/sources.list.d/*twingate*
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl
+
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install python dependencies
               run: |

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -126,6 +126,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1 libxmlsec1-dev libxmlsec1-openssl
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               shell: bash
               run: |

--- a/.github/workflows/ci-rust-flags-integration.yml
+++ b/.github/workflows/ci-rust-flags-integration.yml
@@ -109,6 +109,9 @@ jobs:
                   workspaces: rust
                   save-if: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -395,6 +395,9 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install libxml2-dev libxmlsec1-dev libxmlsec1-openssl postgresql-client
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install python dependencies
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev --directory ..

--- a/.github/workflows/pr-autoresolve-conflicts.yml
+++ b/.github/workflows/pr-autoresolve-conflicts.yml
@@ -282,7 +282,6 @@ jobs:
             - name: Set up ANTLR C++ runtime
               if: steps.merge.outputs.skip != 'true' && steps.merge.outputs.needs_backend == 'true'
               uses: ./.github/actions/setup-antlr-runtime
-
             - name: Install Python dependencies
               if: steps.merge.outputs.skip != 'true' && steps.merge.outputs.needs_backend == 'true'
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/.github/workflows/pr-autoresolve-conflicts.yml
+++ b/.github/workflows/pr-autoresolve-conflicts.yml
@@ -280,6 +280,7 @@ jobs:
               with:
                   python-version: 3.13.13
             - name: Set up ANTLR C++ runtime
+              if: steps.merge.outputs.skip != 'true' && steps.merge.outputs.needs_backend == 'true'
               uses: ./.github/actions/setup-antlr-runtime
 
             - name: Install Python dependencies

--- a/.github/workflows/pr-autoresolve-conflicts.yml
+++ b/.github/workflows/pr-autoresolve-conflicts.yml
@@ -279,6 +279,9 @@ jobs:
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.13.13
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Install Python dependencies
               if: steps.merge.outputs.skip != 'true' && steps.merge.outputs.needs_backend == 'true'
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,10 @@ ENV UV_PROJECT_ENVIRONMENT=/python-runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "build-essential" \
+    "cmake" \
+    "curl" \
+    "unzip" \
+    "uuid-dev" \
     "git" \
     "libpq-dev" \
     "libxmlsec1=1.2.37-2" \
@@ -163,6 +167,10 @@ RUN apt-get update && \
     "pkg-config" \
     && \
     rm -rf /var/lib/apt/lists/*
+
+# Static ANTLR C++ runtime, required to compile hogql-parser from the checkout
+COPY bin/install-antlr4-cpp-runtime bin/install-antlr4-cpp-runtime
+RUN bin/install-antlr4-cpp-runtime
 
 # Install Python dependencies using cache mount for faster rebuilds
 # Cache ID includes libxmlsec1 version to bust cache when system library changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,10 @@ ENV UV_PROJECT_ENVIRONMENT=/python-runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "build-essential" \
+    "cmake" \
+    "curl" \
+    "unzip" \
+    "uuid-dev" \
     "git" \
     "libpq-dev" \
     "libxmlsec1=1.2.37-2" \
@@ -159,6 +163,10 @@ RUN apt-get update && \
     "pkg-config" \
     && \
     rm -rf /var/lib/apt/lists/*
+
+# Static ANTLR C++ runtime, required to compile hogql-parser from the checkout
+COPY bin/install-antlr4-cpp-runtime bin/install-antlr4-cpp-runtime
+RUN bin/install-antlr4-cpp-runtime
 
 # Install Python dependencies using cache mount for faster rebuilds
 # Cache ID includes libxmlsec1 version to bust cache when system library changes

--- a/Dockerfile.llm-analytics
+++ b/Dockerfile.llm-analytics
@@ -28,6 +28,10 @@ ENV UV_PROJECT_ENVIRONMENT=/python-runtime
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     "build-essential" \
+    "cmake" \
+    "curl" \
+    "unzip" \
+    "uuid-dev" \
     "git" \
     "libpq-dev" \
     "libxmlsec1=1.2.37-2" \
@@ -37,6 +41,10 @@ RUN apt-get update && \
     "pkg-config" \
     && \
     rm -rf /var/lib/apt/lists/*
+
+# Static ANTLR C++ runtime, required to compile hogql-parser from the checkout
+COPY bin/install-antlr4-cpp-runtime bin/install-antlr4-cpp-runtime
+RUN bin/install-antlr4-cpp-runtime
 
 # Install Python dependencies including sentiment ML deps
 RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -39,9 +39,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     sudo \
     tmux \
     unzip \
+    uuid-dev \
     vim \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
+
+# Static ANTLR C++ runtime, required to compile hogql-parser from the checkout
+COPY bin/install-antlr4-cpp-runtime /tmp/install-antlr4-cpp-runtime
+RUN /tmp/install-antlr4-cpp-runtime && rm /tmp/install-antlr4-cpp-runtime
 
 # Personal image layers run install snippets as the sandbox user.
 # NOPASSWD sudo is available as an escape hatch for recipes that need

--- a/bin/install-antlr4-cpp-runtime
+++ b/bin/install-antlr4-cpp-runtime
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Builds the ANTLR C++ runtime as a static, position-independent library and installs
+# headers + libantlr4-runtime.a system-wide. With only the static library present,
+# `pip install ./common/hogql_parser` links it into the extension, producing a
+# self-contained module that needs no ANTLR shared library at runtime.
+set -euo pipefail
+
+version="${ANTLR_CPP_RUNTIME_VERSION:-4.13.1}"
+expected_md5="${ANTLR_CPP_RUNTIME_MD5:-c875c148991aacd043f733827644a76f}"
+# Override to install into a user-writable staging dir (the CI composite caches
+# that dir and copies into /usr afterwards); the default suits Docker root builds.
+prefix="${ANTLR_INSTALL_PREFIX:-/usr}"
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+archive="$workdir/antlr4-cpp-runtime.zip"
+curl --fail --location "https://www.antlr.org/download/antlr4-cpp-runtime-${version}-source.zip" --output "$archive" ||
+    curl --fail --location "https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-${version}-source.zip" --output "$archive"
+
+echo "$expected_md5  $archive" | md5sum --check -
+
+unzip -q "$archive" -d "$workdir/source"
+cmake -S "$workdir/source" -B "$workdir/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DANTLR_BUILD_SHARED=OFF \
+    -DANTLR_BUILD_STATIC=ON \
+    -DANTLR_BUILD_CPP_TESTS=OFF \
+    -DBUILD_TESTING=OFF \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+cmake --build "$workdir/build" --parallel "$(nproc)"
+DESTDIR="$workdir/install" cmake --install "$workdir/build"
+
+mkdir -p "$prefix/include" "$prefix/lib"
+cp -r "$workdir/install/usr/local/include/antlr4-runtime" "$prefix/include/"
+find "$workdir/install" -name 'libantlr4-runtime.a' -exec cp {} "$prefix/lib/" \;
+test -f "$prefix/lib/libantlr4-runtime.a"

--- a/bin/install-antlr4-cpp-runtime
+++ b/bin/install-antlr4-cpp-runtime
@@ -5,8 +5,10 @@
 # self-contained module that needs no ANTLR shared library at runtime.
 set -euo pipefail
 
-version="${ANTLR_CPP_RUNTIME_VERSION:-4.13.1}"
-expected_md5="${ANTLR_CPP_RUNTIME_MD5:-c875c148991aacd043f733827644a76f}"
+# Pinned inline, not env-overridable: CI caches the built runtime keyed on this
+# script's hash, so the pin and the cache key can never disagree.
+version="4.13.1"
+expected_md5="c875c148991aacd043f733827644a76f"
 # Override to install into a user-writable staging dir (the CI composite caches
 # that dir and copies into /usr afterwards); the default suits Docker root builds.
 prefix="${ANTLR_INSTALL_PREFIX:-/usr}"

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1198,6 +1198,9 @@ environment:
     start:desktop:
         bin_script: start-desktop
         description: 'Install the nested products/desktop workspace and run its dev stack (Electron app plus package watchers via turbo); used by the desktop intent on hogli start'
+    install:antlr4:cpp:runtime:
+        bin_script: install-antlr4-cpp-runtime
+        description: Build and install the static ANTLR C++ runtime that hogql-parser source builds link against
         hidden: true
     verify:ai:ingestion:stack:
         bin_script: verify-ai-ingestion-stack

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -1175,3 +1175,7 @@ environment:
         bin_script: ensure-local-setup
         description: Idempotent local-dev bootstrap (e.g. the wizard OAuth app); runs automatically on hogli start
         hidden: true
+    install:antlr4:cpp:runtime:
+        bin_script: install-antlr4-cpp-runtime
+        description: Build and install the static ANTLR C++ runtime that hogql-parser source builds link against
+        hidden: true

--- a/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
+++ b/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
@@ -92,7 +92,7 @@ log "installing dev toolchain (brotli, phrocs, go, rust)"
 # process-manager resolution (phrocs), and the Go/Rust procs and rust/bin migrators
 # need their toolchains.
 apt-get update
-# build-essential/cmake/uuid-dev serve the ANTLR runtime build below and the
+# Everything beyond brotli/make serves the ANTLR runtime install below and the
 # hogql-parser source builds that task-time `uv sync` may run.
 apt-get install -y --no-install-recommends brotli make build-essential cmake curl unzip uuid-dev
 rm -rf /var/lib/apt/lists/*

--- a/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
+++ b/products/tasks/backend/sandbox/images/bake-posthog-dev-stack.sh
@@ -92,7 +92,9 @@ log "installing dev toolchain (brotli, phrocs, go, rust)"
 # process-manager resolution (phrocs), and the Go/Rust procs and rust/bin migrators
 # need their toolchains.
 apt-get update
-apt-get install -y --no-install-recommends brotli make
+# build-essential/cmake/uuid-dev serve the ANTLR runtime build below and the
+# hogql-parser source builds that task-time `uv sync` may run.
+apt-get install -y --no-install-recommends brotli make build-essential cmake curl unzip uuid-dev
 rm -rf /var/lib/apt/lists/*
 
 case "$(uname -m)" in
@@ -165,6 +167,9 @@ log "warming go module cache (livestream)"
 # Mirrors the cargo fetch above: GOMODCACHE defaults to /root/go/pkg/mod, outside the
 # checkout, so a task-time bin/start-go-service skips the cold module download.
 (cd livestream && go mod download)
+
+log "installing static ANTLR C++ runtime (hogql-parser source builds)"
+"$REPO_DIR/bin/install-antlr4-cpp-runtime"
 
 log "warming python environment (uv sync)"
 # The checkout's .venv is discarded with the checkout; the uv cache persists in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.83",
-    "hogql-parser-rs==1.3.106",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.107",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3165,16 +3165,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.106"
+version = "1.3.107"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c6/47/6690febe4d1495957c835d00b1f7c01fa625378287ac7ad7b52b86987928/hogql_parser_rs-1.3.106.tar.gz", hash = "sha256:d9fe032470a899644e019211ad7c3bd1170d2d3a23130f3af95d79ab5ee4c86d", size = 287692, upload-time = "2026-07-03T13:55:09.094Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/e0/385f065a76fa80d71f214688b3175c1cf8decdcdb571500a8900a7291db1/hogql_parser_rs-1.3.107.tar.gz", hash = "sha256:5a86c5ccb4b4730e738785f58d8625380ef4d629cfdf349377792a7182e90a8d", size = 289499, upload-time = "2026-07-07T12:09:19.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/80/4f1ebb5af335af91dee119b097564c47c355dedfa8a561b575810a2b13e4/hogql_parser_rs-1.3.106-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9e0c5f58cbe20f4c048c281d02d7a352cc3ac96dccdd3d6f495a15024db988c4", size = 700491, upload-time = "2026-07-03T13:55:00.532Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/09/d980bdd3d945efa9e142986987a35cd223583fab245b61e77fad0d5542e0/hogql_parser_rs-1.3.106-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4b68566d58ee146be561b08d7deace4274485c3ccbfd0ebb60cdf6dd943a605", size = 662023, upload-time = "2026-07-03T13:55:02.134Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/6a/6bc32709cdf00075f32e84211ddbae1462f8ca3812b66363f33a20436d0f/hogql_parser_rs-1.3.106-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46d2e37972147cd285241855b3fb48967515c2bf1440f3b8e5778f0e1bc10824", size = 2410045, upload-time = "2026-07-03T13:55:03.424Z" },
-    { url = "https://files.pythonhosted.org/packages/25/32/9aadfa655cebef10e69804d68bf60c49d01702d17613978e57bf9dab48a2/hogql_parser_rs-1.3.106-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ba1d29683334b4d7b90c046b4603b85ab020e11b1ee80e72a5e54aead3601a99", size = 2664065, upload-time = "2026-07-03T13:55:04.78Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/48/c848fef7e84251dd02bcce78df71d3b56f476e6c65f7378498a96803051b/hogql_parser_rs-1.3.106-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5a581160747ab1784d39ee795491daae752c9d0bb26a1ddaa2a90905c7afe65e", size = 2582693, upload-time = "2026-07-03T13:55:06.164Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/2b/5f6b7a11aeb0a5e2922d9f40fe1722f271e816f8e857b32c7ea3a25e3c09/hogql_parser_rs-1.3.106-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cfa70f607c40373e2eae216cb89ae4fb3b4900a67c7132305f610c2ea4cbe70b", size = 2629564, upload-time = "2026-07-03T13:55:07.586Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6d/1bb395640fb1789d9c440d2c38bc44f0e589ad661169ab536411300d590e/hogql_parser_rs-1.3.107-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e93399c108f6c37c90432f7b21f37269b1332f51848eb0193f425e453cc03c79", size = 700468, upload-time = "2026-07-07T12:09:10.999Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ff/29a21a74ada21c11d67602ec439dc78c2ec3b5162b7b0c79598cd5d21a85/hogql_parser_rs-1.3.107-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4228087d50d66da484b1da41a5975a5080ff78f8ac8861b62183f905aac584a", size = 662258, upload-time = "2026-07-07T12:09:12.459Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b7/3cf047c3fb1951b19d43f3f9f2342dcd73d3e220fd29bfd4ba2c463dcf0a/hogql_parser_rs-1.3.107-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d899ab87ec33c58879e4b498df2103c4193473975303d57268c24ef1c896fa41", size = 2410590, upload-time = "2026-07-07T12:09:13.874Z" },
+    { url = "https://files.pythonhosted.org/packages/65/fb/d1983cac514960c66f54fac9d7c202f17fcadee6bd82de498ec34deeb030/hogql_parser_rs-1.3.107-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:981d0e0524d3202af775b67b07a18e5f6f898e7e406d4cef7fd5ea208c6ecfe0", size = 2664180, upload-time = "2026-07-07T12:09:15.334Z" },
+    { url = "https://files.pythonhosted.org/packages/40/aa/1533d628e22a01fd7e08d182893e804b67465fbce65f73cda2dfa91e3d27/hogql_parser_rs-1.3.107-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:d249d16df46f4d15f001272f6fbd1fc0a16b66b97d99e56ad71c4efc046aaaa3", size = 2582917, upload-time = "2026-07-07T12:09:16.656Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8a/0d66043f305ca6c1c64c443ab8a2f7e9516e5ec310def2a4ee4f4c2953c6/hogql_parser_rs-1.3.107-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0f359c19e589a9d56bab2b99109dd036c11142a5f34bf59c322c31f9eb1de6c7", size = 2629977, upload-time = "2026-07-07T12:09:17.967Z" },
 ]
 
 [[package]]
@@ -5902,7 +5902,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.83" },
-    { name = "hogql-parser-rs", specifier = "==1.3.106" },
+    { name = "hogql-parser-rs", specifier = "==1.3.107" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },


### PR DESCRIPTION
## Problem

- The stacked flip PR compiles `common/hogql_parser` from source wherever `uv sync` runs; every such environment first needs the ANTLR C++ runtime and a C++ toolchain.

## Changes

Inert groundwork. Nothing consumes ANTLR until the flip lands.

| Surface | Change |
| --- | --- |
| 30 project-syncing CI jobs (`.github` + `.depot`) | `setup-antlr-runtime` composite before `uv sync`: restores a static ANTLR 4.13.1 lib from cache, builds once on miss |
| `Dockerfile`, `Dockerfile.llm-analytics`, `Dockerfile.sandbox` | cmake/uuid-dev plus a `bin/install-antlr4-cpp-runtime` layer |
| dev-stack bake script | build tools + ANTLR install before the uv cache warm |
| `bin/install-antlr4-cpp-runtime` (new) | md5-pinned, static PIC build, install prefix parameterized |

In `check-migrations` the composite runs before the master checkout, which would otherwise remove it from the workspace.

> [!NOTE]
> The release bot pushed `Use new hogql-parser-rs version` (1.3.106 to 1.3.107) here: editing `build-hogql-parser-rs.yml` triggers its pipeline exercise. Master's rust source was already versioned 1.3.107 with the pin stuck at 1.3.106, so the bot reconciled a live divergence. Kept and disclosed rather than force-pushed away.

## How did you test this code?

- `bin/hogli lint:workflows` 7/7, shellcheck clean on the installer.
- The composite and Docker layers are exercised for real by the stacked flip PR's CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. Developer docs change in the stacked flip PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5); skills: /authoring-ci-workflows, /writing-code-comments, plus subagent /code-review and /simplify passes whose findings are folded in.
- Cache save is master-gated per WF006; the key is content-addressed on the installer script (the save step reuses the restore's primary key).
