### PR TITLE
feat(conversations): expose AI draft confidence on ticket messages

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2117,8 +2117,43 @@ class TestTicketMessagesAPI(APIBaseTest):
             "author_type",
             "author_name",
             "is_private",
+            "confidence",
             "created_at",
         }
+
+    def test_messages_confidence_passthrough(self, mock_on_commit):
+        base = timezone.now()
+        ai_comment = Comment.objects.create(
+            team=self.team,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="AI draft reply",
+            item_context={
+                "author_type": "AI",
+                "is_private": True,
+                "citations": [],
+                "confidence": 0.85,
+            },
+        )
+        Comment.objects.filter(id=ai_comment.id).update(created_at=base)
+        human_comment = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="conversations_ticket",
+            item_id=str(self.ticket.id),
+            content="Human reply",
+            item_context={"author_type": "support", "is_private": False},
+        )
+        Comment.objects.filter(id=human_comment.id).update(created_at=base + timedelta(seconds=1))
+
+        response = self.client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        assert len(results) == 2
+        assert results[0]["author_type"] == "AI"
+        assert results[0]["confidence"] == 0.85
+        assert results[1]["author_type"] == "support"
+        assert results[1]["confidence"] is None
 
     def test_messages_lookup_by_ticket_number(self, mock_on_commit):
         Comment.objects.create(

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -89,6 +89,11 @@ class TicketMessageSerializer(serializers.Serializer):
     is_private = serializers.BooleanField(
         read_only=True, help_text="True for internal notes not visible to the customer."
     )
+    confidence = serializers.FloatField(
+        read_only=True,
+        allow_null=True,
+        help_text="The AI reply pipeline's self-reported 0-1 confidence for its draft messages; null for human and customer messages.",
+    )
     created_at = serializers.DateTimeField(read_only=True)
 
 
@@ -1094,6 +1099,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             "author_type": author_type,
             "author_name": author_name,
             "is_private": item_context.get("is_private") is True,
+            "confidence": item_context.get("confidence"),
             "created_at": comment.created_at,
         }
 

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -928,6 +928,11 @@ export interface TicketMessageApi {
     readonly author_name: string
     /** True for internal notes not visible to the customer. */
     readonly is_private: boolean
+    /**
+     * The AI reply pipeline's self-reported 0-1 confidence for its draft messages; null for human and customer messages.
+     * @nullable
+     */
+    readonly confidence: number | null
     readonly created_at: string
 }
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48032,6 +48032,11 @@ export namespace Schemas {
       readonly author_name: string;
       /** True for internal notes not visible to the customer. */
       readonly is_private: boolean;
+      /**
+         * The AI reply pipeline's self-reported 0-1 confidence for its draft messages; null for human and customer messages.
+         * @nullable
+         */
+      readonly confidence: number | null;
       readonly created_at: string;
     }
 


### PR DESCRIPTION
## Problem

The AI reply pipeline stamps a 0-1 confidence score on the draft comments it persists (`item_context.confidence`, written by `support_persist_reply_activity`). The generic `/comments/` API exposed this via the raw `item_context`, but the documented `GET /conversations/tickets/:id/messages/` action does not include it. External clients that migrate from the raw comments endpoint to the documented messages action lose the AI-confidence signal, even though the underlying data is right there on the comment.

## Changes

- `_serialize_message` in `products/conversations/backend/api/tickets.py` now passes through `item_context.get("confidence")`. Only AI-authored comments ever carry the key, so human and customer messages serialize it as `null`.
- Added the matching optional `confidence` field on `TicketMessageSerializer` with help text, following the conventions of the neighboring fields.
- Regenerated OpenAPI artifacts (`products/conversations/frontend/generated/api.schemas.ts`, `services/mcp/src/api/generated.ts`) via `hogli build:openapi`. The MCP tool-schema snapshots only cover input parameters, so they are unchanged (verified by running `tests/unit/tool-schema-snapshots.test.ts`, which passes).

## How did you test this code?

- Added `test_messages_confidence_passthrough` to `TestTicketMessagesAPI`: an AI comment with `confidence: 0.85` in `item_context` round-trips through the messages action, and a human reply in the same thread returns `confidence: null`. This catches the regression no existing test did: the documented messages surface silently dropping the confidence the persist activity stamps.
- Updated `test_messages_correct_response_shape` for the new key.
- I could not run the backend pytest suite locally: the test-DB bootstrap in `posthog/conftest.py` shells out to the `sqlx` CLI, which is not installed in this environment, so every test in the file errors at setup. The new and updated tests have not been executed locally and rely on CI.
- As a substitute, I exercised the real code path via `manage.py shell`: built AI, support, and customer `Comment` objects, ran them through `TicketViewSet._serialize_message` and `TicketMessageSerializer(many=True)`, and confirmed the AI message serializes `confidence: 0.85` while support and customer messages serialize `null`, with the expected key set.
- `ruff check` and `ruff format --check` pass on both touched Python files. MCP tool-schema snapshot test passes unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The field is self-describing via the OpenAPI schema (help text included), no separate docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5) on behalf of Christiaan (@christiaan-ph) during a HogDesk API-alignment session. HogDesk's message feed is the consumer: it renders a confidence badge on AI messages and already reads the field when present, so this is a passthrough of existing data rather than new behavior. Decisions: kept it a plain passthrough of `item_context.get("confidence")` rather than gating on `author_type == "AI"`, since only the AI persist activity ever writes the key and gating would just duplicate that invariant. Backend tests were written but not run locally (missing `sqlx` CLI in the sandboxed environment); the serializer was instead verified end-to-end through a Django shell session, and the OpenAPI artifacts were regenerated with `hogli build:openapi`.
