### PR TITLE
feat(desktop): share MCP servers with every agent by default

### DIFF
--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.test.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.test.ts
@@ -31,7 +31,7 @@ describe("buildGatewayInstallRequest", () => {
   it("builds an oauth install with admin team options", () => {
     const request = buildGatewayInstallRequest(
       values({ description: "  Wiki tools  ", agentIds: ["svc-1"] }),
-      { isAdmin: true, canManageAgentAccess: true },
+      { isAdmin: true, canManageAgentAccess: true, availableAgentIds: [] },
     );
     expect(request).toEqual({
       name: "Internal Wiki",
@@ -46,7 +46,7 @@ describe("buildGatewayInstallRequest", () => {
   it("includes the key on api-key installs", () => {
     const request = buildGatewayInstallRequest(
       values({ authType: "api_key", apiKey: "sk-123" }),
-      { isAdmin: true, canManageAgentAccess: true },
+      { isAdmin: true, canManageAgentAccess: true, availableAgentIds: [] },
     );
     expect(request.auth_type).toBe("api_key");
     expect(request.api_key).toBe("sk-123");
@@ -56,11 +56,12 @@ describe("buildGatewayInstallRequest", () => {
     const bare = buildGatewayInstallRequest(values(), {
       isAdmin: true,
       canManageAgentAccess: true,
+      availableAgentIds: [],
     });
     expect(bare.client_id).toBeUndefined();
     const withCreds = buildGatewayInstallRequest(
       values({ clientId: " id ", clientSecret: "secret" }),
-      { isAdmin: true, canManageAgentAccess: true },
+      { isAdmin: true, canManageAgentAccess: true, availableAgentIds: [] },
     );
     expect(withCreds.client_id).toBe("id");
     expect(withCreds.client_secret).toBe("secret");
@@ -69,16 +70,31 @@ describe("buildGatewayInstallRequest", () => {
   it("lets permitted members share with agents without team enablement", () => {
     const request = buildGatewayInstallRequest(
       values({ agentIds: ["svc-1"] }),
-      { isAdmin: false, canManageAgentAccess: true },
+      { isAdmin: false, canManageAgentAccess: true, availableAgentIds: [] },
     );
     expect(request.team_enabled).toBeUndefined();
     expect(request.agent_ids).toEqual(["svc-1"]);
   });
 
+  it("shares with every agent until the selection is narrowed", () => {
+    const shared = buildGatewayInstallRequest(values(), {
+      isAdmin: true,
+      canManageAgentAccess: true,
+      availableAgentIds: ["svc-1", "svc-2"],
+    });
+    expect(shared.agent_ids).toEqual(["svc-1", "svc-2"]);
+    const narrowed = buildGatewayInstallRequest(values({ agentIds: [] }), {
+      isAdmin: true,
+      canManageAgentAccess: true,
+      availableAgentIds: ["svc-1", "svc-2"],
+    });
+    expect(narrowed.agent_ids).toBeUndefined();
+  });
+
   it("omits agent grants when team settings make them admin-only", () => {
     const request = buildGatewayInstallRequest(
       values({ agentIds: ["svc-1"] }),
-      { isAdmin: false, canManageAgentAccess: false },
+      { isAdmin: false, canManageAgentAccess: false, availableAgentIds: [] },
     );
     expect(request.agent_ids).toBeUndefined();
   });

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayAddServer.ts
@@ -14,7 +14,8 @@ export interface GatewayAddServerValues {
   clientSecret: string;
   /** Team sharing options are admin-only; agentIds follows the team setting. */
   teamEnabled: boolean;
-  agentIds: string[];
+  /** Null means every agent — the list only exists once someone narrows it. */
+  agentIds: string[] | null;
 }
 
 export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
@@ -26,8 +27,20 @@ export const GATEWAY_ADD_SERVER_DEFAULTS: GatewayAddServerValues = {
   clientId: "",
   clientSecret: "",
   teamEnabled: true,
-  agentIds: [],
+  agentIds: null,
 };
+
+/**
+ * The agents a new server is shared with. Sharing starts on for every agent, so
+ * a server works everywhere the moment it's added; the list narrows only once
+ * someone switches an agent off.
+ */
+export function resolveSharedAgentIds(
+  selected: string[] | null,
+  availableAgentIds: string[],
+): string[] {
+  return selected ?? availableAgentIds;
+}
 
 export function canSubmitGatewayServer(
   values: Pick<GatewayAddServerValues, "name" | "url">,
@@ -53,8 +66,16 @@ export interface GatewayInstallRequest extends McpGatewayInstallSharingOptions {
  */
 export function buildGatewayInstallRequest(
   values: GatewayAddServerValues,
-  options: { isAdmin: boolean; canManageAgentAccess: boolean },
+  options: {
+    isAdmin: boolean;
+    canManageAgentAccess: boolean;
+    availableAgentIds: string[];
+  },
 ): GatewayInstallRequest {
+  const agentIds = resolveSharedAgentIds(
+    values.agentIds,
+    options.availableAgentIds,
+  );
   return {
     name: values.name.trim(),
     url: values.url.trim(),
@@ -70,8 +91,8 @@ export function buildGatewayInstallRequest(
       ? { client_secret: values.clientSecret.trim() }
       : {}),
     ...(options.isAdmin ? { team_enabled: values.teamEnabled } : {}),
-    ...(options.canManageAgentAccess && values.agentIds.length
-      ? { agent_ids: values.agentIds }
+    ...(options.canManageAgentAccess && agentIds.length
+      ? { agent_ids: agentIds }
       : {}),
   };
 }

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayConnect.test.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayConnect.test.ts
@@ -159,6 +159,16 @@ describe("connectGatewayServer", () => {
     });
   });
 
+  it("shares the server it materializes with the given agents", async () => {
+    const { client, oauth } = fakes();
+    await connectGatewayServer(client, oauth, template, credentials(), {
+      agentIds: ["svc-1", "svc-2"],
+    });
+    expect(client.installMcpTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_ids: ["svc-1", "svc-2"] }),
+    );
+  });
+
   it("connects a custom server with the chosen api_key mechanism", async () => {
     const { client, oauth } = fakes();
     const result = await connectGatewayServer(

--- a/products/desktop/packages/core/src/mcp-gateway/gatewayConnect.ts
+++ b/products/desktop/packages/core/src/mcp-gateway/gatewayConnect.ts
@@ -73,6 +73,15 @@ export interface GatewayConnectTarget {
   description: string;
 }
 
+export interface GatewayConnectOptions {
+  /**
+   * Agents to share the server with as it's created. Only meaningful when the
+   * connect materializes the row, and only accepted when team settings let the
+   * caller manage agent access.
+   */
+  agentIds?: string[];
+}
+
 /**
  * Connect the caller's own credential to a gateway server, or to a catalog
  * template with no row yet — the backend materializes the row. Honors the
@@ -84,15 +93,18 @@ export async function connectGatewayServer(
   oauth: IOAuthCallback,
   target: GatewayConnectTarget,
   credentials: GatewayConnectCredentials = GATEWAY_CONNECT_DEFAULTS,
+  options: GatewayConnectOptions = {},
 ): Promise<OAuthCallbackResult> {
   const apiKey =
     credentials.authType === "api_key" && credentials.apiKey
       ? credentials.apiKey
       : undefined;
+  const agentIds = options.agentIds?.length ? options.agentIds : undefined;
   if (target.template_id) {
     return installTemplateWithOAuth(client, oauth, {
       template_id: target.template_id,
       api_key: apiKey,
+      agent_ids: agentIds,
     });
   }
   return installCustomWithOAuth(client, oauth, {
@@ -101,6 +113,7 @@ export async function connectGatewayServer(
     description: target.description,
     auth_type: credentials.authType,
     api_key: apiKey,
+    agent_ids: agentIds,
     client_id:
       credentials.authType === "oauth" && credentials.clientId.trim()
         ? credentials.clientId.trim()

--- a/products/desktop/packages/core/src/mcp-servers/installFlow.ts
+++ b/products/desktop/packages/core/src/mcp-servers/installFlow.ts
@@ -13,6 +13,7 @@ export interface InstallFlowClient {
   installMcpTemplate(options: {
     template_id: string;
     api_key?: string;
+    agent_ids?: string[];
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
   }): Promise<InstallResult>;
@@ -24,6 +25,7 @@ export interface InstallFlowClient {
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    agent_ids?: string[];
     install_source?: "posthog" | "posthog-code";
     posthog_code_callback_url?: string;
   }): Promise<InstallResult>;
@@ -55,7 +57,7 @@ function hasRedirect(data: InstallResult): data is OAuthRedirect {
 export async function installTemplateWithOAuth(
   client: InstallFlowClient,
   oauth: IOAuthCallback,
-  vars: { template_id: string; api_key?: string },
+  vars: { template_id: string; api_key?: string; agent_ids?: string[] },
 ): Promise<OAuthCallbackResult> {
   const { callbackUrl } = await oauth.getCallbackUrl();
   const data = await client.installMcpTemplate({
@@ -80,6 +82,7 @@ export async function installCustomWithOAuth(
     api_key?: string;
     client_id?: string;
     client_secret?: string;
+    agent_ids?: string[];
   },
 ): Promise<OAuthCallbackResult> {
   const { callbackUrl } = await oauth.getCallbackUrl();

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.test.tsx
@@ -49,4 +49,20 @@ describe("GatewayAddServer", () => {
       screen.queryByText("Allow personal connections"),
     ).not.toBeInTheDocument();
   });
+
+  it("shares with every agent by default", () => {
+    render(
+      <Theme>
+        <GatewayAddServer
+          isAdmin={false}
+          canManageAgentAccess
+          accounts={[account]}
+          onNavigate={vi.fn()}
+        />
+      </Theme>,
+    );
+
+    // Members get no team toggle, so the agent's is the only switch on screen.
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
 });

--- a/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/components/parts/GatewayAddServer.tsx
@@ -5,6 +5,7 @@ import {
   canSubmitGatewayServer,
   GATEWAY_ADD_SERVER_DEFAULTS,
   type GatewayAddServerValues,
+  resolveSharedAgentIds,
 } from "@posthog/core/mcp-gateway/gatewayAddServer";
 import { isValidMcpUrl } from "@posthog/core/mcp-servers/customServerForm";
 import { RobotAvatar } from "@posthog/ui/features/mcp-gateway/components/parts/avatars";
@@ -53,12 +54,19 @@ export function GatewayAddServer({
   const urlInvalid = values.url.trim() !== "" && !isValidMcpUrl(values.url);
   const canSave = canSubmitGatewayServer(values);
 
+  const availableAgentIds = accounts.map((account) => account.id);
+  const sharedAgentIds = resolveSharedAgentIds(
+    values.agentIds,
+    availableAgentIds,
+  );
+
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!canSave || registerPending) return;
     const request = buildGatewayInstallRequest(values, {
       isAdmin,
       canManageAgentAccess,
+      availableAgentIds,
     });
     register(
       { request },
@@ -259,7 +267,7 @@ export function GatewayAddServer({
                   </Text>
                   <div className="overflow-hidden rounded border border-gray-5 bg-gray-2">
                     {accounts.map((account) => {
-                      const on = values.agentIds.includes(account.id);
+                      const on = sharedAgentIds.includes(account.id);
                       return (
                         <Flex
                           key={account.id}
@@ -287,8 +295,8 @@ export function GatewayAddServer({
                               set(
                                 "agentIds",
                                 checked
-                                  ? [...values.agentIds, account.id]
-                                  : values.agentIds.filter(
+                                  ? [...sharedAgentIds, account.id]
+                                  : sharedAgentIds.filter(
                                       (id) => id !== account.id,
                                     ),
                               )

--- a/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useGatewayServers.ts
+++ b/products/desktop/packages/ui/src/features/mcp-gateway/hooks/useGatewayServers.ts
@@ -15,6 +15,7 @@ import {
 import { reauthorizeWithOAuth } from "@posthog/core/mcp-servers/installFlow";
 import { useHostTRPC, useHostTRPCClient } from "@posthog/host-router/react";
 import { gatewayKeys } from "@posthog/ui/features/mcp-gateway/hooks/gatewayKeys";
+import { useGatewayConfig } from "@posthog/ui/features/mcp-gateway/hooks/useGatewayConfig";
 import {
   createOAuthCallback,
   mcpKeys,
@@ -57,6 +58,22 @@ export function useGatewayServers() {
   const recommendedTemplates = useMemo(
     () => recommendedCatalogTemplates(servers ?? [], templates ?? []),
     [servers, templates],
+  );
+
+  // A recommended server connects from a card with no sharing controls, so the
+  // grants ride along with the install: every agent gets it, and anyone who
+  // wants a narrower set trims it on the server page afterwards.
+  const { canManageAgentAccess } = useGatewayConfig();
+  const { data: serviceAccounts } = useAuthenticatedQuery(
+    gatewayKeys.accounts,
+    (client) => client.getMcpServiceAccounts(),
+  );
+  const defaultAgentIds = useMemo(
+    () =>
+      canManageAgentAccess
+        ? (serviceAccounts ?? []).map((account) => account.id)
+        : [],
+    [canManageAgentAccess, serviceAccounts],
   );
 
   const invalidateServers = useCallback(() => {
@@ -195,6 +212,7 @@ export function useGatewayServers() {
           description: vars.template.description ?? "",
         },
         vars.credentials,
+        { agentIds: defaultAgentIds },
       ),
     {
       onSuccess: (data, vars) => {


### PR DESCRIPTION
## Problem

Self-driving should just work. Right now every MCP connection has to be explicitly shared with each agent, so a team with a handful of agents has to remember to flip N toggles before anything can actually use the server they just connected. The control is worth keeping, but off-by-default is the wrong starting point.

## Changes

In PostHog Desktop's MCP gateway:

- **Add a custom server** – every agent in "Share with agents" starts switched on. The form now models the selection as null-until-narrowed, so it defaults to whatever agents exist once the list loads instead of an empty array that can never catch up with an async query.
- **Connect a recommended server** – the catalog cards have no sharing controls at all, so the agent grants ride along with the install call (`agent_ids` on `install_template` / `install_custom`, which the API already accepts).

Both paths still respect the team's `allow_member_agent_access` setting: a member who isn't allowed to manage agent access sends no grants, exactly as before. And narrowing is unchanged, one toggle in the form or on the server page.

Grants are only defaulted where the connect materializes a brand new gateway row. Connecting to a server that already exists deliberately leaves its agent list alone, so a second teammate connecting can't silently undo an admin's earlier decision to keep an agent out.

No backend change needed.

## How did you test this code?

I (Claude, via the PostHog Slack app) ran these locally from `products/desktop`:

- `vitest run` for `@posthog/core` – 2971 tests pass
- `vitest run` for `@posthog/ui` – 2506 tests pass
- `tsc --noEmit` for both packages
- `biome check` over the touched directories

I did not launch the Electron app or take screenshots, so the rendered default state is only verified by the unit test below.

Three tests added, each aimed at this change flipping back:

- `buildGatewayInstallRequest` shares with every available agent when nothing has been narrowed, and sends no grants once the user switches them all off. Catches a regression back to the empty-array default.
- `connectGatewayServer` puts `agent_ids` on the template install. Catches the grants silently dropping off the recommended-server path.
- `GatewayAddServer` renders the agent switch checked on first paint. This is the actual user-visible promise, and it's the one thing the core tests can't see.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, this is a default change with no new surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude through the PostHog Slack app, from a thread about whether explicit sharing is the right default for self-driving agents. The conclusion in that thread was that on-by-default is the more valuable default and the controls stay.

Skills invoked: `/writing-tests`.

The main decision was how to make "on by default" survive an async agent list. Seeding `agentIds` with every account needs the accounts to already be loaded, and they aren't on first render, so an effect would have been needed to backfill. Using `null` as "every agent, nobody has narrowed this yet" avoids the effect entirely and keeps the resolution in one small core helper that's easy to test.

The second decision was scope. It would have been easy to default grants on every connect, including servers that already have a gateway row. I deliberately didn't: re-granting on connect would let one member's connect quietly re-add an agent an admin had removed. Only row-creating connects default to sharing.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785772984253859?thread_ts=1785772984.253859&cid=C09SK2PAGKF)*
