### PR TITLE
fix(hogai): render SQL NULL as (null) instead of "None" for LLMs

### DIFF
--- a/ee/hogai/context/insight/format/__init__.py
+++ b/ee/hogai/context/insight/format/__init__.py
@@ -29,7 +29,7 @@ from .funnel import FunnelResultsFormatter
 from .lifecycle import LifecycleResultsFormatter
 from .paths import PathsResultsFormatter
 from .retention import RetentionResultsFormatter
-from .sql import TRUNCATED_MARKER, SQLResultsFormatter
+from .sql import NULL_MARKER, TRUNCATED_MARKER, SQLResultsFormatter
 from .stickiness import StickinessResultsFormatter
 from .trends import TrendsResultsFormatter
 
@@ -129,6 +129,7 @@ __all__ = [
     "StickinessResultsFormatter",
     "TrendsResultsFormatter",
     "TRUNCATED_MARKER",
+    "NULL_MARKER",
     "format_access_control_warnings",
     "format_query_results_for_llm",
     "format_warehouse_sync_warnings",

--- a/ee/hogai/context/insight/format/sql.py
+++ b/ee/hogai/context/insight/format/sql.py
@@ -3,6 +3,9 @@ from typing import Any
 from posthog.schema import AssistantHogQLQuery, HogQLQuery
 
 TRUNCATED_MARKER = "...truncated"
+# Must stay distinctive: query_executor detects it with a substring check over the whole formatted
+# table (same way it detects TRUNCATED_MARKER), and an LLM must not mistake it for a data value.
+NULL_MARKER = "(null)"
 
 
 class SQLResultsFormatter:
@@ -31,7 +34,16 @@ class SQLResultsFormatter:
 
     def _format_cell(self, cell: Any) -> str:
         """Format a single cell value, truncating large dicts/arrays or stringified JSON."""
+        if cell is None:
+            # Bare str(None) yields "None", which LLMs read as a value rather than as missing data.
+            return NULL_MARKER
+
         cell_str = str(cell)
+
+        if cell_str == NULL_MARKER:
+            # A real value that renders exactly like the marker would otherwise be indistinguishable
+            # from SQL NULL, so the LLM would report present data as missing. Quote it instead.
+            return f'"{NULL_MARKER}"'
 
         # Check if it's a dict/list or a stringified JSON (starts with { or [)
         is_json_like = isinstance(cell, dict | list) or (

--- a/ee/hogai/context/insight/format/test/test_sql.py
+++ b/ee/hogai/context/insight/format/test/test_sql.py
@@ -4,7 +4,7 @@ from posthog.test.base import BaseTest
 
 from posthog.schema import AssistantHogQLQuery
 
-from .. import TRUNCATED_MARKER, SQLResultsFormatter
+from .. import NULL_MARKER, TRUNCATED_MARKER, SQLResultsFormatter
 
 
 class TestSQLResultsFormatter(BaseTest):
@@ -47,7 +47,31 @@ class TestSQLResultsFormatter(BaseTest):
         columns = ["id", "name"]
 
         formatter = SQLResultsFormatter(query, results, columns)
-        expected = "id|name\n1|test\n2|None"
+        expected = f"id|name\n1|test\n2|{NULL_MARKER}"
+        self.assertEqual(formatter.format(), expected)
+
+    def test_format_none_is_distinguishable_from_the_string_none(self):
+        query = AssistantHogQLQuery(query="SELECT id, name")
+        results: list[Any] = [
+            {"id": 1, "name": None},
+            {"id": 2, "name": "None"},
+        ]
+        columns = ["id", "name"]
+
+        formatter = SQLResultsFormatter(query, results, columns)
+        expected = f"id|name\n1|{NULL_MARKER}\n2|None"
+        self.assertEqual(formatter.format(), expected)
+
+    def test_format_none_is_distinguishable_from_a_literal_marker_value(self):
+        query = AssistantHogQLQuery(query="SELECT id, name")
+        results: list[Any] = [
+            {"id": 1, "name": None},
+            {"id": 2, "name": NULL_MARKER},
+        ]
+        columns = ["id", "name"]
+
+        formatter = SQLResultsFormatter(query, results, columns)
+        expected = f'id|name\n1|{NULL_MARKER}\n2|"{NULL_MARKER}"'
         self.assertEqual(formatter.format(), expected)
 
     def test_format_with_numeric_values(self):

--- a/ee/hogai/context/insight/prompts.py
+++ b/ee/hogai/context/insight/prompts.py
@@ -51,6 +51,9 @@ Do not copy the results table as the user sees it in the UI.{{#include_url_remin
 {{#has_truncated_values}}
 Some JSON/array values were truncated. You can write a more specific SQL query to explore individual properties or array elements if needed.
 {{/has_truncated_values}}
+{{#has_null_values}}
+Cells shown as `(null)` are SQL NULL: the column had no value for those rows, usually because the property is absent on that event. Treat them as missing data. Never report `(null)` as a value, and never conclude a property is set to "null" or "None" from them.
+{{/has_null_values}}
 </system_reminder>
 """.strip()
 

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -51,6 +51,7 @@ from posthog.rbac.user_access_control import UserAccessControlError
 from posthog.sync import database_sync_to_async
 
 from ee.hogai.context.insight.format import (
+    NULL_MARKER,
     TRUNCATED_MARKER,
     BoxPlotResultsFormatter,
     FunnelResultsFormatter,
@@ -630,6 +631,10 @@ async def execute_and_format_query(
     has_truncated_values = isinstance(query, AssistantHogQLQuery | HogQLQuery | DataVisualizationNode) and (
         TRUNCATED_MARKER in results and not used_fallback
     )
+    # Check if SQL results contain null values
+    has_null_values = isinstance(query, AssistantHogQLQuery | HogQLQuery | DataVisualizationNode) and (
+        NULL_MARKER in results and not used_fallback
+    )
 
     query_result = format_prompt_string(
         QUERY_RESULTS_PROMPT,
@@ -640,6 +645,7 @@ async def execute_and_format_query(
         project_datetime_display=utc_now_datetime.astimezone(team.timezone_info).strftime("%Y-%m-%d %H:%M:%S"),
         project_timezone=team.timezone_info.tzname(utc_now_datetime),
         has_truncated_values=has_truncated_values,
+        has_null_values=has_null_values,
         sql_query=True if isinstance(query, AssistantHogQLQuery | HogQLQuery | DataVisualizationNode) else None,
     )
 


### PR DESCRIPTION
## Problem

An AI report subscription confidently told its reader that **no** MCP tool call carried an agent intent, when **92.3% of them did**.

The generated HogQL grouped by a property that is genuinely absent on ~8% of rows. `SQLResultsFormatter` rendered those SQL NULLs with a bare `str(cell)`, so the LLM received:

```
intent|calls
None|313031
Kaviar direct-tool adapter|60400
```

The NULL group was the largest row by 5x, the model read `None` as a *value*, and generalised it to every event. The report went out stating "all 26,875 events had `$mcp_intent` set to None", with a recommendation to fix instrumentation that was never broken.

The step was recorded `ok=True` — no error, nothing degraded, so no diagnostic flagged it. The existing `QUERY_FAILED_PREFIX` guard only covers queries that *fail*, not successful queries whose NULLs get misread.

## Fix

Render SQL NULL as `(null)` and tell the model what it means, mirroring the existing `TRUNCATED_MARKER` mechanism end to end:

- `sql.py` — `NULL_MARKER = "(null)"`, returned before `str(cell)`
- `query_executor.py` — `has_null_values` detected exactly like `has_truncated_values`
- `prompts.py` — a `{{#has_null_values}}` note: `(null)` is missing data, never report it as a value
- a real `(null)` string is escaped as `"(null)"` so it stays distinguishable from NULL

Note the sibling formatter for trends/lifecycle (`format_matrix`) already guards this with `"" if cell is None`. Raw HogQL was the one path that leaked `None` — and AI report subscriptions only ever produce raw HogQL.

## Testing

`pytest ee/hogai/context/insight/` on a devbox — **152 passed**, covering the formatter and the `query_executor` plumbing. Includes two new tests: Python `None` vs the string `"None"`, and `None` vs a literal `(null)`.

## Reviewer notes

- **Detection is a substring check** (`NULL_MARKER in results`), inherited from how `TRUNCATED_MARKER` works. Consequence: the advisory note can fire when only *escaped* literals are present — harmless, since nothing is misread. The alternative is plumbing null metadata out of the formatter, but `arun_and_format_query` returns `tuple[str, bool]` unpacked at ~30 test sites and 3 production callers, so I kept it consistent with the existing marker rather than change that signature. Happy to do it properly if you'd prefer.
- This also affects every Max SQL answer, not just subscriptions.
- `test_format_with_none_values` previously *asserted* `2|None`; that expectation is now built from the constant.

Found while debugging a wrong report; a companion PR adds a boolean-comparison rule to the AI-report planner prompt.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*