### PR TITLE
fix(desktop): prefill the picked repo when a sidebar group has no folder

### DIFF
--- a/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TaskListView.tsx
@@ -302,16 +302,16 @@ export function TaskListView({
                     addSpacingBefore={false}
                     tooltipContent={folder?.path ?? group.id}
                     onNewTask={() => {
-                      if (groupFolderId) {
-                        openTaskInput({
-                          folderId: groupFolderId,
-                          folderRunEnvironment: mostRecentRunEnvironment(
-                            group.tasks,
-                          ),
-                        });
-                      } else {
-                        openTaskInput();
-                      }
+                      openTaskInput({
+                        folderId: groupFolderId,
+                        // Cloud-only groups have no registered folder, and the
+                        // group id is the repo slug — without it the new-task
+                        // screen would keep whichever repo was last used.
+                        folderRepository: group.id,
+                        folderRunEnvironment: mostRecentRunEnvironment(
+                          group.tasks,
+                        ),
+                      });
                     }}
                     newTaskTooltip={`Start new task in ${folder?.name ?? group.name}`}
                     onContextMenu={

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -651,7 +651,7 @@ export function TaskInput({
     setConfigOption,
   ]);
 
-  const { folders } = useFolders();
+  const { folders, isLoaded: foldersLoaded } = useFolders();
 
   useEffect(() => {
     if (selectedRepository || !lastUsedCloudRepository) {
@@ -703,6 +703,7 @@ export function TaskInput({
     folderRepository: view.folderRepository,
     requestId: view.taskInputRequestId,
     folders,
+    foldersLoaded,
     repositories,
     reposLoaded: reposReady,
     currentMode: workspaceMode,

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -700,6 +700,7 @@ export function TaskInput({
 
   useInitialRepoSelectionFromFolderId({
     folderId: view.folderId,
+    folderRepository: view.folderRepository,
     requestId: view.taskInputRequestId,
     folders,
     repositories,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.test.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.test.ts
@@ -359,6 +359,7 @@ type HookArgs = {
   folderRepository?: string;
   requestId?: string;
   folders: RegisteredFolder[];
+  foldersLoaded?: boolean;
   repositories: string[];
   reposLoaded: boolean;
   currentMode: WorkspaceMode;
@@ -376,6 +377,7 @@ function renderRepoSelectionHook(initial: HookArgs) {
         folderRepository: props.folderRepository,
         requestId: props.requestId,
         folders: props.folders,
+        foldersLoaded: props.foldersLoaded ?? true,
         repositories: props.repositories,
         reposLoaded: props.reposLoaded,
         currentMode: props.currentMode,
@@ -470,6 +472,7 @@ describe("useInitialRepoSelectionFromFolderId", () => {
     const { rerender, setSelectedDirectory } = renderRepoSelectionHook({
       folderId: "a",
       folders: [],
+      foldersLoaded: false,
       repositories: [],
       reposLoaded: false,
       currentMode: "local",
@@ -481,11 +484,30 @@ describe("useInitialRepoSelectionFromFolderId", () => {
     rerender({
       folderId: "a",
       folders: [folder("a", "/repos/a")],
+      foldersLoaded: true,
       repositories: [],
       reposLoaded: false,
       currentMode: "local",
     });
     expect(setSelectedDirectory).toHaveBeenCalledExactlyOnceWith("/repos/a");
+  });
+
+  it("still selects the repo when a removed folder's id never resolves", () => {
+    // A task can carry the id of a folder the user has since removed. Waiting on
+    // it forever would leave the picker on the last-used repo, the very bug the
+    // group's repo slug is here to prevent.
+    const { setSelectedRepository } = renderRepoSelectionHook({
+      folderId: "gone",
+      folderRepository: "posthog/posthog.com",
+      folders: [folder("a", "/repos/a", "posthog/posthog")],
+      foldersLoaded: true,
+      repositories: ["posthog/posthog", "posthog/posthog.com"],
+      reposLoaded: true,
+      currentMode: "cloud",
+    });
+    expect(setSelectedRepository).toHaveBeenCalledExactlyOnceWith(
+      "posthog/posthog.com",
+    );
   });
 
   it("does not re-sync when folders changes but folderId stays the same", () => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.test.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.test.ts
@@ -236,6 +236,78 @@ describe("resolveRepoSelectionForFolder", () => {
       }),
     ).toEqual(expected);
   });
+
+  // Cloud-only groups have no registered folder, so the group's own repo slug is
+  // all there is to prefill from.
+  it.each<{
+    name: string;
+    input: RepoSelectionInput;
+    expected: RepoSelection;
+  }>([
+    {
+      name: "no folder, connected repo: select it and go to cloud",
+      input: {
+        folderRepository: "posthog/posthog.com",
+        repositories: ["posthog/posthog", "posthog/posthog.com"],
+        reposLoaded: true,
+        currentMode: "local",
+        lastUsedLocalMode: "local",
+      },
+      expected: {
+        directory: undefined,
+        cloudRepository: "posthog/posthog.com",
+        nextMode: "cloud",
+      },
+    },
+    {
+      name: "no folder, repo not connected: change nothing",
+      input: {
+        folderRepository: "acme/private",
+        repositories: ["posthog/posthog"],
+        reposLoaded: true,
+        currentMode: "cloud",
+        lastUsedLocalMode: "local",
+      },
+      expected: {
+        directory: undefined,
+        cloudRepository: undefined,
+        nextMode: undefined,
+      },
+    },
+    {
+      name: "no folder, group id is a folder path: change nothing",
+      input: {
+        folderRepository: "/repos/a",
+        repositories: ["posthog/posthog"],
+        reposLoaded: true,
+        currentMode: "cloud",
+        lastUsedLocalMode: "local",
+      },
+      expected: {
+        directory: undefined,
+        cloudRepository: undefined,
+        nextMode: undefined,
+      },
+    },
+    {
+      name: "folder without a remote falls back to the group's repo slug",
+      input: {
+        folder: folder("a", "/repos/a", null),
+        folderRepository: "posthog/posthog.com",
+        repositories: ["posthog/posthog.com"],
+        reposLoaded: true,
+        currentMode: "cloud",
+        lastUsedLocalMode: "local",
+      },
+      expected: {
+        directory: "/repos/a",
+        cloudRepository: "posthog/posthog.com",
+        nextMode: undefined,
+      },
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(resolveRepoSelectionForFolder(input)).toEqual(expected);
+  });
 });
 
 describe("areReposReady", () => {
@@ -284,6 +356,7 @@ describe("areReposReady", () => {
 
 type HookArgs = {
   folderId: string | undefined;
+  folderRepository?: string;
   requestId?: string;
   folders: RegisteredFolder[];
   repositories: string[];
@@ -300,6 +373,7 @@ function renderRepoSelectionHook(initial: HookArgs) {
     (props: HookArgs) =>
       useInitialRepoSelectionFromFolderId({
         folderId: props.folderId,
+        folderRepository: props.folderRepository,
         requestId: props.requestId,
         folders: props.folders,
         repositories: props.repositories,
@@ -475,6 +549,34 @@ describe("useInitialRepoSelectionFromFolderId", () => {
     expect(setSelectedDirectory).not.toHaveBeenCalled();
     expect(setSelectedRepository).not.toHaveBeenCalled();
     expect(setWorkspaceMode).not.toHaveBeenCalled();
+  });
+
+  it("selects the repo of a group that has no registered folder", () => {
+    const { rerender, setSelectedDirectory, setSelectedRepository } =
+      renderRepoSelectionHook({
+        folderId: undefined,
+        folderRepository: "posthog/posthog.com",
+        folders: [folder("a", "/repos/a", "posthog/posthog")],
+        repositories: ["posthog/posthog", "posthog/posthog.com"],
+        reposLoaded: true,
+        currentMode: "cloud",
+      });
+    expect(setSelectedRepository).toHaveBeenCalledExactlyOnceWith(
+      "posthog/posthog.com",
+    );
+    // Nothing is checked out locally, so there's no directory to select.
+    expect(setSelectedDirectory).not.toHaveBeenCalled();
+
+    // Clicking another group's "+" moves the pick to that group's repo.
+    rerender({
+      folderId: undefined,
+      folderRepository: "posthog/posthog",
+      folders: [folder("a", "/repos/a", "posthog/posthog")],
+      repositories: ["posthog/posthog", "posthog/posthog.com"],
+      reposLoaded: true,
+      currentMode: "cloud",
+    });
+    expect(setSelectedRepository).toHaveBeenLastCalledWith("posthog/posthog");
   });
 
   it("re-syncs the same folderId after it is cleared to undefined", () => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.ts
@@ -161,6 +161,8 @@ export interface UseInitialRepoSelectionParams {
    */
   requestId?: string;
   folders: RegisteredFolder[];
+  /** Whether the folders list has finished loading. */
+  foldersLoaded: boolean;
   /** Lower-cased `owner/repo` slugs the user can use in cloud mode. */
   repositories: string[];
   /** Whether the integrations list has finished loading (gate the mode switch). */
@@ -193,6 +195,7 @@ export function useInitialRepoSelectionFromFolderId({
   folderRepository,
   requestId,
   folders,
+  foldersLoaded,
   repositories,
   reposLoaded,
   currentMode,
@@ -224,9 +227,10 @@ export function useInitialRepoSelectionFromFolderId({
     const folder = folderId
       ? folders.find((f) => f.id === folderId)
       : undefined;
-    // Wait for a folder that is expected but hasn't loaded yet; a group with no
-    // registered folder at all resolves from `folderRepository` alone.
-    if (folderId && !folder) return;
+    // Wait for a folder that is expected but hasn't loaded yet. Only while the
+    // list is loading, though: a folderId left over from a removed folder never
+    // resolves, and blocking on it would strand the repo prefill for good.
+    if (folderId && !folder && !foldersLoaded) return;
 
     const selection = resolveRepoSelectionForFolder({
       folder,
@@ -258,6 +262,7 @@ export function useInitialRepoSelectionFromFolderId({
     folderRepository,
     requestId,
     folders,
+    foldersLoaded,
     repositories,
     reposLoaded,
     lastUsedLocalMode,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useInitialRepoSelectionFromFolderId.ts
@@ -30,7 +30,14 @@ export function areReposReady({
 }
 
 export interface RepoSelectionInput {
-  folder: RegisteredFolder;
+  /** The group's registered local folder, absent for cloud-only repos. */
+  folder?: RegisteredFolder;
+  /**
+   * `owner/repo` the sidebar group stands for. Carries the repo for groups with
+   * no registered folder — cloud-only ones — which otherwise had nothing to
+   * prefill from and left the previous pick in place.
+   */
+  folderRepository?: string;
   /** Lower-cased `owner/repo` slugs the user can use in cloud mode. */
   repositories: string[];
   /** Whether the integrations list has finished loading (gate the mode switch). */
@@ -47,8 +54,8 @@ export interface RepoSelectionInput {
 }
 
 export interface RepoSelection {
-  /** Local directory to select (always the folder's path). */
-  directory: string;
+  /** Local directory to select, or undefined when the group has no folder. */
+  directory?: string;
   /** Cloud `owner/repo` slug to select, or undefined to leave the cloud pick as-is. */
   cloudRepository?: string;
   /**
@@ -60,7 +67,7 @@ export interface RepoSelection {
 }
 
 /**
- * Pure resolver: given the folder a user picked (e.g. via the sidebar "+"), decide
+ * Pure resolver: given the group a user picked (e.g. via the sidebar "+"), decide
  * what to select in both the local-directory and cloud-repo pickers, and whether the
  * workspace mode must change.
  *
@@ -71,40 +78,43 @@ export interface RepoSelection {
  * honoured only when the repo has a connected cloud counterpart; otherwise it drops to
  * the last-used local mode. A desired Local mode keeps the current mode when it's already
  * local (preserving worktree), and otherwise switches to the last-used local mode.
+ *
+ * A group with no registered folder is only workable in the cloud, so it has no
+ * directory to prefill and its mode follows cloud-capability alone.
  */
 export function resolveRepoSelectionForFolder({
   folder,
+  folderRepository,
   repositories,
   reposLoaded,
   currentMode,
   lastUsedLocalMode,
   mostRecentEnvironment,
 }: RepoSelectionInput): RepoSelection {
-  const slug = folder.remoteUrl?.toLowerCase();
-  // A folder is cloud-capable only when its remote is a real `owner/repo` (guards against
-  // legacy single-segment values) AND that repo is one of the user's connected integrations.
+  const slug = (folder?.remoteUrl ?? folderRepository)?.toLowerCase();
+  // A group is cloud-capable only when its remote is a real `owner/repo` (guards against
+  // legacy single-segment values and folder-path group ids) AND that repo is one of the
+  // user's connected integrations.
   const cloudRepository =
     slug && parseRepository(slug) !== null && repositories.includes(slug)
       ? slug
       : undefined;
 
   const selection: RepoSelection = {
-    directory: folder.path,
+    directory: folder?.path,
     cloudRepository,
   };
 
   // Only decide the mode once the integrations list has loaded, so cloud-capability is
   // known and we never switch out of cloud while the repo list is still in flight.
   if (reposLoaded) {
-    // Prefer the repo's own most recent run; fall back to the current global mode.
-    const desiredEnvironment =
-      mostRecentEnvironment ?? (currentMode === "cloud" ? "cloud" : "local");
-    const targetMode: WorkspaceMode =
-      desiredEnvironment === "cloud" && cloudRepository
-        ? "cloud"
-        : currentMode === "cloud"
-          ? lastUsedLocalMode
-          : currentMode;
+    const targetMode = resolveTargetMode({
+      hasFolder: folder !== undefined,
+      cloudRepository,
+      currentMode,
+      lastUsedLocalMode,
+      mostRecentEnvironment,
+    });
     if (targetMode !== currentMode) {
       selection.nextMode = targetMode;
     }
@@ -113,8 +123,36 @@ export function resolveRepoSelectionForFolder({
   return selection;
 }
 
+function resolveTargetMode({
+  hasFolder,
+  cloudRepository,
+  currentMode,
+  lastUsedLocalMode,
+  mostRecentEnvironment,
+}: {
+  hasFolder: boolean;
+  cloudRepository: string | undefined;
+  currentMode: WorkspaceMode;
+  lastUsedLocalMode: LocalWorkspaceMode;
+  mostRecentEnvironment?: "local" | "cloud";
+}): WorkspaceMode {
+  // Nothing is checked out locally, so a local mode would leave the previous repo's
+  // directory selected — go to cloud when we can, otherwise leave the mode alone.
+  if (!hasFolder) return cloudRepository ? "cloud" : currentMode;
+  // Prefer the repo's own most recent run; fall back to the current global mode.
+  const desiredEnvironment =
+    mostRecentEnvironment ?? (currentMode === "cloud" ? "cloud" : "local");
+  if (desiredEnvironment === "cloud" && cloudRepository) return "cloud";
+  return currentMode === "cloud" ? lastUsedLocalMode : currentMode;
+}
+
 export interface UseInitialRepoSelectionParams {
   folderId: string | undefined;
+  /**
+   * `owner/repo` the picked sidebar group stands for, used when the group has no
+   * registered folder (see {@link RepoSelectionInput.folderRepository}).
+   */
+  folderRepository?: string;
   /**
    * Identifier of the navigation request that carried the folder prefill. Each
    * "+" click issues a fresh id, so re-picking the same folder re-applies the
@@ -142,16 +180,17 @@ export interface UseInitialRepoSelectionParams {
 }
 
 /**
- * Applies {@link resolveRepoSelectionForFolder} to the live pickers when a `folderId`
- * prefill arrives, syncing both the local directory and the cloud repo and switching
- * mode when required. Runs once per `folderId` (guarded by refs) so it never clobbers a
- * repo/mode the user changed afterward, and re-runs when `folderId` changes.
+ * Applies {@link resolveRepoSelectionForFolder} to the live pickers when a group prefill
+ * arrives, syncing both the local directory and the cloud repo and switching mode when
+ * required. Runs once per prefill (guarded by refs) so it never clobbers a repo/mode the
+ * user changed afterward, and re-runs when the picked group changes.
  *
  * The dependency on `folders` / `repositories` lets the sync still fire when those lists
  * load after the initial mount.
  */
 export function useInitialRepoSelectionFromFolderId({
   folderId,
+  folderRepository,
   requestId,
   folders,
   repositories,
@@ -174,19 +213,24 @@ export function useInitialRepoSelectionFromFolderId({
   currentModeRef.current = currentMode;
 
   useEffect(() => {
-    if (!folderId) {
+    if (!folderId && !folderRepository) {
       dirInitRef.current = undefined;
       repoModeInitRef.current = undefined;
       return;
     }
     // A fresh requestId makes this a new prefill request even for the same
-    // folder, so clicking a group's "+" always re-selects its directory.
-    const requestKey = `${requestId ?? ""}:${folderId}`;
-    const folder = folders.find((f) => f.id === folderId);
-    if (!folder) return;
+    // group, so clicking a group's "+" always re-selects its repo.
+    const requestKey = `${requestId ?? ""}:${folderId ?? folderRepository}`;
+    const folder = folderId
+      ? folders.find((f) => f.id === folderId)
+      : undefined;
+    // Wait for a folder that is expected but hasn't loaded yet; a group with no
+    // registered folder at all resolves from `folderRepository` alone.
+    if (folderId && !folder) return;
 
     const selection = resolveRepoSelectionForFolder({
       folder,
+      folderRepository,
       repositories,
       reposLoaded,
       currentMode: currentModeRef.current,
@@ -194,7 +238,7 @@ export function useInitialRepoSelectionFromFolderId({
       mostRecentEnvironment,
     });
 
-    if (dirInitRef.current !== requestKey) {
+    if (selection.directory && dirInitRef.current !== requestKey) {
       setSelectedDirectory(selection.directory);
       dirInitRef.current = requestKey;
     }
@@ -211,6 +255,7 @@ export function useInitialRepoSelectionFromFolderId({
     }
   }, [
     folderId,
+    folderRepository,
     requestId,
     folders,
     repositories,

--- a/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/stores/taskInputPrefillStore.ts
@@ -8,6 +8,8 @@ export interface TaskInputReportAssociation {
 export interface TaskInputPrefill {
   requestId?: string;
   folderId?: string;
+  /** `owner/repo` of the picked sidebar group, for groups with no folder. */
+  folderRepository?: string;
   initialPrompt?: string;
   initialCloudRepository?: string;
   initialModel?: string;

--- a/products/desktop/packages/ui/src/router/useAppView.ts
+++ b/products/desktop/packages/ui/src/router/useAppView.ts
@@ -25,6 +25,7 @@ export interface AppView {
   type: AppViewType;
   taskId?: string;
   folderId?: string;
+  folderRepository?: string;
   pendingTaskKey?: string;
   taskInputRequestId?: string;
   initialPrompt?: string;
@@ -145,6 +146,7 @@ export function useAppView(): AppView {
       return {
         ...view,
         folderId: prefill.folderId,
+        folderRepository: prefill.folderRepository,
         initialPrompt: prefill.initialPrompt,
         initialCloudRepository: prefill.initialCloudRepository,
         initialModel: prefill.initialModel,

--- a/products/desktop/packages/ui/src/router/useOpenTask.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.ts
@@ -64,6 +64,12 @@ export function useOpenTask(): (task: Task) => Promise<void> {
 
 export interface TaskInputNavigationOptions {
   folderId?: string;
+  /**
+   * `owner/repo` the picked sidebar group stands for. Cloud-only groups have no
+   * registered folder, so this is the only thing the new-task screen can prefill
+   * its repo from. Unlike `initialCloudRepository` it does not force cloud mode.
+   */
+  folderRepository?: string;
   initialPrompt?: string;
   initialCloudRepository?: string;
   initialModel?: string;
@@ -98,10 +104,11 @@ export function openTaskInput(
       ? { folderId: folderIdOrOptions }
       : (folderIdOrOptions ?? {});
 
-  // folderId counts as transient state: each "+" click must get a fresh
-  // requestId so re-picking the same folder re-applies the prefill.
+  // The folder prefill counts as transient state: each "+" click must get a
+  // fresh requestId so re-picking the same group re-applies the prefill.
   const hasTransientState =
     !!options.folderId ||
+    !!options.folderRepository ||
     !!options.initialPrompt ||
     !!options.initialCloudRepository ||
     !!options.initialModel ||
@@ -111,6 +118,7 @@ export function openTaskInput(
   useTaskInputPrefillStore.setState({
     prefill: {
       folderId: options.folderId,
+      folderRepository: options.folderRepository,
       initialPrompt: options.initialPrompt,
       initialCloudRepository: options.initialCloudRepository,
       initialModel: options.initialModel,


### PR DESCRIPTION
## Problem

Clicking the little "+" next to a repo in the desktop sidebar opens the new-task screen, but it doesn't always switch to that repo. Reported in Slack: clicking "+" on one repo opened the screen still showing a different one, so a task started there would have run against the wrong repo.

The prefill only worked when the repo had a local folder registered. Sidebar groups also come from tasks, though, so a repo you've only ever run in the cloud has no folder behind it. The click then passed nothing along and the screen kept whatever repo was last used.

> [!IMPORTANT]
> This only affects the old sidebar, which you get when the spaces layout is off. That's two flags, not one: `useChannelsLayout()` needs both `code-spaces-layout` and `project-bluebird`, so either one being off lands you here. Neither is fully rolled out, so this is still what an install renders by default. The spaces layout has no repo picker at all (it passes `allowNoRepo` and the agent picks the repo at runtime), so it can't hit this bug.

## Changes

A sidebar group's id is already the repo slug, so the "+" now passes it along, and the picker falls back to it when there's no folder.

The second commit fixes the same thing from another angle: a folderless group can still carry a `folderId` from one of its tasks, pointing at a folder you've since removed. That id never resolves, so the prefill sat waiting on it forever. Now it only waits while folders are still loading.

A group with no local checkout only works in the cloud, so it switches to cloud mode if the repo is connected and leaves the mode alone otherwise. Groups that do have a folder behave exactly as before.

## How did you test this code?

Automated only. I (Claude, via the Slack app) can't run the Electron app against real GitHub integrations here, so there's no manual repro.

- `pnpm --filter @posthog/ui exec vitest run src/features/sidebar src/features/task-detail src/router` (203 tests, green)
- `pnpm --filter @posthog/ui typecheck` and `biome check`

New tests in `useInitialRepoSelectionFromFolderId.test.ts` cover the case no existing test did: a group with no registered folder. They check that it picks the group's repo, that clicking a second group's "+" moves the selection (the reported symptom), and that a removed folder's id no longer blocks the prefill.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing in `docs/` covers this.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported in Slack and handed to me there. I haven't verified a GitHub handle for the reporter, so please assign the DRI yourself.

Tooling: Claude (PostHog Slack app / Claude Code).

Two things worth a look:

- `products/desktop/` is a copy of PostHog/code (see its MIGRATION.md), and upstream still has this bug. If resyncs are still happening, this needs to land there instead or it'll get overwritten.
- I widened the existing folder prefill instead of reusing `initialCloudRepository`, because that field forces cloud mode. It would have thrown local-mode users into the cloud when they clicked "+" on a repo they work on locally.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785770897638599?thread_ts=1785770897.638599&cid=C09G8Q32R6F)*
