### PR TITLE
fix(dags): use grace hash for persons backfills

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -665,6 +665,13 @@ PARQUET_WRITER_SETTINGS: dict[str, Any] = {
     "output_format_parquet_row_group_size": 250_000,  # secondary cap; binds for narrow persons rows
 }
 
+# Grace hash uses this limit to grow spill buckets before the query-wide memory limit,
+# leaving headroom for FINAL and the Parquet writers.
+PERSONS_JOIN_SETTINGS: dict[str, Any] = {
+    "join_algorithm": "grace_hash",
+    "max_bytes_in_join": 10 * ONE_GB_IN_BYTES,
+}
+
 # Shared concurrency key across events + persons backfills. Each duckling
 # connection spins up a duckgres worker, and the per-org worker pool is capped
 # (maxWorkers in the duckgres chart) and shared with product queries — so the
@@ -2173,7 +2180,8 @@ def export_persons_to_duckling_s3(
     """
 
     # Bound per-partition writer memory like the events export (see PARQUET_WRITER_SETTINGS).
-    export_settings = settings.copy()
+    export_settings = PERSONS_JOIN_SETTINGS.copy()
+    export_settings.update(settings)
     export_settings.update(PARQUET_WRITER_SETTINGS)
 
     context.log.info(f"Exporting persons for {info} ({row_count} persons → {fanout} file(s)) to {s3_glob}")
@@ -2228,7 +2236,8 @@ def export_persons_full_to_duckling_s3(
     # No date filtering - export all persons for the team
     # Full exports need more memory due to FINAL + JOIN on large datasets
     # Also enable external sorting to spill to disk if memory is still exceeded
-    full_export_settings = settings.copy()
+    full_export_settings = PERSONS_JOIN_SETTINGS.copy()
+    full_export_settings.update(settings)
     full_export_settings.update(PARQUET_WRITER_SETTINGS)  # bound per-partition writer memory
     full_export_settings.update(
         {

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1789,6 +1789,8 @@ class TestExportFanOut:
 
         export_call = next(call for call in client.execute.call_args_list if "INSERT INTO FUNCTION" in call.args[0])
         assert export_call.kwargs["settings"]["output_format_parquet_row_group_size_bytes"] == 128 * 1024 * 1024
+        assert export_call.kwargs["settings"]["join_algorithm"] == "grace_hash"
+        assert export_call.kwargs["settings"]["max_bytes_in_join"] == 10 * 1024 * 1024 * 1024
 
     def test_persons_full_export_sizes_fanout_and_returns_glob(self, target):
         # 25M rows at the 5M-row default target → 5 files.
@@ -1801,6 +1803,28 @@ class TestExportFanOut:
 
         export_call = next(call for call in client.execute.call_args_list if "INSERT INTO FUNCTION" in call.args[0])
         assert export_call.kwargs["settings"]["output_format_parquet_row_group_size_bytes"] == 128 * 1024 * 1024
+        assert export_call.kwargs["settings"]["join_algorithm"] == "grace_hash"
+        assert export_call.kwargs["settings"]["max_bytes_in_join"] == 10 * 1024 * 1024 * 1024
+
+    @parameterized.expand(
+        [
+            ("daily", export_persons_to_duckling_s3, {"team_id": 2, "date": datetime(2026, 6, 17)}),
+            ("full", export_persons_full_to_duckling_s3, {"team_id": 2}),
+        ]
+    )
+    def test_persons_export_preserves_explicit_join_settings(self, _label, export_fn, kwargs):
+        target = DucklingTarget(team_id=2, organization_id="org-1", bucket="bkt", bucket_region="us-east-1")
+        _insert_sql, _count_sql, _glob, client = self._run_export(
+            export_fn,
+            target,
+            row_count=1,
+            settings={"join_algorithm": "parallel_hash", "max_bytes_in_join": 123},
+            **kwargs,
+        )
+
+        export_call = next(call for call in client.execute.call_args_list if "INSERT INTO FUNCTION" in call.args[0])
+        assert export_call.kwargs["settings"]["join_algorithm"] == "parallel_hash"
+        assert export_call.kwargs["settings"]["max_bytes_in_join"] == 123
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Persons backfill exports join the persons and distinct-ID tables with ClickHouse's default in-memory hash strategy. Large joins can exhaust the query memory budget before the export completes.

## Changes

- Default daily and full persons exports to the Grace hash join algorithm.
- Bound in-memory join data at 10 GiB so ClickHouse can repartition and spill join buckets before the query-wide memory limit.
- Preserve explicitly supplied ClickHouse join settings as overrides.
- Extend the existing export tests to cover the default and override behavior.

## How did you test this code?

- `bin/hogli test posthog/dags/test_events_backfill_to_duckling.py` – 229 passed.
- `ruff check posthog/dags/events_backfill_to_duckling.py posthog/dags/test_events_backfill_to_duckling.py`
- `ruff format --check posthog/dags/events_backfill_to_duckling.py posthog/dags/test_events_backfill_to_duckling.py`
- `bin/hogli ci:preflight --fix`

The extended daily and full export tests guard against reverting to a memory-only join. The parameterized override test guards the explicit `clickhouse_settings` contract.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this changes an internal query execution setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented and validated the change using the GitHub publishing workflow and two focused review agents.
- Repository skills invoked: `/writing-tests` and `/writing-code-comments`.
- I chose an adaptive `max_bytes_in_join` threshold instead of a fixed initial bucket count, so small joins avoid unnecessary partitioning while large joins spill. Explicit per-run settings remain authoritative.
