### PR TITLE
feat(tasks): wake parents when child PRs merge

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -314,6 +314,67 @@ class TestGitHubPRWebhook(TestCase):
         assert run.output is not None
         self.assertIs(run.output.get("pr_merged"), True)
 
+    @parameterized.expand(
+        [
+            ("opted_in_child", {"parent_task_id": "parent", "wake_on": ["pr_merged"]}, True, 1),
+            ("not_opted_in", {"parent_task_id": "parent", "wake_on": []}, True, 0),
+            ("parentless", {"wake_on": ["pr_merged"]}, True, 0),
+            ("closed_unmerged", {"parent_task_id": "parent", "wake_on": ["pr_merged"]}, False, 0),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_pr_merge_parent_wake(self, name, state, merged, expected_wakes, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        pr_url = f"https://github.com/posthog/posthog/pull/{name}"
+        run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={**state, "verified_pr_urls": [pr_url]},
+            output={"pr_url": pr_url},
+        )
+        payload = {
+            "action": "closed",
+            "pull_request": {"html_url": pr_url, "merged": merged},
+        }
+
+        with patch("products.tasks.backend.webhooks.notify_parent_of_child_event") as mock_notify:
+            with self.captureOnCommitCallbacks(execute=True):
+                response = self._make_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mock_notify.call_count, expected_wakes)
+        if expected_wakes:
+            mock_notify.assert_called_once_with(run, "pr_merged")
+
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_duplicate_pr_merge_delivery_wakes_parent_once(self, _mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+        pr_url = "https://github.com/posthog/posthog/pull/782"
+        run = TaskRun.objects.create(
+            task=self.task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            state={
+                "parent_task_id": "parent",
+                "wake_on": ["pr_merged"],
+                "verified_pr_urls": [pr_url],
+            },
+            output={"pr_url": pr_url},
+        )
+        payload = self._merged_pr_payload(pr_url)
+
+        with patch("products.tasks.backend.webhooks.notify_parent_of_child_event") as mock_notify:
+            with self.captureOnCommitCallbacks(execute=True):
+                first_response = self._make_webhook_request(payload)
+                second_response = self._make_webhook_request(payload)
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        mock_notify.assert_called_once_with(run, "pr_merged")
+
     def _closed_pr_payload(self, pr_url: str) -> dict:
         return {
             "action": "closed",

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -17,6 +17,7 @@ from posthog.models.team.team import Team
 from products.signals.backend.models import InvalidStatusTransition, SignalReport
 from products.tasks.backend.facade.api import post_pr_created_thread_update, signal_workflow_completion
 from products.tasks.backend.facade.cancellation import cancel_task_run
+from products.tasks.backend.logic.services.orchestration import notify_parent_of_child_event
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.pr_urls import merge_pr_output, read_pr_urls
 from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX
@@ -300,6 +301,22 @@ def _record_run_pr_merged(task_run: TaskRun) -> None:
     except Exception:
         logger.warning("github_pr_webhook_pr_merged_events_failed", run_id=str(task_run.id), exc_info=True)
     _complete_wizard_run_on_merge(task_run)
+    _notify_parent_of_pr_merge(task_run)
+
+
+def _notify_parent_of_pr_merge(task_run: TaskRun) -> None:
+    state = task_run.state if isinstance(task_run.state, dict) else {}
+    wake_on = state.get("wake_on")
+    if not state.get("parent_task_id") or not isinstance(wake_on, list) or "pr_merged" not in wake_on:
+        return
+
+    def _notify() -> None:
+        try:
+            notify_parent_of_child_event(task_run, "pr_merged")
+        except Exception:
+            logger.warning("github_pr_webhook_parent_wake_failed", run_id=str(task_run.id), exc_info=True)
+
+    transaction.on_commit(_notify)
 
 
 def _complete_wizard_run_on_merge(task_run: TaskRun) -> None:


### PR DESCRIPTION
## Problem

Orchestrated child tasks can already notify their parent when a run finishes, but parents waiting for a merged pull request have no wake path.

**Why:** This enables hands-free sequential orchestration after a child pull request merges.

## Changes

- Wake the parent after the first persisted merge event when the child opted into `pr_merged`.
- Defer delivery until the merge-state write commits and keep webhook processing best-effort.
- Cover opt-in, opt-out, parentless, unmerged, and duplicate-delivery behavior.

## How did you test this code?

- `uv run ruff format products/tasks/backend/webhooks.py products/tasks/backend/tests/test_webhooks.py`
- `uv run ruff check products/tasks/backend/webhooks.py products/tasks/backend/tests/test_webhooks.py`
- `uv run python -m compileall -q products/tasks/backend/webhooks.py products/tasks/backend/tests/test_webhooks.py`
- `.venv/bin/hogli ci:preflight --fix` (no failures)
- The focused webhook suite could not initialize because PostgreSQL was unavailable at `127.0.0.1:5432`.
- Repository-wide mypy found two pre-existing errors in `logic/services/tests/test_orchestration.py`; neither is in this change.

The added tests protect the opt-in fence and the existing idempotent merge-write fence that prevents duplicate wakes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change. This is backend infrastructure behind an unreleased feature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented only step 5 of the supplied orchestration plan on top of the prerequisite step 4 branch. The requested `/i-have-adhd` skill was unavailable in this session and did not shape the code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*