### PR TITLE
feat(mcp-store): share new connections with every agent by default

### DIFF
--- a/products/desktop/packages/api-client/src/mcp-gateway.ts
+++ b/products/desktop/packages/api-client/src/mcp-gateway.ts
@@ -203,6 +203,10 @@ export interface McpGatewayMemberSummary {
 export interface McpGatewayInstallSharingOptions {
   /** Whether the server starts enabled for the whole team. */
   team_enabled?: boolean;
-  /** Service accounts to grant the server to at install time, when team settings allow it. */
+  /**
+   * Service accounts to grant the server to at install time, when team settings
+   * allow it. Omitting the field grants every PostHog agent; send an explicit
+   * list (empty for none) to choose.
+   */
   agent_ids?: string[];
 }

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.test.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.test.ts
@@ -27,11 +27,13 @@ describe("canSubmitGatewayServer", () => {
   });
 });
 
+const BOTH_AGENTS = ["svc-1", "svc-2"];
+
 describe("buildGatewayInstallRequest", () => {
   it("builds an oauth install with admin team options", () => {
     const request = buildGatewayInstallRequest(
-      values({ description: "  Wiki tools  ", agentIds: ["svc-1"] }),
-      { isAdmin: true, canManageAgentAccess: true },
+      values({ description: "  Wiki tools  " }),
+      { isAdmin: true, canManageAgentAccess: true, agentIds: ["svc-1"] },
     );
     expect(request).toEqual({
       name: "Internal Wiki",
@@ -46,7 +48,7 @@ describe("buildGatewayInstallRequest", () => {
   it("includes the key on api-key installs", () => {
     const request = buildGatewayInstallRequest(
       values({ authType: "api_key", apiKey: "sk-123" }),
-      { isAdmin: true, canManageAgentAccess: true },
+      { isAdmin: true, canManageAgentAccess: true, agentIds: [] },
     );
     expect(request.auth_type).toBe("api_key");
     expect(request.api_key).toBe("sk-123");
@@ -56,30 +58,47 @@ describe("buildGatewayInstallRequest", () => {
     const bare = buildGatewayInstallRequest(values(), {
       isAdmin: true,
       canManageAgentAccess: true,
+      agentIds: [],
     });
     expect(bare.client_id).toBeUndefined();
     const withCreds = buildGatewayInstallRequest(
       values({ clientId: " id ", clientSecret: "secret" }),
-      { isAdmin: true, canManageAgentAccess: true },
+      { isAdmin: true, canManageAgentAccess: true, agentIds: [] },
     );
     expect(withCreds.client_id).toBe("id");
     expect(withCreds.client_secret).toBe("secret");
   });
 
   it("lets permitted members share with agents without team enablement", () => {
-    const request = buildGatewayInstallRequest(
-      values({ agentIds: ["svc-1"] }),
-      { isAdmin: false, canManageAgentAccess: true },
-    );
+    const request = buildGatewayInstallRequest(values(), {
+      isAdmin: false,
+      canManageAgentAccess: true,
+      agentIds: ["svc-1"],
+    });
     expect(request.team_enabled).toBeUndefined();
     expect(request.agent_ids).toEqual(["svc-1"]);
   });
 
-  it("omits agent grants when team settings make them admin-only", () => {
-    const request = buildGatewayInstallRequest(
-      values({ agentIds: ["svc-1"] }),
-      { isAdmin: false, canManageAgentAccess: false },
-    );
-    expect(request.agent_ids).toBeUndefined();
+  it.each([
+    ["shares with every agent by default", [], BOTH_AGENTS, true, BOTH_AGENTS],
+    ["drops the agents turned off", ["svc-2"], BOTH_AGENTS, true, ["svc-1"]],
+    ["sends none when all are turned off", BOTH_AGENTS, BOTH_AGENTS, true, []],
+    // No catalog means no informed choice was possible, so let the backend
+    // apply the same all-agents default instead of asserting an empty list.
+    ["omits the field before the catalog loads", [], [], true, undefined],
+    [
+      "omits the field when sharing is admin-only",
+      [],
+      BOTH_AGENTS,
+      false,
+      undefined,
+    ],
+  ])("%s", (_label, excludedAgentIds, agentIds, canManageAgentAccess, sent) => {
+    const request = buildGatewayInstallRequest(values({ excludedAgentIds }), {
+      isAdmin: false,
+      canManageAgentAccess,
+      agentIds,
+    });
+    expect(request.agent_ids).toEqual(sent);
   });
 });

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
@@ -12,9 +12,10 @@ export interface GatewayAddServerValues {
   apiKey: string;
   clientId: string;
   clientSecret: string;
-  /** Team sharing options are admin-only; agentIds follows the team setting. */
+  /** Team sharing is admin-only; agent sharing follows the team setting. */
   teamEnabled: boolean;
-  agentIds: string[];
+  /** Agents turned off by the installer. Every other agent is shared with. */
+  excludedAgentIds: string[];
 }
 
 export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
@@ -26,7 +27,7 @@ export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
   clientId: "",
   clientSecret: "",
   teamEnabled: true,
-  agentIds: [],
+  excludedAgentIds: [],
 };
 
 export function canSubmitGatewayServer(
@@ -50,10 +51,20 @@ export interface GatewayInstallRequest extends McpGatewayInstallSharingOptions {
  * credential is always personal to the installer. Team-wide options are
  * attached only for admins; agent grants are attached whenever the team
  * allows this member to manage agent access.
+ *
+ * A new server is shared with every agent by default. The explicit list is only
+ * sent once the agent catalog has loaded, so turning every agent off still means
+ * "none"; until then the field is omitted and the backend applies the same
+ * all-agents default.
  */
 export function buildGatewayInstallRequest(
   values: GatewayAddServerValues,
-  options: { isAdmin: boolean; canManageAgentAccess: boolean },
+  options: {
+    isAdmin: boolean;
+    canManageAgentAccess: boolean;
+    /** Every agent available to the project. */
+    agentIds: string[];
+  },
 ): GatewayInstallRequest {
   return {
     name: values.name.trim(),
@@ -70,8 +81,12 @@ export function buildGatewayInstallRequest(
       ? { client_secret: values.clientSecret.trim() }
       : {}),
     ...(options.isAdmin ? { team_enabled: values.teamEnabled } : {}),
-    ...(options.canManageAgentAccess && values.agentIds.length
-      ? { agent_ids: values.agentIds }
+    ...(options.canManageAgentAccess && options.agentIds.length
+      ? {
+          agent_ids: options.agentIds.filter(
+            (id) => !values.excludedAgentIds.includes(id),
+          ),
+        }
       : {}),
   };
 }

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -59,6 +59,7 @@ export function GatewayAddServer({
     const request = buildGatewayInstallRequest(values, {
       isAdmin,
       canManageAgentAccess,
+      agentIds: accounts.map((account) => account.id),
     });
     register(
       { request },
@@ -259,7 +260,7 @@ export function GatewayAddServer({
                   </Text>
                   <div className="overflow-hidden rounded border border-gray-5 bg-gray-2">
                     {accounts.map((account) => {
-                      const on = values.agentIds.includes(account.id);
+                      const on = !values.excludedAgentIds.includes(account.id);
                       return (
                         <Flex
                           key={account.id}
@@ -285,12 +286,12 @@ export function GatewayAddServer({
                             checked={on}
                             onCheckedChange={(checked) =>
                               set(
-                                "agentIds",
+                                "excludedAgentIds",
                                 checked
-                                  ? [...values.agentIds, account.id]
-                                  : values.agentIds.filter(
+                                  ? values.excludedAgentIds.filter(
                                       (id) => id !== account.id,
-                                    ),
+                                    )
+                                  : [...values.excludedAgentIds, account.id],
                               )
                             }
                           />

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -3,8 +3,10 @@ import hashlib
 import secrets
 from collections.abc import Mapping
 from datetime import timedelta
+from functools import cached_property
 from typing import Any, cast
 from urllib.parse import urlencode, urlparse
+from uuid import UUID
 
 from django.conf import settings
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -376,9 +378,9 @@ class InstallCustomSerializer(serializers.Serializer):
     agent_ids = serializers.ListField(
         child=serializers.UUIDField(),
         required=False,
-        default=list,
         help_text=(
-            "Service accounts to share the server with at install time. "
+            "Service accounts to share the server with at install time. Omit to share with every "
+            "PostHog agent; send an explicit list (empty for none) to choose. "
             "Available to members when team settings allow member-managed agent access."
         ),
     )
@@ -422,9 +424,9 @@ class InstallTemplateSerializer(serializers.Serializer):
     agent_ids = serializers.ListField(
         child=serializers.UUIDField(),
         required=False,
-        default=list,
         help_text=(
-            "Service accounts to share the server with at install time. "
+            "Service accounts to share the server with at install time. Omit to share with every "
+            "PostHog agent; send an explicit list (empty for none) to choose. "
             "Available to members when team settings allow member-managed agent access."
         ),
     )
@@ -727,18 +729,38 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
     def _wants_team_gateway_options(data: dict) -> bool:
         return not data.get("team_enabled", True)
 
+    @cached_property
+    def _built_in_agents(self) -> list[MCPServiceAccount]:
+        return sync_built_in_agents(self.team)
+
+    def _agent_ids_to_share_with(self, data: dict) -> set[UUID]:
+        """The agents this install should be shared with.
+
+        An explicit ``agent_ids`` list is honored as sent, an empty one included.
+        Omitting the field shares the connection with every built-in agent, so a
+        server is usable by agents from the moment it is connected. That default
+        is skipped for a caller who may not manage agent access, because it was
+        never asked for and a 403 would block an otherwise valid install.
+        """
+        requested = data.get("agent_ids")
+        if requested is not None:
+            return set(requested)
+        if not self._is_project_admin() and not members_can_manage_agent_access(self.team_id):
+            return set()
+        return {account.id for account in self._built_in_agents}
+
     def _validate_gateway_options(self, data: dict) -> None:
         """Validate team-level options and agent grants before creating rows."""
         if self._wants_team_gateway_options(data) and not self._is_project_admin():
             raise PermissionDenied("Only project admins can set team availability.")
 
-        agent_ids = set(data.get("agent_ids") or [])
+        agent_ids = self._agent_ids_to_share_with(data)
         if not agent_ids:
             return
         if not self._is_project_admin() and not members_can_manage_agent_access(self.team_id):
             raise PermissionDenied("Only project admins can share servers with agents in this project.")
 
-        built_in_agent_ids = {account.id for account in sync_built_in_agents(self.team)}
+        built_in_agent_ids = {account.id for account in self._built_in_agents}
         if not agent_ids.issubset(built_in_agent_ids):
             raise serializers.ValidationError({"agent_ids": "Select only the PostHog agents listed for this project."})
 
@@ -749,7 +771,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         Called only once the install is persisted for good; `_validate_gateway_options`
         has already gated team options and agent grants.
         """
-        agent_ids = set(data.get("agent_ids") or [])
+        agent_ids = self._agent_ids_to_share_with(data)
         accounts_by_id = {
             account.id: account for account in MCPServiceAccount.objects.for_team(self.team_id).filter(id__in=agent_ids)
         }

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -1212,6 +1212,72 @@ class TestMCPServiceAccountAPI(APIBaseTest):
         assert installation.scope == "personal"
         assert access_rows == {(account.id, installation.id) for account in accounts}
 
+    @parameterized.expand(
+        [
+            ("omitted", None, True),
+            ("empty", [], False),
+        ]
+    )
+    @ALLOW_URL
+    def test_install_shares_with_every_agent_unless_a_list_is_sent(
+        self, scenario: str, agent_ids: list[str] | None, expect_shared: bool, _mock_is_url_allowed
+    ) -> None:
+        self._make_member()
+        accounts = sync_built_in_agents(self.team)
+        install_url = f"https://mcp.agent-default-{scenario}.example.com/mcp"
+        payload: dict[str, object] = {
+            "name": "Agent default",
+            "url": install_url,
+            "auth_type": "api_key",
+            "api_key": "secret",
+            "scope": "personal",
+        }
+        if agent_ids is not None:
+            payload["agent_ids"] = agent_ids
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/install_custom/",
+            data=payload,
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        installation = MCPServerInstallation.objects.get(team=self.team, url=install_url)
+        shared_with = set(
+            MCPServiceAccountServerAccess.objects.for_team(self.team.id)
+            .filter(gateway_server=installation.gateway_server)
+            .values_list("service_account_id", flat=True)
+        )
+        assert shared_with == ({account.id for account in accounts} if expect_shared else set())
+
+    @ALLOW_URL
+    def test_install_skips_the_agent_default_when_members_cannot_manage_agent_access(
+        self, _mock_is_url_allowed
+    ) -> None:
+        self._make_member()
+        TeamMCPGatewayConfig.objects.for_team(self.team.id).create(team=self.team, allow_member_agent_access=False)
+        install_url = "https://mcp.agent-default-restricted.example.com/mcp"
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/install_custom/",
+            data={
+                "name": "Restricted default",
+                "url": install_url,
+                "auth_type": "api_key",
+                "api_key": "secret",
+                "scope": "personal",
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        installation = MCPServerInstallation.objects.get(team=self.team, url=install_url)
+        assert (
+            not MCPServiceAccountServerAccess.objects.for_team(self.team.id)
+            .filter(gateway_server=installation.gateway_server)
+            .exists()
+        )
+
     @ALLOW_URL
     def test_install_rejects_member_agent_grant_when_team_setting_is_off(self, _mock_is_url_allowed) -> None:
         self._make_member()
@@ -3319,6 +3385,25 @@ class TestInstallTemplateAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest
 
         installation = MCPServerInstallation.objects.get(id=body["id"])
         assert installation.sensitive_configuration["api_key"] == "sk-template"
+
+    def test_install_template_shares_with_every_agent(self):
+        template = self._template(auth_type="api_key", oauth_credentials={}, oauth_metadata={})
+        accounts = sync_built_in_agents(self.team)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/mcp_server_installations/install_template/",
+            data={"template_id": str(template.id), "api_key": "sk-template"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        installation = MCPServerInstallation.objects.get(id=response.json()["id"])
+        shared_with = set(
+            MCPServiceAccountServerAccess.objects.for_team(self.team.id)
+            .filter(gateway_server=installation.gateway_server)
+            .values_list("service_account_id", flat=True)
+        )
+        assert shared_with == {account.id for account in accounts}
 
     def test_install_template_api_key_requires_key(self):
         template = self._template(auth_type="api_key", oauth_credentials={}, oauth_metadata={})

--- a/products/mcp_store/frontend/generated/api.schemas.ts
+++ b/products/mcp_store/frontend/generated/api.schemas.ts
@@ -951,7 +951,7 @@ export interface InstallCustomApi {
     scope?: MCPInstallationScopeEnumApi
     /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
     team_enabled?: boolean
-    /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
+    /** Service accounts to share the server with at install time. Omit to share with every PostHog agent; send an explicit list (empty for none) to choose. Available to members when team settings allow member-managed agent access. */
     agent_ids?: string[]
     /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
     return_path?: string
@@ -973,7 +973,7 @@ export interface InstallTemplateApi {
     scope?: MCPInstallationScopeEnumApi
     /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
     team_enabled?: boolean
-    /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
+    /** Service accounts to share the server with at install time. Omit to share with every PostHog agent; send an explicit list (empty for none) to choose. Available to members when team settings allow member-managed agent access. */
     agent_ids?: string[]
     /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
     return_path?: string

--- a/products/mcp_store/frontend/generated/api.zod.ts
+++ b/products/mcp_store/frontend/generated/api.zod.ts
@@ -471,7 +471,7 @@ export const McpServerInstallationsInstallCustomCreateBody = /* @__PURE__ */ zod
         .array(zod.uuid())
         .optional()
         .describe(
-            'Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access.'
+            'Service accounts to share the server with at install time. Omit to share with every PostHog agent; send an explicit list (empty for none) to choose. Available to members when team settings allow member-managed agent access.'
         ),
     return_path: zod
         .string()
@@ -511,7 +511,7 @@ export const McpServerInstallationsInstallTemplateCreateBody = /* @__PURE__ */ z
         .array(zod.uuid())
         .optional()
         .describe(
-            'Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access.'
+            'Service accounts to share the server with at install time. Omit to share with every PostHog agent; send an explicit list (empty for none) to choose. Available to members when team settings allow member-managed agent access.'
         ),
     return_path: zod
         .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -37601,7 +37601,7 @@ export namespace Schemas {
       scope?: MCPInstallationScopeEnum;
       /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
       team_enabled?: boolean;
-      /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
+      /** Service accounts to share the server with at install time. Omit to share with every PostHog agent; send an explicit list (empty for none) to choose. Available to members when team settings allow member-managed agent access. */
       agent_ids?: string[];
       /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
       return_path?: string;
@@ -37619,7 +37619,7 @@ export namespace Schemas {
       scope?: MCPInstallationScopeEnum;
       /** Whether the server starts enabled for the whole team. Non-default values are admin-only. */
       team_enabled?: boolean;
-      /** Service accounts to share the server with at install time. Available to members when team settings allow member-managed agent access. */
+      /** Service accounts to share the server with at install time. Omit to share with every PostHog agent; send an explicit list (empty for none) to choose. Available to members when team settings allow member-managed agent access. */
       agent_ids?: string[];
       /** In-app path to land back on after the OAuth round-trip. Must be a same-app relative path. */
       return_path?: string;


### PR DESCRIPTION
## Problem

Connecting an MCP server left every agent locked out of it. You'd connect Linear or Notion, then walk back into the gateway and flip a switch per agent before Support or Scout could use it. Nobody connects a server hoping their agents can't reach it.

## Changes

`agent_ids` on `install_custom` and `install_template` is now genuinely optional. Omit it and the install grants every built-in agent. Send an explicit list and it is honored exactly as sent, empty list included, so opting out still works.

Recommended catalog servers connect through `install_template`, so they get the same default.

This lands in the backend, so every client picks it up without a change. The web gateway scene, the web MCP store settings, the desktop app and mobile all omit `agent_ids` today.

Two guards stay in place:

- A member in a project where `allow_member_agent_access` is off gets no grants instead of a 403. They never asked for the default, so it should not block an otherwise valid install.
- An explicit list from a member who cannot manage agent access still 403s, exactly as before.

The desktop add-server form is the one client with its own "Share with agents" switches. Those now start on, and the form sends the resolved list once the agent catalog has loaded, so switching an agent off there still means off.

> [!WARNING]
> Behavior change. A new connection now delegates the installer's own credential to Support and Scout at install time. The grant still binds to the credential the installer connected themselves, and per-tool policies still gate what an agent can actually call.

## How did you test this code?

Automated only. I did not run the web app or the desktop client, so there is no manual verification here.

What I (actually Claude) ran:

- `hogli test products/mcp_store/backend/test/` &rarr; 433 passed
- desktop `gatewayAddServer.test.ts` and `GatewayAddServer.test.tsx` under vitest &rarr; passed
- `uv run mypy --cache-fine-grained .` repo-wide &rarr; clean
- `hogli ci:preflight --fix` &rarr; no failures
- `hogli build:openapi` &rarr; description-only drift in the generated mcp_store and MCP service types, committed here

New tests, and the regression each one catches that nothing else did:

- `test_install_shares_with_every_agent_unless_a_list_is_sent` (parameterized, custom install): the default itself, plus the omitted-vs-empty distinction. The empty case breaks the moment anyone reintroduces `data.get("agent_ids") or []`, which would silently turn "share with nobody" back into "share with everybody".
- `test_install_skips_the_agent_default_when_members_cannot_manage_agent_access`: guards against the new default turning into a 403 on install for members in a locked-down project.
- `test_install_template_shares_with_every_agent`: `install_template` reaches `_apply_gateway_options` through its own branch, and it is the path recommended servers use.
- Desktop `it.each` over `buildGatewayInstallRequest`: deselecting every agent sends `[]`, and the field is omitted while the agent catalog is still loading so a fast submit does not accidentally mean "no agents".

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover MCP store agent sharing today, so there is nothing to update alongside this.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code, Opus 5) at my direction. Skills invoked while producing it: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`.

Two decisions worth flagging for review:

Backend default over per-client changes. Four clients create MCP connections and none of them send `agent_ids`, so a serializer-level default covers all of them at once and keeps future clients consistent. That required dropping `default=list` so the view can tell "omitted" from "explicitly empty" — the whole opt-out story hangs on that distinction.

Desktop switches track exclusions, not selections. The agent catalog loads async, so a selection list seeded from `accounts` would start empty and read as "share with nobody" on the first render. Tracking which agents the installer turned *off* makes the default correct regardless of load order.

I also considered adding copy to the web connect flow explaining the new default, and dropped it: the web connect path has no agent UI at all, and the OAuth template case skips the modal entirely, so it would have been visible in some flows and not others. The server detail page already shows the agent switches in their new on state after connecting.
