### PR TITLE
feat(mcp-analytics): publish the engineering skill to the repo

### DIFF
--- a/products/mcp_analytics/skills/debugging-mcp-analytics/SKILL.md
+++ b/products/mcp_analytics/skills/debugging-mcp-analytics/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: debugging-mcp-analytics
+description: >
+  Debug, support, and build PostHog MCP Analytics — product analytics for MCP
+  servers (the `@posthog/mcp` and `posthog.mcp` SDKs plus the mcp_analytics
+  product). Use when MCP analytics data looks wrong or missing ("events aren't
+  showing", "intent clusters are empty", "sessions are missing", "per-tool
+  numbers look wrong"), when writing queries over `$mcp_*` events by hand, or
+  when doing feature work on the SDKs, the dashboard and its query runners, the
+  self-instrumented MCP server, the `wizard mcp-analytics` install command, or
+  the in-app onboarding. Covers the repo map, the `$mcp_*` vocabulary and where
+  each property comes from, the rules that silently corrupt metrics when
+  ignored, the end-to-end pipeline and where each stage breaks, and which repo
+  to change. For reading the data rather than fixing it, prefer the
+  `exploring-mcp-*` and `improving-mcp-tools` skills.
+---
+
+# Debugging MCP analytics
+
+**Product analytics for MCP servers.** A team ships an MCP server; the `@posthog/mcp` SDK
+wraps it in one line; every tool call, agent **intent**, and failure lands in PostHog as a
+`$mcp_*` event you can query, chart, alert on, and cluster — plus a dedicated dashboard. The
+MCP-layer sibling of `@posthog/ai`.
+
+The differentiator is **intent**: not "ran `query_run` 14 times" but "was trying to find a
+churn cohort". Explicit non-goal: this does **not** replace LLM analytics / AI observability
+— generation traces, prompt/response, and token cost belong there.
+
+Status: **beta**, TypeScript and Python SDKs shipped, whole product still behind the
+`mcp-analytics` early-access flag (`products/mcp_analytics/frontend/featurePreviewGate.ts`).
+PostHog dogfoods it — its own MCP server instruments itself, and that data drives the
+dashboard. Public tracking: mega-issue **PostHog/posthog#64016**, which is the live source
+for roadmap and customer wishlist.
+
+## Repos
+
+GitHub is the source of truth for where the code lives. Paths below are in-repo; for the
+repos outside this monorepo, resolve a local checkout via
+[references/local-repos.md](references/local-repos.md) rather than assuming a location.
+
+| Concern                           | Repo                          | Where to look                                                                                                                                              |
+| --------------------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Product / dashboard**           | `PostHog/posthog` (this repo) | `products/mcp_analytics/` — Django/DRF + HogQL query runners + Temporal, Kea frontend, the `query-mcp-*` tool registry, and the analysis skills            |
+| **Self-instrumented server**      | `PostHog/posthog` (this repo) | `services/mcp/` — PostHog's own MCP server (Hono); the dogfood event producer. Also hosts the _generated_ `query-mcp-*` handlers                           |
+| **Shared query reference**        | `PostHog/posthog` (this repo) | `products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md`                                                                                |
+| **TypeScript SDK** `@posthog/mcp` | `PostHog/posthog-js`          | `packages/mcp/` — the library customers install. Vocabulary source of truth: `src/extensions/constants.ts`. Internals: `docs/ARCHITECTURE.md`              |
+| **Python SDK** `posthog.mcp`      | `PostHog/posthog-python`      | `posthog/mcp/` — mirrors `posthog.ai`. Ships inside `posthog` (`pip install posthog`); `mcp`/`fastmcp` are lazily-imported peer deps, **no `[mcp]` extra** |
+| **Docs**                          | `PostHog/posthog.com`         | `contents/docs/mcp-analytics/` (incl. `surfaces/`), plus `src/hooks/productData/mcp_analytics.tsx` and the `mcp_analytics` entry in `src/data/tools.ts`    |
+| **Install codemod**               | `PostHog/context-mill`        | `context/skills/mcp-analytics/{config.yaml,description.md}`                                                                                                |
+| **Wizard CLI**                    | `PostHog/wizard`              | `bin.ts`, `src/commands/mcp-analytics.ts`, `src/lib/programs/mcp-analytics/`                                                                               |
+| **Wizard test harness**           | `PostHog/wizard-workbench`    | `apps/mcp-analytics/` fixtures                                                                                                                             |
+
+**Don't conflate:**
+
+- `PostHog/mcp-analytics` is the **archived prototype** of this SDK — stuck at `0.0.9` with an
+  old `track(server, {...})` API. It published under the same `@posthog/mcp` name, so grepping
+  that name can land you there. npm `@posthog/mcp` now resolves to `PostHog/posthog-js`.
+- `products/mcp_store/` is the MCP server marketplace / team gateway, not this product. (Older
+  notes also mention a `products/mcp/` build-tooling directory; it no longer exists — the server
+  and its generation tooling live in `services/mcp/`.)
+- `wizard mcp add` installs the PostHog **MCP server** into a coding agent. That is NOT
+  `wizard mcp-analytics`, which instruments the user's _own_ server.
+
+> Line numbers drift and this area moves fast — **grep for the symbol**, never trust a
+> remembered line number. Confirm a checkout is on a sane branch before quoting its code.
+
+## Hard rules (break these and the numbers are silently wrong)
+
+These are the failure modes that produce a plausible-looking answer rather than an error.
+
+1. **Always resolve the effective tool name through `EFFECTIVE_TOOL_SQL`.** The expression
+   lives once, in `products/mcp_analytics/backend/hogql_queries/base.py`:
+   `coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))`.
+   It exists because a single-exec server can report the tool two different ways, and the two
+   eras of data coexist. Today `services/mcp` resolves the inner tool itself and passes it
+   straight in as the tool name (`execToolName()` in `src/hono/tool-executor.ts`, which falls
+   back to the literal `exec` when the inner command isn't recognized), so
+   `$mcp_tool_name` usually already holds the real tool. `$mcp_exec_tool_call_name` is
+   registered in `posthog/taxonomy/taxonomy.py` and coalesced defensively here, but **nothing
+   on master emits it** — treat it as historical rows plus in-flight work, not current
+   producer behaviour. Either way, aggregate through the coalesce: hand-rolling
+   `properties.$mcp_tool_name` alone silently buckets unrecognized exec calls under `exec`,
+   and misses any data that does carry the dedicated property.
+2. **Failures come from `$mcp_is_error` / `$mcp_error_type` / `$mcp_error_status`, never
+   `$exception`.** `$exception` can be disabled, isn't emitted when no error value is passed,
+   and never matched new-SDK events — so querying it returns nothing rather than failing.
+3. **Dash the in-progress bucket.** Every time-bucketed chart zero-fills and marks the final
+   incomplete interval via `products/mcp_analytics/frontend/timeBuckets.ts` (`resolveWindow`,
+   `normalizeBucket`, `buildBucketKeys`, `lastBucketIsInProgress`). Omit it and a partial
+   period reads as a real decline.
+4. **`harness` is derived, and its logic exists in three places that must move in lockstep:**
+   `products/mcp_analytics/backend/mcp_harness.py` (source of truth — see its module
+   docstring), `products/mcp_analytics/frontend/dashboard/harnessRegistry.ts`, and
+   `products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md`.
+5. **Check which SDK version the dogfood server is on before trusting dogfood data.**
+   `services/mcp` consumes the SDK through an alias in its `package.json` and has historically
+   lagged the published version, so version-dependent properties (typed error types, `$lib`
+   identity, payload redaction) can be absent from PostHog's own data even when documented as
+   current. A query filtering on `$lib = 'posthog-node-mcp'` silently excludes all dogfood
+   traffic if that pin predates SDK 0.7.0. Note too that `services/mcp` uses the
+   **custom-dispatcher** (`PostHogMCP`) path rather than `instrument()`, so behaviour living
+   only in the `instrument()` path — stable sessions, `$identify` deduplication, `_meta`-based
+   client identity — has never applied to it at any version.
+6. **There are no SQL template files.** Every dashboard and tool-quality query is a typed
+   query runner behind the generic `/query/` endpoint. A `backend/templates/*.sql` referenced
+   by older notes no longer exists.
+
+## Event vocabulary
+
+All data lives on the shared ClickHouse **`events`** table — there is **no dedicated table**.
+Every metric is an aggregation over `$mcp_tool_call`, usually grouped by `$session_id`.
+
+Source of truth for the SDK-emitted names is `packages/mcp/src/extensions/constants.ts` in
+`PostHog/posthog-js`, exported as `PostHogMCPAnalyticsEvent` / `PostHogMCPAnalyticsProperty`
+(import them for typesafe queries). PostHog-side descriptions — including the server-stamped
+and exec-mode properties the SDK does not define — live in `posthog/taxonomy/taxonomy.py`.
+
+**Events** (all `$`-prefixed; non-`$` names would be treated as customer events):
+`$mcp_tool_call` (primary), `$mcp_tools_list`, `$mcp_initialize`, `$mcp_missing_capability`,
+`$mcp_resource_read` / `$mcp_resources_list`, `$mcp_prompt_get` / `$mcp_prompts_list`,
+`$identify`, `$exception`.
+
+> **`$mcp_initialize` is not a universal session anchor.** The MCP 2026-07-28 stateless
+> revision removes the `initialize` handshake, so clients on that revision never emit it.
+> Anchor on the first `$mcp_tool_call` instead.
+
+Full property tables — split by provenance (SDK-emitted vs stamped by PostHog's own server vs
+exec-mode only), the identifier distinctions, per-version SDK behaviour, and TypeScript/Python
+parity — are in [references/event-vocabulary.md](references/event-vocabulary.md). Read that
+before writing queries or changing what gets captured.
+
+## Reading the data
+
+**Prefer the dedicated analysis skills** over hand-written HogQL; they already encode the
+exec-mode and harness handling that Hard rules 1 and 4 describe:
+
+- `exploring-mcp-tool-usage` — front door / router: takes a broad "how is my MCP doing"
+  question and dispatches to the right typed tool or focused skill. Start here.
+- `exploring-mcp-tool-quality` — error rates, latency, reach, failing and slow tools.
+- `exploring-mcp-sessions` — session list, per-session tool calls, intent.
+- `exploring-mcp-intent-clusters` — "what are people trying to do" clusters.
+- `improving-mcp-tools` — eval-scored campaign loop: measure, make one bounded fix, re-measure.
+
+**Typed tools** exist for most questions and are preferable to raw SQL: `posthog:query-mcp-tool-stats`,
+`-daily-stats`, `-failures`, `-failure-occurrences`, `-descriptions`, `-neighbors`,
+`-sample-intents`, `-top-users`, and `posthog:query-mcp-harness-breakdown`, plus session tools
+(`posthog:mcp-analytics-sessions-list` / `-tool-calls` / `-generate-intent`) and the intent-cluster
+tools. They are declared in `products/mcp_analytics/mcp/tools.yaml`.
+
+**Harness** is the friendly label for the calling client (Claude Code, Cursor, ChatGPT,
+Windsurf, and ~30 other buckets). It is resolved at query time only, with no stored column:
+`mcp_harness.py::HARNESS_TOKEN_SQL` picks the strongest available signal in priority order
+(`mcp_vendor_client` -> Claude Code user-agent surface -> Grok user-agent -> `$mcp_client_name`
+-> `mcp_session_client_name` -> generic user-agent token -> `$mcp_oauth_client_name`), then
+`harness_label_sql()` buckets it. **`$mcp_client_name` is one mid-priority input, not a synonym
+for harness** — grouping by it directly gives a different, messier answer.
+
+For hand-written SQL, `models-mcp.md` (linked in the Repos table) carries the property
+reference and worked query examples.
+
+## The pipeline, and where each stage breaks
+
+1. **Instrument** -> the server emits `$mcp_*` events via the SDK.
+   _Breaks:_ handlers not wrapped (`instrument()` is idempotent and degrades to a silent
+   no-op on failure); a STDIO server writing to stdout with `console.*` (corrupts the
+   protocol stream — wire a `logger`); a disabled or misconfigured posthog-node client.
+   For `services/mcp` there is a **single emission path**: `src/hono/analytics.ts` +
+   `src/hono/tool-executor.ts` -> `getPostHogClient()` (`src/lib/posthog/client.ts`) ->
+   `PostHogMCP`, consumed through the dependency alias `@posthog/mcp-analytics` (the alias
+   matters when grepping imports). The legacy MCPcat/AgentCat shim and the transition shim
+   that dual-emitted non-`$` `mcp_tool_call` / `mcp_initialize` were both removed and are
+   regression-tested in `services/mcp/tests/hono/`. **`services/mcp/ARCHITECTURE.md` still
+   describes the old multi-emitter design and references a deleted `lib/mcpcat.ts` — trust
+   the source, not that document.**
+2. **Ingest** -> events land in ClickHouse `events`. _Breaks:_ ordinary ingestion and quota
+   problems; `$session_id` not materialized, which breaks session grouping.
+3. **Session list** -> `backend/logic.py::list_mcp_sessions` runs HogQL over a **7-day
+   default window** (`DEFAULT_SESSIONS_DATE_FROM`, resolved through `QueryDateRange` with a
+   one-day overlap buffer each side) and caches for 30s (`SESSIONS_CACHE_TTL_SECONDS`).
+   _Breaks:_ anything outside the window simply isn't there; results can be up to 30s stale.
+4. **Charts and tool quality** -> typed `AnalyticsQueryRunner` subclasses in
+   `backend/hogql_queries/` (`base.py`, `dashboard_series.py`, `harness_breakdown.py`,
+   `tool_quality_tables.py`, `tool_tables.py`), dispatched via the generic `/query/` endpoint
+   and enumerated in `backend/facade/queries.py`, with schemas in `posthog/schema.py`.
+   Gate: `hogql_queries/base.py::validate_mcp_analytics_access` — the feature flag **plus**
+   the `mcp_analytics` RBAC resource. _Breaks:_ flag off, RBAC denies, or Hard rules 1-3
+   ignored.
+5. **Intent generation** (on demand, per session) -> collect `$mcp_intent` values -> an LLM
+   summary of at most two sentences -> Postgres `posthog_mcp_session`. A second,
+   project-level path produces the **intent digest / themes** with structured output, bounded
+   by `MAX_DIGEST_THEMES`; `resolve_themes()` derives every countable field from the corpus
+   so the model cannot invent numbers. Model constants live in `backend/intent_generation.py`.
+   _Breaks:_ no `$mcp_intent` captured at all (the agent never filled the injected `context`
+   argument and no `intentFallback` was configured), so there is nothing to summarize; LLM
+   key or quota problems.
+6. **Intent clustering** -> embed (cached in `MCPIntentEmbeddingCache`) -> agglomerative
+   clustering (cosine, average linkage, `DEFAULT_DISTANCE_THRESHOLD`) -> JSONB
+   `MCPIntentClusterSnapshot`. **Temporal end-to-end, no Celery.** On-demand recompute
+   (`trigger_intent_cluster_recompute`, serialized with `select_for_update()` and a
+   deterministic per-team workflow id) and the `cluster_mcp_intents` management command both
+   start the workflow; the daily run is a Temporal **Schedule**
+   (`posthog/temporal/mcp_analytics/intent_clustering/schedule.py`, behind the
+   `mcp-analytics-clustering-schedule` flag) that triggers
+   `IntentClusteringCoordinatorWorkflow`, which fans out one child workflow per team.
+   Two caps will surprise you: `MAX_SNAPSHOT_CLUSTERS` (snapshots keep only the top clusters
+   by volume, enforced at write and again at read) and `MAX_QUERY_ROWS`.
+   Note the corpus does **not** depend on step 5: `fetch_intent_corpus` takes each session's
+   first `$mcp_intent` straight from ClickHouse and only _overrides_ it with the stored LLM
+   summary where one exists. So a project can cluster with no generated summaries at all.
+   _Breaks:_ empty clusters almost always mean no `$mcp_intent` values in the lookback window
+   (check the corpus before chasing summary generation); schedule flag off; stale embeddings.
+   Also check the allowlist — `intent_clustering/team_discovery.py` currently returns a
+   hard-coded `GUARANTEED_TEAM_IDS = [2]`, so the daily schedule covers only PostHog's own
+   project and enabling the flag elsewhere still produces nothing until that changes.
+7. **Serve** -> DRF viewsets at
+   `/api/projects/{id}/mcp_analytics/{sessions,intent_clusters,feedback,missing_capabilities}`
+   (router in `backend/presentation/urls.py`) plus custom actions
+   (`sessions/{id}/tool_calls`, `sessions/{id}/generate_intent`, `sessions/intent_digest`,
+   `sessions/activity_overview`, `intent_clusters/recompute`). Parallel surface: step 4's
+   runners, exposed to agents as the `query-mcp-*` tools.
+8. **Frontend** -> Kea scene `MCPAnalyticsScene.tsx`, with tabs enumerated by
+   `MCPAnalyticsTab` in `mcpAnalyticsSceneLogic.ts`: activity, dashboard, sessions,
+   tool quality, intent clustering, notifications. The landing tab is volume-gated by
+   `dashboardStage` in `mcpAnalyticsOnboardingLogic.ts` and applies only to the bare
+   `/mcp-analytics` redirect — deep links and explicit tab clicks are never overridden.
+   - **Activity** (`earlyData/`): live tool-call feed plus the intent-**themes** card.
+     "Theme" (the LLM digest, Activity tab) is **not** "cluster" (the embedding clustering,
+     its own tab). Conflating the two is the most common mistake here.
+   - **Tool quality** and the per-tool **tool report** (`MCPAnalyticsToolDetail.tsx`, its own
+     registered scene): shared date filter, failure-occurrence drill-down with copyable error
+     context, and "create fix task" straight into `products/tasks`.
+   - **Dashboard**: quill composable `Metric` tiles and `@posthog/quill-primitives`, plus
+     **notable sessions** selected by a `NotableRule` — so that table can legitimately be
+     short or empty.
+   - **Notifications**: first-party destinations for MCP events and recurring AI reports
+     (`frontend/notifications/`), thin wiring over the generic hog-function destination and
+     subscription machinery.
+
+Postgres models (`backend/models.py`): `MCPSession` (the intent store),
+`MCPIntentClusterSnapshot`, `MCPAnalyticsSubmission` (feedback and missing-capability
+reports), `MCPIntentEmbeddingCache`.
+
+**Seeding local data:** `./manage.py seed_mcp_sessions --team-id N`
+(`backend/management/commands/`), with `--sessions`, `--min-calls`/`--max-calls`, `--days`,
+`--missing-capabilities`, `--seed`, and `--clear`. Seeded events are tagged `$mcp_seeded` so
+`--clear` removes only seeded data.
+
+## Which repo to change
+
+| Change                                          | Repo                                     | Workflow                                                                                                                                                                                                                                                                                                                                                                                 |
+| ----------------------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SDK behaviour, events, options, instrumentation | `PostHog/posthog-js`                     | Work in `packages/mcp`. Run its unit tests, build, and lint. **Add a changeset.** Ships to npm; then bump the alias in `services/mcp/package.json` to pick it up.                                                                                                                                                                                                                        |
+| Dashboard, queries, clustering, API             | this repo                                | A new chart means a query runner in `backend/hogql_queries/` behind `validate_mcp_analytics_access` — never a SQL template. Obey Hard rules 1-3.                                                                                                                                                                                                                                         |
+| A new `query-mcp-*` agent tool                  | this repo (two places)                   | 1) an entry in `products/mcp_analytics/mcp/tools.yaml` with `schema_ref`, `scopes`, `description`, `feature_flag`; 2) the matching `<Name>Query` schema and `<Name>QueryRunner` in `backend/hogql_queries/`; 3) regenerate the tool handlers from `services/mcp` (see its `package.json` scripts). The generic `createQueryWrapper` handles the tool shape — no hand-written TypeScript. |
+| PostHog's own dogfood events                    | this repo                                | `services/mcp/src/hono/analytics.ts` + `tool-executor.ts`; client in `src/lib/posthog/client.ts`.                                                                                                                                                                                                                                                                                        |
+| Docs                                            | `PostHog/posthog.com`                    | Keep the event and property tables in `contents/docs/mcp-analytics/events.mdx` synced with **both** the TypeScript `constants.ts` and the Python `posthog/mcp/constants.py`.                                                                                                                                                                                                             |
+| The install codemod or the wizard command       | `PostHog/context-mill`, `PostHog/wizard` | See [references/wizard-and-onboarding.md](references/wizard-and-onboarding.md) — in particular the rule about which changes need a wizard release and which do not.                                                                                                                                                                                                                      |
+
+**Rule of thumb:** a change to _what gets captured, or how servers are instrumented_ belongs
+in the SDKs. _How data is shown, aggregated, or clustered_ belongs in this product. _PostHog's
+own dogfood events_ belong in `services/mcp`. A new customer-facing capability usually spans
+an SDK plus docs, and the product too if it needs a view.
+
+The wizard install flow, the skill-distribution channels, and the in-app onboarding are all in
+[references/wizard-and-onboarding.md](references/wizard-and-onboarding.md).
+
+## Current state
+
+Verified against `master` and the SDK's `main` on 2026-07-31. Treat versions and open threads
+as perishable — re-check `packages/mcp/CHANGELOG.md`, the pinned alias in
+`services/mcp/package.json`, and mega-issue #64016 rather than trusting this section.
+
+Recently shipped: structured intent themes, first-party notification destinations and
+recurring reports, `mcp_analytics` access control, the shared `ProductEmptyState` adoption,
+failure-occurrence drill-down with "create fix task", the migration of every chart to typed
+query runners, the demo seeder, and exec-mode inner-tool breakout (Hard rule 1).
+
+Two code-facing facts that shape debugging, both checkable in this repo: the `services/mcp` SDK
+pin can lag the published SDK (Hard rule 5 — read the alias in its `package.json`), and the
+product is still behind the `mcp-analytics` flag, so a project without it sees nothing. For
+status and planned work, read mega-issue #64016 rather than trusting a snapshot here.

