### PR TITLE
feat(experiments): render exposures with quill charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5890,6 +5890,10 @@ snapshots:
         hash: v1.k794b7964.5467f631734e8f360299aa3d5e4a8da5d7ecc2dbe47a5d0727ddfb0dbc9e7ce6.ZGcS-wnQsOO1G4M5I_hw9Aba6YZ1hKpvya9gfWsZvCs
     scenes-app-experiments--experiment-asymmetric-intervals--light:
         hash: v1.k794b7964.595a7efdddc81a3e15f508362a59e9487a3de93950597c714383efc66b6d4e6e.aeWvu1wPNmshDJ_cD8s1hqgaiNAeRROJnYkZu1m2niI
+    scenes-app-experiments--experiment-exposures-expanded--dark:
+        hash: v1.k794b7964.56095d76684633d164b2bd7f3e3da2aefefba1272f2818e3c8f2e4d1bff595c7.jIZ5N9SItEnQIRj-axX2BfRM21O5JSz_MSSH3JyLAd4
+    scenes-app-experiments--experiment-exposures-expanded--light:
+        hash: v1.k794b7964.724a28250f085bea69008b564ca8266298b8f927f6231d8c3ee40571356c99b5.hX_fvUeWfYI85mX0qLAi3WWzB-bHfef61kIPRKsrw8U
     scenes-app-experiments--experiment-frequentist-five-variants--dark:
         hash: v1.k794b7964.3e22f4570288ab145bb9ad96e4da9ad237e46a29cfefb3f758d9d7cf8db5a5d0.VPkcfBFukWV6eRSdNZJ65235H8o-OPsAkEmop4q68Co
     scenes-app-experiments--experiment-frequentist-five-variants--light:

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -25,12 +25,14 @@ import { exposureCriteriaModalLogic } from './exposureCriteriaModalLogic'
 import { buildExposureSeries } from './exposuresTransforms'
 import { VariantTag } from './VariantTag'
 
