### PR TITLE
fix(subscriptions): make AI report plans use toBool for boolean properties

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/prompts.py
@@ -144,6 +144,11 @@ are common LLM mistakes that HogQL rejects:
 - `properties` (and `person.properties`) is a JSON string column, NOT a Map. Map functions
   (`mapKeys`, `mapValues`, `mapContains`) fail at execution. To enumerate an event's property KEYS
   use `JSONExtractKeys(properties)` — see the property-keys audit pattern below.
+- Wrap a boolean property in `toBool(...)` — `toBool(properties.<name>)`,
+  `toBool(person.properties.<name>)`, keeping whichever namespace the property belongs to — and never
+  compare it to `1` / `'1'` / `'true'`. You are given property names without their types, so a
+  literal comparison bets on one stored encoding; when it bets wrong it matches nothing *without
+  erroring*, and the share built from it reads as a confident 0% instead of a visible failure.
 - Use `arrayFlatten(...)`; `flatten(...)` is not a HogQL function and fails validation.
 - Never nest aggregate functions (e.g. `max(count())`, `sum(uniq(…))`). Compute each aggregate once
   and derive ratios from sibling aggregates in the same SELECT, guarding zero denominators
@@ -369,6 +374,10 @@ rewrite MUST follow the same HogQL syntax constraints used by the planner:
   `mapKeys(properties)` with `JSONExtractKeys(properties)` (expand rows with
   `arrayJoin(JSONExtractKeys(properties))`).
 - `flatten(...)` is not a HogQL function; replace it with `arrayFlatten(...)`.
+- Wrap boolean properties in `toBool(...)` (keeping the property's own namespace, e.g.
+  `toBool(person.properties.<name>)`), never `= 1` / `= '1'` / `= 'true'` — a literal comparison
+  matches only one of the encodings these are stored in, and the mismatch returns zero rows without
+  erroring, silently yielding a 0% share.
 - Never nest aggregate functions (e.g. `max(count())`, `sum(uniq(…))`). Compute each aggregate once
   and derive ratios from sibling aggregates in the same SELECT, guarding zero denominators
   (e.g. `countIf(cond) / nullIf(count(), 0)`).

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -87,7 +87,7 @@ WINDOW_PLACEHOLDERS = (
 )
 # Bumping invalidates every frozen plan (they lazily re-plan on next delivery), so prompt/harness
 # improvements reach existing subscriptions instead of only new ones.
-AI_QUERY_PLAN_VERSION = 3
+AI_QUERY_PLAN_VERSION = 4
 
 
 DEFAULT_PLANNER_MODEL = "gpt-4.1"


### PR DESCRIPTION
## Problem

An AI report told its reader that **0%** of 4M MCP tool calls failed. The real error rate was **3.43%**.

The generated HogQL was:

```sql
countIf(properties.$mcp_is_error = 1)
```

`$mcp_is_error` is a boolean. `= 1` matched **zero rows without erroring**, so the step was recorded `ok=True`, nothing degraded, no diagnostic fired — and the model reported the resulting 0% as fact. A silent wrong answer is worse than a failed query, because the existing `QUERY_FAILED_PREFIX` machinery only catches queries that actually raise.

## Fix

Two things, both small:

**1. Prompt rule** — wrap boolean properties in `toBool(...)`, never compare to `1` / `'1'` / `'true'`. The planner receives property names *without their types* (`spec_generator.py` passes names only), so it cannot know which encoding a property uses; any literal comparison is a bet. Phrased around the property expression so a person property stays `person.properties.<name>`. Added to **both** HogQL constraint blocks — the planner's and the fix-retry rewrite's — so a retry can't reintroduce what the planner just avoided.

**2. `AI_QUERY_PLAN_VERSION` 3 -> 4** — without this the fix reaches **no existing subscription**. A frozen plan replays its stored HogQL verbatim and never consults either prompt, and because the boolean mismatch doesn't error, the fixer never triggers either. Bumping lazily re-plans every frozen subscription on its next delivery, which is exactly what the constant is documented for.

## Reviewer notes

- **The bump re-plans all frozen AI subscriptions org-wide** (one planner LLM call each) on their first delivery after deploy. Intended, but worth weighing deliberately.
- **What is deliberately *not* here:** earlier drafts also had the planner emit a `groupUniqArray(toString(...))` encoding breakdown next to each boolean share, so a wrong number couldn't be reported silently. Successive review passes showed that guidance was subtly wrong in several ways — for a property with a Boolean `PropertyDefinition`, `PropertySwapper` rewrites values as `transform(toString(value), ['true','false'], [1,0], NULL)`, so mixed encodings are coerced to NULL and *omitted* from the aggregate anyway; and the aggregate is unbounded if the planner misidentifies a high-cardinality property as boolean. **Making a report self-verifying needs a post-execution harness check, not a prompt rule.** That's a genuine follow-up; this PR sticks to the part that is unambiguously correct.

## Testing

`pytest products/exports/backend/temporal/subscriptions/ai_subscription/` on a devbox — **187 passed**.

Two caveats, stated plainly:

- The suite also produces setup errors from a polluted `--reuse-db` test database (duplicate `api_token=token123`); these reproduce on unmodified master.
- One integration test (`test_real_hogql_flows_into_synthesis_and_invalid_hogql_degrades`) failed in the full-directory run. I checked it directly: **2 passed on clean master and 2 passed with this patch** when the file runs in isolation, so it's test-order pollution, not this change.
- No test hardcodes the plan version — all references are symbolic — and `test_spec_generator.py` already asserts that a version bump cannot brick a frozen subscription.

**This fix is not provable by unit test**, since it steers an LLM. The real verification is behavioural: `ai_report_diagnostics` persists the generated HogQL per delivery, so post-deploy we can count plans using `toBool` vs a literal comparison and confirm the rule is being followed.

Companion to #76854, which fixes the NULL-rendering half of the same bad report.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*