### PR TITLE
fix(convex): stop reporting already-retried 5xx/429 as tracked errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
@@ -123,6 +123,15 @@ You can find your deployment URL and deploy key in your [Convex Dashboard](https
             "is older than Convex's ~30 day retention window": "Delta cursor is older than Convex's ~30 day retention window. Please trigger a full resync of this source.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_CONVEX_RETRY` (convex.py) already retries 429/5xx — including the Cloudflare 52x/530
+        # family Convex deployments can surface — at the urllib3 layer before this can even raise.
+        # A response that still exhausts that budget is a transient Convex/edge blip, not a bug;
+        # Temporal's activity retry recovers once it clears, so don't surface it as tracked
+        # exception noise. `requests.Response.raise_for_status` derives these prefixes from the
+        # status code alone, not the vendor's reason text, so they're stable to match on.
+        return {"Server Error", "429 Client Error"}
+
     def validate_credentials(
         self,
         config: ConvexSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
@@ -124,10 +124,10 @@ You can find your deployment URL and deploy key in your [Convex Dashboard](https
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # `_CONVEX_RETRY` (convex.py) already retries 429/5xx — including the Cloudflare 52x/530
-        # family Convex deployments can surface — at the urllib3 layer before this can even raise.
-        # A response that still exhausts that budget is a transient Convex/edge blip, not a bug;
-        # Temporal's activity retry recovers once it clears, so don't surface it as tracked
+        # `_CONVEX_RETRY` (convex.py) already retries 429/5xx, including the Cloudflare 52x/530
+        # family Convex deployments can surface, at the urllib3 layer before this can even raise.
+        # A response that still exhausts that budget is a transient Convex/edge blip, not a bug,
+        # so Temporal's activity retry recovers once it clears rather than surfacing it as tracked
         # exception noise. `requests.Response.raise_for_status` derives these prefixes from the
         # status code alone, not the vendor's reason text, so they're stable to match on.
         return {"Server Error", "429 Client Error"}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -538,3 +538,38 @@ class TestConvexNonRetryableErrors:
     def test_transient_errors_do_not_match(self, _name: str, observed_error: str) -> None:
         non_retryable_errors = ConvexSource().get_non_retryable_errors()
         assert not any(key in observed_error for key in non_retryable_errors)
+
+
+class TestConvexRetryableErrors:
+    @parameterized.expand(
+        [
+            (
+                "500",
+                "500 Server Error: Internal Server Error for url: "
+                "https://x.convex.cloud/api/list_snapshot?tableName=events&format=json",
+            ),
+            ("502", "502 Server Error: Bad Gateway for url: https://x.convex.cloud/api/document_deltas"),
+            ("503", "503 Server Error: Service Unavailable for url: https://x.convex.cloud/api/list_snapshot"),
+            ("504", "504 Server Error: Gateway Timeout for url: https://x.convex.cloud/api/document_deltas"),
+            ("cloudflare_520", "520 Server Error: Unknown Error for url: https://x.convex.cloud/api/list_snapshot"),
+            ("429", "429 Client Error: Too Many Requests for url: https://x.convex.cloud/api/list_snapshot"),
+        ]
+    )
+    def test_transient_errors_are_recognised_as_retryable(self, _name: str, observed_error: str) -> None:
+        retryable_errors = ConvexSource().get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors), observed_error
+
+    @parameterized.expand(
+        [
+            ("401", "401 Client Error: Unauthorized for url: https://x.convex.cloud/api/document_deltas"),
+            ("403", "403 Client Error: Forbidden for url: https://x.convex.cloud/api/document_deltas"),
+            (
+                "invalid_window",
+                "Delta cursor for table 'events' is older than Convex's ~30 day retention window. "
+                "Please trigger a full resync of this source.",
+            ),
+        ]
+    )
+    def test_non_retryable_errors_do_not_match(self, _name: str, observed_error: str) -> None:
+        retryable_errors = ConvexSource().get_retryable_errors()
+        assert not any(key in observed_error for key in retryable_errors), observed_error

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -555,7 +555,7 @@ class TestConvexRetryableErrors:
             ("429", "429 Client Error: Too Many Requests for url: https://x.convex.cloud/api/list_snapshot"),
         ]
     )
-    def test_transient_errors_are_recognised_as_retryable(self, _name: str, observed_error: str) -> None:
+    def test_transient_errors_are_recognized_as_retryable(self, _name: str, observed_error: str) -> None:
         retryable_errors = ConvexSource().get_retryable_errors()
         assert any(key in observed_error for key in retryable_errors), observed_error
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError` for the Convex data warehouse source: a `500 Server Error` from the deployment's `list_snapshot` streaming-export endpoint.

Convex's HTTP calls already go through a `urllib3` retry policy (`_CONVEX_RETRY` in `convex.py`) that retries 429s, standard 5xx, and Cloudflare's edge-error family before giving up. Once that internal budget is exhausted, the plain `HTTPError` escaped unclassified by `ConvexSource`, so it was reported to error tracking on every Temporal activity attempt — even though the whole activity is retried by Temporal afterward and the sync self-recovers once the upstream blip clears.

This is a transient, self-recovering failure, not a customer credential/config problem (which is what `get_non_retryable_errors` already covers for Convex) and not a code bug — so it doesn't belong in `NonRetryableErrors`, it belongs in the retryable-noise classification that other sources (Stripe, Snowflake, Salesforce, Notion, etc.) already use for the same situation.

## Changes

- Add `ConvexSource.get_retryable_errors()`, matching the stable `"Server Error"` / `"429 Client Error"` prefixes `requests.Response.raise_for_status()` derives purely from the HTTP status code (not the vendor's reason text, so it's stable across deployments).
- This makes the activity-level error handler (`_handle_import_error`) log these as a warning and re-raise as `NonReportableError`, keeping them out of error tracking while still letting Temporal retry the activity as before — no change to retry counts or backoff.

## How did you test this code?

Automated tests only (agent — no manual testing performed):

- Added `TestConvexRetryableErrors` to `test_convex.py`, parameterized over 500/502/503/504/Cloudflare-520/429 messages asserting they're now recognized as retryable, and over 401/403/invalid-window messages asserting they still aren't. This catches the exact regression: before this change, none of these messages matched anything, and the 500 from the error-tracking issue would still be reported on every retry.
- Ran the full `convex` test suite locally (`pytest .../sources/convex/tests/test_convex.py`) — 77 passed.
- Ran `ruff check --fix`, `ruff format`, and a repo-wide `mypy --cache-fine-grained .` — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) triaged a webhook-delivered error-tracking issue reporting an `HTTPError: 500 Server Error` from the Convex source's `list_snapshot` call. After tracing the call path from `convex.py` through the Temporal activity's error-classification layer (`_handle_import_error` in `import_data_sync.py`), I found the source already retries 5xx/429 internally via urllib3, and Temporal retries the whole activity afterward — but `ConvexSource` never populated `get_retryable_errors()`, so the already-internally-retried failure was still reported as tracked-exception noise on every attempt. I mirrored the existing pattern used by Stripe/Snowflake/Salesforce/Notion for the same class of problem rather than adding it to `NonRetryableErrors` (this isn't a user/credential/config error) or changing any retry/backoff behavior.

Searched open PRs (by exception type, module path, and the maintainer's own open PRs) before opening this one — found none addressing this specific classification gap.