### PR TITLE
fix(web-analytics): Handle list values in first-pageview filter rewrite

### DIFF
--- a/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.test.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.test.ts
@@ -1,0 +1,33 @@
+import { initKeaTests } from '~/test/init'
+import { PropertyFilterType, PropertyOperator } from '~/types'
+
+import { webAnalyticsFilterLogic } from './webAnalyticsFilterLogic'
+
+describe('webAnalyticsFilterLogic', () => {
+    let logic: ReturnType<typeof webAnalyticsFilterLogic.build>
+
+    beforeEach(() => {
+        localStorage.clear()
+        initKeaTests()
+        logic = webAnalyticsFilterLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('keeps the filter type when merging a second value into an existing filter', () => {
+        logic.actions.togglePropertyFilter(PropertyFilterType.Session, '$entry_utm_medium', 'cpc')
+        logic.actions.togglePropertyFilter(PropertyFilterType.Session, '$entry_utm_medium', 'paid')
+
+        expect(logic.values.rawWebAnalyticsFilters).toEqual([
+            {
+                type: PropertyFilterType.Session,
+                key: '$entry_utm_medium',
+                operator: PropertyOperator.Exact,
+                value: ['cpc', 'paid'],
+            },
+        ])
+    })
+})

--- a/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.ts
+++ b/frontend/src/scenes/web-analytics/webAnalyticsFilterLogic.ts
@@ -210,7 +210,7 @@ export const webAnalyticsFilterLogic = kea<webAnalyticsFilterLogicType>([
                                     newValue = [...oldValue, value]
                                 }
                                 return {
-                                    type: PropertyFilterType.Event,
+                                    type,
                                     key,
                                     operator: PropertyOperator.Exact,
                                     value: newValue,

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -713,33 +713,6 @@ def _expr_to_compare_op(
         raise NotImplementedError(f"PropertyOperator {operator} not implemented")
 
 
-def expr_to_compare_op(
-    expr: ast.Expr, value: ValueT, operator: PropertyOperator, property: Property, is_json_field: bool, team: Team
-) -> ast.Expr:
-    if not isinstance(value, list) or operator in (
-        PropertyOperator.BETWEEN,
-        PropertyOperator.NOT_BETWEEN,
-        PropertyOperator.ICONTAINS,
-        PropertyOperator.NOT_ICONTAINS,
-        PropertyOperator.ICONTAINS_MULTI,
-        PropertyOperator.NOT_ICONTAINS_MULTI,
-        PropertyOperator.IN_,
-        PropertyOperator.NOT_IN,
-    ):
-        return _expr_to_compare_op(expr, value, operator, property, is_json_field, team)
-    if len(value) == 0:
-        return ast.Constant(value=1)
-    if len(value) == 1:
-        return _expr_to_compare_op(expr, value[0], operator, property, is_json_field, team)
-    if operator in (PropertyOperator.EXACT, PropertyOperator.IS_NOT):
-        op = ast.CompareOperationOp.In if operator == PropertyOperator.EXACT else ast.CompareOperationOp.NotIn
-        return ast.CompareOperation(op=op, left=expr, right=ast.Tuple(exprs=[ast.Constant(value=v) for v in value]))
-    exprs = [_expr_to_compare_op(expr, v, operator, property, is_json_field, team) for v in value]
-    if operator in (PropertyOperator.NOT_REGEX, PropertyOperator.NOT_STARTS_WITH, PropertyOperator.NOT_ENDS_WITH):
-        return ast.And(exprs=exprs)
-    return ast.Or(exprs=exprs)
-
-
 def apply_path_cleaning(path_expr: ast.Expr, team: Team) -> ast.Expr:
     if not team.path_cleaning_filters:
         return path_expr

--- a/posthog/hogql/property.py
+++ b/posthog/hogql/property.py
@@ -713,6 +713,33 @@ def _expr_to_compare_op(
         raise NotImplementedError(f"PropertyOperator {operator} not implemented")
 
 
+def expr_to_compare_op(
+    expr: ast.Expr, value: ValueT, operator: PropertyOperator, property: Property, is_json_field: bool, team: Team
+) -> ast.Expr:
+    if not isinstance(value, list) or operator in (
+        PropertyOperator.BETWEEN,
+        PropertyOperator.NOT_BETWEEN,
+        PropertyOperator.ICONTAINS,
+        PropertyOperator.NOT_ICONTAINS,
+        PropertyOperator.ICONTAINS_MULTI,
+        PropertyOperator.NOT_ICONTAINS_MULTI,
+        PropertyOperator.IN_,
+        PropertyOperator.NOT_IN,
+    ):
+        return _expr_to_compare_op(expr, value, operator, property, is_json_field, team)
+    if len(value) == 0:
+        return ast.Constant(value=1)
+    if len(value) == 1:
+        return _expr_to_compare_op(expr, value[0], operator, property, is_json_field, team)
+    if operator in (PropertyOperator.EXACT, PropertyOperator.IS_NOT):
+        op = ast.CompareOperationOp.In if operator == PropertyOperator.EXACT else ast.CompareOperationOp.NotIn
+        return ast.CompareOperation(op=op, left=expr, right=ast.Tuple(exprs=[ast.Constant(value=v) for v in value]))
+    exprs = [_expr_to_compare_op(expr, v, operator, property, is_json_field, team) for v in value]
+    if operator in (PropertyOperator.NOT_REGEX, PropertyOperator.NOT_STARTS_WITH, PropertyOperator.NOT_ENDS_WITH):
+        return ast.And(exprs=exprs)
+    return ast.Or(exprs=exprs)
+
+
 def apply_path_cleaning(path_expr: ast.Expr, team: Team) -> ast.Expr:
     if not team.path_cleaning_filters:
         return path_expr

--- a/products/web_analytics/backend/hogql_queries/first_pageview_attribution.py
+++ b/products/web_analytics/backend/hogql_queries/first_pageview_attribution.py
@@ -5,7 +5,7 @@ from posthog.schema import HogQLQueryModifiers, PropertyOperator, SessionPropert
 from posthog.hogql import ast
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
 from posthog.hogql.parser import parse_expr, parse_select
-from posthog.hogql.property import _expr_to_compare_op, property_to_expr
+from posthog.hogql.property import expr_to_compare_op, property_to_expr
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.models.property import Property, ValueT
@@ -178,6 +178,9 @@ def first_pageview_session_filter_expr(
     `distributed_product_mode=global`, so the id set is collected once on the
     initiator rather than re-derived per shard.
     """
+    if isinstance(prop.value, list) and len(prop.value) == 0:
+        return ast.Constant(value=1)
+
     breakdown = SESSION_PROPERTY_TO_FIRST_PAGEVIEW[prop.key]
     matching_sessions = parse_select(
         """
@@ -204,7 +207,7 @@ WHERE {match}
                 if session_id_present is not None
                 else parse_expr("events.$session_id_uuid IS NOT NULL")
             ),
-            "match": _expr_to_compare_op(
+            "match": expr_to_compare_op(
                 expr=first_pageview_filter_value_expr(breakdown, modifiers=modifiers, timings=timings),
                 value=cast(ValueT, prop.value),
                 operator=prop.operator or PropertyOperator.EXACT,

--- a/products/web_analytics/backend/hogql_queries/first_pageview_attribution.py
+++ b/products/web_analytics/backend/hogql_queries/first_pageview_attribution.py
@@ -5,7 +5,7 @@ from posthog.schema import HogQLQueryModifiers, PropertyOperator, SessionPropert
 from posthog.hogql import ast
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
 from posthog.hogql.parser import parse_expr, parse_select
-from posthog.hogql.property import expr_to_compare_op, property_to_expr
+from posthog.hogql.property import _expr_to_compare_op, property_to_expr
 from posthog.hogql.timings import HogQLTimings
 
 from posthog.models.property import Property, ValueT
@@ -154,6 +154,33 @@ def first_pageview_filter_value_expr(
     return first_pageview_prop(breakdown, keys[0])
 
 
+def _list_aware_expr_to_compare_op(
+    expr: ast.Expr, value: ValueT, operator: PropertyOperator, property: Property, is_json_field: bool, team: "Team"
+) -> ast.Expr:
+    if not isinstance(value, list) or operator in (
+        PropertyOperator.BETWEEN,
+        PropertyOperator.NOT_BETWEEN,
+        PropertyOperator.ICONTAINS,
+        PropertyOperator.NOT_ICONTAINS,
+        PropertyOperator.ICONTAINS_MULTI,
+        PropertyOperator.NOT_ICONTAINS_MULTI,
+        PropertyOperator.IN_,
+        PropertyOperator.NOT_IN,
+    ):
+        return _expr_to_compare_op(expr, value, operator, property, is_json_field, team)
+    if len(value) == 0:
+        return ast.Constant(value=1)
+    if len(value) == 1:
+        return _expr_to_compare_op(expr, value[0], operator, property, is_json_field, team)
+    if operator in (PropertyOperator.EXACT, PropertyOperator.IS_NOT):
+        op = ast.CompareOperationOp.In if operator == PropertyOperator.EXACT else ast.CompareOperationOp.NotIn
+        return ast.CompareOperation(op=op, left=expr, right=ast.Tuple(exprs=[ast.Constant(value=v) for v in value]))
+    exprs = [_expr_to_compare_op(expr, v, operator, property, is_json_field, team) for v in value]
+    if operator in (PropertyOperator.NOT_REGEX, PropertyOperator.NOT_STARTS_WITH, PropertyOperator.NOT_ENDS_WITH):
+        return ast.And(exprs=exprs)
+    return ast.Or(exprs=exprs)
+
+
 def first_pageview_session_filter_expr(
     prop: SessionPropertyFilter,
     *,
@@ -207,7 +234,7 @@ WHERE {match}
                 if session_id_present is not None
                 else parse_expr("events.$session_id_uuid IS NOT NULL")
             ),
-            "match": expr_to_compare_op(
+            "match": _list_aware_expr_to_compare_op(
                 expr=first_pageview_filter_value_expr(breakdown, modifiers=modifiers, timings=timings),
                 value=cast(ValueT, prop.value),
                 operator=prop.operator or PropertyOperator.EXACT,

--- a/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_web_stats_table.ambr
+++ b/products/web_analytics/backend/hogql_queries/test/__snapshots__/test_web_stats_table.ambr
@@ -3568,6 +3568,419 @@
                     use_hive_partitioning=0
   '''
 # ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_0_multi_value_exact
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('2015-01-01 00:00:00.000000', 6, 'UTC')))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_0_multi_value_exact.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT filtered_person_id AS filtered_person_id,
+            filtered_pageview_count AS filtered_pageview_count,
+            nullIf(tupleElement(first_pageview_properties, 1), '') AS breakdown_value,
+            session_id AS session_id,
+            is_bounce AS is_bounce,
+            start_timestamp AS start_timestamp
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties,
+               events__session.session_id AS session_id,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), in(events.`$session_id`,
+                                                                                                                                                                                                                                                                                                                                                                         (SELECT session_id AS session_id
+                                                                                                                                                                                                                                                                                                                                                                          FROM
+                                                                                                                                                                                                                                                                                                                                                                            (SELECT events.`$session_id` AS session_id, argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties
+                                                                                                                                                                                                                                                                                                                                                                             FROM events
+                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(events.`$session_id_uuid`)))
+                                                                                                                                                                                                                                                                                                                                                                             GROUP BY session_id)
+                                                                                                                                                                                                                                                                                                                                                                          WHERE in(nullIf(tupleElement(first_pageview_properties, 1), ''), tuple('paid', 'cpc', 'ppc', 'paidsearch', 'paidSocial', 'paid_social')))), isNotNull(events.`$session_id_uuid`)))
+        GROUP BY session_id))
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_1_multi_value_exact_matching_both
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('2015-01-01 00:00:00.000000', 6, 'UTC')))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_1_multi_value_exact_matching_both.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT filtered_person_id AS filtered_person_id,
+            filtered_pageview_count AS filtered_pageview_count,
+            nullIf(tupleElement(first_pageview_properties, 1), '') AS breakdown_value,
+            session_id AS session_id,
+            is_bounce AS is_bounce,
+            start_timestamp AS start_timestamp
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties,
+               events__session.session_id AS session_id,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), in(events.`$session_id`,
+                                                                                                                                                                                                                                                                                                                                                                         (SELECT session_id AS session_id
+                                                                                                                                                                                                                                                                                                                                                                          FROM
+                                                                                                                                                                                                                                                                                                                                                                            (SELECT events.`$session_id` AS session_id, argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties
+                                                                                                                                                                                                                                                                                                                                                                             FROM events
+                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(events.`$session_id_uuid`)))
+                                                                                                                                                                                                                                                                                                                                                                             GROUP BY session_id)
+                                                                                                                                                                                                                                                                                                                                                                          WHERE in(nullIf(tupleElement(first_pageview_properties, 1), ''), tuple('cpc', 'email')))), isNotNull(events.`$session_id_uuid`)))
+        GROUP BY session_id))
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_2_single_element_list
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('2015-01-01 00:00:00.000000', 6, 'UTC')))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_2_single_element_list.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT filtered_person_id AS filtered_person_id,
+            filtered_pageview_count AS filtered_pageview_count,
+            nullIf(tupleElement(first_pageview_properties, 1), '') AS breakdown_value,
+            session_id AS session_id,
+            is_bounce AS is_bounce,
+            start_timestamp AS start_timestamp
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties,
+               events__session.session_id AS session_id,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), in(events.`$session_id`,
+                                                                                                                                                                                                                                                                                                                                                                         (SELECT session_id AS session_id
+                                                                                                                                                                                                                                                                                                                                                                          FROM
+                                                                                                                                                                                                                                                                                                                                                                            (SELECT events.`$session_id` AS session_id, argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties
+                                                                                                                                                                                                                                                                                                                                                                             FROM events
+                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(events.`$session_id_uuid`)))
+                                                                                                                                                                                                                                                                                                                                                                             GROUP BY session_id)
+                                                                                                                                                                                                                                                                                                                                                                          WHERE ifNull(equals(nullIf(tupleElement(first_pageview_properties, 1), ''), 'cpc'), 0))), isNotNull(events.`$session_id_uuid`)))
+        GROUP BY session_id))
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_3_empty_list
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('2015-01-01 00:00:00.000000', 6, 'UTC')))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_3_empty_list.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT filtered_person_id AS filtered_person_id,
+            filtered_pageview_count AS filtered_pageview_count,
+            nullIf(tupleElement(first_pageview_properties, 1), '') AS breakdown_value,
+            session_id AS session_id,
+            is_bounce AS is_bounce,
+            start_timestamp AS start_timestamp
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties,
+               events__session.session_id AS session_id,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), 1, isNotNull(events.`$session_id_uuid`)))
+        GROUP BY session_id))
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_4_multi_value_is_not
+  '''
+  SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp
+  FROM events
+  WHERE and(equals(events.team_id, 99999), greater(events.timestamp, toDateTime64('2015-01-01 00:00:00.000000', 6, 'UTC')))
+  ORDER BY toTimeZone(events.timestamp, 'UTC') ASC
+  LIMIT 1 SETTINGS readonly=2,
+                   max_execution_time=60,
+                   allow_experimental_object_type=1,
+                   max_ast_elements=4000000,
+                   max_expanded_ast_elements=4000000,
+                   max_bytes_before_external_group_by=0,
+                   transform_null_in=1,
+                   optimize_min_equality_disjunction_chain_length=4294967295,
+                   optimize_rewrite_aggregate_function_with_if=0,
+                   optimize_min_inequality_conjunction_chain_length=4294967295,
+                   allow_experimental_join_condition=1,
+                   use_hive_partitioning=0
+  '''
+# ---
+# name: TestWebStatsTableQueryRunner.test_first_pageview_attribution_rewrites_list_valued_filters_4_multi_value_is_not.1
+  '''
+  SELECT breakdown_value AS `context.columns.breakdown_value`,
+         tuple(uniq(filtered_person_id), NULL) AS `context.columns.visitors`,
+         tuple(sum(filtered_pageview_count), NULL) AS `context.columns.views`,
+         divide(`context.columns.visitors`.1, sum(`context.columns.visitors`.1) OVER ()) AS `context.columns.ui_fill_fraction`
+  FROM
+    (SELECT filtered_person_id AS filtered_person_id,
+            filtered_pageview_count AS filtered_pageview_count,
+            nullIf(tupleElement(first_pageview_properties, 1), '') AS breakdown_value,
+            session_id AS session_id,
+            is_bounce AS is_bounce,
+            start_timestamp AS start_timestamp
+     FROM
+       (SELECT any(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id)) AS filtered_person_id,
+               count() AS filtered_pageview_count,
+               argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties,
+               events__session.session_id AS session_id,
+               any(events__session.`$is_bounce`) AS is_bounce,
+               min(events__session.`$start_timestamp`) AS start_timestamp
+        FROM events
+        LEFT JOIN
+          (SELECT toString(reinterpretAsUUID(bitOr(bitShiftLeft(raw_sessions.session_id_v7, 64), bitShiftRight(raw_sessions.session_id_v7, 64)))) AS session_id,
+                  if(equals(uniqMerge(raw_sessions.pageview_uniq), 0), NULL, not(or(greater(uniqMerge(raw_sessions.pageview_uniq), 1), greater(uniqMerge(raw_sessions.autocapture_uniq), 0), greaterOrEquals(dateDiff('second', min(toTimeZone(raw_sessions.min_timestamp, 'UTC')), max(toTimeZone(raw_sessions.max_timestamp, 'UTC'))), 10)))) AS `$is_bounce`,
+                  min(toTimeZone(raw_sessions.min_timestamp, 'UTC')) AS `$start_timestamp`,
+                  raw_sessions.session_id_v7 AS session_id_v7
+           FROM raw_sessions
+           WHERE and(equals(raw_sessions.team_id, 99999), greaterOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), minus(assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC')), toIntervalDay(3))), lessOrEquals(fromUnixTimestamp(intDiv(toUInt64(bitShiftRight(raw_sessions.session_id_v7, 80)), 1000)), plus(assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')), toIntervalDay(3))))
+           GROUP BY raw_sessions.session_id_v7) AS events__session ON equals(events.`$session_id_uuid`, events__session.session_id_v7)
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), in(events.`$session_id`,
+                                                                                                                                                                                                                                                                                                                                                                         (SELECT session_id AS session_id
+                                                                                                                                                                                                                                                                                                                                                                          FROM
+                                                                                                                                                                                                                                                                                                                                                                            (SELECT events.`$session_id` AS session_id, argMinIf(tuple(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'utm_medium'), ''), 'null'), '^"|"$', '')), toTimeZone(events.timestamp, 'UTC'), in(events.event, tuple('$pageview', '$screen'))) AS first_pageview_properties
+                                                                                                                                                                                                                                                                                                                                                                             FROM events
+                                                                                                                                                                                                                                                                                                                                                                             WHERE and(equals(events.team_id, 99999), and(or(and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-26 10:00:00', 'UTC'))), lessOrEquals(toTimeZone(events.timestamp, 'UTC'), assumeNotNull(toDateTime('2024-06-27 23:59:59', 'UTC')))), 0), or(equals(events.event, '$pageview'), equals(events.event, '$screen')), isNotNull(events.`$session_id_uuid`)))
+                                                                                                                                                                                                                                                                                                                                                                             GROUP BY session_id)
+                                                                                                                                                                                                                                                                                                                                                                          WHERE ifNull(notIn(nullIf(tupleElement(first_pageview_properties, 1), ''), tuple('cpc', 'paid')), 1))), isNotNull(events.`$session_id_uuid`)))
+        GROUP BY session_id))
+  GROUP BY `context.columns.breakdown_value`
+  ORDER BY `context.columns.visitors` DESC,
+           `context.columns.views` DESC,
+           `context.columns.breakdown_value` ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
 # name: TestWebStatsTableQueryRunner.test_first_pageview_channel_type_buckets_0_referral_unknown_domain
   '''
   SELECT toTimeZone(events.timestamp, 'UTC') AS timestamp

--- a/products/web_analytics/backend/hogql_queries/test/test_first_pageview_attribution_trends.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_first_pageview_attribution_trends.py
@@ -31,13 +31,11 @@ from products.web_analytics.backend.hogql_queries.test.first_pageview_attributio
 class TestFirstPageviewAttributionTrends(FirstPageviewAttributionTestMixin, ClickhouseTestMixin, APIBaseTest):
     QUERY_TIMESTAMP = "2024-07-30"
 
-    def _paid_search_visitors(self, flag_on, tagged):
+    def _paid_search_visitors(self, flag_on, tagged, value="Paid Search"):
         query = TrendsQuery(
             dateRange=DateRange(date_from="2024-06-01", date_to="2024-06-30"),
             series=[EventsNode(event="$pageview", math=BaseMathType.DAU)],
-            properties=[
-                SessionPropertyFilter(key="$channel_type", value="Paid Search", operator=PropertyOperator.EXACT)
-            ],
+            properties=[SessionPropertyFilter(key="$channel_type", value=value, operator=PropertyOperator.EXACT)],
             tags=QueryLogTags(productKey="web_analytics") if tagged else None,
             modifiers=HogQLQueryModifiers(sessionTableVersion=SessionTableVersion.V2),
         )
@@ -50,15 +48,16 @@ class TestFirstPageviewAttributionTrends(FirstPageviewAttributionTestMixin, Clic
             ("web_analytics_flag_on", True, True, 1),
             ("web_analytics_flag_off", False, True, 0),
             ("other_product_flag_on", True, False, 0),
+            ("web_analytics_flag_on_list_value", True, True, 1, ["Paid Search", "Email"]),
         ]
     )
-    def test_trends_session_filter_rewrite(self, _name, flag_on, tagged, expected):
+    def test_trends_session_filter_rewrite(self, _name, flag_on, tagged, expected, value="Paid Search"):
         # A query from any other product must keep entry attribution: `tags` are
         # stripped from the cache key, so a leak here would also let the two
         # share a cache entry.
         self._seed_ssr_poisoned_session()
 
-        assert self._paid_search_visitors(flag_on=flag_on, tagged=tagged) == expected
+        assert self._paid_search_visitors(flag_on=flag_on, tagged=tagged, value=value) == expected
 
     @parameterized.expand(
         [

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_table.py
@@ -1184,6 +1184,34 @@ class TestWebStatsTableQueryRunner(
         assert drilled_down_values(flag_on=True) == [row_value]
         assert drilled_down_values(flag_on=False) == []
 
+    @parameterized.expand(
+        [
+            (
+                "multi_value_exact",
+                ["paid", "cpc", "ppc", "paidsearch", "paidSocial", "paid_social"],
+                PropertyOperator.EXACT,
+                ["cpc"],
+            ),
+            ("multi_value_exact_matching_both", ["cpc", "email"], PropertyOperator.EXACT, ["cpc", "email"]),
+            ("single_element_list", ["cpc"], PropertyOperator.EXACT, ["cpc"]),
+            ("empty_list", [], PropertyOperator.EXACT, ["cpc", "email"]),
+            ("multi_value_is_not", ["cpc", "paid"], PropertyOperator.IS_NOT, ["email"]),
+        ]
+    )
+    def test_first_pageview_attribution_rewrites_list_valued_filters(self, _name, filter_value, operator, expected):
+        self._seed_ssr_poisoned_session()
+        self._seed_first_pageview_session({"utm_medium": "email"}, distinct_id="d2")
+
+        with self._patch_first_pageview_flag(enabled=True):
+            results = self._run_web_stats_table_query(
+                "all",
+                "2024-06-27",
+                breakdown_by=WebStatsBreakdown.INITIAL_UTM_MEDIUM,
+                properties=[SessionPropertyFilter(key="$entry_utm_medium", value=filter_value, operator=operator)],
+            ).results
+
+        assert sorted(row[0] for row in results) == expected
+
     @parameterized.expand([("bounce_rate", False), ("bounce_rate_and_avg_time", True)])
     def test_first_pageview_attribution_rewrites_drill_down_on_paths_tile(self, _name, include_avg_time_on_page):
         # The Paths tile splits user filters across three separate events scans


### PR DESCRIPTION
## Problem
Session filters with list values compile to `equals(String, Array(String))` under the first-pageview filter rewrite, which ClickHouse rejects with `NO_COMMON_TYPE`, failing every web analytics tile carrying such a filter when web-analytics-first-pageview-attribution is enabled.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Normalize list values in the rewrite the same way `property_to_expr` does and fix `togglePropertyFilter` so merging a second clicked value no longer rewrites a session filter's type to event.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
