### PR TITLE
feat(warehouse_sources): promote Vercel source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
@@ -48,7 +48,7 @@ class VercelSource(ResumableSource[VercelSourceConfig, VercelResumeConfig]):
             name=SchemaExternalDataSourceType.VERCEL,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="Vercel",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             caption="""Enter a Vercel access token to pull your Vercel deployments, projects, teams, domains, aliases, and billing usage into the PostHog Data warehouse.
 
 Create an access token in your [Vercel account settings](https://vercel.com/account/tokens). A read-only token is sufficient.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
@@ -52,7 +52,7 @@ class TestVercelSource:
         config = self.source.get_source_config
         assert config.label == "Vercel"
         assert config.category == DataWarehouseSourceCategory.ENGINEERING___MONITORING
-        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.releaseStatus == ReleaseStatus.BETA
 
     def test_source_config_fields(self) -> None:
         fields = {f.name: cast(SourceFieldInputConfig, f) for f in self.source.get_source_config.fields}


### PR DESCRIPTION
## Problem

The Vercel data-warehouse source has been running as `alpha` since launch. It has now cleared our promotion bar over the last 7 days, so it should carry the `beta` label instead.

## Changes

Promote the Vercel source's `releaseStatus` from `ReleaseStatus.ALPHA` to `ReleaseStatus.BETA` (surfaced by the `/api/public_source_configs/` endpoint). No behavior, schema, or sync-logic changes — this is a status-label promotion only.

The source has no `unreleasedSource` flag or `featureFlag` gate, so nothing else changed alongside the stage.

Promotion metrics (7-day window):
- Used by 32 teams (bar: ≥ 30).
- Import error rate 0.2% (bar: < 5.0%).

## How did you test this code?

Ran the Vercel source metadata test, which now asserts `beta`:
`products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py::TestVercelSource::test_source_config_metadata` — passes. `ruff check` clean on the touched files.

## Docs update

No user-facing doc changes needed for a release-status label bump.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Invoked the `/implementing-warehouse-sources` skill to confirm release-status conventions (use the `ReleaseStatus` enum, `beta` is a soft label on a visible source, no gating to remove here). The change is limited to the `releaseStatus` field and its matching test assertion. Checked open PRs (including the maintainer's own) for an existing Vercel promotion before opening this one — none found.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
