### PR TITLE
chore(desktop): rebrand Claude Code settings as Harness and clarify bypass copy

### DIFF
--- a/products/desktop/packages/ui/src/features/settings/components/SettingsPageContent.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsPageContent.tsx
@@ -1,11 +1,11 @@
 import { McpServersView } from "@posthog/ui/features/mcp-servers/components/McpServersView";
 import { AdvancedSettings } from "@posthog/ui/features/settings/sections/AdvancedSettings";
 import { AgentsSettings } from "@posthog/ui/features/settings/sections/AgentsSettings";
-import { ClaudeCodeSettings } from "@posthog/ui/features/settings/sections/ClaudeCodeSettings";
 import { DiscordSettings } from "@posthog/ui/features/settings/sections/DiscordSettings";
 import { EnvironmentsSettings } from "@posthog/ui/features/settings/sections/environments/EnvironmentsSettings";
 import { GeneralSettings } from "@posthog/ui/features/settings/sections/GeneralSettings";
 import { GitHubSettings } from "@posthog/ui/features/settings/sections/GitHubSettings";
+import { HarnessSettings } from "@posthog/ui/features/settings/sections/HarnessSettings";
 import { NotificationsSettings } from "@posthog/ui/features/settings/sections/NotificationsSettings";
 import { PersonalizationSettings } from "@posthog/ui/features/settings/sections/PersonalizationSettings";
 import { PlanUsageSettings } from "@posthog/ui/features/settings/sections/PlanUsageSettings";
@@ -72,7 +72,7 @@ const SETTINGS_PAGES: Record<SettingsCategory, SettingsPageDefinition> = {
   ),
   sidebar: defineSettingsPage("Sidebar", CustomizeSidebarSettings),
   terminal: defineSettingsPage("Terminal", TerminalSettings),
-  "claude-code": defineSettingsPage("Claude Code", ClaudeCodeSettings),
+  harness: defineSettingsPage("Harness", HarnessSettings),
   shortcuts: defineSettingsPage("Shortcuts", ShortcutsSettings),
   github: defineSettingsPage("GitHub", GitHubSettings),
   slack: defineSettingsPage("Slack integration", SlackSettings),