--- a/products/mcp_analytics/skills/debugging-mcp-analytics/references/event-vocabulary.md
+++ b/products/mcp_analytics/skills/debugging-mcp-analytics/references/event-vocabulary.md
@@ -1,0 +1,178 @@
+# MCP analytics event vocabulary
+
+Source of truth for SDK-emitted names: `packages/mcp/src/extensions/constants.ts` in
+`PostHog/posthog-js`, exported as `PostHogMCPAnalyticsEvent` / `PostHogMCPAnalyticsProperty`.
+PostHog-side descriptions, including everything the SDK does not define, live in
+`posthog/taxonomy/taxonomy.py`. **When this file and those disagree, they win** — grep them.
+
+Properties fall into three groups, and the distinction matters: SDK-emitted properties exist
+for any instrumented customer server, server-stamped ones exist only for PostHog's own
+dogfood traffic, and exec-mode ones only appear when a server runs a single `exec` dispatcher.
+
+## Events
+
+All `$`-prefixed — a non-`$` name would be treated as a customer event.
+
+| Event                                        | Notes                                                                                                                                                                       |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$mcp_tool_call`                             | The primary event. Almost every metric aggregates over it.                                                                                                                  |
+| `$mcp_tools_list`                            | A `tools/list` request. Carries the advertised catalog — the basis for zombie-tool queries.                                                                                 |
+| `$mcp_initialize`                            | The `initialize` handshake. **Not emitted by clients on the MCP 2026-07-28 stateless revision**, which removes the handshake — do not use it as a universal session anchor. |
+| `$mcp_missing_capability`                    | The agent wanted something the server does not offer. The clearest roadmap signal in the dataset.                                                                           |
+| `$mcp_resource_read` / `$mcp_resources_list` | Resource access. Not emitted by `instrument()` in either SDK.                                                                                                               |
+| `$mcp_prompt_get` / `$mcp_prompts_list`      | Prompt access. Same caveat as resources.                                                                                                                                    |
+| `$identify`                                  | Person identity. Since TS 0.9.1 this fires at most once per session, not before every tool call.                                                                            |
+| `$exception`                                 | Error sibling event. Can be disabled, and is not emitted when no error value is passed — see the failures rule below.                                                       |
+
+`$mcp_custom` is registered in the enum, but `analytics.capture()` sends the verbatim event
+name it is given rather than `$mcp_custom`.
+
+## SDK-emitted properties
+
+On `$mcp_tool_call` unless noted. These are the properties any instrumented server produces.
+
+| Property                                   | Notes                                                                                                                                                                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `$mcp_tool_name`                           | The tool the agent called. In single-exec mode this holds the resolved inner tool, or the literal `exec` when unrecognized — see exec-mode below.                                                                                    |
+| `$mcp_tool_description`                    | The description the agent saw. In single-exec mode this is the dispatcher's static text on every call.                                                                                                                               |
+| `$mcp_tool_category`                       | Server-assigned grouping. Used by the Signals scout to group problem tools.                                                                                                                                                          |
+| `$mcp_intent`                              | Why the agent made the call — the product's differentiator. Populated from the injected `context` argument, or a configured fallback.                                                                                                |
+| `$mcp_intent_source`                       | `context_parameter` or `inferred`. Tells you whether the agent actually filled the context argument.                                                                                                                                 |
+| `$mcp_is_error`                            | Boolean failure flag. **The canonical failure signal.**                                                                                                                                                                              |
+| `$mcp_duration_ms`                         | Call latency. Cast before aggregating: `quantile(0.95)(toFloat(properties.$mcp_duration_ms))`.                                                                                                                                       |
+| `$mcp_parameters`                          | Captured arguments, sanitized.                                                                                                                                                                                                       |
+| `$mcp_response`                            | Captured response, sanitized. May be empty by configuration.                                                                                                                                                                         |
+| `$mcp_listed_tool_names`                   | On `$mcp_tools_list`. JSON array of advertised tools. Diff against called tool names for zombie tools. In single-exec mode `$mcp_exec_inner_tool_names` is the intended catalog field, but is unemitted today — see exec-mode below. |
+| `$mcp_error_type`                          | Since TS 0.8.0. Low-cardinality label — `validation`, `permission`, `timeout`, `rate_limited`, etc. Defaults to the thrown error's type; hosts can pass an explicit label.                                                           |
+| `$mcp_error_message`                       | Since TS 0.8.0. Redacted automatically as of TS 0.10.2.                                                                                                                                                                              |
+| `$mcp_client_name` / `$mcp_client_version` | The calling client as _it_ reported itself. One mid-priority input to harness resolution — not the harness label.                                                                                                                    |
+| `$mcp_server_name` / `$mcp_server_version` | The instrumented server's own identity.                                                                                                                                                                                              |
+| `$mcp_protocol_version`                    | Since TS 0.10.0. The negotiated MCP spec version, stamped on `$mcp_initialize` **and every subsequent event of the session**. Use it to track spec-revision adoption or to break metrics down by revision.                           |
+| `$mcp_conversation_id`                     | Agent-supplied conversation id. **Survives reconnects** — see identifiers below.                                                                                                                                                     |
+| `$mcp_resource_name`                       | On resource events.                                                                                                                                                                                                                  |
+| `$session_id`                              | The standard PostHog session id, materialized. The usual grouping key.                                                                                                                                                               |
+| `$mcp_source`                              | Always `posthog_mcp_analytics`. The reliable way to isolate MCP events from everything else on the `events` table.                                                                                                                   |
+
+## Server-stamped properties
+
+Added by PostHog's own server (`services/mcp/src/hono/analytics.ts::buildBaseProperties`),
+**not** by the SDK. They exist for PostHog's dogfood data and will be absent for a customer
+server, so never rely on them in customer-facing queries or docs without checking.
+
+`$mcp_session_id` (transport-level), `$mcp_region`, `$mcp_mode`, `$mcp_consumer`,
+`$mcp_version`, `$mcp_client_user_agent`, `$mcp_transport`, `$mcp_organization_id`,
+`$mcp_project_id`, `$mcp_project_uuid`, `$mcp_project_name`, `$ai_product` (`mcp`), and the
+non-`$`-prefixed `mcp_runtime` (`hono`) and `mcp_vendor_client` — the last of which is the
+**top-priority harness signal**, so it appears inside harness SQL.
+
+Per-event additions: `$mcp_error_status` (upstream HTTP status, stamped by
+`services/mcp/src/hono/tool-executor.ts` — **server-side, despite sitting next to the SDK's
+typed error properties in queries**); and `tool_count`, `read_only`, `via_sse_redirect` on
+`$mcp_initialize`. `execute-sql` calls additionally emit a separate `$ai_generation` event
+carrying `$ai_trace_id`, `$ai_input`, `$ai_output_choices`, and `$ai_latency`.
+
+## Exec-mode properties
+
+When a server exposes a single `exec` dispatcher instead of many tools, the inner tool has to be
+recovered from the exec command's `call <tool> ...` form.
+
+**Read this before writing an exec-mode query.** These properties are registered in
+`posthog/taxonomy/taxonomy.py` and coalesced by the read path, but **no producer on master emits
+them**. `services/mcp`'s `ToolExecutor.callExecTool()` resolves the inner tool itself and passes
+it to `trackToolCall()` as the tool name, falling back to the literal `exec` when the command
+isn't recognized — so in current data the inner tool arrives in `$mcp_tool_name`, and these
+dedicated fields are empty. A query built only on them returns nothing.
+
+| Property                          | Notes                                                                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$mcp_exec_tool_call_name`        | The inner tool invoked. Read it via `EFFECTIVE_TOOL_SQL` (`backend/hogql_queries/base.py`), which coalesces it ahead of `$mcp_tool_name` — never alone. |
+| `$mcp_exec_tool_call_description` | The inner tool's description rather than the dispatcher's static text.                                                                                  |
+| `$mcp_exec_inner_tool_names`      | On `$mcp_tools_list`: the inner catalog, intended to stand in for `$mcp_listed_tool_names` in this mode.                                                |
+
+So for per-tool aggregation, always go through `EFFECTIVE_TOOL_SQL` — it is correct whether the
+inner tool arrives in `$mcp_tool_name` (current) or in the dedicated property (historical rows,
+and whatever lands when the emitter ships). For zombie tools, prefer `$mcp_listed_tool_names`
+and treat `$mcp_exec_inner_tool_names` as a fallback that is empty today; if a zombie-tool query
+returns no tools at all, that absence is the first thing to check.
+
+## The three identifiers
+
+A frequent source of wrong session math:
+
+- **`$session_id`** — the standard PostHog session id, a materialized column. The default
+  grouping key for "a session" in this product.
+- **`$mcp_session_id`** — transport-level, from the `Mcp-Session-Id` header. **Rotates on
+  reconnect**, so counting it overcounts sessions.
+- **`$mcp_conversation_id`** — agent-supplied. **Survives reconnects**, so it is the right key
+  for "one agent conversation" spanning drops.
+
+## Library identity
+
+Since TS 0.7.0 events stamp the standard `$lib` = `posthog-node-mcp` (plus `$lib_version`) via
+`applyMcpLibIdentity`. The short-lived 0.6.0 custom `$mcp_lib` / `$mcp_lib_version` properties
+were dropped — any document mentioning them is stale.
+
+Note that posthog-node sets `$lib` at the client level, so `instrument()` relabels **every**
+event sent by the client you pass it. Give an MCP server a posthog-node client dedicated to its
+analytics rather than sharing the app's.
+
+## TypeScript SDK behaviour by version
+
+Read `packages/mcp/CHANGELOG.md` for the current list; this covers the changes that alter data
+semantics rather than the API surface.
+
+- **0.5.0** — `instrumentMutator(posthog)`, a point-free `(server) => server` helper for
+  framework server-mutation hooks such as `@rekog/mcp-nest`'s `serverMutator`.
+- **0.7.0** — standard `$lib` identity (above).
+- **0.8.0** — typed `$mcp_error_type` / `$mcp_error_message` on failed calls, so failures can
+  be broken down by reason without joining to `$exception`.
+- **0.9.0** — **stateless sessions.** Mints an `Mcp-Session-Id` response header at
+  `initialize` encoding the session id plus client name/version, so multi-pod and stateless
+  servers stop fragmenting sessions. Auto-minting requires `enableJsonResponse: true` on
+  `StreamableHTTPServerTransport`; SSE-mode servers set the header at the HTTP layer using the
+  exported `encodeSessionId`, `decodeSessionId`, `MCP_SESSION_HEADER`, and `newSessionId`.
+  This is now the _legacy handshake_ identity path.
+- **0.9.1** — standalone `$identify` fires at most once per session (at `initialize`, on
+  first-seen identity, or on a material identity change) rather than before every tool call.
+  `distinct_id` and `$set` still ride every event, so no person data is lost.
+- **0.10.0** — `$mcp_protocol_version` (above), persisted in session info and recovered
+  cross-pod from the session token.
+- **0.10.1** — the MCP 2026-07-28 stateless revision removes the `initialize` handshake and
+  the `Mcp-Session-Id` header for clients on it. The SDK therefore also reads client
+  name/version and protocol version from **every request's** `params._meta`
+  (`io.modelcontextprotocol/clientInfo`, `io.modelcontextprotocol/protocolVersion`) and stamps
+  them per request rather than into shared session state — so concurrent multiplexed requests
+  from different clients cannot clobber each other's attribution. Clients without `_meta` fall
+  back to the session-token path unchanged.
+- **0.10.2** — exception messages and large binary payload encodings are redacted
+  automatically, through the same sanitizer as parameters and responses. Unconditional, with
+  no configuration knob.
+
+## Python SDK parity
+
+`posthog/mcp/` in `PostHog/posthog-python`, mirroring the `posthog.ai` layout. `instrument()`
+covers the official SDK's FastMCP and low-level `Server`, **and** jlowin's standalone
+fastmcp 2.0 (routed via its `_mcp_server`, stripping the injected `context` because that
+library rejects unexpected kwargs). `PostHogMCP` covers custom dispatchers.
+
+Has: stateless sessions, `$mcp_protocol_version`, once-per-session `$identify`, payload
+sanitization. Resources and prompts are intentionally omitted, matching TS `instrument()`.
+
+**Known gaps against the TypeScript SDK** — verify before promising parity:
+
+- no typed `$mcp_error_type` / `$mcp_error_message` taxonomy (the largest gap)
+- no `_meta`-based client identity for the 2026-07-28 stateless revision
+- no `instrumentMutator` equivalent
+
+## Query gotchas
+
+- Aggregate per tool on the **effective** tool name, coalescing `$mcp_exec_tool_call_name`
+  ahead of `$mcp_tool_name`.
+- Take failures from `$mcp_is_error` (with `$mcp_error_type` / `$mcp_error_status` for the
+  reason), never from `$exception`, which can be absent by design and so returns nothing
+  rather than erroring.
+- Group clients by the resolved **harness** label, not raw `$mcp_client_name`.
+- Zombie tools = `arrayJoin($mcp_listed_tool_names)` from `$mcp_tools_list`, minus the distinct
+  effective tool names seen on `$mcp_tool_call`. `$mcp_exec_inner_tool_names` is the intended
+  single-exec equivalent but is unemitted today, so a query resting on it returns nothing.
+- Scope to `$mcp_source = 'posthog_mcp_analytics'` to isolate MCP events.

