### PR TITLE
fix(desktop): stop tailwind's size-* utility collapsing the combobox popup

### DIFF
--- a/products/desktop/packages/ui/src/primitives/combobox/Combobox.css
+++ b/products/desktop/packages/ui/src/primitives/combobox/Combobox.css
@@ -1,4 +1,7 @@
-.rt-PopoverContent:has(.combobox-content) {
+/* The popup's chrome belongs to the cmdk root below, not to the themes popover.
+   Radix Themes puts `rt-PopoverContent` on the same element our className lands
+   on, so this has to match that element — a descendant selector never fires. */
+.rt-PopoverContent.combobox-content {
   padding: 0;
   background: transparent;
   border: none;
@@ -17,15 +20,15 @@
   overflow: hidden;
 }
 
-.combobox-content.size-1 [cmdk-root] {
+.combobox-content.combobox-size-1 [cmdk-root] {
   --combobox-content-padding: var(--space-1);
   --combobox-item-height: var(--space-5);
   --combobox-item-indicator-width: calc(var(--space-5) / 1.2);
   border-radius: var(--radius-3);
 }
 
-.combobox-content.size-2 [cmdk-root],
-.combobox-content.size-3 [cmdk-root] {
+.combobox-content.combobox-size-2 [cmdk-root],
+.combobox-content.combobox-size-3 [cmdk-root] {
   --combobox-content-padding: var(--space-2);
   --combobox-item-height: var(--space-6);
   --combobox-item-indicator-width: var(--space-5);
@@ -63,17 +66,17 @@
   flex: 1;
 }
 
-.combobox-content.size-1 [cmdk-input] {
+.combobox-content.combobox-size-1 [cmdk-input] {
   font-size: 13px;
   line-height: 20px;
 }
 
-.combobox-content.size-2 [cmdk-input] {
+.combobox-content.combobox-size-2 [cmdk-input] {
   font-size: 14px;
   line-height: 20px;
 }
 
-.combobox-content.size-3 [cmdk-input] {
+.combobox-content.combobox-size-3 [cmdk-input] {
   font-size: 16px;
   line-height: 24px;
 }
@@ -139,14 +142,14 @@
   cursor: default;
 }
 
-.combobox-content.size-1 [cmdk-group-heading] {
+.combobox-content.combobox-size-1 [cmdk-group-heading] {
   font-size: 13px;
   letter-spacing: var(--letter-spacing-1);
   line-height: 20px;
 }
 
-.combobox-content.size-2 [cmdk-group-heading],
-.combobox-content.size-3 [cmdk-group-heading] {
+.combobox-content.combobox-size-2 [cmdk-group-heading],
+.combobox-content.combobox-size-3 [cmdk-group-heading] {
   font-size: 14px;
   letter-spacing: var(--letter-spacing-2);
   line-height: 20px;
@@ -221,7 +224,7 @@
   padding-bottom: var(--combobox-content-padding);
 }
 
-.combobox-content.size-1 [cmdk-item] {
+.combobox-content.combobox-size-1 [cmdk-item] {
   font-size: 13px;
   line-height: 20px;
   letter-spacing: var(--letter-spacing-1);
@@ -229,26 +232,26 @@
   margin-bottom: 2px;
 }
 
-.combobox-content.size-2 [cmdk-item] {
+.combobox-content.combobox-size-2 [cmdk-item] {
   font-size: 14px;
   line-height: 20px;
   letter-spacing: var(--letter-spacing-2);
   border-radius: var(--radius-2);
 }
 
-.combobox-content.size-3 [cmdk-item] {
+.combobox-content.combobox-size-3 [cmdk-item] {
   font-size: 16px;
   line-height: 24px;
   letter-spacing: var(--letter-spacing-3);
   border-radius: var(--radius-2);
 }
 
-.combobox-content.variant-solid [cmdk-item][data-selected="true"] {
+.combobox-content.combobox-variant-solid [cmdk-item][data-selected="true"] {
   background: var(--accent-9);
   color: var(--accent-contrast);
 }
 
-.combobox-content.variant-soft [cmdk-item][data-selected="true"] {
+.combobox-content.combobox-variant-soft [cmdk-item][data-selected="true"] {
   background: var(--accent-a4);
   color: var(--accent-12);
 }
@@ -414,11 +417,11 @@
   justify-content: center;
 }
 
-.combobox-trigger:not(.variant-ghost) .combobox-trigger-icon {
+.combobox-trigger:not(.combobox-variant-ghost) .combobox-trigger-icon {
   opacity: 0.9;
 }
 
-.combobox-trigger.size-1 {
+.combobox-trigger.combobox-size-1 {
   height: var(--space-5);
   gap: var(--space-2);
   font-size: 13px;
@@ -427,16 +430,16 @@
   border-radius: max(var(--radius-1), var(--radius-full));
 }
 
-.combobox-trigger.size-1:not(.variant-ghost) {
+.combobox-trigger.combobox-size-1:not(.variant-ghost) {
   padding-left: var(--space-2);
   padding-right: var(--space-2);
 }
 
-.combobox-trigger.size-1.variant-ghost {
+.combobox-trigger.combobox-size-1.variant-ghost {
   padding: var(--space-1) var(--space-2);
 }
 
-.combobox-trigger.size-2 {
+.combobox-trigger.combobox-size-2 {
   height: var(--space-6);
   gap: calc(var(--space-1) * 1.5);
   font-size: 14px;
@@ -445,16 +448,16 @@
   border-radius: max(var(--radius-2), var(--radius-full));
 }
 
-.combobox-trigger.size-2:not(.variant-ghost) {
+.combobox-trigger.combobox-size-2:not(.variant-ghost) {
   padding-left: var(--space-3);
   padding-right: var(--space-3);
 }
 
-.combobox-trigger.size-2.variant-ghost {
+.combobox-trigger.combobox-size-2.variant-ghost {
   padding: var(--space-1) var(--space-2);
 }
 
-.combobox-trigger.size-3 {
+.combobox-trigger.combobox-size-3 {
   height: var(--space-7);
   gap: var(--space-2);
   font-size: 16px;
@@ -463,45 +466,46 @@
   border-radius: max(var(--radius-3), var(--radius-full));
 }
 
-.combobox-trigger.size-3:not(.variant-ghost) {
+.combobox-trigger.combobox-size-3:not(.variant-ghost) {
   padding-left: var(--space-4);
   padding-right: var(--space-4);
 }
 
-.combobox-trigger.size-3.variant-ghost {
+.combobox-trigger.combobox-size-3.variant-ghost {
   padding: calc(var(--space-1) * 1.5) var(--space-3);
 }
 
-.combobox-trigger.size-3 .combobox-trigger-icon {
+.combobox-trigger.combobox-size-3 .combobox-trigger-icon {
   width: 11px;
   height: 11px;
 }
 
-.combobox-trigger.variant-surface {
+.combobox-trigger.combobox-variant-surface {
   color: var(--gray-12);
   background-color: var(--color-surface);
   box-shadow: inset 0 0 0 1px var(--gray-a7);
 }
 
-.combobox-trigger.variant-surface:hover {
+.combobox-trigger.combobox-variant-surface:hover {
   box-shadow: inset 0 0 0 1px var(--gray-a8);
 }
 
-.combobox-trigger.variant-surface[data-state="open"] {
+.combobox-trigger.combobox-variant-surface[data-state="open"] {
   box-shadow: inset 0 0 0 1px var(--gray-a8);
 }
 
-.combobox-trigger.variant-surface:disabled {
+.combobox-trigger.combobox-variant-surface:disabled {
   color: var(--gray-a11);
   background-color: var(--gray-a2);
   box-shadow: inset 0 0 0 1px var(--gray-a6);
 }
 
-.combobox-trigger.variant-surface[data-placeholder] .combobox-trigger-inner {
+.combobox-trigger.combobox-variant-surface[data-placeholder]
+  .combobox-trigger-inner {
   color: var(--gray-a10);
 }
 
-.combobox-trigger.variant-classic {
+.combobox-trigger.combobox-variant-classic {
   color: var(--gray-12);
   background-image: linear-gradient(var(--gray-2), var(--gray-1));
   box-shadow:
@@ -512,7 +516,7 @@
   z-index: 0;
 }
 
-.combobox-trigger.variant-classic::before {
+.combobox-trigger.combobox-variant-classic::before {
   content: "";
   position: absolute;
   z-index: -1;
@@ -526,7 +530,7 @@
     linear-gradient(var(--color-surface), transparent);
 }
 
-.combobox-trigger.variant-classic:hover {
+.combobox-trigger.combobox-variant-classic:hover {
   box-shadow:
     inset 0 0 0 1px var(--gray-a3),
     inset 0 0 0 1px var(--white-a4),
@@ -534,13 +538,13 @@
     inset 0 -1px 1px var(--black-a9);
 }
 
-.combobox-trigger.variant-classic:hover::before {
+.combobox-trigger.combobox-variant-classic:hover::before {
   background-image:
     linear-gradient(var(--black-a1) -15%, transparent, var(--white-a1) 120%),
     linear-gradient(var(--gray-2), var(--gray-1));
 }
 
-.combobox-trigger.variant-classic[data-state="open"] {
+.combobox-trigger.combobox-variant-classic[data-state="open"] {
   box-shadow:
     inset 0 0 0 1px var(--gray-a3),
     inset 0 0 0 1px var(--white-a4),
@@ -548,106 +552,110 @@
     inset 0 -1px 1px var(--black-a9);
 }
 
-.combobox-trigger.variant-classic[data-state="open"]::before {
+.combobox-trigger.combobox-variant-classic[data-state="open"]::before {
   background-image:
     linear-gradient(var(--black-a1) -15%, transparent, var(--white-a1) 120%),
     linear-gradient(var(--gray-2), var(--gray-1));
 }
 
-.combobox-trigger.variant-classic:disabled {
+.combobox-trigger.combobox-variant-classic:disabled {
   color: var(--gray-a11);
   background-color: var(--gray-2);
   background-image: none;
 }
 
-.combobox-trigger.variant-classic[data-placeholder] .combobox-trigger-inner {
+.combobox-trigger.combobox-variant-classic[data-placeholder]
+  .combobox-trigger-inner {
   color: var(--gray-a10);
 }
 
-.combobox-trigger.variant-soft {
+.combobox-trigger.combobox-variant-soft {
   color: var(--accent-12);
 }
 
-.combobox-trigger.variant-soft[data-placeholder] .combobox-trigger-inner {
+.combobox-trigger.combobox-variant-soft[data-placeholder]
+  .combobox-trigger-inner {
   color: var(--accent-12);
   opacity: 0.6;
 }
 
-.combobox-trigger.variant-ghost {
+.combobox-trigger.combobox-variant-ghost {
   color: var(--gray-11);
 }
 
-.combobox-trigger.variant-ghost[data-placeholder] .combobox-trigger-inner {
+.combobox-trigger.combobox-variant-ghost[data-placeholder]
+  .combobox-trigger-inner {
   color: var(--gray-11);
   opacity: 0.6;
 }
 
-.combobox-trigger.variant-ghost .combobox-trigger-icon {
+.combobox-trigger.combobox-variant-ghost .combobox-trigger-icon {
   color: var(--gray-9);
 }
 
-.combobox-trigger.variant-soft {
+.combobox-trigger.combobox-variant-soft {
   background-color: var(--accent-a3);
 }
 
-.combobox-trigger.variant-soft:hover {
+.combobox-trigger.combobox-variant-soft:hover {
   background-color: var(--accent-a4);
 }
 
-.combobox-trigger.variant-soft[data-state="open"] {
+.combobox-trigger.combobox-variant-soft[data-state="open"] {
   background-color: var(--accent-a4);
 }
 
-.combobox-trigger.variant-soft:focus-visible {
+.combobox-trigger.combobox-variant-soft:focus-visible {
   outline-color: var(--accent-8);
 }
 
-.combobox-trigger.variant-soft:disabled {
+.combobox-trigger.combobox-variant-soft:disabled {
   color: var(--gray-a11);
   background-color: var(--gray-a3);
 }
 
-.combobox-trigger.variant-ghost {
+.combobox-trigger.combobox-variant-ghost {
   background-color: transparent;
 }
 
-.combobox-trigger.variant-ghost:hover {
+.combobox-trigger.combobox-variant-ghost:hover {
   background-color: var(--gray-a3);
 }
 
-.combobox-trigger.variant-ghost[data-state="open"] {
+.combobox-trigger.combobox-variant-ghost[data-state="open"] {
   background-color: var(--gray-a3);
 }
 
-.combobox-trigger.variant-ghost:disabled {
+.combobox-trigger.combobox-variant-ghost:disabled {
   color: var(--gray-a11);
   background-color: transparent;
 }
 
-.combobox-trigger.variant-outline {
+.combobox-trigger.combobox-variant-outline {
   color: var(--gray-12);
   background-color: transparent;
   box-shadow: inset 0 0 0 1px var(--gray-a7);
 }
 
-.combobox-trigger.variant-outline:hover {
+.combobox-trigger.combobox-variant-outline:hover {
   background-color: var(--gray-a2);
 }
 
-.combobox-trigger.variant-outline[data-state="open"] {
+.combobox-trigger.combobox-variant-outline[data-state="open"] {
   background-color: var(--gray-a2);
 }
 
-.combobox-trigger.variant-outline:disabled {
+.combobox-trigger.combobox-variant-outline:disabled {
   color: var(--gray-a11);
   box-shadow: inset 0 0 0 1px var(--gray-a6);
 }
 
-.combobox-trigger.variant-outline[data-placeholder] .combobox-trigger-inner {
+.combobox-trigger.combobox-variant-outline[data-placeholder]
+  .combobox-trigger-inner {
   color: var(--gray-a10);
 }
 
-.combobox-trigger.variant-outline .combobox-trigger-icon {
+.combobox-trigger.combobox-variant-outline .combobox-trigger-icon {
   color: var(--gray-12);
 }
 

--- a/products/desktop/packages/ui/src/primitives/combobox/Combobox.tsx
+++ b/products/desktop/packages/ui/src/primitives/combobox/Combobox.tsx
@@ -272,7 +272,9 @@ function ComboboxContent<T>({
 
   const content = (
     <Popover.Content
-      className={`combobox-content p-0 size-${size} variant-${variant} ${className}`}
+      // `combobox-` prefixed: a bare `size-1` is also a Tailwind utility, which
+      // would win and shrink the popup to 4px square.
+      className={`combobox-content combobox-size-${size} combobox-variant-${variant} ${className}`}
       side={side}
       sideOffset={sideOffset}
       align={align}


### PR DESCRIPTION
## Problem

Opening "Add task" from an empty Command Center tile showed a dropdown only a few pixels tall, with nothing visible inside. Same root cause as the popup width regression fixed in #76570, which set a `min-width` and so only masked one half of it.

`Combobox.Content` built its class list as:

```
combobox-content p-0 size-${size} variant-${variant}
```

`size-1`, `size-2` and `size-3` are also Tailwind v4 utilities. `size-1` compiles to `width: 0.25rem; height: 0.25rem`, and because the generated utility sits in the `utilities` cascade layer while `Combobox.css` is unlayered but keyed off the *same* class names, Tailwind's version applies to the popover element itself. The popup collapsed to a 4px box and its cmdk root spilled out of it invisibly.

Tailwind only emits `.size-1` if it finds that literal somewhere it scans, which it now does. So this affected every combobox in the app, not just the Command Center one, and it turns on and off depending on unrelated code.

## Changes

- Prefix the modifier classes with `combobox-` (`combobox-size-1`, `combobox-variant-soft`, ...) in both the component and the stylesheet, so they can't collide with a utility.
- Fix the popover reset selector. Radix Themes puts `rt-PopoverContent` on the *same* element our `className` lands on, so `.rt-PopoverContent:has(.combobox-content)` never matched and the themes popover chrome (its own padding, panel background and shadow) was never actually reset. Now that it matches, the `p-0` utility that was papering over the padding is no longer needed.

## How did you test this code?

I (Claude, via the PostHog Slack app) could not run the packaged Electron app here, so verification is via Storybook rendered in headless Chromium.

Measuring `.rt-PopoverContent` for a Command Center style task picker inside a grid cell:

| | before | after |
| --- | --- | --- |
| popup box | 240 x 34 (content 300 x 242 overflowing) | 300 x 242 |

The 34px is `0.25rem` plus the themes padding that the broken reset let through. Chromium's matched-rules dump named the culprit directly: `.size-1 { height: 0.25rem }` from the `utilities` layer.

The existing `Combobox` stories (default size 2, which was collapsing to an 8px box) render correctly after the change.

Automated tests actually run: `packages/ui` `TaskSelector.test.tsx` (2 passed). I did not add a test, because the failure is a CSS cascade collision that jsdom cannot observe. The Storybook visual regression suite is the layer that would catch it.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported in Slack alongside a separate Command Center drag-and-drop regression, which was already fixed by #76565.

I started from the assumption this was fallout from the desktop app landing in the monorepo, but diffing `products/desktop` against the standalone repo showed the combobox code identical in both, so that was a dead end. A standalone Vite reproduction with just Radix Themes plus cmdk rendered the popup correctly, which pointed at the app's Tailwind setup rather than the component. Rendering the same markup inside the real Storybook (which loads `globals.css`, the cascade layer order and quill) reproduced it, and CDP's matched-styles dump identified the `size-1` utility.

Considered leaving the reset selector alone to keep the diff tight, but with the collapse fixed the themes popover chrome would have sat visibly behind the cmdk root, and the reset was clearly intended to apply. No skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785787881571639)*
