### PR TITLE
feat(hogql): build hogql-parser as uv workspace member

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1744,6 +1744,12 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
+                  # No-op once the branch has flipped hogql-parser to a uv workspace
+                  # member: uv sync already built it from these sources.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                      echo "hogql-parser is a workspace member; skipping the wheel-override build."
+                      exit 0
+                  fi
                   sudo apt-get install unzip cmake curl uuid pkg-config
                   curl --fail --location https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip || curl --fail --location https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1693,6 +1693,12 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
+                  # No-op once the branch has flipped hogql-parser to a uv workspace
+                  # member: uv sync already built it from these sources.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                      echo "hogql-parser is a workspace member; skipping the wheel-override build."
+                      exit 0
+                  fi
                   sudo apt-get install unzip cmake curl uuid pkg-config
                   curl --fail --location https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip || curl --fail --location https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 !.devcontainer
 !.kearc
 !bin
+!common/hogql_parser
 !common/hogvm
 !common/esbuilder
 !common/migration_utils
@@ -78,6 +79,12 @@ services/agent-*/.next
 !tools/pr-approval-agent
 !tsconfig.json
 !unit.json.tpl
+# Local hogql-parser build artifacts must not leak into image builds.
+common/hogql_parser/.cache
+common/hogql_parser/build
+common/hogql_parser/build_wasm
+common/hogql_parser/*.egg-info
+common/hogql_parser/*.so
 common/*/*/node_modules
 common/*/node_modules
 common/*/*/dist

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -346,12 +346,14 @@ fi
 # needs the ANTLR C++ runtime. Warn up front with the fix instead of letting the
 # sync die mid-build on a C++ include error.
 if [[ "$_UV_SKIP" -ne 1 ]]; then
-  if [[ "$(uname)" == "Darwin" ]]; then
-    if [[ ! -d /opt/homebrew/include/antlr4-runtime && ! -d /usr/local/include/antlr4-runtime ]]; then
-      echo "warning: ANTLR C++ runtime not found; 'uv sync' cannot build hogql-parser. Fix: brew install antlr4-cpp-runtime"
-    fi
+  _ANTLR_FIX=""
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    [[ -d /opt/homebrew/include/antlr4-runtime || -d /usr/local/include/antlr4-runtime ]] || _ANTLR_FIX="brew install antlr4-cpp-runtime"
   elif [[ ! -d /usr/include/antlr4-runtime ]]; then
-    echo "warning: ANTLR C++ runtime not found; 'uv sync' cannot build hogql-parser. Fix: sudo $FLOX_ENV_PROJECT/bin/install-antlr4-cpp-runtime"
+    _ANTLR_FIX="sudo $FLOX_ENV_PROJECT/bin/install-antlr4-cpp-runtime"
+  fi
+  if [[ -n "$_ANTLR_FIX" ]]; then
+    echo "warning: ANTLR C++ runtime not found; 'uv sync' cannot build hogql-parser. Fix: $_ANTLR_FIX"
   fi
 fi
 

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -342,6 +342,19 @@ if [[ "$_PHROCS_SKIP" -eq 0 ]]; then
   _BG_PHROCS_START=$(date +%s)
 fi
 
+# hogql-parser is a workspace member compiled from source during `uv sync`, which
+# needs the ANTLR C++ runtime. Warn up front with the fix instead of letting the
+# sync die mid-build on a C++ include error.
+if [[ "$_UV_SKIP" -ne 1 ]]; then
+  if [[ "$(uname)" == "Darwin" ]]; then
+    if [[ ! -d /opt/homebrew/include/antlr4-runtime && ! -d /usr/local/include/antlr4-runtime ]]; then
+      echo "warning: ANTLR C++ runtime not found; 'uv sync' cannot build hogql-parser. Fix: brew install antlr4-cpp-runtime"
+    fi
+  elif [[ ! -d /usr/include/antlr4-runtime ]]; then
+    echo "warning: ANTLR C++ runtime not found; 'uv sync' cannot build hogql-parser. Fix: sudo $FLOX_ENV_PROJECT/bin/install-antlr4-cpp-runtime"
+  fi
+fi
+
 # ── Step 1: Python packages (must run before hogli — it needs Click) ─
 if [[ "$_UV_SKIP" -eq 1 ]]; then
   done_step "Python packages (cached)"

