### PR TITLE
feat(tasks): notify parents when child runs finish

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -213,6 +213,7 @@ __all__ = [
     "resume_task_run_in_cloud",
     "run_task",
     "run_task_automation_now",
+    "send_child_message_to_parent",
     "send_cancel",
     "select_repository_for_message",
     "set_task_run_output",
@@ -494,6 +495,16 @@ def get_task_run(run_id: str | UUID, team_id: int | None = None) -> contracts.Ta
     if run is None:
         return None
     return _task_run_to_dto(run)
+
+
+def send_child_message_to_parent(child_run_id: str | UUID, team_id: int, message: str) -> None:
+    child_run = TaskRun.objects.for_team(team_id).filter(id=child_run_id).first()
+    if child_run is None:
+        raise ValueError("Calling run was not found")
+
+    from products.tasks.backend.logic.services.orchestration import send_child_message_to_parent as send_message
+
+    send_message(child_run, message)
 
 
 def find_signal_implementation_run(

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -498,7 +498,7 @@ def get_task_run(run_id: str | UUID, team_id: int | None = None) -> contracts.Ta
 
 
 def send_child_message_to_parent(child_run_id: str | UUID, team_id: int, message: str) -> None:
-    child_run = TaskRun.objects.for_team(team_id).filter(id=child_run_id).first()
+    child_run = TaskRun.objects.filter(team_id=team_id, id=child_run_id).first()
     if child_run is None:
         raise ValueError("Calling run was not found")
 

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2288,6 +2288,18 @@ def update_task_run(
     # applies the same guard on its side.
     if new_status in _TERMINAL_TASK_RUN_STATUSES and old_status != new_status:
         handle_loop_run_terminal(run)
+        from products.tasks.backend.facade.tasks import (
+            notify_parent_of_child_event_task,  # noqa: PLC0415 — keeps Celery off the facade import path
+        )
+        from products.tasks.backend.logic.services.loop_runs import (
+            LOOP_TERMINAL_NOTIFICATION_GRACE_SECONDS,  # noqa: PLC0415 — shared terminal-write grace
+        )
+
+        transaction.on_commit(
+            lambda: notify_parent_of_child_event_task.apply_async(
+                args=[str(run.id), "terminal"], countdown=LOOP_TERMINAL_NOTIFICATION_GRACE_SECONDS
+            )
+        )
 
     if new_status in _TERMINAL_TASK_RUN_STATUSES and old_status != new_status:
         if new_status == TaskRun.Status.FAILED:

--- a/products/tasks/backend/facade/tasks.py
+++ b/products/tasks/backend/facade/tasks.py
@@ -5,6 +5,7 @@ Re-exports the beat-scheduled loop sweeps that core's scheduler registers.
 """
 
 import logging
+from typing import cast
 
 from celery import shared_task
 
@@ -14,6 +15,18 @@ from products.tasks.backend.loop_retention import sweep_loop_task_retention_task
 __all__ = ["reconcile_loop_trigger_schedules_task", "sweep_loop_task_retention_task"]
 
 logger = logging.getLogger(__name__)
+
+
+@shared_task(ignore_result=True)
+def notify_parent_of_child_event_task(child_run_id: str, event: str) -> None:
+    from products.tasks.backend.logic.services.orchestration import (  # noqa: PLC0415 — keeps Temporal off the Celery import path
+        ChildEvent,
+        notify_parent_of_child_event,
+    )
+
+    if event not in {"terminal", "pr_merged"}:
+        raise ValueError(f"Unsupported child event: {event}")
+    notify_parent_of_child_event(child_run_id, cast(ChildEvent, event))
 
 
 @shared_task(ignore_result=True)

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -98,3 +98,21 @@ def notify_parent_of_child_event(child_run: TaskRun | str, event: ChildEvent) ->
         return
 
     _queue_wake(delivery_run, child_run, event, message)
+
+
+def send_child_message_to_parent(child_run: TaskRun, message: str) -> None:
+    state = child_run.state if isinstance(child_run.state, dict) else {}
+    parent_task_id = state.get("parent_task_id")
+    parent_run_id = state.get("parent_run_id")
+    if not parent_task_id or not parent_run_id:
+        raise ValueError("Calling run is not an orchestrated child")
+
+    parent_run = (
+        TaskRun.objects.filter(id=parent_run_id, task_id=parent_task_id, team_id=child_run.team_id)
+        .filter(status__in=_NON_TERMINAL_STATUSES)
+        .first()
+    )
+    if parent_run is None:
+        raise ValueError("Parent run is not available")
+
+    signal_task_followup_message(parent_run.workflow_id, message, [], source=FOLLOWUP_SOURCE_CHILD)

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -56,9 +56,10 @@ def _queue_wake(parent_run: TaskRun, child_run: TaskRun, event: ChildEvent, mess
 
 def notify_parent_of_child_event(child_run: TaskRun | str, event: ChildEvent) -> None:
     if isinstance(child_run, str):
-        child_run = TaskRun.objects.select_related("task").filter(id=child_run).first()
-        if child_run is None:
+        resolved_child_run = TaskRun.objects.select_related("task").filter(id=child_run).first()
+        if resolved_child_run is None:
             return
+        child_run = resolved_child_run
 
     state = child_run.state if isinstance(child_run.state, dict) else {}
     parent_task_id = state.get("parent_task_id")

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -1,0 +1,99 @@
+import logging
+from typing import Any, Literal
+
+from temporalio.service import RPCError, RPCStatusCode
+
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.client import signal_task_followup_message
+from products.tasks.backend.temporal.constants import CHILD_EVENT_MESSAGE_TEMPLATE
+from products.tasks.backend.temporal.execute_sandbox.workflow import FOLLOWUP_SOURCE_CHILD
+
+logger = logging.getLogger(__name__)
+
+ChildEvent = Literal["terminal", "pr_merged"]
+PENDING_ORCHESTRATION_WAKES_STATE_KEY = "pending_orchestration_wakes"
+
+_NON_TERMINAL_STATUSES = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS)
+
+
+def _build_child_event_message(child_run: TaskRun, event: ChildEvent) -> str:
+    output = child_run.output if isinstance(child_run.output, dict) else {}
+    pr_url = output.get("pr_url")
+    error_line = (
+        f"\nError: {child_run.error_message}"
+        if child_run.status == TaskRun.Status.FAILED and child_run.error_message
+        else ""
+    )
+    pr_line = f"\nPull request: {pr_url}" if isinstance(pr_url, str) and pr_url else ""
+    task_number = child_run.task.task_number if child_run.task.task_number is not None else "unknown"
+    return CHILD_EVENT_MESSAGE_TEMPLATE.format(
+        task_number=task_number,
+        title=child_run.task.title,
+        event=event.replace("_", " "),
+        status=child_run.status,
+        error_line=error_line,
+        pr_line=pr_line,
+    )
+
+
+def _queue_wake(parent_run: TaskRun, child_run: TaskRun, event: ChildEvent, message: str) -> None:
+    entry: dict[str, Any] = {
+        "message": message,
+        "artifact_ids": [],
+        "source": FOLLOWUP_SOURCE_CHILD,
+        "event": event,
+        "child_run_id": str(child_run.id),
+    }
+
+    def append_wake(state: dict[str, Any]) -> None:
+        pending = state.get(PENDING_ORCHESTRATION_WAKES_STATE_KEY)
+        queue = list(pending) if isinstance(pending, list) else []
+        queue.append(entry)
+        state[PENDING_ORCHESTRATION_WAKES_STATE_KEY] = queue
+
+    TaskRun.mutate_state_atomic(parent_run.id, append_wake)
+
+
+def notify_parent_of_child_event(child_run: TaskRun | str, event: ChildEvent) -> None:
+    if isinstance(child_run, str):
+        child_run = TaskRun.objects.select_related("task").filter(id=child_run).first()
+        if child_run is None:
+            return
+
+    state = child_run.state if isinstance(child_run.state, dict) else {}
+    parent_task_id = state.get("parent_task_id")
+    if not parent_task_id:
+        return
+
+    parent_task = Task.objects.filter(id=parent_task_id, team_id=child_run.team_id).first()
+    if parent_task is None:
+        return
+
+    most_recent_run = parent_task.runs.order_by("-created_at", "-id").first()
+    if most_recent_run is None:
+        return
+
+    live_run = parent_task.runs.filter(status__in=_NON_TERMINAL_STATUSES).order_by("-created_at", "-id").first()
+    delivery_run = live_run or most_recent_run
+    message = _build_child_event_message(child_run, event)
+
+    if live_run is not None:
+        try:
+            signal_task_followup_message(
+                live_run.workflow_id,
+                message,
+                [],
+                source=FOLLOWUP_SOURCE_CHILD,
+            )
+        except RPCError as error:
+            if error.status == RPCStatusCode.NOT_FOUND:
+                _queue_wake(delivery_run, child_run, event, message)
+                return
+            logger.exception(
+                "orchestration_child_wake_signal_failed",
+                extra={"child_run_id": str(child_run.id), "parent_run_id": str(live_run.id), "event": event},
+            )
+            raise
+        return
+
+    _queue_wake(delivery_run, child_run, event, message)

--- a/products/tasks/backend/logic/services/tests/test_orchestration.py
+++ b/products/tasks/backend/logic/services/tests/test_orchestration.py
@@ -1,0 +1,100 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from parameterized import parameterized
+from temporalio.service import RPCError, RPCStatusCode
+
+from posthog.models import Organization, Team
+
+from products.tasks.backend.logic.services.orchestration import (
+    PENDING_ORCHESTRATION_WAKES_STATE_KEY,
+    notify_parent_of_child_event,
+)
+from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.execute_sandbox.workflow import FOLLOWUP_SOURCE_CHILD
+
+
+class TestNotifyParentOfChildEvent(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        organization = Organization.objects.create(name="Orchestration test")
+        cls.team = Team.objects.create(organization=organization, name="Test team")
+
+    def _task(self, title: str) -> Task:
+        return Task.objects.create(
+            team=self.team,
+            title=title,
+            description="Test task",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+
+    def _runs(self, status: str, *, error_message: str | None = None) -> tuple[TaskRun, TaskRun]:
+        parent_task = self._task("Parent task")
+        parent_run = parent_task.create_run(mode="background")
+        parent_run.status = TaskRun.Status.IN_PROGRESS
+        parent_run.save(update_fields=["status"])
+
+        child_task = self._task("Child task")
+        child_run = child_task.create_run(
+            mode="background",
+            extra_state={"parent_task_id": str(parent_task.id), "parent_run_id": str(parent_run.id), "wake_on": []},
+        )
+        child_run.status = status
+        child_run.error_message = error_message
+        child_run.output = {"pr_url": "https://github.com/PostHog/posthog/pull/123"}
+        child_run.save(update_fields=["status", "error_message", "output"])
+        return parent_run, child_run
+
+    @parameterized.expand(
+        [
+            (TaskRun.Status.COMPLETED, None),
+            (TaskRun.Status.FAILED, "Tests failed"),
+            (TaskRun.Status.CANCELLED, None),
+        ]
+    )
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    def test_signals_live_parent_with_server_built_message(self, status, error_message, mock_signal) -> None:
+        parent_run, child_run = self._runs(status, error_message=error_message)
+
+        notify_parent_of_child_event(child_run, "terminal")
+
+        message = mock_signal.call_args.args[1]
+        self.assertIn(f"Status: {status}", message)
+        self.assertIn("Child task", message)
+        self.assertIn("https://github.com/PostHog/posthog/pull/123", message)
+        if error_message:
+            self.assertIn(error_message, message)
+        mock_signal.assert_called_once_with(
+            parent_run.workflow_id,
+            message,
+            [],
+            source=FOLLOWUP_SOURCE_CHILD,
+        )
+
+    @patch(
+        "products.tasks.backend.logic.services.orchestration.signal_task_followup_message",
+        side_effect=RPCError("workflow gone", RPCStatusCode.NOT_FOUND, b""),
+    )
+    def test_queues_wake_when_parent_workflow_is_cold(self, mock_signal) -> None:
+        parent_run, child_run = self._runs(TaskRun.Status.COMPLETED)
+
+        notify_parent_of_child_event(child_run, "terminal")
+
+        parent_run.refresh_from_db()
+        queued = parent_run.state[PENDING_ORCHESTRATION_WAKES_STATE_KEY]
+        self.assertEqual(len(queued), 1)
+        self.assertEqual(queued[0]["child_run_id"], str(child_run.id))
+        self.assertEqual(queued[0]["source"], FOLLOWUP_SOURCE_CHILD)
+        mock_signal.assert_called_once()
+
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    def test_run_without_parent_state_is_ignored(self, mock_signal) -> None:
+        child_task = self._task("Independent task")
+        child_run = child_task.create_run(mode="background")
+        child_run.status = TaskRun.Status.COMPLETED
+        child_run.save(update_fields=["status"])
+
+        notify_parent_of_child_event(child_run, "terminal")
+
+        mock_signal.assert_not_called()

--- a/products/tasks/backend/logic/services/tests/test_orchestration.py
+++ b/products/tasks/backend/logic/services/tests/test_orchestration.py
@@ -16,6 +16,8 @@ from products.tasks.backend.temporal.execute_sandbox.workflow import FOLLOWUP_SO
 
 
 class TestNotifyParentOfChildEvent(TestCase):
+    team: Team
+
     @classmethod
     def setUpTestData(cls) -> None:
         organization = Organization.objects.create(name="Orchestration test")

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -813,6 +813,10 @@ class TaskSpawnRequestSerializer(serializers.Serializer):
         return attrs
 
 
+class TaskParentMessageRequestSerializer(serializers.Serializer):
+    message = serializers.CharField(allow_blank=False, trim_whitespace=True)
+
+
 class TaskRunSetOutputRequestSerializer(serializers.Serializer):
     output = serializers.JSONField(
         help_text="Output data from the run. Validated against the task's json_schema if one is set."

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -97,6 +97,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskAutomationWriteSerializer,
     TaskCreateSerializer,
     TaskListQuerySerializer,
+    TaskParentMessageRequestSerializer,
     TaskPinRequestSerializer,
     TaskPinResponseSerializer,
     TaskPresenceBeaconRequestSerializer,
@@ -452,6 +453,33 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         created = tasks_facade.get_task_detail(child_task.id, self.team_id, self._user_id())
         return Response(TaskSerializer(created).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        request=TaskParentMessageRequestSerializer,
+        responses={204: None, 400: TaskRunErrorResponseSerializer},
+        operation_id="tasks_message_parent_create",
+        summary="Send a message to the parent task",
+    )
+    @action(detail=False, methods=["post"], url_path="message-parent", required_scopes=["task:write"])
+    def message_parent(self, request, **kwargs):
+        serializer = TaskParentMessageRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        child_run_id = request.headers.get("X-PostHog-Task-Run-Id")
+        if not child_run_id:
+            raise ValidationError({"detail": "message-parent requires a calling task-run context"})
+        try:
+            child_run_uuid = UUID(child_run_id)
+        except ValueError:
+            raise ValidationError({"detail": "Calling task-run context must be a valid UUID"})
+
+        try:
+            tasks_facade.send_child_message_to_parent(
+                child_run_uuid, self.team_id, serializer.validated_data["message"]
+            )
+        except ValueError as error:
+            raise ValidationError({"detail": str(error)})
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _forward_signals_discussion_note(
         self, request, task: tasks_contracts.TaskDetailDTO, relationship: str | None

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -101,6 +101,19 @@ def _terminalize_unstarted_task_run(run_id: str, error_message: str) -> bool:
         handle_loop_run_terminal(task_run)
     except Exception:
         logger.warning("task_processing_start_failure_loop_bookkeeping_failed", extra={"run_id": run_id}, exc_info=True)
+
+    from products.tasks.backend.facade.tasks import (
+        notify_parent_of_child_event_task,  # noqa: PLC0415 — keeps Celery off the Temporal client import path
+    )
+    from products.tasks.backend.logic.services.loop_runs import (
+        LOOP_TERMINAL_NOTIFICATION_GRACE_SECONDS,  # noqa: PLC0415 — shared terminal-write grace
+    )
+
+    transaction.on_commit(
+        lambda: notify_parent_of_child_event_task.apply_async(
+            args=[str(task_run.id), "terminal"], countdown=LOOP_TERMINAL_NOTIFICATION_GRACE_SECONDS
+        )
+    )
     return True
 
 
@@ -563,6 +576,7 @@ def signal_task_followup_message(
     context: dict[str, Any] | None = None,
     *,
     steer: bool = False,
+    source: str | None = None,
 ) -> None:
     """Legacy positional signal args stay frozen for worker deploy compatibility."""
     client = sync_connect()
@@ -585,7 +599,10 @@ def signal_task_followup_message(
             else:
                 if isinstance(protocol_version, int) and protocol_version >= STEERING_PROTOCOL_VERSION:
                     signal_name = SEND_STEER_SIGNAL
-        signal_args = [message, artifact_ids, message_id, actor_user_id, context]
+        message_context = dict(context or {})
+        if source is not None:
+            message_context["followup_source"] = source
+        signal_args = [message, artifact_ids, message_id, actor_user_id, message_context or None]
         await handle.signal(signal_name, args=signal_args)
 
     asyncio.run(signal())

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -125,6 +125,13 @@ OUTBOUND_RETRY_BACKOFF = timedelta(seconds=10)
 # the terminal flush before the child records the undelivered signals and exits.
 MAX_FINAL_OUTBOUND_FLUSH_ATTEMPTS = 5
 
+CHILD_EVENT_MESSAGE_TEMPLATE = """\
+Child task #{task_number} ({title}) reported {event}.
+Status: {status}{error_line}{pr_line}
+
+Decide the next step: spawn the next child task, report to the user, or finish.
+""".strip()
+
 DEFAULT_CI_MESSAGE = f"""\
 You are re-entering this run to address CI feedback on the pull request you opened.
 

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -140,6 +140,7 @@ SHUTDOWN_REJECTION_DETAIL = "child_shutting_down"
 # to drive CI-vs-user-message metrics.
 FOLLOWUP_SOURCE_USER = "user"
 FOLLOWUP_SOURCE_CI = "ci"
+FOLLOWUP_SOURCE_CHILD = "child"
 
 
 @dataclass

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py
@@ -173,6 +173,18 @@ class TestUpdateTaskRunStatusActivity:
         assert len(completed) == 1
 
     @pytest.mark.django_db(transaction=True)
+    @patch("products.tasks.backend.facade.tasks.notify_parent_of_child_event_task.apply_async")
+    def test_repeated_terminal_update_schedules_one_parent_notification(
+        self, mock_notify, activity_environment, test_task_run
+    ):
+        input_data = UpdateTaskRunStatusInput(run_id=str(test_task_run.id), status=TaskRun.Status.COMPLETED)
+
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+        async_to_sync(activity_environment.run)(update_task_run_status, input_data)
+
+        mock_notify.assert_called_once_with(args=[str(test_task_run.id), "terminal"], countdown=20)
+
+    @pytest.mark.django_db(transaction=True)
     def test_terminal_transition_updates_loop_bookkeeping_exactly_once(self, activity_environment, test_task_run):
         # This activity is how workflow-driven loop runs reach a terminal status, so it must
         # drive loop bookkeeping (last_run_status, consecutive_failures -> auto-pause) — the

--- a/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
+++ b/products/tasks/backend/temporal/process_task/activities/update_task_run_status.py
@@ -117,6 +117,20 @@ def update_task_run_status(input: UpdateTaskRunStatusInput) -> None:
         except Exception:
             activity.logger.warning(f"Failed loop terminal bookkeeping for run {task_run.id}", exc_info=True)
 
+        if input.status in _TERMINAL_STATUSES:
+            from products.tasks.backend.facade.tasks import (
+                notify_parent_of_child_event_task,  # noqa: PLC0415 — keeps Celery off the activity import path
+            )
+            from products.tasks.backend.logic.services.loop_runs import (
+                LOOP_TERMINAL_NOTIFICATION_GRACE_SECONDS,  # noqa: PLC0415 — shared terminal-write grace
+            )
+
+            transaction.on_commit(
+                lambda: notify_parent_of_child_event_task.apply_async(
+                    args=[str(task_run.id), "terminal"], countdown=LOOP_TERMINAL_NOTIFICATION_GRACE_SECONDS
+                )
+            )
+
     log_with_activity_context(
         "Task run status updated",
         run_id=input.run_id,

--- a/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
+++ b/products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py
@@ -14,7 +14,11 @@ from products.tasks.backend.temporal.constants import (
     SEND_STEER_SIGNAL,
     STEERING_PROTOCOL_VERSION,
 )
-from products.tasks.backend.temporal.execute_sandbox.workflow import PARENT_ATTACHED_SIGNAL, ChildCompletionPayload
+from products.tasks.backend.temporal.execute_sandbox.workflow import (
+    FOLLOWUP_SOURCE_CHILD,
+    PARENT_ATTACHED_SIGNAL,
+    ChildCompletionPayload,
+)
 from products.tasks.backend.temporal.process_task.activities.get_pr_context import GetPrContextOutput, get_pr_context
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.task_management import workflow as task_management_workflow_module
@@ -116,6 +120,21 @@ class TestExternalSignalHandlers:
         await workflow.send_followup_message("hello")
         assert workflow._pending_external_followups == [
             PendingExternalFollowup(message="hello", artifact_ids=[], source="user")
+        ]
+
+    async def test_send_followup_message_passes_child_source_through(self):
+        workflow = TaskManagementWorkflow()
+        await workflow.send_followup_message(
+            "child finished",
+            message_context={"followup_source": FOLLOWUP_SOURCE_CHILD, "request_id": "request-1"},
+        )
+        assert workflow._pending_external_followups == [
+            PendingExternalFollowup(
+                message="child finished",
+                artifact_ids=[],
+                source=FOLLOWUP_SOURCE_CHILD,
+                context={"request_id": "request-1"},
+            )
         ]
 
     async def test_send_steer_message_preserves_steer_intent(self):

--- a/products/tasks/backend/temporal/task_management/workflow.py
+++ b/products/tasks/backend/temporal/task_management/workflow.py
@@ -357,14 +357,18 @@ class TaskManagementWorkflow(PostHogWorkflow):
         *,
         steer: bool,
     ) -> None:
+        context = dict(message_context) if isinstance(message_context, dict) else {}
+        source = context.pop("followup_source", FOLLOWUP_SOURCE_USER)
+        if not isinstance(source, str):
+            source = FOLLOWUP_SOURCE_USER
         self._pending_external_followups.append(
             PendingExternalFollowup(
                 message=message,
                 artifact_ids=artifact_ids or [],
-                source=FOLLOWUP_SOURCE_USER,
+                source=source,
                 actor_user_id=actor_user_id,
                 message_id=message_id,
-                context=message_context if isinstance(message_context, dict) else {},
+                context=context,
                 steer=steer,
                 sequence=self._next_followup_sequence,
             )

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1275,6 +1275,65 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         self.assertTrue(child.deleted)
 
 
+class TestTaskParentMessageAPI(BaseTaskAPITest):
+    url = "/api/projects/@current/tasks/message-parent/"
+
+    def _runs(self) -> tuple[TaskRun, TaskRun]:
+        parent_task = self.create_task()
+        parent_run = parent_task.create_run(mode="background")
+        parent_run.status = TaskRun.Status.IN_PROGRESS
+        parent_run.save(update_fields=["status", "updated_at"])
+
+        child_task = self.create_task()
+        child_run = child_task.create_run(
+            mode="background",
+            extra_state={
+                "parent_task_id": str(parent_task.id),
+                "parent_run_id": str(parent_run.id),
+                "wake_on": [],
+            },
+        )
+        child_run.status = TaskRun.Status.IN_PROGRESS
+        child_run.save(update_fields=["status", "updated_at"])
+        return parent_run, child_run
+
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    def test_child_can_send_multiple_messages_to_parent(self, signal):
+        parent_run, child_run = self._runs()
+
+        for message in ("First update", "Second update"):
+            response = self.client.post(
+                self.url, {"message": message}, format="json", HTTP_X_POSTHOG_TASK_RUN_ID=str(child_run.id)
+            )
+            self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+
+        self.assertEqual([call.args[1] for call in signal.call_args_list], ["First update", "Second update"])
+        self.assertTrue(all(call.args[0] == parent_run.workflow_id for call in signal.call_args_list))
+
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    def test_non_child_run_is_rejected(self, signal):
+        independent_run = self.create_task().create_run(mode="background")
+
+        response = self.client.post(
+            self.url, {"message": "Update"}, format="json", HTTP_X_POSTHOG_TASK_RUN_ID=str(independent_run.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        signal.assert_not_called()
+
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    def test_sending_message_does_not_change_child_status(self, _signal):
+        _, child_run = self._runs()
+
+        response = self.client.post(
+            self.url, {"message": "Still working"}, format="json", HTTP_X_POSTHOG_TASK_RUN_ID=str(child_run.id)
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.content)
+        child_run.refresh_from_db()
+        self.assertEqual(child_run.status, TaskRun.Status.IN_PROGRESS)
+
+
 class TestTaskAPI(BaseTaskAPITest):
     def _oauth_client(self, client_id: str, *, scope: str = "task:read task:write") -> APIClient:
         application = OAuthApplication.objects.create(

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3463,6 +3463,10 @@ export interface WizardCloudRunDTOApi {
     started_at?: string | null
 }
 
+export interface TaskParentMessageRequestApi {
+    message: string
+}
+
 export interface PinnedTaskIdsResponseApi {
     /** Visible task IDs pinned by the requester, newest pin first. */
     task_ids: string[]

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -75,6 +75,7 @@ import type {
     TaskCreateApi,
     TaskDetailDTOApi,
     TaskMentionsListParams,
+    TaskParentMessageRequestApi,
     TaskPinRequestApi,
     TaskPinResponseApi,
     TaskPresenceBeaconRequestApi,
@@ -2238,6 +2239,27 @@ export const tasksActiveWizardRunRetrieve = async (
     return apiMutator<WizardCloudRunDTOApi | void>(getTasksActiveWizardRunRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
+    })
+}
+
+export const getTasksMessageParentCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/tasks/message-parent/`
+}
+
+/**
+ * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
+ * @summary Send a message to the parent task
+ */
+export const tasksMessageParentCreate = async (
+    projectId: string,
+    taskParentMessageRequestApi: TaskParentMessageRequestApi,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getTasksMessageParentCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskParentMessageRequestApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3017,6 +3017,14 @@ export const TasksThreadMessagesSendToAgentCreateBody = /* @__PURE__ */ zod
 
 /**
  * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
+ * @summary Send a message to the parent task
+ */
+export const TasksMessageParentCreateBody = /* @__PURE__ */ zod.object({
+    message: zod.string(),
+})
+
+/**
+ * API for managing tasks within a project. Tasks represent units of work to be performed by an agent.
  * @summary Spawn a child task
  */
 export const tasksSpawnCreateBodyTitleMax = 255

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -384,6 +384,9 @@ tools:
                 - internal
                 - created_at
                 - updated_at
+    tasks-message-parent-create:
+        operation: tasks_message_parent_create
+        enabled: false
     tasks-partial-update:
         operation: tasks_partial_update
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -72026,6 +72026,10 @@ export namespace Schemas {
       runtime?: RuntimeEnum;
     }
 
+    export interface TaskParentMessageRequest {
+      message: string;
+    }
+
     export interface TaskPinRequest {
       /** Whether the task should be pinned for the requester. */
       pinned: boolean;


### PR DESCRIPTION
## Problem

Orchestrated parent tasks need a durable, trusted notification when a spawned child run finishes. Without this wake path, the parent cannot continue its plan based on child outcomes.

**Why:** This is the delivery layer between the existing spawn endpoint and later cold-parent auto-resume support.

## Changes

- Add a single orchestration notification service that builds child status messages from stored task and run records.
- Signal the parent task’s newest live run, or persist a structured wake when its workflow is gone.
- Dispatch terminal wakes from all three existing terminal transition paths after the final-write grace period.

> [!NOTE]
> This is stacked on #76751 because the supervision state keys are not merged yet. There is deliberately no Task model parent/child relationship.

## How did you test this code?

- `uv run pytest products/tasks/backend/logic/services/tests/test_orchestration.py products/tasks/backend/temporal/process_task/activities/tests/test_update_task_run_status.py::TestUpdateTaskRunStatusActivity::test_repeated_terminal_update_schedules_one_parent_notification products/tasks/backend/temporal/task_management/tests/test_task_management_workflow.py::TestExternalSignalHandlers::test_send_followup_message_passes_child_source_through products/tasks/backend/tests/test_temporal_client.py::TestSignalTaskFollowupMessage --reuse-db -q` (13 passed)
- `.venv/bin/hogli ci:preflight --fix` (no failures)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change. This is backend infrastructure behind an unreleased feature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code using Codex implemented the requested second step only. The `/i-have-adhd` output-shaping skill was active for session communication and did not affect code design. The wake queue is separate from existing user follow-ups so the next stacked change can own cold-run draining and single-flight resume behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*