### PR TITLE
fix(marketing-analytics): resolve ActionsNode goals against the action, not the goal id

### DIFF
--- a/products/marketing_analytics/backend/services/conversion_goals_inspector.py
+++ b/products/marketing_analytics/backend/services/conversion_goals_inspector.py
@@ -310,6 +310,12 @@ async def _summarize_goal(
     user: User | None = None,
 ) -> ConversionGoalSummary:
     goal_id = str(goal.get("conversion_goal_id") or goal.get("id") or "")
+    # `conversion_goal_id` identifies the goal within the team's config; `id` is what
+    # the goal points AT — an action's primary key for ActionsNode. Conflating them
+    # made every ActionsNode goal with a `conversion_goal_id` (which the schema
+    # requires, so: all of them) resolve its action against the wrong value and report
+    # itself misconfigured.
+    target_id = str(goal.get("id") or "")
     name = goal.get("conversion_goal_name") or goal.get("name") or goal_id
     # `kind_raw: str` keeps the "unknown kind" fallback reachable — a GoalKind
     # would let mypy treat the branches below as exhaustive.
@@ -344,7 +350,7 @@ async def _summarize_goal(
         )
 
     if kind_raw == "ActionsNode":
-        action, action_error = await _resolve_action(team, goal_id)
+        action, action_error = await _resolve_action(team, target_id)
         if action is None:
             return ConversionGoalSummary(
                 id=goal_id,
@@ -358,7 +364,7 @@ async def _summarize_goal(
                 non_integrated_count=None,
                 integrated_pct=None,
                 is_misconfigured=True,
-                misconfig_reason=action_error or f"Action {goal_id} no longer exists",
+                misconfig_reason=action_error or f"Action {target_id} no longer exists",
             )
         target_label = f"Action: {action.name}"
         total, integrated, without_utm, unmatched_with_utm = await _count_action_goal(

--- a/products/marketing_analytics/backend/services/test_conversion_goals_inspector.py
+++ b/products/marketing_analytics/backend/services/test_conversion_goals_inspector.py
@@ -25,12 +25,21 @@ def _events_goal(goal_id: str = "purchase", event: str | None = "purchase"):
     }
 
 
-def _actions_goal(goal_id: str = "42"):
+def _actions_goal(goal_id: str = "42", action_id: int | str | None = None):
+    """An ActionsNode goal.
+
+    `conversion_goal_id` identifies the goal in the team's config; `id` is the action
+    it points at. Real goals use a slug for the former ("cg_demos") and the action's
+    primary key for the latter — the default here keeps them equal only because older
+    tests were written that way, which is exactly how a bug conflating the two went
+    unnoticed. Pass `action_id` to exercise the realistic shape.
+    """
     return {
         "conversion_goal_id": goal_id,
         "conversion_goal_name": "Sign up action",
         "kind": "ActionsNode",
         "schema_map": {},
+        "id": action_id if action_id is not None else goal_id,
     }
 
 
@@ -126,6 +135,27 @@ class TestListConversionGoals(_InspectorMixin):
         assert response.has_misconfigured is True
         assert response.goals[0].is_misconfigured is True
         assert "999" in (response.goals[0].misconfig_reason or "")
+
+    @pytest.mark.asyncio
+    async def test_actions_node_resolves_the_action_id_not_the_goal_id(self):
+        # `conversion_goal_id` names the goal; `id` names the action it points at.
+        # Resolving against the former made every real ActionsNode goal report itself
+        # misconfigured ("'cg_demos' is not a valid integer"), because real goals use a
+        # slug there. The earlier tests missed it by mocking `_resolve_action` away and
+        # using a numeric goal id, so the two values were accidentally interchangeable.
+        action_mock = MagicMock()
+        action_mock.name = "Demo booked"
+        self.mocks["config"].return_value = ([_actions_goal("cg_demos", action_id=42)], 90, "last_touch")
+        self.mocks["resolve_action"].return_value = (action_mock, None)
+        self.mocks["action_count"].return_value = (10, 10, 0, 0)
+
+        response = await list_conversion_goals(self.team)
+
+        self.mocks["resolve_action"].assert_awaited_once_with(self.team, "42")
+        assert response.goals[0].is_misconfigured is False
+        # The summary still identifies the goal by its own id, which is what the setup
+        # plan uses to open the right editor.
+        assert response.goals[0].id == "cg_demos"
 
     @pytest.mark.asyncio
     async def test_actions_node_with_resolved_action_uses_action_name(self):


### PR DESCRIPTION
Every `ActionsNode` conversion goal reported itself misconfigured.

`_summarize_goal` resolved the action by passing `conversion_goal_id` — the goal's own
identifier, a slug like `cg_demos` — to `_resolve_action`, which does `int()` on it. Real
goals therefore failed with *"'cg_demos' is not a valid integer for ActionsNode"* and were
surfaced as broken in the goals list and in `has_misconfigured`.

The action's primary key lives in the goal's `id`. This separates the two: `goal_id` stays
the identity used for reporting (so the setup plan still opens the right editor), and
`target_id` is what gets resolved.

## Why the existing tests missed it

They mocked `_resolve_action` away *and* used a numeric `conversion_goal_id`, which made the
two values accidentally interchangeable. The `_actions_goal` fixture now takes `action_id`
separately and documents that trap, and the new test asserts the resolver is called with the
action's key rather than the goal's.

Verified the new test fails when the bug is reintroduced.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*