### PR TITLE
fix(data-catalog): exclude CTEs from referenced table extraction

### DIFF
--- a/products/data_catalog/backend/logic/validation.py
+++ b/products/data_catalog/backend/logic/validation.py
@@ -12,12 +12,11 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import ActionsNode, DataWarehouseNode, EventsNode, FunnelsQuery, HogQLQuery, TrendsQuery
 
-from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import ExposedHogQLError, ResolutionError
+from posthog.hogql.metadata import get_table_names
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing
-from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
@@ -42,18 +41,6 @@ MAX_MARKDOWN_DEFINITION_LENGTH = 20_000
 # HogQLQuery carries fields that would let a caller bypass team query controls (a raw ClickHouse
 # passthrough, an arbitrary DB connection). A metric definition may only set these.
 _HOGQL_ALLOWED_KEYS = {"kind", "query", "values"}
-
-
-class _TableReferenceCollector(TraversingVisitor):
-    """Collects the identifiers used directly as FROM/JOIN targets in a parsed HogQL query."""
-
-    def __init__(self) -> None:
-        self.tables: set[str] = set()
-
-    def visit_join_expr(self, node: ast.JoinExpr) -> None:
-        if isinstance(node.table, ast.Field):
-            self.tables.add(".".join(str(part) for part in node.table.chain))
-        super().visit_join_expr(node)
 
 
 def _fail(error: str, hint: str) -> NoReturn:
@@ -153,9 +140,8 @@ def _validate_hogql(definition: dict, team: Team, user: Optional[User]) -> tuple
         capture_exception(e)
         _fail("Unexpected error resolving the query.", "Simplify the query and try again.")
 
-    collector = _TableReferenceCollector()
-    collector.visit(ast_node)
-    return definition, sorted(collector.tables)
+    # get_table_names subtracts CTE names, so a WITH alias never lands in referenced_table_names.
+    return definition, sorted(get_table_names(ast_node))
 
 
 def _validate_schema_model(definition: dict, model_class: type[BaseModel]) -> tuple[dict, list[str]]:

--- a/products/data_catalog/backend/logic/validation.py
+++ b/products/data_catalog/backend/logic/validation.py
@@ -12,11 +12,12 @@ from rest_framework.exceptions import ValidationError
 
 from posthog.schema import ActionsNode, DataWarehouseNode, EventsNode, FunnelsQuery, HogQLQuery, TrendsQuery
 
+from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.errors import ExposedHogQLError, ResolutionError
-from posthog.hogql.metadata import get_table_names
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing
+from posthog.hogql.visitor import TraversingVisitor
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
@@ -41,6 +42,46 @@ MAX_MARKDOWN_DEFINITION_LENGTH = 20_000
 # HogQLQuery carries fields that would let a caller bypass team query controls (a raw ClickHouse
 # passthrough, an arbitrary DB connection). A metric definition may only set these.
 _HOGQL_ALLOWED_KEYS = {"kind", "query", "values"}
+
+
+class _TableReferenceCollector(TraversingVisitor):
+    """Collects the real tables a query reads, excluding CTE aliases.
+
+    Global CTE-name subtraction (``get_table_names``) is not enough here: a CTE named after a
+    real table would erase that table even when the CTE body reads it (a non-recursive CTE body
+    does not see its own name), silently defeating the catalog's denied-table filter. So CTE
+    names are tracked per scope: each CTE body is visited under the scope of the CTEs defined
+    before it, and only single-part FROM/JOIN targets naming an in-scope CTE are skipped.
+    """
+
+    def __init__(self) -> None:
+        self.tables: set[str] = set()
+        self._cte_scopes: list[set[str]] = [set()]
+
+    def visit_select_query(self, node: ast.SelectQuery) -> None:
+        scope = set(self._cte_scopes[-1])
+        for cte_name, cte in (node.ctes or {}).items():
+            self._cte_scopes.append(set(scope))
+            self.visit(cte.expr)
+            self._cte_scopes.pop()
+            scope.add(cte_name)
+        self._cte_scopes.append(scope)
+        # CTEs were just visited with the right scopes; blank them out so the generic traversal
+        # of the remaining children doesn't re-visit them under this (wider) scope.
+        ctes, node.ctes = node.ctes, None
+        try:
+            super().visit_select_query(node)
+        finally:
+            node.ctes = ctes
+            self._cte_scopes.pop()
+
+    def visit_join_expr(self, node: ast.JoinExpr) -> None:
+        if isinstance(node.table, ast.Field):
+            chain = [str(part) for part in node.table.chain]
+            if len(chain) != 1 or chain[0] not in self._cte_scopes[-1]:
+                self.tables.add(".".join(chain))
+        # The generic traversal also covers subqueries in the join target and in ON constraints.
+        super().visit_join_expr(node)
 
 
 def _fail(error: str, hint: str) -> NoReturn:
