### PR TITLE
feat(batch-exports): pin export queries to ClickHouse 26.6 compatibility

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -602,6 +602,10 @@ async def _write_batch_export_record_batches_to_internal_stage(
         min_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
         # Disable all of these so only the bytes limits counts.
         min_insert_block_size_rows=0,
+        # TEMPORARY: pin batch export queries to ClickHouse 26.6 semantics during the initial
+        # upgrade period, so query behavior stays stable while the cluster is upgraded. Remove
+        # once the upgrade has settled.
+        compatibility="26.6",
     ) as client:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -602,9 +602,8 @@ async def _write_batch_export_record_batches_to_internal_stage(
         min_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
         # Disable all of these so only the bytes limits counts.
         min_insert_block_size_rows=0,
-        # TEMPORARY: pin batch export queries to ClickHouse 26.6 semantics during the initial
-        # upgrade period, so query behavior stays stable while the cluster is upgraded. Remove
-        # once the upgrade has settled.
+        # TEMPORARY: pin batch export queries to ClickHouse 26.6 semantics to ensure compatibility
+        # after upgrade
         compatibility="26.6",
     ) as client:
         if not await client.is_alive():


### PR DESCRIPTION
## Problem

During the initial ClickHouse upgrade period we want batch export queries to keep stable behavior regardless of the server's actual CH version.

## Changes

Adds `compatibility = '26.6'` to the internal-stage batch export ClickHouse client (`_write_batch_export_record_batches_to_internal_stage` in `internal_stage.py`). Because `get_client(**kwargs)` forwards extra kwargs into `ClickHouseClient.params` as HTTP query-settings, this applies the setting to the `INSERT INTO FUNCTION s3(...) SELECT ...` export query for **all internal-stage pipeline destinations**: S3, BigQuery, Snowflake, Postgres, Redshift, Databricks, Azure Blob, workflows, and file-download.

Scoped to the internal-stage pipeline only — the legacy HTTP destination and the auxiliary monitoring/backfill-estimation queries are intentionally left unchanged.

**Temporary** — to be removed once the upgrade has settled.

## Testing

`pytest products/batch_exports/backend/tests/temporal/pipeline/test_internal_stage.py` → 53 passed, 2 skipped, against the local ClickHouse (26.6.1.1193), confirming the setting is accepted and exports succeed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*