### PR TITLE
fix(inbox): show scout and discussion runs in desktop/mobile Runs section (Fixes #76347)

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useReportTasks.ts
@@ -31,9 +31,16 @@ function derivePurpose(taskRun: {
     if (taskRun.type === "implementation") {
       return { purpose: "implementation", purposeLabel: "Implementation" };
     }
-    // repo_selection runs are plumbing, not report work — never displayed (matches the
-    // pre-derivation behavior of only showing research/implementation).
-    return null;
+    // Only repo_selection is pipeline plumbing — hide it. All other non-research/non-implementation
+    // signals types (scout, discussion, etc.) are report work and should be visible in the Runs
+    // section, matching the web frontend's `deriveTaskPurpose` behaviour.
+    if (taskRun.type === "repo_selection") {
+      return null;
+    }
+    return {
+      purpose: "other",
+      purposeLabel: `Signals — ${humanizeIdentifier(taskRun.type)}`,
+    };
   }
   return {
     purpose: "other",
@@ -133,11 +140,15 @@ export function findContinuableImplementationTask(
   reportTasks: ReportTaskData[] | undefined,
 ): Task | null {
   if (!reportTasks) return null;
+  // First check any task that already produced a PR — a non-implementation run
+  // (e.g. a Discuss task that shipped a PR) should be resumed rather than
+  // starting a fresh implementation task, preventing duplicate PRs.
+  const anyWithPr = reportTasks.find((t) => getTaskPrUrl(t.task));
+  if (anyWithPr) return anyWithPr.task;
+  // Fall back to a running implementation task with no PR yet.
   const implementation = reportTasks.filter(
     (t) => t.purpose === "implementation",
   );
-  const withPr = implementation.find((t) => getTaskPrUrl(t.task));
-  if (withPr) return withPr.task;
   const running = implementation.find((t) => {
     const status = t.task.latest_run?.status;
     return status != null && !isTerminalStatus(status);


### PR DESCRIPTION
## Problem

The desktop and mobile `derivePurpose` function was dropping all non-research/non-implementation signals runs (scout, discussion, etc.) by returning `null` for any unmatched type. The comment only justified excluding `repo_selection`, but the catch-all `return null` also excluded legitimate report work.

Additionally, `findContinuableImplementationTask` only considered `purpose === "implementation"` tasks, so a Discuss task that already shipped a PR was invisible — re-engaging the report would start a fresh implementation task, creating a **duplicate PR** for work already done.

## Changes

### Fix 1 — `derivePurpose`
Only return `null` for `repo_selection` (pipeline plumbing). All other signals types (`scout`, `discussion`, etc.) fall through to `other` with a humanized label, matching the web frontend's `deriveTaskPurpose` behaviour.

### Fix 2 — `findContinuableImplementationTask`
Widen the search so any task that already produced a PR counts as continuable, not just `implementation`-purposed tasks. This prevents a duplicate PR when a non-implementation run (e.g. a Discuss task) already shipped a PR.

## Related
- Fixes #76347
- Related: #76346 (same underlying blind spot, backend side)