### PR TITLE
fix(lazy-loader): stop reloading a null-cached key on every lookup

### DIFF
--- a/nodejs/src/common/utils/lazy-loader.test.ts
+++ b/nodejs/src/common/utils/lazy-loader.test.ts
@@ -381,6 +381,27 @@ describe('LazyLoader', () => {
             expect(loadSpy).toHaveBeenCalledTimes(0)
             expect(loader).toHaveBeenCalledTimes(0)
         })
+
+        it('re-caches a key that reloads from null to null', async () => {
+            loader.mockResolvedValueOnce({ key1: 'value1' })
+            expect(await lazyLoader.get('key1')).toBe('value1')
+
+            // Past refreshAgeMs, so this get reloads. The loader omits key1, caching it as null.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 2.5)
+            loader.mockResolvedValue({})
+            expect(await lazyLoader.get('key1')).toBeNull()
+
+            // Past the null TTL, so this get reloads and the loader omits key1 again. The reload
+            // has to stamp a fresh null TTL, otherwise the entry stays expired forever.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 5)
+            expect(await lazyLoader.get('key1')).toBeNull()
+            loader.mockClear()
+
+            // Inside the new null TTL, so this is a cache hit rather than another blocking load.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 5.5)
+            expect(await lazyLoader.get('key1')).toBeNull()
+            expect(loader).toHaveBeenCalledTimes(0)
+        })
     })
 
     describe('LRU eviction with maxSize', () => {

--- a/nodejs/src/common/utils/lazy-loader.test.ts
+++ b/nodejs/src/common/utils/lazy-loader.test.ts
@@ -111,6 +111,7 @@ describe('LazyLoader', () => {
             // Ingest tokens become cache keys verbatim, so a token of `__proto__` must miss rather
             // than resolve up the prototype chain and let a write land on a shared builtin.
             loader.mockResolvedValue({})
+            const builtinFields = new Set(Object.getOwnPropertyNames(Object.prototype))
 
             try {
                 expect(await lazyLoader.get('__proto__')).toBeNull()
@@ -121,8 +122,12 @@ describe('LazyLoader', () => {
                 expect(await lazyLoader.get('__proto__')).toBeNull()
                 expect(loader).toHaveBeenCalledTimes(1)
             } finally {
-                for (const field of ['value', 'lastUsed', 'cacheUntil', 'backgroundRefreshAfter']) {
-                    delete (Object.prototype as Record<string, unknown>)[field]
+                // On regression the assertions above fail; strip whatever leaked so the rest of the
+                // file isn't debugging a mutated builtin instead of the real failure.
+                for (const field of Object.getOwnPropertyNames(Object.prototype)) {
+                    if (!builtinFields.has(field)) {
+                        delete (Object.prototype as Record<string, unknown>)[field]
+                    }
                 }
             }
         })
@@ -364,13 +369,16 @@ describe('LazyLoader', () => {
             loader.mockResolvedValue({})
             expect(await lazyLoader.get('key1')).toBeNull()
             loader.mockClear()
+            loadSpy.mockClear()
 
             // Still inside refreshNullAgeMs, so the null is served from cache. The background
             // deadline from when key1 held a real value is long past, so one left behind on the
             // entry would reload the key on every lookup until the null expires.
             jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 3)
             expect(await lazyLoader.get('key1')).toBeNull()
-            await delay(10)
+            // loadSpy, not loader: a background refresh calls load() synchronously during the get,
+            // so this observes a scheduled reload without waiting out the buffer for it to surface.
+            expect(loadSpy).toHaveBeenCalledTimes(0)
             expect(loader).toHaveBeenCalledTimes(0)
         })
     })

--- a/nodejs/src/common/utils/lazy-loader.test.ts
+++ b/nodejs/src/common/utils/lazy-loader.test.ts
@@ -106,6 +106,26 @@ describe('LazyLoader', () => {
             expect(result2).toBe('value2')
             expect(loader).toHaveBeenCalledTimes(1)
         })
+
+        it('treats a key naming an Object.prototype member as a normal miss', async () => {
+            // Ingest tokens become cache keys verbatim, so a token of `__proto__` must miss rather
+            // than resolve up the prototype chain and let a write land on a shared builtin.
+            loader.mockResolvedValue({})
+
+            try {
+                expect(await lazyLoader.get('__proto__')).toBeNull()
+                expect(loader).toHaveBeenCalledWith(['__proto__'])
+                expect(Object.getOwnPropertyNames(Object.prototype)).not.toContain('lastUsed')
+
+                // And it caches like any other null rather than reloading on every lookup.
+                expect(await lazyLoader.get('__proto__')).toBeNull()
+                expect(loader).toHaveBeenCalledTimes(1)
+            } finally {
+                for (const field of ['value', 'lastUsed', 'cacheUntil', 'backgroundRefreshAfter']) {
+                    delete (Object.prototype as Record<string, unknown>)[field]
+                }
+            }
+        })
     })
 
     describe('getMany', () => {
@@ -334,6 +354,25 @@ describe('LazyLoader', () => {
             expect(loadSpy).toHaveBeenCalledTimes(0)
             expect(loader).toHaveBeenCalledTimes(1)
         })
+
+        it('does not background-refresh a key whose value has become null', async () => {
+            loader.mockResolvedValueOnce({ key1: 'value1' })
+            expect(await lazyLoader.get('key1')).toBe('value1')
+
+            // Past refreshAgeMs, so this get reloads. The loader omits key1, caching it as null.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 2.5)
+            loader.mockResolvedValue({})
+            expect(await lazyLoader.get('key1')).toBeNull()
+            loader.mockClear()
+
+            // Still inside refreshNullAgeMs, so the null is served from cache. The background
+            // deadline from when key1 held a real value is long past, so one left behind on the
+            // entry would reload the key on every lookup until the null expires.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 3)
+            expect(await lazyLoader.get('key1')).toBeNull()
+            await delay(10)
+            expect(loader).toHaveBeenCalledTimes(0)
+        })
     })
 
     describe('LRU eviction with maxSize', () => {
@@ -364,6 +403,30 @@ describe('LazyLoader', () => {
             const cache = customLoader.getCache()
             expect(Object.keys(cache).length).toBe(3)
             expect(cache).toEqual({ key1: 'value1', key2: 'value2', key4: 'value4' })
+        })
+
+        it('does not evict when refreshing a key already in the cache', async () => {
+            const customLoader = new LazyLoader({
+                name: 'test',
+                loader,
+                maxSize: 3,
+                refreshJitterMs: 0,
+            })
+
+            loader.mockResolvedValueOnce({ key1: 'value1', key2: 'value2', key3: 'value3' })
+            await customLoader.getMany(['key1', 'key2', 'key3'])
+
+            // Reloading an expired key replaces its entry rather than adding one, so the cache is
+            // still at maxSize and nothing live gets evicted.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 6)
+            loader.mockResolvedValueOnce({ key1: 'value1-refreshed' })
+            await customLoader.get('key1')
+
+            expect(customLoader.getCache()).toEqual({
+                key1: 'value1-refreshed',
+                key2: 'value2',
+                key3: 'value3',
+            })
         })
 
         it('should handle bulk additions that exceed maxSize', async () => {

--- a/nodejs/src/common/utils/lazy-loader.ts
+++ b/nodejs/src/common/utils/lazy-loader.ts
@@ -338,7 +338,10 @@ export class LazyLoader<T> {
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
             const entry = this.cache[key]
-            if (results[i] === null && entry?.value !== null) {
+            // An entry already holding null is rewritten once its deadline has lapsed. Nothing else
+            // would refresh it, since `setValues` only touches keys the loader returned, so leaving
+            // it alone would strand it permanently expired and make every later lookup block.
+            if (results[i] === null && (!entry || entry.value !== null || entry.cacheUntil <= now)) {
                 if (!entry) {
                     this.cacheSize++
                 }

--- a/nodejs/src/common/utils/lazy-loader.ts
+++ b/nodejs/src/common/utils/lazy-loader.ts
@@ -86,11 +86,22 @@ export type LazyLoaderOptions<T> = {
 
 type LazyLoaderMap<T> = Record<string, T | null | undefined>
 
+/**
+ * A cached value together with the deadlines that govern it. These live on one object so that
+ * writing a value and stamping its deadlines cannot come apart: any code path that sets the
+ * value has to produce the deadlines too.
+ */
+type CacheEntry<T> = {
+    value: T | null
+    lastUsed: number
+    /** Past this, the next lookup reloads before returning. */
+    cacheUntil: number
+    /** Past this, the next lookup returns the cached value and reloads in the background. */
+    backgroundRefreshAfter?: number
+}
+
 export class LazyLoader<T> {
-    private cache: LazyLoaderMap<T>
-    private lastUsed: Record<string, number | undefined>
-    private cacheUntil: Record<string, number | undefined>
-    private backgroundRefreshAfter: Record<string, number | undefined>
+    private cache: Record<string, CacheEntry<T> | undefined>
     private pendingLoads: Record<string, Promise<T | null> | undefined>
 
     private refreshAgeMs: number
@@ -108,11 +119,11 @@ export class LazyLoader<T> {
         | undefined
 
     constructor(private readonly options: LazyLoaderOptions<T>) {
-        this.cache = {}
-        this.lastUsed = {}
-        this.cacheUntil = {}
-        this.backgroundRefreshAfter = {}
-        this.pendingLoads = {}
+        // Keys come from callers and can be ingest tokens or distinct ids, so these maps have no
+        // prototype. On a plain object a key like `__proto__` resolves to `Object.prototype`
+        // instead of missing, and writing through it mutates a builtin the whole process shares.
+        this.cache = Object.create(null)
+        this.pendingLoads = Object.create(null)
 
         this.refreshAgeMs = this.options.refreshAgeMs ?? 1000 * 60 * 5 // 5 minutes
         this.refreshNullAgeMs = this.options.refreshNullAgeMs ?? this.refreshAgeMs
@@ -125,8 +136,15 @@ export class LazyLoader<T> {
         }
     }
 
-    public getCache(): LazyLoaderMap<T> {
-        return this.cache
+    /** A snapshot of the cached values. Mutating the result does not affect the cache. */
+    public getCache(): Record<string, T | null> {
+        const values: Record<string, T | null> = Object.create(null)
+        for (const [key, entry] of Object.entries(this.cache)) {
+            if (entry) {
+                values[key] = entry.value
+            }
+        }
+        return values
     }
 
     public async get(key: string): Promise<T | null> {
@@ -140,15 +158,18 @@ export class LazyLoader<T> {
 
     public markForRefresh(key: string | string[]): void {
         for (const k of Array.isArray(key) ? key : [key]) {
-            delete this.cacheUntil[k]
+            const entry = this.cache[k]
+            if (entry) {
+                // A cacheUntil of 0 forces the next lookup to reload before returning. The
+                // background deadline goes with it so the entry never holds two that disagree.
+                entry.cacheUntil = 0
+                entry.backgroundRefreshAfter = undefined
+            }
         }
     }
 
     public clear(): void {
-        this.cache = {}
-        this.lastUsed = {}
-        this.cacheUntil = {}
-        this.backgroundRefreshAfter = {}
+        this.cache = Object.create(null)
         this.cacheSize = 0
         // this.pendingLoads = {} // NOTE: We don't clear this
         this.updateCacheSizeMetric()
@@ -159,22 +180,19 @@ export class LazyLoader<T> {
         const keys = Object.keys(map)
         for (const key of keys) {
             const value = map[key] ?? null
-            // Track if this is a new key being added
-            const isNewKey = !(key in this.cache)
-            this.cache[key] = value
-            if (isNewKey) {
-                this.cacheSize++
-            }
-            // Always update the lastUsed time
-            this.lastUsed[key] = now
             const jitter = Math.floor(Math.random() * this.refreshJitterMs)
             const refreshAge = value === null ? this.refreshNullAgeMs : this.refreshAgeMs
-            this.cacheUntil[key] = now + refreshAge + jitter
+            const cacheUntil = now + refreshAge + jitter
+            // A null takes refreshNullAgeMs for both deadlines, putting them on the same instant,
+            // so nulls hard-refresh and never background-refresh.
+            const backgroundRefreshAfter = this.refreshBackgroundAgeMs
+                ? now + (value === null ? this.refreshNullAgeMs : this.refreshBackgroundAgeMs) + jitter
+                : undefined
 
-            if (this.refreshBackgroundAgeMs) {
-                const bgAge = value === null ? this.refreshNullAgeMs : this.refreshBackgroundAgeMs
-                this.backgroundRefreshAfter[key] = now + bgAge + jitter
+            if (this.cache[key] === undefined) {
+                this.cacheSize++
             }
+            this.cache[key] = { value, lastUsed: now, cacheUntil, backgroundRefreshAfter }
         }
         this.evictLRU()
         this.updateCacheSizeMetric()
@@ -189,7 +207,9 @@ export class LazyLoader<T> {
      */
     private async loadViaCache(keys: string[]): Promise<Record<string, T | null>> {
         return await instrumentFn(`lazyLoader.loadViaCache`, async () => {
-            const results: Record<string, T | null> = {}
+            // No prototype, for the same reason as the cache: keys are caller-supplied, and this
+            // object is handed back to callers who may iterate or spread it.
+            const results: Record<string, T | null> = Object.create(null)
             const keysToLoad = new Set<string>()
 
             // First, check if all keys are already cached and update the lastUsed time
@@ -197,12 +217,12 @@ export class LazyLoader<T> {
                 const cached = this.cache[key]
 
                 if (cached !== undefined) {
-                    results[key] = cached
+                    results[key] = cached.value
                     // Always update the lastUsed time
-                    this.lastUsed[key] = Date.now()
+                    cached.lastUsed = Date.now()
 
-                    const cacheUntil = this.cacheUntil[key] ?? 0
-                    const backgroundRefreshAfter = this.backgroundRefreshAfter[key]
+                    const cacheUntil = cached.cacheUntil
+                    const backgroundRefreshAfter = cached.backgroundRefreshAfter
 
                     if (Date.now() > cacheUntil) {
                         keysToLoad.add(key)
@@ -242,7 +262,7 @@ export class LazyLoader<T> {
 
             for (const key of keys) {
                 // Grab the new cached result for all keys
-                results[key] = this.cache[key] ?? null
+                results[key] = this.cache[key]?.value ?? null
             }
 
             return results
@@ -312,22 +332,45 @@ export class LazyLoader<T> {
         // For keys the loader omitted (resolved to null), update the cache
         // so deleted/disabled items don't serve stale data.
         const now = Date.now()
-        const result: LazyLoaderMap<T> = {}
+        // Keys are caller-supplied: on a plain object, assigning `__proto__` would reassign this
+        // map's prototype instead of storing the value under that key.
+        const result: LazyLoaderMap<T> = Object.create(null)
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
-            if (results[i] === null && this.cache[key] !== null) {
-                const isNewKey = !(key in this.cache)
-                this.cache[key] = null
-                if (isNewKey) {
+            const entry = this.cache[key]
+            if (results[i] === null && entry?.value !== null) {
+                if (!entry) {
                     this.cacheSize++
                 }
-                this.lastUsed[key] = now
+                // Replace the entry rather than patching the previous value's fields. A
+                // backgroundRefreshAfter left over from when this key held a real value is
+                // necessarily in the past, because refreshBackgroundAgeMs is smaller than the
+                // refreshAgeMs the key just exceeded. Keeping it would background-refresh the key
+                // on every lookup for the whole null TTL.
                 const jitter = Math.floor(Math.random() * this.refreshJitterMs)
-                this.cacheUntil[key] = now + this.refreshNullAgeMs + jitter
+                this.cache[key] = {
+                    value: null,
+                    lastUsed: now,
+                    cacheUntil: now + this.refreshNullAgeMs + jitter,
+                }
             }
-            result[key] = this.cache[key] ?? null
+            result[key] = this.cache[key]?.value ?? null
         }
         return result
+    }
+
+    /**
+     * Invoke the loader and normalize its result into a map this class owns: no prototype, and
+     * `undefined` collapsed to `null`. The loader hands back a plain object, where a key like
+     * `__proto__` resolves up the prototype chain instead of reading as absent.
+     */
+    private async invokeLoader(keys: string[]): Promise<Record<string, T | null>> {
+        const loaded = await this.invokeLoaderWithRetry(keys)
+        const map: Record<string, T | null> = Object.create(null)
+        for (const [key, value] of Object.entries(loaded)) {
+            map[key] = value ?? null
+        }
+        return map
     }
 
     /**
@@ -337,7 +380,7 @@ export class LazyLoader<T> {
      * retry time rather than reusing a stale result. Only retriable errors (`error.isRetriable === true`)
      * are retried; anything else is rethrown immediately so genuine bugs surface rather than being masked.
      */
-    private async invokeLoader(keys: string[]): Promise<LazyLoaderMap<T>> {
+    private async invokeLoaderWithRetry(keys: string[]): Promise<LazyLoaderMap<T>> {
         const retry = this.options.loaderRetry
         if (!retry) {
             return await this.options.loader(keys)
@@ -384,16 +427,12 @@ export class LazyLoader<T> {
         const toEvict = this.cacheSize - this.maxSize + headroom
 
         const cacheKeys = Object.keys(this.cache)
-        cacheKeys.sort((a, b) => (this.lastUsed[a] ?? 0) - (this.lastUsed[b] ?? 0))
+        cacheKeys.sort((a, b) => (this.cache[a]?.lastUsed ?? 0) - (this.cache[b]?.lastUsed ?? 0))
 
         // Evict the least recently used entries
         const evictCount = Math.min(toEvict, cacheKeys.length)
         for (let i = 0; i < evictCount; i++) {
-            const key = cacheKeys[i]
-            delete this.cache[key]
-            delete this.lastUsed[key]
-            delete this.cacheUntil[key]
-            delete this.backgroundRefreshAfter[key]
+            delete this.cache[cacheKeys[i]]
             this.cacheSize--
         }
     }


### PR DESCRIPTION
## Problem

A key that reloads from a real value to null kept the `backgroundRefreshAfter` deadline stamped for the earlier value. That deadline is always in the past by then, because `refreshBackgroundAgeMs` is smaller than the `refreshAgeMs` the key just exceeded. So every lookup for the rest of the null TTL fired a background reload instead of serving the cached null, which defeats the point of `refreshNullAgeMs`.

This reaches the three loaders that set `refreshBackgroundAgeMs`: `hog_flow_manager`, `plugin_config_hog_functions`, and `quota_limited_tokens`. Any key that resolves to null in one of them is affected for the length of its null TTL. `quota_limited_tokens` is the worst case, caching for an hour while refreshing in the background after a minute.

The underlying cause is that the cache kept four parallel maps keyed by the same string (`cache`, `lastUsed`, `cacheUntil`, `backgroundRefreshAfter`), and the null path wrote three of them.

The same symptom also had a second route, which @matheus-vb spotted in review. Once a key was already cached as null, the null-reload path skipped it, so its deadline was never refreshed. Nothing else refreshes it either, since `setValues` only writes keys the loader returned. After the first null TTL lapsed the entry stayed permanently expired and every later lookup was a blocking load. That one predates this PR and is not limited to loaders that set `refreshBackgroundAgeMs`, but it lives in the block this PR rewrites, so it is fixed here rather than left as a follow-up. It also covers `markForRefresh`, which writes `cacheUntil = 0`: on a key already cached null that used to wedge the entry immediately, with no TTL left to recover from.

## Changes

Each cached key now maps to a single `CacheEntry` holding its value alongside the deadlines that govern it. Every path that caches a value constructs a whole entry, so a value and its deadlines cannot come apart. That is what fixes the bug.

The null-reload path now also rewrites an entry that already holds null once its deadline has lapsed, instead of skipping it and stranding it expired.

Cache keys are caller-supplied and include raw ingest tokens, so the maps keyed by them are built with `Object.create(null)`. On a plain object a key like `__proto__` resolves to `Object.prototype` instead of missing, which with entry objects would let a lookup write onto a builtin the whole process shares. It also makes `getTeamByToken('__proto__')` a proper miss instead of returning `Object.prototype` cast as a `Team`.

`getCache()` now returns a snapshot instead of the live map. Only tests call it.

Caching behavior is otherwise unchanged.

## How did you test this code?

Automated tests only. I did not test this manually.

Four tests added to `nodejs/src/common/utils/lazy-loader.test.ts`, each catching a regression no existing test covered:

- `does not background-refresh a key whose value has become null` catches the bug above. I checked that it fails against the old code with 1 loader call instead of 0, and passes against the new. No existing test exercised a value transitioning to null with `refreshBackgroundAgeMs` set.
- `re-caches a key that reloads from null to null` catches the second route. It reloads a null-cached key past its null TTL and asserts the next lookup inside the new TTL is a cache hit. It fails against the old code with 1 loader call instead of 0. The background-refresh test above stops one reload short of reaching this.
- `treats a key naming an Object.prototype member as a normal miss` catches a `__proto__` key resolving up the prototype chain, including a write landing on `Object.prototype`.
- `does not evict when refreshing a key already in the cache` guards the cache-size accounting in the rewritten `setValues`, so refreshing an existing key replaces its entry rather than counting a new one and evicting something live.

The full lazy-loader suite is 28 passing. I could not run the two consumer suites that use `LazyLoader` (`cdp-legacy-event.consumer.test.ts` and `hogflow-manager.service.test.ts`) because they need a running test Postgres, so CI covers those.

## Automatic notifications

- [ ] Publish to changelog?
