### PR TITLE
feat(tasks): add orchestrated task spawn endpoint

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1936,6 +1936,18 @@ def spawned_task_run_rate_capped(team_id: int) -> bool:
     )
 
 
+def get_task_run_imported_mcp_servers(run_id: str | UUID, team_id: int) -> list[dict] | None:
+    return TaskRun.objects.only("imported_mcp_servers").get(id=run_id, team_id=team_id).imported_mcp_servers
+
+
+def copy_task_run_skill_bundle_artifacts(source_run_id: str | UUID, target_run_id: str | UUID, team_id: int) -> None:
+    from products.tasks.backend.logic.services.loop_runs import copy_task_run_skill_bundle_artifacts as copy_bundles
+
+    source_run = TaskRun.objects.get(id=source_run_id, team_id=team_id)
+    target_run = TaskRun.objects.get(id=target_run_id, team_id=team_id)
+    copy_bundles(source_run, target_run)
+
+
 # `output.pr_merged` is GitHub's word, recorded by the PR webhook (`_record_run_pr_merged`) — never
 # the caller's. Signals reads it to decide refund finality (billing.report_pr_is_merged): a report
 # whose PR merged keeps its resolved status through a refund instead of being suppressed and having

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4125,6 +4125,12 @@ def compute_repository_readiness(team_id: int, *, repository: str, window_days: 
     return _compute(team=team, repository=repository, window_days=window_days, refresh=refresh)
 
 
+def tasks_orchestration_enabled(*, distinct_id: str, organization_id: str) -> bool:
+    from products.tasks.backend.feature_flags import is_tasks_orchestration_enabled
+
+    return is_tasks_orchestration_enabled(distinct_id=distinct_id, organization_id=organization_id)
+
+
 def create_task(
     team_id: int,
     user_id: int | None,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1901,6 +1901,9 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
         "loop_trigger_id",
         "trigger_context",
         "config_snapshot",
+        "parent_task_id",
+        "parent_run_id",
+        "wake_on",
         # Stamped once at run creation. The review carve-outs read ai_stage="implementation" as proof
         # a run is self-driving, so a PATCHable value would forge that and unlock the bot/draft bypass.
         "ai_stage",
@@ -1922,6 +1925,16 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
 )
 
 _TERMINAL_TASK_RUN_STATUSES = (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED)
+SPAWNED_TASK_RUN_TEAM_RATE_CAP_PER_DAY = 500
+
+
+def spawned_task_run_rate_capped(team_id: int) -> bool:
+    since = django_timezone.now() - timedelta(hours=24)
+    return (
+        TaskRun.objects.filter(team_id=team_id, state__has_key="parent_task_id", created_at__gte=since).count()
+        >= SPAWNED_TASK_RUN_TEAM_RATE_CAP_PER_DAY
+    )
+
 
 # `output.pr_merged` is GitHub's word, recorded by the PR webhook (`_record_run_pr_merged`) — never
 # the caller's. Signals reads it to decide refund finality (billing.report_pr_is_merged): a report
@@ -3365,7 +3378,12 @@ def _github_credential_source_extra_state(pr_authorship_mode, github_user_token:
 
 
 def bootstrap_task_run(
-    task_id: str | UUID, team_id: int, user_id: int | None, *, validated_data: dict
+    task_id: str | UUID,
+    team_id: int,
+    user_id: int | None,
+    *,
+    validated_data: dict,
+    trusted_extra_state: dict | None = None,
 ) -> contracts.TaskRunCreateResult | None:
     """Create a task run (without starting execution) from validated bootstrap data.
 
@@ -3408,6 +3426,8 @@ def bootstrap_task_run(
     extra_state: dict | None = None
     if initial_permission_mode is not None:
         extra_state = {"initial_permission_mode": initial_permission_mode}
+    if trusted_extra_state:
+        extra_state = {**(extra_state or {}), **trusted_extra_state}
 
     provider = get_provider_for_runtime_adapter(runtime_adapter)
     for key, value in {
@@ -4111,6 +4131,7 @@ def create_task(
     *,
     validated_data: dict,
     client_provenance: TaskClientProvenance | None = None,
+    creation_event_properties: dict | None = None,
 ) -> contracts.TaskDetailDTO:
     """Create a task, mirroring ``TaskSerializer.create`` byte-for-byte.
 
@@ -4295,7 +4316,9 @@ def create_task(
 
     logger.info("Creating task with data: %s", validated_data)
     with transaction.atomic():
-        task = Task.objects.create(**validated_data)
+        task = Task(**validated_data)
+        task._creation_event_properties = creation_event_properties or {}
+        task.save()
         if task.signal_report_id and task.origin_product == Task.OriginProduct.SIGNAL_REPORT:
             # Record the task↔report association + work-log artefact for the asserted relationship
             # (defaults to implementation, which also writes the auto-start spend gate row) so a

--- a/products/tasks/backend/feature_flags.py
+++ b/products/tasks/backend/feature_flags.py
@@ -87,6 +87,9 @@ def is_agent_otel_telemetry_enabled(*, distinct_id: str, organization_id: str) -
 
 
 def is_tasks_orchestration_enabled(*, distinct_id: str, organization_id: str) -> bool:
+    if settings.DEBUG:
+        return True
+
     try:
         return bool(
             posthoganalytics.feature_enabled(

--- a/products/tasks/backend/feature_flags.py
+++ b/products/tasks/backend/feature_flags.py
@@ -18,6 +18,7 @@ NATIVE_STEERING_SIGNALS_FEATURE_FLAG = "tasks-native-steering-signals"
 NATIVE_STEERING_SIGNALS_DISTINCT_ID = "tasks-native-steering-signals"
 
 DEV_STACK_IMAGE_BAKE_DISTINCT_ID = "tasks-dev-stack-image-bake"
+TASKS_ORCHESTRATION_FEATURE_FLAG = "tasks-orchestration"
 
 
 def is_dev_stack_image_bake_enabled() -> bool:
@@ -82,6 +83,23 @@ def is_agent_otel_telemetry_enabled(*, distinct_id: str, organization_id: str) -
         )
     except Exception:
         logger.exception("agent_otel_telemetry_flag_check_failed")
+        return False
+
+
+def is_tasks_orchestration_enabled(*, distinct_id: str, organization_id: str) -> bool:
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                TASKS_ORCHESTRATION_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception("tasks_orchestration_feature_flag_check_failed")
         return False
 
 

--- a/products/tasks/backend/logic/services/loop_runs.py
+++ b/products/tasks/backend/logic/services/loop_runs.py
@@ -621,18 +621,34 @@ def _seed_skill_bundle_artifacts(task_run: TaskRun) -> None:
     if not bundles:
         return
 
-    from posthog.storage import object_storage  # noqa: PLC0415 — keep storage deps off the fire path import
-
-    from products.tasks.backend.logic.services.staged_artifacts import get_safe_artifact_name  # noqa: PLC0415
-
-    # `state` is a client-PATCHable surface (the seeds key is server-protected, but this
-    # copy primitive must not trust it anyway): every source path has to sit under the
-    # owning loop's own bundle prefix, and the target segments are re-sanitized, or a
-    # forged entry would read or write arbitrary bucket keys via the recovery path.
     loop_id = task_run.task.loop_id
     if loop_id is None:
         raise ValueError("skill bundle seeds on a run without a loop")
     loop_prefix = f"{Loop.skill_bundle_s3_prefix_for(task_run.team_id, loop_id)}/"
+
+    _copy_skill_bundle_artifacts(task_run, bundles, source_prefix=loop_prefix)
+
+
+def copy_task_run_skill_bundle_artifacts(source_run: TaskRun, target_run: TaskRun) -> None:
+    bundles = [
+        entry
+        for entry in (source_run.artifacts or [])
+        if isinstance(entry, dict) and entry.get("type") == "skill_bundle" and entry.get("storage_path")
+    ]
+    _copy_skill_bundle_artifacts(
+        target_run,
+        bundles,
+        source_prefix=f"{source_run.get_artifact_s3_prefix()}/",
+    )
+
+
+def _copy_skill_bundle_artifacts(task_run: TaskRun, bundles: list[dict], *, source_prefix: str) -> None:
+    if not bundles:
+        return
+
+    from posthog.storage import object_storage  # noqa: PLC0415 — keep storage deps off the fire path import
+
+    from products.tasks.backend.logic.services.staged_artifacts import get_safe_artifact_name  # noqa: PLC0415
 
     run_prefix = task_run.get_artifact_s3_prefix()
     manifest = list(task_run.artifacts or [])
@@ -641,8 +657,8 @@ def _seed_skill_bundle_artifacts(task_run: TaskRun) -> None:
         for bundle in bundles:
             entry = dict(bundle)
             source_path = str(entry["storage_path"])
-            if not source_path.startswith(loop_prefix):
-                raise ValueError("skill bundle seed escapes the loop's storage prefix")
+            if not source_path.startswith(source_prefix):
+                raise ValueError("skill bundle source escapes the owning run's storage prefix")
             entry_id = str(entry["id"])
             if not re.fullmatch(r"[0-9a-f]{8,64}", entry_id):
                 raise ValueError("skill bundle seed has a malformed id")

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -381,7 +381,7 @@ class Task(DeletedMetaFields, models.Model):
     def _track_task_created(self) -> None:
         self.capture_event(
             "task_created",
-            {"has_json_schema": self.json_schema is not None},
+            {"has_json_schema": self.json_schema is not None, **getattr(self, "_creation_event_properties", {})},
         )
 
     @staticmethod

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -149,6 +149,7 @@ class TaskClientProvenance(models.TextChoices):
 
 class Task(DeletedMetaFields, models.Model):
     _creation_event_properties: dict[str, Any]
+
     class Runtime(models.TextChoices):
         ACP = "acp", "ACP"
         PI = "pi", "Pi"

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -148,6 +148,7 @@ class TaskClientProvenance(models.TextChoices):
 
 
 class Task(DeletedMetaFields, models.Model):
+    _creation_event_properties: dict[str, Any]
     class Runtime(models.TextChoices):
         ACP = "acp", "ACP"
         PI = "pi", "Pi"

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -756,7 +756,10 @@ class TaskCreateSerializer(TaskWriteSerializer):
 
 
 class TaskSpawnRequestSerializer(serializers.Serializer):
-    parent_run_id = serializers.UUIDField(help_text="Cloud run that is spawning this child task.")
+    parent_run_id = serializers.UUIDField(
+        required=False,
+        help_text="Cloud run that is spawning this child task. Defaults to the calling task-run context.",
+    )
     title = serializers.CharField(max_length=255, help_text="Title for the child task.")
     description = serializers.CharField(help_text="Prompt passed verbatim to the child task.")
     repository = serializers.CharField(

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -772,6 +772,8 @@ class TaskSpawnRequestSerializer(serializers.Serializer):
     reasoning_effort = serializers.ChoiceField(
         choices=[effort.value for effort in PUBLIC_REASONING_EFFORTS], required=False, default=None
     )
+    sandbox_environment_id = serializers.UUIDField(required=False, allow_null=True)
+    custom_image_id = serializers.UUIDField(required=False, allow_null=True)
     wake_on = serializers.ListField(child=serializers.ChoiceField(choices=["pr_merged"]), required=False, default=list)
 
     def validate_repository(self, value: str | None) -> str | None:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -755,6 +755,59 @@ class TaskCreateSerializer(TaskWriteSerializer):
     )
 
 
+class TaskSpawnRequestSerializer(serializers.Serializer):
+    parent_run_id = serializers.UUIDField(help_text="Cloud run that is spawning this child task.")
+    title = serializers.CharField(max_length=255, help_text="Title for the child task.")
+    description = serializers.CharField(help_text="Prompt passed verbatim to the child task.")
+    repository = serializers.CharField(
+        max_length=255,
+        required=False,
+        allow_null=True,
+        help_text="Optional target repository in organization/repository format.",
+    )
+    runtime_adapter = serializers.ChoiceField(
+        choices=[adapter.value for adapter in RuntimeAdapter], required=False, default=None
+    )
+    model = serializers.CharField(required=False, default=None, allow_blank=False)
+    reasoning_effort = serializers.ChoiceField(
+        choices=[effort.value for effort in PUBLIC_REASONING_EFFORTS], required=False, default=None
+    )
+    wake_on = serializers.ListField(child=serializers.ChoiceField(choices=["pr_merged"]), required=False, default=list)
+
+    def validate_repository(self, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        parts = normalized.split("/")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise serializers.ValidationError("Repository must be in the format organization/repository")
+        return normalized
+
+    def validate_wake_on(self, value: list[str]) -> list[str]:
+        if len(set(value)) != len(value):
+            raise serializers.ValidationError("Values must be unique")
+        return value
+
+    def validate(self, attrs: dict) -> dict:
+        runtime_fields = ("runtime_adapter", "model")
+        if any(attrs.get(field) is not None for field in (*runtime_fields, "reasoning_effort")):
+            errors = {
+                field: "This field is required when selecting a cloud runtime."
+                for field in runtime_fields
+                if attrs.get(field) is None
+            }
+            reasoning_error = get_reasoning_effort_error(
+                runtime_adapter=attrs.get("runtime_adapter"),
+                model=attrs.get("model"),
+                reasoning_effort=attrs.get("reasoning_effort"),
+            )
+            if reasoning_error is not None:
+                errors["reasoning_effort"] = reasoning_error
+            if errors:
+                raise serializers.ValidationError(errors)
+        return attrs
+
+
 class TaskRunSetOutputRequestSerializer(serializers.Serializer):
     output = serializers.JSONField(
         help_text="Output data from the run. Validated against the task's json_schema if one is set."

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -134,6 +134,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskSerializer,
     TaskSessionResponseSerializer,
     TaskSessionSyncResponseSerializer,
+    TaskSpawnRequestSerializer,
     TaskStagedArtifactsFinalizeUploadRequestSerializer,
     TaskStagedArtifactsFinalizeUploadResponseSerializer,
     TaskStagedArtifactsPrepareUploadRequestSerializer,
@@ -352,6 +353,91 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         )
         self._forward_signals_discussion_note(request, task, relationship)
         return Response(TaskSerializer(task).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        request=TaskSpawnRequestSerializer,
+        responses={201: TaskSerializer, 400: TaskRunErrorResponseSerializer, 403: TaskRunErrorResponseSerializer},
+        operation_id="tasks_spawn_create",
+        summary="Spawn a child task",
+    )
+    @action(detail=False, methods=["post"], url_path="spawn", required_scopes=["task:write"])
+    def spawn(self, request, **kwargs):
+        from products.tasks.backend.feature_flags import is_tasks_orchestration_enabled
+
+        serializer = TaskSpawnRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = dict(serializer.validated_data)
+
+        if not is_tasks_orchestration_enabled(
+            distinct_id=str(request.user.distinct_id), organization_id=str(self.organization.id)
+        ):
+            return Response({"detail": "Task orchestration is not enabled"}, status=status.HTTP_403_FORBIDDEN)
+
+        parent_run = tasks_facade.get_task_run(data.pop("parent_run_id"), self.team_id)
+        if parent_run is None:
+            raise NotFound("Parent run not found")
+        if parent_run.is_terminal:
+            raise ValidationError({"parent_run_id": "Parent run must be active"})
+        if parent_run.state.get("parent_task_id") is not None:
+            raise ValidationError({"parent_run_id": "Child runs cannot spawn tasks"})
+
+        parent_task = tasks_facade.get_task_detail(parent_run.task_id, self.team_id, self._user_id())
+        if parent_task is None:
+            raise NotFound("Parent task not found")
+
+        if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+            return limit_response
+        if tasks_facade.spawned_task_run_rate_capped(self.team_id):
+            return Response({"detail": "Team task run rate limit exceeded"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
+
+        wake_on = data.pop("wake_on")
+        run_data = {
+            "environment": tasks_facade.TaskRunEnvironment.CLOUD,
+            "mode": "background",
+            "runtime_adapter": data.pop("runtime_adapter"),
+            "model": data.pop("model"),
+            "reasoning_effort": data.pop("reasoning_effort"),
+        }
+        task_data = data
+        if parent_task.channel is not None:
+            task_data["channel"] = tasks_facade.channel_queryset().filter(id=parent_task.channel).first()
+
+        child_task = tasks_facade.create_task(
+            self.team_id,
+            self._user_id(),
+            validated_data=task_data,
+            creation_event_properties={"is_spawned": True, "parent_task_id": str(parent_run.task_id)},
+        )
+        try:
+            result = tasks_facade.bootstrap_task_run(
+                child_task.id,
+                self.team_id,
+                self._user_id(),
+                validated_data=run_data,
+                trusted_extra_state={
+                    "parent_task_id": str(parent_run.task_id),
+                    "parent_run_id": str(parent_run.id),
+                    "wake_on": wake_on,
+                },
+            )
+            if result is None or result.error is not None or result.run is None:
+                detail = result.error.detail if result and result.error else "Could not create child run"
+                raise ValidationError(detail)
+            outcome, _ = tasks_facade.start_task_run(
+                result.run.id,
+                child_task.id,
+                self.team_id,
+                self._user_id(),
+                validated_data={"pending_user_message": child_task.description},
+            )
+            if outcome != "started":
+                raise ValidationError(outcome)
+        except Exception:
+            tasks_facade.soft_delete_task(child_task.id, self.team_id, self._user_id())
+            raise
+
+        created = tasks_facade.get_task_detail(child_task.id, self.team_id, self._user_id())
+        return Response(TaskSerializer(created).data, status=status.HTTP_201_CREATED)
 
     def _forward_signals_discussion_note(
         self, request, task: tasks_contracts.TaskDetailDTO, relationship: str | None

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -389,12 +389,18 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return Response({"detail": "Team task run rate limit exceeded"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
         wake_on = data.pop("wake_on")
+        parent_state = parent_run.state or {}
+        sandbox_environment_id = data.pop("sandbox_environment_id", parent_state.get("sandbox_environment_id"))
+        custom_image_id = data.pop("custom_image_id", parent_state.get("custom_image_id"))
         run_data = {
             "environment": tasks_facade.TaskRunEnvironment.CLOUD,
             "mode": "background",
             "runtime_adapter": data.pop("runtime_adapter"),
             "model": data.pop("model"),
             "reasoning_effort": data.pop("reasoning_effort"),
+            "sandbox_environment_id": sandbox_environment_id,
+            "custom_image_id": custom_image_id,
+            "imported_mcp_servers": tasks_facade.get_task_run_imported_mcp_servers(parent_run.id, self.team_id),
         }
         task_data = data
         if parent_task.channel is not None:
@@ -421,6 +427,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             if result is None or result.error is not None or result.run is None:
                 detail = result.error.detail if result and result.error else "Could not create child run"
                 raise ValidationError(detail)
+            tasks_facade.copy_task_run_skill_bundle_artifacts(parent_run.id, result.run.id, self.team_id)
             outcome, _ = tasks_facade.start_task_run(
                 result.run.id,
                 child_task.id,

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -366,12 +366,21 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         data = dict(serializer.validated_data)
 
+        parent_run_id = data.pop("parent_run_id", None)
+        if header_parent_run_id := request.headers.get("X-PostHog-Task-Run-Id"):
+            try:
+                parent_run_id = UUID(header_parent_run_id)
+            except ValueError:
+                raise ValidationError({"parent_run_id": "Must be a valid UUID"})
+        if parent_run_id is None:
+            raise ValidationError({"parent_run_id": "spawn requires a calling task-run context"})
+
         if not tasks_facade.tasks_orchestration_enabled(
             distinct_id=str(request.user.distinct_id), organization_id=str(self.organization.id)
         ):
             return Response({"detail": "Task orchestration is not enabled"}, status=status.HTTP_403_FORBIDDEN)
 
-        parent_run = tasks_facade.get_task_run(data.pop("parent_run_id"), self.team_id)
+        parent_run = tasks_facade.get_task_run(parent_run_id, self.team_id)
         if parent_run is None:
             raise NotFound("Parent run not found")
         if parent_run.is_terminal:

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -362,13 +362,11 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     @action(detail=False, methods=["post"], url_path="spawn", required_scopes=["task:write"])
     def spawn(self, request, **kwargs):
-        from products.tasks.backend.feature_flags import is_tasks_orchestration_enabled
-
         serializer = TaskSpawnRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = dict(serializer.validated_data)
 
-        if not is_tasks_orchestration_enabled(
+        if not tasks_facade.tasks_orchestration_enabled(
             distinct_id=str(request.user.distinct_id), organization_id=str(self.organization.id)
         ):
             return Response({"detail": "Task orchestration is not enabled"}, status=status.HTTP_403_FORBIDDEN)

--- a/products/tasks/backend/temporal/execute_sandbox/tests/test_execute_sandbox_workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/tests/test_execute_sandbox_workflow.py
@@ -124,6 +124,7 @@ class TestShouldForwardPendingUserMessage:
             ({"mode": "interactive", "pending_user_message": "hi"}, False),
             # Background mode is the normal "queue and forward" path.
             ({"mode": "background", "pending_user_message": "hi"}, True),
+            ({"mode": "background", "pending_user_message": "hi", "parent_run_id": "parent"}, False),
             # Resume runs already replay the original prompt — forwarding would
             # double up. Both resume markers must short-circuit.
             ({"mode": "background", "resume_from_run_id": "prev"}, False),

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -1248,7 +1248,8 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
             return False
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))
-        return self.context.mode != "interactive" and not is_resume
+        is_spawned_child = bool(state.get("parent_run_id"))
+        return self.context.mode != "interactive" and not is_resume and not is_spawned_child
 
     async def _track_workflow_event(self, event_name: str, properties: dict, capture_analytics: bool = True) -> None:
         await workflow.execute_activity(

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -376,6 +376,7 @@ def _refresh_sandbox_mcp(
         scopes=scopes,
         interaction_origin=(state or {}).get("interaction_origin"),
         task_id=str(task_run.task_id),
+        task_run_id=str(task_run.id),
     )
     user_mcp_configs = get_user_mcp_server_configs(
         token=access_token,

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -244,6 +244,7 @@ def _prepare_launch(ctx: TaskProcessingContext, scopes: PosthogMcpScopes, sandbo
         scopes=scopes,
         interaction_origin=ctx.interaction_origin,
         task_id=str(ctx.task_id),
+        task_run_id=str(ctx.run_id),
     )
     include_personal = _include_personal_mcp_for_task(task)
     user_mcp_configs = get_user_mcp_server_configs(

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase, TestCase, override_settings
@@ -126,9 +128,14 @@ class TestRunStateSnapshotPaths(TestCase):
                 {},
             ),
             ("no_snapshot", {}, {}),
+            (
+                "orchestration_without_snapshot",
+                {"parent_task_id": "task-1", "parent_run_id": "run-1", "wake_on": ["pr_merged"]},
+                {"parent_task_id": "task-1", "parent_run_id": "run-1", "wake_on": ["pr_merged"]},
+            ),
         ]
     )
-    def test_resume_snapshot_carry_state(self, _name: str, state: dict[str, str], expected: dict[str, str]) -> None:
+    def test_resume_snapshot_carry_state(self, _name: str, state: dict[str, Any], expected: dict[str, Any]) -> None:
         assert RunState.model_validate(state).resume_snapshot_carry_state() == expected
 
 

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -279,6 +279,16 @@ class TestGetSandboxMcpConfigs(TestCase):
                 {"name": "X-PostHog-Task-Id", "value": "task-uuid-123"},
             ]
 
+    def test_task_run_id_adds_context_header(self) -> None:
+        with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:
+            mock_settings.SANDBOX_MCP_URL = None
+            mock_settings.SITE_URL = "https://app.posthog.com"
+            configs = get_sandbox_ph_mcp_configs(self.TOKEN, self.PROJECT_ID, task_run_id="run-uuid-123")
+            assert configs[0].headers == [
+                *self._expected_headers(),
+                {"name": "X-PostHog-Task-Run-Id", "value": "run-uuid-123"},
+            ]
+
     def test_no_task_id_omits_attribution_header(self) -> None:
         with patch("products.tasks.backend.temporal.process_task.utils.settings") as mock_settings:
             mock_settings.SANDBOX_MCP_URL = None

--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -842,6 +842,14 @@ class TestProcessTaskWorkflowUnit:
                 {
                     "mode": "background",
                     "pending_user_message": "this is nice",
+                    "parent_run_id": "parent-run-id",
+                },
+                False,
+            ),
+            (
+                {
+                    "mode": "background",
+                    "pending_user_message": "this is nice",
                     "resume_from_run_id": "previous-run-id",
                 },
                 False,
@@ -856,6 +864,20 @@ class TestProcessTaskWorkflowUnit:
         )
 
         assert workflow._should_forward_pending_user_message() is expected
+
+    def test_spawned_child_initial_prompt_has_one_delivery_owner(self):
+        workflow = ProcessTaskWorkflow()
+        workflow._context = _build_context(
+            github_integration_id=123,
+            state={
+                "mode": "background",
+                "pending_user_message": "Make the focused change",
+                "parent_run_id": "parent-run-id",
+            },
+        )
+
+        assert workflow.context.state["pending_user_message"] == "Make the focused change"
+        assert workflow._should_forward_pending_user_message() is False
 
     @pytest.mark.parametrize(
         "payload, expected_prewarmed",

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -704,12 +704,13 @@ def get_sandbox_ph_mcp_configs(
     scopes: PosthogMcpScopes = "read_only",
     interaction_origin: str | None = None,
     task_id: str | None = None,
+    task_run_id: str | None = None,
 ) -> list[McpServerConfig]:
     """Return PostHog MCP server configurations for sandbox agents.
 
-    `task_id` is baked into an `X-PostHog-Task-Id` header so the MCP server (and through it the
-    PostHog API) can deterministically attribute the agent's writes to its task — the LLM never
-    handles its own task id.
+    `task_id` and `task_run_id` are baked into headers so the MCP server (and through it the PostHog
+    API) can deterministically attribute the agent's writes and run context — the LLM never handles
+    its own task or task-run id.
 
     Uses SANDBOX_MCP_URL if explicitly set, otherwise derives it from SITE_URL:
     - app.posthog.com / us.posthog.com → https://mcp.posthog.com/mcp
@@ -730,6 +731,8 @@ def get_sandbox_ph_mcp_configs(
     ]
     if task_id:
         headers.append({"name": "X-PostHog-Task-Id", "value": str(task_id)})
+    if task_run_id:
+        headers.append({"name": "X-PostHog-Task-Run-Id", "value": str(task_run_id)})
     return [McpServerConfig(type="http", name="posthog", url=url, headers=headers)]
 
 

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -311,6 +311,9 @@ def is_resume_snapshot_usable(kind: SnapshotKind, mount_path: str | None) -> boo
 
 
 class RunState(BaseModel, extra="allow"):
+    parent_task_id: str | None = None
+    parent_run_id: str | None = None
+    wake_on: list[str] | None = None
     pr_authorship_mode: PrAuthorshipMode | None = None
     auto_publish: bool | None = None
     github_credential_source: GitHubCredentialSource | None = None
@@ -357,12 +360,19 @@ class RunState(BaseModel, extra="allow"):
     def resume_snapshot_carry_state(self) -> dict[str, Any]:
         """State keys a successor run must copy (always the full set, never the external ID
         alone) to resume from this run's snapshot; ``{}`` when there is no usable snapshot."""
-        if not self.snapshot_external_id or not self.resume_snapshot_is_usable():
-            return {}
-        carried: dict[str, Any] = {
-            "snapshot_external_id": self.snapshot_external_id,
-            "snapshot_kind": self.resume_snapshot_kind(),
+        carried = {
+            key: value
+            for key in ("parent_task_id", "parent_run_id", "wake_on")
+            if (value := getattr(self, key, None)) is not None
         }
+        if not self.snapshot_external_id or not self.resume_snapshot_is_usable():
+            return carried
+        carried.update(
+            {
+                "snapshot_external_id": self.snapshot_external_id,
+                "snapshot_kind": self.resume_snapshot_kind(),
+            }
+        )
         mount_path = self.resume_snapshot_mount_path()
         if mount_path is not None:
             carried["snapshot_mount_path"] = mount_path

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1606,7 +1606,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
 
         state = self.context.state or {}
         is_resume = bool(state.get("resume_from_run_id") or state.get("handoff_resumed"))
-        return self.context.mode != "interactive" and not is_resume
+        is_spawned_child = bool(state.get("parent_run_id"))
+        return self.context.mode != "interactive" and not is_resume and not is_spawned_child
 
     async def _track_workflow_event(self, event_name: str, properties: dict, capture_analytics: bool = True) -> None:
         track_input = TrackWorkflowEventInput(

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1057,6 +1057,7 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         run = child.runs.get()
         self.assertEqual(child.channel_id, channel.id)
         self.assertEqual(run.environment, TaskRun.Environment.CLOUD)
+        self.assertEqual(run.state["pending_user_message"], child.description)
         self.assertEqual(
             {key: run.state[key] for key in ("parent_task_id", "parent_run_id", "wake_on")},
             {

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1012,6 +1012,95 @@ class TestTaskVisibilityInternalDebugRegionGate(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
+class TestTaskSpawnAPI(BaseTaskAPITest):
+    url = "/api/projects/@current/tasks/spawn/"
+
+    def _parent_run(self, *, state=None, status=TaskRun.Status.IN_PROGRESS, channel=None):
+        task = self.create_task()
+        task.channel = channel
+        task.save(update_fields=["channel", "updated_at"])
+        run = task.create_run(mode="background", extra_state=state)
+        run.status = status
+        run.save(update_fields=["status", "updated_at"])
+        return run
+
+    def _payload(self, parent_run, **overrides):
+        return {
+            "parent_run_id": str(parent_run.id),
+            "title": "Implement child",
+            "description": "Make the focused change",
+            **overrides,
+        }
+
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_creates_and_starts_child_with_protected_state(self, _flag, _gate, trigger):
+        channel = Channel.objects.create(team=self.team, name="orchestration")
+        parent_run = self._parent_run(channel=channel)
+
+        response = self.client.post(self.url, self._payload(parent_run, wake_on=["pr_merged"]), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        child = Task.objects.get(id=response.json()["id"])
+        run = child.runs.get()
+        self.assertEqual(child.channel_id, channel.id)
+        self.assertEqual(run.environment, TaskRun.Environment.CLOUD)
+        self.assertEqual(
+            {key: run.state[key] for key in ("parent_task_id", "parent_run_id", "wake_on")},
+            {
+                "parent_task_id": str(parent_run.task_id),
+                "parent_run_id": str(parent_run.id),
+                "wake_on": ["pr_merged"],
+            },
+        )
+        trigger.assert_called_once()
+
+        patched = self.client.patch(
+            f"/api/projects/@current/tasks/{child.id}/runs/{run.id}/",
+            {"state": {"parent_task_id": "forged", "parent_run_id": "forged", "wake_on": []}},
+            format="json",
+        )
+        self.assertEqual(patched.status_code, status.HTTP_200_OK)
+        run.refresh_from_db()
+        self.assertEqual(run.state["parent_task_id"], str(parent_run.task_id))
+        self.assertEqual(run.state["wake_on"], ["pr_merged"])
+
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_rejects_child_parent_run(self, _flag):
+        parent_run = self._parent_run(state={"parent_task_id": str(uuid.uuid4())})
+        response = self.client.post(self.url, self._payload(parent_run), format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_rejects_terminal_parent_run(self, _flag):
+        parent_run = self._parent_run(status=TaskRun.Status.COMPLETED)
+        response = self.client.post(self.url, self._payload(parent_run), format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_rejects_cross_team_parent_run(self, _flag):
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        other_task = Task.objects.create(team=other_team, created_by=self.user, title="Other", description="Other")
+        parent_run = other_task.create_run(mode="background")
+        response = self.client.post(self.url, self._payload(parent_run), format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=False)
+    def test_spawn_rejects_when_flag_is_off(self, _flag):
+        response = self.client.post(self.url, self._payload(self._parent_run()), format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow", side_effect=RuntimeError("boom"))
+    def test_spawn_soft_deletes_partial_task_when_start_fails(self, _trigger, _flag, _gate):
+        with self.assertRaises(RuntimeError):
+            self.client.post(self.url, self._payload(self._parent_run()), format="json")
+        child = Task.objects.get(title="Implement child")
+        self.assertTrue(child.deleted)
+
+
 class TestTaskAPI(BaseTaskAPITest):
     def _oauth_client(self, client_id: str, *, scope: str = "task:read task:write") -> APIClient:
         application = OAuthApplication.objects.create(

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1045,7 +1045,8 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
     @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
     @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
     @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
-    def test_spawn_creates_and_starts_child_with_protected_state(self, _flag, _gate, trigger):
+    @patch.object(Task, "capture_event", autospec=True)
+    def test_spawn_creates_and_starts_child_with_protected_state(self, capture_event, _flag, _gate, trigger):
         channel = Channel.objects.create(team=self.team, name="orchestration")
         parent_run = self._parent_run(channel=channel)
 
@@ -1075,6 +1076,59 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         run.refresh_from_db()
         self.assertEqual(run.state["parent_task_id"], str(parent_run.task_id))
         self.assertEqual(run.state["wake_on"], ["pr_merged"])
+        self.assertTrue(
+            any(
+                call.args[0].id == child.id and call.args[1] == "task_created" and call.args[2]["is_spawned"] is True
+                for call in capture_event.call_args_list
+            )
+        )
+
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_uses_parent_run_from_header(self, _flag, _gate, _trigger):
+        parent_run = self._parent_run()
+        payload = self._payload(parent_run)
+        payload.pop("parent_run_id")
+
+        response = self.client.post(
+            self.url,
+            payload,
+            format="json",
+            HTTP_X_POSTHOG_TASK_RUN_ID=str(parent_run.id),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        child_run = Task.objects.get(id=response.json()["id"]).runs.get()
+        self.assertEqual(child_run.state["parent_run_id"], str(parent_run.id))
+
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_requires_calling_task_run_context(self, _flag):
+        payload = self._payload(self._parent_run())
+        payload.pop("parent_run_id")
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["parent_run_id"], ["spawn requires a calling task-run context"])
+
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_header_parent_run_takes_precedence_over_body(self, _flag, _gate, _trigger):
+        header_parent = self._parent_run()
+        body_parent = self._parent_run()
+
+        response = self.client.post(
+            self.url,
+            self._payload(body_parent),
+            format="json",
+            HTTP_X_POSTHOG_TASK_RUN_ID=str(header_parent.id),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        child_run = Task.objects.get(id=response.json()["id"]).runs.get()
+        self.assertEqual(child_run.state["parent_run_id"], str(header_parent.id))
 
     @patch("posthog.storage.object_storage.tag")
     @patch("posthog.storage.object_storage.copy")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1032,6 +1032,16 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
             **overrides,
         }
 
+    def _bundle_entry(self, run, **overrides):
+        entry = {
+            "id": "abcdef0123456789abcdef0123456789",
+            "name": "my-skill.zip",
+            "type": "skill_bundle",
+            "storage_path": f"{run.get_artifact_s3_prefix()}/abcdef01_my-skill.zip",
+        }
+        entry.update(overrides)
+        return entry
+
     @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
     @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
     @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
@@ -1065,6 +1075,115 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         run.refresh_from_db()
         self.assertEqual(run.state["parent_task_id"], str(parent_run.task_id))
         self.assertEqual(run.state["wake_on"], ["pr_merged"])
+
+    @patch("posthog.storage.object_storage.tag")
+    @patch("posthog.storage.object_storage.copy")
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_copies_parent_skill_bundles(self, _flag, _gate, _trigger, copy, _tag):
+        parent_run = self._parent_run()
+        entry = self._bundle_entry(parent_run)
+        parent_run.artifacts = [entry]
+        parent_run.save(update_fields=["artifacts", "updated_at"])
+
+        response = self.client.post(self.url, self._payload(parent_run), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        child_run = Task.objects.get(id=response.json()["id"]).runs.get()
+        target = f"{child_run.get_artifact_s3_prefix()}/abcdef01_my-skill.zip"
+        copy.assert_called_once_with(entry["storage_path"], target)
+        self.assertEqual(child_run.artifacts[0]["storage_path"], target)
+
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_rejects_forged_parent_bundle_path_and_cleans_up(self, _flag, _gate):
+        parent_run = self._parent_run()
+        parent_run.artifacts = [self._bundle_entry(parent_run, storage_path="other-team/private.zip")]
+        parent_run.save(update_fields=["artifacts", "updated_at"])
+
+        with self.assertRaisesRegex(ValueError, "owning run"):
+            self.client.post(self.url, self._payload(parent_run), format="json")
+
+        self.assertTrue(Task.objects.get(title="Implement child").deleted)
+
+    @patch("posthog.storage.object_storage.copy", side_effect=RuntimeError("s3 down"))
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_bundle_copy_failure_cleans_up_without_starting(self, _flag, _gate, _copy):
+        parent_run = self._parent_run()
+        parent_run.artifacts = [self._bundle_entry(parent_run)]
+        parent_run.save(update_fields=["artifacts", "updated_at"])
+
+        with self.assertRaisesRegex(RuntimeError, "s3 down"):
+            self.client.post(self.url, self._payload(parent_run), format="json")
+
+        child = Task.objects.get(title="Implement child")
+        self.assertTrue(child.deleted)
+        self.assertEqual(child.runs.get().status, TaskRun.Status.NOT_STARTED)
+
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_copies_imported_mcp_servers_without_relayed_servers(self, _flag, _gate, _trigger):
+        parent_run = self._parent_run()
+        parent_run.imported_mcp_servers = [{"type": "http", "name": "docs", "url": "https://example.com"}]
+        parent_run.relayed_mcp_servers = [{"name": "local"}]
+        parent_run.save(update_fields=["imported_mcp_servers", "relayed_mcp_servers", "updated_at"])
+
+        response = self.client.post(self.url, self._payload(parent_run), format="json")
+
+        child_run = Task.objects.get(id=response.json()["id"]).runs.get()
+        self.assertEqual(child_run.imported_mcp_servers, parent_run.imported_mcp_servers)
+        self.assertIsNone(child_run.relayed_mcp_servers)
+
+    @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
+    @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)
+    @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
+    def test_spawn_inherits_and_overrides_sandbox_environment(self, _flag, _gate, _trigger):
+        inherited = SandboxEnvironment.objects.create(team=self.team, created_by=self.user, name="Inherited")
+        override = SandboxEnvironment.objects.create(team=self.team, created_by=self.user, name="Override")
+        inherited_image = SandboxCustomImage.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Inherited image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="inherited:latest",
+        )
+        override_image = SandboxCustomImage.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Override image",
+            status=SandboxCustomImage.Status.READY,
+            modal_image_name="override:latest",
+        )
+        parent_run = self._parent_run(
+            state={
+                "sandbox_environment_id": str(inherited.id),
+                "custom_image_id": str(inherited_image.id),
+            }
+        )
+
+        inherited_response = self.client.post(
+            self.url, self._payload(parent_run, title="Inherited child"), format="json"
+        )
+        override_response = self.client.post(
+            self.url,
+            self._payload(
+                parent_run,
+                title="Override child",
+                sandbox_environment_id=str(override.id),
+                custom_image_id=str(override_image.id),
+            ),
+            format="json",
+        )
+
+        inherited_run = Task.objects.get(id=inherited_response.json()["id"]).runs.get()
+        override_run = Task.objects.get(id=override_response.json()["id"]).runs.get()
+        self.assertEqual(inherited_run.state["sandbox_environment_id"], str(inherited.id))
+        self.assertEqual(inherited_run.state["custom_image_id"], str(inherited_image.id))
+        self.assertEqual(override_run.state["sandbox_environment_id"], str(override.id))
+        self.assertEqual(override_run.state["custom_image_id"], str(override_image.id))
 
     @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
     def test_spawn_rejects_child_parent_run(self, _flag):

--- a/products/tasks/backend/tests/test_feature_flags.py
+++ b/products/tasks/backend/tests/test_feature_flags.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
-from products.tasks.backend.feature_flags import is_dev_stack_image_bake_enabled
+from products.tasks.backend.feature_flags import is_dev_stack_image_bake_enabled, is_tasks_orchestration_enabled
 
 
 class TestIsDevStackImageBakeEnabled:
@@ -47,3 +47,10 @@ class TestIsDevStackImageBakeEnabled:
             assert is_dev_stack_image_bake_enabled() is False
 
         feature_enabled_mock.assert_not_called()
+
+
+@override_settings(DEBUG=True)
+def test_tasks_orchestration_is_enabled_in_development() -> None:
+    with patch("products.tasks.backend.feature_flags.posthoganalytics.feature_enabled") as feature_enabled:
+        assert is_tasks_orchestration_enabled(distinct_id="user", organization_id="org") is True
+        feature_enabled.assert_not_called()

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -42,11 +42,11 @@ Source: `products/tasks/backend/models.py`
 
 Tracked when a new Task is saved. Additional properties:
 
-| Property          | Type   | Description                       |
-| ----------------- | ------ | --------------------------------- |
-| `has_json_schema` | `bool` | Whether a JSON schema is attached |
+| Property          | Type    | Description                              |
+| ----------------- | ------- | ---------------------------------------- |
+| `has_json_schema` | `bool`  | Whether a JSON schema is attached        |
 | `is_spawned`      | `bool?` | Whether an orchestrator spawned the task |
-| `parent_task_id`  | `str?`  | Parent task UUID for spawned tasks        |
+| `parent_task_id`  | `str?`  | Parent task UUID for spawned tasks       |
 
 ### `task_run_created`
 

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -45,6 +45,8 @@ Tracked when a new Task is saved. Additional properties:
 | Property          | Type   | Description                       |
 | ----------------- | ------ | --------------------------------- |
 | `has_json_schema` | `bool` | Whether a JSON schema is attached |
+| `is_spawned`      | `bool?` | Whether an orchestrator spawned the task |
+| `parent_task_id`  | `str?`  | Parent task UUID for spawned tasks        |
 
 ### `task_run_created`
 

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3710,6 +3710,37 @@ export interface SlackThreadContextResponseApi {
     runs: SlackThreadContextRunApi[]
 }
 
+/**
+ * * `pr_merged` - pr_merged
+ */
+export type WakeOnEnumApi = (typeof WakeOnEnumApi)[keyof typeof WakeOnEnumApi]
+
+export const WakeOnEnumApi = {
+    PrMerged: 'pr_merged',
+} as const
+
+export interface TaskSpawnRequestApi {
+    /** Cloud run that is spawning this child task. */
+    parent_run_id: string
+    /**
+     * Title for the child task.
+     * @maxLength 255
+     */
+    title: string
+    /** Prompt passed verbatim to the child task. */
+    description: string
+    /**
+     * Optional target repository in organization/repository format.
+     * @maxLength 255
+     * @nullable
+     */
+    repository?: string | null
+    runtime_adapter?: RuntimeAdapterEnumApi
+    model?: string
+    reasoning_effort?: ReasoningEffortEnumApi
+    wake_on?: WakeOnEnumApi[]
+}
+
 export interface TaskSummariesRequestApi {
     /**
      * Task IDs to fetch summaries for (max 5000). Response is paginated; follow the `next` cursor to retrieve all results.

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3720,8 +3720,8 @@ export const WakeOnEnumApi = {
 } as const
 
 export interface TaskSpawnRequestApi {
-    /** Cloud run that is spawning this child task. */
-    parent_run_id: string
+    /** Cloud run that is spawning this child task. Defaults to the calling task-run context. */
+    parent_run_id?: string
     /**
      * Title for the child task.
      * @maxLength 255

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3738,6 +3738,10 @@ export interface TaskSpawnRequestApi {
     runtime_adapter?: RuntimeAdapterEnumApi
     model?: string
     reasoning_effort?: ReasoningEffortEnumApi
+    /** @nullable */
+    sandbox_environment_id?: string | null
+    /** @nullable */
+    custom_image_id?: string | null
     wake_on?: WakeOnEnumApi[]
 }
 

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -106,6 +106,7 @@ import type {
     TaskRunStartRequestApi,
     TaskSessionResponseApi,
     TaskSessionSyncResponseApi,
+    TaskSpawnRequestApi,
     TaskStagedArtifactsFinalizeUploadRequestApi,
     TaskStagedArtifactsFinalizeUploadResponseApi,
     TaskStagedArtifactsPrepareUploadRequestApi,
@@ -2341,6 +2342,27 @@ export const tasksSlackThreadContextRetrieve = async (
     return apiMutator<SlackThreadContextResponseApi>(getTasksSlackThreadContextRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getTasksSpawnCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tasks/spawn/`
+}
+
+/**
+ * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
+ * @summary Spawn a child task
+ */
+export const tasksSpawnCreate = async (
+    projectId: string,
+    taskSpawnRequestApi: TaskSpawnRequestApi,
+    options?: RequestInit
+): Promise<TaskDetailDTOApi> => {
+    return apiMutator<TaskDetailDTOApi>(getTasksSpawnCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskSpawnRequestApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3040,6 +3040,8 @@ export const TasksSpawnCreateBody = /* @__PURE__ */ zod.object({
         .describe(
             '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
         ),
+    sandbox_environment_id: zod.uuid().nullish(),
+    custom_image_id: zod.uuid().nullish(),
     wake_on: zod.array(zod.enum(['pr_merged']).describe('\* `pr_merged` - pr_merged')).optional(),
 })
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3024,7 +3024,10 @@ export const tasksSpawnCreateBodyTitleMax = 255
 export const tasksSpawnCreateBodyRepositoryMax = 255
 
 export const TasksSpawnCreateBody = /* @__PURE__ */ zod.object({
-    parent_run_id: zod.uuid().describe('Cloud run that is spawning this child task.'),
+    parent_run_id: zod
+        .uuid()
+        .optional()
+        .describe('Cloud run that is spawning this child task. Defaults to the calling task-run context.'),
     title: zod.string().max(tasksSpawnCreateBodyTitleMax).describe('Title for the child task.'),
     description: zod.string().describe('Prompt passed verbatim to the child task.'),
     repository: zod

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3016,6 +3016,34 @@ export const TasksThreadMessagesSendToAgentCreateBody = /* @__PURE__ */ zod
     .describe("Response shape for one message in a task's thread.")
 
 /**
+ * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
+ * @summary Spawn a child task
+ */
+export const tasksSpawnCreateBodyTitleMax = 255
+
+export const tasksSpawnCreateBodyRepositoryMax = 255
+
+export const TasksSpawnCreateBody = /* @__PURE__ */ zod.object({
+    parent_run_id: zod.uuid().describe('Cloud run that is spawning this child task.'),
+    title: zod.string().max(tasksSpawnCreateBodyTitleMax).describe('Title for the child task.'),
+    description: zod.string().describe('Prompt passed verbatim to the child task.'),
+    repository: zod
+        .string()
+        .max(tasksSpawnCreateBodyRepositoryMax)
+        .nullish()
+        .describe('Optional target repository in organization\/repository format.'),
+    runtime_adapter: zod.enum(['claude', 'codex']).optional().describe('\* `claude` - claude\n\* `codex` - codex'),
+    model: zod.string().optional(),
+    reasoning_effort: zod
+        .enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
+        .optional()
+        .describe(
+            '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+        ),
+    wake_on: zod.array(zod.enum(['pr_merged']).describe('\* `pr_merged` - pr_merged')).optional(),
+})
+
+/**
  * Returns summary for the requested tasks: `id`, `title`, `repository`, `created_at`, `updated_at`, and the latest run's `status` and `environment`.
  * @summary Fetch task summaries by ID
  */

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -571,6 +571,9 @@ tools:
     tasks-slack-thread-context-retrieve:
         operation: tasks_slack_thread_context_retrieve
         enabled: false
+    tasks-spawn-create:
+        operation: tasks_spawn_create
+        enabled: false
     tasks-staged-artifacts-finalize-upload-create:
         operation: tasks_staged_artifacts_finalize_upload_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -72838,6 +72838,38 @@ export namespace Schemas {
       content_sha256: string;
     }
 
+    /**
+     * * `pr_merged` - pr_merged
+     */
+    export type WakeOnEnum = typeof WakeOnEnum[keyof typeof WakeOnEnum];
+
+
+    export const WakeOnEnum = {
+      PrMerged: 'pr_merged',
+    } as const;
+
+    export interface TaskSpawnRequest {
+      /** Cloud run that is spawning this child task. */
+      parent_run_id: string;
+      /**
+         * Title for the child task.
+         * @maxLength 255
+         */
+      title: string;
+      /** Prompt passed verbatim to the child task. */
+      description: string;
+      /**
+         * Optional target repository in organization/repository format.
+         * @maxLength 255
+         * @nullable
+         */
+      repository?: string | null;
+      runtime_adapter?: RuntimeAdapterEnum;
+      model?: string;
+      reasoning_effort?: ReasoningEffortEnum;
+      wake_on?: WakeOnEnum[];
+    }
+
     export interface TaskStagedArtifactFinalizeUpload {
       /** Stable identifier returned by the staged prepare upload endpoint */
       id: string;

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -72849,8 +72849,8 @@ export namespace Schemas {
     } as const;
 
     export interface TaskSpawnRequest {
-      /** Cloud run that is spawning this child task. */
-      parent_run_id: string;
+      /** Cloud run that is spawning this child task. Defaults to the calling task-run context. */
+      parent_run_id?: string;
       /**
          * Title for the child task.
          * @maxLength 255

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -72867,6 +72867,10 @@ export namespace Schemas {
       runtime_adapter?: RuntimeAdapterEnum;
       model?: string;
       reasoning_effort?: ReasoningEffortEnum;
+      /** @nullable */
+      sandbox_environment_id?: string | null;
+      /** @nullable */
+      custom_image_id?: string | null;
       wake_on?: WakeOnEnum[];
     }
 


### PR DESCRIPTION
## Problem

Large cloud tasks need a safe way to delegate bounded work to independent child tasks. The orchestration relationship must remain outside the Task schema so ordinary task lifecycle actions never propagate between parent and child. This follows the state-only direction considered in #51629.

**Why:** A composed, gated spawn operation provides the foundation for later child-status notifications without introducing schema-level task hierarchy.

## Changes

- Add a flag-gated `tasks_spawn_create` endpoint that validates the parent run, applies usage and team rate gates, creates a cloud child run, and starts it.
- Stamp protected `parent_task_id`, `parent_run_id`, and `wake_on` run-state keys, and carry them into continuation runs.
- Inherit parent skill bundles, imported MCP servers, sandbox environment, and custom image for headless child creation.
- Add focused API and state-carry regression coverage plus instrumentation documentation.

There is deliberately no parent or child field on Task or TaskRun. Children remain independent tasks, and this PR adds no wake or notification behavior.

### Non-goals

Desktop-relayed MCP servers (stdio or private-network) cannot work for children. Their relay executor is the creating desktop's live process, which has no binding to a server-created run, so relayed designations are not copied.

## How did you test this code?

- Focused mypy: passed.
- Ruff formatting and lint: passed.
- OpenAPI generation: passed.
- `git diff --check`: passed.
- Database-backed API tests require PostgreSQL, which is unavailable locally at `127.0.0.1:5432`.

The API tests cover protected orchestration state, parent skill-bundle copying and path validation, copy-failure compensation, imported MCP inheritance without relayed servers, and sandbox environment/custom-image inheritance and overrides.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Instrumentation docs describe the spawned-task analytics properties.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested first plan step and its headless-child inheritance addendum. The design keeps supervision in protected run state, composes existing task/run facade operations, and intentionally excludes wake delivery from this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
