### PR TITLE
feat(replay-vision): capture gemini reasoning and group scan traces in llma

### DIFF
--- a/products/ai_observability/frontend/messageNormalization.test.ts
+++ b/products/ai_observability/frontend/messageNormalization.test.ts
@@ -48,6 +48,44 @@ describe('messageNormalization', () => {
         })
     })
 
+    describe('thinking blocks alongside typed function blocks', () => {
+        // The Gemini SDK emits a thought summary block next to a tool call. The thinking
+        // block knocks the message off compat_array's envelope rule, so the function block
+        // must survive per-block delegation as a typed tool call, not stringified JSON.
+        it('renders the thought as thinking and keeps the sibling tool call typed', () => {
+            const { messages, recognized } = normalizeMessages(
+                [
+                    {
+                        role: 'assistant',
+                        content: [
+                            { type: 'thinking', thinking: 'Two rapid clicks, check the events.' },
+                            {
+                                type: 'function',
+                                function: { name: 'get_events_around', arguments: { rec_t: 320 } },
+                            },
+                        ],
+                    },
+                ],
+                'assistant'
+            )
+            expect(recognized).toBe(true)
+            expect(messages).toEqual([
+                { role: 'assistant (thinking)', content: 'Two rapid clicks, check the events.' },
+                {
+                    role: 'assistant',
+                    content: '',
+                    tool_calls: [
+                        {
+                            type: 'function',
+                            id: undefined,
+                            function: { name: 'get_events_around', arguments: { rec_t: 320 } },
+                        },
+                    ],
+                },
+            ])
+        })
+    })
+
     describe('offloaded media', () => {
         const HASH = 'a'.repeat(64)
         const POINTER = `phaiblob://v1/sha256/${HASH}?mime=image%2Fpng&size=332378`

--- a/products/ai_observability/frontend/normalizer/recipe/default_recipes/compat_array.yaml
+++ b/products/ai_observability/frontend/normalizer/recipe/default_recipes/compat_array.yaml
@@ -36,3 +36,19 @@ rules:
                       id: $.id
                       name: $.function.name
                       args: $.function.arguments
+
+    # A bare `{type: function}` block — reached when a sibling block outside the
+    # allowlist above (e.g. a `thinking` block from a Gemini thought summary)
+    # knocks the whole message off the envelope rule and per-block delegation
+    # dispatches each block on its own. Without this no rule claims the block and
+    # salvage stringifies the tool call into raw JSON.
+    - on:
+          type: function
+          function:
+              name: { exists: true }
+      emit:
+          content: ''
+          toolCall:
+              id: $.id
+              name: $.function.name
+              args: $.function.arguments

--- a/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
+++ b/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
@@ -14,7 +14,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, TypeVar
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from django.utils import timezone
 
@@ -144,10 +144,20 @@ async def _call_scanner_provider(inputs: CallScannerProviderInputs) -> ScannerCa
         preamble_text=preamble_text,
         team_id=inputs.team_id,
         llm_inputs=llm_inputs,
+        trace_id=_scan_trace_id(inputs),
     )
     duration_ms = int(llm_inputs.metadata.duration_seconds * 1000)
     finalized = _resolve_citations(finalized, scanner, duration_ms)
     return ScannerCallOutput(model_output=finalized, signals=signals)
+
+
+def _scan_trace_id(inputs: CallScannerProviderInputs) -> str:
+    """LLM analytics trace id for one scan: the observation id, so every step, tool round-trip, and retry of
+    a scan reads as a single conversation and the observation id doubles as the trace search key. Evaluation
+    re-runs (snapshot_override) get a fresh id so they don't interleave with the real scan's trace."""
+    if inputs.snapshot_override is not None:
+        return str(uuid4())
+    return str(inputs.observation_id)
 
 
 def _resolve_citations(
@@ -297,6 +307,7 @@ async def _run_mission(
     preamble_text: str,
     team_id: int,
     llm_inputs: ScannerLlmInputs,
+    trace_id: str,
 ) -> tuple[BaseScannerOutput, list[SignalFinding]]:
     """Cache the video, run every mission step as a tool-using turn, then assemble the output + side-mission findings.
 
@@ -337,6 +348,7 @@ async def _run_mission(
         dispatch=dispatch,
         team_id=team_id,
         metric_labels=metric_labels,
+        trace_id=trace_id,
     )
     try:
         step_outputs = await _run_mission_attempts(run=run, cache=cache, model=snapshot.model)
@@ -405,6 +417,7 @@ async def _run_steps(
     dispatch: Any,
     team_id: int,
     metric_labels: dict[str, str],
+    trace_id: str,
 ) -> dict[str, BaseModel]:
     """Run the ordered steps over one growing conversation; return the validated output keyed by step name."""
     # The video + preamble lead the conversation inline unless they're already cached as the prefix.
@@ -422,6 +435,7 @@ async def _run_steps(
             dispatch=dispatch,
             team_id=team_id,
             metric_labels=metric_labels,
+            trace_id=trace_id,
         )
         if result.output is None:
             # Roll the failed step's half-finished exchange back so the next instruction follows the last good
@@ -459,6 +473,7 @@ async def _run_step(
     dispatch: Any,
     team_id: int,
     metric_labels: dict[str, str],
+    trace_id: str,
 ) -> "_StepResult":
     """Run one step's tool loop with one re-prompt on failure. Returns the validated output, or why it was exhausted.
 
@@ -474,6 +489,8 @@ async def _run_step(
             contents=c,
             config=cfg,
             posthog_distinct_id=replay_vision_distinct_id(team_id),
+            posthog_trace_id=trace_id,
+            posthog_properties={"$ai_span_name": step.name},
             posthog_groups={"project": str(team_id)},
         )
 
@@ -589,6 +606,9 @@ def _step_config(step: MissionStep, cache_name: str | None, *, allow_tools: bool
     kwargs: dict[str, Any] = {
         "response_mime_type": "application/json",
         "response_json_schema": step.response_model.model_json_schema(),
+        # Return thought summaries so the model's reasoning is visible in LLM analytics. Answer parsing is
+        # unaffected (`response.text` skips thought parts); models with thinking off just return none.
+        "thinking_config": types.ThinkingConfig(include_thoughts=True),
     }
     if cache_name:
         kwargs["cached_content"] = cache_name  # video, preamble, and the tool all live in the cache

--- a/products/replay_vision/backend/tests/test_call_scanner_provider.py
+++ b/products/replay_vision/backend/tests/test_call_scanner_provider.py
@@ -75,6 +75,7 @@ async def _run(client: _FakeClient, steps: list[MissionStep], dispatch: Any = la
         dispatch=dispatch,
         team_id=1,
         metric_labels=_LABELS,
+        trace_id="trace-1",
     )
 
 
@@ -328,6 +329,7 @@ class TestStepConfig:
         assert config.tools is not None
         assert config.cached_content is None
         assert config.response_json_schema is not None
+        assert config.thinking_config is not None and config.thinking_config.include_thoughts is True
 
     def test_cached_path_references_the_cache_and_omits_tools(self) -> None:
         config = _step_config(MissionStep(name="core", instruction="c", response_model=_Core), cache_name="caches/abc")


### PR DESCRIPTION
## Problem

Replay Vision's scanner runs are instrumented with LLM analytics, but two things keep the traces from being useful for debugging scans:

- **No reasoning visible.** The Gemini calls never set `thinking_config`, so the model's thought summaries are never returned or captured — you can see reasoning *token counts* on generations, but not what the model was actually thinking.
- **Fragmented traces.** No `posthog_trace_id` is passed, so the SDK generates a fresh trace id per `generate_content` call. A scan is a multi-step, tool-using conversation (preamble → mission steps → tool round-trips → validation retries), and in LLM analytics today nearly every generation lands as its own single-event trace — you can't read a scan as one conversation, and there's no way to find the trace for a given observation.

## Changes

- `_step_config` now sets `thinking_config=ThinkingConfig(include_thoughts=True)`, so thought summaries land in the captured generation output. Answer parsing is unaffected: `response.text` skips thought parts, and carrying them forward in the conversation is the already-recommended pattern (the code already preserves thought signatures).
- Every `generate_content` call in a scan now shares one `posthog_trace_id` — the observation id — so all steps, tool round-trips, and retries of a scan read as a single trace, and the observation id doubles as the trace search key. Evaluation re-runs (`snapshot_override`) get a fresh uuid so they don't interleave with the real scan's trace.
- Each generation is named after its mission step via `$ai_span_name`, so the trace tree reads as the mission plan.
- AI observability normalizer: a bare `{type: function}` block gets a rule in `compat_array`, so a thinking block sitting next to a Gemini-style tool-call block no longer knocks the tool call into stringified-JSON salvage. Needed because a thinking block takes the message off `compat_array`'s envelope allowlist onto per-block delegation, where nothing claimed the function block.

Companion SDK PR that types Gemini thought summaries as `thinking` blocks (so the UI renders them as reasoning rather than plain text): [PostHog/posthog-python#827](https://github.com/PostHog/posthog-python/pull/827)

## How did you test this code?

- `pytest products/replay_vision/backend/tests/test_call_scanner_provider.py` — 23 passed. Extended the existing `_step_config` test to assert the thinking config is present (catches a regression where a config refactor silently drops thought capture).
- AIO frontend: new `messageNormalization` test proving a thinking block + typed function block normalizes into a thinking message plus a typed tool call (fails with stringified JSON without the new rule). Full AIO frontend jest suite: 631 passed across 45 suites.
- `hogli ci:preflight --fix` — clean.
- Verified against the pinned SDKs: `posthoganalytics==7.30.1`'s Gemini wrapper captures thought parts as output content blocks and already maps `thoughts_token_count` to reasoning tokens; `google-genai==1.46.0`'s `response.text` excludes `thought=True` parts, so the JSON parsing path is unchanged.
- Not tested against the live Gemini API from this environment; the flash-lite tier has thinking off by default and simply returns no thought parts.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A — internal instrumentation only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (PostHog Code cloud task). Investigated the existing instrumentation in `call_scanner_provider.py`, the `posthoganalytics` Gemini wrapper, and production LLM analytics data, which confirmed generations ≈ traces (full fragmentation) and that reasoning tokens are reported while reasoning content is absent.
- Considered gating `include_thoughts` per model tier, but all models in `billing.GEMINI_MODELS` support thinking configuration, and thinking-off models return no thoughts rather than erroring, so it's unconditional.
- Trace id is the observation id (rather than a random uuid per activity attempt) so Temporal retries of the same observation land in the same trace and the id is searchable from the observation row.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
