### PR TITLE
fix(error-tracking): stop sticky filter bar covering source maps banner bottom

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -306,7 +306,6 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_RATE_LIMITING_PER_ISSUE: 'error-tracking-rate-limiting-per-issue', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RECOMMENDATIONS: 'error-tracking-recommendations', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_RELATED_ISSUES: 'error-tracking-related-issues', // owner: #team-error-tracking
-    ERROR_TRACKING_SOURCE_MAPS_BANNER: 'error-tracking-source-maps-banner', // owner: @ablaszkiewicz #team-error-tracking
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_CLEANUP_E2E_DUMMY: 'experiment-cleanup-e2e-dummy', // owner: @jurajmajerik #team-experiments multivariate=control,test, throwaway dogfood flag validating the flag-cleanup PR flow end to end

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/ErrorTrackingScene.tsx
@@ -53,7 +53,6 @@ export function ErrorTrackingScene(): JSX.Element {
     const { activeTab } = useValues(errorTrackingSceneLogic)
     const { setActiveTab } = useActions(errorTrackingSceneLogic)
     const hasRecommendations = useFeatureFlag('ERROR_TRACKING_RECOMMENDATIONS')
-    const hasSourceMapsBanner = useFeatureFlag('ERROR_TRACKING_SOURCE_MAPS_BANNER')
     // Same gate as the settings section: configuration endpoints require error tracking viewer access.
     const configurationAccessDeniedReason = getAccessControlDisabledReason(
         AccessControlResourceType.ErrorTracking,
@@ -84,7 +83,7 @@ export function ErrorTrackingScene(): JSX.Element {
                 <ErrorTrackingSetupPrompt>
                     <ErrorTrackingIssueFilteringTool />
                     {hasSentExceptionEventLoading || hasSentExceptionEvent ? null : <IngestionStatusCheck />}
-                    {hasSourceMapsBanner ? <SourceMapsBanner /> : null}
+                    <SourceMapsBanner />
                     <IssuesList />
                 </ErrorTrackingSetupPrompt>
             ),

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
@@ -48,7 +48,11 @@ function SourceMapsBannerContent({ percent, lookbackHours }: { percent: number; 
 
     return (
         <>
-            <div className="mb-2">
+            {/* mb-6 rather than mb-2: the sticky filter bar below (IssuesList's SceneStickyBar)
+                pulls itself up with -mt-4 to sit flush under the tab bar when it's the first
+                element — the extra bottom margin absorbs that pull so the bar doesn't paint
+                over the card's bottom edge. */}
+            <div className="mb-6">
                 <div className="rounded-lg border border-border bg-bg-light pl-3 pr-4 py-3 mt-2">
                     <div className="flex items-center gap-4">
                         {/* The hog is absolutely positioned so it doesn't drive the card height —

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/SourceMapsBanner.tsx
@@ -48,10 +48,8 @@ function SourceMapsBannerContent({ percent, lookbackHours }: { percent: number; 
 
     return (
         <>
-            {/* mb-6 rather than mb-2: the sticky filter bar below (IssuesList's SceneStickyBar)
-                pulls itself up with -mt-4 to sit flush under the tab bar when it's the first
-                element — the extra bottom margin absorbs that pull so the bar doesn't paint
-                over the card's bottom edge. */}
+            {/* Use mb-6 (not mb-2) because IssuesList's SceneStickyBar uses -mt-4 to pull up under the tab bar.
+                The extra bottom margin prevents the sticky bar from overlapping the card's bottom edge. */}
             <div className="mb-6">
                 <div className="rounded-lg border border-border bg-bg-light pl-3 pr-4 py-3 mt-2">
                     <div className="flex items-center gap-4">


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="461" height="181" alt="CleanShot 2026-08-03 at 16 33 09" src="https://github.com/user-attachments/assets/2ff881ac-18ef-427e-a4dc-fa9b5b5a751b" /> | <img width="461" height="181" alt="CleanShot 2026-08-03 at 16 33 36" src="https://github.com/user-attachments/assets/bd80e7de-1668-470f-abdf-1f38dde41a44" /> | 
