### PR TITLE
fix(desktop): use mod+comma instead of mod+, to prevent bare modifier key triggering settings

### DIFF
--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -4,7 +4,7 @@ export const SHORTCUTS = {
   COMMAND_MENU: "mod+k",
   NEW_TASK: "mod+n",
   NEW_TAB: "mod+t",
-  SETTINGS: "mod+,",
+  SETTINGS: "mod+comma",
   SHORTCUTS_SHEET: "mod+/",
   GO_BACK: "mod+[",
   GO_FORWARD: "mod+]",
@@ -328,6 +328,7 @@ function formatKey(key: string): string {
   if (k === "down" || k === "arrowdown") return "↓";
   if (k === "left" || k === "arrowleft") return "←";
   if (k === "right" || k === "arrowright") return "→";
+  if (k === "comma") return ",";
   if (k === ",") return ",";
   if (k === "[") return "[";
   if (k === "]") return "]";


### PR DESCRIPTION
## Description

Fixes #76193

react-hotkeys-hook uses comma as the default hotkey-list separator (splitKey), so `"mod+,"` is parsed as two degenerate hotkeys `["mod+", ""]`. Once a synthetic event with empty `code` is processed, the empty string `""` gets seeded into the internal pressed-keys set, and every bare modifier keydown (Right Shift, Windows key, etc.) fires the settings callback.

## Changes

1. `SHORTCUTS.SETTINGS`: `"mod+,"` → `"mod+comma"` (react-hotkeys-hook's documented spelling for the comma key)
2. `formatKey()`: Added `if (k === "comma") return ","` so the shortcuts sheet still renders as `Ctrl+,` / `⌘,`

The issue author confirmed this fix works by byte-patching the shipped renderer bundle.