### PR TITLE
fix(desktop): show toast when Create PR dialog is dismissed without submitting

### DIFF
--- a/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx
@@ -190,7 +190,15 @@ export function TaskActionsMenu({ taskId, isCloud }: TaskActionsMenuProps) {
           <CreatePrDialog
             open={modals.createPrOpen}
             onOpenChange={(open) => {
-              if (!open) gitActions.closeCreatePr();
+              if (!open) {
+                gitActions.closeCreatePr();
+                // Show a toast so the user knows the PR was not created
+                // (dismissing the dialog by clicking outside / pressing Escape
+                // only saves the draft — it does not trigger creation).
+                toast.info("Create PR cancelled", {
+                  description: "Draft saved.",
+                });
+              }
             }}
             currentBranch={modals.createPrBaseBranch}
             diffStats={gitState.diffStats}


### PR DESCRIPTION
## Problem

When the user opens the **Create PR** dialog and dismisses it (by clicking outside, pressing Escape, or clicking Cancel) without clicking the Create PR button, the dialog silently closes. The draft is saved to the store, but the PR is never created and there is no indication that the action was cancelled — the user is left wondering whether the PR was created.

## Steps to reproduce

1. Click **Create PR** to open the create-PR dialog.
2. Click outside the dialog (or otherwise dismiss it) instead of clicking the dialog's **Create PR** button.
3. Navigate to a different task.

**Expected**: Either the PR gets created, or it's clear the action was cancelled.

**Actual**: No PR is created. The draft fields are persisted, but nothing was submitted, and there's no feedback.

## Fix

Add an info toast when the dialog is dismissed without submitting, so the user knows the PR was not created and their draft was saved.

## Changes

- `products/desktop/packages/ui/src/features/git-interaction/components/TaskActionsMenu.tsx`: show `toast.info('Create PR cancelled', { description: 'Draft saved.' })` on dialog dismiss

Fixes #76214