### PR TITLE
feat(conversations): support quote blocks in the support editor

### DIFF
--- a/products/conversations/frontend/components/Editor/SupportEditor.test.ts
+++ b/products/conversations/frontend/components/Editor/SupportEditor.test.ts
@@ -54,6 +54,32 @@ describe('SupportEditor serialization and preview schema', () => {
             '1. parent\n   - child',
         ],
         [
+            'multi-paragraph blockquote staying a single quote',
+            {
+                type: 'doc',
+                content: [{ type: 'blockquote', content: [paragraph('a'), paragraph('b')] }],
+            },
+            '> a\n>\n> b',
+        ],
+        [
+            'blockquote wrapping a list',
+            {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'blockquote',
+                        content: [
+                            {
+                                type: 'bulletList',
+                                content: [listItem(paragraph('one')), listItem(paragraph('two'))],
+                            },
+                        ],
+                    },
+                ],
+            },
+            '> - one\n> - two',
+        ],
+        [
             'list followed by paragraph and image keeps all blocks',
             {
                 type: 'doc',

--- a/products/conversations/frontend/components/Editor/SupportEditor.test.ts
+++ b/products/conversations/frontend/components/Editor/SupportEditor.test.ts
@@ -80,6 +80,24 @@ describe('SupportEditor serialization and preview schema', () => {
             '> - one\n> - two',
         ],
         [
+            'blockquote inside a list item indented under the marker',
+            {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'bulletList',
+                        content: [
+                            listItem(paragraph('item'), {
+                                type: 'blockquote',
+                                content: [paragraph('a'), paragraph('b')],
+                            }),
+                        ],
+                    },
+                ],
+            },
+            '- item\n  > a\n  >\n  > b',
+        ],
+        [
             'list followed by paragraph and image keeps all blocks',
             {
                 type: 'doc',

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -293,10 +293,14 @@ export const serializationOptions: { textSerializers?: Record<string, TextSerial
 
 /**
  * Escape special markdown characters in plain text to prevent unintended formatting.
- * Characters: \ ` * _ { } [ ] ( ) # + - . ! | >
+ * Characters: \ ` * _ { } [ ] ( ) # + - . ! |
+ *
+ * Deliberately mirrors _RE_MD_ESCAPE in products/conversations/backend/formatting.py, whose
+ * _RE_MD_ESCAPED_CHAR unescapes this exact set for Slack mrkdwn. Adding a character here
+ * without adding it to both of those leaks a backslash into outbound Slack messages.
  */
 function escapeMarkdown(text: string): string {
-    return text.replace(/([\\`*_{}[\]()#+\-.!|>])/g, '\\$1')
+    return text.replace(/([\\`*_{}[\]()#+\-.!|])/g, '\\$1')
 }
 
 /**

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -22,7 +22,7 @@ import { common, createLowlight } from 'lowlight'
 import posthog from 'posthog-js'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconCode, IconCopy, IconImage, IconList, IconTerminal } from '@posthog/icons'
+import { IconCode, IconCopy, IconImage, IconList, IconQuote, IconTerminal } from '@posthog/icons'
 
 import { EmojiPickerPopover } from 'lib/components/EmojiPicker/EmojiPickerPopover'
 import { useRichContentEditor } from 'lib/components/RichContentEditor'
@@ -243,7 +243,7 @@ export const SUPPORT_EXTENSIONS = [
         document: false,
         link: false, // We use our own Link extension
         heading: false,
-        blockquote: false,
+        // blockquote: enabled - Cmd+Shift+B, and the "> " input rule
         // bold: enabled - Cmd+B
         // bulletList: enabled - Cmd+Shift+8
         // code: enabled - inline code (Cmd+E) - just visual styling, not executable
@@ -293,10 +293,10 @@ export const serializationOptions: { textSerializers?: Record<string, TextSerial
 
 /**
  * Escape special markdown characters in plain text to prevent unintended formatting.
- * Characters: \ ` * _ { } [ ] ( ) # + - . ! |
+ * Characters: \ ` * _ { } [ ] ( ) # + - . ! | >
  */
 function escapeMarkdown(text: string): string {
-    return text.replace(/([\\`*_{}[\]()#+\-.!|])/g, '\\$1')
+    return text.replace(/([\\`*_{}[\]()#+\-.!|>])/g, '\\$1')
 }
 
 /**
@@ -308,7 +308,7 @@ function escapeAltText(text: string): string {
 
 /**
  * Serialize tiptap JSON to markdown string.
- * Handles: bold, italic, code, images, mentions, hard breaks, bullet/ordered lists
+ * Handles: bold, italic, code, images, mentions, hard breaks, bullet/ordered lists, blockquotes
  * Note: underline has no standard markdown syntax and is stripped
  */
 export function serializeToMarkdown(content: JSONContent): string {
@@ -382,6 +382,20 @@ function serializeNode(node: JSONContent): string {
 
         case 'orderedList':
             return serializeListNode(node, true, '') + '\n\n'
+
+        case 'blockquote': {
+            const inner = (node.content || []).map(serializeNode).join('').replace(/\n+$/, '')
+            if (!inner) {
+                return ''
+            }
+            // Blank lines between child blocks need the marker too, otherwise the quote ends there
+            // and the following paragraph arrives outside it.
+            const quoted = inner
+                .split('\n')
+                .map((line) => (line ? `> ${line}` : '>'))
+                .join('\n')
+            return quoted + '\n\n'
+        }
 
         case 'hardBreak':
             // Two spaces + newline is the standard markdown hard break
@@ -654,6 +668,13 @@ export function SupportEditor({
                         onClick={() => ttEditor?.chain().focus().toggleOrderedList().run()}
                         icon={<IconOrderedList />}
                         tooltip="Numbered list (Cmd+Shift+7)"
+                    />
+                    <LemonButton
+                        size="small"
+                        active={ttEditor?.isActive('blockquote')}
+                        onClick={() => ttEditor?.chain().focus().toggleBlockquote().run()}
+                        icon={<IconQuote />}
+                        tooltip="Quote (Cmd+Shift+B)"
                     />
                     <LemonButton
                         size="small"


### PR DESCRIPTION
## Problem

The editor we use for drafting support tickets and replies (`SupportEditor`, shared by the staff reply box and the new-ticket composer) cannot author quote blocks. The blockquote node is disabled, so typing `> ` does nothing and there is no toolbar button. Quoting a line of a customer's message back at them is a normal support move, so it should be available.

Everything downstream is already ready for it. #73165 added the read side (`SUPPORT_PREVIEW_EXTENSIONS` accepts blockquote, `SupportEditor.scss` styles it) and the outbound side (`rich_content_to_html` emits `<blockquote>`, `rich_content_to_markdown` prefixes each line). posthog-js renders `rich_content` with an explicit blockquote case. The composer was the only piece that could not produce one.

## Changes

- Enable the blockquote node in `SUPPORT_EXTENSIONS`. StarterKit brings the `> ` input rule and `Cmd+Shift+B` with it.
- Add a `blockquote` case to `serializeToMarkdown`, keeping the `> ` marker on the blank lines between child blocks so a multi-paragraph quote stays one quote. Nested quotes fall out of the recursion.
- Add a toolbar button after the list buttons, using `IconQuote`.

No SCSS and no backend changes needed.

> [!NOTE]
> Slack-channel replies containing a quote are delivered as mrkdwn text rather than rich_text blocks, since `_SLACK_BLOCK_NODE_TYPES` doesn't cover blockquote. This is the same tradeoff #73165 accepted for lists: text is complete, block-level styling (underline) is traded for not losing content. Slack renders a leading `>` natively.

### Channel check

| Channel | Result |
|---|---|
| Email HTML | Real `<blockquote>`, no sanitizer in the path |
| Email plain text | `> ` prefixed lines |
| Widget (customer) | Real styled quote, via the `rich_content` blockquote case in posthog-js |
| Staff ticket view | Real quote via `LemonMarkdown` |
| GitHub / Teams | Native markdown quotes |
| Slack | mrkdwn text fallback, see the note above |

An earlier revision of this PR also escaped `>` in `escapeMarkdown`, so that a paragraph merely starting with `>` could not read as a quote downstream. I reverted it. That function deliberately mirrors `_RE_MD_ESCAPE` in `products/conversations/backend/formatting.py`, and `_RE_MD_ESCAPED_CHAR` unescapes the same set on the way to Slack mrkdwn. Changing one of the three in isolation sent `5 > 3` to the Slack fallback path as `5 \> 3`. Left a comment above the function recording the coupling. Widening that set is a separate change across all three.

No screenshot: there is no Storybook story for this editor and I did not stand up the inbox, so I have not seen the button rendered. It follows the shape of the six `LemonButton`s beside it.

## How did you test this code?

Automated, run locally:

- `jest products/conversations` — 145 tests passing. Full sharded CI matrix green (all 8 Jest shards, typecheck, formatting).
- Three new rows in the existing `test.each` table in `SupportEditor.test.ts`. All three guard the concern that file documents, that anything `serializeToMarkdown` drops is invisible on the plain-content fallback path: a multi-paragraph quote serializing to `> a\n>\n> b`; a quote wrapping a list; and a quote nested inside a list item, which covers `serializeListNode` indenting a multi-line non-list child by the marker width. Nothing existing covered blockquote, since the node did not exist, and nothing covered a multi-line block inside a list item.
- `pnpm --filter=@posthog/frontend fix` clean.

I also ran a throwaway check (not committed) confirming `blockquote` lands in the schema built from `SUPPORT_EXTENSIONS` and that `toggleBlockquote()` on a paragraph serializes to `> hello`.

Not verified: the `> ` input rule and `Cmd+Shift+B` firing in a real browser, and the toolbar active state. All three are stock StarterKit behavior, but I did not click them.

Unrelated observation while tracing the channels, not fixed here: the comment at the top of `SupportEditor.test.ts` says the widget renders only the plain-text field. posthog-js is `rich_content`-first now and only falls back to plain text when `rich_content` is missing or fails validation, so that comment overstates how customer-visible the `content` field is.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No user-facing docs describe the composer's formatting options.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) started from the question of whether the support composer supported `> ` quote blocks. It did not, so the work was to enable it rather than to fix a bug.

The read/write asymmetry made this smaller than expected: only the extension flag, the serializer, and the toolbar needed touching. I originally also escaped `>` on the grounds that a literal `>` leaking through as a quote was the same inconsistency inverted, then traced the outbound channels and found the three-way mirror between the frontend escape set and the backend escape/unescape pair. Reverted, since enabling the node does not depend on it and a one-sided change leaks backslashes to Slack.

I considered a slash command instead of a toolbar button, matching `inlineMarkdownSlashCommands`. This editor has no slash menu and its formatting is all toolbar-driven, so a button fits.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