-/** `LineChart` rather than quill's `Sparkline`: the sparkline reserves 6px top and bottom for its
- *  hover ring, which in this 20px box would leave an 8px plot. This chart is inert, so it can use
- *  nearly the full height — 1px a side keeps the peak point's 2px stroke off the canvas edge.
- *  Held outside `useChartConfig` because the app defaults turn on axis lines and tick marks, which
- *  `hideXAxis`/`hideYAxis` don't suppress and which have nowhere to go in a 20px box. */
-const MICRO_CHART_CONFIG: LineChartConfig = {
+const srmFailureTooltipText =
+    "The distribution of users across variants doesn't match your configured rollout percentages (p < 0.001). This may indicate issues with randomization or data collection."
+
+interface MicroChartProps {
+    exposures: ExperimentExposureQueryResponse
+}
+
+const CHART_CONFIG: LineChartConfig = {
     hideXAxis: true,
     hideYAxis: true,
     showGrid: false,
@@ -40,37 +42,18 @@ const MICRO_CHART_CONFIG: LineChartConfig = {
     tooltip: { enabled: false },
 }
 
-const srmFailureTooltipText =
-    "The distribution of users across variants doesn't match your configured rollout percentages (p < 0.001). This may indicate issues with randomization or data collection."
-
-interface MicroChartProps {
-    exposures: ExperimentExposureQueryResponse
-}
-
 export function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
     const theme = useChartTheme()
     const timeseries = exposures?.timeseries
-    const { labels, series } = useMemo(
-        () => (timeseries?.length ? buildExposureSeries(timeseries) : { labels: [], series: [] }),
-        [timeseries]
-    )
+    const { labels, series } = useMemo(() => buildExposureSeries(timeseries ?? []), [timeseries])
 
     if (!timeseries?.length) {
         return null
     }
 
     return (
-        <div
-            className="inline-block"
-            style={{
-                width: '60px',
-                height: '20px',
-                pointerEvents: 'none',
-                borderBottom: '1px solid var(--color-border-primary)',
-                borderRight: '1px solid var(--color-border-primary)',
-            }}
-        >
-            <LineChart series={series} labels={labels} theme={theme} config={MICRO_CHART_CONFIG} />
+        <div className="inline-block w-[60px] h-[20px] pointer-events-none border-b border-r border-primary">
+            <LineChart series={series} labels={labels} theme={theme} config={CHART_CONFIG} />
         </div>
     )
 }
@@ -83,7 +66,6 @@ function ExposuresChart({ exposures }: ExposuresChartProps): JSX.Element {
     const { timezone } = useValues(teamLogic)
     const theme = useChartTheme()
     const { labels, series } = useMemo(() => buildExposureSeries(exposures.timeseries), [exposures.timeseries])
-    // quill's built-in date tick formatter only kicks in when both interval and timezone are set.
     const config = useChartConfig<TimeSeriesLineChartConfig>(
         () => ({ xAxis: { interval: 'day', timezone }, tooltip: { placement: 'cursor' } }),
         [timezone]

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -1,14 +1,22 @@
 import { useActions, useValues } from 'kea'
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { IconCheckCircle, IconCorrelationAnalysis, IconInfo, IconPencil, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonCollapse, LemonTable, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
+import {
+    LineChart,
+    type LineChartConfig,
+    type Series,
+    TimeSeriesLineChart,
+    type TimeSeriesLineChartConfig,
+} from '@posthog/quill-charts'
 
-import { getSeriesBackgroundColor, getSeriesColor } from 'lib/colors'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
+import { getSeriesColor } from 'lib/colors'
 import { dayjs } from 'lib/dayjs'
-import { useChart } from 'lib/hooks/useChart'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils/numbers'
 import { pluralize } from 'lib/utils/strings'
+import { teamLogic } from 'scenes/teamLogic'
 
 import {
     ExperimentExposureCriteria,
@@ -19,10 +27,22 @@ import {
 import { EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { isDefaultExposureConfig } from '../exposureContract'
-import { useChartColors } from '../MetricsView/shared/colors'
 import { filterLowMultipleVariant, getExposureConfigDisplayName, resolveMultipleVariantHandling } from '../utils'
 import { exposureCriteriaModalLogic } from './exposureCriteriaModalLogic'
 import { VariantTag } from './VariantTag'
+
+/** `LineChart` rather than quill's `Sparkline`: the sparkline reserves 6px top and bottom for its
+ *  hover ring, which in this 20px box would leave an 8px plot. This chart is inert, so it can use
+ *  the full height. */
+const MICRO_CHART_CONFIG: LineChartConfig = {
+    hideXAxis: true,
+    hideYAxis: true,
+    showGrid: false,
+    showCrosshair: false,
+    curve: 'monotone',
+    margins: { top: 0, right: 0, bottom: 0, left: 0 },
+    tooltip: { enabled: false },
+}
 
 const srmFailureTooltipText =
     "The distribution of users across variants doesn't match your configured rollout percentages (p < 0.001). This may indicate issues with randomization or data collection."
@@ -31,97 +51,38 @@ interface MicroChartProps {
     exposures: ExperimentExposureQueryResponse
 }
 
-interface ExposureSeries {
-    variant: string
-    data: number[]
-}
-
 // Single-day timeseries get a synthetic prior day with 0 exposures so the chart
 // can draw a line instead of a single point.
-function buildExposureDatasets(timeseries: ExperimentExposureTimeSeries[]): {
+function buildExposureSeries(timeseries: ExperimentExposureTimeSeries[]): {
     labels: string[]
-    datasets: ExposureSeries[]
+    series: Series[]
 } {
-    let labels = timeseries[0].days.map((day: string) => dayjs(day).format('MM/DD'))
-    let datasets: ExposureSeries[] = timeseries.map((series: ExperimentExposureTimeSeries) => ({
-        variant: series.variant,
-        data: series.exposure_counts,
+    const [firstDay] = timeseries[0].days
+    let labels = timeseries[0].days
+    let series: Series[] = timeseries.map((variantSeries, index) => ({
+        key: variantSeries.variant,
+        label: variantSeries.variant,
+        color: getSeriesColor(index),
+        data: variantSeries.exposure_counts,
     }))
 
-    if (timeseries[0].days.length === 1) {
-        const previousDay = dayjs(timeseries[0].days[0]).subtract(1, 'day').format('MM/DD')
-        labels = [previousDay, ...labels]
-        datasets = datasets.map((dataset) => ({
-            ...dataset,
-            data: [0, ...dataset.data],
-        }))
+    if (labels.length === 1) {
+        // Mirror the backend's day shape (`date` vs `datetime` isoformat) so both labels parse alike.
+        const dayFormat = firstDay.includes('T') ? 'YYYY-MM-DDTHH:mm:ss' : 'YYYY-MM-DD'
+        labels = [dayjs(firstDay).subtract(1, 'day').format(dayFormat), ...labels]
+        series = series.map((variantSeries) => ({ ...variantSeries, data: [0, ...variantSeries.data] }))
     }
 
-    return { labels, datasets }
+    return { labels, series }
 }
 
 export function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
-    const { canvasRef } = useChart({
-        getConfig: () => {
-            if (!exposures?.timeseries?.length) {
-                return null
-            }
+    const theme = useChartTheme()
+    const timeseries = exposures?.timeseries
+    const series = useMemo(() => (timeseries?.length ? buildExposureSeries(timeseries).series : []), [timeseries])
+    const labels = useMemo(() => series[0]?.data.map((_, i) => String(i)) ?? [], [series])
 
-            const { datasets: rawDatasets } = buildExposureDatasets(exposures.timeseries)
-            const datasets = rawDatasets.map((series, index) => ({
-                data: series.data,
-                borderColor: getSeriesColor(index),
-                fill: false,
-                tension: 0.3,
-                borderWidth: 1.5,
-                pointRadius: 0,
-            }))
-
-            return {
-                type: 'line' as const,
-                data: {
-                    labels: datasets[0].data.map((_, i) => i),
-                    datasets,
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    animation: false,
-                    scales: {
-                        x: {
-                            display: false,
-                            grid: {
-                                display: false,
-                            },
-                        },
-                        y: {
-                            display: false,
-                            beginAtZero: true,
-                            grid: {
-                                display: false,
-                            },
-                        },
-                    },
-                    plugins: {
-                        legend: {
-                            display: false,
-                        },
-                        tooltip: {
-                            enabled: false,
-                        },
-                    },
-                    elements: {
-                        line: {
-                            borderJoinStyle: 'round',
-                        },
-                    },
-                },
-            }
-        },
-        deps: [exposures],
-    })
-
-    if (!exposures?.timeseries?.length) {
+    if (!timeseries?.length) {
         return null
     }
 
@@ -136,87 +97,28 @@ export function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
                 borderRight: '1px solid var(--color-border-primary)',
             }}
         >
-            <canvas ref={canvasRef} />
+            <LineChart series={series} labels={labels} theme={theme} config={MICRO_CHART_CONFIG} />
         </div>
     )
 }
 
 interface ExposuresChartProps {
     exposures: ExperimentExposureQueryResponse
-    axisLineColor: string
 }
 
-function ExposuresChart({ exposures, axisLineColor }: ExposuresChartProps): JSX.Element {
-    const { canvasRef } = useChart({
-        getConfig: () => {
-            if (!exposures?.timeseries?.length) {
-                return null
-            }
-
-            const { labels, datasets: rawDatasets } = buildExposureDatasets(exposures.timeseries)
-            const datasets = rawDatasets.map((series, index) => ({
-                label: series.variant,
-                data: series.data,
-                borderColor: getSeriesColor(index),
-                backgroundColor: getSeriesBackgroundColor(index),
-                fill: false,
-                tension: 0,
-                borderWidth: 2,
-                pointRadius: 0,
-            }))
-
-            return {
-                type: 'line' as const,
-                data: { labels, datasets },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: false,
-                    interaction: {
-                        intersect: false,
-                        mode: 'nearest',
-                        axis: 'x',
-                    },
-                    scales: {
-                        x: {
-                            ticks: {
-                                maxTicksLimit: 8,
-                                autoSkip: true,
-                                maxRotation: 0,
-                                minRotation: 0,
-                            },
-                            grid: {
-                                display: true,
-                                color: axisLineColor,
-                            },
-                        },
-                        y: {
-                            beginAtZero: true,
-                            grid: {
-                                display: true,
-                                color: axisLineColor,
-                            },
-                        },
-                    },
-                    plugins: {
-                        legend: {
-                            display: false,
-                            labels: {
-                                boxWidth: 4,
-                                boxPadding: 20,
-                                pointStyle: 'dash',
-                            },
-                        },
-                        crosshair: false,
-                    },
-                },
-            }
-        },
-        deps: [exposures, axisLineColor],
-    })
+function ExposuresChart({ exposures }: ExposuresChartProps): JSX.Element {
+    const { timezone } = useValues(teamLogic)
+    const theme = useChartTheme()
+    const { labels, series } = useMemo(() => buildExposureSeries(exposures.timeseries), [exposures.timeseries])
+    // quill's built-in date tick formatter only kicks in when both interval and timezone are set.
+    const config = useChartConfig<TimeSeriesLineChartConfig>(
+        () => ({ xAxis: { interval: 'day', timezone }, tooltip: { placement: 'cursor' } }),
+        [timezone]
+    )
 
     return (
         <div className="relative h-[200px]">
-            <canvas ref={canvasRef} />
+            <TimeSeriesLineChart series={series} labels={labels} theme={theme} config={config} />
         </div>
     )
 }
@@ -245,7 +147,6 @@ export function Exposures(): JSX.Element {
         resolvedExposureEvent,
     } = useValues(experimentLogic)
     const { openExposureCriteriaModal } = useActions(exposureCriteriaModalLogic)
-    const colors = useChartColors()
 
     const [isCollapsed, setIsCollapsed] = useState(true)
 
@@ -397,7 +298,7 @@ export function Exposures(): JSX.Element {
                                     </div>
                                 </div>
                             ) : (
-                                <ExposuresChart exposures={exposures} axisLineColor={colors.EXPOSURES_AXIS_LINES} />
+                                <ExposuresChart exposures={exposures} />
                             )}
 
                             {/* Exposure Criteria Section */}

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -52,7 +52,8 @@ export function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
     }
 
     return (
-        <div className="inline-block w-[60px] h-[20px] pointer-events-none border-b border-r border-primary">
+        // Flex column, not block: the chart root is `flex-1 min-h-0` and collapses to 0 without it.
+        <div className="inline-flex flex-col w-[60px] h-[20px] pointer-events-none border-b border-r border-primary">
             <LineChart series={series} labels={labels} theme={theme} config={CHART_CONFIG} />
         </div>
     )
@@ -72,7 +73,7 @@ function ExposuresChart({ exposures }: ExposuresChartProps): JSX.Element {
     )
 
     return (
-        <div className="relative h-[200px]">
+        <div className="relative h-[200px] flex flex-col">
             <TimeSeriesLineChart series={series} labels={labels} theme={theme} config={config} />
         </div>
     )

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -52,7 +52,6 @@ export function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
     }
 
     return (
-        // Flex column, not block: the chart root is `flex-1 min-h-0` and collapses to 0 without it.
         <div className="inline-flex flex-col w-[60px] h-[20px] pointer-events-none border-b border-r border-primary">
             <LineChart series={series} labels={labels} theme={theme} config={CHART_CONFIG} />
         </div>

--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -6,41 +6,37 @@ import { LemonButton, LemonCollapse, LemonTable, LemonTag, Spinner, Tooltip } fr
 import {
     LineChart,
     type LineChartConfig,
-    type Series,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
 } from '@posthog/quill-charts'
 
 import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
-import { getSeriesColor } from 'lib/colors'
-import { dayjs } from 'lib/dayjs'
 import { humanFriendlyLargeNumber, humanFriendlyNumber } from 'lib/utils/numbers'
 import { pluralize } from 'lib/utils/strings'
 import { teamLogic } from 'scenes/teamLogic'
 
-import {
-    ExperimentExposureCriteria,
-    ExperimentExposureQueryResponse,
-    ExperimentExposureTimeSeries,
-} from '~/queries/schema/schema-general'
+import { ExperimentExposureCriteria, ExperimentExposureQueryResponse } from '~/queries/schema/schema-general'
 
 import { EXPERIMENT_VARIANT_MULTIPLE } from '../constants'
 import { experimentLogic } from '../experimentLogic'
 import { isDefaultExposureConfig } from '../exposureContract'
 import { filterLowMultipleVariant, getExposureConfigDisplayName, resolveMultipleVariantHandling } from '../utils'
 import { exposureCriteriaModalLogic } from './exposureCriteriaModalLogic'
+import { buildExposureSeries } from './exposuresTransforms'
 import { VariantTag } from './VariantTag'
 
 /** `LineChart` rather than quill's `Sparkline`: the sparkline reserves 6px top and bottom for its
  *  hover ring, which in this 20px box would leave an 8px plot. This chart is inert, so it can use
- *  the full height. */
+ *  nearly the full height — 1px a side keeps the peak point's 2px stroke off the canvas edge.
+ *  Held outside `useChartConfig` because the app defaults turn on axis lines and tick marks, which
+ *  `hideXAxis`/`hideYAxis` don't suppress and which have nowhere to go in a 20px box. */
 const MICRO_CHART_CONFIG: LineChartConfig = {
     hideXAxis: true,
     hideYAxis: true,
     showGrid: false,
     showCrosshair: false,
     curve: 'monotone',
-    margins: { top: 0, right: 0, bottom: 0, left: 0 },
+    margins: { top: 1, right: 0, bottom: 1, left: 0 },
     tooltip: { enabled: false },
 }
 
@@ -51,36 +47,13 @@ interface MicroChartProps {
     exposures: ExperimentExposureQueryResponse
 }
 
-// Single-day timeseries get a synthetic prior day with 0 exposures so the chart
-// can draw a line instead of a single point.
-function buildExposureSeries(timeseries: ExperimentExposureTimeSeries[]): {
-    labels: string[]
-    series: Series[]
-} {
-    const [firstDay] = timeseries[0].days
-    let labels = timeseries[0].days
-    let series: Series[] = timeseries.map((variantSeries, index) => ({
-        key: variantSeries.variant,
-        label: variantSeries.variant,
-        color: getSeriesColor(index),
-        data: variantSeries.exposure_counts,
-    }))
-
-    if (labels.length === 1) {
-        // Mirror the backend's day shape (`date` vs `datetime` isoformat) so both labels parse alike.
-        const dayFormat = firstDay.includes('T') ? 'YYYY-MM-DDTHH:mm:ss' : 'YYYY-MM-DD'
-        labels = [dayjs(firstDay).subtract(1, 'day').format(dayFormat), ...labels]
-        series = series.map((variantSeries) => ({ ...variantSeries, data: [0, ...variantSeries.data] }))
-    }
-
-    return { labels, series }
-}
-
 export function MicroChart({ exposures }: MicroChartProps): JSX.Element | null {
     const theme = useChartTheme()
     const timeseries = exposures?.timeseries
-    const series = useMemo(() => (timeseries?.length ? buildExposureSeries(timeseries).series : []), [timeseries])
-    const labels = useMemo(() => series[0]?.data.map((_, i) => String(i)) ?? [], [series])
+    const { labels, series } = useMemo(
+        () => (timeseries?.length ? buildExposureSeries(timeseries) : { labels: [], series: [] }),
+        [timeseries]
+    )
 
     if (!timeseries?.length) {
         return null

--- a/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.test.ts
@@ -1,0 +1,46 @@
+import { ExperimentExposureTimeSeries } from '~/queries/schema/schema-general'
+
+import { buildExposureSeries } from './exposuresTransforms'
+
+describe('buildExposureSeries', () => {
+    it('passes the backend days through as labels, one series per variant', () => {
+        const timeseries: ExperimentExposureTimeSeries[] = [
+            { variant: 'control', days: ['2025-05-25', '2025-05-26'], exposure_counts: [10, 25] },
+            { variant: 'test', days: ['2025-05-25', '2025-05-26'], exposure_counts: [12, 30] },
+        ]
+
+        const { labels, series } = buildExposureSeries(timeseries)
+
+        // Raw day strings, not pre-formatted — the chart's date axis parses them against the project timezone.
+        expect(labels).toEqual(['2025-05-25', '2025-05-26'])
+        expect(series).toEqual([
+            { key: 'control', label: 'control', data: [10, 25] },
+            { key: 'test', label: 'test', data: [12, 30] },
+        ])
+    })
+
+    it('pads a single-day timeseries with a zeroed prior day so the chart draws a line', () => {
+        const timeseries: ExperimentExposureTimeSeries[] = [
+            { variant: 'control', days: ['2025-05-26'], exposure_counts: [10] },
+            { variant: 'test', days: ['2025-05-26'], exposure_counts: [12] },
+        ]
+
+        const { labels, series } = buildExposureSeries(timeseries)
+
+        expect(labels).toEqual(['2025-05-25', '2025-05-26'])
+        expect(series).toEqual([
+            { key: 'control', label: 'control', data: [0, 10] },
+            { key: 'test', label: 'test', data: [0, 12] },
+        ])
+    })
+
+    it('keeps every series the same length as the labels', () => {
+        const timeseries: ExperimentExposureTimeSeries[] = [
+            { variant: 'control', days: ['2025-05-26'], exposure_counts: [10] },
+        ]
+
+        const { labels, series } = buildExposureSeries(timeseries)
+
+        expect(series.map((s) => s.data.length)).toEqual([labels.length])
+    })
+})

--- a/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.test.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.test.ts
@@ -11,7 +11,6 @@ describe('buildExposureSeries', () => {
 
         const { labels, series } = buildExposureSeries(timeseries)
 
-        // Raw day strings, not pre-formatted — the chart's date axis parses them against the project timezone.
         expect(labels).toEqual(['2025-05-25', '2025-05-26'])
         expect(series).toEqual([
             { key: 'control', label: 'control', data: [10, 25] },
@@ -32,6 +31,10 @@ describe('buildExposureSeries', () => {
             { key: 'control', label: 'control', data: [0, 10] },
             { key: 'test', label: 'test', data: [0, 12] },
         ])
+    })
+
+    it('returns nothing for an empty timeseries', () => {
+        expect(buildExposureSeries([])).toEqual({ labels: [], series: [] })
     })
 
     it('keeps every series the same length as the labels', () => {

--- a/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.ts
@@ -4,12 +4,14 @@ import { dayjs } from 'lib/dayjs'
 
 import { ExperimentExposureTimeSeries } from '~/queries/schema/schema-general'
 
-// Single-day timeseries get a synthetic prior day with 0 exposures so the chart
-// can draw a line instead of a single point.
 export function buildExposureSeries(timeseries: ExperimentExposureTimeSeries[]): {
     labels: string[]
     series: Series[]
 } {
+    if (!timeseries.length) {
+        return { labels: [], series: [] }
+    }
+
     let labels = timeseries[0].days
     let series: Series[] = timeseries.map((variantTimeseries) => ({
         key: variantTimeseries.variant,
@@ -17,6 +19,7 @@ export function buildExposureSeries(timeseries: ExperimentExposureTimeSeries[]):
         data: variantTimeseries.exposure_counts,
     }))
 
+    // A single point draws nothing, so give it a zeroed prior day to draw a line from.
     if (labels.length === 1) {
         labels = [dayjs(labels[0]).subtract(1, 'day').format('YYYY-MM-DD'), ...labels]
         series = series.map((variantSeries) => ({ ...variantSeries, data: [0, ...variantSeries.data] }))

--- a/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/exposuresTransforms.ts
@@ -1,0 +1,26 @@
+import type { Series } from '@posthog/quill-charts'
+
+import { dayjs } from 'lib/dayjs'
+
+import { ExperimentExposureTimeSeries } from '~/queries/schema/schema-general'
+
+// Single-day timeseries get a synthetic prior day with 0 exposures so the chart
+// can draw a line instead of a single point.
+export function buildExposureSeries(timeseries: ExperimentExposureTimeSeries[]): {
+    labels: string[]
+    series: Series[]
+} {
+    let labels = timeseries[0].days
+    let series: Series[] = timeseries.map((variantTimeseries) => ({
+        key: variantTimeseries.variant,
+        label: variantTimeseries.variant,
+        data: variantTimeseries.exposure_counts,
+    }))
+
+    if (labels.length === 1) {
+        labels = [dayjs(labels[0]).subtract(1, 'day').format('YYYY-MM-DD'), ...labels]
+        series = series.map((variantSeries) => ({ ...variantSeries, data: [0, ...variantSeries.data] }))
+    }
+
+    return { labels, series }
+}

--- a/frontend/src/scenes/experiments/stories/ExperimentExposuresExpanded.stories.tsx
+++ b/frontend/src/scenes/experiments/stories/ExperimentExposuresExpanded.stories.tsx
@@ -1,0 +1,61 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { within } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+
+import { makeDelay } from 'lib/utils/async'
+import { App } from 'scenes/App'
+import { urls } from 'scenes/urls'
+
+import { mswDecorator } from '~/mocks/browser'
+import EXPERIMENT_WITH_MEAN_METRIC from '~/mocks/fixtures/api/experiments/experiment_with_mean_metric.json'
+import EXPOSURE_QUERY_RESULT from '~/mocks/fixtures/api/experiments/exposure_query_result.json'
+import MEAN_METRIC_RESULT from '~/mocks/fixtures/api/experiments/mean_metric_result.json'
+import { NodeKind } from '~/queries/schema/schema-general'
+
+const meta: Meta = {
+    component: App,
+    title: 'Scenes-App/Experiments',
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2025-01-27',
+        pageUrl: urls.experiment(EXPERIMENT_WITH_MEAN_METRIC.id),
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                [`/api/projects/:team_id/experiments/${EXPERIMENT_WITH_MEAN_METRIC.id}/`]: EXPERIMENT_WITH_MEAN_METRIC,
+                [`/api/projects/:team_id/experiment_holdouts`]: [],
+                [`/api/projects/:team_id/experiment_saved_metrics/`]: [],
+                [`/api/projects/:team_id/feature_flags/${EXPERIMENT_WITH_MEAN_METRIC.feature_flag.id}/`]: {},
+                [`/api/projects/:team_id/feature_flags/${EXPERIMENT_WITH_MEAN_METRIC.feature_flag.id}/status/`]: {},
+                [`/api/environments/:team_id/default_release_conditions/`]: [],
+            },
+            post: {
+                '/api/environments/:team_id/query/:kind': async ({ request }) => {
+                    const body = (await request.json()) as Record<string, any>
+
+                    if (body.query.kind === NodeKind.ExperimentExposureQuery) {
+                        return [200, EXPOSURE_QUERY_RESULT]
+                    }
+
+                    return [200, MEAN_METRIC_RESULT]
+                },
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj<{}>
+
+// The cumulative exposures chart only mounts once the panel is open, so no default-render story
+// reaches it.
+export const ExperimentExposuresExpanded: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement)
+        await makeDelay(500)()
+        await userEvent.click(await canvas.findByText('Exposures'))
+        await makeDelay(500)()
+    },
+}


### PR DESCRIPTION
## Problem

Experiments is nearly off Chart.js, but the exposures panel still rendered two Chart.js canvases: the 60×20 inline micro chart in the collapsed header, and the cumulative-exposures chart in the expanded panel.
These are two of the last three Chart.js consumers in the product (`VariantTimeseriesChart` is the remaining one), and they block deleting `lib/Chart.ts` and `lib/hooks/useChart.ts`.

## Changes

- `ExposuresChart` → `TimeSeriesLineChart`. Labels are now the backend's raw day strings rather than pre-formatted `MM/DD`, so the date axis and tooltip format against the project timezone. Grid and axis styling come from the shared chart theme, so the hand-passed `EXPOSURES_AXIS_LINES` color is gone (the constant stays — legacy and `VariantTimeseriesChart` still use it).
- `MicroChart` → `LineChart`, **not** quill's `Sparkline`. `Sparkline` hardcodes `LINE_MARGINS = { top: 6, bottom: 6 }` for its hover ring with no override, which in this 20px box would leave an 8px plot. This chart is inert, so it uses nearly the full height — 1px a side keeps the peak point's 2px stroke off the canvas edge. Its config is held outside `useChartConfig` because the app defaults turn on axis lines and tick marks, which `hideXAxis`/`hideYAxis` don't suppress and which have nowhere to go in a 20px box.
- The series transform moves to `exposuresTransforms.ts` so it can be unit-tested without pulling kea, quill, and lemon-ui into the test.

### Two deliberate visual changes

Both are adoptions of the app-wide quill look rather than faithful ports, so they're worth a glance rather than being buried:

- **Grid styling.** Was solid x/y grid lines in `EXPOSURES_AXIS_LINES` and nothing else. Now `gridColor` at `rgba(0,0,0,0.06)` with a `[3,3]` dash, plus axis lines and tick marks from `CHART_CONFIG_DEFAULTS`.
- **Curve.** The expanded chart inherits `curve: 'monotone'` from the app defaults; the Chart.js config it replaces used `tension: 0` (linear) for that chart. Taking the app default is the documented convention for this migration, but it does mean smoothing over integer cumulative counts.

Variant colors still come from the theme palette by index, unchanged — the explicit `color` field was dropped so quill resolves them per theme (see below).

## How did you test this code?

I'm an agent, so no manual browser testing. What I ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the touched files (the fresh checkout has pre-existing unrelated failures from an unbuilt `@posthog/quill`)
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt)
- `jest src/scenes/experiments/ExperimentView/exposuresTransforms.test.ts` — 4 passing

New `exposuresTransforms.test.ts` covers the single-day synthetic-prior-day path, which had no coverage of any kind: the shared story fixture has 9 days, so nothing ever reached `labels.length === 1`. The regressions it catches: losing the `[0, ...data]` prepend renders one point instead of a line (the case the code exists to prevent), and losing the `.format()` puts a `Dayjs` in a `string[]`.

New `ExperimentExposuresExpanded` story clicks the collapse open. The expanded chart only mounts when the panel is open, so no existing story rendered it — the larger of the two charts had no automated coverage at all. The micro chart was already covered by the ~9 experiment stories that render the collapsed header.

This PR was reviewed by a multi-perspective agent fan-out; the review threads on it record what was found, fixed, and consciously declined.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Sam directed the work: finish migrating experiments off Chart.js. Key decisions:

- Direct replacement rather than a feature flag, matching how the other experiments chart adoptions landed.
- `LineChart` over `Sparkline` for the micro chart, after reading quill's hardcoded `LINE_MARGINS`. Extending `Sparkline` with a `margins` override is the better long-term fix and is now wanted by a second consumer, but it's a cross-package API change and wasn't in scope here.
- Series colors are left to the theme palette rather than baked in via `getSeriesColor`, which resolves the CSS variable to a concrete hex at call time and went stale on a dark-mode toggle.
- Kept index-based variant coloring rather than routing through `getVariantColor`; that would resolve colors at call time again and reintroduce the staleness, and it's a behavior change beyond a rendering swap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
