### PR TITLE
feat(tasks): report desktop compute credits

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4636,7 +4636,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_posthog_code_credits_only_counts_posthog_code_events(self, mock_region: MagicMock) -> None:
         """The posthog_code query only counts generations tagged ai_product='posthog_code'."""
-        from posthog.tasks.usage_report import get_teams_with_posthog_code_token_credits_used_in_period
+        from posthog.tasks.usage_report import get_teams_with_posthog_code_credits_used_in_period
 
         mock_region.return_value = "US"
         self._setup_teams()
@@ -4681,7 +4681,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         flush_persons_and_events()
 
-        posthog_code_result = get_teams_with_posthog_code_token_credits_used_in_period(period_start, period_end)
+        posthog_code_result = get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
 
         # posthog_code bills at cost (no markup): 2.0 USD * 100 * 1.0 = 200 — only the
         # posthog_code event, not the signals one.
@@ -4702,7 +4702,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         PostHog Desktop never emits a matching $ai_trace event, so the LEFT JOIN never matches and the
         empty-trace fallback is what makes posthog_code billable at all — but only for $ai_billable=true.
         """
-        from posthog.tasks.usage_report import get_teams_with_posthog_code_token_credits_used_in_period
+        from posthog.tasks.usage_report import get_teams_with_posthog_code_credits_used_in_period
 
         mock_region.return_value = "US"
         self._setup_teams()
@@ -4730,7 +4730,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         flush_persons_and_events()
 
-        result = get_teams_with_posthog_code_token_credits_used_in_period(period_start, period_end)
+        result = get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
 
         expected = [(self.org_1_team_1.id, expected_credits)] if expected_credits is not None else []
         self.assertEqual(result, expected)

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4636,7 +4636,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
     @patch("posthog.tasks.usage_report.get_instance_region")
     def test_posthog_code_credits_only_counts_posthog_code_events(self, mock_region: MagicMock) -> None:
         """The posthog_code query only counts generations tagged ai_product='posthog_code'."""
-        from posthog.tasks.usage_report import get_teams_with_posthog_code_credits_used_in_period
+        from posthog.tasks.usage_report import get_teams_with_posthog_code_token_credits_used_in_period
 
         mock_region.return_value = "US"
         self._setup_teams()
@@ -4681,7 +4681,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         flush_persons_and_events()
 
-        posthog_code_result = get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
+        posthog_code_result = get_teams_with_posthog_code_token_credits_used_in_period(period_start, period_end)
 
         # posthog_code bills at cost (no markup): 2.0 USD * 100 * 1.0 = 200 — only the
         # posthog_code event, not the signals one.
@@ -4702,7 +4702,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
         PostHog Desktop never emits a matching $ai_trace event, so the LEFT JOIN never matches and the
         empty-trace fallback is what makes posthog_code billable at all — but only for $ai_billable=true.
         """
-        from posthog.tasks.usage_report import get_teams_with_posthog_code_credits_used_in_period
+        from posthog.tasks.usage_report import get_teams_with_posthog_code_token_credits_used_in_period
 
         mock_region.return_value = "US"
         self._setup_teams()
@@ -4730,7 +4730,7 @@ class TestAIEventsUsageReport(ClickhouseDestroyTablesMixin, TestCase, Clickhouse
 
         flush_persons_and_events()
 
-        result = get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
+        result = get_teams_with_posthog_code_token_credits_used_in_period(period_start, period_end)
 
         expected = [(self.org_1_team_1.id, expected_credits)] if expected_credits is not None else []
         self.assertEqual(result, expected)
@@ -4803,6 +4803,33 @@ class TestTaskSandboxUsageReport(APIBaseTest):
 
         self.assertFalse(has_non_zero_usage(UsageReportCounters(**zero)))
         self.assertTrue(has_non_zero_usage(UsageReportCounters(**{**zero, "task_sandbox_seconds_in_period": 5})))
+
+
+class TestPostHogCodeComputeUsageReport(SimpleTestCase):
+    def test_combined_credits_reconcile_with_components(self) -> None:
+        from posthog.tasks.usage_report import combine_posthog_code_credits
+
+        assert combine_posthog_code_credits(123, 45) == 168
+
+    @patch("posthog.tasks.usage_report.capture_exception")
+    @patch("posthog.tasks.usage_report.get_billable_sandbox_compute_usage_by_team")
+    def test_invalid_compute_configuration_is_observed_without_breaking_report(
+        self, mock_compute: MagicMock, mock_capture: MagicMock
+    ) -> None:
+        from posthog.tasks.usage_report import get_teams_with_billable_sandbox_compute_usage_in_period
+
+        from products.tasks.backend.facade.billing import SandboxComputeUsageByTeam
+        from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCardConfigurationError
+
+        error = ComputeRateCardConfigurationError("invalid")
+        mock_compute.side_effect = error
+
+        result = get_teams_with_billable_sandbox_compute_usage_in_period(
+            datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC)
+        )
+
+        assert result == SandboxComputeUsageByTeam([], [], [], [], [])
+        mock_capture.assert_called_once_with(error)
 
 
 class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4832,9 +4832,9 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
     ) -> None:
         from posthog.tasks.usage_report import get_teams_with_billable_sandbox_compute_usage_in_period
 
-        from products.tasks.backend.facade.billing import SandboxComputeUsageByTeam
+        from products.tasks.backend.facade.billing import ComputeRateCardConfigurationError, SandboxComputeUsageByTeam
 
-        error = ValueError("invalid")
+        error = ComputeRateCardConfigurationError("invalid")
         mock_compute.side_effect = error
 
         result = get_teams_with_billable_sandbox_compute_usage_in_period(
@@ -4843,6 +4843,24 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
 
         assert result == SandboxComputeUsageByTeam([], [], [])
         mock_capture.assert_called_once_with(error)
+
+    @patch("retry.api.time.sleep")
+    @patch("posthog.tasks.usage_report.capture_exception")
+    @patch("posthog.tasks.usage_report.get_billable_sandbox_compute_usage_by_team")
+    def test_transient_compute_failure_propagates_after_retries(
+        self, mock_compute: MagicMock, mock_capture: MagicMock, _mock_sleep: MagicMock
+    ) -> None:
+        from posthog.tasks.usage_report import QUERY_RETRIES, get_teams_with_billable_sandbox_compute_usage_in_period
+
+        mock_compute.side_effect = RuntimeError("transient database failure")
+
+        with self.assertRaises(RuntimeError):
+            get_teams_with_billable_sandbox_compute_usage_in_period(
+                datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC)
+            )
+
+        assert mock_compute.call_count == QUERY_RETRIES
+        mock_capture.assert_not_called()
 
 
 class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest):

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4814,8 +4814,6 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
             "sandbox_compute_credits_used_in_period",
             "sandbox_compute_cpu_millicore_seconds_in_period",
             "sandbox_compute_memory_mib_seconds_in_period",
-            "sandbox_compute_cpu_cost_microusd_in_period",
-            "sandbox_compute_memory_cost_microusd_in_period",
         }
 
         assert all(UsageReportCounters.__annotations__[metric] is int for metric in component_metrics)
@@ -4843,7 +4841,7 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
             datetime(2026, 1, 2, tzinfo=UTC), datetime(2026, 1, 3, tzinfo=UTC)
         )
 
-        assert result == SandboxComputeUsageByTeam([], [], [], [], [])
+        assert result == SandboxComputeUsageByTeam([], [], [])
         mock_capture.assert_called_once_with(error)
 
 

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4819,9 +4819,8 @@ class TestPostHogCodeComputeUsageReport(SimpleTestCase):
         from posthog.tasks.usage_report import get_teams_with_billable_sandbox_compute_usage_in_period
 
         from products.tasks.backend.facade.billing import SandboxComputeUsageByTeam
-        from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCardConfigurationError
 
-        error = ComputeRateCardConfigurationError("invalid")
+        error = ValueError("invalid")
         mock_compute.side_effect = error
 
         result = get_teams_with_billable_sandbox_compute_usage_in_period(

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -4806,6 +4806,22 @@ class TestTaskSandboxUsageReport(APIBaseTest):
 
 
 class TestPostHogCodeComputeUsageReport(SimpleTestCase):
+    def test_component_contract_uses_integer_historical_metric_types(self) -> None:
+        from posthog.tasks.usage_report import UsageReportCounters
+
+        component_metrics = {
+            "posthog_code_token_credits_used_in_period",
+            "sandbox_compute_credits_used_in_period",
+            "sandbox_compute_cpu_millicore_seconds_in_period",
+            "sandbox_compute_memory_mib_seconds_in_period",
+            "sandbox_compute_cpu_cost_microusd_in_period",
+            "sandbox_compute_memory_cost_microusd_in_period",
+        }
+
+        assert all(UsageReportCounters.__annotations__[metric] is int for metric in component_metrics)
+        assert "sandbox_compute_cpu_core_seconds_in_period" not in UsageReportCounters.__annotations__
+        assert "sandbox_compute_memory_gib_seconds_in_period" not in UsageReportCounters.__annotations__
+
     def test_combined_credits_reconcile_with_components(self) -> None:
         from posthog.tasks.usage_report import combine_posthog_code_credits
 

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -2809,7 +2809,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_signals_credits_used_in_period": get_teams_with_signals_credits_used_in_period(
             period_start, period_end
         ),
