### PR TITLE
feat(tasks): polish orchestrated task ergonomics

### DIFF
--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -6327,7 +6327,7 @@ export class SessionService {
         type: "user_message",
         content: seedContent,
         timestamp: Date.now(),
-        ...(isResumeRun ? { pinToTop: false } : {}),
+        pinToTop: false,
       });
     }
     if (hasCurrentRunUserPrompt || isTerminalRun) {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.test.tsx
@@ -147,6 +147,23 @@ describe("ActivityTimeline", () => {
     ).toBeNull();
   });
 
+  it("hides orchestration framing alongside genuine custom instructions", () => {
+    renderTimeline(true, [
+      {
+        type: "user_message",
+        id: "orchestrated-message",
+        content:
+          "<orchestration_instructions>\nThe following system-generated instructions apply to this orchestrated child run. Follow them.\n\nUse tasks-notify-parent for progress.\n</orchestration_instructions>\n\nMake the focused change\n\n<user_custom_instructions>\nThe user has saved custom instructions that apply to all of their tasks. Follow them.\n\nAlways use tabs.\n</user_custom_instructions>",
+        timestamp: Date.parse("2026-07-17T09:05:00Z"),
+      },
+    ]);
+
+    expect(screen.getByText("Make the focused change")).toBeInTheDocument();
+    expect(screen.queryByText(/orchestration_instructions/)).toBeNull();
+    expect(screen.queryByText(/tasks-notify-parent/)).toBeNull();
+    expect(screen.queryByText(/Always use tabs/)).toBeNull();
+  });
+
   it("shows user-authored custom-instruction tag examples", () => {
     renderTimeline(true, [
       {

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityTimeline.tsx
@@ -35,6 +35,7 @@ import { userDisplayName } from "@posthog/ui/features/canvas/utils/userDisplay";
 import type { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
+import { extractOrchestrationInstructions } from "@posthog/ui/features/sessions/components/session-update/orchestrationInstructions";
 import { useThreadNavigationStore } from "@posthog/ui/features/sessions/threadNavigationStore";
 import { Fragment, type KeyboardEvent, type ReactNode, useMemo } from "react";
 
@@ -85,11 +86,18 @@ function UserMessageRow({
     [content],
   );
   const afterChannelContext = channelContext?.stripped ?? content;
-  const customInstructions = useMemo(
-    () => extractCustomInstructions(afterChannelContext),
+  const orchestrationInstructions = useMemo(
+    () => extractOrchestrationInstructions(afterChannelContext),
     [afterChannelContext],
   );
-  const displayContent = customInstructions?.stripped ?? afterChannelContext;
+  const afterOrchestrationInstructions =
+    orchestrationInstructions?.stripped ?? afterChannelContext;
+  const customInstructions = useMemo(
+    () => extractCustomInstructions(afterOrchestrationInstructions),
+    [afterOrchestrationInstructions],
+  );
+  const displayContent =
+    customInstructions?.stripped ?? afterOrchestrationInstructions;
   // The row itself is the hit target. `ThreadItem` renders an <article>, which a
   // <button> may not wrap and which can't become one (quill's primitive takes no
   // `render`), so it carries the button role and its own key handling.

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -74,7 +74,7 @@ import {
   type ThreadScrollResume,
   type TurnRow,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
-import { buildResponseCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 import { usePromptRecallSource } from "@posthog/ui/features/sessions/components/chat-thread/usePromptRecallSource";
 import { VirtualThreadScrollBody } from "@posthog/ui/features/sessions/components/chat-thread/VirtualThreadScrollBody";
 import { copyFromContextMenu } from "@posthog/ui/features/sessions/components/copyContextTarget";
@@ -314,7 +314,7 @@ function formatTimestamp(ts: number): string {
 
 /**
  * Hover-revealed footer under a completed agent turn: the turn's timestamp plus a button copying
- * the agent response. It is rendered right-aligned under agent-side content while the end-aligned
+ * the whole turn. It is rendered right-aligned under agent-side content while the end-aligned
  * user bubble keeps its own footer. The `group` container reveals it when the turn is hovered.
  */
 function TurnFooter({
@@ -330,7 +330,7 @@ function TurnFooter({
       <span className="text-muted-foreground">
         {formatTimestamp(timestamp)}
       </span>
-      {copyText && <CopyButton value={copyText} label="Copy response" />}
+      {copyText && <CopyButton value={copyText} label="Copy turn" />}
     </ChatMessageFooter>
   );
 }
@@ -723,7 +723,11 @@ const ThreadRow = memo(function ThreadRow({
         </div>
         <TurnFooter
           timestamp={completedTurnTimestamp(item)}
-          copyText={buildResponseCopyText(item.items) ?? undefined}
+          copyText={
+            buildTurnCopyText(
+              item.prompt ? [item.prompt, ...item.items] : item.items,
+            ) ?? undefined
+          }
         />
       </ChatMessageScrollerItem>
     );

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -74,7 +74,7 @@ import {
   type ThreadScrollResume,
   type TurnRow,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
-import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { buildResponseCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 import { usePromptRecallSource } from "@posthog/ui/features/sessions/components/chat-thread/usePromptRecallSource";
 import { VirtualThreadScrollBody } from "@posthog/ui/features/sessions/components/chat-thread/VirtualThreadScrollBody";
 import { copyFromContextMenu } from "@posthog/ui/features/sessions/components/copyContextTarget";
@@ -85,6 +85,7 @@ import { mergeConversationItems } from "@posthog/ui/features/sessions/components
 import { extractCanvasInstructions } from "@posthog/ui/features/sessions/components/session-update/canvasInstructions";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
+import { extractOrchestrationInstructions } from "@posthog/ui/features/sessions/components/session-update/orchestrationInstructions";
 import {
   hasFileMentions,
   MentionChip,
@@ -313,9 +314,8 @@ function formatTimestamp(ts: number): string {
 
 /**
  * Hover-revealed footer under a completed agent turn: the turn's timestamp plus a button copying
- * the whole turn. Rendered right-aligned under agent-side content — the end-aligned user bubble
- * keeps its own footer — inside a `group` container, so it fades in only while that turn is
- * hovered. Once per turn rather than per row, which was too noisy.
+ * the agent response. It is rendered right-aligned under agent-side content while the end-aligned
+ * user bubble keeps its own footer. The `group` container reveals it when the turn is hovered.
  */
 function TurnFooter({
   timestamp,
@@ -330,7 +330,7 @@ function TurnFooter({
       <span className="text-muted-foreground">
         {formatTimestamp(timestamp)}
       </span>
-      {copyText && <CopyButton value={copyText} label="Copy turn" />}
+      {copyText && <CopyButton value={copyText} label="Copy response" />}
     </ChatMessageFooter>
   );
 }
@@ -408,12 +408,21 @@ function UserBubble({
   const afterCanvasInstructions = canvasInstructions
     ? canvasInstructions.stripped
     : afterChannelContext;
-  const customInstructions = useMemo(
-    () => extractCustomInstructions(afterCanvasInstructions),
+  const orchestrationInstructions = useMemo(
+    () => extractOrchestrationInstructions(afterCanvasInstructions),
     [afterCanvasInstructions],
   );
+  const afterOrchestrationInstructions = orchestrationInstructions
+    ? orchestrationInstructions.stripped
+    : afterCanvasInstructions;
+  const customInstructions = useMemo(
+    () => extractCustomInstructions(afterOrchestrationInstructions),
+    [afterOrchestrationInstructions],
+  );
   const displayContent = collapsePiSkillInvocation(
-    customInstructions ? customInstructions.stripped : afterCanvasInstructions,
+    customInstructions
+      ? customInstructions.stripped
+      : afterOrchestrationInstructions,
   );
   const showChannelContextTag = !!channelContext && bluebirdEnabled;
   const showCanvasInstructionsTag = !!canvasInstructions && bluebirdEnabled;
@@ -714,11 +723,7 @@ const ThreadRow = memo(function ThreadRow({
         </div>
         <TurnFooter
           timestamp={completedTurnTimestamp(item)}
-          copyText={
-            buildTurnCopyText(
-              item.prompt ? [item.prompt, ...item.items] : item.items,
-            ) ?? undefined
-          }
+          copyText={buildResponseCopyText(item.items) ?? undefined}
         />
       </ChatMessageScrollerItem>
     );

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/composerPromptRecall.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/composerPromptRecall.test.ts
@@ -189,6 +189,11 @@ describe("resolvePromptRecall", () => {
         "fix the bug\n\n<user_custom_instructions>\nThe user has saved custom instructions that apply to all of their tasks. Follow them.\n\nbe terse\n</user_custom_instructions>",
     },
     {
+      name: "orchestration framing alongside custom instructions",
+      content:
+        "<orchestration_instructions>\nThe following system-generated instructions apply to this orchestrated child run. Follow them.\n\nUse tasks-notify-parent for progress.\n</orchestration_instructions>\n\nfix the bug\n\n<user_custom_instructions>\nThe user has saved custom instructions that apply to all of their tasks. Follow them.\n\nbe terse\n</user_custom_instructions>",
+    },
+    {
       name: "a trailing attachment summary",
       content: "fix the bug\n\nAttached files: screenshot.png",
     },

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/composerPromptRecall.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/composerPromptRecall.ts
@@ -2,6 +2,7 @@ import { stripTrailingAttachmentSummary } from "@posthog/core/editor/cloud-promp
 import { extractCanvasInstructions } from "@posthog/ui/features/sessions/components/session-update/canvasInstructions";
 import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
 import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
+import { extractOrchestrationInstructions } from "@posthog/ui/features/sessions/components/session-update/orchestrationInstructions";
 
 export const PROMPT_RECALL_HINT_KEY = "recall-message-nav";
 
@@ -59,8 +60,11 @@ function stripInjectedPromptBlocks(content: string): string {
   const withoutChannel = extractChannelContext(content)?.stripped ?? content;
   const withoutCanvas =
     extractCanvasInstructions(withoutChannel)?.stripped ?? withoutChannel;
+  const withoutOrchestration =
+    extractOrchestrationInstructions(withoutCanvas)?.stripped ?? withoutCanvas;
   const withoutInstructions =
-    extractCustomInstructions(withoutCanvas)?.stripped ?? withoutCanvas;
+    extractCustomInstructions(withoutOrchestration)?.stripped ??
+    withoutOrchestration;
   return stripTrailingAttachmentSummary(withoutInstructions);
 }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -112,7 +112,7 @@ describe("flattenTurnRows", () => {
     ]);
   });
 
-  it("excludes the prompt that opened the turn from copied responses", () => {
+  it("includes the prompt that opened the copied turn", () => {
     const done = agentTurn(
       "d",
       [
@@ -124,7 +124,9 @@ describe("flattenTurnRows", () => {
       ],
       userMessage("u1"),
     );
-    expect(flattenTurnRows([done]).at(-1)?.turnCopyText).toBe("reply");
+    expect(flattenTurnRows([done]).at(-1)?.turnCopyText).toBe(
+      "msg u1\n\nreply",
+    );
   });
 
   it("leaves copy text off a turn that is still streaming", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -112,7 +112,7 @@ describe("flattenTurnRows", () => {
     ]);
   });
 
-  it("leads the copy text with the prompt that opened the turn", () => {
+  it("excludes the prompt that opened the turn from copied responses", () => {
     const done = agentTurn(
       "d",
       [
@@ -124,9 +124,7 @@ describe("flattenTurnRows", () => {
       ],
       userMessage("u1"),
     );
-    expect(flattenTurnRows([done]).at(-1)?.turnCopyText).toBe(
-      "msg u1\n\nreply",
-    );
+    expect(flattenTurnRows([done]).at(-1)?.turnCopyText).toBe("reply");
   });
 
   it("leaves copy text off a turn that is still streaming", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -1,6 +1,6 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
-import { buildResponseCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 
 /** A row is either a parsed conversation item or a synthesized group of tool calls. */
 export type ThreadItem = ConversationItem | ToolGroupItem;
@@ -113,7 +113,9 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
       const copyText =
         timestamp == null
           ? undefined
-          : (buildResponseCopyText(row.items) ?? undefined);
+          : (buildTurnCopyText(
+              row.prompt ? [row.prompt, ...row.items] : row.items,
+            ) ?? undefined);
       for (let i = 0; i < row.items.length; i++) {
         const item = row.items[i];
         const isTrailing = i === row.items.length - 1;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -1,6 +1,6 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
-import { buildTurnCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
+import { buildResponseCopyText } from "@posthog/ui/features/sessions/components/chat-thread/turnCopyText";
 
 /** A row is either a parsed conversation item or a synthesized group of tool calls. */
 export type ThreadItem = ConversationItem | ToolGroupItem;
@@ -113,9 +113,7 @@ export function flattenTurnRows(rows: TurnRow[]): FlatThreadRow[] {
       const copyText =
         timestamp == null
           ? undefined
-          : (buildTurnCopyText(
-              row.prompt ? [row.prompt, ...row.items] : row.items,
-            ) ?? undefined);
+          : (buildResponseCopyText(row.items) ?? undefined);
       for (let i = 0; i < row.items.length; i++) {
         const item = row.items[i];
         const isTrailing = i === row.items.length - 1;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
@@ -1,7 +1,7 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
 import { describe, expect, it } from "vitest";
-import { buildTurnCopyText } from "./turnCopyText";
+import { buildResponseCopyText } from "./turnCopyText";
 
 function userMessage(id: string, content: string): ConversationItem {
   return { type: "user_message", id, content, timestamp: 0 };
@@ -47,9 +47,9 @@ function toolGroup(id: string): ToolGroupItem {
   return { type: "tool_group", id, tools: [] } as unknown as ToolGroupItem;
 }
 
-describe("buildTurnCopyText", () => {
+describe("buildResponseCopyText", () => {
   it("joins the rows' prose in order", () => {
-    const text = buildTurnCopyText([
+    const text = buildResponseCopyText([
       agentText("a1", "first paragraph"),
       agentText("a2", "second paragraph"),
     ]);
@@ -58,14 +58,14 @@ describe("buildTurnCopyText", () => {
   });
 
   it("skips tool calls, tool groups and other non-prose rows", () => {
-    const text = buildTurnCopyText([
+    const text = buildResponseCopyText([
       userMessage("u1", "do the thing"),
       toolCall("t1"),
       toolGroup("g1"),
       agentText("a1", "done"),
     ]);
 
-    expect(text).toBe("do the thing\n\ndone");
+    expect(text).toBe("done");
   });
 
   it.each([
@@ -73,6 +73,6 @@ describe("buildTurnCopyText", () => {
     ["tools only", [toolCall("t1"), toolGroup("g1")]],
     ["blank prose", [userMessage("u1", "   "), agentText("a1", "\n")]],
   ])("returns null when there is nothing to copy: %s", (_label, items) => {
-    expect(buildTurnCopyText(items)).toBeNull();
+    expect(buildResponseCopyText(items)).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.test.ts
@@ -1,7 +1,7 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
 import { describe, expect, it } from "vitest";
-import { buildResponseCopyText } from "./turnCopyText";
+import { buildTurnCopyText } from "./turnCopyText";
 
 function userMessage(id: string, content: string): ConversationItem {
   return { type: "user_message", id, content, timestamp: 0 };
@@ -47,9 +47,9 @@ function toolGroup(id: string): ToolGroupItem {
   return { type: "tool_group", id, tools: [] } as unknown as ToolGroupItem;
 }
 
-describe("buildResponseCopyText", () => {
+describe("buildTurnCopyText", () => {
   it("joins the rows' prose in order", () => {
-    const text = buildResponseCopyText([
+    const text = buildTurnCopyText([
       agentText("a1", "first paragraph"),
       agentText("a2", "second paragraph"),
     ]);
@@ -58,14 +58,17 @@ describe("buildResponseCopyText", () => {
   });
 
   it("skips tool calls, tool groups and other non-prose rows", () => {
-    const text = buildResponseCopyText([
-      userMessage("u1", "do the thing"),
+    const text = buildTurnCopyText([
+      userMessage(
+        "u1",
+        "<orchestration_instructions>\nThe following system-generated instructions apply to this orchestrated child run. Follow them.\n\nhidden\n</orchestration_instructions>\n\ndo the thing\n\n<user_custom_instructions>\nThe user has saved custom instructions that apply to all of their tasks. Follow them.\n\nbe terse\n</user_custom_instructions>",
+      ),
       toolCall("t1"),
       toolGroup("g1"),
       agentText("a1", "done"),
     ]);
 
-    expect(text).toBe("done");
+    expect(text).toBe("do the thing\n\ndone");
   });
 
   it.each([
@@ -73,6 +76,6 @@ describe("buildResponseCopyText", () => {
     ["tools only", [toolCall("t1"), toolGroup("g1")]],
     ["blank prose", [userMessage("u1", "   "), agentText("a1", "\n")]],
   ])("returns null when there is nothing to copy: %s", (_label, items) => {
-    expect(buildResponseCopyText(items)).toBeNull();
+    expect(buildTurnCopyText(items)).toBeNull();
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
@@ -1,18 +1,44 @@
 import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
+import { extractCanvasInstructions } from "@posthog/ui/features/sessions/components/session-update/canvasInstructions";
+import { extractChannelContext } from "@posthog/ui/features/sessions/components/session-update/channelContext";
+import { extractCustomInstructions } from "@posthog/ui/features/sessions/components/session-update/customInstructions";
+import { extractOrchestrationInstructions } from "@posthog/ui/features/sessions/components/session-update/orchestrationInstructions";
+
+function visiblePromptContent(content: string): string {
+  const channelContext = extractChannelContext(content);
+  const afterChannelContext = channelContext?.stripped ?? content;
+  const canvasInstructions = extractCanvasInstructions(afterChannelContext);
+  const afterCanvasInstructions =
+    canvasInstructions?.stripped ?? afterChannelContext;
+  const orchestrationInstructions = extractOrchestrationInstructions(
+    afterCanvasInstructions,
+  );
+  const afterOrchestrationInstructions =
+    orchestrationInstructions?.stripped ?? afterCanvasInstructions;
+  const customInstructions = extractCustomInstructions(
+    afterOrchestrationInstructions,
+  );
+  return customInstructions?.stripped ?? afterOrchestrationInstructions;
+}
 
 /**
- * Plain-text transcript of a turn's agent prose, in order.
+ * Plain-text transcript of a turn's visible prompt and agent prose, in order.
  *
  * Tool calls, thoughts and status rows are left out — this is for pasting an answer somewhere else,
  * not for reproducing the run. Returns null when the rows carry no prose.
  */
-export function buildResponseCopyText(
+export function buildTurnCopyText(
   items: Array<ConversationItem | ToolGroupItem>,
 ): string | null {
   const parts: string[] = [];
 
   for (const item of items) {
+    if (item.type === "user_message") {
+      const content = visiblePromptContent(item.content).trim();
+      if (content) parts.push(content);
+      continue;
+    }
     if (item.type !== "session_update") continue;
     const update = item.update;
     if (update.sessionUpdate !== "agent_message_chunk") continue;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/turnCopyText.ts
@@ -2,22 +2,17 @@ import type { ConversationItem } from "@posthog/ui/features/sessions/components/
 import type { ToolGroupItem } from "@posthog/ui/features/sessions/components/chat-thread/ToolGroup";
 
 /**
- * Plain-text transcript of a turn's rows: user prompts and agent prose, in order.
+ * Plain-text transcript of a turn's agent prose, in order.
  *
  * Tool calls, thoughts and status rows are left out — this is for pasting an answer somewhere else,
  * not for reproducing the run. Returns null when the rows carry no prose.
  */
-export function buildTurnCopyText(
+export function buildResponseCopyText(
   items: Array<ConversationItem | ToolGroupItem>,
 ): string | null {
   const parts: string[] = [];
 
   for (const item of items) {
-    if (item.type === "user_message") {
-      const content = item.content.trim();
-      if (content) parts.push(content);
-      continue;
-    }
     if (item.type !== "session_update") continue;
     const update = item.update;
     if (update.sessionUpdate !== "agent_message_chunk") continue;

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
@@ -1,6 +1,6 @@
 import { ServiceProvider } from "@posthog/di/react";
 import { Theme } from "@radix-ui/themes";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Container } from "inversify";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -32,6 +32,9 @@ const PROMPT_WITH_CANVAS_INSTRUCTIONS =
 
 const PROMPT_WITH_PI_SKILL =
   '<skill name="code-review" location="/skills/code-review/SKILL.md">\nReferences are relative to /skills/code-review.\n\n# Review\n\nInspect the diff.\n</skill>\n\nReview this pull request.';
+
+const ORCHESTRATED_PROMPT =
+  "<orchestration_instructions>\nThe following system-generated instructions apply to this orchestrated child run. Follow them.\n\nUse tasks-notify-parent for progress.\n</orchestration_instructions>\n\nMake the focused change\n\n<user_custom_instructions>\nThe user has saved custom instructions that apply to all of their tasks. Follow them.\n\nAlways use tabs.\n</user_custom_instructions>";
 
 describe("UserMessage", () => {
   // useFeatureFlag falls back to import.meta.env.DEV, which is true under
@@ -115,5 +118,22 @@ describe("UserMessage", () => {
     expect(
       screen.queryByText(/canvas_generation_instructions/),
     ).not.toBeInTheDocument();
+  });
+
+  it("hides orchestration framing and genuine custom instructions from display and copy", () => {
+    const writeText = vi.fn();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    renderWithFlags(<UserMessage content={ORCHESTRATED_PROMPT} />, true);
+
+    expect(screen.getByText("Make the focused change")).toBeInTheDocument();
+    expect(screen.queryByText(/orchestration_instructions/)).toBeNull();
+    expect(screen.queryByText(/tasks-notify-parent/)).toBeNull();
+    expect(screen.queryByText(/Always use tabs/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+    expect(writeText).toHaveBeenCalledWith("Make the focused change");
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -19,6 +19,7 @@ import { CollapsibleMessageContent } from "./CollapsibleMessageContent";
 import { extractCanvasInstructions } from "./canvasInstructions";
 import { extractChannelContext } from "./channelContext";
 import { extractCustomInstructions } from "./customInstructions";
+import { extractOrchestrationInstructions } from "./orchestrationInstructions";
 import {
   hasFileMentions,
   MentionChip,
@@ -89,12 +90,21 @@ export const UserMessage = memo(function UserMessage({
   const afterCanvasInstructions = canvasInstructions
     ? canvasInstructions.stripped
     : afterChannelContext;
-  const customInstructions = useMemo(
-    () => extractCustomInstructions(afterCanvasInstructions),
+  const orchestrationInstructions = useMemo(
+    () => extractOrchestrationInstructions(afterCanvasInstructions),
     [afterCanvasInstructions],
   );
+  const afterOrchestrationInstructions = orchestrationInstructions
+    ? orchestrationInstructions.stripped
+    : afterCanvasInstructions;
+  const customInstructions = useMemo(
+    () => extractCustomInstructions(afterOrchestrationInstructions),
+    [afterOrchestrationInstructions],
+  );
   const displayContent = collapsePiSkillInvocation(
-    customInstructions ? customInstructions.stripped : afterCanvasInstructions,
+    customInstructions
+      ? customInstructions.stripped
+      : afterOrchestrationInstructions,
   );
   const showChannelContextTag = !!channelContext && bluebirdEnabled;
   const showCanvasInstructionsTag = !!canvasInstructions && bluebirdEnabled;
@@ -204,6 +214,7 @@ export const UserMessage = memo(function UserMessage({
           )}
           <Tooltip content={copied ? "Copied!" : "Copy message"}>
             <IconButton
+              aria-label="Copy message"
               size="1"
               variant="ghost"
               color={copied ? "green" : "gray"}

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/orchestrationInstructions.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/orchestrationInstructions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { extractCustomInstructions } from "./customInstructions";
+import { extractOrchestrationInstructions } from "./orchestrationInstructions";
+
+const ORCHESTRATION_BLOCK =
+  "<orchestration_instructions>\nThe following system-generated instructions apply to this orchestrated child run. Follow them.\n\nReport progress with tasks-notify-parent.\n</orchestration_instructions>";
+const CUSTOM_INSTRUCTIONS_BLOCK =
+  "<user_custom_instructions>\nThe user has saved custom instructions that apply to all of their tasks. Follow them.\n\nAlways use tabs.\n</user_custom_instructions>";
+
+describe("extractOrchestrationInstructions", () => {
+  it("strips orchestration framing without changing genuine custom instructions", () => {
+    const content = `${ORCHESTRATION_BLOCK}\n\nBuild the focused change\n\n${CUSTOM_INSTRUCTIONS_BLOCK}`;
+
+    const orchestration = extractOrchestrationInstructions(content);
+    expect(orchestration?.body).toContain("tasks-notify-parent");
+    expect(orchestration?.stripped).toContain("Build the focused change");
+    expect(orchestration?.stripped).toContain(CUSTOM_INSTRUCTIONS_BLOCK);
+
+    const customInstructions = extractCustomInstructions(
+      orchestration?.stripped ?? "",
+    );
+    expect(customInstructions?.body).toContain("Always use tabs.");
+    expect(customInstructions?.stripped).toBe("Build the focused change");
+  });
+
+  it("preserves user-authored orchestration tag examples", () => {
+    const content =
+      "Render this example: <orchestration_instructions>report often</orchestration_instructions>";
+
+    expect(extractOrchestrationInstructions(content)).toBeNull();
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/orchestrationInstructions.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/orchestrationInstructions.ts
@@ -1,0 +1,17 @@
+const ORCHESTRATION_INSTRUCTIONS_REGEX =
+  /<orchestration_instructions\b[^>]*>(\r?\nThe following system-generated instructions apply to this orchestrated child run\. Follow them\.\r?\n\r?\n[\s\S]*?)<\/orchestration_instructions>/;
+
+export function extractOrchestrationInstructions(content: string): {
+  body: string;
+  stripped: string;
+} | null {
+  const match = ORCHESTRATION_INSTRUCTIONS_REGEX.exec(content);
+  if (match?.index === undefined) return null;
+
+  const body = match[1].trim();
+  const stripped = (
+    content.slice(0, match.index) + content.slice(match.index + match[0].length)
+  ).trim();
+
+  return { body, stripped };
+}

--- a/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/sessionServiceHost.test.ts
@@ -4023,6 +4023,7 @@ describe("SessionService", () => {
           expect.objectContaining({
             type: "user_message",
             content: "build me a thing",
+            pinToTop: false,
           }),
         );
       });
@@ -4094,6 +4095,7 @@ describe("SessionService", () => {
           expect.objectContaining({
             type: "user_message",
             content: "build me a thing",
+            pinToTop: false,
           }),
         );
       });

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -179,6 +179,7 @@ __all__ = [
     "get_task_run_session",
     "sync_task_run_session",
     "get_task_run_detail",
+    "capture_task_run_event",
     "get_task_run_sandbox_connection",
     "get_task_run_living_artifact",
     "capture_relay_command_telemetry",
@@ -607,6 +608,12 @@ def get_task_id_for_run(run_id: str | UUID, team_id: int) -> UUID | None:
     need to deep-link a run to its task.
     """
     return TaskRun.objects.filter(id=run_id, team_id=team_id).values_list("task_id", flat=True).first()
+
+
+def capture_task_run_event(run_id: str | UUID, team_id: int, event: str, properties: dict) -> None:
+    run = TaskRun.objects.filter(id=run_id, team_id=team_id).first()
+    if run is not None:
+        run.capture_event(event, properties)
 
 
 def task_exists(task_id: str | UUID, team_id: int) -> bool:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -124,6 +124,7 @@ def render_child_run_message(child_instructions: str) -> str:
 
     return render(child_instructions)
 
+
 __all__ = [
     "CODE_INVITE_INVALID_CODE",
     "CODE_INVITE_NOT_REDEEMABLE",

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -118,6 +118,12 @@ WIZARD_CLOUD_RUN_RUNTIME_ADAPTER = "claude"
 WIZARD_CLOUD_RUN_MODEL = "claude-sonnet-5"
 WIZARD_CLOUD_RUN_AI_STAGE = "wizard_pr_agent"
 
+
+def render_child_run_message(child_instructions: str) -> str:
+    from products.tasks.backend.logic.services.orchestration import render_child_run_message as render
+
+    return render(child_instructions)
+
 __all__ = [
     "CODE_INVITE_INVALID_CODE",
     "CODE_INVITE_NOT_REDEEMABLE",
@@ -150,6 +156,7 @@ __all__ = [
     "create_task_run_living_artifact",
     "create_task_run_stream_read_token",
     "resolve_stream_base_url",
+    "render_child_run_message",
     "claim_and_fail_stale_run",
     "delete_sandbox_custom_image",
     "delete_sandbox_environment",

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -86,7 +86,7 @@ def _queue_wake(parent_run: TaskRun, child_run: TaskRun, event: ChildEvent, mess
 
 def _claim_resume(run_id: str) -> tuple[TaskRun | None, list[dict[str, Any]], int]:
     with transaction.atomic():
-        run = TaskRun.objects.select_for_update().select_related("task", "task__created_by").get(id=run_id)
+        run = TaskRun.objects.select_for_update(of=("self",)).select_related("task", "task__created_by").get(id=run_id)
         state = dict(run.state or {})
         resume = state.get(ORCHESTRATION_RESUME_STATE_KEY)
         resume = dict(resume) if isinstance(resume, dict) else {}

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -25,7 +25,25 @@ PENDING_ORCHESTRATION_WAKES_STATE_KEY = "pending_orchestration_wakes"
 ORCHESTRATION_RESUME_STATE_KEY = "orchestration_resume"
 MAX_ORCHESTRATION_RESUME_ATTEMPTS = 3
 
+CHILD_FRAMING_BLOCK = (
+    "You were spawned by an orchestrator task. Stay strictly within the scope of your prompt. "
+    "Your terminal status and final message are reported to the parent automatically, so write "
+    "your final message as that report. Do not spawn further tasks; orchestration supports one "
+    "level of child tasks."
+)
+
 _NON_TERMINAL_STATUSES = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS)
+
+
+def render_child_run_message(child_instructions: str) -> str:
+    escaped_framing = CHILD_FRAMING_BLOCK.replace("</user_custom_instructions>", "&lt;/user_custom_instructions&gt;")
+    hidden_context = (
+        "<user_custom_instructions>\n"
+        "The following system-generated instructions apply to this orchestrated child run. Follow them.\n\n"
+        f"{escaped_framing}\n"
+        "</user_custom_instructions>"
+    )
+    return f"{hidden_context}\n\n{child_instructions}"
 
 
 def _build_child_event_message(child_run: TaskRun, event: ChildEvent) -> str:

--- a/products/tasks/backend/logic/services/orchestration.py
+++ b/products/tasks/backend/logic/services/orchestration.py
@@ -28,7 +28,9 @@ MAX_ORCHESTRATION_RESUME_ATTEMPTS = 3
 CHILD_FRAMING_BLOCK = (
     "You were spawned by an orchestrator task. Stay strictly within the scope of your prompt. "
     "Your terminal status and final message are reported to the parent automatically, so write "
-    "your final message as that report. Do not spawn further tasks; orchestration supports one "
+    "your final message as that report. Use tasks-notify-parent when the parent needs an update "
+    "before you finish. Notifying the parent does not complete or stop your task; continue working "
+    "until your assigned work is complete. Do not spawn further tasks; orchestration supports one "
     "level of child tasks."
 )
 
@@ -36,12 +38,11 @@ _NON_TERMINAL_STATUSES = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED, Tas
 
 
 def render_child_run_message(child_instructions: str) -> str:
-    escaped_framing = CHILD_FRAMING_BLOCK.replace("</user_custom_instructions>", "&lt;/user_custom_instructions&gt;")
     hidden_context = (
-        "<user_custom_instructions>\n"
+        "<orchestration_instructions>\n"
         "The following system-generated instructions apply to this orchestrated child run. Follow them.\n\n"
-        f"{escaped_framing}\n"
-        "</user_custom_instructions>"
+        f"{CHILD_FRAMING_BLOCK}\n"
+        "</orchestration_instructions>"
     )
     return f"{hidden_context}\n\n{child_instructions}"
 

--- a/products/tasks/backend/logic/services/tests/test_orchestration.py
+++ b/products/tasks/backend/logic/services/tests/test_orchestration.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from parameterized import parameterized
 from temporalio.service import RPCError, RPCStatusCode
@@ -12,10 +12,29 @@ from products.tasks.backend.logic.services.orchestration import (
     ORCHESTRATION_RESUME_STATE_KEY,
     PENDING_ORCHESTRATION_WAKES_STATE_KEY,
     notify_parent_of_child_event,
+    render_child_run_message,
     resume_parent_with_pending_wakes,
 )
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.execute_sandbox.workflow import FOLLOWUP_SOURCE_CHILD
+
+
+class TestRenderChildRunMessage(SimpleTestCase):
+    def test_uses_dedicated_framing_and_preserves_custom_instructions(self) -> None:
+        custom_instructions = (
+            "<user_custom_instructions>\n"
+            "The user has saved custom instructions that apply to all of their tasks. Follow them.\n\n"
+            "Always use tabs.\n"
+            "</user_custom_instructions>"
+        )
+
+        message = render_child_run_message(f"Make the focused change\n\n{custom_instructions}")
+
+        self.assertTrue(message.startswith("<orchestration_instructions>"))
+        self.assertIn("tasks-notify-parent", message)
+        self.assertIn("does not complete or stop your task", message)
+        self.assertEqual(message.count("<user_custom_instructions>"), 1)
+        self.assertTrue(message.endswith(custom_instructions))
 
 
 class TestNotifyParentOfChildEvent(TestCase):

--- a/products/tasks/backend/logic/services/tests/test_orchestration.py
+++ b/products/tasks/backend/logic/services/tests/test_orchestration.py
@@ -68,6 +68,7 @@ class TestNotifyParentOfChildEvent(TestCase):
         self.assertIn(f"Status: {status}", message)
         self.assertIn("Child task", message)
         self.assertIn("https://github.com/PostHog/posthog/pull/123", message)
+        self.assertIn("channel context as the plan of record", message)
         if error_message:
             self.assertIn(error_message, message)
         mock_signal.assert_called_once_with(

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -386,10 +386,14 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if parent_run is None:
             raise NotFound("Parent run not found")
         if parent_run.is_terminal:
-            parent_run.capture_event("task_spawn_rejected", {"reason": "terminal_parent"})
+            tasks_facade.capture_task_run_event(
+                parent_run.id, self.team_id, "task_spawn_rejected", {"reason": "terminal_parent"}
+            )
             raise ValidationError({"parent_run_id": "Parent run must be active"})
         if parent_run.state.get("parent_task_id") is not None:
-            parent_run.capture_event("task_spawn_rejected", {"reason": "depth_limit"})
+            tasks_facade.capture_task_run_event(
+                parent_run.id, self.team_id, "task_spawn_rejected", {"reason": "depth_limit"}
+            )
             raise ValidationError({"parent_run_id": "Child runs cannot spawn tasks"})
 
         parent_task = tasks_facade.get_task_detail(parent_run.task_id, self.team_id, self._user_id())
@@ -397,10 +401,14 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             raise NotFound("Parent task not found")
 
         if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
-            parent_run.capture_event("task_spawn_rejected", {"reason": "usage_limit"})
+            tasks_facade.capture_task_run_event(
+                parent_run.id, self.team_id, "task_spawn_rejected", {"reason": "usage_limit"}
+            )
             return limit_response
         if tasks_facade.spawned_task_run_rate_capped(self.team_id):
-            parent_run.capture_event("task_spawn_rejected", {"reason": "rate_limit"})
+            tasks_facade.capture_task_run_event(
+                parent_run.id, self.team_id, "task_spawn_rejected", {"reason": "rate_limit"}
+            )
             return Response({"detail": "Team task run rate limit exceeded"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
         wake_on = data.pop("wake_on")

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -77,7 +77,6 @@ from products.tasks.backend.facade.streams import (
     get_task_run_stream_key,
     run_uses_dedicated_stream,
 )
-from products.tasks.backend.logic.services.orchestration import render_child_run_message
 from products.tasks.backend.presentation.serializers import (
     CodeInviteRedeemRequestSerializer,
     ConnectionTokenResponseSerializer,
@@ -456,7 +455,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 child_task.id,
                 self.team_id,
                 self._user_id(),
-                validated_data={"pending_user_message": render_child_run_message(child_task.description)},
+                validated_data={"pending_user_message": tasks_facade.render_child_run_message(child_task.description)},
             )
             if outcome != "started":
                 raise ValidationError(outcome)

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -77,6 +77,7 @@ from products.tasks.backend.facade.streams import (
     get_task_run_stream_key,
     run_uses_dedicated_stream,
 )
+from products.tasks.backend.logic.services.orchestration import render_child_run_message
 from products.tasks.backend.presentation.serializers import (
     CodeInviteRedeemRequestSerializer,
     ConnectionTokenResponseSerializer,
@@ -385,8 +386,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if parent_run is None:
             raise NotFound("Parent run not found")
         if parent_run.is_terminal:
+            parent_run.capture_event("task_spawn_rejected", {"reason": "terminal_parent"})
             raise ValidationError({"parent_run_id": "Parent run must be active"})
         if parent_run.state.get("parent_task_id") is not None:
+            parent_run.capture_event("task_spawn_rejected", {"reason": "depth_limit"})
             raise ValidationError({"parent_run_id": "Child runs cannot spawn tasks"})
 
         parent_task = tasks_facade.get_task_detail(parent_run.task_id, self.team_id, self._user_id())
@@ -394,8 +397,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             raise NotFound("Parent task not found")
 
         if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+            parent_run.capture_event("task_spawn_rejected", {"reason": "usage_limit"})
             return limit_response
         if tasks_facade.spawned_task_run_rate_capped(self.team_id):
+            parent_run.capture_event("task_spawn_rejected", {"reason": "rate_limit"})
             return Response({"detail": "Team task run rate limit exceeded"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
         wake_on = data.pop("wake_on")
@@ -443,7 +448,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 child_task.id,
                 self.team_id,
                 self._user_id(),
-                validated_data={"pending_user_message": child_task.description},
+                validated_data={"pending_user_message": render_child_run_message(child_task.description)},
             )
             if outcome != "started":
                 raise ValidationError(outcome)

--- a/products/tasks/backend/temporal/constants.py
+++ b/products/tasks/backend/temporal/constants.py
@@ -129,7 +129,7 @@ CHILD_EVENT_MESSAGE_TEMPLATE = """\
 Child task #{task_number} ({title}) reported {event}.
 Status: {status}{error_line}{pr_line}
 
-Decide the next step: spawn the next child task, report to the user, or finish.
+Use your channel context as the plan of record. Decide the next step: spawn the next child task, report to the user, or finish.
 """.strip()
 
 DEFAULT_CI_MESSAGE = f"""\

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1057,7 +1057,8 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         run = child.runs.get()
         self.assertEqual(child.channel_id, channel.id)
         self.assertEqual(run.environment, TaskRun.Environment.CLOUD)
-        self.assertEqual(run.state["pending_user_message"], child.description)
+        self.assertIn("You were spawned by an orchestrator task", run.state["pending_user_message"])
+        self.assertTrue(run.state["pending_user_message"].endswith("Make the focused change"))
         self.assertEqual(
             {key: run.state[key] for key in ("parent_task_id", "parent_run_id", "wake_on")},
             {
@@ -1240,11 +1241,13 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         self.assertEqual(override_run.state["sandbox_environment_id"], str(override.id))
         self.assertEqual(override_run.state["custom_image_id"], str(override_image.id))
 
+    @patch("products.tasks.backend.models.TaskRun.capture_event")
     @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
-    def test_spawn_rejects_child_parent_run(self, _flag):
+    def test_spawn_rejects_child_parent_run(self, _flag, capture_event):
         parent_run = self._parent_run(state={"parent_task_id": str(uuid.uuid4())})
         response = self.client.post(self.url, self._payload(parent_run), format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        capture_event.assert_called_once_with("task_spawn_rejected", {"reason": "depth_limit"})
 
     @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
     def test_spawn_rejects_terminal_parent_run(self, _flag):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1038,6 +1038,7 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
             "name": "my-skill.zip",
             "type": "skill_bundle",
             "storage_path": f"{run.get_artifact_s3_prefix()}/abcdef01_my-skill.zip",
+            "uploaded_at": "2026-08-03T00:00:00Z",
         }
         entry.update(overrides)
         return entry
@@ -1047,7 +1048,7 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
     @patch("products.tasks.backend.feature_flags.is_tasks_orchestration_enabled", return_value=True)
     @patch.object(Task, "capture_event", autospec=True)
     def test_spawn_creates_and_starts_child_with_protected_state(self, capture_event, _flag, _gate, trigger):
-        channel = Channel.objects.create(team=self.team, name="orchestration")
+        channel = Channel.objects.unscoped().create(team=self.team, name="orchestration")
         parent_run = self._parent_run(channel=channel)
 
         response = self.client.post(self.url, self._payload(parent_run, wake_on=["pr_merged"]), format="json")
@@ -1199,14 +1200,14 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
     def test_spawn_inherits_and_overrides_sandbox_environment(self, _flag, _gate, _trigger):
         inherited = SandboxEnvironment.objects.create(team=self.team, created_by=self.user, name="Inherited")
         override = SandboxEnvironment.objects.create(team=self.team, created_by=self.user, name="Override")
-        inherited_image = SandboxCustomImage.objects.create(
+        inherited_image = SandboxCustomImage.objects.unscoped().create(
             team=self.team,
             created_by=self.user,
             name="Inherited image",
             status=SandboxCustomImage.Status.READY,
             modal_image_name="inherited:latest",
         )
-        override_image = SandboxCustomImage.objects.create(
+        override_image = SandboxCustomImage.objects.unscoped().create(
             team=self.team,
             created_by=self.user,
             name="Override image",

--- a/products/tasks/docs/INSTRUMENTATION.md
+++ b/products/tasks/docs/INSTRUMENTATION.md
@@ -94,13 +94,21 @@ Additional properties:
 
 ### `parent_woken`
 
-Tracked when a cold orchestrator parent is resumed and its queued child wakes are delivered.
+Tracked when an orchestrator parent receives a child wake, either through its live workflow or after an automatic resume.
 
 | Property       | Type   | Description                                       |
 | -------------- | ------ | ------------------------------------------------- |
 | `source`       | `str`  | `terminal`, `pr_merged`, or `multiple`            |
 | `cold`         | `bool` | Whether delivery required an automatic resume     |
 | `queued_count` | `int`  | Number of queued wake messages delivered together |
+
+### `task_spawn_rejected`
+
+Tracked on the parent run when a valid parent run cannot spawn a child.
+
+| Property | Type  | Description                                                      |
+| -------- | ----- | ---------------------------------------------------------------- |
+| `reason` | `str` | `terminal_parent`, `depth_limit`, `usage_limit`, or `rate_limit` |
 
 ## Loop Fire Metrics
 

--- a/products/tasks/docs/ORCHESTRATION.md
+++ b/products/tasks/docs/ORCHESTRATION.md
@@ -1,0 +1,45 @@
+# Orchestrated tasks
+
+Orchestrated tasks let one cloud task plan work and spawn cloud child tasks that each complete a focused part of that plan. The parent and children normally share a channel, and the channel context is their plan of record.
+
+The `tasks-orchestration` organization feature flag controls child spawning and the `tasks-spawn` MCP tool.
+
+## Parent and child model
+
+Parentage is stored only in protected child-run state:
+
+- `parent_task_id` identifies the parent task.
+- `parent_run_id` records the run that spawned the child.
+- `wake_on` stores optional wake sources.
+
+There is no parent-child field on `Task`. Grouping belongs to channels, and adding a schema relationship would require every task action to define whether it affects related tasks. This keeps children independent: archive, cancel, and delete operations never propagate. This decision also incorporates the concerns raised in [#51629](https://github.com/PostHog/posthog/issues/51629).
+
+Orchestration has a depth limit of one. A run with `parent_task_id` cannot spawn another child.
+
+## Wake delivery
+
+Every terminal child status wakes the parent. A child can also wake the parent when its pull request merges by including `pr_merged` in `wake_on` at spawn time.
+
+The wake service resolves the parent task's current run when it delivers the message. It follows this delivery order:
+
+1. Signal a live parent workflow.
+2. Queue the wake in the parent run's state when the workflow is unavailable.
+3. Resume a cold parent and deliver all queued wakes.
+
+Wake messages are built from task and run records. They include the child's status, error, and pull request URL when available.
+
+## Running dependent child tasks
+
+Run dependent child tasks serially through pull request merge. The CI follow-up loop can push fixes to a child's branch, which makes a stacked branch based on that child unstable. Spawn the next dependent child after the previous pull request merges.
+
+## Headless creation gaps
+
+Children are created in the cloud without a desktop client. They inherit the parent's skill bundles, imported public-URL MCP servers, sandbox environment, and custom image.
+
+Desktop-relayed MCP servers do not work for child tasks. Their stdio or private-network executor exists only in the desktop process that created the parent, and a server-created child has no relay binding.
+
+## Follow-ups
+
+- Allow parents to steer active children through `tasks-runs-command-create`.
+- Wake parents when a child pull request closes without merging.
+- Add a children-list filter or tree view if the product needs hierarchy. A `Task` foreign key can be backfilled from run-state keys when that UI has a concrete consumer.

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -859,6 +859,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'review-hog',
                 'warehouse-person-properties',
                 'streamlit-apps',
+                'tasks-orchestration',
             ])
         )
         expect(flags).toHaveLength(29)


### PR DESCRIPTION
## Problem

Orchestrated tasks are functionally complete, but child prompts and parent wake messages need enough protocol context to keep agents scoped and moving through the shared plan. The feature also needs complete rollout instrumentation and developer documentation.

## Changes

- Add hidden child-run framing and clearer parent wake guidance.
- Track rejected spawn attempts and document orchestration events.
- Document the state-only parent model, wake delivery, headless inheritance, and follow-ups.

**Why:** Clear run framing and observable rollout behavior make orchestrated tasks safer to dogfood and easier to operate.

## How did you test this code?

- `ruff check`, `ruff format`, Python compile checks, and `git diff --check` pass.
- Extended the existing spawn API test to catch child framing being omitted and the depth rejection test to catch missing rejection telemetry.
- Extended the existing orchestration service test to catch wake messages losing the channel plan-of-record guidance.
- Focused pytest suites could not start in this environment because repository-wide pytest startup/collection stalled before any test ran. The dev stack's ingestion process also failed while compiling its existing `lz4` dependency under Node 24.
- `hogli ci:preflight --fix` passed Ruff and Markdown checks. Its OpenAPI check reports existing stacked-branch drift against `master`; this PR does not change serializers or API schemas.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Added `products/tasks/docs/ORCHESTRATION.md` and completed orchestration event coverage in `INSTRUMENTATION.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented only the consolidation step on top of the existing orchestration PR stack. Skills used: `/i-have-adhd`, `/writing-user-facing-copy`, `/writing-code-comments`, `/improving-drf-endpoints`, and `/writing-tests`. The change reuses existing spawn and wake mechanisms and adds no schema or workflow mechanism.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*