### PR TITLE
feat(tasks): auto-resume cold orchestrator parents

### DIFF
--- a/products/tasks/backend/facade/tasks.py
+++ b/products/tasks/backend/facade/tasks.py
@@ -17,6 +17,16 @@ __all__ = ["reconcile_loop_trigger_schedules_task", "sweep_loop_task_retention_t
 logger = logging.getLogger(__name__)
 
 
+@shared_task(ignore_result=True, bind=True, max_retries=2)
+def resume_parent_with_pending_wakes_task(self, parent_run_id: str) -> None:
+    from products.tasks.backend.logic.services.orchestration import resume_parent_with_pending_wakes
+
+    try:
+        resume_parent_with_pending_wakes(parent_run_id)
+    except Exception as error:
+        raise self.retry(exc=error, countdown=10 * (self.request.retries + 1))
+
+
 @shared_task(ignore_result=True)
 def notify_parent_of_child_event_task(child_run_id: str, event: str) -> None:
     from products.tasks.backend.logic.services.orchestration import (  # noqa: PLC0415 — keeps Temporal off the Celery import path

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from django.db import transaction
 
@@ -78,7 +78,7 @@ def _claim_resume(run_id: str) -> tuple[TaskRun | None, list[dict[str, Any]], in
         if attempts >= MAX_ORCHESTRATION_RESUME_ATTEMPTS:
             return None, [], attempts
         queued = state.get(PENDING_ORCHESTRATION_WAKES_STATE_KEY)
-        wakes = list(queued) if isinstance(queued, list) else []
+        wakes = cast(list[dict[str, Any]], list(queued)) if isinstance(queued, list) else []
         if not wakes:
             return None, [], attempts
         state[ORCHESTRATION_RESUME_STATE_KEY] = {"in_flight": True, "attempts": attempts + 1}

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -1,8 +1,18 @@
 import logging
 from typing import Any, Literal
 
+from django.db import transaction
+
 from temporalio.service import RPCError, RPCStatusCode
 
+from products.notifications.backend.facade.api import (
+    NotificationData,
+    NotificationType,
+    Priority,
+    TargetType,
+    create_notification,
+)
+from products.tasks.backend.facade.api import resume_task_run_in_cloud
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.client import signal_task_followup_message
 from products.tasks.backend.temporal.constants import CHILD_EVENT_MESSAGE_TEMPLATE
@@ -12,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 ChildEvent = Literal["terminal", "pr_merged"]
 PENDING_ORCHESTRATION_WAKES_STATE_KEY = "pending_orchestration_wakes"
+ORCHESTRATION_RESUME_STATE_KEY = "orchestration_resume"
+MAX_ORCHESTRATION_RESUME_ATTEMPTS = 3
 
 _NON_TERMINAL_STATUSES = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS)
 
@@ -54,6 +66,113 @@ def _queue_wake(parent_run: TaskRun, child_run: TaskRun, event: ChildEvent, mess
     TaskRun.mutate_state_atomic(parent_run.id, append_wake)
 
 
+def _claim_resume(run_id: str) -> tuple[TaskRun | None, list[dict[str, Any]], int]:
+    with transaction.atomic():
+        run = TaskRun.objects.select_for_update().select_related("task", "task__created_by").get(id=run_id)
+        state = dict(run.state or {})
+        resume = state.get(ORCHESTRATION_RESUME_STATE_KEY)
+        resume = dict(resume) if isinstance(resume, dict) else {}
+        if resume.get("in_flight"):
+            return None, [], int(resume.get("attempts", 0))
+        attempts = int(resume.get("attempts", 0))
+        if attempts >= MAX_ORCHESTRATION_RESUME_ATTEMPTS:
+            return None, [], attempts
+        queued = state.get(PENDING_ORCHESTRATION_WAKES_STATE_KEY)
+        wakes = list(queued) if isinstance(queued, list) else []
+        if not wakes:
+            return None, [], attempts
+        state[ORCHESTRATION_RESUME_STATE_KEY] = {"in_flight": True, "attempts": attempts + 1}
+        run.state = state
+        run.save(update_fields=["state", "updated_at"])
+        return run, wakes, attempts + 1
+
+
+def _release_resume(run_id: str, *, delivered: list[dict[str, Any]], success: bool) -> bool:
+    has_pending = False
+
+    def update(state: dict[str, Any]) -> None:
+        nonlocal has_pending
+        resume = state.get(ORCHESTRATION_RESUME_STATE_KEY)
+        resume = dict(resume) if isinstance(resume, dict) else {}
+        resume["in_flight"] = False
+        if success:
+            resume["attempts"] = 0
+            queued = state.get(PENDING_ORCHESTRATION_WAKES_STATE_KEY)
+            queue = list(queued) if isinstance(queued, list) else []
+            remaining = list(queue)
+            for entry in delivered:
+                if entry in remaining:
+                    remaining.remove(entry)
+            if remaining:
+                state[PENDING_ORCHESTRATION_WAKES_STATE_KEY] = remaining
+                has_pending = True
+            else:
+                state.pop(PENDING_ORCHESTRATION_WAKES_STATE_KEY, None)
+        state[ORCHESTRATION_RESUME_STATE_KEY] = resume
+
+    TaskRun.mutate_state_atomic(run_id, update)
+    return has_pending
+
+
+def _notify_resume_exhausted(run: TaskRun) -> None:
+    if run.task.created_by_id is None:
+        return
+    create_notification(
+        NotificationData(
+            team_id=run.team_id,
+            notification_type=NotificationType.PIPELINE_FAILURE,
+            priority=Priority.CRITICAL,
+            title=f'Could not resume task "{run.task.title}"'[:100],
+            body="Automatic resume failed repeatedly. Open the task to retry and review pending child updates.",
+            target_type=TargetType.USER,
+            target_id=str(run.task.created_by_id),
+            resource_type="task",
+            resource_id=str(run.task_id),
+        )
+    )
+
+
+def resume_parent_with_pending_wakes(run_id: str) -> bool:
+    run, wakes, attempt = _claim_resume(run_id)
+    if run is None:
+        if attempt >= MAX_ORCHESTRATION_RESUME_ATTEMPTS:
+            exhausted_run = TaskRun.objects.select_related("task", "task__created_by").get(id=run_id)
+            _notify_resume_exhausted(exhausted_run)
+        return False
+
+    message = "\n\n".join(str(entry.get("message", "")) for entry in wakes if entry.get("message"))
+    try:
+        outcome, _, _ = resume_task_run_in_cloud(run.id, run.task_id, run.team_id, run.task.created_by_id)
+        if outcome not in {"resumed", "already_active"}:
+            raise RuntimeError(f"Cold parent resume failed: {outcome}")
+        signal_task_followup_message(run.workflow_id, message, [], source=FOLLOWUP_SOURCE_CHILD)
+    except Exception:
+        _release_resume(str(run.id), delivered=[], success=False)
+        if attempt >= MAX_ORCHESTRATION_RESUME_ATTEMPTS:
+            _notify_resume_exhausted(run)
+        raise
+
+    has_pending = _release_resume(str(run.id), delivered=wakes, success=True)
+    sources = {entry.get("event") for entry in wakes}
+    run.capture_event(
+        "parent_woken",
+        {
+            "source": next(iter(sources)) if len(sources) == 1 else "multiple",
+            "cold": True,
+            "queued_count": len(wakes),
+        },
+    )
+    if has_pending:
+        _schedule_cold_resume(str(run.id))
+    return True
+
+
+def _schedule_cold_resume(run_id: str) -> None:
+    from products.tasks.backend.facade.tasks import resume_parent_with_pending_wakes_task
+
+    resume_parent_with_pending_wakes_task.delay(run_id)
+
+
 def notify_parent_of_child_event(child_run: TaskRun | str, event: ChildEvent) -> None:
     if isinstance(child_run, str):
         resolved_child_run = TaskRun.objects.select_related("task").filter(id=child_run).first()
@@ -89,15 +208,18 @@ def notify_parent_of_child_event(child_run: TaskRun | str, event: ChildEvent) ->
         except RPCError as error:
             if error.status == RPCStatusCode.NOT_FOUND:
                 _queue_wake(delivery_run, child_run, event, message)
+                _schedule_cold_resume(str(delivery_run.id))
                 return
             logger.exception(
                 "orchestration_child_wake_signal_failed",
                 extra={"child_run_id": str(child_run.id), "parent_run_id": str(live_run.id), "event": event},
             )
             raise
+        live_run.capture_event("parent_woken", {"source": event, "cold": False, "queued_count": 0})
         return
 
     _queue_wake(delivery_run, child_run, event, message)
+    _schedule_cold_resume(str(delivery_run.id))
 
 
 def send_child_message_to_parent(child_run: TaskRun, message: str) -> None:

--- a/products/tasks/backend/logic/services/tests/test_orchestration.py
+++ b/products/tasks/backend/logic/services/tests/test_orchestration.py
@@ -8,8 +8,11 @@ from temporalio.service import RPCError, RPCStatusCode
 from posthog.models import Organization, Team
 
 from products.tasks.backend.logic.services.orchestration import (
+    MAX_ORCHESTRATION_RESUME_ATTEMPTS,
+    ORCHESTRATION_RESUME_STATE_KEY,
     PENDING_ORCHESTRATION_WAKES_STATE_KEY,
     notify_parent_of_child_event,
+    resume_parent_with_pending_wakes,
 )
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.execute_sandbox.workflow import FOLLOWUP_SOURCE_CHILD
@@ -78,7 +81,8 @@ class TestNotifyParentOfChildEvent(TestCase):
         "products.tasks.backend.logic.services.orchestration.signal_task_followup_message",
         side_effect=RPCError("workflow gone", RPCStatusCode.NOT_FOUND, b""),
     )
-    def test_queues_wake_when_parent_workflow_is_cold(self, mock_signal) -> None:
+    @patch("products.tasks.backend.logic.services.orchestration._schedule_cold_resume")
+    def test_queues_wake_when_parent_workflow_is_cold(self, mock_schedule, mock_signal) -> None:
         parent_run, child_run = self._runs(TaskRun.Status.COMPLETED)
 
         notify_parent_of_child_event(child_run, "terminal")
@@ -89,6 +93,7 @@ class TestNotifyParentOfChildEvent(TestCase):
         self.assertEqual(queued[0]["child_run_id"], str(child_run.id))
         self.assertEqual(queued[0]["source"], FOLLOWUP_SOURCE_CHILD)
         mock_signal.assert_called_once()
+        mock_schedule.assert_called_once_with(str(parent_run.id))
 
     @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
     def test_run_without_parent_state_is_ignored(self, mock_signal) -> None:
@@ -100,3 +105,80 @@ class TestNotifyParentOfChildEvent(TestCase):
         notify_parent_of_child_event(child_run, "terminal")
 
         mock_signal.assert_not_called()
+
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    @patch("products.tasks.backend.logic.services.orchestration.resume_task_run_in_cloud")
+    def test_cold_resume_drains_a_burst_once(self, mock_resume, mock_signal) -> None:
+        parent_run, child_run = self._runs(TaskRun.Status.COMPLETED)
+        second_child = self._task("Second child").create_run(
+            mode="background",
+            extra_state={"parent_task_id": str(parent_run.task_id), "parent_run_id": str(parent_run.id)},
+        )
+        second_child.status = TaskRun.Status.COMPLETED
+        second_child.save(update_fields=["status"])
+        with patch("products.tasks.backend.logic.services.orchestration._schedule_cold_resume"):
+            parent_run.status = TaskRun.Status.COMPLETED
+            parent_run.save(update_fields=["status"])
+            notify_parent_of_child_event(child_run, "terminal")
+            notify_parent_of_child_event(second_child, "terminal")
+        mock_resume.return_value = ("resumed", None, None)
+
+        self.assertTrue(resume_parent_with_pending_wakes(str(parent_run.id)))
+
+        mock_resume.assert_called_once()
+        self.assertIn("Child task", mock_signal.call_args.args[1])
+        self.assertIn("Second child", mock_signal.call_args.args[1])
+        parent_run.refresh_from_db()
+        self.assertNotIn(PENDING_ORCHESTRATION_WAKES_STATE_KEY, parent_run.state)
+
+    @patch("products.tasks.backend.logic.services.orchestration._schedule_cold_resume")
+    @patch("products.tasks.backend.logic.services.orchestration.signal_task_followup_message")
+    @patch("products.tasks.backend.logic.services.orchestration.resume_task_run_in_cloud")
+    def test_wake_arriving_during_resume_is_scheduled_for_delivery(
+        self, mock_resume, mock_signal, mock_schedule
+    ) -> None:
+        parent_run, child_run = self._runs(TaskRun.Status.COMPLETED)
+        parent_run.status = TaskRun.Status.COMPLETED
+        parent_run.save(update_fields=["status"])
+        with patch("products.tasks.backend.logic.services.orchestration._schedule_cold_resume"):
+            notify_parent_of_child_event(child_run, "terminal")
+
+        def enqueue_during_resume(*args):
+            TaskRun.mutate_state_atomic(
+                parent_run.id,
+                lambda state: state[PENDING_ORCHESTRATION_WAKES_STATE_KEY].append(
+                    {"message": "late wake", "event": "terminal", "child_run_id": "late"}
+                ),
+            )
+            return "resumed", None, None
+
+        mock_resume.side_effect = enqueue_during_resume
+        self.assertTrue(resume_parent_with_pending_wakes(str(parent_run.id)))
+
+        parent_run.refresh_from_db()
+        self.assertEqual(parent_run.state[PENDING_ORCHESTRATION_WAKES_STATE_KEY][0]["message"], "late wake")
+        self.assertFalse(parent_run.state[ORCHESTRATION_RESUME_STATE_KEY]["in_flight"])
+        mock_signal.assert_called_once()
+        mock_schedule.assert_called_once_with(str(parent_run.id))
+
+    @patch("products.tasks.backend.logic.services.orchestration._notify_resume_exhausted")
+    @patch(
+        "products.tasks.backend.logic.services.orchestration.resume_task_run_in_cloud",
+        return_value=("workflow_failed", None, None),
+    )
+    def test_resume_failure_caps_and_notifies(self, mock_resume, mock_notify) -> None:
+        parent_run, child_run = self._runs(TaskRun.Status.COMPLETED)
+        parent_run.status = TaskRun.Status.COMPLETED
+        parent_run.save(update_fields=["status"])
+        with patch("products.tasks.backend.logic.services.orchestration._schedule_cold_resume"):
+            notify_parent_of_child_event(child_run, "terminal")
+
+        for _ in range(MAX_ORCHESTRATION_RESUME_ATTEMPTS):
+            with self.assertRaises(RuntimeError):
+                resume_parent_with_pending_wakes(str(parent_run.id))
+
+        self.assertFalse(resume_parent_with_pending_wakes(str(parent_run.id)))
+        self.assertEqual(mock_resume.call_count, MAX_ORCHESTRATION_RESUME_ATTEMPTS)
+        mock_notify.assert_called()
+        parent_run.refresh_from_db()
+        self.assertEqual(len(parent_run.state[PENDING_ORCHESTRATION_WAKES_STATE_KEY]), 1)

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -96,8 +96,8 @@ Additional properties:
 
 Tracked when a cold orchestrator parent is resumed and its queued child wakes are delivered.
 
-| Property       | Type   | Description                                      |
-| -------------- | ------ | ------------------------------------------------ |
+| Property       | Type   | Description                                       |
+| -------------- | ------ | ------------------------------------------------- |
 | `source`       | `str`  | `terminal`, `pr_merged`, or `multiple`            |
 | `cold`         | `bool` | Whether delivery required an automatic resume     |
 | `queued_count` | `int`  | Number of queued wake messages delivered together |

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -92,6 +92,16 @@ Additional properties:
 | `error_message`    | `str`   | Error message (truncated to the **last** 500 chars — the root cause sits at the tail)                                                                                                                          |
 | `duration_seconds` | `float` | Time from creation to failure                                                                                                                                                                                  |
 
+### `parent_woken`
+
+Tracked when a cold orchestrator parent is resumed and its queued child wakes are delivered.
+
+| Property       | Type   | Description                                      |
+| -------------- | ------ | ------------------------------------------------ |
+| `source`       | `str`  | `terminal`, `pr_merged`, or `multiple`            |
+| `cold`         | `bool` | Whether delivery required an automatic resume     |
+| `queued_count` | `int`  | Number of queued wake messages delivered together |
+
 ## Loop Fire Metrics
 
 Source: `products/tasks/backend/metrics.py`, emitted from `products/tasks/backend/logic/services/loop_runs.py::fire_loop`.


### PR DESCRIPTION
## Problem

Orchestrated child tasks can finish while their parent workflow is no longer running. Their wake messages are durable, but the parent currently remains cold until a person resumes it.

**Why:** Parent tasks need to continue automatically after child completion without losing concurrent child updates or starting duplicate workflows.

## Changes

- Claims cold-parent resume work atomically and resumes the same run so its transcript and workflow identity remain stable.
- Drains queued wakes as a combined follow-up, preserves arrivals during resume, and caps failed attempts before notifying the task creator.
- Captures `parent_woken` analytics and documents its properties.

The same-run resume path was chosen over a continuation run because it rehydrates from the existing run log and keeps future wake routing on the established workflow ID.

## How did you test this code?

- `uv run ruff check products/tasks/backend/logic/services/orchestration.py products/tasks/backend/logic/services/tests/test_orchestration.py products/tasks/backend/facade/tasks.py`
- `uv run ruff format --check products/tasks/backend/logic/services/orchestration.py products/tasks/backend/logic/services/tests/test_orchestration.py products/tasks/backend/facade/tasks.py`
- `uv run mypy products/tasks/backend/logic/services/orchestration.py products/tasks/backend/facade/tasks.py`
- Added regression coverage for burst single-flight resume, mid-resume wake preservation, and bounded failure notification. The focused pytest suite could not initialize because PostgreSQL was unavailable in the local environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `products/tasks/docs/INSTRUMENTATION.md` for `parent_woken`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested third step on top of the two prerequisite PR branches. The `/i-have-adhd` output-shaping skill was invoked for the session. The implementation deliberately uses the existing same-run cloud handoff rather than creating a continuation run.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*