### PR TITLE
feat(conversations): attach PDFs and documents to ticket replies

### DIFF
--- a/frontend/src/lib/hooks/useUploadFiles.ts
+++ b/frontend/src/lib/hooks/useUploadFiles.ts
@@ -112,7 +112,11 @@ export function useUploadFiles({
 
     useEffect(() => {
         const uploadFiles = async (): Promise<void> => {
-            if (filesToUpload.length === 0 || uploadInProgressRef.current) {
+            if (uploadInProgressRef.current) {
+                // Leave `uploading` alone, or the spinner disappears while the in-flight upload runs on
+                return
+            }
+            if (filesToUpload.length === 0) {
                 setUploading(false)
                 return
             }

--- a/frontend/src/lib/hooks/useUploadFiles.ts
+++ b/frontend/src/lib/hooks/useUploadFiles.ts
@@ -71,28 +71,36 @@ function canReduceThisBlobType(file: File): boolean {
     return supportedTypes.includes(file.type)
 }
 
-export async function uploadFile(file: File): Promise<MediaUploadResponse> {
-    if (!file.type.startsWith('image/')) {
+export async function uploadFile(
+    file: File,
+    { allowDocuments = false }: { allowDocuments?: boolean } = {}
+): Promise<MediaUploadResponse> {
+    const isImage = file.type.startsWith('image/')
+    if (!isImage && !allowDocuments) {
         throw new Error('File is not an image')
     }
 
     let fileToUpload = file
-    if (canReduceThisBlobType(file)) {
+    if (isImage && canReduceThisBlobType(file)) {
         const compressedBlob = await lazyImageBlobReducer(file)
         fileToUpload = new File([compressedBlob], file.name, { type: compressedBlob.type })
     }
 
     const formData = new FormData()
-    formData.append('image', fileToUpload)
+    // The `file` field is what allows documents through; `image` stays image-only
+    formData.append(allowDocuments ? 'file' : 'image', fileToUpload)
     return await api.media.upload(formData)
 }
 
 export function useUploadFiles({
     onUpload,
     onError,
+    allowDocuments = false,
 }: {
-    onUpload?: (url: string, fileName: string, uploadedMediaId: string) => void
+    onUpload?: (url: string, fileName: string, uploadedMediaId: string, contentType?: string) => void
     onError: (detail: string) => void
+    /** Accept documents (PDF, CSV, Office files) as well as images */
+    allowDocuments?: boolean
 }): {
     setFilesToUpload: (files: File[]) => void
     filesToUpload: File[]
@@ -113,8 +121,8 @@ export function useUploadFiles({
                 uploadInProgressRef.current = true
                 setUploading(true)
                 const file: File = filesToUpload[0]
-                const media = await uploadFile(file)
-                onUpload?.(media.image_location, media.name, media.id)
+                const media = await uploadFile(file, { allowDocuments })
+                onUpload?.(media.image_location, media.name, media.id, media.content_type)
             } catch (error) {
                 const errorDetail = (error as any).detail || 'unknown error'
                 onError(errorDetail)

--- a/frontend/src/lib/hooks/useUploadFiles.ts
+++ b/frontend/src/lib/hooks/useUploadFiles.ts
@@ -5,6 +5,11 @@ import api from 'lib/api'
 
 import { MediaUploadResponse } from '~/types'
 
+export interface UploadedMediaResponse extends MediaUploadResponse {
+    /** Content type the API stored, which for documents can differ from what the browser reported */
+    content_type?: string
+}
+
 export const lazyImageBlobReducer = async (blob: Blob): Promise<Blob> => {
     try {
         const blobReducer = (await import('image-blob-reduce')).default()
@@ -74,7 +79,7 @@ function canReduceThisBlobType(file: File): boolean {
 export async function uploadFile(
     file: File,
     { allowDocuments = false }: { allowDocuments?: boolean } = {}
-): Promise<MediaUploadResponse> {
+): Promise<UploadedMediaResponse> {
     const isImage = file.type.startsWith('image/')
     if (!isImage && !allowDocuments) {
         throw new Error('File is not an image')

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5693,7 +5693,6 @@ export interface MediaUploadResponse {
     id: string
     image_location: string
     name: string
-    content_type?: string
 }
 
 export enum Resource {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5693,6 +5693,7 @@ export interface MediaUploadResponse {
     id: string
     image_location: string
     name: string
+    content_type?: string
 }
 
 export enum Resource {

--- a/posthog/api/test/test_uploaded_media.py
+++ b/posthog/api/test/test_uploaded_media.py
@@ -165,6 +165,12 @@ class TestMediaAPI(APIBaseTest):
             ("archive", "bundle.zip", "application/zip"),
             ("executable", "installer.exe", "application/octet-stream"),
             ("no extension", "attachment", "application/octet-stream"),
+            # A caller-declared content type must not let an arbitrary extension through:
+            # the stored name is what the download is saved as
+            ("executable declaring an allowed type", "payload.exe", "application/pdf"),
+            ("executable with a trailing dot", "payload.exe.", "application/pdf"),
+            ("extension disagreeing with an allowed type", "notes.txt", "text/csv"),
+            ("legacy office format", "macros.doc", "application/msword"),
         ]
     )
     def test_rejects_files_outside_the_document_allowlist(self, _name: str, file_name: str, content_type: str) -> None:
@@ -190,6 +196,21 @@ class TestMediaAPI(APIBaseTest):
                 response.json()["content_type"]
                 == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             )
+
+    def test_strips_bidi_characters_from_the_stored_file_name(self) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_MEDIA_UPLOADS_FOLDER=TEST_BUCKET):
+            disguised = SimpleUploadedFile(
+                name="report‮fdp.pdf",
+                content=b"%PDF-1.4",
+                content_type="application/pdf",
+            )
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/uploaded_media",
+                {"file": disguised},
+                format="multipart",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+            assert response.json()["name"] == "reportfdp.pdf"
 
     def test_rejects_too_large_document(self) -> None:
         fake_big_file = SimpleUploadedFile(

--- a/posthog/api/test/test_uploaded_media.py
+++ b/posthog/api/test/test_uploaded_media.py
@@ -159,15 +159,37 @@ class TestMediaAPI(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, response.json())
 
-    @parameterized.expand([("html", "text/html"), ("zip", "application/zip"), ("binary", "application/octet-stream")])
-    def test_rejects_content_types_outside_the_document_allowlist(self, _name: str, content_type: str) -> None:
-        file = SimpleUploadedFile(name="attachment", content=b"some bytes", content_type=content_type)
+    @parameterized.expand(
+        [
+            ("html", "notes.html", "text/html"),
+            ("archive", "bundle.zip", "application/zip"),
+            ("executable", "installer.exe", "application/octet-stream"),
+            ("no extension", "attachment", "application/octet-stream"),
+        ]
+    )
+    def test_rejects_files_outside_the_document_allowlist(self, _name: str, file_name: str, content_type: str) -> None:
+        file = SimpleUploadedFile(name=file_name, content=b"some bytes", content_type=content_type)
         response = self.client.post(
             f"/api/projects/{self.team.id}/uploaded_media",
             {"file": file},
             format="multipart",
         )
         self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, response.json())
+
+    @parameterized.expand([("zip", "application/zip"), ("generic", "application/octet-stream")])
+    def test_accepts_an_office_document_the_browser_reports_generically(self, _name: str, content_type: str) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_MEDIA_UPLOADS_FOLDER=TEST_BUCKET):
+            docx = SimpleUploadedFile(name="report.docx", content=b"PK\x03\x04", content_type=content_type)
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/uploaded_media",
+                {"file": docx},
+                format="multipart",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+            assert (
+                response.json()["content_type"]
+                == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            )
 
     def test_rejects_too_large_document(self) -> None:
         fake_big_file = SimpleUploadedFile(

--- a/posthog/api/test/test_uploaded_media.py
+++ b/posthog/api/test/test_uploaded_media.py
@@ -127,6 +127,62 @@ class TestMediaAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
         self.assertEqual(response.json()["detail"], "Uploaded media must be less than 4MB")
 
+    def test_can_upload_and_download_a_document(self) -> None:
+        with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_MEDIA_UPLOADS_FOLDER=TEST_BUCKET):
+            pdf = SimpleUploadedFile(
+                name="certificate.pdf",
+                content=b"%PDF-1.4 not really a pdf",
+                content_type="application/pdf",
+            )
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/uploaded_media",
+                {"file": pdf},
+                format="multipart",
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+            assert response.json()["content_type"] == "application/pdf"
+            media_location = response.json()["image_location"]
+
+            self.client.logout()
+            download = self.client.get(media_location)
+
+            assert download.status_code == status.HTTP_200_OK
+            assert download.headers["Content-Type"] == "application/octet-stream"
+            assert download.headers["Content-Disposition"] == 'attachment; filename="certificate.pdf"'
+
+    def test_rejects_a_document_uploaded_as_an_image(self) -> None:
+        pdf = SimpleUploadedFile(name="certificate.pdf", content=b"%PDF-1.4", content_type="application/pdf")
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/uploaded_media",
+            {"image": pdf},
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, response.json())
+
+    @parameterized.expand([("html", "text/html"), ("zip", "application/zip"), ("binary", "application/octet-stream")])
+    def test_rejects_content_types_outside_the_document_allowlist(self, _name: str, content_type: str) -> None:
+        file = SimpleUploadedFile(name="attachment", content=b"some bytes", content_type=content_type)
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/uploaded_media",
+            {"file": file},
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, response.json())
+
+    def test_rejects_too_large_document(self) -> None:
+        fake_big_file = SimpleUploadedFile(
+            name="certificate.pdf",
+            content=b"1" * (10 * 1024 * 1024 + 1),
+            content_type="application/pdf",
+        )
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/uploaded_media",
+            {"file": fake_big_file},
+            format="multipart",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        self.assertEqual(response.json()["detail"], "Uploaded media must be less than 10MB")
+
     def test_download_sets_nosniff_and_strict_csp(self) -> None:
         with self.settings(OBJECT_STORAGE_ENABLED=True, OBJECT_STORAGE_MEDIA_UPLOADS_FOLDER=TEST_BUCKET):
             with open(get_path_to("a-small-but-valid.gif"), "rb") as image:

--- a/posthog/api/uploaded_media.py
+++ b/posthog/api/uploaded_media.py
@@ -1,3 +1,4 @@
+import os
 from io import BytesIO
 from typing import Optional
 from urllib.parse import quote
@@ -29,19 +30,18 @@ TEN_MEGABYTES = 10 * 1024 * 1024
 # than embed them (support ticket replies). These are never rendered inline — the
 # download endpoint serves anything outside _INLINE_SAFE_CONTENT_TYPES as an
 # opaque attachment — so the list only needs to cover what people actually send.
-_ALLOWED_DOCUMENT_CONTENT_TYPES = frozenset(
-    {
-        "application/pdf",
-        "text/plain",
-        "text/csv",
-        "application/msword",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "application/vnd.ms-excel",
-        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "application/vnd.ms-powerpoint",
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    }
-)
+_DOCUMENT_EXTENSION_CONTENT_TYPES = {
+    ".pdf": "application/pdf",
+    ".txt": "text/plain",
+    ".csv": "text/csv",
+    ".doc": "application/msword",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".xls": "application/vnd.ms-excel",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".ppt": "application/vnd.ms-powerpoint",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+}
+_ALLOWED_DOCUMENT_CONTENT_TYPES = frozenset(_DOCUMENT_EXTENSION_CONTENT_TYPES.values())
 
 # Content types safe to render inline in a browser when served from the
 # unauthenticated /uploaded_media endpoint. Anything outside this set is
@@ -70,6 +70,19 @@ def _normalize_content_type(value: str | None) -> str:
 
 def _is_inline_safe_content_type(content_type: str | None) -> bool:
     return _normalize_content_type(content_type) in _INLINE_SAFE_CONTENT_TYPES
+
+
+def _resolve_document_content_type(file_name: str | None, content_type: str) -> str | None:
+    """Pick the content type to store for a document, or None if it isn't an allowed one.
+
+    Browsers report Office files and CSVs inconsistently — a .docx often arrives as
+    application/zip or application/octet-stream depending on what the OS has registered —
+    so the extension gets a say, and what it maps to is what we store.
+    """
+    if content_type in _ALLOWED_DOCUMENT_CONTENT_TYPES:
+        return content_type
+    extension = os.path.splitext(file_name or "")[1].lower()
+    return _DOCUMENT_EXTENSION_CONTENT_TYPES.get(extension)
 
 
 def _attachment_disposition(file_name: str | None) -> str:
@@ -186,9 +199,9 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         description="""
     When object storage is available this API allows upload of media which can be used, for example, in text cards on dashboards.
 
-    Send the file as `image` for images, which must have a content type beginning with 'image/' and be less than 4MB.
+    Send the file as `image` to only allow images, or as `file` to also allow documents (PDF, plain text, CSV and Office formats).
 
-    Send it as `file` to also allow documents (PDF, plain text, CSV and Office formats), which must be less than 10MB.
+    Images must have a content type beginning with 'image/' and be less than 4MB. Documents must be less than 10MB.
     """,
         responses={201: OpenApiTypes.OBJECT},
     )
@@ -201,8 +214,13 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
             content_type = _normalize_content_type(file.content_type)
             is_image = content_type.startswith("image/")
-            if not is_image and not (documents_allowed and content_type in _ALLOWED_DOCUMENT_CONTENT_TYPES):
-                raise UnsupportedMediaType(file.content_type)
+            if not is_image:
+                document_content_type = (
+                    _resolve_document_content_type(file.name, content_type) if documents_allowed else None
+                )
+                if document_content_type is None:
+                    raise UnsupportedMediaType(file.content_type)
+                content_type = document_content_type
 
             size_limit = FOUR_MEGABYTES if is_image else TEN_MEGABYTES
             if file.size > size_limit:
@@ -215,7 +233,7 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 team=self.team,
                 created_by=request.user,
                 file_name=file.name,
-                content_type=file.content_type,
+                content_type=content_type,
                 content=file.file,
             )
             if uploaded_media is None:
@@ -243,7 +261,7 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             headers = self.get_success_headers(uploaded_media.get_absolute_url())
             statsd.incr(
                 "uploaded_media.uploaded",
-                tags={"team_id": self.team.pk, "content_type": file.content_type},
+                tags={"team_id": self.team.pk, "content_type": content_type},
             )
             return Response(
                 {

--- a/posthog/api/uploaded_media.py
+++ b/posthog/api/uploaded_media.py
@@ -30,18 +30,19 @@ TEN_MEGABYTES = 10 * 1024 * 1024
 # than embed them (support ticket replies). These are never rendered inline — the
 # download endpoint serves anything outside _INLINE_SAFE_CONTENT_TYPES as an
 # opaque attachment — so the list only needs to cover what people actually send.
+# The legacy OLE formats (.doc/.xls/.ppt) are deliberately absent: nothing scans
+# these bytes, and they can carry VBA that their OpenXML equivalents cannot.
 _DOCUMENT_EXTENSION_CONTENT_TYPES = {
     ".pdf": "application/pdf",
     ".txt": "text/plain",
     ".csv": "text/csv",
-    ".doc": "application/msword",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    ".xls": "application/vnd.ms-excel",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ".ppt": "application/vnd.ms-powerpoint",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
 _ALLOWED_DOCUMENT_CONTENT_TYPES = frozenset(_DOCUMENT_EXTENSION_CONTENT_TYPES.values())
+
+MAX_FILE_NAME_LENGTH = 255
 
 # Content types safe to render inline in a browser when served from the
 # unauthenticated /uploaded_media endpoint. Anything outside this set is
@@ -72,17 +73,36 @@ def _is_inline_safe_content_type(content_type: str | None) -> bool:
     return _normalize_content_type(content_type) in _INLINE_SAFE_CONTENT_TYPES
 
 
-def _resolve_document_content_type(file_name: str | None, content_type: str) -> str | None:
+def _safe_file_name(file_name: str | None) -> str:
+    """Clean up a caller-supplied filename before we store it.
+
+    Both the name and the reported content type come straight from multipart headers.
+    The name is what the download is saved as and what recipients see as link text in
+    an outbound reply, so drop control and bidi-override characters (which can disguise
+    an extension) along with path separators.
+    """
+    cleaned = "".join(ch for ch in (file_name or "") if ch.isprintable())
+    cleaned = cleaned.replace("/", "_").replace("\\", "_").strip()
+    return cleaned[:MAX_FILE_NAME_LENGTH] or "attachment"
+
+
+def _resolve_document_content_type(file_name: str, content_type: str) -> str | None:
     """Pick the content type to store for a document, or None if it isn't an allowed one.
 
-    Browsers report Office files and CSVs inconsistently — a .docx often arrives as
-    application/zip or application/octet-stream depending on what the OS has registered —
-    so the extension gets a say, and what it maps to is what we store.
+    The extension is the gate, because it decides what the recipient's machine opens.
+    The reported content type can't widen that: it only gets consulted to reject a file
+    claiming to be a different allowed document than its extension says. Browsers report
+    Office files and CSVs inconsistently (a .docx often arrives as application/zip or
+    application/octet-stream), so a type outside the allowlist is not itself a reason to
+    reject.
     """
-    if content_type in _ALLOWED_DOCUMENT_CONTENT_TYPES:
-        return content_type
-    extension = os.path.splitext(file_name or "")[1].lower()
-    return _DOCUMENT_EXTENSION_CONTENT_TYPES.get(extension)
+    extension = os.path.splitext(file_name.rstrip("."))[1].lower()
+    resolved = _DOCUMENT_EXTENSION_CONTENT_TYPES.get(extension)
+    if resolved is None:
+        return None
+    if content_type in _ALLOWED_DOCUMENT_CONTENT_TYPES and content_type != resolved:
+        return None
+    return resolved
 
 
 def _attachment_disposition(file_name: str | None) -> str:
@@ -199,9 +219,10 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         description="""
     When object storage is available this API allows upload of media which can be used, for example, in text cards on dashboards.
 
-    Send the file as `image` to only allow images, or as `file` to also allow documents (PDF, plain text, CSV and Office formats).
+    Send the file as `image` to only allow images, or as `file` to also allow documents (PDF, plain text, CSV, .docx, .xlsx and .pptx).
 
-    Images must have a content type beginning with 'image/' and be less than 4MB. Documents must be less than 10MB.
+    Images must have a content type beginning with 'image/' and be less than 4MB. Documents are recognized by
+    their extension and must be less than 10MB.
     """,
         responses={201: OpenApiTypes.OBJECT},
     )
@@ -212,11 +233,12 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             documents_allowed = "file" in request.data
             file = request.data["file"] if documents_allowed else request.data["image"]
 
+            file_name = _safe_file_name(file.name)
             content_type = _normalize_content_type(file.content_type)
             is_image = content_type.startswith("image/")
             if not is_image:
                 document_content_type = (
-                    _resolve_document_content_type(file.name, content_type) if documents_allowed else None
+                    _resolve_document_content_type(file_name, content_type) if documents_allowed else None
                 )
                 if document_content_type is None:
                     raise UnsupportedMediaType(file.content_type)
@@ -232,7 +254,7 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             uploaded_media = UploadedMedia.save_content(
                 team=self.team,
                 created_by=request.user,
-                file_name=file.name,
+                file_name=file_name,
                 content_type=content_type,
                 content=file.file,
             )
@@ -249,7 +271,7 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 if not validate_image_file(bytes_to_verify, user=request.user.id):
                     statsd.incr(
                         "uploaded_media.image_failed_validation",
-                        tags={"file_name": file.name, "team": self.team_id},
+                        tags={"file_name": file_name, "team": self.team_id},
                     )
                     # TODO a batch process can delete media with no records in the DB or for deleted teams
                     uploaded_media.delete()

--- a/posthog/api/uploaded_media.py
+++ b/posthog/api/uploaded_media.py
@@ -23,6 +23,25 @@ from posthog.models.uploaded_media import ObjectStorageUnavailable
 from posthog.storage import object_storage
 
 FOUR_MEGABYTES = 4 * 1024 * 1024
+TEN_MEGABYTES = 10 * 1024 * 1024
+
+# Document types accepted alongside images, for surfaces that attach files rather
+# than embed them (support ticket replies). These are never rendered inline — the
+# download endpoint serves anything outside _INLINE_SAFE_CONTENT_TYPES as an
+# opaque attachment — so the list only needs to cover what people actually send.
+_ALLOWED_DOCUMENT_CONTENT_TYPES = frozenset(
+    {
+        "application/pdf",
+        "text/plain",
+        "text/csv",
+        "application/msword",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    }
+)
 
 # Content types safe to render inline in a browser when served from the
 # unauthenticated /uploaded_media endpoint. Anything outside this set is
@@ -167,32 +186,47 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         description="""
     When object storage is available this API allows upload of media which can be used, for example, in text cards on dashboards.
 
-    Uploaded media must have a content type beginning with 'image/' and be less than 4MB.
+    Send the file as `image` for images, which must have a content type beginning with 'image/' and be less than 4MB.
+
+    Send it as `file` to also allow documents (PDF, plain text, CSV and Office formats), which must be less than 10MB.
     """,
         responses={201: OpenApiTypes.OBJECT},
     )
     def create(self, request, *args, **kwargs) -> Response:
         try:
-            file = request.data["image"]
+            # `image` is the long-standing field and stays image-only; `file` additionally
+            # accepts the document types we allow as attachments.
+            documents_allowed = "file" in request.data
+            file = request.data["file"] if documents_allowed else request.data["image"]
 
-            if file.size > FOUR_MEGABYTES:
-                raise ValidationError(code="file_too_large", detail="Uploaded media must be less than 4MB")
+            content_type = _normalize_content_type(file.content_type)
+            is_image = content_type.startswith("image/")
+            if not is_image and not (documents_allowed and content_type in _ALLOWED_DOCUMENT_CONTENT_TYPES):
+                raise UnsupportedMediaType(file.content_type)
 
-            if file.content_type.startswith("image/"):
-                uploaded_media = UploadedMedia.save_content(
-                    team=self.team,
-                    created_by=request.user,
-                    file_name=file.name,
-                    content_type=file.content_type,
-                    content=file.file,
+            size_limit = FOUR_MEGABYTES if is_image else TEN_MEGABYTES
+            if file.size > size_limit:
+                raise ValidationError(
+                    code="file_too_large",
+                    detail=f"Uploaded media must be less than {size_limit // (1024 * 1024)}MB",
                 )
-                if uploaded_media is None:
-                    raise APIException("Could not save media")
 
+            uploaded_media = UploadedMedia.save_content(
+                team=self.team,
+                created_by=request.user,
+                file_name=file.name,
+                content_type=file.content_type,
+                content=file.file,
+            )
+            if uploaded_media is None:
+                raise APIException("Could not save media")
+
+            if uploaded_media.media_location is None:
+                raise APIException("Could not read uploaded media")
+
+            if is_image:
                 # to save having to copy the stream so that we can read it to verify the image,
                 # save it to minio anyway and then delete the record if it's not valid
-                if uploaded_media.media_location is None:
-                    raise APIException("Could not read uploaded media")
                 bytes_to_verify = object_storage.read_bytes(uploaded_media.media_location)
                 if not validate_image_file(bytes_to_verify, user=request.user.id):
                     statsd.incr(
@@ -206,24 +240,23 @@ class MediaViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                         detail="Uploaded media must be a valid image",
                     )
 
-                headers = self.get_success_headers(uploaded_media.get_absolute_url())
-                statsd.incr(
-                    "uploaded_media.uploaded",
-                    tags={"team_id": self.team.pk, "content_type": file.content_type},
-                )
-                return Response(
-                    {
-                        "id": uploaded_media.id,
-                        "image_location": uploaded_media.get_absolute_url(),
-                        "name": uploaded_media.file_name,
-                    },
-                    status=status.HTTP_201_CREATED,
-                    headers=headers,
-                )
-            else:
-                raise UnsupportedMediaType(file.content_type)
+            headers = self.get_success_headers(uploaded_media.get_absolute_url())
+            statsd.incr(
+                "uploaded_media.uploaded",
+                tags={"team_id": self.team.pk, "content_type": file.content_type},
+            )
+            return Response(
+                {
+                    "id": uploaded_media.id,
+                    "image_location": uploaded_media.get_absolute_url(),
+                    "name": uploaded_media.file_name,
+                    "content_type": uploaded_media.content_type,
+                },
+                status=status.HTTP_201_CREATED,
+                headers=headers,
+            )
         except KeyError:
-            raise ValidationError(code="no-image-provided", detail="An image file must be provided")
+            raise ValidationError(code="no-image-provided", detail="An image or file must be provided")
         except ObjectStorageUnavailable:
             raise ValidationError(
                 code="object_storage_required",

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -170,7 +170,7 @@ export function MessageInput({
           : isEmpty
             ? 'No message'
             : isUploading
-              ? 'Uploading image...'
+              ? 'Uploading attachment...'
               : undefined
     const sendControlDisabledReason =
         typeof sendDisabledReason === 'string'

--- a/products/conversations/frontend/components/Editor/SupportEditor.test.ts
+++ b/products/conversations/frontend/components/Editor/SupportEditor.test.ts
@@ -64,6 +64,25 @@ describe('SupportEditor serialization and preview schema', () => {
             },
             '- item\n\n![cat](https://example.com/cat.png)',
         ],
+        [
+            'file attachment as a download link',
+            {
+                type: 'doc',
+                content: [
+                    {
+                        type: 'paragraph',
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'certificate.pdf',
+                                marks: [{ type: 'link', attrs: { href: 'https://example.com/uploaded_media/abc' } }],
+                            },
+                        ],
+                    },
+                ],
+            },
+            '[certificate\\.pdf](https://example.com/uploaded_media/abc)',
+        ],
     ])('serializeToMarkdown handles %s', (_name, doc, expected) => {
         expect(serializeToMarkdown(doc)).toBe(expected)
     })

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -193,7 +193,14 @@ const DEFAULT_INITIAL_CONTENT: JSONContent = {
 }
 
 /** Keep in sync with the content types the media upload API accepts for the `file` field */
-const ATTACHMENT_ACCEPT = 'image/*,.pdf,.txt,.csv,.doc,.docx,.xls,.xlsx,.ppt,.pptx'
+const ATTACHMENT_EXTENSIONS = ['.pdf', '.txt', '.csv', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx']
+const ATTACHMENT_ACCEPT = ['image/*', ...ATTACHMENT_EXTENSIONS].join(',')
+
+/** Matches the API, which takes an allowed content type or an allowed extension. A drop bypasses `accept`. */
+function isAttachable(file: File): boolean {
+    const name = file.name.toLowerCase()
+    return file.type.startsWith('image/') || ATTACHMENT_EXTENSIONS.some((extension) => name.endsWith(extension))
+}
 
 const ImageExtension = Image.configure({
     HTMLAttributes: {
@@ -622,7 +629,7 @@ export function SupportEditor({
     }
 
     const attachDisabledReason = !objectStorageAvailable
-        ? 'Enable object storage to attach images and files'
+        ? 'Enable object storage to attach files'
         : uploading
           ? 'Wait for the current upload to finish'
           : undefined
@@ -632,6 +639,12 @@ export function SupportEditor({
         (files: File[]): void => {
             if (uploading) {
                 lemonToast.error('Wait for the current upload to finish before attaching another file')
+                return
+            }
+            if (files.some((file) => !isAttachable(file))) {
+                lemonToast.error(
+                    "That file type isn't supported. You can attach images, PDFs, documents and spreadsheets"
+                )
                 return
             }
             setFilesToUpload(files)

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -193,7 +193,7 @@ const DEFAULT_INITIAL_CONTENT: JSONContent = {
 }
 
 /** Keep in sync with the content types the media upload API accepts for the `file` field */
-const ATTACHMENT_EXTENSIONS = ['.pdf', '.txt', '.csv', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx']
+const ATTACHMENT_EXTENSIONS = ['.pdf', '.txt', '.csv', '.docx', '.xlsx', '.pptx']
 const ATTACHMENT_ACCEPT = ['image/*', ...ATTACHMENT_EXTENSIONS].join(',')
 
 /** Matches the API, which takes an allowed content type or an allowed extension. A drop bypasses `accept`. */

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -22,7 +22,7 @@ import { common, createLowlight } from 'lowlight'
 import posthog from 'posthog-js'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconCode, IconCopy, IconImage, IconList, IconTerminal } from '@posthog/icons'
+import { IconCode, IconCopy, IconList, IconTerminal } from '@posthog/icons'
 
 import { EmojiPickerPopover } from 'lib/components/EmojiPicker/EmojiPickerPopover'
 import { useRichContentEditor } from 'lib/components/RichContentEditor'
@@ -132,6 +132,28 @@ function IconOrderedList(): JSX.Element {
     )
 }
 
+// Paperclip icon (not in @posthog/icons)
+function IconPaperclip({ className }: { className?: string }): JSX.Element {
+    return (
+        <svg
+            className={className}
+            width="1em"
+            height="1em"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M20 11.5 12 19.5a5 5 0 0 1-7-7l8-8a3.5 3.5 0 0 1 5 5l-8 8a2 2 0 0 1-3-3l7-7"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    )
+}
+
 // Underline icon (not in @posthog/icons)
 function IconUnderline(): JSX.Element {
     return (
@@ -169,6 +191,9 @@ const DEFAULT_INITIAL_CONTENT: JSONContent = {
         },
     ],
 }
+
+/** Keep in sync with the content types the media upload API accepts for the `file` field */
+const ATTACHMENT_ACCEPT = 'image/*,.pdf,.txt,.csv,.doc,.docx,.xls,.xlsx,.ppt,.pptx'
 
 const ImageExtension = Image.configure({
     HTMLAttributes: {
@@ -528,15 +553,38 @@ export function SupportEditor({
     const dropRef = useRef<HTMLDivElement>(null)
 
     const { setFilesToUpload, filesToUpload, uploading } = useUploadFiles({
-        onUpload: (url, fileName) => {
+        allowDocuments: true,
+        onUpload: (url, fileName, _uploadedMediaId, contentType) => {
             if (ttEditor) {
-                ttEditor.chain().focus().setImage({ src: url, alt: fileName }).run()
+                if (contentType?.startsWith('image/')) {
+                    ttEditor.chain().focus().setImage({ src: url, alt: fileName }).run()
+                } else {
+                    // Documents can't render inline, so they go in as a download link —
+                    // the same shape inbound channel attachments use
+                    ttEditor
+                        .chain()
+                        .focus()
+                        .insertContent([
+                            {
+                                type: 'paragraph',
+                                content: [
+                                    {
+                                        type: 'text',
+                                        text: fileName,
+                                        marks: [{ type: 'link', attrs: { href: url } }],
+                                    },
+                                ],
+                            },
+                            { type: 'paragraph' },
+                        ])
+                        .run()
+                }
             }
-            posthog.capture('rich text image uploaded', { name: fileName })
+            posthog.capture('rich text attachment uploaded', { name: fileName, content_type: contentType })
         },
         onError: (detail) => {
-            posthog.capture('rich text image upload failed', { error: detail })
-            lemonToast.error(`Error uploading image: ${detail}`)
+            posthog.capture('rich text attachment upload failed', { error: detail })
+            lemonToast.error(`Error uploading attachment: ${detail}`)
         },
     })
 
@@ -578,12 +626,12 @@ export function SupportEditor({
             if (!objectStorageAvailable || !e.clipboardData) {
                 return
             }
-            const imageItem = Array.from(e.clipboardData.items).find((item) => item.type.startsWith('image/'))
-            if (imageItem) {
-                const imageFile = imageItem.getAsFile()
-                if (imageFile) {
+            const fileItem = Array.from(e.clipboardData.items).find((item) => item.kind === 'file')
+            if (fileItem) {
+                const file = fileItem.getAsFile()
+                if (file) {
                     e.preventDefault()
-                    setFilesToUpload([imageFile])
+                    setFilesToUpload([file])
                 }
             }
         },
@@ -738,7 +786,7 @@ export function SupportEditor({
                     <div className="w-px h-4 bg-border mx-1" />
                     <LemonFileInput
                         key="file-upload"
-                        accept={'image/*'}
+                        accept={ATTACHMENT_ACCEPT}
                         multiple={false}
                         alternativeDropTargetRef={dropRef}
                         onChange={setFilesToUpload}
@@ -752,15 +800,19 @@ export function SupportEditor({
                                     uploading ? (
                                         <Spinner className="text-lg" textColored={true} />
                                     ) : (
-                                        <IconImage className="text-lg" />
+                                        <IconPaperclip className="text-lg" />
                                     )
                                 }
                                 disabledReason={
                                     objectStorageAvailable
                                         ? undefined
-                                        : 'Enable object storage to add images by dragging and dropping'
+                                        : 'Enable object storage to attach images and files'
                                 }
-                                tooltip={objectStorageAvailable ? 'Click here or drag and drop to upload images' : null}
+                                tooltip={
+                                    objectStorageAvailable
+                                        ? 'Click here or drag and drop to attach an image, PDF or document'
+                                        : null
+                                }
                             />
                         }
                     />

--- a/products/conversations/frontend/components/Editor/SupportEditor.tsx
+++ b/products/conversations/frontend/components/Editor/SupportEditor.tsx
@@ -621,6 +621,24 @@ export function SupportEditor({
         setIsDragging(false)
     }
 
+    const attachDisabledReason = !objectStorageAvailable
+        ? 'Enable object storage to attach images and files'
+        : uploading
+          ? 'Wait for the current upload to finish'
+          : undefined
+
+    // One upload at a time: a second file set while one is in flight replaces it and never uploads
+    const attachFiles = useCallback(
+        (files: File[]): void => {
+            if (uploading) {
+                lemonToast.error('Wait for the current upload to finish before attaching another file')
+                return
+            }
+            setFilesToUpload(files)
+        },
+        [uploading, setFilesToUpload]
+    )
+
     const handlePaste = useCallback(
         (e: ClipboardEvent): void => {
             if (!objectStorageAvailable || !e.clipboardData) {
@@ -631,11 +649,11 @@ export function SupportEditor({
                 const file = fileItem.getAsFile()
                 if (file) {
                     e.preventDefault()
-                    setFilesToUpload([file])
+                    attachFiles([file])
                 }
             }
         },
-        [objectStorageAvailable, setFilesToUpload]
+        [objectStorageAvailable, attachFiles]
     )
 
     useEffect(() => {
@@ -789,10 +807,11 @@ export function SupportEditor({
                         accept={ATTACHMENT_ACCEPT}
                         multiple={false}
                         alternativeDropTargetRef={dropRef}
-                        onChange={setFilesToUpload}
+                        onChange={attachFiles}
                         loading={uploading}
                         value={filesToUpload}
                         showUploadedFiles={false}
+                        disabledReason={attachDisabledReason}
                         callToAction={
                             <LemonButton
                                 size="small"
@@ -803,15 +822,11 @@ export function SupportEditor({
                                         <IconPaperclip className="text-lg" />
                                     )
                                 }
-                                disabledReason={
-                                    objectStorageAvailable
-                                        ? undefined
-                                        : 'Enable object storage to attach images and files'
-                                }
+                                disabledReason={attachDisabledReason}
                                 tooltip={
-                                    objectStorageAvailable
-                                        ? 'Click here or drag and drop to attach an image, PDF or document'
-                                        : null
+                                    attachDisabledReason
+                                        ? null
+                                        : 'Click here or drag and drop to attach an image, PDF or document'
                                 }
                             />
                         }


### PR DESCRIPTION
## Problem

The support composer only accepted images, so there was no way to send a customer a PDF or other document from a ticket. Some workflows produce a PDF for the customer (for example a certificate generated by a completed request), and today that has to go out through some other channel.

Refs #64659 (that issue covers the customer/widget side, which this PR does not touch).

## Changes

Reuses the existing `uploaded_media` storage rather than standing up a second pool of attachments.

- The media upload API keeps the long-standing `image` field image-only, and gains a `file` field that also accepts a small allowlist of document types (PDF, plain text, CSV, Office formats) up to 10MB. Images keep their 4MB limit and PIL validation.
- Documents are never served inline. The download endpoint already serves anything outside the inline-safe image allowlist as `application/octet-stream` with an attachment disposition, so a PDF comes back as a named download and can't execute in the app origin.
- In the support composer, a non-image upload is inserted as a download link instead of an image node. That's the same shape inbound Slack, Teams and email attachments already use, so it flows through the existing serializers with no changes: an anchor in the email HTML, a link element in Slack, and a markdown link in the plain-text body the widget renders.
- The attach button now accepts images and documents, and paste picks up any file rather than images only.

> [!NOTE]
> The customer-facing widget still can't upload anything. This is the agent side only.

## How did you test this code?

I (actually Claude, driven by a request in Slack) could not run the Django tests here, since this environment has no Postgres or object storage. Frontend checks I did run: `oxlint`, `oxfmt --check`, `tsgo --noEmit` (no errors in the changed files, the remaining errors are a pre-existing unbuilt quill workspace in this sandbox), and the conversations editor jest suite, which passes.

Automated tests added:

- `posthog/api/test/test_uploaded_media.py`: a PDF uploaded via `file` is stored and served back as a named `application/octet-stream` attachment; a PDF sent via `image` is still rejected 415 (guards against widening the image field, which dashboards embed); content types outside the document allowlist are rejected 415 (this endpoint serves publicly by UUID, so the allowlist is the boundary that matters); a document over 10MB is rejected, which is the only guard on the new limit.
- `SupportEditor.test.ts`: one parameterized case asserting an attachment link survives markdown serialization. The widget renders only the plain-text field, so a regression there would make attachments silently invisible to widget customers — the existing cases cover lists and images but no links.

Manual verification of the end-to-end send (upload a PDF, reply, check the email and Slack rendering) has not been done and is worth a pass before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude via the PostHog Slack app. Skills invoked: `/writing-tests`.

The main decision was where attachments should live. Building a separate attachment table and storage path was rejected in favor of `UploadedMedia`, which already has team scoping, object storage, and a hardened download endpoint that forces non-image content to download rather than render. The second decision was representation: rather than adding a new tiptap node type for attachments, a non-image upload becomes a link-marked paragraph, which is exactly what `build_content_with_images` already produces for inbound channel attachments. That keeps every outbound serializer (email HTML, Slack blocks, markdown) working untouched.

Size limit is 10MB for documents, chosen to sit under the 20MB ceiling inbound channel attachments already use while staying well clear of request size limits.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1785779362885849?thread_ts=1785779362.885849&cid=C08S2L0S5MZ)*
