### PR TITLE
fix(desktop): allow scrolling past prompt input in tiled Command Center views

### DIFF
--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterGrid.tsx
@@ -121,7 +121,7 @@ function GridCell({
     <div
       ref={cellRef}
       data-grid-cell
-      className="relative overflow-hidden bg-gray-1"
+      className="relative overflow-y-auto bg-gray-1"
       onClick={handleCellClick}
       onPointerDownCapture={markActive}
       onFocusCapture={markActive}

--- a/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
+++ b/products/desktop/packages/ui/src/features/message-editor/components/PromptInput.tsx
@@ -501,7 +501,7 @@ export const PromptInput = forwardRef<EditorHandle, PromptInputProps>(
             <div
               className={clsx(
                 "cli-editor-scroll relative min-h-[37px] w-full overflow-y-auto py-2 pr-10 pl-2 text-[14px]",
-                editorHeight === "large" ? "max-h-[45vh]" : "max-h-[200px]",
+                editorHeight === "large" ? "max-h-none" : "max-h-[40vh]",
                 // A disabled editor still looks editable: the caret is the only
                 // tell, and it is absent precisely because you cannot focus it.
                 disabled && "text-muted-foreground",


### PR DESCRIPTION
## Summary

Fixes #76211 — In the Command Center with a tiled layout (2x2, 3x2, or 3x3), the scroll was trapped inside the Tiptap editor text area. The execute button, branch/repo selector, and suggestions were unreachable when the prompt was long.

## Changes

### `CommandCenterGrid.tsx`
Changed `GridCell` from `overflow-hidden` to `overflow-y-auto`, making the tile itself the scroll container instead of clipping content.

### `PromptInput.tsx`
Increased the `max-h` caps on the editor text area:
- Normal mode: `max-h-[200px]` → `max-h-[40vh]` 
- Large mode: `max-h-[45vh]` → `max-h-none`

The editor can now grow naturally, and the tile scrolls to show the full prompt, controls, and suggestions.

## Root cause

The tile (`GridCell`) had `overflow-hidden` with no scroll region. The prompt editor had `overflow-y-auto` with a `max-h` cap, which trapped the scroll inside the text area. Controls positioned at `bottom-full` and `top-full` overflowed the tile and were clipped.

## Testing

1. Open Command Center and switch to a tiled layout (2x2, 3x2, or 3x3)
2. Type/paste a long prompt that overflows the input
3. Verify that the tile scrolls to show the execute button, suggestions, and branch/repo selector
4. Verify that 1x1 and 1x2 layouts continue to work as before