### PR TITLE
fix(desktop): show loading feedback while branch checkout is in progress

### DIFF
--- a/products/desktop/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/BranchSelector.tsx
@@ -249,11 +249,18 @@ export function BranchSelector({
       ? BUSY_OPERATION_LABEL[busyState.operation]
       : null;
 
-  const displayText = effectiveLoading
-    ? "Loading..."
-    : busyOperationLabel && !displayedBranch
-      ? busyOperationLabel
-      : (displayedBranch ?? "No branch");
+  const isCheckoutPending = checkoutMutation.isPending;
+  const checkoutTargetBranch = isCheckoutPending
+    ? checkoutMutation.variables?.branchName
+    : null;
+
+  const displayText = isCheckoutPending
+    ? `Switching to ${checkoutTargetBranch}…`
+    : effectiveLoading
+      ? "Loading..."
+      : busyOperationLabel && !displayedBranch
+        ? busyOperationLabel
+        : (displayedBranch ?? "No branch");
 
   // Which checkout the branch applies to. With several checkouts of the same
   // repo registered (main clone + worktrees), a bare branch name is ambiguous
@@ -261,9 +268,9 @@ export function BranchSelector({
   const checkoutName = !isCloudMode && repoPath ? getFileName(repoPath) : null;
 
   const showSpinner =
-    effectiveLoading || (isCloudMode && open && cloudBranchesFetchingMore);
+    isCheckoutPending || effectiveLoading || (isCloudMode && open && cloudBranchesFetchingMore);
 
-  const isDisabled = !!(disabled || !repoPath || localBusy);
+  const isDisabled = !!(disabled || !repoPath || localBusy || isCheckoutPending);
   const disabledReason =
     localBusy && busyOperationLabel
       ? `${busyOperationLabel} in progress — finish or abort it to switch branches.`


### PR DESCRIPTION
## Problem

When the user selects a branch in Local mode, the dropdown closes immediately but the button keeps showing the old branch name for 3-4 seconds while `git checkout` runs in the background — with no indication that anything is happening. This makes the UI feel broken or unresponsive.

## What changed

- **Immediate feedback**: While the checkout mutation is pending, the button now shows `Switching to {branch}…` with a spinner
- **Disabled during checkout**: The branch selector is disabled while checkout is in progress, preventing concurrent checkout attempts

## How it works

The `BranchSelector` component uses `useMutation` for checkout operations. This adds a check for `checkoutMutation.isPending` to:

1. Set the display text to `Switching to {branch}…` while the mutation is running
2. Show the `Spinner` icon on the button during the mutation
3. Disable the trigger button during the mutation

## Test Plan

1. Open the new task screen in Local mode
2. Select a different branch from the dropdown
3. Observe: the button should immediately show `Switching to {branch}…` with a spinner
4. Wait for checkout to complete → the button updates to the new branch name
5. Verify the selector is disabled during checkout (no double-clicks)

Fixes #76209