### PR TITLE
fix(replay): explain why a non-matching recording stays in the list

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/Playlist.tsx
@@ -320,9 +320,9 @@ export function Playlist({
                             <LemonTableLoader loading={sessionRecordingsResponseLoading} />
                         </div>
                         {selectedRecordingOutsideFilters && (
-                            <LemonBanner type="info" className="m-2 text-xs">
-                                The selected recording doesn't match the current filters. It's shown because it was
-                                opened from a direct link.
+                            <LemonBanner type="warning" className="m-2">
+                                The recording you have open doesn't match the current filters. It stays in the list
+                                until you close it.
                             </LemonBanner>
                         )}
                         <div className="overflow-y-auto flex-1 min-h-0" onScroll={handleScroll} ref={contentRef}>

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingPreview.tsx
@@ -13,7 +13,7 @@ import {
     IconLive,
     IconPlusSmall,
 } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag, Spinner } from '@posthog/lemon-ui'
 
 import { PropertyIcon } from 'lib/components/PropertyIcon/PropertyIcon'
 import { TZLabel } from 'lib/components/TZLabel'
@@ -363,8 +363,15 @@ const SessionRecordingPreviewBase = memo(
                     {selectable && <ItemCheckbox recording={recording} />}
                     <div className="grow overflow-hidden flex flex-col gap-y-2 ml-1">
                         <div className="flex items-center justify-between gap-x-0.5">
-                            <div className="flex overflow-hidden font-medium ph-no-capture">
+                            <div className="flex overflow-hidden items-center gap-x-1 font-medium ph-no-capture">
                                 <span className="truncate">{asDisplay(recording.person)}</span>
+                                {recording.matches_filters === false && (
+                                    <Tooltip title="This recording is listed only because it's open. It doesn't match the current filters.">
+                                        <LemonTag type="warning" size="small" className="shrink-0">
+                                            Doesn't match filters
+                                        </LemonTag>
+                                    </Tooltip>
+                                )}
                             </div>
 
                             {playlistTimestampFormat === TimestampFormat.Relative ? (
@@ -454,6 +461,9 @@ const SessionRecordingPreviewBase = memo(
     },
     (prevProps, nextProps) =>
         prevProps.recording.id === nextProps.recording.id &&
+        // The row renders matches_filters, and the same recording flips in and out of matching
+        // as filters change around an open player, so comparing only the id would keep it stale.
+        prevProps.recording.matches_filters === nextProps.recording.matches_filters &&
         prevProps.isActive === nextProps.isActive &&
         prevProps.selectable === nextProps.selectable &&
         prevProps.order === nextProps.order
@@ -474,6 +484,9 @@ export const SessionRecordingPreview = memo(
     },
     (prevProps, nextProps) =>
         prevProps.recording.id === nextProps.recording.id &&
+        // The row renders matches_filters, and the same recording flips in and out of matching
+        // as filters change around an open player, so comparing only the id would keep it stale.
+        prevProps.recording.matches_filters === nextProps.recording.matches_filters &&
         prevProps.isActive === nextProps.isActive &&
         prevProps.selectable === nextProps.selectable &&
         prevProps.order === nextProps.order

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -2006,6 +2006,12 @@ def _load_recording_if_matches_filters(
     Check if a specific recording matches the current filters (ignoring pagination).
     Returns the recording if it matches, None otherwise.
     """
+    # An explicit id set is itself a filter: callers that pass session_ids (pinned recordings,
+    # comment search, the experiment recordings tab's session buckets) are asking for that set
+    # and nothing else, so an id outside it does not match however well it fits the rest.
+    if query.session_ids is not None and session_id not in query.session_ids:
+        return None
+
     prepend_check_query = query.model_copy(
         update={
             "session_ids": [session_id],
@@ -2084,27 +2090,24 @@ def list_recordings_from_query(
 
     timer = ServerTimingsGathered()
 
-    # If session_recording_id is provided, add it to session_ids to fetch it along with the rest
+    # An explicitly requested recording gets the same treatment whatever else the query asks for.
+    # Folding it into session_ids instead would load it straight from Postgres by id, which skips
+    # both the match check (so it is never flagged) and, for a recording not yet persisted to S3,
+    # the guarantee that it comes back at all.
     if session_recording_id_to_prepend:
-        if all_session_ids:
-            all_session_ids = [session_recording_id_to_prepend] + [
-                sid for sid in all_session_ids if sid != session_recording_id_to_prepend
-            ]
-        else:
-            # We need to fetch this specific recording alongside the filtered results
-            with timer("load_prepend_recording"):
-                prepend_recording = _load_recording_if_matches_filters(
-                    session_recording_id_to_prepend,
-                    query,
-                    team,
-                    allow_event_property_expansion,
-                )
-                if prepend_recording is None:
-                    # The recording was explicitly requested (e.g. a shared link) but doesn't match
-                    # the current filters - include it anyway so the link still opens it
-                    prepend_recording = _load_selected_recording_ignoring_filters(session_recording_id_to_prepend, team)
-                if prepend_recording:
-                    recordings.append(prepend_recording)
+        with timer("load_prepend_recording"):
+            prepend_recording = _load_recording_if_matches_filters(
+                session_recording_id_to_prepend,
+                query,
+                team,
+                allow_event_property_expansion,
+            )
+            if prepend_recording is None:
+                # The recording was explicitly requested (e.g. a shared link) but doesn't match
+                # the current filters - include it anyway so the link still opens it
+                prepend_recording = _load_selected_recording_ignoring_filters(session_recording_id_to_prepend, team)
+            if prepend_recording:
+                recordings.append(prepend_recording)
 
     if all_session_ids:
         with timer("load_persisted_recordings"), tracer.start_as_current_span("load_persisted_recordings"):
@@ -2168,12 +2171,12 @@ def list_recordings_from_query(
             recordings_from_clickhouse = SessionRecording.get_or_build_from_clickhouse(team, ch_session_recordings)
             recordings = recordings + recordings_from_clickhouse
 
-            # If we have specified session_ids we need to sort them by the order they were specified
+            # If we have specified session_ids we need to sort them by the order they were specified.
+            # An explicitly requested recording outside that set sorts first, which is where
+            # prepending already put it.
             if all_session_ids:
-                recordings = sorted(
-                    recordings,
-                    key=lambda x: cast(list[str], all_session_ids).index(x.session_id),
-                )
+                ordering = {session_id: index for index, session_id in enumerate(all_session_ids)}
+                recordings = sorted(recordings, key=lambda x: ordering.get(x.session_id, -1))
 
     # Deduplicate recordings by session_id (if session_recording_id was fetched separately and also in results)
     if session_recording_id_to_prepend:

--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -2171,12 +2171,13 @@ def list_recordings_from_query(
             recordings_from_clickhouse = SessionRecording.get_or_build_from_clickhouse(team, ch_session_recordings)
             recordings = recordings + recordings_from_clickhouse
 
-            # If we have specified session_ids we need to sort them by the order they were specified.
-            # An explicitly requested recording outside that set sorts first, which is where
-            # prepending already put it.
-            if all_session_ids:
-                ordering = {session_id: index for index, session_id in enumerate(all_session_ids)}
-                recordings = sorted(recordings, key=lambda x: ordering.get(x.session_id, -1))
+    # If we have specified session_ids we need to sort them by the order they were specified. This sits
+    # outside the ClickHouse branch because a request whose ids are all already persisted skips that
+    # branch entirely, and it needs the caller's ordering just the same. An explicitly requested
+    # recording outside the set sorts first, which is where prepending already put it.
+    if all_session_ids:
+        ordering = {session_id: index for index, session_id in enumerate(all_session_ids)}
+        recordings = sorted(recordings, key=lambda x: ordering.get(x.session_id, -1))
 
     # Deduplicate recordings by session_id (if session_recording_id was fetched separately and also in results)
     if session_recording_id_to_prepend:

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -1,4 +1,5 @@
 import os
+import json
 from datetime import UTC, datetime, timedelta
 from typing import cast
 from urllib.parse import urlencode
@@ -582,6 +583,19 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         # any-user mode excludes it
         any_user = self.client.get(f"/api/projects/{self.team.id}/session_recordings?hide_viewed_recordings=any-user")
         assert self._result_ids(any_user) == ["unviewed"]
+
+    def test_session_ids_results_follow_the_requested_order(self):
+        base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
+        for index, session_id in enumerate(["alpha", "beta", "gamma"]):
+            self.produce_replay_summary("user1", session_id, base_time + relativedelta(seconds=index * 10))
+
+        # Pinned collections and the experiment tab's session buckets both rely on the response
+        # keeping the order they asked for, which is not the list's own recency ordering.
+        requested = ["gamma", "alpha", "beta"]
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/session_recordings?session_ids={json.dumps(requested)}"
+        )
+        assert self._result_ids(response) == requested
 
     def test_hide_viewed_recordings_does_not_apply_to_explicit_session_ids(self):
         base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
@@ -2108,6 +2122,38 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
                 {"recent_session": True},  # must be in results, with expected matches_filters
                 ["no_such_session"],  # must NOT be in results
             ),
+            (
+                "recording_outside_supplied_session_ids_is_included_but_flagged",
+                # The caller supplies an explicit session_ids set (how the experiment recordings tab
+                # sends bucket results) and asks for a recording that isn't in it.
+                {
+                    "recordings": [
+                        {"session_id": "bucket_session", "days_ago": 1},
+                        {"session_id": "open_session", "days_ago": 1},
+                    ],
+                    "date_from": "-3d",
+                    "session_ids": ["bucket_session"],
+                    "session_recording_id": "open_session",
+                },
+                {"bucket_session": True, "open_session": False},
+                [],  # must NOT be in results
+            ),
+            (
+                "recording_inside_supplied_session_ids_is_not_flagged",
+                # The same shape, except the requested recording is part of the supplied set, so it
+                # is a genuine member of the list rather than a retained selection.
+                {
+                    "recordings": [
+                        {"session_id": "bucket_session", "days_ago": 1},
+                        {"session_id": "open_session", "days_ago": 1},
+                    ],
+                    "date_from": "-3d",
+                    "session_ids": ["bucket_session", "open_session"],
+                    "session_recording_id": "open_session",
+                },
+                {"bucket_session": True, "open_session": True},
+                [],  # must NOT be in results
+            ),
         ]
     )
     def test_session_recording_id_respects_filters(
@@ -2138,6 +2184,8 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
             params["limit"] = config["limit"]
         if "session_recording_id" in config:
             params["session_recording_id"] = config["session_recording_id"]
+        if "session_ids" in config:
+            params["session_ids"] = json.dumps(config["session_ids"])
 
         params_string = urlencode(params)
         response = self.client.get(f"/api/projects/{self.team.id}/session_recordings?{params_string}")

--- a/posthog/session_recordings/test/test_session_recordings.py
+++ b/posthog/session_recordings/test/test_session_recordings.py
@@ -584,13 +584,20 @@ class TestSessionRecordings(APIBaseTest, ClickhouseTestMixin, QueryMatchingTest)
         any_user = self.client.get(f"/api/projects/{self.team.id}/session_recordings?hide_viewed_recordings=any-user")
         assert self._result_ids(any_user) == ["unviewed"]
 
-    def test_session_ids_results_follow_the_requested_order(self):
+    @parameterized.expand([("from_clickhouse", False), ("persisted_to_s3", True)])
+    def test_session_ids_results_follow_the_requested_order(self, _name: str, persisted: bool):
         base_time = (now() - relativedelta(days=1)).replace(microsecond=0)
         for index, session_id in enumerate(["alpha", "beta", "gamma"]):
             self.produce_replay_summary("user1", session_id, base_time + relativedelta(seconds=index * 10))
+            if persisted:
+                SessionRecording.objects.create(
+                    team=self.team, session_id=session_id, full_recording_v2_path=f"s3://bucket/{session_id}"
+                )
 
         # Pinned collections and the experiment tab's session buckets both rely on the response
-        # keeping the order they asked for, which is not the list's own recency ordering.
+        # keeping the order they asked for, which is not the list's own recency ordering. Once every
+        # requested recording is persisted there is nothing left to look up in ClickHouse, so the
+        # ordering has to survive skipping that branch.
         requested = ["gamma", "alpha", "beta"]
         response = self.client.get(
             f"/api/projects/{self.team.id}/session_recordings?session_ids={json.dumps(requested)}"


### PR DESCRIPTION
## Problem

The playlist deliberately keeps the open recording in the list when you change filters around it. It re-requests it by id and the backend returns it flagged `matches_filters: false`, a mechanism that shipped a while ago in #62982.

On the experiment recordings tab this reads as a bug. The list says nothing matched, while the player shows a recording that plainly fired the metric. Both are true, about two different things, and nothing on screen reconciles them.

The one existing explanation did not help. It was a small `info` banner whose copy claimed the recording was "opened from a direct link", which is wrong for the path people actually hit (changing filters while watching), and the open filter dropdown covers the banner anyway.

Then, testing the fix on a real experiment, the tag did not appear at all. That turned out to be a second, older bug in the API, and it is why this PR touches the backend too.

## Changes

### The row explains itself (frontend)

- Banner/box made more visible & change text
- A row-level marker "Doesn't match filters" beside the person name with a tooltip. This is the part that survives a covering dropdown, which the banner does not
- A staleness bug found on the way: Both `memo` comparators on the preview row compared only `recording.id`, so a row flipping in or out of matching around an open player kept rendering its old state. `matches_filters` now takes part in both comparisons.

<img width="788" height="557" alt="new-warning" src="https://github.com/user-attachments/assets/46e13184-f28e-4c69-af8b-e59d36314a93" />


### The flag actually gets set (backend)

`matches_filters` is written in exactly one place in the API, and only one of the listing's branches could reach it. When the caller supplied `session_ids`, the requested recording was spliced into that list and loaded straight from Postgres by id, which skipped the match check entirely. Two consequences:

1. The recording came back unflagged, so no banner and no tag. The experiment recordings tab hits this whenever a session bucket is active, because that is exactly when it sends `session_ids`.
2. Worse, the "an explicitly requested recording always comes back" guarantee was not actually held. A recording not yet persisted to S3 went to ClickHouse with the caller's filters still applied, so a date or duration filter made it vanish instead of being retained.

An empty `session_ids` list is falsy in Python, so it fell into the working branch. That is why this looks fine in some configurations and dead in others.

Three changes give every routing the same treatment:

- An explicit id set now counts as a filter. `_load_recording_if_matches_filters` returns `None` for an id outside the caller's `session_ids`, rather than overwriting `session_ids` and answering a question nobody asked.
- The splice branch is gone. Every request takes the check-then-fall-back path that already worked.
- The `session_ids` ordering sort no longer uses `list.index`, which would raise once the requested id is not guaranteed to be in that list.

> [!NOTE]
> One deliberate behavior change beyond the bug: a recording that **is** in the caller's `session_ids` but falls outside the date range is now flagged `matches_filters: false`. Previously, if it happened to be persisted to S3, it came back unflagged, because that path skipped filters entirely. This affects pinned collections and comment search, not only the experiment tab. False is the honest answer, and it is what makes the flag mean one thing everywhere.

The cost is one extra ClickHouse query when a recording is open and `session_ids` is supplied. It is `limit 1` against a single id, and the no-`session_ids` path already paid exactly this on every request.

## Options I considered and rejected on the frontend side

- **Deselect on mismatch.** Yanks away what you are watching, mid-review.
- **Deselect only in the experiment tab.** Introduces a behavioral fork between two surfaces that look identical.
- **Make the player's experiments box filter-aware.** Couples a shared player surface to the tab's filter state, which it deliberately knows nothing about.

## How did you test this code?

Verified in the app on a local experiment: with a filter that excludes the open recording, the row keeps its place and now carries both the banner and the tag.

Automated, run locally:

- `posthog/session_recordings/` in full: 884 passed. This is the guard that matters, since the change is on a shared listing path.
- `uv run mypy --cache-fine-grained .`: no issues in 17,439 files.
- `sessionRecordingsPlaylistLogic.test.ts`: 84 passed. `tsgo --noEmit`: no errors under `session-recordings`. ruff and oxlint clean.

Three new backend cases, added as rows on the existing parameterized `test_session_recording_id_respects_filters` rather than as new test functions:

| Case | Regression it catches |
| --- | --- |
| requested id outside a supplied `session_ids` | The bug above. Confirmed failing before the fix (`Expected open_session to have matches_filters=False, but got True`) and passing after. |
| requested id inside a supplied `session_ids` | The new "an id set is a filter" guard being applied unconditionally, which would flag every recording in a bucket. |
| `session_ids` ordering (own test) | The rewritten sort. Response order following the requested ids was not asserted anywhere before, and pinned collections depend on it. |


## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The backend half came out of the change not working when I tried it. Claude traced it to the `session_ids` branch, and the first diagnosis it gave me was too broad ("bucket mode always routes around the flag"). Reading the selector properly showed the real condition is a *non-empty* bucket result that excludes the open recording, since an empty list is falsy and falls into the working branch. Worth knowing when reproducing: an empty-result bucket will look correct.

Two edits to my original frontend code: the memo comments used an em-dash, which `/writing-code-comments` disallows, and the banner copy repeated "open" twice in two sentences.

Skills invoked: `/writing-code-comments`, `/writing-user-facing-copy`, `/writing-tests` (which is why the new cases are parameterized rows rather than three more test functions, and why there are three of them and not six).