--- a/products/mcp_analytics/skills/debugging-mcp-analytics/references/local-repos.md
+++ b/products/mcp_analytics/skills/debugging-mcp-analytics/references/local-repos.md
@@ -1,0 +1,74 @@
+# Local repo registry
+
+MCP analytics spans this monorepo plus `posthog-js` (the TypeScript SDK), `posthog-python`
+(the Python SDK), `posthog.com` (docs), and — for the install flow — `context-mill`, `wizard`,
+and `wizard-workbench`. Different maintainers keep their clones in different places, so this
+registry records where each maintainer's checkouts live and a repo is found once and reused
+instead of re-cloned every session.
+
+GitHub stays the source of truth for _where the code lives_ (see the Repos table in SKILL.md).
+The registry is purely a local cache of _where this maintainer cloned it_.
+
+## Repo keys
+
+Keys match the GitHub repo names under the `PostHog` org:
+
+| Key                | Why you'd need it                                                                               |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| `posthog`          | The monorepo: the product, `services/mcp`, the skills. Usually the checkout you are already in. |
+| `posthog-js`       | The TypeScript SDK, at `packages/mcp/`. The event-vocabulary source of truth.                   |
+| `posthog-python`   | The Python SDK, at `posthog/mcp/`.                                                              |
+| `posthog.com`      | Docs under `contents/docs/mcp-analytics/`, plus the product-data and tools entries.             |
+| `context-mill`     | The `wizard mcp-analytics` install codemod.                                                     |
+| `wizard`           | The wizard CLI that registers the command.                                                      |
+| `wizard-workbench` | Local harness and fixtures for exercising the install flow.                                     |
+
+`context-mill`, `wizard`, and `wizard-workbench` are internal repos — expect them to be absent
+on a machine that has only ever worked on the public SDKs, and say so rather than guessing a
+path.
+
+## Resolving a repo
+
+Follow this order, and write the answer back so later sessions skip the search:
+
+1. **Check the registry.** A JSON map of repo key -> absolute path at
+   `~/.config/posthog-mcp-analytics/repos.json`. If the repo is listed and the path exists,
+   use it.
+
+   ```json
+   {
+     "posthog": "/Users/me/src/posthog",
+     "posthog-js": "/Users/me/src/posthog-js",
+     "posthog-python": "/Users/me/src/posthog-python"
+   }
+   ```
+
+2. **Scan the conventional code roots** — the current checkout's parent directories, and
+   `~/src`, `~/code`, `~/dev`, `~/projects`, `~/repos`, `~/work`, `~/git` — for a git checkout
+   whose `git remote get-url origin` points at `github.com/PostHog/<repo>`. Match on the
+   remote, not the directory name: worktrees and topic clones are routinely named things like
+   `posthog-<topic>`. There is no global git config listing clone locations, so the filesystem
+   plus the `origin` remote is the only reliable signal.
+3. **Ask, or clone.** If it is still not found, ask the maintainer where it is, or offer to
+   `git clone https://github.com/PostHog/<repo>` into a default location (`~/src/<repo>`).
+4. **Record the resolved path** in the registry.
+
+The `debugging-surveys` skill ships a `scripts/repos.py` implementing this same algorithm
+(`init` / `ensure` / `get` / `set` / `list`), and it is worth reading as a reference. **Do not
+expect it to work for this skill as-is:** it matches remotes only against its own
+surveys-specific `KNOWN_REPOS`, which excludes `posthog-python`, `context-mill`, `wizard`, and
+`wizard-workbench`, and it reads and writes `~/.config/posthog-surveys/repos.json` rather than
+the registry described above. So its `init` and `ensure` cannot discover most of what this
+skill needs. Either follow the manual steps above, or adapt a copy with this skill's repo list
+and registry path.
+
+## Before quoting code from a resolved checkout
+
+- Confirm the branch. A topic branch or a stale worktree is not what the reader means by
+  "current", and several of these repos have long-lived unmerged branches. When you need the
+  shipped state, read it explicitly from the remote ref — `git show origin/main:<path>` or
+  `git show origin/master:<path>` — rather than whatever the working tree happens to be on.
+  Trunk is `master` for `posthog` and `posthog.com`, `main` for the others.
+- Never modify a checkout you were only asked to read, and never switch its branch: these are
+  working checkouts that frequently hold uncommitted work.
+- Grep for symbols rather than trusting remembered line numbers; this area moves fast.

