### PR TITLE
fix(code): persist feed custom image selection

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -153,6 +153,9 @@ export const ChannelHomeComposer = forwardRef<
   const [selectedCloudEnvId, setSelectedCloudEnvId] = useState<string | null>(
     null,
   );
+  const [selectedCustomImageId, setSelectedCustomImageId] = useState<
+    string | null
+  >(null);
   const setWorkspaceMode = useCallback(
     (mode: WorkspaceMode) => {
       setWorkspaceModeState(mode);
@@ -298,6 +301,10 @@ export const ChannelHomeComposer = forwardRef<
       workspaceMode === "cloud" && selectedCloudEnvId
         ? selectedCloudEnvId
         : undefined,
+    customImageId:
+      workspaceMode === "cloud" && selectedCustomImageId
+        ? selectedCustomImageId
+        : undefined,
     editorIsEmpty,
     adapter,
     executionMode: currentExecutionMode,
@@ -402,6 +409,8 @@ export const ChannelHomeComposer = forwardRef<
             overrideModes={["local", "cloud"]}
             selectedCloudEnvironmentId={selectedCloudEnvId}
             onCloudEnvironmentChange={setSelectedCloudEnvId}
+            selectedCustomImageId={selectedCustomImageId}
+            onCustomImageChange={setSelectedCustomImageId}
             size="1"
             disabled={isBusy}
           />


### PR DESCRIPTION
## Problem

The channel feed composer exposed custom cloud images, but did not retain the selection or include it when creating a task. Users saw no visual confirmation and the selected image was not used.

**Why:** Custom cloud images should behave consistently across the feed composer and the main new-task page.

## Changes

Wire the selected custom image through the feed composer state, selector label, and cloud task creation payload.

## How did you test this code?

- `pnpm exec turbo typecheck --filter=@posthog/ui`
- `pnpm exec biome check packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx`

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex diagnosed the mismatch by comparing the feed composer with the working new-task composer, then applied the same state and payload wiring. No repository-provided or public skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*