### PR TITLE
fix(desktop): make permissions prompt options scrollable when command is long (Fixes #76205)

### DIFF
--- a/products/desktop/packages/ui/src/primitives/action-selector/ActionSelector.tsx
+++ b/products/desktop/packages/ui/src/primitives/action-selector/ActionSelector.tsx
@@ -263,91 +263,91 @@ export function ActionSelector({
                 {question}
               </Text>
             )}
+
+            <Box mt="3">
+              <Flex direction="column" gap="1" px="2">
+                {allOptions.map((option, index) => {
+                  if (isSubmitOption(option.id) || isCancelOption(option.id)) {
+                    return null;
+                  }
+                  const isSelected = selectedIndex === index;
+                  const isHovered = hoveredIndex === index;
+                  const isChecked = checkedOptions.has(option.id);
+
+                  return (
+                    <OptionRow
+                      key={option.id}
+                      option={option}
+                      index={index}
+                      isSelected={isSelected}
+                      isHovered={isHovered}
+                      isChecked={isChecked}
+                      showCheckbox={showSubmitButton}
+                      multiSelect={multiSelect}
+                      customInput={customInput}
+                      customInputPlaceholder={customInputPlaceholder}
+                      isEditing={showInlineEdit && isSelected}
+                      submitLabel={getSubmitLabel()}
+                      onCustomInputChange={setCustomInput}
+                      onNavigateUp={handleNavigateUp}
+                      onNavigateDown={handleNavigateDown}
+                      onEscape={handleEscape}
+                      onInlineSubmit={handleInlineSubmit}
+                      onClick={() => handleClick(index)}
+                      onMouseEnter={() => setHoveredIndex(index)}
+                      onMouseLeave={() => setHoveredIndex(null)}
+                    />
+                  );
+                })}
+              </Flex>
+
+              <Flex direction="row" gap="2" mt="2">
+                {allOptions.map((option, index) => {
+                  if (!isSubmitOption(option.id) && !isCancelOption(option.id)) {
+                    return null;
+                  }
+                  const isSelected = selectedIndex === index;
+
+                  const isHovered = hoveredIndex === index;
+                  const isDisabled =
+                    isSubmitOption(option.id) &&
+                    showSubmitButton &&
+                    !canSubmitOrAdvance;
+                  return (
+                    <OptionRow
+                      key={option.id}
+                      option={option}
+                      index={index}
+                      isSelected={isSelected}
+                      isHovered={isHovered}
+                      isChecked={false}
+                      showCheckbox={false}
+                      multiSelect={multiSelect}
+                      customInput=""
+                      customInputPlaceholder=""
+                      isEditing={false}
+                      submitLabel={getSubmitLabel()}
+                      disabled={isDisabled}
+                      onCustomInputChange={setCustomInput}
+                      onNavigateUp={handleNavigateUp}
+                      onNavigateDown={handleNavigateDown}
+                      onEscape={handleEscape}
+                      onInlineSubmit={handleInlineSubmit}
+                      onClick={() => handleClick(index)}
+                      onMouseEnter={() => setHoveredIndex(index)}
+                      onMouseLeave={() => setHoveredIndex(null)}
+                    />
+                  );
+                })}
+              </Flex>
+
+              <Text color="gray" mt="2" as="p" className="text-[13px]">
+                Enter to select · Tab/Arrow keys to navigate
+                {onCancel ? " · Esc to cancel" : ""}
+              </Text>
+            </Box>
           </Box>
         )}
-
-        <Box>
-          <Flex direction="column" gap="1" px="2">
-            {allOptions.map((option, index) => {
-              if (isSubmitOption(option.id) || isCancelOption(option.id)) {
-                return null;
-              }
-              const isSelected = selectedIndex === index;
-              const isHovered = hoveredIndex === index;
-              const isChecked = checkedOptions.has(option.id);
-
-              return (
-                <OptionRow
-                  key={option.id}
-                  option={option}
-                  index={index}
-                  isSelected={isSelected}
-                  isHovered={isHovered}
-                  isChecked={isChecked}
-                  showCheckbox={showSubmitButton}
-                  multiSelect={multiSelect}
-                  customInput={customInput}
-                  customInputPlaceholder={customInputPlaceholder}
-                  isEditing={showInlineEdit && isSelected}
-                  submitLabel={getSubmitLabel()}
-                  onCustomInputChange={setCustomInput}
-                  onNavigateUp={handleNavigateUp}
-                  onNavigateDown={handleNavigateDown}
-                  onEscape={handleEscape}
-                  onInlineSubmit={handleInlineSubmit}
-                  onClick={() => handleClick(index)}
-                  onMouseEnter={() => setHoveredIndex(index)}
-                  onMouseLeave={() => setHoveredIndex(null)}
-                />
-              );
-            })}
-          </Flex>
-
-          <Flex direction="row" gap="2" mt="2">
-            {allOptions.map((option, index) => {
-              if (!isSubmitOption(option.id) && !isCancelOption(option.id)) {
-                return null;
-              }
-              const isSelected = selectedIndex === index;
-
-              const isHovered = hoveredIndex === index;
-              const isDisabled =
-                isSubmitOption(option.id) &&
-                showSubmitButton &&
-                !canSubmitOrAdvance;
-              return (
-                <OptionRow
-                  key={option.id}
-                  option={option}
-                  index={index}
-                  isSelected={isSelected}
-                  isHovered={isHovered}
-                  isChecked={false}
-                  showCheckbox={false}
-                  multiSelect={multiSelect}
-                  customInput=""
-                  customInputPlaceholder=""
-                  isEditing={false}
-                  submitLabel={getSubmitLabel()}
-                  disabled={isDisabled}
-                  onCustomInputChange={setCustomInput}
-                  onNavigateUp={handleNavigateUp}
-                  onNavigateDown={handleNavigateDown}
-                  onEscape={handleEscape}
-                  onInlineSubmit={handleInlineSubmit}
-                  onClick={() => handleClick(index)}
-                  onMouseEnter={() => setHoveredIndex(index)}
-                  onMouseLeave={() => setHoveredIndex(null)}
-                />
-              );
-            })}
-          </Flex>
-
-          <Text color="gray" mt="2" as="p" className="text-[13px]">
-            Enter to select · Tab/Arrow keys to navigate
-            {onCancel ? " · Esc to cancel" : ""}
-          </Text>
-        </Box>
       </Flex>
     </Box>
   );


### PR DESCRIPTION
## Problem

When the agent runs a long command, the permissions prompt's pendingAction area (command text) takes up the entire available height, pushing the options ("Read Only", "Default", etc.) and action buttons off-screen. The user can't see or select any option.

## Root cause

The `ActionSelector` component renders the pendingAction/command text in a scrollable `Box` with `overflow-y-auto` and `flex-1`, but the option buttons and submit/cancel buttons are rendered *outside* this scrollable area in a separate `<Box>`. When the command text is very long, the scrollable area fills the entire `max-h-[80vh]` container, and the options are pushed below the visible area.

## Fix

Move the options, submit/cancel buttons, and keyboard shortcut hints into the same scrollable container as the pendingAction text. This ensures the user can always scroll down to see and select an option, regardless of command length.

## Changes

- `ActionSelector.tsx`: consolidated the options/buttons box into the scrollable `(pendingAction || question)` block

Fixes #76205