### PR TITLE
chore(ci): scope merge-queue tripwires and enumerate the widened set

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -8,8 +8,16 @@
 // without ever having been tested together. Reporting extra targets only costs
 // parallelism; reporting too few lets conflicting PRs land side by side and
 // breaks master. Every rule here is therefore biased toward over-reporting,
-// and anything unrecognized falls through to "ALL" (overlaps everything, which
-// is the single-lane behavior we had before this script existed).
+// and anything unrecognized widens to every known target (the single-lane
+// behavior we had before this script existed).
+//
+// Widening enumerates that set rather than emitting Trunk's "ALL" sentinel.
+// The intersection Trunk computes is identical, but the uploaded list says
+// which lanes the PR claimed, so the telemetry can compare it against the lanes
+// the PR should have claimed. "ALL" is kept for the cases where the set cannot
+// be built at all — an unreadable crate graph or services/ listing here, and a
+// failed diff in the workflow, which never reaches this script. That is a
+// different statement from "everything": it means "unknown".
 //
 // The bias is relaxed in exactly two places, both bounded by what one PR can
 // name in another. The conflict that lanes exist to prevent is semantic rather
@@ -61,9 +69,10 @@
 // paths in ci-e2e-playwright.yml, which puts all such PRs back in one lane.
 //
 // Input:  changed file paths, one per line, on stdin
-// Output: JSON on stdout, either the string "ALL" or an array of target names.
-//         A change set of nothing but prose reports the single "prose" lane,
-//         which overlaps only other prose-only PRs.
+// Output: JSON on stdout, an array of target names, or the string "ALL" when
+//         the target universe could not be enumerated. A change set of nothing
+//         but prose reports the single "prose" lane, which overlaps only other
+//         prose-only PRs.
 //         Diagnostics on stderr
 
 const fs = require('fs')
@@ -73,74 +82,148 @@ const ALL = 'ALL'
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..')
 
-// Files whose effect crosses every lane boundary: lockfiles and workspace
+// Files whose effect crosses lane boundaries: lockfiles and workspace
 // manifests (a dependency bump changes what every tree compiles against),
 // cross-language contracts (a schema or proto change lands in generated code
 // on both sides), the module graphs that this script and turbo-discover read,
 // and the CI definitions that decide what runs for everyone.
