### PR TITLE
fix(docker): make Granian the default application server

### DIFF
--- a/bin/docker-server-unit
+++ b/bin/docker-server-unit
@@ -11,8 +11,9 @@ chmod -R 777 $PROMETHEUS_MULTIPROC_DIR
 export PROMETHEUS_METRICS_EXPORT_PORT=8001
 export STATSD_PORT=${STATSD_PORT:-8125}
 
-# Dual-mode support: USE_GRANIAN env var switches between Granian and Unit (default)
-if [ "${USE_GRANIAN:-false}" = "true" ]; then
+# Dual-mode support: USE_GRANIAN env var switches between Granian (default) and Unit.
+# Set USE_GRANIAN=false to revert to the legacy NGINX Unit server.
+if [ "${USE_GRANIAN:-true}" = "true" ]; then
     # Granian config is env-only and uses granian's own documented GRANIAN_*
     # env vars (the CLI reads them natively) — no aliases, no flag plumbing.
     # The exports below only set PostHog defaults where they differ from
@@ -47,7 +48,7 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
         export GRANIAN_LOOP=${GRANIAN_LOOP:-uvloop}
     fi
 
-    echo "🚀 Starting with Granian ${GRANIAN_INTERFACE} server (opt-in via USE_GRANIAN=true)..."
+    echo "🚀 Starting with Granian ${GRANIAN_INTERFACE} server..."
 
     # The container runs as root (Unit needs it for its control socket), but the
     # application must not: Unit drops its app processes to nobody via
@@ -64,7 +65,7 @@ if [ "${USE_GRANIAN:-false}" = "true" ]; then
 
     exec $DROP_PRIVILEGES granian "$APP_TARGET"
 else
-    echo "🔧 Starting with Nginx Unit server (default, stable)..."
+    echo "⚠️  Starting with Nginx Unit server (archived/unmaintained, legacy fallback)..."
 
     export NGINX_UNIT_PYTHON_PROTOCOL=${NGINX_UNIT_PYTHON_PROTOCOL:-wsgi}
     export NGINX_UNIT_APP_PROCESSES=${NGINX_UNIT_APP_PROCESSES:-4}


### PR DESCRIPTION
## Problem

NGINX Unit was [archived and marked unmaintained](https://github.com/nginx/unit/issues/1220) in October 2025. Continuing to use it as the default server exposes self-hosted deployments to unpatched security vulnerabilities indefinitely.

Granian is already the production-ready replacement -- it has a full configuration path in this script and has been battle-tested on PostHog Cloud. The `USE_GRANIAN` opt-in was the right transitional design; it's time to flip the default.

Closes #70589

## Changes

Flip `USE_GRANIAN` default from `false` to `true` in `bin/docker-server-unit`. Deployments that need to stay on NGINX Unit can set `USE_GRANIAN=false` as an explicit opt-out. Updated the log messages to reflect new defaults and mark Unit as a legacy fallback.

```diff
-if [ "${USE_GRANIAN:-false}" = "true" ]; then
+if [ "${USE_GRANIAN:-true}" = "true" ]; then
```

## How did you test this code?

I did not run a full container build -- the change is a 2-character default flip in a shell conditional. The Granian path is unchanged; only the default branch changes. Manual container testing would be needed before merging.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Self-hosted deployment docs should note that Granian is now the default and `USE_GRANIAN=false` opts back to NGINX Unit. Adding `skip-inkeep-docs` label since this is a behavioral change that needs a deliberate doc update, not an auto-generated one.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Identified via open issue #70589. The fix is a one-line default change; the Granian path already existed and was opt-in. No skills were invoked -- no Django migrations, DRF endpoints, or frontend code touched.