@@ -140,8 +181,9 @@ def _validate_hogql(definition: dict, team: Team, user: Optional[User]) -> tuple
         capture_exception(e)
         _fail("Unexpected error resolving the query.", "Simplify the query and try again.")
 
-    # get_table_names subtracts CTE names, so a WITH alias never lands in referenced_table_names.
-    return definition, sorted(get_table_names(ast_node))
+    collector = _TableReferenceCollector()
+    collector.visit(ast_node)
+    return definition, sorted(collector.tables)
 
 
 def _validate_schema_model(definition: dict, model_class: type[BaseModel]) -> tuple[dict, list[str]]:

--- a/products/data_catalog/backend/tests/test_logic.py
+++ b/products/data_catalog/backend/tests/test_logic.py
@@ -114,11 +114,19 @@ class TestMetricUpdate(BaseTest):
 
 
 class TestValidateMetricDefinition(BaseTest):
-    def test_valid_hogql_extracts_referenced_tables(self) -> None:
-        _, tables = validate_metric_definition(
-            {"kind": "HogQLQuery", "query": "select count() from events"}, self.team, self.user
-        )
-        assert tables == ["events"]
+    @parameterized.expand(
+        [
+            ("plain", "select count() from events", ["events"]),
+            (
+                "cte_excluded",
+                "with monthly as (select count() as c from events) select c from monthly join persons on 1 = 1",
+                ["events", "persons"],
+            ),
+        ]
+    )
+    def test_valid_hogql_extracts_referenced_tables(self, _name: str, query: str, expected: list[str]) -> None:
+        _, tables = validate_metric_definition({"kind": "HogQLQuery", "query": query}, self.team, self.user)
+        assert tables == expected
 
     def test_insight_viz_node_is_unwrapped(self) -> None:
         canonical, _ = validate_metric_definition(

--- a/products/data_catalog/backend/tests/test_logic.py
+++ b/products/data_catalog/backend/tests/test_logic.py
@@ -122,6 +122,16 @@ class TestValidateMetricDefinition(BaseTest):
                 "with monthly as (select count() as c from events) select c from monthly join persons on 1 = 1",
                 ["events", "persons"],
             ),
+            (
+                "cte_shadowing_real_table",
+                "with events as (select uuid from events) select uuid from events",
+                ["events"],
+            ),
+            (
+                "join_constraint_subquery",
+                "select count() from persons join groups on persons.id in (select person_id from events)",
+                ["events", "groups", "persons"],
+            ),
         ]
     )
     def test_valid_hogql_extracts_referenced_tables(self, _name: str, query: str, expected: list[str]) -> None:


### PR DESCRIPTION
## Problem

The data catalog stores each metric's referenced tables at write time (they power the "Referenced tables" chips on the metric scene and the denied-table filter behind `system.information_schema.metrics`). The extractor collected every FROM/JOIN target from the parsed query, including CTE aliases, so a metric defined with a `WITH` clause listed its CTE names as referenced tables.

## Changes

- `validate_metric_definition` now extracts tables with a scope-aware collector: CTE names are tracked per scope, each CTE body is visited under the scope of the CTEs defined before it, and only in-scope single-part FROM/JOIN targets are skipped. The generic traversal still covers JOIN ON constraints and nested subqueries.
- Review of the first version (which reused the global-subtraction `get_table_names` helper) surfaced two ways global subtraction fails open for the denied-table filter, both now covered by regression tests: a CTE named after a real table erased that table even when the CTE body reads it, and JOIN ON constraint subqueries were not traversed.
- Side effect on the denied-table filter: a metric whose CTE alias happens to match a denied table is no longer spuriously hidden from `information_schema.metrics`.

> [!NOTE]
> `referenced_table_names` is computed at write time, so existing rows keep their stored names until the next definition write or insight resync. No backfill migration: parsing HogQL inside a migration is fragile, and rows self-heal on the next edit.

## How did you test this code?

- Parameterized the extraction test in `products/data_catalog/backend/tests/test_logic.py` with: a plain query, a CTE query asserting the alias is excluded, a same-named CTE (`with events as (select uuid from events) select uuid from events`) asserting the real table survives, and a table referenced only from a JOIN ON constraint subquery. Each catches a regression no existing test did (CTE-blind collection, global-subtraction erasure, constraint-blind traversal).
- Full `products/data_catalog/backend/tests/` suite passes locally (256 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, no user-facing workflow change beyond the corrected list.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code from dogfood feedback that the referenced-tables list showed CTE definitions. Skills invoked: /writing-tests. First version reused `posthog.hogql.metadata.get_table_names` (global CTE subtraction); review bots correctly flagged that global subtraction is weaker than scoped exclusion (same-named CTEs, join constraints), so the extractor became a scope-aware `TraversingVisitor` local to the catalog's validation module. The shared helper was left unchanged to keep the blast radius small.