-        "teams_with_posthog_code_token_credits_used_in_period": token_credits,
+        "teams_with_posthog_code_credits_used_in_period": token_credits,
         "teams_with_sandbox_compute_credits_used_in_period": sandbox_compute_usage.credits,
         "teams_with_sandbox_compute_cpu_millicore_seconds_in_period": sandbox_compute_usage.cpu_millicore_seconds,
         "teams_with_sandbox_compute_memory_mib_seconds_in_period": sandbox_compute_usage.memory_mib_seconds,
@@ -3008,10 +3008,10 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         ai_credits_used_in_period=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0),
         signals_credits_used_in_period=all_data["teams_with_signals_credits_used_in_period"].get(team.id, 0),
         posthog_code_credits_used_in_period=combine_posthog_code_credits(
-            all_data["teams_with_posthog_code_token_credits_used_in_period"].get(team.id, 0),
+            all_data["teams_with_posthog_code_credits_used_in_period"].get(team.id, 0),
             all_data["teams_with_sandbox_compute_credits_used_in_period"].get(team.id, 0),
         ),
-        posthog_code_token_credits_used_in_period=all_data["teams_with_posthog_code_token_credits_used_in_period"].get(
+        posthog_code_token_credits_used_in_period=all_data["teams_with_posthog_code_credits_used_in_period"].get(
             team.id, 0
         ),
         sandbox_compute_credits_used_in_period=all_data["teams_with_sandbox_compute_credits_used_in_period"].get(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -253,8 +253,8 @@ class UsageReportCounters:
     posthog_code_credits_used_in_period: int
     posthog_code_token_credits_used_in_period: int
     sandbox_compute_credits_used_in_period: int
-    sandbox_compute_cpu_core_seconds_in_period: float
-    sandbox_compute_memory_gib_seconds_in_period: float
+    sandbox_compute_cpu_millicore_seconds_in_period: int
+    sandbox_compute_memory_mib_seconds_in_period: int
     sandbox_compute_cpu_cost_microusd_in_period: int
     sandbox_compute_memory_cost_microusd_in_period: int
 
@@ -2818,8 +2818,8 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         ),
         "teams_with_posthog_code_token_credits_used_in_period": token_credits,
         "teams_with_sandbox_compute_credits_used_in_period": sandbox_compute_usage.credits,
-        "teams_with_sandbox_compute_cpu_core_seconds_in_period": sandbox_compute_usage.cpu_core_seconds,
-        "teams_with_sandbox_compute_memory_gib_seconds_in_period": sandbox_compute_usage.memory_gib_seconds,
+        "teams_with_sandbox_compute_cpu_millicore_seconds_in_period": sandbox_compute_usage.cpu_millicore_seconds,
+        "teams_with_sandbox_compute_memory_mib_seconds_in_period": sandbox_compute_usage.memory_mib_seconds,
         "teams_with_sandbox_compute_cpu_cost_microusd_in_period": sandbox_compute_usage.cpu_cost_microusd,
         "teams_with_sandbox_compute_memory_cost_microusd_in_period": sandbox_compute_usage.memory_cost_microusd,
         "teams_with_task_sandbox_seconds_in_period": task_sandbox_usage.seconds,
@@ -3024,11 +3024,11 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         sandbox_compute_credits_used_in_period=all_data["teams_with_sandbox_compute_credits_used_in_period"].get(
             team.id, 0
         ),
-        sandbox_compute_cpu_core_seconds_in_period=all_data[
-            "teams_with_sandbox_compute_cpu_core_seconds_in_period"
+        sandbox_compute_cpu_millicore_seconds_in_period=all_data[
+            "teams_with_sandbox_compute_cpu_millicore_seconds_in_period"
         ].get(team.id, 0),
-        sandbox_compute_memory_gib_seconds_in_period=all_data[
-            "teams_with_sandbox_compute_memory_gib_seconds_in_period"
+        sandbox_compute_memory_mib_seconds_in_period=all_data[
+            "teams_with_sandbox_compute_memory_mib_seconds_in_period"
         ].get(team.id, 0),
         sandbox_compute_cpu_cost_microusd_in_period=all_data[
             "teams_with_sandbox_compute_cpu_cost_microusd_in_period"

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -255,8 +255,6 @@ class UsageReportCounters:
     sandbox_compute_credits_used_in_period: int
     sandbox_compute_cpu_millicore_seconds_in_period: int
     sandbox_compute_memory_mib_seconds_in_period: int
-    sandbox_compute_cpu_cost_microusd_in_period: int
-    sandbox_compute_memory_cost_microusd_in_period: int
 
     # Cloud task sandbox compute, all task origins (raw user-attributed usage from the
     # SandboxSession ledger — unpriced until a billing model is decided; pre-warm time excluded)
@@ -1764,7 +1762,7 @@ def get_teams_with_billable_sandbox_compute_usage_in_period(
     except Exception as err:
         logger.exception("sandbox_compute.usage_report_failed")
         capture_exception(err)
-        return SandboxComputeUsageByTeam([], [], [], [], [])
+        return SandboxComputeUsageByTeam([], [], [])
 
 
 def combine_posthog_code_credits(token_credits: int, compute_credits: int) -> int:
@@ -2813,8 +2811,6 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_sandbox_compute_credits_used_in_period": sandbox_compute_usage.credits,
         "teams_with_sandbox_compute_cpu_millicore_seconds_in_period": sandbox_compute_usage.cpu_millicore_seconds,
         "teams_with_sandbox_compute_memory_mib_seconds_in_period": sandbox_compute_usage.memory_mib_seconds,
-        "teams_with_sandbox_compute_cpu_cost_microusd_in_period": sandbox_compute_usage.cpu_cost_microusd,
-        "teams_with_sandbox_compute_memory_cost_microusd_in_period": sandbox_compute_usage.memory_cost_microusd,
         "teams_with_task_sandbox_seconds_in_period": task_sandbox_usage.seconds,
         "teams_with_task_sandbox_cpu_core_seconds_in_period": task_sandbox_usage.cpu_core_seconds,
         "teams_with_task_sandbox_memory_gib_seconds_in_period": task_sandbox_usage.memory_gib_seconds,
@@ -3022,12 +3018,6 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         ].get(team.id, 0),
         sandbox_compute_memory_mib_seconds_in_period=all_data[
             "teams_with_sandbox_compute_memory_mib_seconds_in_period"
-        ].get(team.id, 0),
-        sandbox_compute_cpu_cost_microusd_in_period=all_data[
-            "teams_with_sandbox_compute_cpu_cost_microusd_in_period"
-        ].get(team.id, 0),
-        sandbox_compute_memory_cost_microusd_in_period=all_data[
-            "teams_with_sandbox_compute_memory_cost_microusd_in_period"
         ].get(team.id, 0),
         task_sandbox_seconds_in_period=all_data["teams_with_task_sandbox_seconds_in_period"].get(team.id, 0),
         task_sandbox_cpu_core_seconds_in_period=all_data["teams_with_task_sandbox_cpu_core_seconds_in_period"].get(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -66,6 +66,7 @@ from products.surveys.backend.util import (
     get_unique_survey_event_uuids_sql_subquery,
 )
 from products.tasks.backend.facade.billing import (
+    ComputeRateCardConfigurationError,
     SandboxComputeUsageByTeam,
     SandboxUsageByTeam,
     get_billable_sandbox_compute_usage_by_team,
@@ -1754,12 +1755,17 @@ def get_teams_with_task_sandbox_usage_in_period(begin: datetime, end: datetime) 
 
 
 @timed_log()
+@retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_billable_sandbox_compute_usage_in_period(
     begin: datetime, end: datetime
 ) -> SandboxComputeUsageByTeam:
+    """A rate-card misconfiguration degrades to empty usage rather than aborting quota/report
+    runs for every product; anything else (e.g. a transient DB failure) propagates so the
+    retry/abort-and-preserve semantics of the sibling billing queries apply.
+    """
     try:
         return get_billable_sandbox_compute_usage_by_team(begin, end)
-    except Exception as err:
+    except ComputeRateCardConfigurationError as err:
         logger.exception("sandbox_compute.usage_report_failed")
         capture_exception(err)
         return SandboxComputeUsageByTeam([], [], [])

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1726,7 +1726,7 @@ def get_self_driving_credits_used_in_period_for_org(
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_posthog_code_token_credits_used_in_period(
+def get_teams_with_posthog_code_credits_used_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
@@ -1742,13 +1742,6 @@ def get_teams_with_posthog_code_token_credits_used_in_period(
         product_tag=Product.POSTHOG_CODE,
         markup_percent=POSTHOG_CODE_COST_MARKUP_PERCENT,
     )
-
-
-def get_teams_with_posthog_code_credits_used_in_period(
-    begin: datetime,
-    end: datetime,
-) -> list[tuple[int, int]]:
-    return get_teams_with_posthog_code_token_credits_used_in_period(begin, end)
 
 
 @timed_log()
@@ -2579,7 +2572,7 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
     )
     task_sandbox_usage = get_teams_with_task_sandbox_usage_in_period(period_start, period_end)
     sandbox_compute_usage = get_teams_with_billable_sandbox_compute_usage_in_period(period_start, period_end)
-    token_credits = get_teams_with_posthog_code_token_credits_used_in_period(period_start, period_end)
+    token_credits = get_teams_with_posthog_code_credits_used_in_period(period_start, period_end)
 
     return {
         "teams_with_event_count_in_period": get_teams_with_billable_event_count_in_period(

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -1744,6 +1744,13 @@ def get_teams_with_posthog_code_token_credits_used_in_period(
     )
 
 
+def get_teams_with_posthog_code_credits_used_in_period(
+    begin: datetime,
+    end: datetime,
+) -> list[tuple[int, int]]:
+    return get_teams_with_posthog_code_token_credits_used_in_period(begin, end)
+
+
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
 def get_teams_with_task_sandbox_usage_in_period(begin: datetime, end: datetime) -> SandboxUsageByTeam:

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -65,7 +65,12 @@ from products.surveys.backend.util import (
     get_survey_property_string_expr,
     get_unique_survey_event_uuids_sql_subquery,
 )
-from products.tasks.backend.facade.billing import SandboxUsageByTeam, get_task_sandbox_usage_by_team
+from products.tasks.backend.facade.billing import (
+    SandboxComputeUsageByTeam,
+    SandboxUsageByTeam,
+    get_billable_sandbox_compute_usage_by_team,
+    get_task_sandbox_usage_by_team,
+)
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataJob, ExternalDataSchema
 
 logger = structlog.get_logger(__name__)
@@ -244,8 +249,14 @@ class UsageReportCounters:
     # Signals Billing Credits (flat credits per report whose implementation shipped a PR)
     signals_credits_used_in_period: int
 
-    # PostHog Desktop Billing Credits (PostHog Desktop product usage — same cost math as ai_credits, scoped to ai_product='posthog_code')
+    # PostHog Desktop Billing Credits
     posthog_code_credits_used_in_period: int
+    posthog_code_token_credits_used_in_period: int
+    sandbox_compute_credits_used_in_period: int
+    sandbox_compute_cpu_core_seconds_in_period: float
+    sandbox_compute_memory_gib_seconds_in_period: float
+    sandbox_compute_cpu_cost_microusd_in_period: int
+    sandbox_compute_memory_cost_microusd_in_period: int
 
     # Cloud task sandbox compute, all task origins (raw user-attributed usage from the
     # SandboxSession ledger — unpriced until a billing model is decided; pre-warm time excluded)
@@ -1715,7 +1726,7 @@ def get_self_driving_credits_used_in_period_for_org(
 
 @timed_log()
 @retry(tries=QUERY_RETRIES, delay=QUERY_RETRY_DELAY, backoff=QUERY_RETRY_BACKOFF)
-def get_teams_with_posthog_code_credits_used_in_period(
+def get_teams_with_posthog_code_token_credits_used_in_period(
     begin: datetime,
     end: datetime,
 ) -> list[tuple[int, int]]:
@@ -1742,6 +1753,22 @@ def get_teams_with_task_sandbox_usage_in_period(begin: datetime, end: datetime) 
     Unpriced: reported for visibility until a sandbox billing model is decided.
     """
     return get_task_sandbox_usage_by_team(begin, end)
+
+
+@timed_log()
+def get_teams_with_billable_sandbox_compute_usage_in_period(
+    begin: datetime, end: datetime
+) -> SandboxComputeUsageByTeam:
+    try:
+        return get_billable_sandbox_compute_usage_by_team(begin, end)
+    except Exception as err:
+        logger.exception("sandbox_compute.usage_report_failed")
+        capture_exception(err)
+        return SandboxComputeUsageByTeam([], [], [], [], [])
+
+
+def combine_posthog_code_credits(token_credits: int, compute_credits: int) -> int:
+    return token_credits + compute_credits
 
 
 dwh_pricing_free_period_start = datetime(2025, 10, 29, 0, 0, 0, tzinfo=UTC)
@@ -2544,6 +2571,8 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         period_start, period_end
     )
     task_sandbox_usage = get_teams_with_task_sandbox_usage_in_period(period_start, period_end)
+    sandbox_compute_usage = get_teams_with_billable_sandbox_compute_usage_in_period(period_start, period_end)
+    token_credits = get_teams_with_posthog_code_token_credits_used_in_period(period_start, period_end)
 
     return {
         "teams_with_event_count_in_period": get_teams_with_billable_event_count_in_period(
@@ -2780,9 +2809,12 @@ def _get_all_usage_data(period_start: datetime, period_end: datetime) -> dict[st
         "teams_with_signals_credits_used_in_period": get_teams_with_signals_credits_used_in_period(
             period_start, period_end
         ),
-        "teams_with_posthog_code_credits_used_in_period": get_teams_with_posthog_code_credits_used_in_period(
-            period_start, period_end
-        ),
+        "teams_with_posthog_code_token_credits_used_in_period": token_credits,
+        "teams_with_sandbox_compute_credits_used_in_period": sandbox_compute_usage.credits,
+        "teams_with_sandbox_compute_cpu_core_seconds_in_period": sandbox_compute_usage.cpu_core_seconds,
+        "teams_with_sandbox_compute_memory_gib_seconds_in_period": sandbox_compute_usage.memory_gib_seconds,
+        "teams_with_sandbox_compute_cpu_cost_microusd_in_period": sandbox_compute_usage.cpu_cost_microusd,
+        "teams_with_sandbox_compute_memory_cost_microusd_in_period": sandbox_compute_usage.memory_cost_microusd,
         "teams_with_task_sandbox_seconds_in_period": task_sandbox_usage.seconds,
         "teams_with_task_sandbox_cpu_core_seconds_in_period": task_sandbox_usage.cpu_core_seconds,
         "teams_with_task_sandbox_memory_gib_seconds_in_period": task_sandbox_usage.memory_gib_seconds,
@@ -2975,7 +3007,28 @@ def _get_team_report(all_data: dict[str, Any], team: Team) -> UsageReportCounter
         ai_event_count_in_period=all_data["teams_with_ai_event_count_in_period"].get(team.id, 0),
         ai_credits_used_in_period=all_data["teams_with_ai_credits_used_in_period"].get(team.id, 0),
         signals_credits_used_in_period=all_data["teams_with_signals_credits_used_in_period"].get(team.id, 0),
-        posthog_code_credits_used_in_period=all_data["teams_with_posthog_code_credits_used_in_period"].get(team.id, 0),
+        posthog_code_credits_used_in_period=combine_posthog_code_credits(
+            all_data["teams_with_posthog_code_token_credits_used_in_period"].get(team.id, 0),
+            all_data["teams_with_sandbox_compute_credits_used_in_period"].get(team.id, 0),
+        ),
+        posthog_code_token_credits_used_in_period=all_data["teams_with_posthog_code_token_credits_used_in_period"].get(
+            team.id, 0
+        ),
+        sandbox_compute_credits_used_in_period=all_data["teams_with_sandbox_compute_credits_used_in_period"].get(
+            team.id, 0
+        ),
+        sandbox_compute_cpu_core_seconds_in_period=all_data[
+            "teams_with_sandbox_compute_cpu_core_seconds_in_period"
+        ].get(team.id, 0),
+        sandbox_compute_memory_gib_seconds_in_period=all_data[
+            "teams_with_sandbox_compute_memory_gib_seconds_in_period"
+        ].get(team.id, 0),
+        sandbox_compute_cpu_cost_microusd_in_period=all_data[
+            "teams_with_sandbox_compute_cpu_cost_microusd_in_period"
+        ].get(team.id, 0),
+        sandbox_compute_memory_cost_microusd_in_period=all_data[
+            "teams_with_sandbox_compute_memory_cost_microusd_in_period"
+        ].get(team.id, 0),
         task_sandbox_seconds_in_period=all_data["teams_with_task_sandbox_seconds_in_period"].get(team.id, 0),
         task_sandbox_cpu_core_seconds_in_period=all_data["teams_with_task_sandbox_cpu_core_seconds_in_period"].get(
             team.id, 0

--- a/posthog/temporal/tests/usage_report/test_aggregator.py
+++ b/posthog/temporal/tests/usage_report/test_aggregator.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 from posthog.tasks.usage_report import InstanceMetadata, OrgReport, UsageReportCounters
 from posthog.temporal.usage_report.aggregator import (
+    add_pre_sandbox_compute_patch_defaults,
     batched,
     build_manifest,
     filter_org_reports,
@@ -152,6 +153,23 @@ def test_load_all_data_multi_output_missing_source_key_yields_empty() -> None:
 
     assert all_data["teams_with_web_events_count_in_period"] == {1: 1}
     assert all_data["teams_with_ruby_events_count_in_period"] == {}
+
+
+def test_load_all_data_defaults_compute_for_pre_patch_workflow_history() -> None:
+    all_data: dict[str, dict[int, int]] = {}
+    add_pre_sandbox_compute_patch_defaults(all_data, [])
+
+    assert all_data["teams_with_sandbox_compute_credits_used_in_period"] == {}
+    assert all_data["teams_with_sandbox_compute_cpu_millicore_seconds_in_period"] == {}
+    assert all_data["teams_with_sandbox_compute_memory_mib_seconds_in_period"] == {}
+
+
+def test_load_all_data_does_not_default_compute_for_patched_workflow_history() -> None:
+    all_data: dict[str, dict[int, int]] = {}
+    results = [RunQueryToS3Result(query_name="sandbox_compute_usage", s3_key="unused", duration_ms=1)]
+    add_pre_sandbox_compute_patch_defaults(all_data, results)
+
+    assert all_data == {}
 
 
 # ---- iter_chunk_lines ----------------------------------------------------

--- a/posthog/temporal/tests/usage_report/test_workflow.py
+++ b/posthog/temporal/tests/usage_report/test_workflow.py
@@ -28,7 +28,17 @@ from posthog.temporal.usage_report.types import (
     RunQueryToS3Result,
     RunUsageReportsInputs,
 )
-from posthog.temporal.usage_report.workflow import RunUsageReportsWorkflow, build_context
+from posthog.temporal.usage_report.workflow import (
+    SANDBOX_COMPUTE_QUERY_NAME,
+    RunUsageReportsWorkflow,
+    _queries_for_sandbox_compute_patch,
+    build_context,
+)
+
+
+def test_sandbox_compute_query_is_versioned_for_existing_histories() -> None:
+    assert SANDBOX_COMPUTE_QUERY_NAME not in [spec.name for spec in _queries_for_sandbox_compute_patch(False)]
+    assert SANDBOX_COMPUTE_QUERY_NAME in [spec.name for spec in _queries_for_sandbox_compute_patch(True)]
 
 
 @parameterized.expand(

--- a/posthog/temporal/usage_report/activities.py
+++ b/posthog/temporal/usage_report/activities.py
@@ -22,6 +22,7 @@ from posthog.tasks.usage_report import get_instance_metadata
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.metrics import ExecutionTimeRecorder
 from posthog.temporal.usage_report.aggregator import (
+    add_pre_sandbox_compute_patch_defaults,
     batched,
     build_manifest,
     build_org_reports,
@@ -129,6 +130,7 @@ async def aggregate_and_chunk_org_reports(inputs: AggregateInputs) -> AggregateR
             description="Aggregate per-query S3 results into org-report chunks.",
         ):
             all_data = await sync_to_async(load_all_data)(inputs.query_results)
+            add_pre_sandbox_compute_patch_defaults(all_data, inputs.query_results)
 
             @database_sync_to_async
             def aggregate_per_org() -> dict[str, Any]:

--- a/posthog/temporal/usage_report/aggregator.py
+++ b/posthog/temporal/usage_report/aggregator.py
@@ -34,6 +34,13 @@ from posthog.temporal.usage_report.queries import QUERY_INDEX
 from posthog.temporal.usage_report.storage import bucket, read_json
 from posthog.temporal.usage_report.types import Manifest, RunQueryToS3Result, WorkflowContext
 
+_SANDBOX_COMPUTE_QUERY_NAME = "sandbox_compute_usage"
+_SANDBOX_COMPUTE_DESTINATION_KEYS = (
+    "teams_with_sandbox_compute_credits_used_in_period",
+    "teams_with_sandbox_compute_cpu_millicore_seconds_in_period",
+    "teams_with_sandbox_compute_memory_mib_seconds_in_period",
+)
+
 
 def load_all_data(query_results: list[RunQueryToS3Result]) -> dict[str, dict[int, int]]:
     """Reconstruct the legacy `all_data` map from per-query S3 files.
@@ -54,6 +61,14 @@ def load_all_data(query_results: list[RunQueryToS3Result]) -> dict[str, dict[int
         else:
             all_data[spec.name] = convert_team_usage_rows_to_dict(raw)
     return all_data
+
+
+def add_pre_sandbox_compute_patch_defaults(
+    all_data: dict[str, dict[int, int]], query_results: list[RunQueryToS3Result]
+) -> None:
+    if not any(result.query_name == _SANDBOX_COMPUTE_QUERY_NAME for result in query_results):
+        for key in _SANDBOX_COMPUTE_DESTINATION_KEYS:
+            all_data[key] = {}
 
 
 def iter_chunk_lines(

--- a/posthog/temporal/usage_report/queries.py
+++ b/posthog/temporal/usage_report/queries.py
@@ -59,6 +59,7 @@ from posthog.tasks.usage_report import (
     get_teams_with_apm_tracing_usage_in_period,
     get_teams_with_billable_enhanced_persons_event_count_in_period,
     get_teams_with_billable_event_count_in_period,
+    get_teams_with_billable_sandbox_compute_usage_in_period,
     get_teams_with_cdp_billable_invocations_in_period,
     get_teams_with_dwh_mat_views_storage_in_s3,
     get_teams_with_dwh_tables_storage_in_s3,
@@ -213,6 +214,15 @@ def _task_sandbox_usage(begin: datetime, end: datetime) -> dict[str, list[tuple[
         "seconds": usage.seconds,
         "cpu_core_seconds": usage.cpu_core_seconds,
         "memory_gib_seconds": usage.memory_gib_seconds,
+    }
+
+
+def _sandbox_compute_usage(begin: datetime, end: datetime) -> dict[str, list[tuple[int, int]]]:
+    usage = get_teams_with_billable_sandbox_compute_usage_in_period(begin, end)
+    return {
+        "credits": usage.credits,
+        "cpu_millicore_seconds": usage.cpu_millicore_seconds,
+        "memory_mib_seconds": usage.memory_mib_seconds,
     }
 
 
@@ -486,6 +496,16 @@ QUERIES: list[QuerySpec] = [
             "seconds": "teams_with_task_sandbox_seconds_in_period",
             "cpu_core_seconds": "teams_with_task_sandbox_cpu_core_seconds_in_period",
             "memory_gib_seconds": "teams_with_task_sandbox_memory_gib_seconds_in_period",
+        },
+    ),
+    QuerySpec(
+        name="sandbox_compute_usage",
+        fn=_sandbox_compute_usage,
+        output="multi",
+        multi_keys_mapping={
+            "credits": "teams_with_sandbox_compute_credits_used_in_period",
+            "cpu_millicore_seconds": "teams_with_sandbox_compute_cpu_millicore_seconds_in_period",
+            "memory_mib_seconds": "teams_with_sandbox_compute_memory_mib_seconds_in_period",
         },
     ),
     # ---- ClickHouse: workflows / messaging ----------------------------------

--- a/posthog/temporal/usage_report/workflow.py
+++ b/posthog/temporal/usage_report/workflow.py
@@ -43,6 +43,14 @@ from posthog.temporal.usage_report.types import (
 # Cap concurrent gather queries so we don't overwhelm ClickHouse / Postgres
 # with ~40 simultaneous heavy queries.
 QUERY_CONCURRENCY = 4
+SANDBOX_COMPUTE_QUERY_PATCH_ID = "usage-report-sandbox-compute-query-2026-08"
+SANDBOX_COMPUTE_QUERY_NAME = "sandbox_compute_usage"
+
+
+def _queries_for_sandbox_compute_patch(patch_applied: bool) -> list[QuerySpec]:
+    if patch_applied:
+        return QUERIES
+    return [spec for spec in QUERIES if spec.name != SANDBOX_COMPUTE_QUERY_NAME]
 
 
 def build_context(inputs: RunUsageReportsInputs, run_id: str, now: datetime) -> WorkflowContext:
@@ -90,6 +98,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
         status = "FAILED"
         try:
             ctx = build_context(inputs, run_id=workflow.info().run_id, now=started_at)
+            queries = _queries_for_sandbox_compute_patch(workflow.patched(SANDBOX_COMPUTE_QUERY_PATCH_ID))
             workflow.logger.info(
                 "Starting usage reports workflow",
                 extra={
@@ -98,7 +107,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
                     "report_completeness": ctx.report_completeness,
                     "period_start": ctx.period_start.isoformat(),
                     "period_end": ctx.period_end.isoformat(),
-                    "spec_count": len(QUERIES),
+                    "spec_count": len(queries),
                 },
             )
 
@@ -113,7 +122,7 @@ class RunUsageReportsWorkflow(PostHogWorkflow):
                     return await self._run_query(ctx, spec)
 
             query_results: list[RunQueryToS3Result] = list(
-                await asyncio.gather(*(_run_with_sem(spec) for spec in QUERIES))
+                await asyncio.gather(*(_run_with_sem(spec) for spec in queries))
             )
 
             agg = await workflow.execute_activity(

--- a/products/tasks/backend/facade/billing.py
+++ b/products/tasks/backend/facade/billing.py
@@ -4,6 +4,16 @@ The usage reporter (posthog/tasks/usage_report.py) lives in the ``posthog`` modu
 which may only import ``products.tasks`` through the facade (see tach.toml).
 """
 
-from products.tasks.backend.logic.services.sandbox_usage import SandboxUsageByTeam, get_task_sandbox_usage_by_team
+from products.tasks.backend.logic.services.sandbox_usage import (
+    SandboxComputeUsageByTeam,
+    SandboxUsageByTeam,
+    get_billable_sandbox_compute_usage_by_team,
+    get_task_sandbox_usage_by_team,
+)
 
-__all__ = ["SandboxUsageByTeam", "get_task_sandbox_usage_by_team"]
+__all__ = [
+    "SandboxComputeUsageByTeam",
+    "SandboxUsageByTeam",
+    "get_billable_sandbox_compute_usage_by_team",
+    "get_task_sandbox_usage_by_team",
+]

--- a/products/tasks/backend/facade/billing.py
+++ b/products/tasks/backend/facade/billing.py
@@ -4,6 +4,7 @@ The usage reporter (posthog/tasks/usage_report.py) lives in the ``posthog`` modu
 which may only import ``products.tasks`` through the facade (see tach.toml).
 """
 
+from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCardConfigurationError
 from products.tasks.backend.logic.services.sandbox_usage import (
     SandboxComputeUsageByTeam,
     SandboxUsageByTeam,
@@ -12,6 +13,7 @@ from products.tasks.backend.logic.services.sandbox_usage import (
 )
 
 __all__ = [
+    "ComputeRateCardConfigurationError",
     "SandboxComputeUsageByTeam",
     "SandboxUsageByTeam",
     "get_billable_sandbox_compute_usage_by_team",

--- a/products/tasks/backend/logic/services/sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/sandbox_pricing.py
@@ -52,6 +52,13 @@ class SandboxComputeCost:
 COMPUTE_RATE_CARDS: tuple[ComputeRateCard, ...] = ()
 
 
+def validate_reporting_window(reporting_start: datetime, reporting_end: datetime) -> None:
+    if timezone.is_naive(reporting_start) or timezone.is_naive(reporting_end):
+        raise ValueError("reporting timestamps must be timezone-aware")
+    if reporting_end <= reporting_start:
+        raise ValueError("reporting end must follow reporting start")
+
+
 def validate_compute_rate_cards(rate_cards: Sequence[ComputeRateCard]) -> tuple[ComputeRateCard, ...]:
     cards = tuple(rate_cards)
     if not cards:
@@ -92,10 +99,7 @@ def calculate_sandbox_compute_cost(
     rate_cards: Sequence[ComputeRateCard] = COMPUTE_RATE_CARDS,
 ) -> SandboxComputeCost:
     cards = validate_compute_rate_cards(rate_cards)
-    if timezone.is_naive(reporting_start) or timezone.is_naive(reporting_end):
-        raise ValueError("reporting timestamps must be timezone-aware")
-    if reporting_end <= reporting_start:
-        raise ValueError("reporting end must follow reporting start")
+    validate_reporting_window(reporting_start, reporting_end)
 
     now = calculated_at or timezone.now()
     if timezone.is_naive(now):

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -175,9 +175,16 @@ def get_billable_sandbox_compute_usage_by_team(
         SandboxSession.objects.unscoped()
         .filter(
             client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
-            origin_product=Task.OriginProduct.USER_CREATED,
             user_attributed_at__isnull=False,
             user_attributed_at__lt=end,
+        )
+        .filter(
+            Q(origin_product=Task.OriginProduct.USER_CREATED)
+            | Q(
+                origin_product=Task.OriginProduct.LOOP,
+                task_run__task__loop__isnull=False,
+                task_run__task__loop__internal=False,
+            )
         )
         .filter(Q(ended_at__isnull=True, ttl_expires_at__gt=begin) | Q(ended_at__gt=begin))
     )

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -11,9 +11,10 @@ The write helpers swallow and log every failure: the ledger must never break
 sandbox provisioning, cleanup, or user-message delivery.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from decimal import ROUND_HALF_EVEN, Decimal
 from functools import wraps
 from typing import ParamSpec, TypeVar
 from uuid import UUID
@@ -25,7 +26,13 @@ from django.utils import timezone
 import structlog
 
 from products.tasks.backend.logic.services.sandbox import SandboxConfig
-from products.tasks.backend.models import SandboxSession, TaskRun
+from products.tasks.backend.logic.services.sandbox_pricing import (
+    COMPUTE_RATE_CARDS,
+    ComputeRateCard,
+    calculate_sandbox_compute_cost,
+    validate_compute_rate_cards,
+)
+from products.tasks.backend.models import SandboxSession, Task, TaskClientProvenance, TaskRun
 
 logger = structlog.get_logger(__name__)
 
@@ -142,6 +149,67 @@ class SandboxUsageByTeam:
     seconds: list[tuple[int, int]]
     cpu_core_seconds: list[tuple[int, int]]
     memory_gib_seconds: list[tuple[int, int]]
+
+
+@dataclass(frozen=True)
+class SandboxComputeUsageByTeam:
+    credits: list[tuple[int, int]]
+    cpu_core_seconds: list[tuple[int, float]]
+    memory_gib_seconds: list[tuple[int, float]]
+    cpu_cost_microusd: list[tuple[int, int]]
+    memory_cost_microusd: list[tuple[int, int]]
+
+
+def get_billable_sandbox_compute_usage_by_team(
+    begin: datetime,
+    end: datetime,
+    *,
+    rate_cards: Sequence[ComputeRateCard] | None = None,
+) -> SandboxComputeUsageByTeam:
+    rate_cards = COMPUTE_RATE_CARDS if rate_cards is None else rate_cards
+    if not rate_cards:
+        return SandboxComputeUsageByTeam([], [], [], [], [])
+
+    cards = validate_compute_rate_cards(rate_cards)
+    sessions = (
+        SandboxSession.objects.unscoped()
+        .filter(
+            client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+            origin_product=Task.OriginProduct.USER_CREATED,
+            user_attributed_at__isnull=False,
+            user_attributed_at__lt=end,
+        )
+        .filter(Q(ended_at__isnull=True, ttl_expires_at__gt=begin) | Q(ended_at__gt=begin))
+    )
+
+    usage: dict[int, list[Decimal]] = {}
+    calculated_at = timezone.now()
+    for session in sessions.iterator():
+        cost = calculate_sandbox_compute_cost(session, begin, end, calculated_at=calculated_at, rate_cards=cards)
+        totals = usage.setdefault(session.team_id, [Decimal(0) for _ in range(4)])
+        totals[0] += cost.cpu_core_seconds
+        totals[1] += cost.memory_gib_seconds
+        totals[2] += cost.cpu_cost_usd
+        totals[3] += cost.memory_cost_usd
+
+    credits: list[tuple[int, int]] = []
+    cpu_core_seconds: list[tuple[int, float]] = []
+    memory_gib_seconds: list[tuple[int, float]] = []
+    cpu_cost_microusd: list[tuple[int, int]] = []
+    memory_cost_microusd: list[tuple[int, int]] = []
+    for team_id, totals in usage.items():
+        cpu_quantity, memory_quantity, cpu_usd, memory_usd = totals
+        credits.append((team_id, int(((cpu_usd + memory_usd) * 100).to_integral_value(rounding=ROUND_HALF_EVEN))))
+        cpu_core_seconds.append((team_id, float(cpu_quantity)))
+        memory_gib_seconds.append((team_id, float(memory_quantity)))
+        cpu_cost_microusd.append((team_id, int((cpu_usd * 1_000_000).to_integral_value(rounding=ROUND_HALF_EVEN))))
+        memory_cost_microusd.append(
+            (team_id, int((memory_usd * 1_000_000).to_integral_value(rounding=ROUND_HALF_EVEN)))
+        )
+
+    return SandboxComputeUsageByTeam(
+        credits, cpu_core_seconds, memory_gib_seconds, cpu_cost_microusd, memory_cost_microusd
+    )
 
 
 def get_task_sandbox_usage_by_team(begin: datetime, end: datetime) -> SandboxUsageByTeam:

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -31,6 +31,7 @@ from products.tasks.backend.logic.services.sandbox_pricing import (
     ComputeRateCard,
     calculate_sandbox_compute_cost,
     validate_compute_rate_cards,
+    validate_reporting_window,
 )
 from products.tasks.backend.models import SandboxSession, Task, TaskClientProvenance, TaskRun
 
@@ -164,6 +165,7 @@ def get_billable_sandbox_compute_usage_by_team(
     *,
     rate_cards: Sequence[ComputeRateCard] | None = None,
 ) -> SandboxComputeUsageByTeam:
+    validate_reporting_window(begin, end)
     rate_cards = COMPUTE_RATE_CARDS if rate_cards is None else rate_cards
     if not rate_cards:
         return SandboxComputeUsageByTeam([], [], [])

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -156,8 +156,6 @@ class SandboxComputeUsageByTeam:
     credits: list[tuple[int, int]]
     cpu_millicore_seconds: list[tuple[int, int]]
     memory_mib_seconds: list[tuple[int, int]]
-    cpu_cost_microusd: list[tuple[int, int]]
-    memory_cost_microusd: list[tuple[int, int]]
 
 
 def get_billable_sandbox_compute_usage_by_team(
@@ -168,7 +166,7 @@ def get_billable_sandbox_compute_usage_by_team(
 ) -> SandboxComputeUsageByTeam:
     rate_cards = COMPUTE_RATE_CARDS if rate_cards is None else rate_cards
     if not rate_cards:
-        return SandboxComputeUsageByTeam([], [], [], [], [])
+        return SandboxComputeUsageByTeam([], [], [])
 
     cards = validate_compute_rate_cards(rate_cards)
     sessions = (
@@ -193,30 +191,21 @@ def get_billable_sandbox_compute_usage_by_team(
     calculated_at = timezone.now()
     for session in sessions.iterator():
         cost = calculate_sandbox_compute_cost(session, begin, end, calculated_at=calculated_at, rate_cards=cards)
-        totals = usage.setdefault(session.team_id, [Decimal(0) for _ in range(4)])
+        totals = usage.setdefault(session.team_id, [Decimal(0) for _ in range(3)])
         totals[0] += cost.cpu_core_seconds
         totals[1] += cost.memory_gib_seconds
-        totals[2] += cost.cpu_cost_usd
-        totals[3] += cost.memory_cost_usd
+        totals[2] += cost.cpu_cost_usd + cost.memory_cost_usd
 
     credits: list[tuple[int, int]] = []
     cpu_millicore_seconds: list[tuple[int, int]] = []
     memory_mib_seconds: list[tuple[int, int]] = []
-    cpu_cost_microusd: list[tuple[int, int]] = []
-    memory_cost_microusd: list[tuple[int, int]] = []
     for team_id, totals in usage.items():
-        cpu_quantity, memory_quantity, cpu_usd, memory_usd = totals
-        credits.append((team_id, int(((cpu_usd + memory_usd) * 100).to_integral_value(rounding=ROUND_HALF_EVEN))))
+        cpu_quantity, memory_quantity, total_usd = totals
+        credits.append((team_id, int((total_usd * 100).to_integral_value(rounding=ROUND_HALF_EVEN))))
         cpu_millicore_seconds.append((team_id, int((cpu_quantity * 1000).to_integral_value(rounding=ROUND_HALF_EVEN))))
         memory_mib_seconds.append((team_id, int((memory_quantity * 1024).to_integral_value(rounding=ROUND_HALF_EVEN))))
-        cpu_cost_microusd.append((team_id, int((cpu_usd * 1_000_000).to_integral_value(rounding=ROUND_HALF_EVEN))))
-        memory_cost_microusd.append(
-            (team_id, int((memory_usd * 1_000_000).to_integral_value(rounding=ROUND_HALF_EVEN)))
-        )
 
-    return SandboxComputeUsageByTeam(
-        credits, cpu_millicore_seconds, memory_mib_seconds, cpu_cost_microusd, memory_cost_microusd
-    )
+    return SandboxComputeUsageByTeam(credits, cpu_millicore_seconds, memory_mib_seconds)
 
 
 def get_task_sandbox_usage_by_team(begin: datetime, end: datetime) -> SandboxUsageByTeam:

--- a/products/tasks/backend/logic/services/sandbox_usage.py
+++ b/products/tasks/backend/logic/services/sandbox_usage.py
@@ -154,8 +154,8 @@ class SandboxUsageByTeam:
 @dataclass(frozen=True)
 class SandboxComputeUsageByTeam:
     credits: list[tuple[int, int]]
-    cpu_core_seconds: list[tuple[int, float]]
-    memory_gib_seconds: list[tuple[int, float]]
+    cpu_millicore_seconds: list[tuple[int, int]]
+    memory_mib_seconds: list[tuple[int, int]]
     cpu_cost_microusd: list[tuple[int, int]]
     memory_cost_microusd: list[tuple[int, int]]
 
@@ -200,22 +200,22 @@ def get_billable_sandbox_compute_usage_by_team(
         totals[3] += cost.memory_cost_usd
 
     credits: list[tuple[int, int]] = []
-    cpu_core_seconds: list[tuple[int, float]] = []
-    memory_gib_seconds: list[tuple[int, float]] = []
+    cpu_millicore_seconds: list[tuple[int, int]] = []
+    memory_mib_seconds: list[tuple[int, int]] = []
     cpu_cost_microusd: list[tuple[int, int]] = []
     memory_cost_microusd: list[tuple[int, int]] = []
     for team_id, totals in usage.items():
         cpu_quantity, memory_quantity, cpu_usd, memory_usd = totals
         credits.append((team_id, int(((cpu_usd + memory_usd) * 100).to_integral_value(rounding=ROUND_HALF_EVEN))))
-        cpu_core_seconds.append((team_id, float(cpu_quantity)))
-        memory_gib_seconds.append((team_id, float(memory_quantity)))
+        cpu_millicore_seconds.append((team_id, int((cpu_quantity * 1000).to_integral_value(rounding=ROUND_HALF_EVEN))))
+        memory_mib_seconds.append((team_id, int((memory_quantity * 1024).to_integral_value(rounding=ROUND_HALF_EVEN))))
         cpu_cost_microusd.append((team_id, int((cpu_usd * 1_000_000).to_integral_value(rounding=ROUND_HALF_EVEN))))
         memory_cost_microusd.append(
             (team_id, int((memory_usd * 1_000_000).to_integral_value(rounding=ROUND_HALF_EVEN)))
         )
 
     return SandboxComputeUsageByTeam(
-        credits, cpu_core_seconds, memory_gib_seconds, cpu_cost_microusd, memory_cost_microusd
+        credits, cpu_millicore_seconds, memory_mib_seconds, cpu_cost_microusd, memory_cost_microusd
     )
 
 

--- a/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_pricing.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime, timedelta, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -9,6 +9,7 @@ from products.tasks.backend.logic.services.sandbox_pricing import (
     ComputeRateCardConfigurationError,
     calculate_sandbox_compute_cost,
     validate_compute_rate_cards,
+    validate_reporting_window,
 )
 
 EFFECTIVE_AT = datetime(2026, 8, 1, tzinfo=UTC)
@@ -283,3 +284,21 @@ def test_usage_before_compute_billing_effective_date_is_not_priced():
 def test_invalid_missing_overlapping_or_ambiguous_rate_cards_fail_safely(cards, message):
     with pytest.raises(ComputeRateCardConfigurationError, match=message):
         validate_compute_rate_cards(cards)
+
+
+@pytest.mark.parametrize(
+    "start,end,message",
+    [
+        (datetime(2026, 1, 1), EFFECTIVE_AT, "timezone-aware"),
+        (EFFECTIVE_AT, datetime(2026, 1, 2), "timezone-aware"),
+        (EFFECTIVE_AT, EFFECTIVE_AT, "must follow"),
+        (EFFECTIVE_AT + timedelta(seconds=1), EFFECTIVE_AT, "must follow"),
+    ],
+)
+def test_invalid_reporting_windows_are_rejected(start, end, message):
+    with pytest.raises(ValueError, match=message):
+        validate_reporting_window(start, end)
+
+
+def test_reporting_window_accepts_different_aware_offsets():
+    validate_reporting_window(EFFECTIVE_AT, EFFECTIVE_AT.astimezone(timezone(timedelta(hours=1))) + timedelta(1))

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -6,6 +6,7 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
 from posthog.models.organization import Organization
+from posthog.models.scoping import team_scope
 from posthog.models.team.team import Team
 
 from products.tasks.backend.logic.services.sandbox import SandboxConfig
@@ -250,14 +251,15 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
     def _loop_session(
         self, *, internal: bool, client_provenance: TaskClientProvenance | None = TaskClientProvenance.POSTHOG_DESKTOP
     ) -> SandboxSession:
-        loop = Loop.objects.create(
-            team=self.team,
-            name="loop",
-            instructions="run",
-            runtime_adapter="claude",
-            internal=internal,
-            client_provenance=client_provenance,
-        )
+        with team_scope(self.team.id):
+            loop = Loop.objects.create(
+                team=self.team,
+                name="loop",
+                instructions="run",
+                runtime_adapter="claude",
+                internal=internal,
+                client_provenance=client_provenance,
+            )
         task = Task.objects.create(
             team=self.team,
             title="loop run",

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -274,16 +274,22 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
             client_provenance=client_provenance,
         )
 
-    def _rate(self, **overrides) -> ComputeRateCard:
-        defaults = {
-            "version": "v1",
-            "effective_at": self.BEGIN,
-            "expires_at": None,
-            "cpu_core_second_usd": Decimal("0.001"),
-            "memory_gib_second_usd": Decimal("0.0001"),
-        }
-        defaults.update(overrides)
-        return ComputeRateCard(**defaults)
+    def _rate(
+        self,
+        *,
+        version: str = "v1",
+        effective_at: datetime | None = None,
+        expires_at: datetime | None = None,
+        cpu_core_second_usd: Decimal = Decimal("0.001"),
+        memory_gib_second_usd: Decimal = Decimal("0.0001"),
+    ) -> ComputeRateCard:
+        return ComputeRateCard(
+            version=version,
+            effective_at=effective_at or self.BEGIN,
+            expires_at=expires_at,
+            cpu_core_second_usd=cpu_core_second_usd,
+            memory_gib_second_usd=memory_gib_second_usd,
+        )
 
     def test_billable_compute_requires_trusted_desktop_user_created_snapshot(self):
         self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -360,6 +360,33 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         assert usage.cpu_millicore_seconds == [(self.team.id, 125)]
         assert usage.memory_mib_seconds == [(self.team.id, 384)]
 
+    def test_integer_resource_units_support_large_values(self):
+        self._session(
+            client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+            cpu_request_cores=999.999,
+            memory_request_mb=1_048_576,
+        )
+
+        usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
+
+        assert usage.cpu_millicore_seconds == [(self.team.id, 3_599_996_400)]
+        assert usage.memory_mib_seconds == [(self.team.id, 3_774_873_600)]
+
+    def test_pre_effective_usage_reports_explicit_integer_zeros(self):
+        self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)
+
+        usage = get_billable_sandbox_compute_usage_by_team(
+            self.BEGIN, self.END, rate_cards=(self._rate(effective_at=self.BEGIN + timedelta(hours=3)),)
+        )
+
+        expected = [(self.team.id, 0)]
+        assert usage.credits == expected
+        assert usage.cpu_millicore_seconds == expected
+        assert usage.memory_mib_seconds == expected
+        assert usage.cpu_cost_microusd == expected
+        assert usage.memory_cost_microusd == expected
+        assert all(type(value) is int for rows in usage.__dict__.values() for _, value in rows)
+
     def test_compute_before_first_rate_is_free_and_rate_changes_are_applied(self):
         self._session(
             client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -299,8 +299,8 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
 
         usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
 
-        assert usage.cpu_core_seconds == [(self.team.id, 14400.0)]
-        assert usage.memory_gib_seconds == [(self.team.id, 57600.0)]
+        assert usage.cpu_millicore_seconds == [(self.team.id, 14_400_000)]
+        assert usage.memory_mib_seconds == [(self.team.id, 58_982_400)]
         assert usage.cpu_cost_microusd == [(self.team.id, 14_400_000)]
         assert usage.memory_cost_microusd == [(self.team.id, 5_760_000)]
         assert usage.credits == [(self.team.id, 2016)]
@@ -312,7 +312,7 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
 
         usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
 
-        assert usage.cpu_core_seconds == [(self.team.id, 14400.0)]
+        assert usage.cpu_millicore_seconds == [(self.team.id, 14_400_000)]
         assert usage.credits == [(self.team.id, 2016)]
 
     def test_billable_compute_uses_session_snapshot_after_task_changes(self):
@@ -342,6 +342,24 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         assert usage.cpu_cost_microusd == [(self.team.id, 5000)]
         assert usage.memory_cost_microusd == [(self.team.id, 5000)]
 
+    def test_integer_resource_units_round_only_after_exact_aggregation(self):
+        for sandbox_id in ("sb-units-a", "sb-units-b"):
+            self._session(
+                sandbox_id=sandbox_id,
+                client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+                cpu_request_cores=0.125,
+                memory_request_mb=384,
+                ended_at=self.BEGIN + timedelta(seconds=1),
+                user_attributed_at=self.BEGIN,
+            )
+
+        usage = get_billable_sandbox_compute_usage_by_team(
+            self.BEGIN, self.BEGIN + timedelta(microseconds=500_000), rate_cards=(self._rate(),)
+        )
+
+        assert usage.cpu_millicore_seconds == [(self.team.id, 125)]
+        assert usage.memory_mib_seconds == [(self.team.id, 384)]
+
     def test_compute_before_first_rate_is_free_and_rate_changes_are_applied(self):
         self._session(
             client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
@@ -364,7 +382,7 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
 
         usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=rates)
 
-        assert usage.cpu_core_seconds == [(self.team.id, 2.0)]
+        assert usage.cpu_millicore_seconds == [(self.team.id, 2000)]
         assert usage.cpu_cost_microusd == [(self.team.id, 3000)]
         assert usage.memory_cost_microusd == [(self.team.id, 300)]
 

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -17,7 +17,7 @@ from products.tasks.backend.logic.services.sandbox_usage import (
     open_sandbox_session,
     record_task_run_user_activity,
 )
-from products.tasks.backend.models import SandboxSession, Task, TaskClientProvenance, TaskRun
+from products.tasks.backend.models import Loop, SandboxSession, Task, TaskClientProvenance, TaskRun
 
 
 def _config(**overrides) -> SandboxConfig:
@@ -230,7 +230,7 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
     END = datetime(2026, 1, 3, tzinfo=UTC)
 
     def _session(self, **overrides) -> SandboxSession:
-        run = self._run()
+        run = overrides.pop("task_run", None) or self._run()
         defaults: dict = {
             "team": self.team,
             "task_run": run,
@@ -246,6 +246,33 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         defaults.setdefault("sandbox_id", f"sb-{SandboxSession.objects.unscoped().count()}")
         defaults.setdefault("ttl_expires_at", defaults["created_at"] + timedelta(seconds=defaults["ttl_seconds"]))
         return SandboxSession.objects.unscoped().create(**defaults)
+
+    def _loop_session(
+        self, *, internal: bool, client_provenance: TaskClientProvenance | None = TaskClientProvenance.POSTHOG_DESKTOP
+    ) -> SandboxSession:
+        loop = Loop.objects.create(
+            team=self.team,
+            name="loop",
+            instructions="run",
+            runtime_adapter="claude",
+            internal=internal,
+            client_provenance=client_provenance,
+        )
+        task = Task.objects.create(
+            team=self.team,
+            title="loop run",
+            description="",
+            origin_product=Task.OriginProduct.LOOP,
+            internal=True,
+            loop=loop,
+            client_provenance=client_provenance,
+        )
+        run = TaskRun.objects.create(task=task, team=self.team)
+        return self._session(
+            task_run=run,
+            origin_product=Task.OriginProduct.LOOP,
+            client_provenance=client_provenance,
+        )
 
     def _rate(self, **overrides) -> ComputeRateCard:
         defaults = {
@@ -270,6 +297,16 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         assert usage.memory_gib_seconds == [(self.team.id, 57600.0)]
         assert usage.cpu_cost_microusd == [(self.team.id, 14_400_000)]
         assert usage.memory_cost_microusd == [(self.team.id, 5_760_000)]
+        assert usage.credits == [(self.team.id, 2016)]
+
+    def test_billable_compute_includes_user_loops_and_excludes_internal_loops(self):
+        self._loop_session(internal=False)
+        self._loop_session(internal=True)
+        self._loop_session(internal=False, client_provenance=None)
+
+        usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
+
+        assert usage.cpu_core_seconds == [(self.team.id, 14400.0)]
         assert usage.credits == [(self.team.id, 2016)]
 
     def test_billable_compute_uses_session_snapshot_after_task_changes(self):

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -301,8 +301,6 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
 
         assert usage.cpu_millicore_seconds == [(self.team.id, 14_400_000)]
         assert usage.memory_mib_seconds == [(self.team.id, 58_982_400)]
-        assert usage.cpu_cost_microusd == [(self.team.id, 14_400_000)]
-        assert usage.memory_cost_microusd == [(self.team.id, 5_760_000)]
         assert usage.credits == [(self.team.id, 2016)]
 
     def test_billable_compute_includes_user_loops_and_excludes_internal_loops(self):
@@ -339,8 +337,6 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(rate,))
 
         assert usage.credits == [(self.team.id, 1)]
-        assert usage.cpu_cost_microusd == [(self.team.id, 5000)]
-        assert usage.memory_cost_microusd == [(self.team.id, 5000)]
 
     def test_integer_resource_units_round_only_after_exact_aggregation(self):
         for sandbox_id in ("sb-units-a", "sb-units-b"):
@@ -383,8 +379,6 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         assert usage.credits == expected
         assert usage.cpu_millicore_seconds == expected
         assert usage.memory_mib_seconds == expected
-        assert usage.cpu_cost_microusd == expected
-        assert usage.memory_cost_microusd == expected
         assert all(type(value) is int for rows in usage.__dict__.values() for _, value in rows)
 
     def test_compute_before_first_rate_is_free_and_rate_changes_are_applied(self):
@@ -410,8 +404,6 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=rates)
 
         assert usage.cpu_millicore_seconds == [(self.team.id, 2000)]
-        assert usage.cpu_cost_microusd == [(self.team.id, 3000)]
-        assert usage.memory_cost_microusd == [(self.team.id, 300)]
 
     def test_empty_rate_card_is_not_launched_but_invalid_configuration_fails(self):
         self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)

--- a/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
+++ b/products/tasks/backend/logic/services/tests/test_sandbox_usage.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
@@ -8,8 +9,10 @@ from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 
 from products.tasks.backend.logic.services.sandbox import SandboxConfig
+from products.tasks.backend.logic.services.sandbox_pricing import ComputeRateCard, ComputeRateCardConfigurationError
 from products.tasks.backend.logic.services.sandbox_usage import (
     close_sandbox_session,
+    get_billable_sandbox_compute_usage_by_team,
     get_task_sandbox_usage_by_team,
     open_sandbox_session,
     record_task_run_user_activity,
@@ -243,6 +246,92 @@ class TestSandboxUsageAggregation(SandboxUsageBase):
         defaults.setdefault("sandbox_id", f"sb-{SandboxSession.objects.unscoped().count()}")
         defaults.setdefault("ttl_expires_at", defaults["created_at"] + timedelta(seconds=defaults["ttl_seconds"]))
         return SandboxSession.objects.unscoped().create(**defaults)
+
+    def _rate(self, **overrides) -> ComputeRateCard:
+        defaults = {
+            "version": "v1",
+            "effective_at": self.BEGIN,
+            "expires_at": None,
+            "cpu_core_second_usd": Decimal("0.001"),
+            "memory_gib_second_usd": Decimal("0.0001"),
+        }
+        defaults.update(overrides)
+        return ComputeRateCard(**defaults)
+
+    def test_billable_compute_requires_trusted_desktop_user_created_snapshot(self):
+        self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)
+        for origin in (Task.OriginProduct.SLACK, Task.OriginProduct.SIGNAL_REPORT, Task.OriginProduct.LOOP, None):
+            self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP, origin_product=origin)
+        self._session(client_provenance=None)
+
+        usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
+
+        assert usage.cpu_core_seconds == [(self.team.id, 14400.0)]
+        assert usage.memory_gib_seconds == [(self.team.id, 57600.0)]
+        assert usage.cpu_cost_microusd == [(self.team.id, 14_400_000)]
+        assert usage.memory_cost_microusd == [(self.team.id, 5_760_000)]
+        assert usage.credits == [(self.team.id, 2016)]
+
+    def test_billable_compute_uses_session_snapshot_after_task_changes(self):
+        session = self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)
+        Task.objects.filter(id=session.task_run.task_id).update(
+            origin_product=Task.OriginProduct.SLACK, client_provenance=None
+        )
+
+        usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(self._rate(),))
+
+        assert usage.credits == [(self.team.id, 2016)]
+
+    def test_exact_session_costs_aggregate_before_bankers_credit_rounding(self):
+        for sandbox_id in ("sb-fraction-a", "sb-fraction-b"):
+            self._session(
+                sandbox_id=sandbox_id,
+                client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+                cpu_cores=1,
+                memory_gb=1,
+                ended_at=datetime(2026, 1, 2, 1, 0, 1, tzinfo=UTC),
+            )
+        rate = self._rate(cpu_core_second_usd=Decimal("0.0025"), memory_gib_second_usd=Decimal("0.0025"))
+
+        usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(rate,))
+
+        assert usage.credits == [(self.team.id, 1)]
+        assert usage.cpu_cost_microusd == [(self.team.id, 5000)]
+        assert usage.memory_cost_microusd == [(self.team.id, 5000)]
+
+    def test_compute_before_first_rate_is_free_and_rate_changes_are_applied(self):
+        self._session(
+            client_provenance=TaskClientProvenance.POSTHOG_DESKTOP,
+            cpu_cores=1,
+            memory_gb=1,
+            created_at=self.BEGIN,
+            user_attributed_at=self.BEGIN,
+            ended_at=self.BEGIN + timedelta(seconds=3),
+        )
+        boundary = self.BEGIN + timedelta(seconds=2)
+        rates = (
+            self._rate(effective_at=self.BEGIN + timedelta(seconds=1), expires_at=boundary),
+            self._rate(
+                version="v2",
+                effective_at=boundary,
+                cpu_core_second_usd=Decimal("0.002"),
+                memory_gib_second_usd=Decimal("0.0002"),
+            ),
+        )
+
+        usage = get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=rates)
+
+        assert usage.cpu_core_seconds == [(self.team.id, 2.0)]
+        assert usage.cpu_cost_microusd == [(self.team.id, 3000)]
+        assert usage.memory_cost_microusd == [(self.team.id, 300)]
+
+    def test_empty_rate_card_is_not_launched_but_invalid_configuration_fails(self):
+        self._session(client_provenance=TaskClientProvenance.POSTHOG_DESKTOP)
+
+        assert get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=()).credits == []
+        invalid = self._rate(cpu_core_second_usd=Decimal("0"))
+        with self.assertRaises(ComputeRateCardConfigurationError):
+            get_billable_sandbox_compute_usage_by_team(self.BEGIN, self.END, rate_cards=(invalid,))
 
     def test_sums_attributed_window_with_resource_multipliers(self):
         # Attributed an hour after creation: only [01:30, 02:30) bills, not boot/pre-warm time.


### PR DESCRIPTION
## Problem

PostHog Desktop needs cloud-compute usage to share the existing billed credit total while retaining token, compute, and resource history as separate components. This stacks on [#76080](https://github.com/PostHog/posthog/pull/76080) and defines the contract consumed by Billing [#2113](https://github.com/PostHog/billing/pull/2113), Billing [#2114](https://github.com/PostHog/billing/pull/2114), and PostHog [#76826](https://github.com/PostHog/posthog/pull/76826).

## Changes

- Price trusted Desktop sandbox sessions using the canonical rate-card implementation.
- Emit combined credits, token credits, compute credits, CPU millicore-seconds, and memory MiB-seconds as integers.
- Keep `posthog_code_credits_used_in_period` as the only billable counter and reconcile it as token plus compute credits.
- Keep exact CPU and memory cost arithmetic internal to the compute-credit calculation. CPU and memory microUSD subtotals are not part of the usage-report contract.
- Preserve older report compatibility and explicit integer zeros before the first effective rate.

**Why:** Compute credits answer what was charged, while CPU and memory quantities describe the resources consumed. Separate CPU and memory price counters are not billing inputs and do not belong in the public usage contract.

## How did you test this code?

- Canonical sandbox-pricing suite: 27 passed.
- Focused usage-report contract suite: 3 passed.
- Gateway response and quota-resolver suites in the descendant layer: 64 passed.
- Database-backed sandbox aggregation requires the local Postgres service and remains covered by CI.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No public documentation change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex simplified the stacked Desktop compute usage contract while preserving canonical exact pricing and the combined-credit invariant.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
