### PR TITLE
fix(bing_ads): classify transient SOAP 400 as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/source.py
@@ -143,6 +143,16 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             "Bing Ads OAuth application credentials not configured": None,
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A Bing SOAP call that comes back with a bare HTTP 400 (no SOAP fault) is rejected at the
+        # transport/edge layer, not by request validation — suds surfaces it as `Exception((400,
+        # 'Bad Request'))`, which our wrapper re-raises as `ValueError(... Exception: (400, 'Bad
+        # Request'))`. A genuinely malformed report request instead returns a coded WebFault
+        # (InvalidReportColumn, etc.), so this shape is a transient upstream blip that Temporal's
+        # activity retry clears — keep it out of error tracking as noise rather than paging as a bug.
+        # Match the stable status tuple only; a fault-backed 400 never produces this substring.
+        return {"(400, 'Bad Request')"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -5,6 +5,7 @@ from posthog.schema import ReleaseStatus, SourceFieldOauthAccountSelectConfig, S
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bing_ads.source import BingAdsSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.bing_ads.utils import BingAdsResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import error_message_matches
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.bingads import (
     BingAdsSourceConfig,
@@ -397,8 +398,9 @@ class TestBingAdsSource:
         # any non-retryable pattern, or a transient blip would disable the schema.
         error_message = "Failed to generate ad_performance_report report: Exception: (400, 'Bad Request')"
 
-        assert any(pattern in error_message for pattern in self.source.get_retryable_errors())
-        assert not any(pattern in error_message for pattern in self.source.get_non_retryable_errors())
+        # Assert through the same case-insensitive matcher production classification uses.
+        assert error_message_matches(error_message, self.source.get_retryable_errors())
+        assert not error_message_matches(error_message, self.source.get_non_retryable_errors())
 
     def test_get_resumable_source_manager(self):
         """Test that get_resumable_source_manager returns a manager that round-trips BingAdsResumeConfig."""

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_source.py
@@ -391,6 +391,15 @@ class TestBingAdsSource:
 
         assert not any(pattern in transient_message for pattern in non_retryable_errors)
 
+    def test_transient_bad_request_is_retryable_not_disabling(self):
+        # A bare transport-level HTTP 400 on a Bing SOAP call (no coded WebFault) is a transient edge
+        # rejection: it must be recognised as retryable (kept out of error tracking) and must NOT match
+        # any non-retryable pattern, or a transient blip would disable the schema.
+        error_message = "Failed to generate ad_performance_report report: Exception: (400, 'Bad Request')"
+
+        assert any(pattern in error_message for pattern in self.source.get_retryable_errors())
+        assert not any(pattern in error_message for pattern in self.source.get_non_retryable_errors())
+
     def test_get_resumable_source_manager(self):
         """Test that get_resumable_source_manager returns a manager that round-trips BingAdsResumeConfig."""
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ValueError` from the Bing Ads warehouse import:

```
Failed to generate ad_performance_report report: Exception: (400, 'Bad Request')
```

The stack originates in this source's code (`bing_ads/client.py` → `get_performance_report`, via `utils.download_and_extract_report_csv`). The underlying exception chain is `urllib HTTPError 400` → `suds.transport.TransportError` → suds raising a bare `Exception((400, 'Bad Request'))`.

suds only raises that bare tuple when a SOAP call returns a non-200 HTTP status that is **not** a SOAP fault (`suds/client.py`). A genuinely malformed report request (bad column, bad scope) comes back as a coded `WebFault` (`InvalidReportColumn`, etc.), which we already handle. A raw transport-level 400 with no fault detail is an edge/gateway rejection: transient, self-recovering, and deterministically retryable. The single non-recurring occurrence matches that shape — our report request is built deterministically, so a real bug here would fail every sync, not once.

So this is neither a customer config error (nothing to make non-retryable) nor a bug in our code. It is a transient upstream failure that already retries at the Temporal activity level. The only issue is that, being unclassified, it logs as an exception and shows up as error-tracking noise.

## Changes

Add a `get_retryable_errors()` override to `BingAdsSource` matching the stable status tuple `(400, 'Bad Request')`. That routes it through the framework's retryable path (`import_data_sync._handle_import_error`): still retried by Temporal, but logged at warning level and re-raised as `NonReportableError` so it stays out of error tracking. This mirrors the existing pattern in the Meta Ads and LinkedIn Ads sources.

This does not change retry behavior (the error already retried) and does not touch `NonRetryableErrors`, so it cannot disable a source. A fault-backed 400 never produces this substring, keeping false positives at zero.

> [!NOTE]
> Scope is deliberately tight to the observed `(400, 'Bad Request')`. Sibling transport statuses (5xx) share the same suds shape but haven't been observed here, so they're left out rather than speculatively matched.

## How did you test this code?

Added one unit test (`test_transient_bad_request_is_retryable_not_disabling`) asserting the observed message is matched by `get_retryable_errors()` and **not** by `get_non_retryable_errors()`. The second assertion is the important one: it guards against a future edit adding a `400`/`Bad Request` substring to the non-retryable map, which would disable a schema on a transient blip. No existing test covered `get_retryable_errors` for this source (there was no override before).

Ran the source test file locally (`pytest .../bing_ads/tests/test_bing_ads_source.py -k "retryable or transient"`) — 20 passed. Ruff check + format clean. No manual end-to-end run against the live Bing Ads API.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged by Claude (Claude Code) from an error-tracking webhook. Read the full exception chain, confirmed the frame originates in `bing_ads/` code, and traced the bare `Exception((400, 'Bad Request'))` back to suds' non-fault HTTP path to establish it as transport-level (transient) rather than a validated request error. Invoked `/writing-tests` before adding the test. Considered and rejected: (1) adding it to `NonRetryableErrors` — wrong, it's not a customer/config error and would wrongly disable the source; (2) no change at all — valid, but leaves recurring error-tracking noise for a self-recovering failure the framework has a purpose-built mechanism to suppress. Checked open PRs (including the maintainer's) for a duplicate; none touch this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