-const TRIPWIRES = [
-    'pnpm-lock.yaml',
-    'pnpm-workspace.yaml',
-    'package.json',
-    'uv.lock',
-    'pyproject.toml',
-    'requirements.txt',
-    'requirements-dev.txt',
-    'rust/Cargo.lock',
-    'rust/Cargo.toml',
-    'rust/.sqlx/**',
-    'tach.toml',
-    'turbo.json',
-    'hogli.yaml',
-    '.nvmrc',
-    '.github/**',
-    'docker-compose*.yml',
-    'Dockerfile*',
-    'proto/**',
+//
+// Each entry carries the blast radius the file can be held to, and `universal`
+// is the honest answer whenever that radius is not confidently narrower. The
+// three toolchain domains are supersets by construction: `python` claims every
+// lane that runs Python, `javascript` every lane that runs TypeScript or
+// JavaScript, `rust` every crate. A domain never names less than the file can
+// break; it only stops asserting a radius the file does not have, which is what
+// keeps a frontend lint rule from serializing against Rust.
+//
+// Entries are matched in order and the first match wins, so a narrower entry
+// has to precede the tree it sits in. A `null` domain is an explicit
+// non-tripwire: the file falls through to the ordinary directory rules below.
+const UNIVERSAL = 'universal'
+const PYTHON = 'python'
+const JAVASCRIPT = 'javascript'
+const RUST = 'rust'
+
+// Resolved per file from the rule's own `languages:` declaration rather than
+// from its path, so it cannot be expressed as a static domain here.
+const SEMGREP = 'semgrep'
+
+const TRIPWIRE_RULES = [
+    // Markdown in these trees compiles into nothing and no suite reads it, so
+    // it is prose like any other. Ahead of the trees themselves, which would
+    // otherwise read a pull request template as a repo-wide CI change.
+    ['.github/**/*.md', null],
+    ['.semgrep/**/*.md', null],
+
+    // The lane rules themselves, and the graphs they read. Two PRs that
+    // disagree about the partition cannot be safely placed in it, which is the
+    // self-gating hazard CONTRACT_DECLARATIONS is here for, so these stay
+    // universal however narrow the rest of their diff looks.
+    ['.github/scripts/trunk-impacted-targets*.js', UNIVERSAL],
+    ['.github/scripts/trunk-lane-telemetry*.js', UNIVERSAL],
+    ['.github/scripts/turbo-discover*.js', UNIVERSAL],
+    ['.github/workflows/trunk-impacted-targets.yml', UNIVERSAL],
+    ['tach.toml', UNIVERSAL],
+    ['turbo.json', UNIVERSAL],
+
+    // A workflow decides which suites run, so one that defines a single
+    // language's suite can be held to that language's lanes. Everything else
+    // under .github/ stays universal: the list grows by decision, and a
+    // workflow nobody has placed here keeps the old radius.
+    ['.github/workflows/ci-frontend.yml', JAVASCRIPT],
+    ['.github/workflows/ci-storybook.yml', JAVASCRIPT],
+    ['.github/workflows/ci-storybook-update-test-timing.yml', JAVASCRIPT],
+    ['.github/workflows/ci-nodejs.yml', JAVASCRIPT],
+    ['.github/workflows/ci-nodejs-container.yml', JAVASCRIPT],
+    ['.github/workflows/ci-mcp.yml', JAVASCRIPT],
+    ['.github/workflows/ci-backend.yml', PYTHON],
+    ['.github/workflows/ci-backend-update-test-timing.yml', PYTHON],
+    ['.github/workflows/ci-backend-shadow-drift.yml', PYTHON],
+    ['.github/workflows/ci-dagster.yml', PYTHON],
+    ['.github/workflows/ci-rust.yml', RUST],
+    ['.github/workflows/ci-rust-flags-integration.yml', RUST],
+
+    // Lint rules that run repo-wide: a new rule fails code that merged in a
+    // parallel lane, which is the same conflict .oxlintrc.json is here for. The
+    // radius is the languages the rule matches, and semgrep requires every rule
+    // to declare them, so the declaration is a sound source. A rule file that
+    // does not parse, names a language with no lane mapping, or spans more than
+    // one domain falls back to universal. The .py/.ts files beside the rules
+    // are its test fixtures, which can only exercise their own language.
+    ['.semgrep/**/*.yaml', SEMGREP],
+    ['.semgrep/**/*.yml', SEMGREP],
+    ['.semgrep/**/*.py', PYTHON],
+    ['.semgrep/**/*.ts', JAVASCRIPT],
+    ['.semgrep/**/*.tsx', JAVASCRIPT],
+    ['.semgrep/**', UNIVERSAL],
+
+    // Toolchain configuration for a single language: a compiler, linter, or
+    // formatter setting can only fail the code that tool reads.
+    ['tsconfig.json', JAVASCRIPT],
+    ['tsconfig.*.json', JAVASCRIPT],
+    ['babel.config.js', JAVASCRIPT],
+    ['webpack.config.js', JAVASCRIPT],
+    ['.oxlintrc.json', JAVASCRIPT],
+    ['.oxfmtrc*', JAVASCRIPT],
+    ['.nvmrc', JAVASCRIPT],
+    ['mypy.ini', PYTHON],
+    ['pytest.ini', PYTHON],
+    ['conftest.py', PYTHON],
+
+    // Lockfiles and workspace manifests stay universal. pnpm-workspace.yaml
+    // lists frontend, nodejs, services, tools, products, and three rust node
+    // bindings, and pyproject.toml roots every product package, so a resolution
+    // change in either really does reach almost every lane. The telemetry says
+    // the same: a lockfile was the widening reason for one PR, against 26 for
+    // the CI and lint rules split above.
+    ['pnpm-lock.yaml', UNIVERSAL],
+    ['pnpm-workspace.yaml', UNIVERSAL],
+    ['package.json', UNIVERSAL],
+    ['uv.lock', UNIVERSAL],
+    ['pyproject.toml', UNIVERSAL],
+    ['requirements.txt', UNIVERSAL],
+    ['requirements-dev.txt', UNIVERSAL],
+    ['rust/Cargo.lock', UNIVERSAL],
+    ['rust/Cargo.toml', UNIVERSAL],
+    ['rust/.sqlx/**', UNIVERSAL],
+    ['hogli.yaml', UNIVERSAL],
+    ['.github/**', UNIVERSAL],
+    ['docker-compose*.yml', UNIVERSAL],
+    ['Dockerfile*', UNIVERSAL],
+    ['proto/**', UNIVERSAL],
     // schema.json generates posthog/schema.py, and both sides are committed.
-    'frontend/src/queries/schema.json',
-    'posthog/schema.py',
+    ['frontend/src/queries/schema.json', UNIVERSAL],
+    ['posthog/schema.py', UNIVERSAL],
     // products.json is loaded at runtime by posthog/products.py and generated
     // from every product's manifest.
-    'frontend/src/products.json',
-    'products/*/manifest.tsx',
+    ['frontend/src/products.json', UNIVERSAL],
+    ['products/*/manifest.tsx', UNIVERSAL],
     // Generates the frontend API types from the backend serializers, so a
     // change lands on both sides of the fe/py split at once.
-    'tools/openapi-codegen/**',
+    ['tools/openapi-codegen/**', UNIVERSAL],
     // Ownership data read by the backend, frontend, and script suites alike.
-    'tools/owners/**',
-    'conftest.py',
-    'pytest.ini',
-    'mypy.ini',
-    '.test_durations',
-    '.test_quarantine.json',
+    ['tools/owners/**', UNIVERSAL],
+    ['.test_durations', UNIVERSAL],
+    ['.test_quarantine.json', UNIVERSAL],
     // bin/ appears in the backend, frontend, and E2E path filters alike.
-    'bin/**',
-    'patches/**',
+    ['bin/**', UNIVERSAL],
+    ['patches/**', UNIVERSAL],
     // Holds the Depot-runner copies of the workflows and composite actions in
     // .github/, so it decides what runs for everyone the same way.
-    '.depot/**',
+    ['.depot/**', UNIVERSAL],
     // The toolchain every suite runs inside. ci-python.yml gates on
     // .flox/env/manifest.toml for that reason.
-    '.flox/**',
+    ['.flox/**', UNIVERSAL],
     // ClickHouse, Postgres, and Temporal configuration mounted by every
     // docker-compose file, so it defines the services all the suites test
     // against.
-    'docker/**',
+    ['docker/**', UNIVERSAL],
     // duckgres.yaml is mounted into the same stack, and intent-map.yaml steers
     // bin/sandbox and hogli, both already tripwires.
-    'devenv/**',
-    // Lint rules that run repo-wide: a new rule fails code that merged in a
-    // parallel lane, which is the same conflict .oxlintrc.json is here for.
-    '.semgrep/**',
-    // Holds the markdownlint config, which is the same class of rule change.
-    '.config/**',
-    'tsconfig.json',
-    'tsconfig.*.json',
-    'babel.config.js',
-    'webpack.config.js',
-    '.oxlintrc.json',
-    '.oxfmtrc*',
+    ['devenv/**', UNIVERSAL],
+    // Holds the markdownlint config, which is the same class of rule change,
+    // and markdown is the one thing every tree has.
+    ['.config/**', UNIVERSAL],
 ]
 
 // Subdirectories of common/ that belong to a single domain. Anything else
@@ -240,10 +323,115 @@ function globToRegExp(glob) {
     return new RegExp(`^${body}$`)
 }
 
-const TRIPWIRE_MATCHERS = TRIPWIRES.map(globToRegExp)
+const TRIPWIRE_MATCHERS = TRIPWIRE_RULES.map(([glob, domain]) => [globToRegExp(glob), domain])
+
+// The domain of the first rule matching the file, or null when no rule claims
+// it and when a rule claims it as an explicit non-tripwire. Both mean the same
+// thing to every caller: the file falls through to the ordinary rules.
+function tripwireDomain(file) {
+    const matched = TRIPWIRE_MATCHERS.find(([re]) => re.test(file))
+    return matched ? matched[1] : null
+}
 
 function isTripwire(file) {
-    return TRIPWIRE_MATCHERS.some((re) => re.test(file))
+    return tripwireDomain(file) !== null
+}
+
+// --- Semgrep rule languages ---
+
+const SEMGREP_DIR = '.semgrep'
+
+// Only languages whose lanes this script can name. `generic`, `yaml`, and the
+// rest are deliberately absent so a rule using them widens.
+const SEMGREP_LANGUAGE_DOMAINS = new Map([
+    ['python', PYTHON],
+    ['py', PYTHON],
+    ['typescript', JAVASCRIPT],
+    ['ts', JAVASCRIPT],
+    ['javascript', JAVASCRIPT],
+    ['js', JAVASCRIPT],
+    ['tsx', JAVASCRIPT],
+    ['jsx', JAVASCRIPT],
+])
+
+// Collects every `languages:` value in a rule file. Semgrep accepts the inline
+// list and the block-sequence spellings, and a file holds many rules, so the
+// result is the union across all of them.
+function parseSemgrepLanguages(text) {
+    const languages = new Set()
+    const clean = (value) =>
+        value
+            .trim()
+            .replace(/^['"]|['"]$/g, '')
+            .toLowerCase()
+    const lines = text.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+        const declaration = lines[i].match(/^\s*languages:\s*(.*)$/)
+        if (!declaration) {
+            continue
+        }
+        const inline = declaration[1].replace(/#.*$/, '').trim()
+        if (inline.startsWith('[')) {
+            for (const language of inline.slice(1).split(']')[0].split(',')) {
+                if (language.trim()) {
+                    languages.add(clean(language))
+                }
+            }
+            continue
+        }
+        if (inline) {
+            languages.add(clean(inline))
+            continue
+        }
+        for (let j = i + 1; j < lines.length; j++) {
+            const item = lines[j].match(/^\s*-\s*(.+)$/)
+            if (!item) {
+                break
+            }
+            languages.add(clean(item[1].replace(/#.*$/, '')))
+        }
+    }
+    return languages
+}
+
+// A rule file is held to one domain only when every language it declares maps
+// to that same domain. No declaration, an unmapped language, or a rule spanning
+// both sides yields universal.
+function semgrepDomain(text) {
+    const languages = parseSemgrepLanguages(text)
+    if (languages.size === 0) {
+        return UNIVERSAL
+    }
+    const domains = new Set()
+    for (const language of languages) {
+        const domain = SEMGREP_LANGUAGE_DOMAINS.get(language)
+        if (!domain) {
+            return UNIVERSAL
+        }
+        domains.add(domain)
+    }
+    return domains.size === 1 ? [...domains][0] : UNIVERSAL
+}
+
+function loadSemgrepDomains(repoRoot) {
+    const domains = new Map()
+    const walk = (dir) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            const full = path.join(dir, entry.name)
+            if (entry.isDirectory()) {
+                walk(full)
+            } else if (/\.ya?ml$/.test(entry.name)) {
+                const relative = path.relative(repoRoot, full).split(path.sep).join('/')
+                domains.set(relative, semgrepDomain(fs.readFileSync(full, 'utf8')))
+            }
+        }
+    }
+    try {
+        walk(path.join(repoRoot, SEMGREP_DIR))
+    } catch (error) {
+        console.error(`Semgrep rules unreadable (${error.message}); every rule change widens`)
+    }
+    return domains
 }
 
 // Tool caches share the directory with the products, so a local run can pick up
@@ -770,6 +958,118 @@ const pyProduct = (product) => `py:product:${product}`
 const feProduct = (product) => `fe:product:${product}`
 const rustCrate = (crate) => `rust:crate:${crate}`
 
+// Every target this script can emit. A widening decision names this set instead
+// of the "ALL" sentinel, so the set intersection Trunk computes is unchanged
+// while the target list stays readable: the telemetry can show which lanes a
+// widened PR claimed, and diffing that against the lanes it should have claimed
+// is how a rule gets tuned. "ALL" survives only for the cases below where the
+// set cannot be built at all, which is a different statement — not "everything"
+// but "unknown".
+//
+// THE INVARIANT: every target computeTargets can produce has to appear here. A
+// target missing from this set makes a widened PR disjoint from the PR that
+// claims it, which is the one failure mode that silently breaks master. The
+// dynamic parts (products, services, crates) are read rather than listed for
+// that reason, and a missing one returns null so the caller falls back to ALL.
+function allKnownTargets(context) {
+    const { products, services, rustGraph } = context
+    if (!rustGraph || !services) {
+        return null
+    }
+    const targets = new Set(['py:core', 'fe:core', 'node:ingestion', 'agents'])
+    for (const product of products) {
+        targets.add(pyProduct(product))
+        targets.add(feProduct(product))
+    }
+    for (const service of services) {
+        targets.add(`svc:${service}`)
+    }
+    for (const tool of TOOLS_INDEPENDENT) {
+        targets.add(`tools:${tool}`)
+    }
+    for (const entries of STANDALONE_TREES.values()) {
+        for (const target of entries) {
+            targets.add(target)
+        }
+    }
+    for (const crate of rustGraph.dependsOn.keys()) {
+        targets.add(rustCrate(crate))
+    }
+    // "ALL" overlapped the prose lane too, so a docs PR serialized behind a
+    // lockfile bump. Keeping prose here preserves that exactly rather than
+    // smuggling a narrowing into a change that is meant to be a rename.
+    targets.add('prose')
+    return [...targets].sort()
+}
+
+function everything(context) {
+    return allKnownTargets(context) || ALL
+}
+
+// The lanes a tripwire domain claims. Each is a superset of what a file in that
+// domain can break, and each returns false when it cannot name its lanes in
+// full, which sends the caller to the universal set rather than to a partial
+// one.
+function addPythonLanes(targets, context) {
+    targets.add('py:core')
+    for (const product of context.products) {
+        targets.add(pyProduct(product))
+    }
+    // pyproject.toml roots products, but Python also lives under tools/, and
+    // tools/pr-approval-agent holds a lane of its own through .stamphog.
+    for (const tool of TOOLS_INDEPENDENT) {
+        targets.add(`tools:${tool}`)
+    }
+    targets.add('tools:pr-approval-agent')
+    return true
+}
+
+function addJavaScriptLanes(targets, context) {
+    if (!context.services) {
+        return false
+    }
+    targets.add('fe:core')
+    for (const product of context.products) {
+        targets.add(feProduct(product))
+    }
+    // The pnpm workspace spans frontend, nodejs, services, tools, and products,
+    // and ci-cli.yml builds the CLI from services/mcp sources.
+    targets.add('node:ingestion')
+    for (const service of context.services) {
+        targets.add(`svc:${service}`)
+    }
+    for (const tool of TOOLS_INDEPENDENT) {
+        targets.add(`tools:${tool}`)
+    }
+    targets.add('cli')
+    targets.add('svc:mcp')
+    return true
+}
+
+function addRustLanes(targets, context) {
+    if (!context.rustGraph) {
+        return false
+    }
+    for (const crate of context.rustGraph.dependsOn.keys()) {
+        targets.add(rustCrate(crate))
+    }
+    return true
+}
+
+const TRIPWIRE_DOMAIN_LANES = new Map([
+    [PYTHON, addPythonLanes],
+    [JAVASCRIPT, addJavaScriptLanes],
+    [RUST, addRustLanes],
+])
+
+// Returns false when the file's domain is universal, which is the caller's cue
+// to abandon the per-file accumulation and report the whole set.
+function applyTripwireDomain(domain, file, targets, context) {
+    const resolved = domain === SEMGREP ? (context.semgrepDomains || new Map()).get(file) || UNIVERSAL : domain
+    const addLanes = TRIPWIRE_DOMAIN_LANES.get(resolved)
+    return addLanes ? addLanes(targets, context) : false
+}
+
 function computeTargets(changedFiles, context) {
     const {
         products,
@@ -799,8 +1099,12 @@ function computeTargets(changedFiles, context) {
     let inertFiles = 0
 
     for (const file of changedFiles) {
-        if (isTripwire(file)) {
-            return ALL
+        const tripwire = tripwireDomain(file)
+        if (tripwire) {
+            if (!applyTripwireDomain(tripwire, file, targets, context)) {
+                return everything(context)
+            }
+            continue
         }
 
         const segments = file.split('/')
@@ -880,7 +1184,7 @@ function computeTargets(changedFiles, context) {
             // selection, playwright spec selection, the selection verdict).
             // Those decide what runs across every suite, so they widen fully.
             if (segments.length < 3) {
-                return ALL
+                return everything(context)
             }
             if (TOOLS_INDEPENDENT.includes(segments[1])) {
                 targets.add(`tools:${segments[1]}`)
@@ -898,7 +1202,7 @@ function computeTargets(changedFiles, context) {
                 allFeProducts()
                 continue
             }
-            return ALL
+            return everything(context)
         }
         if (top === 'rust') {
             if (!rustGraph) {
@@ -909,7 +1213,7 @@ function computeTargets(changedFiles, context) {
                 (entry) => file.startsWith(`rust/${entry.dir}/`) || file === `rust/${entry.dir}`
             )
             if (!crate) {
-                return ALL
+                return everything(context)
             }
             targets.add(rustCrate(crate.name))
             continue
@@ -917,7 +1221,7 @@ function computeTargets(changedFiles, context) {
         if (top === 'products' && segments.length > 2) {
             const product = segments[1]
             if (!products.includes(product)) {
-                return ALL
+                return everything(context)
             }
             const isBackend = segments[2] === 'backend' || file.endsWith('.py')
             const isFrontend = segments[2] === 'frontend' || /\.tsx?$/.test(file)
@@ -961,8 +1265,8 @@ function computeTargets(changedFiles, context) {
 
         // Nothing claimed this path. Defaulting to an empty target set would
         // read as "parallel with everything", which is the one failure mode
-        // that silently breaks master, so widen to ALL instead.
-        return ALL
+        // that silently breaks master, so claim every lane instead.
+        return everything(context)
     }
 
     // Naming a dependent's target is all a lane needs: it puts the two PRs in
@@ -1003,7 +1307,7 @@ function computeTargets(changedFiles, context) {
                 targets.add(rustCrate(crate))
             }
         } else {
-            return ALL
+            return everything(context)
         }
     }
 
@@ -1018,8 +1322,8 @@ function computeTargets(changedFiles, context) {
         //
         // Anything else that reaches an empty set contains a path no rule
         // claimed, which is the failure mode that silently breaks master, so it
-        // still widens to ALL.
-        return inertFiles === changedFiles.length ? ['prose'] : ALL
+        // still widens.
+        return inertFiles === changedFiles.length ? ['prose'] : everything(context)
     }
     return [...targets].sort()
 }
@@ -1055,15 +1359,33 @@ function loadTachGraph(repoRoot) {
     }
 }
 
+// Every directory under services/ holds a lane, so the list has to be read
+// rather than declared or allKnownTargets would miss a newly added one. Null on
+// failure, which widens to the "ALL" sentinel instead of to a partial set.
+function listServices(repoRoot) {
+    try {
+        return fs
+            .readdirSync(path.join(repoRoot, 'services'), { withFileTypes: true })
+            .filter((entry) => entry.isDirectory() && isProductDirectory(entry.name))
+            .map((entry) => entry.name)
+            .sort()
+    } catch (error) {
+        console.error(`Could not list services/ (${error.message}); widening decisions fall back to ALL`)
+        return null
+    }
+}
+
 function buildContext(repoRoot) {
     const products = listProducts(repoRoot)
     const tachGraph = loadTachGraph(repoRoot)
     return {
         products,
+        services: listServices(repoRoot),
         isolatedProducts: listIsolatedProducts(repoRoot, products),
         contractSurfaces: loadContractSurfaces(repoRoot, products),
         productWorkspaces: loadProductWorkspaces(repoRoot, products),
         backendDetachedProducts: loadBackendDetachedProducts(repoRoot, products, tachGraph),
+        semgrepDomains: loadSemgrepDomains(repoRoot),
         rustGraph: loadRustGraph(repoRoot),
         tachGraph,
     }
@@ -1071,19 +1393,28 @@ function buildContext(repoRoot) {
 
 module.exports = {
     computeTargets,
+    allKnownTargets,
     buildContext,
     compileContractMatcher,
     compileWorkspaceMatcher,
     globToRegExp,
     isProductDirectory,
     isTripwire,
-    parsePytestIgnores,
-    parseWorkspacePackageGlobs,
     parseCrateDependencies,
     parseCrateName,
+    parsePytestIgnores,
+    parseSemgrepLanguages,
+    parseWorkspacePackageGlobs,
     reverseClosure,
+    semgrepDomain,
     stripJsonComments,
+    tripwireDomain,
     ALL,
+    JAVASCRIPT,
+    PYTHON,
+    REPO_ROOT,
+    RUST,
+    UNIVERSAL,
 }
 
 if (require.main === module) {

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -12,6 +12,7 @@ const assert = require('node:assert/strict')
 
 const {
     computeTargets,
+    allKnownTargets,
     compileContractMatcher,
     compileWorkspaceMatcher,
     globToRegExp,
@@ -19,15 +20,28 @@ const {
     isTripwire,
     parseCrateDependencies,
     parsePytestIgnores,
+    parseSemgrepLanguages,
     parseWorkspacePackageGlobs,
     reverseClosure,
+    semgrepDomain,
+    tripwireDomain,
     ALL,
+    JAVASCRIPT,
+    PYTHON,
+    RUST,
+    UNIVERSAL,
 } = require('./trunk-impacted-targets')
 const { parseTachModules, tachDependents } = require('./turbo-discover')
 
 const CONTEXT = {
     products: ['alpha', 'beta', 'gamma'],
+    services: ['mcp', 'oauth-proxy'],
     isolatedProducts: new Set(['alpha', 'beta']),
+    semgrepDomains: new Map([
+        ['.semgrep/rules/security/py-rule.yaml', PYTHON],
+        ['.semgrep/rules/devex/ts-rule.yaml', JAVASCRIPT],
+        ['.semgrep/rules/devex/generic-rule.yaml', UNIVERSAL],
+    ]),
     rustGraph: {
         dependsOn: new Map([
             ['shared', []],
@@ -47,6 +61,9 @@ const CONTEXT = {
     },
 }
 
+// What a widening decision now uploads in place of the "ALL" sentinel.
+const EVERYTHING = allKnownTargets(CONTEXT)
+
 // gamma vendors its own pnpm workspace; alpha and beta keep the conventional
 // backend/ + frontend/ layout, so the cases above stay on the old behavior.
 const WORKSPACE_CONTEXT = {
@@ -54,13 +71,16 @@ const WORKSPACE_CONTEXT = {
     productWorkspaces: new Map([['gamma', compileWorkspaceMatcher(['apps/*', 'packages/*', 'tooling/*'])]]),
 }
 
-test('every tripwire forces ALL', () => {
+// Nothing here has a blast radius the script can hold to one language: the
+// lockfiles span the whole pnpm and uv workspaces, the schemas land on both
+// sides of the fe/py split, and the rest steer what every suite runs or what it
+// runs against.
+test('a universal tripwire claims every known target', () => {
     const tripwireFiles = [
         'pnpm-lock.yaml',
         'uv.lock',
         'rust/Cargo.lock',
         'tach.toml',
-        '.github/workflows/ci-backend.yml',
         'proto/events.proto',
         'frontend/src/queries/schema.json',
         'posthog/schema.py',
@@ -69,28 +89,131 @@ test('every tripwire forces ALL', () => {
         '.test_durations',
         // Trees that steer what every suite runs or what it runs against: the
         // Depot copies of the workflows, the toolchain, the service configs the
-        // stack mounts, and the lint rules that run repo-wide.
+        // stack mounts, and the markdownlint config every tree's prose obeys.
         '.depot/workflows/ci-backend.yml',
         '.flox/env/manifest.toml',
         'docker/clickhouse/config.d/default.xml',
         'devenv/duckgres.yaml',
-        '.semgrep/rules/security/prefer-codegen-api.yaml',
         '.config/.markdownlint-cli2.jsonc',
+        // A workflow nobody has placed in a domain keeps the old radius.
+        '.github/workflows/ci-e2e-playwright.yml',
     ]
     for (const file of tripwireFiles) {
         assert.equal(isTripwire(file), true, `${file} should be a tripwire`)
-        assert.equal(computeTargets([file], CONTEXT), ALL, `${file} should force ALL`)
+        assert.deepEqual(computeTargets([file], CONTEXT), EVERYTHING, `${file} should claim every target`)
     }
 })
 
-test('a tripwire anywhere in the change set forces ALL even alongside narrow files', () => {
-    assert.equal(computeTargets(['products/alpha/backend/api.py', 'pnpm-lock.yaml'], CONTEXT), ALL)
+// The lane rules and the graphs they read are the one case that must stay
+// universal on principle rather than for want of a narrower radius: two PRs
+// that disagree about the partition cannot be safely placed in it. Same
+// self-gating hazard as CONTRACT_DECLARATIONS.
+test('a change to the lane rules themselves stays universal', () => {
+    for (const file of [
+        '.github/scripts/trunk-impacted-targets.js',
+        '.github/scripts/trunk-impacted-targets.test.js',
+        '.github/scripts/trunk-lane-telemetry.js',
+        '.github/scripts/turbo-discover.js',
+        '.github/workflows/trunk-impacted-targets.yml',
+        'tach.toml',
+        'turbo.json',
+    ]) {
+        assert.deepEqual(computeTargets([file], CONTEXT), EVERYTHING, file)
+    }
+})
+
+// A tripwire held to one language claims every lane running that language and
+// nothing else, which is the whole point: a frontend lint rule no longer
+// serializes against Rust, and a backend one no longer serializes against the
+// frontend.
+test('a language-scoped tripwire claims only that language', () => {
+    const javascript = computeTargets(['.oxlintrc.json'], CONTEXT)
+    assert.equal(javascript.includes('fe:core'), true)
+    assert.equal(javascript.includes('fe:product:alpha'), true)
+    assert.equal(javascript.includes('node:ingestion'), true)
+    assert.equal(javascript.includes('svc:mcp'), true)
+    assert.equal(javascript.includes('py:core'), false)
+    assert.equal(
+        javascript.some((target) => target.startsWith('rust:crate:')),
+        false
+    )
+
+    const python = computeTargets(['mypy.ini'], CONTEXT)
+    assert.equal(python.includes('py:core'), true)
+    assert.equal(python.includes('py:product:alpha'), true)
+    assert.equal(python.includes('fe:core'), false)
+    assert.equal(python.includes('node:ingestion'), false)
+
+    const rust = computeTargets(['.github/workflows/ci-rust.yml'], CONTEXT)
+    assert.deepEqual(rust, ['rust:crate:consumer', 'rust:crate:shared', 'rust:crate:unrelated'])
+})
+
+// A workflow decides which suites run, so the suite it defines is the radius.
+// ci-frontend.yml was the single most common reason a PR widened.
+test('a single-language workflow claims that language rather than everything', () => {
+    assert.deepEqual(
+        computeTargets(['.github/workflows/ci-frontend.yml'], CONTEXT),
+        computeTargets(['.oxlintrc.json'], CONTEXT)
+    )
+    assert.deepEqual(
+        computeTargets(['.github/workflows/ci-backend.yml'], CONTEXT),
+        computeTargets(['mypy.ini'], CONTEXT)
+    )
+})
+
+// Semgrep enforces the languages: declaration on every rule, so it is a sound
+// source for the radius. The IDOR allowlist every new team-scoped model has to
+// touch is a python rule, and used to serialize those PRs against the frontend.
+test('a semgrep rule claims the lanes of the languages it declares', () => {
+    assert.deepEqual(
+        computeTargets(['.semgrep/rules/security/py-rule.yaml'], CONTEXT),
+        computeTargets(['mypy.ini'], CONTEXT)
+    )
+    assert.deepEqual(
+        computeTargets(['.semgrep/rules/devex/ts-rule.yaml'], CONTEXT),
+        computeTargets(['.oxlintrc.json'], CONTEXT)
+    )
+    // A rule spanning languages with no single lane mapping, and a rule file
+    // the context never resolved, both keep the old radius.
+    assert.deepEqual(computeTargets(['.semgrep/rules/devex/generic-rule.yaml'], CONTEXT), EVERYTHING)
+    assert.deepEqual(computeTargets(['.semgrep/rules/devex/unknown-rule.yaml'], CONTEXT), EVERYTHING)
+})
+
+test('semgrep language declarations resolve to a single domain or widen', () => {
+    assert.deepEqual([...parseSemgrepLanguages('      languages: [python]')], ['python'])
+    assert.deepEqual([...parseSemgrepLanguages('  languages: [typescript, javascript]')], ['typescript', 'javascript'])
+    assert.deepEqual([...parseSemgrepLanguages('languages:\n    - python\n    - py\n')], ['python', 'py'])
+    assert.equal(semgrepDomain('languages: [python]\nlanguages: [py]'), PYTHON)
+    assert.equal(semgrepDomain('languages: [typescript, javascript]'), JAVASCRIPT)
+    // Both sides of the split, an unmapped language, and no declaration at all.
+    assert.equal(semgrepDomain('languages: [python]\nlanguages: [typescript]'), UNIVERSAL)
+    assert.equal(semgrepDomain('languages: [generic]'), UNIVERSAL)
+    assert.equal(semgrepDomain('rules:\n  - id: x\n'), UNIVERSAL)
+})
+
+// Markdown in a tripwire tree compiles into nothing and no suite reads it. A
+// pull request template used to serialize a PR against the entire repo.
+test('markdown inside a tripwire tree is prose, not a CI change', () => {
+    for (const file of ['.github/pull_request_template.md', '.semgrep/rules/devex/README.md']) {
+        assert.equal(isTripwire(file), false, file)
+        assert.deepEqual(computeTargets([file], CONTEXT), ['prose'], file)
+    }
+})
+
+test('the widest tripwire in a change set wins', () => {
+    // A language-scoped tripwire accumulates alongside the narrow files rather
+    // than replacing them, so the product's own lane survives.
+    const scoped = computeTargets(['products/alpha/backend/api.py', 'mypy.ini'], CONTEXT)
+    assert.equal(scoped.includes('py:product:alpha'), true)
+    assert.equal(scoped.includes('fe:core'), false)
+    // A universal one still swallows everything.
+    assert.deepEqual(computeTargets(['products/alpha/backend/api.py', 'pnpm-lock.yaml'], CONTEXT), EVERYTHING)
 })
 
 // The single most dangerous failure mode: an unclaimed path yielding an empty
 // target set reads to Trunk as "overlaps nothing", so the PR merges in parallel
 // with everything. A new top-level directory must widen, never narrow.
-test('an unmapped path forces ALL rather than an empty target set', () => {
+test('an unmapped path widens rather than yielding an empty target set', () => {
     for (const file of [
         'some-new-toplevel/thing.go',
         'common/unrecognized/x.ts',
@@ -99,8 +222,70 @@ test('an unmapped path forces ALL rather than an empty target set', () => {
         'share/geoip.py',
         'agent-os/generate.py',
     ]) {
-        assert.equal(computeTargets([file], CONTEXT), ALL, `${file} should force ALL`)
+        assert.deepEqual(computeTargets([file], CONTEXT), EVERYTHING, `${file} should widen`)
     }
+})
+
+// THE INVARIANT behind replacing the sentinel: a widened PR is only equivalent
+// to "ALL" if the enumerated set contains every target any other PR can claim.
+// One missing target makes the widened PR disjoint from the PR claiming it,
+// which is exactly the silent break the sentinel existed to prevent.
+test('every target the rules can emit appears in the enumerated universe', () => {
+    const everyRule = [
+        'posthog/models/team.py',
+        'ee/settings.py',
+        'ee/frontend/x.tsx',
+        'frontend/src/index.tsx',
+        'packages/quill/src/index.ts',
+        'playwright/spec.ts',
+        'nodejs/src/main.ts',
+        'services/mcp/src/index.ts',
+        'services/oauth-proxy/src/index.ts',
+        'docs/onboarding/index.ts',
+        '.agents/skills/merging-prs/SKILL.md',
+        'cli/src/main.rs',
+        'livestream/auth/jwt.go',
+        'funnel-udf/src/codec.rs',
+        'terraform/us/dashboards.tf',
+        '.stamphog/policy.yml',
+        '.vscode/launch.json',
+        'tools/phrocs/src/main.rs',
+        'tools/pr-approval-agent/policy.py',
+        'common/hogvm/x.py',
+        'common/storybook/x.ts',
+        'rust/shared/src/lib.rs',
+        'products/alpha/backend/api.py',
+        'products/beta/frontend/Scene.tsx',
+        'README.md',
+        '.oxlintrc.json',
+        'mypy.ini',
+        '.github/workflows/ci-rust.yml',
+    ]
+    for (const file of everyRule) {
+        const targets = computeTargets([file], CONTEXT)
+        assert.notEqual(targets, ALL, `${file} should enumerate`)
+        for (const target of targets) {
+            assert.equal(EVERYTHING.includes(target), true, `${target} (from ${file}) is missing from allKnownTargets`)
+        }
+    }
+})
+
+// Enumeration is only safe when it is complete, so a context that cannot name
+// every crate or service has to fall back to the sentinel rather than upload a
+// set that is missing lanes.
+test('an incomplete context falls back to the ALL sentinel', () => {
+    assert.equal(allKnownTargets({ ...CONTEXT, rustGraph: null }), null)
+    assert.equal(allKnownTargets({ ...CONTEXT, services: null }), null)
+    assert.equal(computeTargets(['some-new-toplevel/thing.go'], { ...CONTEXT, services: null }), ALL)
+})
+
+test('tripwire domains are reported for telemetry', () => {
+    assert.equal(tripwireDomain('pnpm-lock.yaml'), UNIVERSAL)
+    assert.equal(tripwireDomain('.oxlintrc.json'), JAVASCRIPT)
+    assert.equal(tripwireDomain('mypy.ini'), PYTHON)
+    assert.equal(tripwireDomain('.github/workflows/ci-rust.yml'), RUST)
+    assert.equal(tripwireDomain('.github/pull_request_template.md'), null)
+    assert.equal(tripwireDomain('products/alpha/backend/api.py'), null)
 })
 
 // Each of these went to ALL only because no rule named the directory, which
@@ -184,8 +369,8 @@ test('an unresolvable rust crate graph reports every crate instead of narrowing'
     assert.equal(computeTargets(['rust/shared/src/lib.rs'], noGraph), ALL)
 })
 
-test('a rust path outside every known crate forces ALL', () => {
-    assert.equal(computeTargets(['rust/not-a-crate/file.rs'], CONTEXT), ALL)
+test('a rust path outside every known crate widens', () => {
+    assert.deepEqual(computeTargets(['rust/not-a-crate/file.rs'], CONTEXT), EVERYTHING)
 })
 
 test('reverseClosure walks transitively and excludes unrelated nodes', () => {
@@ -573,16 +758,16 @@ test('backend-coupled and unrecognized tools stay in the backend lanes', () => {
 })
 
 // These steer what every suite runs, so they cannot sit in one domain's lane.
-test('CI-steering scripts directly under tools/ force ALL', () => {
-    assert.equal(computeTargets(['tools/playwright_spec_selection.py'], CONTEXT), ALL)
-    assert.equal(computeTargets(['tools/snob_backend_test_selection_shadow.py'], CONTEXT), ALL)
+test('CI-steering scripts directly under tools/ widen', () => {
+    assert.deepEqual(computeTargets(['tools/playwright_spec_selection.py'], CONTEXT), EVERYTHING)
+    assert.deepEqual(computeTargets(['tools/snob_backend_test_selection_shadow.py'], CONTEXT), EVERYTHING)
 })
 
 // Both sit on the fe/py boundary: openapi-codegen generates the frontend types
 // from backend serializers, and owners is read by both suites.
 test('cross-domain tools are tripwires rather than backend-only', () => {
-    assert.equal(computeTargets(['tools/openapi-codegen/config.ts'], CONTEXT), ALL)
-    assert.equal(computeTargets(['tools/owners/owners/__init__.py'], CONTEXT), ALL)
+    assert.deepEqual(computeTargets(['tools/openapi-codegen/config.ts'], CONTEXT), EVERYTHING)
+    assert.deepEqual(computeTargets(['tools/owners/owners/__init__.py'], CONTEXT), EVERYTHING)
 })
 
 // Prose overlaps only other prose, and has to reach that lane through the
@@ -619,8 +804,8 @@ test('docs/onboarding sources claim the frontend domain', () => {
 
 // Everything under docs/ is prose today apart from that package, so a new
 // non-prose tree there must widen rather than inherit the inert classification.
-test('an unrecognized non-prose file under docs forces ALL', () => {
-    assert.equal(computeTargets(['docs/tooling/generate.py'], CONTEXT), ALL)
+test('an unrecognized non-prose file under docs widens', () => {
+    assert.deepEqual(computeTargets(['docs/tooling/generate.py'], CONTEXT), EVERYTHING)
 })
 
 test('independent trees stay disjoint so they can share no lane', () => {

--- a/.github/scripts/trunk-lane-telemetry.js
+++ b/.github/scripts/trunk-lane-telemetry.js
@@ -70,8 +70,17 @@ function buildProperties(changedFiles, impactedTargets, universe) {
     // Which blast radius each tripwire claimed, so a domain that turns out to
     // widen more than its share is visible without re-deriving it from paths.
     const tripwireDomains = {}
+    let semgrepDomains = null
     for (const file of tripwireFiles) {
-        const domain = tripwireDomain(file)
+        let domain = tripwireDomain(file)
+        if (domain === 'semgrep') {
+            try {
+                semgrepDomains = semgrepDomains || buildContext(REPO_ROOT).semgrepDomains || new Map()
+                domain = semgrepDomains.get(file) || 'universal'
+            } catch (error) {
+                domain = 'universal'
+            }
+        }
         tripwireDomains[domain] = (tripwireDomains[domain] || 0) + 1
     }
 

--- a/.github/scripts/trunk-lane-telemetry.js
+++ b/.github/scripts/trunk-lane-telemetry.js
@@ -14,15 +14,22 @@
 // Raw paths are deliberately not sent. A PR can touch thousands of them, they
 // blow past property limits, and in aggregate the directory histogram answers
 // the same questions. The exception is tripwire_files, which names the handful
-// of paths that forced ALL, because that is the field that says which rule to
-// go tune.
+// of paths that widened the PR, because that is the field that says which rule
+// to go tune, alongside tripwire_domains for how far each one reached.
 //
 // Input:  changed file paths, one per line, on stdin
 //         IMPACTED_TARGETS — the JSON uploaded to Trunk, {"impactedTargets": ...}
 // Output: JSON object of event properties on stdout
 
 const fs = require('fs')
-const { isTripwire } = require('./trunk-impacted-targets')
+const {
+    ALL,
+    allKnownTargets,
+    buildContext,
+    isTripwire,
+    tripwireDomain,
+    REPO_ROOT,
+} = require('./trunk-impacted-targets')
 
 // Enough to name the culprit without turning a wide PR into a huge payload.
 const MAX_LISTED = 20
@@ -32,9 +39,14 @@ function domainOf(target) {
     return ['py', 'fe', 'rust', 'svc', 'node', 'tools', 'agents', 'prose'].includes(prefix) ? prefix : 'other'
 }
 
-function buildProperties(changedFiles, impactedTargets) {
-    const isAll = impactedTargets === 'ALL'
+// A widened PR now uploads the enumerated target list rather than "ALL", so a
+// widening and a genuinely repo-wide change are the same array and only the
+// universe tells them apart. Without it the dashboard would read every widening
+// as a PR that legitimately claimed every lane, which is the distinction this
+// event exists to make.
+function buildProperties(changedFiles, impactedTargets, universe) {
     const targets = Array.isArray(impactedTargets) ? impactedTargets : []
+    const isAll = impactedTargets === ALL || (Boolean(universe) && targets.length === universe.length)
     const isProse = targets.length === 1 && targets[0] === 'prose'
 
     const targetDomains = {}
@@ -55,6 +67,14 @@ function buildProperties(changedFiles, impactedTargets) {
 
     const tripwireFiles = changedFiles.filter(isTripwire)
 
+    // Which blast radius each tripwire claimed, so a domain that turns out to
+    // widen more than its share is visible without re-deriving it from paths.
+    const tripwireDomains = {}
+    for (const file of tripwireFiles) {
+        const domain = tripwireDomain(file)
+        tripwireDomains[domain] = (tripwireDomains[domain] || 0) + 1
+    }
+
     return {
         changed_file_count: changedFiles.length,
         changed_top_dirs: topDirs,
@@ -66,6 +86,7 @@ function buildProperties(changedFiles, impactedTargets) {
         targets: targets.slice(0, MAX_LISTED),
         target_domains: targetDomains,
         tripwire_files: tripwireFiles.slice(0, MAX_LISTED),
+        tripwire_domains: tripwireDomains,
         // Separates the three ways a PR ends up in one lane: a rule that
         // deliberately widened it, a path no rule claimed (the early warning
         // that the script needs a rule for a directory someone just added), and
@@ -95,5 +116,11 @@ if (require.main === module) {
     } catch (error) {
         console.error(`Could not read IMPACTED_TARGETS (${error.message}); reporting the file side only`)
     }
-    process.stdout.write(JSON.stringify(buildProperties(changedFiles, impactedTargets)))
+    let universe = null
+    try {
+        universe = allKnownTargets(buildContext(REPO_ROOT))
+    } catch (error) {
+        console.error(`Could not enumerate the target universe (${error.message}); is_all reports the sentinel only`)
+    }
+    process.stdout.write(JSON.stringify(buildProperties(changedFiles, impactedTargets, universe)))
 }

--- a/.github/scripts/trunk-lane-telemetry.test.js
+++ b/.github/scripts/trunk-lane-telemetry.test.js
@@ -5,14 +5,17 @@ const assert = require('node:assert/strict')
 
 const { buildProperties } = require('./trunk-lane-telemetry')
 
+// Stands in for the enumerated set a widening decision now uploads.
+const UNIVERSE = ['fe:core', 'fe:product:alpha', 'prose', 'py:core', 'py:product:alpha']
+
 // widening_reason is the field the dashboard acts on: a tripwire hit is a rule
 // doing its job, while an unclassified path means a directory exists that no
 // rule claims yet. Collapsing the two would hide the second behind the noise of
 // the first, which is every workflow edit.
 test('widening is attributed to the rule that caused it', () => {
     const cases = [
-        [['.github/workflows/ci.yml'], 'ALL', 'tripwire'],
-        [['terraform/main.tf'], 'ALL', 'unclassified_path'],
+        [['.github/workflows/ci.yml'], UNIVERSE, 'tripwire'],
+        [['terraform/main.tf'], UNIVERSE, 'unclassified_path'],
         [['products/alpha/frontend/Scene.tsx'], ['fe:product:alpha'], null],
         // The compute step widens and exits early when the merge base or diff
         // is unavailable, so the file list never reaches the script. Reading
@@ -20,18 +23,40 @@ test('widening is attributed to the rule that caused it', () => {
         [[], 'ALL', 'diff_unavailable'],
     ]
     for (const [files, targets, expected] of cases) {
-        assert.equal(buildProperties(files, targets).widening_reason, expected, files[0])
+        assert.equal(buildProperties(files, targets, UNIVERSE).widening_reason, expected, files[0])
     }
+})
+
+// A widened PR uploads the same array a genuinely repo-wide PR would, so only
+// the universe separates them. Without it every widening reads as a PR that
+// legitimately claimed every lane.
+test('widening is recognized from the enumerated set, not just the sentinel', () => {
+    const widened = buildProperties(['bin/start'], UNIVERSE, UNIVERSE)
+    assert.equal(widened.is_all, true)
+    assert.equal(widened.target_count, UNIVERSE.length)
+    assert.deepEqual(widened.tripwire_files, ['bin/start'])
+
+    const narrow = buildProperties(['products/alpha/frontend/Scene.tsx'], ['fe:product:alpha'], UNIVERSE)
+    assert.equal(narrow.is_all, false)
 })
 
 // ALL is the string "ALL", not an array, so anything reading .length off it
 // reports a target_count of 0 for both the widest and the narrowest outcome.
-test('an ALL change set reports no targets but is flagged', () => {
-    const props = buildProperties(['bin/start'], 'ALL')
+// It survives for the degraded cases, where the universe cannot be built.
+test('the ALL sentinel still reports no targets but is flagged', () => {
+    const props = buildProperties(['bin/start'], 'ALL', null)
     assert.equal(props.is_all, true)
     assert.equal(props.target_count, 0)
     assert.deepEqual(props.targets, [])
     assert.deepEqual(props.tripwire_files, ['bin/start'])
+})
+
+// Which domain widened a PR is the field that says whether a rule is pulling
+// its weight, and it is not recoverable from the paths alone once the split
+// exists.
+test('tripwire domains are counted alongside the files', () => {
+    const props = buildProperties(['.oxlintrc.json', 'mypy.ini', 'pnpm-lock.yaml'], UNIVERSE, UNIVERSE)
+    assert.deepEqual(props.tripwire_domains, { javascript: 1, python: 1, universal: 1 })
 })
 
 test('file paths are summarized rather than sent', () => {

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -99,7 +99,7 @@ jobs:
                   echo "$changed" | sed 's/^/  /'
                   printf '%s\n' "$changed" > "$RUNNER_TEMP/changed-files.txt"
 
-                  # The script prints a JSON array on stdout, or "ALL" when it
+                  # The script prints a JSON array on stdout, or the JSON string "ALL" when it
                   # could not enumerate the targets, and never exits non-zero;
                   # it degrades to "ALL" internally on any error.
                   computed="$(printf '%s\n' "$changed" | node .github/scripts/trunk-impacted-targets.js)"

--- a/.github/workflows/trunk-impacted-targets.yml
+++ b/.github/workflows/trunk-impacted-targets.yml
@@ -7,8 +7,10 @@ name: Trunk impacted targets
 # Targets are computed by .github/scripts/trunk-impacted-targets.js, which maps
 # changed paths onto lane names. Trunk runs two PRs in parallel only when their
 # target sets are disjoint, so that script is biased toward over-reporting and
-# falls back to "ALL" (overlaps everything, the old single-lane behavior)
-# whenever it cannot classify a change with confidence.
+# claims every known target (the old single-lane behavior) whenever it cannot
+# classify a change with confidence. The "ALL" sentinel below is reserved for
+# the degraded cases where the target list cannot be computed at all, which
+# means "unknown" rather than "everything".
 #
 # The upload authenticates with the org API token (x-api-token) on internal PRs.
 # Fork PR workflow runs do NOT receive repo secrets — GitHub withholds them from
@@ -97,8 +99,9 @@ jobs:
                   echo "$changed" | sed 's/^/  /'
                   printf '%s\n' "$changed" > "$RUNNER_TEMP/changed-files.txt"
 
-                  # The script prints "ALL" or a JSON array on stdout and never
-                  # exits non-zero; it degrades to "ALL" internally on any error.
+                  # The script prints a JSON array on stdout, or "ALL" when it
+                  # could not enumerate the targets, and never exits non-zero;
+                  # it degrades to "ALL" internally on any error.
                   computed="$(printf '%s\n' "$changed" | node .github/scripts/trunk-impacted-targets.js)"
                   printf 'targets=%s\n' "$(jq -cn --argjson t "$computed" '{impactedTargets: $t}')" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem

We started sending merge-queue lane assignment to engineering analytics a few hours ago, and the first data made two things obvious.

**37% of PRs widen to the single lane, and every one of them is a tripwire hit.** Not an unclassified path (that count is zero) - a rule deliberately widening. The tripwire list is one flat bucket with one behavior, so `.semgrep/rules/security/idor-team-scoped-models.yaml` widens a PR exactly as hard as `pnpm-lock.yaml` does. That file is the one every new team-scoped model has to touch, and the change is always additive: two model names appended to an allowlist regex. It cannot fail anyone else's code. It was still costing the whole repo's parallelism.

Bucketing the widened PRs by what actually tripped them:

| Bucket | PRs |
| --- | --- |
| Mixed / genuinely cross-cutting | 31 |
| Lane-rule change | 17 |
| CI definitions only | 16 |
| Lint rules only | 10 |
| Backend toolchain only | 1 |

**The other thing: `ALL` is opaque.** It is a magic string, so a widened PR's uploaded payload says nothing about which lanes it claimed. You cannot diff "what it claimed" against "what it should have claimed", which is the whole loop for tuning a rule.

## Changes

### Tripwires carry a blast radius

`TRIPWIRES` (flat glob list) becomes `TRIPWIRE_RULES` - ordered `[glob, domain]` pairs, first match wins. Four domains, each a superset by construction of what a file in it can break:

| Domain | Claims |
| --- | --- |
| `python` | `py:core` + every `py:product:*` + every `tools:*` |
| `javascript` | `fe:core` + every `fe:product:*` + `node:ingestion` + every `svc:*` + `cli` + `tools:*` |
| `rust` | every crate |
| `universal` | everything - the default whenever the radius is not confidently narrower |

Three rules drive the win:

**Semgrep by declared language.** Every semgrep rule declares `languages:` and semgrep enforces it, so it is a sound source. This sidesteps the tighten-vs-loosen problem entirely: a Python rule can only fail Python, whichever direction it moves. A rule spanning both sides, naming an unmapped language like `generic`, or failing to parse falls back to universal.

**Single-language workflows.** A workflow decides which suites run, so one defining a single language's suite is held to that language's lanes. Explicit allowlist (`ci-frontend`, `ci-storybook`, `ci-nodejs`, `ci-mcp`, `ci-backend`, `ci-dagster`, `ci-rust`). Everything else under `.github/` stays universal - the list grows by decision, same as `STANDALONE_TREES`.

**Markdown in a tripwire tree is prose.** `.github/**/*.md` and `.semgrep/**/*.md` are explicit non-tripwires. The pull request template alone was widening 13 PRs.

Measured against the real repo:

| Change | Before | After |
| --- | --- | --- |
| `.semgrep/.../idor-team-scoped-models.yaml` | ALL (254) | 89 |
| `.semgrep/.../toolbar-no-raw-fetch.yaml` | ALL (254) | 97 |
| `.github/workflows/ci-frontend.yml` | ALL (254) | 97 |
| `.github/workflows/ci-backend.yml` | ALL (254) | 89 |
| `.github/workflows/ci-rust.yml` | ALL (254) | 69 |
| `.github/pull_request_template.md` | ALL (254) | 1 (`prose`) |

> [!NOTE]
> Lockfiles deliberately stay universal. I considered splitting them, then read `pnpm-workspace.yaml`: it lists frontend, nodejs, services, tools, products **and** three Rust node bindings, and `pyproject.toml` roots every product package. They really are near-universal. The telemetry agreed - one PR, against 26 for the CI and lint rules.

> [!WARNING]
> Lane-rule files stay universal on principle, not for want of a narrower radius. `trunk-impacted-targets*.js`, `trunk-lane-telemetry*.js`, `turbo-discover*.js`, `trunk-impacted-targets.yml`, `tach.toml`, `turbo.json`. Two PRs that disagree about the partition cannot be safely placed in it. Same self-gating hazard `CONTRACT_DECLARATIONS` already exists for.

### Widening enumerates instead of shouting ALL

`allKnownTargets(context)` builds the universe by reading products, services, and crates rather than listing them, so a newly added one cannot be missed. Every widening branch returns it. Trunk computes the same set intersection, so queue behavior is unchanged - but the payload is now readable.

`ALL` survives in exactly one role, and it is a different statement: **unknown**, not everything. An unreadable crate graph or `services/` listing here, and the workflow's own degraded paths (no merge base, failed diff, missing compute output), which run in a job with no checkout and genuinely cannot enumerate.

```diff
- return ALL
+ return everything(context)   // allKnownTargets(context) || ALL
```

### Telemetry

This is the part that would have broken silently. A widened PR now uploads the same array a genuinely repo-wide PR would, so `is_all` is no longer readable off the payload. `trunk-lane-telemetry.js` builds the universe itself and compares. Also adds `tripwire_domains`, so you can see how far each tripwire reached without re-deriving it from paths.

## How did you test this code?

I (actually Claude) ran these. No manual or in-browser testing - this is a CI script with no UI.

- `node --test` across `trunk-impacted-targets.test.js`, `trunk-lane-telemetry.test.js`, and both `turbo-discover` suites: **90 pass, 0 fail**.
- `bin/hogli lint:workflows`: 7 checks across 123 workflows, clean.
- `oxfmt` on all four scripts. `oxlint` does not cover `.github/`.
- Ran the script against real repo paths and against PR #75748's actual 46-file diff (the PR that prompted this - it widened on one semgrep line). Numbers in the table above are from those runs, not from fixtures.
- End-to-end through the telemetry script to confirm the widening signal survives: `pnpm-lock.yaml` → `is_all=true reason=tripwire`, an unclassified tree → `is_all=true reason=unclassified_path`, a new model plus the IDOR rule → `is_all=false count=89`.

New tests and the regression each catches, none of which an existing test covered:

- **`every target the rules can emit appears in the enumerated universe`** - the load-bearing one. Enumeration is only equivalent to `ALL` if the universe contains every target another PR can claim. One missing target makes a widened PR *disjoint* from the PR claiming it, which is the silent master break the sentinel existed to prevent. Runs 28 representative paths through `computeTargets` and asserts membership for every target.
- **`an incomplete context falls back to the ALL sentinel`** - a context that cannot name every crate or service must not upload a partial set.
- **`a change to the lane rules themselves stays universal`** - guards the self-gating carve-out against someone later "optimizing" `.github/scripts/trunk-*.js` into a domain.
- **`a language-scoped tripwire claims only that language`** and **`a semgrep rule claims the lanes of the languages it declares`** - the new narrowing, asserted in both directions (what it claims and what it must not).
- **`markdown inside a tripwire tree is prose`** - the template case.
- **`the widest tripwire in a change set wins`** - a scoped tripwire accumulates alongside narrow files, a universal one still swallows everything.

Existing `forces ALL` assertions became `deepEqual(..., EVERYTHING)` rather than being deleted, so the widening cases are still pinned.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude whether the lane telemetry we shipped this morning was flowing yet. It was, so we read it, and the read turned into this.

Worth recording what got rejected, because the first proposal was mine and it was wrong. I suggested killing `TRIPWIRES` and `ALL` outright: give tripwires their own lane, and put anything unmatched in a shared `default` lane reported to engineering analytics. Claude pushed back on both halves and I agree with the pushback.

A tripwire lane inverts the semantics. Trunk parallelizes iff target sets are disjoint, so a `tripwire` lane would let a lockfile bump merge beside frontend code that was never compiled against it - precisely the conflict the tripwire exists to prevent. The only safe version emits `tripwire` plus every real target, which is `ALL` with extra spelling.

A `default` lane flips the one deliberately fail-safe branch to fail-open, and buys nothing measurable: `unclassified_path` is zero. Reporting does not substitute for serialization, because it is after the fact - you learn you had a gap once the two PRs already merged in parallel. And one shared `default` lane serializes the wrong pairs: two unrelated new trees block each other while each runs parallel to the code that imports them. That visibility already exists today via `widening_reason`, without giving up the protection.

What survived is the half with evidence behind it: split tripwires by blast radius (26 PRs), and keep `ALL`'s behavior while dropping the magic string.

One knob left deliberately untouched. `prose` is included in `allKnownTargets`, so a docs-only PR still serializes behind a widened one, exactly as `ALL` did. Dropping it is a one-line follow-up, but it is a real behavior change and deserves its own decision rather than riding along inside what is meant to be a rename.

Tools: Claude Code (Opus 5), PostHog MCP for the lane telemetry queries. No repo skills applied - `/writing-tests` and `/writing-code-comments` conventions were followed from AGENTS.md but the skills themselves were not invoked.