--- a/.github/workflows/build-hogql-parser.yml
+++ b/.github/workflows/build-hogql-parser.yml
@@ -48,6 +48,15 @@ jobs:
                   IS_FORK: ${{ github.event.pull_request.head.repo.full_name != 'PostHog/posthog' }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
+                  # The uv workspace flip removes the registry pin; on flipped branches
+                  # this pre-merge publish flow is fully disabled (a post-merge release
+                  # workflow supersedes it) so the bot can never re-pin the package.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                    echo "hogql-parser is a workspace member; pre-merge publishing is disabled."
+                    echo "version-release-needed=false" >> $GITHUB_OUTPUT
+                    echo "parser-release-needed=false" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
                   parser_release_needed='false'
                   if [[ "$PARSER_CHANGED" == 'true' ]]; then
                     local=$(cd common/hogql_parser && python setup.py --version)
@@ -215,6 +224,12 @@ jobs:
               env:
                   RETRIES: 20
               run: |
+                  # Same workspace-member guard as check-version: never rewrite the
+                  # manifest of a branch that has no registry pin.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                    echo "hogql-parser is a workspace member; no pin to update."
+                    exit 0
+                  fi
                   # setuptools isn't installed by default after actions/setup-python, but
                   # `python setup.py --version` needs it. Mirrors the sdist step above.
                   pip install setuptools==80.9.0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2761,6 +2761,12 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
+                  # No-op once the branch has flipped hogql-parser to a uv workspace
+                  # member: uv sync already built it from these sources.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                      echo "hogql-parser is a workspace member; skipping the wheel-override build."
+                      exit 0
+                  fi
                   sudo apt-get install unzip cmake curl uuid pkg-config
                   curl --fail --location https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip || curl --fail --location https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2645,6 +2645,12 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
+                  # No-op once the branch has flipped hogql-parser to a uv workspace
+                  # member: uv sync already built it from these sources.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                      echo "hogql-parser is a workspace member; skipping the wheel-override build."
+                      exit 0
+                  fi
                   sudo apt-get install unzip cmake curl uuid pkg-config
                   curl --fail --location https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip || curl --fail --location https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure

--- a/.github/workflows/ci-dev-setup.yml
+++ b/.github/workflows/ci-dev-setup.yml
@@ -35,6 +35,9 @@ jobs:
                   # Re-downloading the installer on a free runner is cheaper than the churn.
                   use-cache: false
 
+            - name: Set up ANTLR C++ runtime
+              uses: ./.github/actions/setup-antlr-runtime
+
             - name: Activate Flox and verify dev setup
               run: |
                   flox activate -- bash -c '

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -646,6 +646,12 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
+                  # No-op once the branch has flipped hogql-parser to a uv workspace
+                  # member: uv sync already built it from these sources.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                      echo "hogql-parser is a workspace member; skipping the wheel-override build."
+                      exit 0
+                  fi
                   sudo apt-get install unzip cmake curl uuid pkg-config
                   curl --fail --location https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip || curl --fail --location https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -633,6 +633,12 @@ jobs:
               # This is not cached currently, as it's important to build the current HEAD version of hogql-parser if it has
               # changed (requirements.txt has the already-published version)
               run: |
+                  # No-op once the branch has flipped hogql-parser to a uv workspace
+                  # member: uv sync already built it from these sources.
+                  if ! grep -q 'hogql-parser==' pyproject.toml; then
+                      echo "hogql-parser is a workspace member; skipping the wheel-override build."
+                      exit 0
+                  fi
                   sudo apt-get install unzip cmake curl uuid pkg-config
                   curl --fail --location https://www.antlr.org/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip || curl --fail --location https://raw.githubusercontent.com/antlr/website-antlr4/gh-pages/download/antlr4-cpp-runtime-4.13.1-source.zip --output antlr4-source.zip
                   # Check that the downloaded archive is the expected runtime - a security measure

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,6 +181,9 @@ RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     # uv sync validates workspace membership even with --no-dev, so every
     # workspace member must be present in the build context.
     --mount=type=bind,source=tools/owners,target=tools/owners \
+    # hogql-parser builds from these sources during the sync. rw because
+    # setuptools writes build/ into the source dir; BuildKit discards the writes.
+    --mount=type=bind,source=common/hogql_parser,target=common/hogql_parser,rw \
     uv sync --locked --no-dev --no-install-project --no-binary-package lxml --no-binary-package xmlsec
 
 ENV PATH=/python-runtime/bin:$PATH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,9 @@ RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     # uv sync validates workspace membership even with --no-dev, so every
     # workspace member must be present in the build context.
     --mount=type=bind,source=tools/owners,target=tools/owners \
+    # hogql-parser builds from these sources during the sync. rw because
+    # setuptools writes build/ into the source dir; BuildKit discards the writes.
+    --mount=type=bind,source=common/hogql_parser,target=common/hogql_parser,rw \
     uv sync --locked --no-dev --no-install-project --no-binary-package lxml --no-binary-package xmlsec
 
 ENV PATH=/python-runtime/bin:$PATH \

--- a/Dockerfile.llm-analytics
+++ b/Dockerfile.llm-analytics
@@ -54,6 +54,9 @@ RUN --mount=type=cache,id=uv-libxmlsec1.2.37-2,target=/root/.cache/uv \
     # uv sync validates workspace membership even with --no-dev, so every
     # workspace member must be present in the build context.
     --mount=type=bind,source=tools/owners,target=tools/owners \
+    # hogql-parser builds from these sources during the sync. rw because
+    # setuptools writes build/ into the source dir; BuildKit discards the writes.
+    --mount=type=bind,source=common/hogql_parser,target=common/hogql_parser,rw \
     uv sync --locked --no-dev --no-install-project --group sentiment --no-binary-package lxml --no-binary-package xmlsec
 
 # Copy project files

--- a/common/hogql_parser/CONTRIBUTING.md
+++ b/common/hogql_parser/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Developing `hogql-parser`
 
+## How the parser ships
+
+The Python extension is a uv workspace member.
+Every consumer of the monorepo (local dev, CI, Docker images) compiles it from the sources in this directory during `uv sync`, so the code you see is always the code that runs.
+There is no internal dependency on the PyPI package, and no version to bump for day-to-day parser changes.
+
+The version in `pyproject.toml` only matters for the PyPI release (`hogql-parser`), which exists for consumers outside this repository.
+Bump it when you want a new public release; the release workflow publishes wheels built from the merged sources.
+
+The WebAssembly build (`@posthog/hogql-parser` on npm, used by the frontend SQL editor) still ships as a published package, because building it requires Emscripten.
+
 ## Mandatory reading
 
 If you're new to Python C/C++ extensions, there are some things you must have in mind. The [Python/C API Reference Manual](https://docs.python.org/3/c-api/index.html) is worth a read as a whole.
@@ -52,11 +63,14 @@ Key takeaways:
    brew install antlr4-cpp-runtime
    ```
 
-2. Install `hogql_parser` by building from local sources:
+2. Sync your environment, which builds `hogql_parser` from the local sources:
 
    ```bash
-   pip install ./common/hogql_parser
+   uv sync
    ```
+
+   Editing any `.cpp` or `.h` file here makes the next `uv sync` rebuild the extension.
+   For a tighter loop you can also install it directly with `pip install ./common/hogql_parser`.
 
    > If you're getting compilation errors like this on macOS Sonoma:  
    > `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cstring:66:5: error: <cstring> tried including <string.h> but didn't find libc++'s <string.h> header.`  
@@ -71,9 +85,12 @@ Key takeaways:
 
 ## How to install dependencies on Ubuntu
 
-Antlr runtime provided in Ubuntu packages might be of an older version, which results in compilation errors.
+The ANTLR runtime in Ubuntu packages might be of an older version, which results in compilation errors.
+Build and install the pinned static runtime instead:
 
-In that case run commands from [this step](https://github.com/PostHog/posthog/blob/4fba6a63e351131fdb27b85e7ba436446fdb3093/.github/actions/run-backend-tests/action.yml#L100).
+```bash
+sudo bin/install-antlr4-cpp-runtime
+```
 
 ## WebAssembly (JavaScript/TypeScript) build
 

--- a/common/hogql_parser/pyproject.toml
+++ b/common/hogql_parser/pyproject.toml
@@ -1,3 +1,44 @@
+[build-system]
+requires = ["setuptools==80.9.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hogql-parser"
+version = "1.3.83"
+description = "HogQL parser for internal PostHog use"
+readme = "README.md"
+requires-python = ">=3.10"
+# Table form, not the PEP 639 SPDX string: the string form needs packaging>=24.2
+# at build time, which older environments running `setup.py --version` lack.
+license = { text = "MIT" }
+authors = [{ name = "PostHog Inc.", email = "hey@posthog.com" }]
+maintainers = [{ name = "PostHog Inc.", email = "hey@posthog.com" }]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+
+[project.urls]
+Homepage = "https://github.com/PostHog/posthog/tree/master/common/hogql_parser"
+
+[tool.uv]
+# uv only rebuilds a path dependency when pyproject.toml/setup.py change; these
+# keys make edits to the C++ sources and stubs invalidate the cached build too.
+# Deliberately flat globs so build/ and build_wasm/ artifacts don't churn the key.
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "setup.py" },
+    { file = "*.cpp" },
+    { file = "*.h" },
+    { file = "hogql_parser-stubs/*.pyi" },
+]
+
 [tool.black]
 line-length = 120
 target-version = ['py310']

--- a/common/hogql_parser/pyproject.toml
+++ b/common/hogql_parser/pyproject.toml
@@ -27,6 +27,10 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/PostHog/posthog/tree/master/common/hogql_parser"
 
+# Dependency cooldown does not apply here: this member declares no registry
+# dependencies, and uv resolves the workspace against the root pyproject.toml,
+# whose [tool.uv] already sets exclude-newer = "7 days".
+# nosemgrep: package_managers.uv.uv-missing-dependency-cooldown.uv-missing-dependency-cooldown
 [tool.uv]
 # uv only rebuilds a path dependency when pyproject.toml/setup.py change; these
 # keys make edits to the C++ sources and stubs invalidate the cached build too.

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -34,30 +34,10 @@ module = Extension(
     extra_compile_args=["-std=c++20"],
 )
 
+# Project metadata lives in pyproject.toml [project]; this file only wires up
+# the C++ extension build, which setuptools cannot express declaratively.
 setup(
-    name="hogql_parser",
-    version="1.3.83",
-    url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
-    description="HogQL parser for internal PostHog use",
-    author="PostHog Inc.",
-    author_email="hey@posthog.com",
-    maintainer="PostHog Inc.",
-    maintainer_email="hey@posthog.com",
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
     packages=["hogql_parser-stubs"],
     include_package_data=True,
     ext_modules=[module],
-    python_requires=">=3.10",
-    license="MIT",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Operating System :: MacOS",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-    ],
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.83",
+    "hogql-parser",
     "hogql-parser-rs==1.3.107",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
@@ -294,14 +294,15 @@ hogql-parser-parity = [
 required-version = ">=0.10.2"
 add-bounds = "major"
 exclude-newer = "7 days"
-exclude-newer-package = { hogql-parser = false, hogql-parser-rs = false, deltalite = false, posthoganalytics = false, pixelhog = false, django = false, modal = false, posthog-hogland = false, google-ads = false }
+exclude-newer-package = { hogql-parser-rs = false, deltalite = false, posthoganalytics = false, pixelhog = false, django = false, modal = false, posthog-hogland = false, google-ads = false }
 
 [tool.uv.workspace]
-members = ["tools/hogli", "tools/owners"]
+members = ["common/hogql_parser", "tools/hogli", "tools/owners"]
 
 [tool.uv.sources]
 hogli = { workspace = true }
 posthog-owners = { workspace = true }
+hogql-parser = { workspace = true, editable = false }
 infi-clickhouse-orm = { git = "https://github.com/PostHog/infi.clickhouse_orm", rev = "4e3996becf66bf5c26580aff12a80425d9d56fe5" }
 # pytest-split: pinned to PostHog's fork (immutable tag) for the order-preserving
 # optimal_chunks split. Fork: PostHog/pytest-split (of jerry-git/pytest-split).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.83",
+    "hogql-parser",
     "hogql-parser-rs==1.3.106",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
@@ -302,13 +302,13 @@ members = ["common/hogql_parser", "tools/hogli", "tools/owners"]
 [tool.uv.sources]
 hogli = { workspace = true }
 posthog-owners = { workspace = true }
+hogql-parser = { workspace = true, editable = false }
 infi-clickhouse-orm = { git = "https://github.com/PostHog/infi.clickhouse_orm", rev = "4e3996becf66bf5c26580aff12a80425d9d56fe5" }
 # pytest-split: pinned to PostHog's fork (immutable tag) for the order-preserving
 # optimal_chunks split. Fork: PostHog/pytest-split (of jerry-git/pytest-split).
 # To pull upstream fixes: rebase the fork's feat branch onto upstream, cut the next
 # v0.11.0-posthog.N tag, and bump this pin.
 pytest-split = { git = "https://github.com/PostHog/pytest-split", tag = "v0.11.0-posthog.6" }
-hogql-parser = { workspace = true }
 
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser",
+    "hogql-parser==1.3.83",
     "hogql-parser-rs==1.3.106",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
@@ -302,13 +302,13 @@ members = ["common/hogql_parser", "tools/hogli", "tools/owners"]
 [tool.uv.sources]
 hogli = { workspace = true }
 posthog-owners = { workspace = true }
-hogql-parser = { workspace = true, editable = false }
 infi-clickhouse-orm = { git = "https://github.com/PostHog/infi.clickhouse_orm", rev = "4e3996becf66bf5c26580aff12a80425d9d56fe5" }
 # pytest-split: pinned to PostHog's fork (immutable tag) for the order-preserving
 # optimal_chunks split. Fork: PostHog/pytest-split (of jerry-git/pytest-split).
 # To pull upstream fixes: rebase the fork's feat branch onto upstream, cut the next
 # v0.11.0-posthog.N tag, and bump this pin.
 pytest-split = { git = "https://github.com/PostHog/pytest-split", tag = "v0.11.0-posthog.6" }
+hogql-parser = { workspace = true }
 
 
 [tool.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.83",
+    "hogql-parser",
     "hogql-parser-rs==1.3.106",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
@@ -294,14 +294,15 @@ hogql-parser-parity = [
 required-version = ">=0.10.2"
 add-bounds = "major"
 exclude-newer = "7 days"
-exclude-newer-package = { hogql-parser = false, hogql-parser-rs = false, deltalite = false, posthoganalytics = false, pixelhog = false, django = false, modal = false, posthog-hogland = false, google-ads = false }
+exclude-newer-package = { hogql-parser-rs = false, deltalite = false, posthoganalytics = false, pixelhog = false, django = false, modal = false, posthog-hogland = false, google-ads = false }
 
 [tool.uv.workspace]
-members = ["tools/hogli", "tools/owners"]
+members = ["common/hogql_parser", "tools/hogli", "tools/owners"]
 
 [tool.uv.sources]
 hogli = { workspace = true }
 posthog-owners = { workspace = true }
+hogql-parser = { workspace = true, editable = false }
 infi-clickhouse-orm = { git = "https://github.com/PostHog/infi.clickhouse_orm", rev = "4e3996becf66bf5c26580aff12a80425d9d56fe5" }
 # pytest-split: pinned to PostHog's fork (immutable tag) for the order-preserving
 # optimal_chunks split. Fork: PostHog/pytest-split (of jerry-git/pytest-split).

--- a/tools/hogli-commands/hogli_commands/devbox/mutagen_defaults.yml
+++ b/tools/hogli-commands/hogli_commands/devbox/mutagen_defaults.yml
@@ -39,7 +39,9 @@ sync:
                 # CMakeLists.txt...) that must sync. Its build outputs are caught
                 # by the *.so/build/dist/.cache/build_wasm ignores instead.
                 - 'common/hogql_parser/.cache'
+                - 'common/hogql_parser/build'
                 - 'common/hogql_parser/build_wasm'
+                - 'common/hogql_parser/hogql_parser.egg-info'
                 - 'frontend/types'
                 - 'frontend/dist'
                 - 'frontend/.cache'

--- a/uv.lock
+++ b/uv.lock
@@ -21,13 +21,13 @@ posthoganalytics = false
 django = false
 google-ads = false
 deltalite = false
-hogql-parser = false
 posthog-hogland = false
 hogql-parser-rs = false
 
 [manifest]
 members = [
     "hogli",
+    "hogql-parser",
     "posthog",
     "posthog-owners",
 ]
@@ -3154,14 +3154,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "hogql-parser"
 version = "1.3.83"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/454ad6b88a8413dcfd3d9836882bb07100c7104f34f4344fb007b98823c6/hogql_parser-1.3.83.tar.gz", hash = "sha256:918d01242c520133ef9ecfcb10777c1fad50bbefb33ec6fa4e223dd57bfaa0cd", size = 93004, upload-time = "2026-07-30T13:24:39.648Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/47/03db0642fb99ec9f1e85117c6a33deca82a5dd02ad1e0c61470c6c6ff75e/hogql_parser-1.3.83-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:35c70d6e32c943ea2a0169ebecd82cf7ec87637991c5a6480cb04e1433613455", size = 659095, upload-time = "2026-07-30T13:24:33.378Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/da/5ba6cc064dc1793a27d875eb2cc00c46f633e64f361923bb1150feeca038/hogql_parser-1.3.83-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:81b7f3dd65efdb5dc0e127d076b91163b1deee5caf69bb85d1cd025dec44df58", size = 668701, upload-time = "2026-07-30T13:24:35.006Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ed/97179b82f94e548e577dc3fd78832d8d2ba1bab591051936cf2a15eea24a/hogql_parser-1.3.83-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bc8d0b44e6bf012e28861fcc5d1dfc5b652c9c67c5a345de2bca281dd2119116", size = 5119661, upload-time = "2026-07-30T13:24:36.542Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/de/13b7ad4db2c2fa87fb811b437bb511f128f71a3c6f8461684c8e0a08a165/hogql_parser-1.3.83-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:491fe843ea4d386cd2f067ea77d78ee9431fc0ceedd224ac3b1ffe663ae2c166", size = 5229817, upload-time = "2026-07-30T13:24:38.23Z" },
-]
+source = { directory = "common/hogql_parser" }
 
 [[package]]
 name = "hogql-parser-rs"
@@ -5901,7 +5894,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.83" },
+    { name = "hogql-parser", directory = "common/hogql_parser" },
     { name = "hogql-parser-rs", specifier = "==1.3.107" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },

--- a/uv.lock
+++ b/uv.lock
@@ -3154,7 +3154,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "hogql-parser"
 version = "1.3.83"
-source = { directory = "common/hogql_parser" }
+source = { editable = "common/hogql_parser" }
 
 [[package]]
 name = "hogql-parser-rs"
@@ -4654,7 +4654,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4665,7 +4665,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4692,9 +4692,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4705,7 +4705,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -5364,7 +5364,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5894,7 +5894,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", directory = "common/hogql_parser" },
+    { name = "hogql-parser", editable = "common/hogql_parser" },
     { name = "hogql-parser-rs", specifier = "==1.3.106" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
@@ -7635,7 +7635,7 @@ name = "shadowcopy"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wmi", marker = "sys_platform != 'emscripten'" },
+    { name = "wmi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
 wheels = [
@@ -8069,7 +8069,7 @@ name = "tbb"
 version = "2022.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tcmlib", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "tcmlib" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/59/8d381a2cfe8d36c4f4ff9f94769ff2809bfc16014d888360b0e24c7e5c6b/tbb-2022.3.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:534c089eca6bcf148408684c156229d5f09c01d323b685b15739f41985b529d7", size = 4178630, upload-time = "2026-01-22T05:30:20.589Z" },
@@ -8451,7 +8451,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "setuptools" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
@@ -9158,7 +9158,7 @@ name = "wmi"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform != 'emscripten'" },
+    { name = "pywin32" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -3154,7 +3154,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "hogql-parser"
 version = "1.3.83"
-source = { editable = "common/hogql_parser" }
+source = { directory = "common/hogql_parser" }
 
 [[package]]
 name = "hogql-parser-rs"
@@ -4654,7 +4654,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4665,7 +4665,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4692,9 +4692,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4705,7 +4705,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -5364,7 +5364,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5894,7 +5894,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", editable = "common/hogql_parser" },
+    { name = "hogql-parser", directory = "common/hogql_parser" },
     { name = "hogql-parser-rs", specifier = "==1.3.106" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
@@ -7635,7 +7635,7 @@ name = "shadowcopy"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wmi" },
+    { name = "wmi", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
 wheels = [
@@ -8069,7 +8069,7 @@ name = "tbb"
 version = "2022.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tcmlib" },
+    { name = "tcmlib", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/59/8d381a2cfe8d36c4f4ff9f94769ff2809bfc16014d888360b0e24c7e5c6b/tbb-2022.3.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:534c089eca6bcf148408684c156229d5f09c01d323b685b15739f41985b529d7", size = 4178630, upload-time = "2026-01-22T05:30:20.589Z" },
@@ -8451,7 +8451,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
@@ -9158,7 +9158,7 @@ name = "wmi"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -21,13 +21,13 @@ posthoganalytics = false
 django = false
 google-ads = false
 deltalite = false
-hogql-parser = false
 posthog-hogland = false
 hogql-parser-rs = false
 
 [manifest]
 members = [
     "hogli",
+    "hogql-parser",
     "posthog",
     "posthog-owners",
 ]
@@ -3154,14 +3154,7 @@ provides-extras = ["dev"]
 [[package]]
 name = "hogql-parser"
 version = "1.3.83"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/74/454ad6b88a8413dcfd3d9836882bb07100c7104f34f4344fb007b98823c6/hogql_parser-1.3.83.tar.gz", hash = "sha256:918d01242c520133ef9ecfcb10777c1fad50bbefb33ec6fa4e223dd57bfaa0cd", size = 93004, upload-time = "2026-07-30T13:24:39.648Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/47/03db0642fb99ec9f1e85117c6a33deca82a5dd02ad1e0c61470c6c6ff75e/hogql_parser-1.3.83-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:35c70d6e32c943ea2a0169ebecd82cf7ec87637991c5a6480cb04e1433613455", size = 659095, upload-time = "2026-07-30T13:24:33.378Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/da/5ba6cc064dc1793a27d875eb2cc00c46f633e64f361923bb1150feeca038/hogql_parser-1.3.83-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:81b7f3dd65efdb5dc0e127d076b91163b1deee5caf69bb85d1cd025dec44df58", size = 668701, upload-time = "2026-07-30T13:24:35.006Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ed/97179b82f94e548e577dc3fd78832d8d2ba1bab591051936cf2a15eea24a/hogql_parser-1.3.83-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bc8d0b44e6bf012e28861fcc5d1dfc5b652c9c67c5a345de2bca281dd2119116", size = 5119661, upload-time = "2026-07-30T13:24:36.542Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/de/13b7ad4db2c2fa87fb811b437bb511f128f71a3c6f8461684c8e0a08a165/hogql_parser-1.3.83-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:491fe843ea4d386cd2f067ea77d78ee9431fc0ceedd224ac3b1ffe663ae2c166", size = 5229817, upload-time = "2026-07-30T13:24:38.23Z" },
-]
+source = { directory = "common/hogql_parser" }
 
 [[package]]
 name = "hogql-parser-rs"
@@ -4661,7 +4654,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4672,7 +4665,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4699,9 +4692,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4712,7 +4705,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -5371,7 +5364,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5901,7 +5894,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.83" },
+    { name = "hogql-parser", directory = "common/hogql_parser" },
     { name = "hogql-parser-rs", specifier = "==1.3.106" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
@@ -7642,7 +7635,7 @@ name = "shadowcopy"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wmi" },
+    { name = "wmi", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
 wheels = [
@@ -8076,7 +8069,7 @@ name = "tbb"
 version = "2022.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tcmlib" },
+    { name = "tcmlib", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/59/8d381a2cfe8d36c4f4ff9f94769ff2809bfc16014d888360b0e24c7e5c6b/tbb-2022.3.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:534c089eca6bcf148408684c156229d5f09c01d323b685b15739f41985b529d7", size = 4178630, upload-time = "2026-01-22T05:30:20.589Z" },
@@ -8458,7 +8451,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
@@ -9165,7 +9158,7 @@ name = "wmi"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
 wheels = [


### PR DESCRIPTION
## Problem

- The monorepo consumes its own `hogql-parser` through PyPI: PRs publish a wheel pre-merge, a bot commits the pin, everything trusts the pin. A dual write across git and PyPI with no transaction.
- It has torn twice: the lost pin commit behind #55087, and #73945 + #73958 both claiming 1.3.82 last week; `skip-existing` silently dropped one publish and master shipped source whose wheel lacked the recursion guard (#75473).

## Changes

Before:

```mermaid
flowchart LR
    PR[parser PR] --> W[publish wheel pre-merge] --> PyPI[(PyPI)]
    W --> Pin[bot commits pin]
    PyPI --> Sync[uv sync: dev, CI, images]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class PyPI phRed;
    class Sync phGray;
```

After:

```mermaid
flowchart LR
    Src[common/hogql_parser sources] --> Sync[uv sync builds from checkout: dev, CI, images]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    class Sync phBlue;
```

- `common/hogql_parser` becomes a workspace member, installed non-editable; the dependency is unversioned and PyPI drops out of the lock.
- `cache-keys` on the member: uv only tracks pyproject/setup.py by default, so `.cpp` edits must invalidate the cached build.
- Static metadata moves from `setup.py` to `[project]` (uv requires it); `setup.py --version` still works.
- Docker: parser sources bind-mounted `rw` into the sync (setuptools writes `build/` in-tree; BuildKit discards it).
- The CI source-build fallback self-disables on flipped branches; unrebased PRs keep the old path.
- The legacy pre-merge publish workflow also self-disables on flipped branches, in its version check and its pin-update step.
- Flox warns up front when ANTLR is missing, with the fix per platform.

> [!WARNING]
> The still-armed legacy workflow proved the need for that guard on this very branch: it ran against the flipped manifest, read a bogus version, and bot-committed a revert of the flip (since reverted here). Without the guard every parser-touching PR after this merges would get the same bot revert until the post-merge release PR lands.

## How did you test this code?

- Fresh env `uv sync`: parser compiles, `parse_expr_json("1 + 2")` returns an AST.
- Edited a `.cpp`, re-synced: module hash changed, proving cache-keys rebuilds (the staleness this PR must not reintroduce).
- `python setup.py --version` still prints 1.3.83; `bin/hogli lint:workflows` 7/7.
- Not tested by me: the macOS dev-sandbox seatbelt profile around a real compile; needs a human Mac run before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- `common/hogql_parser/CONTRIBUTING.md`: new "How the parser ships" section; dead 2023 permalink replaced with `bin/install-antlr4-cpp-runtime`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5); skills: /authoring-ci-workflows, /writing-code-comments, /writing-user-facing-copy, plus subagent /code-review and /simplify passes whose findings are folded in.
- Chose non-editable (`editable = false`) so the built `.so` lands in site-packages, not the checkout; editable buys nothing for a C extension.
- License stays table form: the SPDX string needs packaging>=24.2 at build time, which the dev group pins below.
