### PR TITLE
feat(desktop): add a default directory setting for new terminals

### DIFF
--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterPanel.tsx
@@ -293,7 +293,10 @@ function TerminalCell({
 }) {
   const clearCell = useCommandCenterStore((s) => s.clearCell);
   const { getRecentFolders, getFolderDisplayName } = useFolders();
-  const cwd = terminalCwd ?? getRecentFolders(1)[0]?.path;
+  const defaultCwd = useSettingsStore((s) => s.terminalDefaultCwd);
+  // Cells restored from a previous session may predate the setting, so fall
+  // back to it here too rather than only at creation time.
+  const cwd = terminalCwd ?? (defaultCwd || getRecentFolders(1)[0]?.path);
   const folderName = cwd ? getFolderDisplayName(cwd) : null;
   const stateKey = getTerminalCellStateKey(terminalId);
 

--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.test.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.test.tsx
@@ -1,7 +1,9 @@
+import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 import { Theme } from "@radix-ui/themes";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@posthog/ui/features/command-center/hooks/useAvailableTasks", () => ({
   useAvailableTasks: () => [],
@@ -18,19 +20,30 @@ vi.mock("@posthog/ui/features/folders/useFolders", () => ({
 
 import { TaskSelector } from "./TaskSelector";
 
-function renderSelector() {
-  return render(
+// Mirrors how CommandCenterPanel drives the selector: `open` is real state, so
+// the popup can actually unmount when a choice closes it.
+function ControlledSelector({
+  onNewTerminal,
+}: {
+  onNewTerminal: (cwd?: string) => void;
+}) {
+  const [open, setOpen] = useState(true);
+  return (
     <Theme>
       <TaskSelector
         cellIndex={0}
-        open
-        onOpenChange={() => {}}
-        onNewTerminal={() => {}}
+        open={open}
+        onOpenChange={setOpen}
+        onNewTerminal={onNewTerminal}
       >
         <button type="button">Add task</button>
       </TaskSelector>
-    </Theme>,
+    </Theme>
   );
+}
+
+function renderSelector(onNewTerminal: (cwd?: string) => void = () => {}) {
+  return render(<ControlledSelector onNewTerminal={onNewTerminal} />);
 }
 
 function expectPopupWidth(input: HTMLElement) {
@@ -40,6 +53,12 @@ function expectPopupWidth(input: HTMLElement) {
 }
 
 describe("TaskSelector", () => {
+  // Reset before rather than after: an afterEach hook runs ahead of Testing
+  // Library's auto-cleanup, so it would update a still-mounted component.
+  beforeEach(() => {
+    useSettingsStore.setState({ terminalDefaultCwd: "" });
+  });
+
   it("keeps the task popup wider than its compact trigger", () => {
     renderSelector();
 
@@ -52,5 +71,27 @@ describe("TaskSelector", () => {
     await userEvent.click(screen.getByRole("button", { name: "Terminal" }));
 
     expectPopupWidth(screen.getByPlaceholderText("Search folders..."));
+  });
+
+  it("opens the default directory instead of prompting for a folder", async () => {
+    useSettingsStore.setState({ terminalDefaultCwd: "/default" });
+    const onNewTerminal = vi.fn();
+    renderSelector(onNewTerminal);
+
+    await userEvent.click(screen.getByRole("button", { name: "Terminal" }));
+
+    expect(onNewTerminal).toHaveBeenCalledWith("/default");
+    // The popup closes outright, so neither step is left on screen.
+    expect(screen.queryByPlaceholderText("Search folders...")).toBeNull();
+    expect(screen.queryByPlaceholderText("Search tasks...")).toBeNull();
+  });
+
+  it("still offers an explicit folder choice once a default is set", async () => {
+    useSettingsStore.setState({ terminalDefaultCwd: "/default" });
+    renderSelector();
+
+    await userEvent.click(screen.getByRole("button", { name: "Terminal in…" }));
+
+    expect(screen.getByPlaceholderText("Search folders...")).toBeVisible();
   });
 });

--- a/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/TaskSelector.tsx
@@ -10,6 +10,7 @@ import { Popover } from "@radix-ui/themes";
 import { type ReactNode, useCallback, useState } from "react";
 import { Combobox } from "../../../primitives/combobox/Combobox";
 import { useFolders } from "../../folders/useFolders";
+import { useSettingsStore } from "../../settings/settingsStore";
 import { useCommandCenterStore } from "../commandCenterStore";
 import { useAvailableTasks } from "../hooks/useAvailableTasks";
 
@@ -39,6 +40,7 @@ export function TaskSelector({
   const assignTask = useCommandCenterStore((s) => s.assignTask);
   const { getRecentFolders } = useFolders();
   const folders = getRecentFolders();
+  const defaultCwd = useSettingsStore((s) => s.terminalDefaultCwd);
   const [step, setStep] = useState<"tasks" | "folder">("tasks");
 
   const handleOpenChange = useCallback(
@@ -70,14 +72,21 @@ export function TaskSelector({
     }
   }, [handleOpenChange, onNewTask]);
 
+  // A configured default wins outright: no folder prompt, even with several
+  // folders registered. "Terminal in…" below stays as the one-off escape hatch.
   const handleNewTerminal = useCallback(() => {
+    if (defaultCwd) {
+      handleOpenChange(false);
+      onNewTerminal?.(defaultCwd);
+      return;
+    }
     if (folders.length > 1) {
       setStep("folder");
       return;
     }
     handleOpenChange(false);
     onNewTerminal?.(folders[0]?.path);
-  }, [folders, handleOpenChange, onNewTerminal]);
+  }, [defaultCwd, folders, handleOpenChange, onNewTerminal]);
 
   const handleBrainrot = useCallback(() => {
     handleOpenChange(false);
@@ -175,6 +184,16 @@ export function TaskSelector({
                   >
                     <Terminal size={11} weight="bold" />
                     Terminal
+                  </button>
+                )}
+                {onNewTerminal && defaultCwd && folders.length > 0 && (
+                  <button
+                    type="button"
+                    className="combobox-footer-button"
+                    onClick={() => setStep("folder")}
+                  >
+                    <Folder size={11} weight="bold" />
+                    Terminal in…
                   </button>
                 )}
                 {onBrainrot && (

--- a/products/desktop/packages/ui/src/features/settings/sections/TerminalSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/TerminalSettings.tsx
@@ -1,13 +1,21 @@
-import { ANALYTICS_EVENTS } from "@posthog/shared";
+import { X } from "@phosphor-icons/react";
+import { useHostTRPCClient } from "@posthog/host-router/react";
+import { Button } from "@posthog/quill";
+import { ANALYTICS_EVENTS, compactHomePath } from "@posthog/shared";
 import { SettingRow } from "@posthog/ui/features/settings/SettingRow";
 import {
   type TerminalFont,
   useSettingsStore,
 } from "@posthog/ui/features/settings/settingsStore";
 import { useDebounce } from "@posthog/ui/primitives/hooks/useDebounce";
+import { toast } from "@posthog/ui/primitives/toast";
 import { track } from "@posthog/ui/shell/analytics";
+import { logger } from "@posthog/ui/shell/logger";
+import { useHostCapabilities } from "@posthog/ui/shell/useHostCapabilities";
 import { Flex, Select, Switch, Text, TextField } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
+
+const log = logger.scope("terminal-settings");
 
 export function TerminalSettings() {
   const terminalFont = useSettingsStore((s) => s.terminalFont);
@@ -22,6 +30,14 @@ export function TerminalSettings() {
   const setTerminalGpuRendering = useSettingsStore(
     (s) => s.setTerminalGpuRendering,
   );
+  const terminalDefaultCwd = useSettingsStore((s) => s.terminalDefaultCwd);
+  const setTerminalDefaultCwd = useSettingsStore(
+    (s) => s.setTerminalDefaultCwd,
+  );
+
+  const hostClient = useHostTRPCClient();
+  const { localWorkspaces } = useHostCapabilities();
+  const [isChoosingDirectory, setIsChoosingDirectory] = useState(false);
 
   const [draftCustomFont, setDraftCustomFont] = useState(
     terminalCustomFontFamily,
@@ -67,10 +83,69 @@ export function TerminalSettings() {
     setTerminalGpuRendering(enabled);
   };
 
+  const handleDefaultCwdChange = (path: string) => {
+    track(ANALYTICS_EVENTS.SETTING_CHANGED, {
+      setting_name: "terminal_default_cwd",
+      new_value: path.length > 0,
+      old_value: terminalDefaultCwd.length > 0,
+    });
+    setTerminalDefaultCwd(path);
+  };
+
+  const handleChooseDefaultCwd = async () => {
+    if (isChoosingDirectory) return;
+    setIsChoosingDirectory(true);
+    try {
+      const path = await hostClient.os.selectDirectory.query();
+      if (path) handleDefaultCwdChange(path);
+    } catch (error) {
+      log.error("Failed to open directory picker", { error });
+      toast.error("Failed to open directory picker");
+    } finally {
+      setIsChoosingDirectory(false);
+    }
+  };
+
   const showCustomInput = terminalFont === "custom";
 
   return (
     <Flex direction="column" gap="1" py="4">
+      {localWorkspaces && (
+        <SettingRow
+          label="Default directory"
+          description="Choose which directory new terminal sessions open in. Leave this unset to use the directory you most recently worked in."
+        >
+          <Flex align="center" gap="2" className="min-w-0">
+            {terminalDefaultCwd && (
+              <>
+                <Text
+                  className="max-w-[220px] truncate text-[12px]"
+                  title={terminalDefaultCwd}
+                >
+                  {compactHomePath(terminalDefaultCwd)}
+                </Text>
+                <button
+                  type="button"
+                  aria-label="Clear default directory"
+                  className="cursor-pointer p-0 opacity-60 hover:opacity-100"
+                  onClick={() => handleDefaultCwdChange("")}
+                >
+                  <X size={12} />
+                </button>
+              </>
+            )}
+            <Button
+              size="sm"
+              variant="outline"
+              loading={isChoosingDirectory}
+              onClick={() => void handleChooseDefaultCwd()}
+            >
+              {terminalDefaultCwd ? "Change…" : "Choose directory…"}
+            </Button>
+          </Flex>
+        </SettingRow>
+      )}
+
       <SettingRow
         label="Font"
         description="Font used to render the terminal output"

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.test.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.test.ts
@@ -48,6 +48,10 @@ describe("feature settingsStore defaults", () => {
       "local",
     );
   });
+
+  it("leaves the default terminal directory unset", () => {
+    expect(useSettingsStore.getState().terminalDefaultCwd).toBe("");
+  });
 });
 
 describe("feature settingsStore cloud selections", () => {
@@ -597,5 +601,44 @@ describe("feature settingsStore hydration", () => {
     await useSettingsStore.persist.rehydrate();
 
     expect(useSettingsStore.getState()._hasHydrated).toBe(true);
+  });
+});
+
+describe("feature settingsStore terminal default directory", () => {
+  beforeEach(async () => {
+    await resetPersistenceMocks();
+
+    useSettingsStore.setState({ terminalDefaultCwd: "" });
+  });
+
+  it.each([
+    ["a chosen directory", "/Users/luke/Documents/Jarvis"],
+    ["a cleared directory", ""],
+  ])("persists %s", async (_label, value) => {
+    useSettingsStore.getState().setTerminalDefaultCwd(value);
+
+    await waitForPersistedWrite();
+
+    const lastCall = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const persisted = JSON.parse(lastCall[1]);
+
+    expect(persisted.state.terminalDefaultCwd).toBe(value);
+  });
+
+  it("rehydrates the default terminal directory", async () => {
+    getItem.mockResolvedValue(
+      JSON.stringify({
+        state: { terminalDefaultCwd: "/Users/luke/Documents/Jarvis" },
+        version: 0,
+      }),
+    );
+
+    useSettingsStore.setState({ terminalDefaultCwd: "" });
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().terminalDefaultCwd).toBe(
+      "/Users/luke/Documents/Jarvis",
+    );
   });
 });

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -233,9 +233,13 @@ interface SettingsStore {
   terminalFont: TerminalFont;
   terminalCustomFontFamily: string;
   terminalGpuRendering: boolean;
+  // Directory new standalone terminals open in. Any path, not just a
+  // registered project folder. Empty means "infer from recent folders".
+  terminalDefaultCwd: string;
   setTerminalFont: (font: TerminalFont) => void;
   setTerminalCustomFontFamily: (value: string) => void;
   setTerminalGpuRendering: (enabled: boolean) => void;
+  setTerminalDefaultCwd: (path: string) => void;
 
   // Conversation thread (new-thread)
   conversationCollapseMode: CollapseMode;
@@ -466,11 +470,13 @@ export const useSettingsStore = create<SettingsStore>()(
       terminalFont: "berkeley-mono",
       terminalCustomFontFamily: "",
       terminalGpuRendering: true,
+      terminalDefaultCwd: "",
       setTerminalFont: (font) => set({ terminalFont: font }),
       setTerminalCustomFontFamily: (value) =>
         set({ terminalCustomFontFamily: value }),
       setTerminalGpuRendering: (enabled) =>
         set({ terminalGpuRendering: enabled }),
+      setTerminalDefaultCwd: (path) => set({ terminalDefaultCwd: path }),
 
       // Conversation thread (new-thread)
       conversationCollapseMode: COLLAPSE_MODE_DEFAULT,
@@ -613,6 +619,7 @@ export const useSettingsStore = create<SettingsStore>()(
         terminalFont: state.terminalFont,
         terminalCustomFontFamily: state.terminalCustomFontFamily,
         terminalGpuRendering: state.terminalGpuRendering,
+        terminalDefaultCwd: state.terminalDefaultCwd,
 
         // Conversation thread (new-thread)
         conversationCollapseMode: state.conversationCollapseMode,

--- a/products/desktop/packages/workspace-server/src/services/shell/shell.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/shell/shell.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockRepositoryRepository } from "../../db/repositories/repository-repository.mock";
@@ -190,6 +190,69 @@ describe("ShellService.createSession workspace env", () => {
     } finally {
       restoreEnv("ELECTRON_RUN_AS_NODE", saved.runAsNode);
       restoreEnv("POSTHOG_CODE_INTERNAL_CHILD", saved.internalChild);
+    }
+  });
+});
+
+describe("ShellService.createSession working directory", () => {
+  function spawnedCwd(): string {
+    return mockPty.spawn.mock.calls[0][2].cwd;
+  }
+
+  beforeEach(() => {
+    mockPty.spawn.mockReset();
+    mockPty.spawn.mockReturnValue(createMockPtyProcess());
+  });
+
+  it("spawns in a cwd that exists on disk", async () => {
+    const tempDir = mkdtempSync(path.join(tmpdir(), "shell-cwd-"));
+    try {
+      const { service } = createService();
+
+      await service.createSession({ sessionId: "session-1", cwd: tempDir });
+
+      expect(spawnedCwd()).toBe(tempDir);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["no cwd", undefined],
+    ["an empty cwd", ""],
+    ["a cwd that does not exist", "/does/not/exist"],
+  ])("falls back to home for %s", async (_label, cwd) => {
+    const { service } = createService();
+
+    await service.createSession({ sessionId: "session-1", cwd });
+
+    expect(spawnedCwd()).toBe(homedir());
+  });
+
+  it.each([
+    ["a bare tilde", "~"],
+    ["a trailing-slash tilde", "~/"],
+  ])("expands %s to the home directory", async (_label, cwd) => {
+    const { service } = createService();
+
+    await service.createSession({ sessionId: "session-1", cwd });
+
+    expect(spawnedCwd()).toBe(homedir());
+  });
+
+  it("expands a tilde path before checking that it exists", async () => {
+    const tempDir = mkdtempSync(path.join(homedir(), ".shell-cwd-test-"));
+    try {
+      const { service } = createService();
+
+      await service.createSession({
+        sessionId: "session-1",
+        cwd: `~/${path.basename(tempDir)}`,
+      });
+
+      expect(spawnedCwd()).toBe(tempDir);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
     }
   });
 });

--- a/products/desktop/packages/workspace-server/src/services/shell/shell.ts
+++ b/products/desktop/packages/workspace-server/src/services/shell/shell.ts
@@ -1,6 +1,7 @@
 import { exec } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir, platform } from "node:os";
+import { join } from "node:path";
 import {
   ROOT_LOGGER,
   type RootLogger,
@@ -50,6 +51,15 @@ function getDefaultShell(): string {
     return process.env.COMSPEC || "cmd.exe";
   }
   return process.env.SHELL || "/bin/bash";
+}
+
+/** Resolve a leading "~" against the home directory. Other paths pass through. */
+export function expandHomePath(path: string, home: string): string {
+  if (path === "~") return home;
+  if (path.startsWith("~/") || path.startsWith("~\\")) {
+    return join(home, path.slice(2));
+  }
+  return path;
 }
 
 function getShellArgs(shell: string): string[] {
@@ -403,7 +413,9 @@ export class ShellService extends TypedEventEmitter<ShellEvents> {
 
   private resolveWorkingDir(sessionId: string, cwd?: string): string {
     const home = homedir();
-    const workingDir = cwd || home;
+    // Expand "~" before the existence check: a tilde path is real to the user
+    // but not to existsSync, so it would otherwise be discarded for home.
+    const workingDir = cwd ? expandHomePath(cwd, home) : home;
 
     if (!existsSync(workingDir)) {
       this.log.warn(


### PR DESCRIPTION
## Problem

New terminals in the desktop app pick their working directory implicitly. With one registered project folder that folder gets used, with several you get a folder prompt every time, and with none it falls back to your home directory. There is no way to pin a directory, and it has to be a registered project folder, so a plain notes or scratch directory cannot be the default at all.

## Changes

Settings > Terminal now has a **Default directory** row: a native directory picker that accepts any path, not just a registered project folder. Once set, new terminals open there with no prompt. A "Terminal in..." entry stays in the new-terminal footer for one-off overrides, so folder choice is not lost. When the setting is empty, behaviour is exactly what it is today.

`ShellService.resolveWorkingDir` now expands a leading `~` before its `existsSync` check. A tilde path previously failed that check and was silently swapped for the home directory, which also quietly affected the `cwd="~"` used by the CLI onboarding step.

The preference lives in the existing persisted `settingsStore` next to the other terminal settings, so there is no new tRPC procedure or host-side store. The row is hidden on hosts without local workspaces, since there is no local pty there.

No screenshots: I was not able to run the Electron app in this environment. See below for what that leaves unverified.

## How did you test this code?

Automated only, all run by me (Claude) in this repo after porting the change:

| Check | Result |
| --- | --- |
| `packages/ui` `settingsStore.test.ts` | 43 passed |
| `packages/ui` `command-center` (incl. `TaskSelector.test.tsx`) | 37 passed |
| `packages/workspace-server` `shell.test.ts` | 14 passed |
| biome check, 8 touched files | clean |
| `packages/ui` typecheck | 76 errors, identical count to the unmodified tree (unbuilt `@posthog/agent` dist in my sandbox), none in touched files |

New test groups, and the regression each one catches that no existing test did:

- **`settingsStore.test.ts` > "terminal default directory"**: the setting silently failing to persist. Adding a field to the store but omitting it from `partialize` still type-checks and still passes every other test, and the value is then lost on restart.
- **`shell.test.ts` > "createSession working directory"**: a tilde path being discarded in favour of the home directory, which is the exact bug fixed here, plus the empty, missing and undefined cwd fallbacks that nothing pinned before.
- **`TaskSelector.test.tsx` > two new cases**: the default being ignored so the folder prompt still appears, and the "Terminal in..." escape hatch vanishing once a default is set. The two existing cases in that file only cover popup width.

> [!NOTE]
> Not verified: I did not drive the running app, so the directory picker dialog and the new-terminal footer layout are unexercised. That footer can now show up to four buttons (New task, Terminal, Terminal in..., Brainrot) and may want a width check before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke asked for new terminals to always open in a directory of his choosing. I (Claude, via PostHog Code) wrote all of the code here. No skills invoked.

This began as PostHog/code#3890. That repo froze on 1 August behind the monorepo migration, and a repo-wide ruleset now blocks every ref update there, so the finished branch could not be pushed. I rebased it onto `products/desktop` here instead. `terminalDefaultCwd` did not exist in the monorepo yet, so nothing is duplicated.

Decisions worth a reviewer's eye:

- Did not reuse `FolderPicker`. Its "Open folder..." path calls `addFolder()`, which registers the directory as a project repository. A default terminal directory should be able to be any directory, so this calls `os.selectDirectory` directly, matching "Default folders for new chats" in `WorkspacesSettings`.
- Kept the "Terminal in..." escape hatch rather than removing folder choice, so a pinned default does not make one-off terminals elsewhere impossible.
- Analytics records set versus unset rather than the path, since a local filesystem path is user data. Same reasoning as `terminal_custom_font_family`.

Only `TaskSelector.tsx` had moved on in the monorepo (#76570 swapped a utility class for an inline style). No overlap with my hunks, and both changes coexist. Its `TaskSelector.test.tsx` is new here and had no counterpart in the old repo, which is where the two component tests went.