--- a/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
+++ b/products/desktop/packages/ui/src/features/settings/components/SettingsPanel.tsx
@@ -87,7 +87,7 @@ const SIDEBAR_GROUPS: SidebarGroup[] = [
       { id: "agents", label: "Agents", icon: <Robot size={16} /> },
       { id: "skills", label: "Skills", icon: <Lightbulb size={16} /> },
       { id: "mcp-servers", label: "MCP servers", icon: <Plugs size={16} /> },
-      { id: "claude-code", label: "Claude Code", icon: <Code size={16} /> },
+      { id: "harness", label: "Harness", icon: <Code size={16} /> },
       {
         id: "signals",
         label: "Self-driving",

--- a/products/desktop/packages/ui/src/features/settings/sections/ClaudeCodeSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/ClaudeCodeSettings.tsx
@@ -171,8 +171,8 @@ export function ClaudeCodeSettings() {
       <PermissionsSettings />
 
       <SettingRow
-        label="Bypass permissions"
-        description="Skip all permission prompts. Claude will run bash commands, edit files, browse the web and use any tool without asking first"
+        label="Allow bypass permissions mode"
+        description="Adds bypass permissions to the mode menu so you can pick it for a single task. Tasks keep asking for approval until you choose it. A task in that mode runs bash commands, file edits and web requests without asking. This also unlocks Full access in Codex"
         noBorder
       >
         <Switch
@@ -188,9 +188,10 @@ export function ClaudeCodeSettings() {
             <Warning weight="fill" />
           </Callout.Icon>
           <Callout.Text>
-            Bypass Permissions is enabled. All actions (shell commands, file
-            edits, web requests) run without approval. Pick this mode from the
-            mode menu in the prompt input per session.
+            Bypass permissions is now available in the mode menu in the prompt
+            input. Pick it per session when you want that session to run shell
+            commands, file edits and web requests without approval. Other
+            sessions are unaffected.
           </Callout.Text>
         </Callout.Root>
       )}
@@ -204,31 +205,36 @@ export function ClaudeCodeSettings() {
             <Flex align="center" gap="2">
               <Warning size={20} weight="fill" color="var(--red-9)" />
               <Text color="red" className="font-bold">
-                Enable bypass permissions
+                Allow bypass permissions mode
               </Text>
             </Flex>
           </AlertDialog.Title>
           <AlertDialog.Description className="text-sm">
             <Flex direction="column" gap="3">
+              <Text>
+                This makes bypass permissions selectable in the mode menu. It
+                does not turn it on for your tasks. Each session keeps its
+                current mode until you pick bypass for it.
+              </Text>
               <Text color="red" className="font-medium">
-                With bypass enabled, Claude will execute every action without
-                asking -- including shell commands, file edits, web requests and
+                A session running in bypass mode executes every action without
+                asking, including shell commands, file edits, web requests and
                 any installed MCP tools.
               </Text>
               <Text>
-                This mode is intended for sandboxed environments (containers or
-                VMs) with restricted network access that can be easily restored.
+                Pick it for sandboxed environments (containers or VMs) with
+                restricted network access that can be easily restored.
               </Text>
               <Text className="font-medium">
                 By proceeding, you accept all responsibility for actions taken
-                while bypass is enabled.
+                in sessions you run with bypass.
               </Text>
             </Flex>
           </AlertDialog.Description>
           <Flex gap="3" mt="4" justify="end">
             <AlertDialog.Cancel>
               <Button variant="soft" color="gray">
-                No, exit
+                Cancel
               </Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action>
@@ -237,7 +243,7 @@ export function ClaudeCodeSettings() {
                 color="red"
                 onClick={handleConfirmBypassPermissions}
               >
-                Yes, I accept
+                Allow bypass mode
               </Button>
             </AlertDialog.Action>
           </Flex>

--- a/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
@@ -226,7 +226,7 @@ export function HarnessSettings() {
 
       <SettingRow
         label="Allow bypass permissions mode"
-        description="Adds bypass permissions to the mode menu so you can pick it for a single task. Tasks keep asking for approval until you choose it. A task in that mode runs bash commands, file edits and web requests without asking. This also unlocks Full access in Codex"
+        description="Adds bypass permissions to the mode menu so you can pick it per session. Sessions keep asking for approval until you pick it. This also unlocks Full access in Codex"
         noBorder
       >
         <Switch

--- a/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
@@ -69,7 +69,7 @@ function SettingDescription({
   );
 }
 
-export function ClaudeCodeSettings() {
+export function HarnessSettings() {
   const { allowBypassPermissions, setAllowBypassPermissions } =
     useSettingsStore();
 
@@ -104,8 +104,8 @@ export function ClaudeCodeSettings() {
 
   return (
     <Flex direction="column">
-      {/* Extensions */}
-      <Text className="mt-1 mb-2 font-medium text-sm">Extensions</Text>
+      {/* Claude Code */}
+      <Text className="mt-1 mb-2 font-medium text-sm">Claude Code</Text>
 
       <SettingRow
         label="MCP servers"
@@ -156,14 +156,68 @@ export function ClaudeCodeSettings() {
         <CopyableCommand command="claude /hooks" />
       </SettingRow>
 
+      {/* Codex */}
+      <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
+        Codex
+      </Text>
+
+      <SettingRow
+        label="MCP servers"
+        description={
+          <SettingDescription
+            text="Extend Codex's capabilities with MCP servers"
+            docsUrl="https://learn.chatgpt.com/docs/extend/mcp"
+          />
+        }
+      >
+        <CopyableCommand command="codex mcp" />
+      </SettingRow>
+
+      <SettingRow
+        label="Skills"
+        description={
+          <SettingDescription
+            text="Reusable instructions in .agents/skills/, mentioned with $skill-name"
+            docsUrl="https://learn.chatgpt.com/docs/build-skills"
+          />
+        }
+      >
+        <span />
+      </SettingRow>
+
+      <SettingRow
+        label="Memory"
+        description={
+          <SettingDescription
+            text="Persistent context stored in AGENTS.md files"
+            docsUrl="https://learn.chatgpt.com/docs/agent-configuration/agents-md"
+          />
+        }
+      >
+        <span />
+      </SettingRow>
+
+      <SettingRow
+        label="Hooks"
+        description={
+          <SettingDescription
+            text="Execute commands at specific points in Codex's lifecycle. In beta, turn on codex_hooks in config.toml to use them"
+            docsUrl="https://learn.chatgpt.com/docs/configuration"
+          />
+        }
+        noBorder
+      >
+        <span />
+      </SettingRow>
+
       {/* Permissions */}
       <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
         Permissions
       </Text>
 
       <SettingRow
-        label="Permission rules"
-        description="Tool permissions from your Claude settings. Allowed tools run without prompting. Denied tools are always blocked"
+        label="Claude permission rules"
+        description="Tool permissions from your Claude settings. Allowed tools run without prompting. Denied tools are always blocked. Codex keeps its own rules in config.toml"
       >
         <CopyableCommand command="claude config" />
       </SettingRow>
@@ -188,10 +242,10 @@ export function ClaudeCodeSettings() {
             <Warning weight="fill" />
           </Callout.Icon>
           <Callout.Text>
-            Bypass permissions is now available in the mode menu in the prompt
-            input. Pick it per session when you want that session to run shell
-            commands, file edits and web requests without approval. Other
-            sessions are unaffected.
+            Bypass permissions, and Full access in Codex, are now available in
+            the mode menu in the prompt input. Pick one per session when you
+            want that session to run shell commands, file edits and web requests
+            without approval. Other sessions are unaffected.
           </Callout.Text>
         </Callout.Root>
       )}

--- a/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
@@ -201,13 +201,13 @@ export function HarnessSettings() {
         label="Hooks"
         description={
           <SettingDescription
-            text="Execute commands at specific points in Codex's lifecycle, defined in .codex/hooks.json or config.toml"
+            text="Execute commands at specific points in Codex's lifecycle, defined in .codex/hooks.json or config.toml. Review them with /hooks inside a session"
             docsUrl="https://learn.chatgpt.com/docs/hooks"
           />
         }
         noBorder
       >
-        <CopyableCommand command="/hooks" />
+        <span />
       </SettingRow>
 
       {/* Permissions */}

--- a/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/HarnessSettings.tsx
@@ -201,13 +201,13 @@ export function HarnessSettings() {
         label="Hooks"
         description={
           <SettingDescription
-            text="Execute commands at specific points in Codex's lifecycle. In beta, turn on codex_hooks in config.toml to use them"
-            docsUrl="https://learn.chatgpt.com/docs/configuration"
+            text="Execute commands at specific points in Codex's lifecycle, defined in .codex/hooks.json or config.toml"
+            docsUrl="https://learn.chatgpt.com/docs/hooks"
           />
         }
         noBorder
       >
-        <span />
+        <CopyableCommand command="/hooks" />
       </SettingRow>
 
       {/* Permissions */}

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.test.ts
@@ -32,7 +32,7 @@ describe("getHiddenSettingsCategories", () => {
         "workspaces",
         "worktrees",
         "terminal",
-        "claude-code",
+        "harness",
         "discord",
         "updates",
       ],

--- a/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsVisibility.ts
@@ -7,7 +7,7 @@ const LOCAL_ONLY_CATEGORIES: ReadonlySet<SettingsCategory> = new Set([
   "workspaces",
   "worktrees",
   "terminal",
-  "claude-code",
+  "harness",
   "discord",
   "updates",
 ]);

--- a/products/desktop/packages/ui/src/features/settings/types.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/types.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { isSettingsCategory } from "./types";
+import { isSettingsCategory, resolveSettingsCategory } from "./types";
 
 describe("isSettingsCategory", () => {
   it("recognizes sidebar experience settings", () => {
     expect(isSettingsCategory("sidebar")).toBe(true);
+  });
+});
+
+describe("resolveSettingsCategory", () => {
+  it.each([
+    ["sidebar", "sidebar"],
+    // Startup restores the last URL, so dropping this mapping would silently
+    // land anyone parked on the old Claude Code page in General.
+    ["claude-code", "harness"],
+    ["not-a-category", null],
+  ])("resolves %s to %s", (value, expected) => {
+    expect(resolveSettingsCategory(value)).toBe(expected);
   });
 });

--- a/products/desktop/packages/ui/src/features/settings/types.ts
+++ b/products/desktop/packages/ui/src/features/settings/types.ts
@@ -12,7 +12,7 @@ export type SettingsCategory =
   | "personalization"
   | "sidebar"
   | "terminal"
-  | "claude-code"
+  | "harness"
   | "shortcuts"
   | "github"
   | "slack"
@@ -35,7 +35,7 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategory[] = [
   "personalization",
   "sidebar",
   "terminal",
-  "claude-code",
+  "harness",
   "shortcuts",
   "github",
   "slack",

--- a/products/desktop/packages/ui/src/features/settings/types.ts
+++ b/products/desktop/packages/ui/src/features/settings/types.ts
@@ -48,3 +48,17 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategory[] = [
 export function isSettingsCategory(value: string): value is SettingsCategory {
   return (SETTINGS_CATEGORIES as readonly string[]).includes(value);
 }
+
+// The app restores the last location on startup, so a renamed category has to
+// keep resolving for anyone whose remembered URL still names the old one.
+const RENAMED_SETTINGS_CATEGORIES: Readonly<Record<string, SettingsCategory>> =
+  {
+    "claude-code": "harness",
+  };
+
+export function resolveSettingsCategory(
+  value: string,
+): SettingsCategory | null {
+  if (isSettingsCategory(value)) return value;
+  return RENAMED_SETTINGS_CATEGORIES[value] ?? null;
+}

--- a/products/desktop/packages/ui/src/router/routes/settings/$category.tsx
+++ b/products/desktop/packages/ui/src/router/routes/settings/$category.tsx
@@ -1,6 +1,6 @@
 import { SettingsPanel } from "@posthog/ui/features/settings/components/SettingsPanel";
 import { useSettingsPageStore } from "@posthog/ui/features/settings/stores/settingsPageStore";
-import { isSettingsCategory } from "@posthog/ui/features/settings/types";
+import { resolveSettingsCategory } from "@posthog/ui/features/settings/types";
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect } from "react";
 
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/settings/$category")({
 
 function SettingsRoute() {
   const { category } = Route.useParams();
-  const cat = isSettingsCategory(category) ? category : "general";
+  const cat = resolveSettingsCategory(category) ?? "general";
 
   // Reset transient state when leaving the route entirely. Switching between
   // categories (e.g. general → environments) does not unmount this component,


### PR DESCRIPTION
## Problem

The bypass permissions setting sounded like it turned off approval prompts for everything, forever. It doesn't — it just adds bypass mode to the mode menu, and you pick it per session. The old copy and the red dialog put people off a setting that's actually opt-in each time.

Also, the page is called "Claude Code" but the bypass toggle also unlocks Full access in Codex, and Codex has its own version of every extension the page documents.

## Changes

Copy, naming and layout only — no behavior change.

- Bypass row is now "Allow bypass permissions mode", and the copy leads with what the toggle does (adds the mode to the menu) before what the mode does. Dialog buttons are "Cancel" / "Allow bypass mode". Also mentions it unlocks Full access in Codex, which the UI never said anywhere.
- Renamed the page from "Claude Code" to "Harness" and split the extension rows into Claude Code and Codex groups. Old URLs still resolve.
- The permission rules row is now "Claude permission rules", since that list comes from Claude's settings. Codex keeps its own in config.toml.

## How did you test this code?

Manually, see this vid.

https://screen.studio/share/IOWfH3PY

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude through the PostHog Slack app, from a thread where someone said the wording made bypass sound like a new global default rather than a per-task choice.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785759093263259?thread_ts=1785759093.263259&cid=C09G8Q32R6F)*
