### PR TITLE
fix(onboarding): add Google account picker and improve Log out button contrast (Fixes #76217)

### DIFF
--- a/products/desktop/packages/core/src/oauth/oauth.ts
+++ b/products/desktop/packages/core/src/oauth/oauth.ts
@@ -442,6 +442,7 @@ export class OAuthService {
     authUrl.searchParams.set("code_challenge_method", "S256");
     authUrl.searchParams.set("scope", OAUTH_SCOPES.join(" "));
     authUrl.searchParams.set("required_access_level", "project");
+    authUrl.searchParams.set("prompt", "select_account");
     return authUrl;
   }
 

--- a/products/desktop/packages/ui/src/features/auth/components/InviteCodeScreen.tsx
+++ b/products/desktop/packages/ui/src/features/auth/components/InviteCodeScreen.tsx
@@ -34,7 +34,6 @@ export function InviteCodeScreen() {
       variant="ghost"
       color="gray"
       onClick={() => logoutMutation.mutate()}
-      className="opacity-50"
     >
       <SignOut size={14} />
       Log out


### PR DESCRIPTION
## Summary

Fixes #76217 — Onboarding: can't switch Google account (no account picker + nearly invisible Log out).

## Changes

### 1. Show Google account chooser on every sign-in

Added `prompt=select_account` to the OAuth authorize URL in `oauth.ts`. This forces Google to show the account picker every time, letting users choose the right account instead of silently reusing whatever session is active in the browser.

**File:** `products/desktop/packages/core/src/oauth/oauth.ts` — `buildAuthorizeUrl()`

### 2. Improve Log out button visibility

Removed `opacity-50` from the Log out button on the `InviteCodeScreen`. The button was low-contrast grey-on-dark and hard to discover. Without the 50% opacity it now uses the default `ghost` / `gray` Radix button style, which is still subtle but readable.

**File:** `products/desktop/packages/ui/src/features/auth/components/InviteCodeScreen.tsx`

## Notes

- `prompt=select_account` is the primary fix — it lets users pick the correct account on sign-in, often eliminating the need to log out and retry.
- The Log out button contrast fix is a secondary improvement for the edge case where the user is already signed in with the wrong account and needs to switch.