--- a/products/mcp_analytics/skills/debugging-mcp-analytics/references/wizard-and-onboarding.md
+++ b/products/mcp_analytics/skills/debugging-mcp-analytics/references/wizard-and-onboarding.md
@@ -1,0 +1,194 @@
+# Wizard install, skill distribution, and in-app onboarding
+
+A customer counts as "onboarded" only once we have captured MCP events from their server. The
+loop is: instrument (wizard) -> events flow -> analyze (dashboard or agent). This file covers
+the install half and the in-app half.
+
+Resolve `context-mill`, `wizard`, and `wizard-workbench` checkouts via
+[local-repos.md](local-repos.md); they are internal repos and may be absent.
+
+## `wizard mcp-analytics`
+
+`npx -y @posthog/wizard@latest mcp-analytics` runs an agentic codemod that instruments a
+user's _own_ MCP server, in TypeScript/JavaScript **or Python**. It is not `wizard mcp add`,
+which installs the PostHog MCP server into a coding agent.
+
+Two repos cooperate:
+
+- **`context-mill`** holds the skill at `context/skills/mcp-analytics/`: `config.yaml` (with
+  the `cli:` block that declares the command) and `description.md` (the codemod instructions
+  themselves). `CONTRIBUTING.md` is the spec for skills and for the `cli:` block.
+- **`wizard`** registers the command word: `src/commands/mcp-analytics.ts` calls
+  `nativeCommandFactory(...)`, whose config lives in `src/lib/programs/mcp-analytics/index.ts`
+  (built with `createSkillProgram`), wired in via `.use()` in `bin.ts`.
+
+**Version source of truth in context-mill is its git tags**, not `package.json` — that field is
+private and does not track releases.
+
+## The rule for adding or changing a wizard command
+
+The wizard is a thin Claude-Agent-SDK wrapper; capabilities come from context-mill skills
+fetched at runtime via `skill-menu.json`. Which repos you touch depends on the shape:
+
+- **A subcommand under an existing family** (e.g. another `wizard audit <thing>`) needs a
+  **context-mill release only — no wizard PR.** It resolves at runtime from `cliEntries` by
+  `parentCommand`, handled by `dispatch-family.ts` / `family-command-factory.ts`.
+- **A brand-new top-level command** (which `mcp-analytics` is) **also needs a wizard PR**,
+  because `bin.ts` statically `.use()`s every top-level command and yargs has no dynamic
+  top-level registration. Ship both: the `cli:` block in context-mill, and a
+  `nativeCommandFactory(ProgramConfig)` stub in the wizard
+  (`src/lib/programs/<cmd>/index.ts` via `createSkillProgram`, plus `src/commands/<cmd>.ts`,
+  plus `.use()` in `bin.ts`).
+
+Model a new one on `migrate`, which is also a flat `createSkillProgram` call.
+`revenue-analytics` uses the same factory but a fully hand-authored `ProgramConfig`, so it is a
+weaker template. Keep a command flat until a second subcommand actually exists. The
+`developing-the-wizard.mdx` handbook page in `posthog.com` documents this.
+
+## The release gate
+
+Nothing reaches users until a **context-mill release**: merge the skill PR with the
+`mcp-publish` label plus one of `major` / `minor` / `patch`, and `build-release.yml` publishes
+the GitHub release and moves the `latest` tag that the wizard pulls from. A change to the
+command _word_ additionally needs a **wizard release** (release-please to npm). Order matters:
+context-mill first, then wizard.
+
+## Codemod instrumentation paths
+
+Defined in the skill's `description.md`. Each detects a server shape and applies the matching
+instrumentation:
+
+| Path        | Target                                                        | Approach                                                                    |
+| ----------- | ------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **A**       | official `@modelcontextprotocol/sdk` (`Server` / `McpServer`) | `instrument(server, posthog)`                                               |
+| **B**       | `mcp-handler` (Vercel/Next)                                   | `instrument()` plus `identify` plus a per-invocation flush                  |
+| **C**       | custom dispatcher (Hono/edge, no server object)               | `PostHogMCP` with `captureToolCall` / `captureInitialize`                   |
+| **D**       | `@rekog/mcp-nest` (NestJS)                                    | `instrumentMutator()` through the framework's `serverMutator` hook          |
+| **P1 / P2** | Python (`posthog.mcp`)                                        | official-SDK/FastMCP `instrument()`, or `PostHogMCP` for custom dispatchers |
+
+Only path A has been verified against a real third-party server. B, C, D and the Python paths
+are unverified — treat a report of them working as new information.
+
+The codemod also handles credentials (the project token, fetched via the PostHog MCP
+`posthog:projects-get` tool), lifecycle (shutdown and flush), STDIO-safe logging (stderr is fine,
+stdout corrupts the protocol stream), and version pinning. The TypeScript paths **never hardcode
+an SDK version** — they install the current published one and read the result back. The Python
+paths are different: they require a floor (`posthog>=7.21`), which _can_ go stale, so check it
+against the current `posthog` release when touching the Python instrumentation.
+
+On failure it emits exactly one `[ABORT] <reason>` line and stops, from this vocabulary:
+
+- `[ABORT] no mcp server found`
+- `[ABORT] unsupported language for mcp analytics`
+- `[ABORT] could not locate the server entry point`
+- `[ABORT] <short specific reason>` (catch-all)
+
+The wizard maps these reasons to friendlier messages in `MCP_ANALYTICS_ABORT_CASES`
+(`src/lib/programs/mcp-analytics/index.ts`), matching each with an anchored regex against the
+reason text after the `[ABORT]` prefix is stripped. Anything unmatched falls through to
+generic handling.
+
+**The two sides drift, so check both before trusting the mapping.** The table has carried a case
+for `not a javascript mcp server` — a reason the codemod does not emit — while having none for
+`could not locate the server entry point`, which it does. The result is dead copy that never
+renders and a real abort that degrades to a generic message. If you add or rename a reason in
+the codemod, update that table in the same change, and verify the regex against how the
+consumer extracts the reason rather than assuming.
+
+## Skill distribution — three channels
+
+Do not confuse these; they have different audiences and different release mechanics.
+
+1. **Team skills store** (Postgres) — reachable over MCP via `posthog:skill-list` / `posthog:skill-get`, and
+   in-app under `/llm-analytics/skills/`. Per-team and editable without a deploy.
+   `sync_canonical_skills` (`products/signals/backend/scout_harness/lazy_seed.py`) only
+   promotes directories under `products/signals/skills/` matching `signals-scout-*` or listed
+   in `_COMPANION_SKILL_DIRS`, so **no `mcp_analytics` skill is canonical through it**. The
+   `signals-scout-mcp-tool-calls` scout qualifies purely by prefix.
+2. **context-mill release** (`skills-mcp-resources.zip`) — the wizard/**install** skills,
+   including the `mcp-analytics` codemod, served by `services/mcp`'s `ResourceCatalog`
+   (`src/hono/resource-catalog.ts`) as MCP prompts and resources. This is **also the sole
+   backend for `posthog-cli api skill list|install`** (`services/mcp/src/cli/skills.ts`).
+3. **`posthog_ai` `build_skills`** — `products/posthog_ai/scripts/build_skills.py` scans
+   `products/*/skills/` into `dist/skills.zip`, which `ci-agent-skills.yml` publishes as a
+   GitHub release. This is the channel that carries the customer-facing **analysis** skills
+   (`querying-posthog-data`, the `exploring-mcp-*` set, `improving-mcp-tools`) and this skill.
+   Consumed by PostHog Desktop and PostHog AI. **Not** by `posthog-cli` — that is channel 2.
+
+Two lookalikes are **not** MCP-analytics skills:
+`products/managed_migrations/skills/testing-mcp-tools-locally/` and
+`.agents/skills/implementing-mcp-tools/`. Both concern building and testing PostHog's own MCP
+server tools, not analyzing MCP usage.
+
+Note the activation gap: `wizard mcp add` installs the PostHog MCP server but does **not**
+auto-load the analysis skills, so a freshly onboarded user has the data and the server without
+the skills that read them.
+
+## In-app onboarding
+
+Two entry paths coexist, sharing one install hero.
+
+1. **In-scene empty state — the current default.** MCP analytics is the reference adoption of
+   the shared `ProductEmptyState` platform (`frontend/src/lib/components/ProductEmptyState/`).
+   A scene's `SceneExport` declares `emptyState`; `productSetupStatusLogic` exposes a
+   normalized `ProductSetupStatus` (`loading`, `needs-setup`, `waiting-for-data`, `has-data`).
+   MCP's config is `products/mcp_analytics/frontend/emptyState/mcpAnalyticsEmptyState.tsx`,
+   mapped from the product's own onboarding state by
+   `emptyStateStatusForOnboardingState()`. **Projects that have never been set up render the
+   setup screen in place — there is no redirect into the app-wide `/onboarding` flow.**
+   `manifest.tsx` declares the `setupProbe` (`hasDataEvents: ['$mcp_tool_call']`,
+   `waitingEvents: ['$mcp_initialize']`).
+2. **The legacy app-wide `/onboarding` flow** is still registered, under
+   `frontend/src/scenes/onboarding/legacy/stepProviderRegistry.ts` — the `legacy/` segment
+   signals it is being phased out. Registering a product there takes roughly six touches:
+   `ProductKey.MCP_ANALYTICS` (`schema-general.ts`), `Scene.MCPAnalytics` (`sceneTypes.ts`),
+   the `AvailableOnboardingProducts` union (`types.ts`), an `availableOnboardingProducts` entry
+   (`onboarding/shared/utils.tsx`), the provider in `legacy/stepProviderRegistry.ts`, and the
+   custom install step (`products/mcp_analytics/frontend/onboarding/steps.tsx`).
+
+**They do not share a component — check which one you're editing.** Only the legacy path renders
+`MCPAnalyticsInstallHero` (`frontend/onboarding/MCPAnalyticsInstall.tsx`, imported by
+`onboarding/steps.tsx`). The default in-scene path is `emptyState/mcpAnalyticsEmptyState.tsx`,
+which imports just `MCP_ANALYTICS_DOCS_URL` and `MCPListeningIndicator` from that file and
+otherwise renders through the shared `ProductEmptyState`. Editing the hero therefore does _not_
+change the setup screen most users see.
+
+Both surfaces do use `useWizardCommand('mcp-analytics', { pinProjectId: true })` — `pinProjectId`
+appends `--project-id=<team>` so the wizard instruments the project the user is looking at —
+together with the rainbow `CommandBlock`, deliberately bypassing the shared
+`WizardCommandBlock` for **bundle weight**, since the empty-state gate is eagerly loaded.
+(`WizardCommandBlock` does support a `subcommand` prop, so "it can't express a subcommand" is
+no longer the reason.)
+
+`mcpAnalyticsOnboardingLogic` drives all of it with a single **unbounded** HogQL query
+(`ONBOARDING_SIGNAL_QUERY`, effectively "has this project ever been onboarded" — cheap,
+because the event-name filter hits the sort key) returning `has_initialize`,
+`tool_calls_total`, `tool_calls_7d`, and `first_call_at`, polled on an interval and torn down
+through `cache.disposables`. States are `not-instrumented`, `connected-no-calls`, and
+`onboarded`; it also derives the `dashboardStage` that gates the landing tab. Product-intent
+reporting is suppressed during staff impersonation via `isImpersonatedSession()`.
+
+Not yet adopted: the generic wizard **setup-report handoff** (`publish_handoff` ->
+`handoff_text` -> `WizardHandoffDialog`). The `mcp-analytics` program gets the publishing side
+automatically, as any `createSkillProgram` program with a report file does, but no
+MCP-analytics surface consumes the report yet.
+
+## Testing the install flow locally
+
+`wizard-workbench` drives the real command against fixture apps. Run its setup script (see the
+repo's README), which brings up the local stack, then run `wizard mcp-analytics` against the
+fixtures in `apps/mcp-analytics/`: `typescript-sdk/stdio-server/` exercises path A and
+`custom-dispatcher/hono-server/` exercises path C. **There are still no Python fixtures**, so
+the Python paths cannot be exercised here yet.
+
+By default the wizard pulls skills from the latest context-mill _release_; the `--local-mcp`
+flag serves the unreleased local skill instead, which is what you want when testing a codemod
+change before publishing it.
+
+Two things that cost people time:
+
+- Workbench **CI** no longer runs a local MCP server at all — it points `MCP_URL` at the
+  production MCP endpoint to decouple CI from monorepo breakage. So a CI green does not prove
+  the local-stack path works, and vice versa.
+- The local `mcp` process is not started automatically by the process manager even though older
+  README text implies it is; start it explicitly if something expects it to be listening.


### PR DESCRIPTION
The MCP Analytics engineering knowledge — the repo map, the `$mcp_*` vocabulary, the pipeline and where it breaks — only existed in one team's private skills store, so nobody else could reach it. This ships it through the agent-skills channel as `debugging-mcp-analytics`.

Modelled directly on `debugging-surveys`, the existing product-internal skill of this shape: a ~19k `SKILL.md` map plus `references/` for the heavy detail, and a repo registry instead of hardcoded checkout paths so it works on anyone's machine.

## Why it's worth reviewing rather than skimming

The content is an audit of the product as of 2026-07-31, and the private copy had drifted badly enough to be actively misleading. The corrections it encodes:

- **Aggregate through `EFFECTIVE_TOOL_SQL`.** A single-exec server can report the tool two ways and both eras of data coexist. Hand-rolling `properties.$mcp_tool_name` buckets unrecognized exec calls under `exec`. Worth knowing precisely: `services/mcp` resolves the inner tool itself and passes it in as the tool name, and **nothing on master emits `$mcp_exec_tool_call_name`** — it's in `taxonomy.py` and coalesced defensively, but the emitter is still on an unmerged branch.
- **Failures come from `$mcp_is_error`/`$mcp_error_type`/`$mcp_error_status`, never `$exception`** (#70135) — which returns nothing rather than erroring, so the query looks fine.
- **Empty intent clusters usually mean no `$mcp_intent` in the window, not "summaries weren't generated"** — `fetch_intent_corpus` reads events directly and only *overrides* with the stored summary. Plus `team_discovery.py` returns a hard-coded `GUARANTEED_TEAM_IDS = [2]`, so the daily schedule only ever covers project 2.
- **Tool-quality queries are typed query runners behind `/query/`**; the SQL template older notes called canonical was deleted in #71465.
- **`$mcp_initialize` is no longer a universal session anchor** — the MCP 2026-07-28 stateless revision removes the handshake.
- **Onboarding renders in-scene via the shared `ProductEmptyState`**; the old auto-redirect into `/onboarding` is gone (#72442).
- Adds `$mcp_protocol_version`, the SDK-emitted vs server-stamped vs exec-mode property split, harness resolution and its three lockstep copies, the `query-mcp-*` tool family and how to add one, and the demo seeder.

## Deliberately excluded

Machine-specific paths, one maintainer's P0-P4 roadmap, and local proxy-cert workarounds — none of which belong in something everyone installs. The dated "Current state" section points at mega-issue #64016 rather than duplicating a list that rots.

## Testing

Frontmatter parses and `name` matches the directory (the two fields `build_skills` requires); all five cross-file reference links resolve; no absolute or user-specific paths anywhere. Confirmed skill discovery is a plain directory scan of `products/*/skills`, so no manifest or allowlist needed updating. The full `build:skills` needs Postgres locally (unrelated skills' Jinja templates import product code), so `ci-agent-skills` is the real gate.

`codex review --base master` raised six findings; five were legitimate and are fixed in this branch (the exec-mode framing above, the clustering prerequisite, the team allowlist, `posthog:` prefixes on MCP tool references per the handbook, and two pieces of wrong cross-repo advice). I dismissed the em-dash finding: `AGENTS.md` scopes that rule to user-facing copy, and all six sibling skills in this directory use em dashes freely.

## Note for reviewers

This overlaps the `mcp-analytics` entry in the team skills store, which I've updated to point here. Maintaining both by hand will drift — the intent is for this to be canonical and that entry to shrink to a pointer.

Part of a batch also covering the wizard abort copy, the posthog.com beta status, `models-mcp.md` property drift, and the dogfood SDK pin.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*