### PR TITLE
fix(hogql): bump @posthog/hogql-parser to 1.3.83

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,7 @@
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
         "@posthog/hedgehog-mode": "^0.0.52",
-        "@posthog/hogql-parser": "1.3.75",
+        "@posthog/hogql-parser": "1.3.83",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "catalog:",
         "@posthog/products-access-control": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,8 +618,8 @@ importers:
         specifier: ^0.0.52
         version: 0.0.52(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
-        specifier: 1.3.75
-        version: 1.3.75
+        specifier: 1.3.83
+        version: 1.3.83
       '@posthog/hogvm':
         specifier: workspace:*
         version: link:../common/hogvm/typescript
@@ -9812,8 +9812,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/hogql-parser@1.3.75':
-    resolution: {integrity: sha512-r282QitLBwxaT5YHGi6iAq1lCE5SMkg0Oq/qzvqNio4jh/P4lK70UpyTRMDZ6VFbqJWDg8Ly7T6TBUHxhmmiVg==}
+  '@posthog/hogql-parser@1.3.83':
+    resolution: {integrity: sha512-c57mIcQjR/l8RY7CHYgx2e5/C/IVSv3do4LMadtfYrPPrVdJZhO2bkbX17LDl7LTof646b5fjAezcjJ3rDEF6g==}
 
   '@posthog/icons@0.38.0':
     resolution: {integrity: sha512-Y458v7A9ipKvHCo77rAc2/ELUDvfNjFpn9AwV8aVYUl5/wvLH9CwEfq1IxgQDj33OaML4IE2w5LQ0TbKbo63XA==}
@@ -29356,7 +29356,7 @@ snapshots:
     transitivePeerDependencies:
       - prop-types
 
-  '@posthog/hogql-parser@1.3.75': {}
+  '@posthog/hogql-parser@1.3.83': {}
 
   '@posthog/icons@0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Problem

- The frontend WASM parser pin has been stuck at 1.3.75 since late June while npm is at 1.3.83: the automated pin commits were failing on the pnpm `trustPolicy: no-downgrade` check via `undici-types`.
- The SQL editor has been parsing with a grammar 8 versions behind the backend.

## Changes

- `frontend/package.json`: `@posthog/hogql-parser` 1.3.75 to 1.3.83; lockfile updates are the version and integrity hash only.

## How did you test this code?

- Full `pnpm install` passes cleanly, so the trust-downgrade blocker no longer reproduces.
- 57 jest tests green against the real 1.3.83 WASM (`hogqlParserCjs`, `multiQueryUtils`, `sql-utils`).
- A review subagent diffed the published tarballs: `index.d.ts`, `index.cjs`, and the error shape are byte-identical between 1.3.75 and 1.3.83, and deep-nesting input now fails fast instead of hanging minutes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Independent of the workspace-member stack; the npm pin path keeps its current publish flow for now.
- Known follow-up (not this diff): in the ~600-1000 nesting band the WASM build traps before the depth guard fires and `hogqlParserSingleton` caches the poisoned instance until reload.
