### PR TITLE
docs(desktop): clarify README feedback prompt

### DIFF
--- a/products/desktop/README.md
+++ b/products/desktop/README.md
@@ -3,7 +3,7 @@
 
 **[Download the latest version](https://github.com/PostHog/code/releases/latest)**
 
-Found a bug or have feedback? [Open an issue](https://github.com/PostHog/code/issues/new) on GitHub.
+Found a bug or want to share feedback? [Open an issue](https://github.com/PostHog/code/issues/new) on GitHub.
 
 # PostHog
 


### PR DESCRIPTION
## Problem

Ports PostHog/code#3777. The desktop README feedback prompt reads awkwardly.

## Changes

- Reword the feedback prompt in `products/desktop/README.md` ("have feedback" to "want to share feedback").

## How did you test this code?

N/A, docs-only wording change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude ported this from PostHog/code#3777 at @charlesvien's direction using /porting-code-prs, applying the source patch with `git am --directory=products/desktop/` so the original commit keeps @k11kirky's authorship.
