### PR TITLE
chore(ci): derive non-isolated product lanes from the tach graph

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -25,17 +25,32 @@
 // renames a facade function and updates every current caller, PR B adds a new
 // call to the old name, and master breaks on a combination neither run held.
 //
-//   1. Only a change to a product's declared contract surface seeds the
-//      dependent cascade. A file that no module outside the product can import
-//      cannot be the shared symbol two PRs disagree about, so a change confined
-//      to internals keeps its own product's lane. The surface is the product's
-//      own `backend:contract-check` inputs in products/<name>/turbo.json, the
-//      same declaration turbo-discover reads to decide whether dependent test
-//      suites run, so the two mechanisms cannot drift apart. A product that
-//      declares no narrowed inputs cascades on every backend file as before.
-//      This makes the declaration load-bearing for correctness: an input list
-//      that omits a file other products import puts those products in a
-//      parallel lane.
+//   1. A product change claims its own lane plus its direct importers, rather
+//      than every backend lane. tach.toml is the enforced Python module graph
+//      (`tach check` runs in CI), so for a product it declares, the modules
+//      that may import it are exactly the ones listing it in `depends_on`. A
+//      product absent from that graph is unconstrained and still widens.
+//
+//      This does NOT require the product to be isolated. Isolation is the
+//      stronger claim that a change inside the product can only break the
+//      product's own tests, which is what lets CI skip the full Django suite,
+//      and products/architecture.md is explicit that tach cannot prove it:
+//      cross-cutting tests reach a product's endpoints by URL, in process,
+//      with no import for any graph to see. A lane only has to answer whether
+//      another PR can reference the symbols this one changed, which is the
+//      import half that tach does enforce. So a product too unsealed to skip
+//      the suite still has a bounded importer set, and gets a lane from it.
+//
+//      Which of the product's own files seed that cascade is the narrower
+//      question isolation does govern. An isolated product declares a contract
+//      surface as its `backend:contract-check` inputs in
+//      products/<name>/turbo.json — the same declaration turbo-discover reads
+//      to decide whether dependent test suites run, so the two mechanisms
+//      cannot drift apart — and a change confined to its internals keeps its
+//      own lane without cascading. This makes the declaration load-bearing for
+//      correctness: an input list that omits a file other products import puts
+//      those products in a parallel lane. A product that declares no narrowed
+//      inputs, isolated or not, cascades on every backend file.
 //
 //   2. The cascade names direct importers rather than the transitive closure.
 //      Only a direct importer can reference the changed product's symbols.
@@ -636,14 +651,26 @@ function loadBackendDetachedProducts(repoRoot, products, tachGraph) {
     }
     const detached = new Set()
     for (const product of products) {
-        // tach spells its modules both ways across the file, so a product
-        // counts as declared under either spelling.
-        const declared = tachGraph.graph.has(product) || tachGraph.graph.has(product.replace(/_/g, '-'))
-        if (ignored.has(`products/${product}`) && !declared) {
+        if (ignored.has(`products/${product}`) && !isTachDeclared(product, tachGraph)) {
             detached.add(product)
         }
     }
     return detached
+}
+
+// tach spells its modules both ways across the file, so a product counts as
+// declared under either spelling. A product absent from the graph, or a graph
+// that could not be read at all, is not constrained by `tach check` and so has
+// no bounded importer set.
+function isTachDeclared(product, tachGraph) {
+    if (!tachGraph) {
+        return false
+    }
+    return tachGraph.graph.has(product) || tachGraph.graph.has(product.replace(/_/g, '-'))
+}
+
+function listTachDeclaredProducts(products, tachGraph) {
+    return new Set(products.filter((product) => isTachDeclared(product, tachGraph)))
 }
 
 // --- Contract surfaces ---
@@ -1079,6 +1106,7 @@ function computeTargets(changedFiles, context) {
         contractSurfaces = new Map(),
         productWorkspaces = new Map(),
         backendDetachedProducts = new Set(),
+        tachDeclaredProducts = listTachDeclaredProducts(products, tachGraph),
     } = context
     const targets = new Set()
 
@@ -1247,13 +1275,27 @@ function computeTargets(changedFiles, context) {
                     // case below: a product absent from the module graph has no
                     // importers for the cascade to name.
                     targets.add(pyProduct(product))
-                } else if (isContractDeclaration(product, file)) {
-                    // A non-isolated product's backend code has no declared
-                    // boundary, so it keeps widening below. Its declarations
-                    // are a different kind of file: they configure this
-                    // product's own tasks, including the backend:test command
-                    // most of them carry, and every importer that a change to
-                    // them can reach is named by the cascade instead.
+                } else if (isContractDeclaration(product, file) || tachDeclaredProducts.has(product)) {
+                    // A non-isolated product has declared no contract surface,
+                    // so every backend file in it counts as contract and seeds
+                    // the cascade. That names its direct importers, which is
+                    // what a lane needs.
+                    //
+                    // Isolation is a stronger claim than this one and is not
+                    // required here. It says a change inside the product can
+                    // only break the product's own tests, which lets CI skip
+                    // the full Django suite, and products/architecture.md is
+                    // explicit that tach cannot prove it: cross-cutting tests
+                    // reach a product's endpoints by URL, in process, with no
+                    // import to see. A lane only has to answer whether another
+                    // PR can reference the symbols this one changed, and that
+                    // is the import half, which `tach check` does enforce. So a
+                    // product can be too unsealed to skip the suite and still
+                    // have a bounded importer set.
+                    //
+                    // The bound only holds for a product tach declares. One
+                    // absent from the graph is unconstrained by `tach check`,
+                    // so anything may import it and it still widens below.
                     targets.add(pyProduct(product))
                     cascadeSeeds.add(product)
                 } else {
@@ -1385,6 +1427,7 @@ function buildContext(repoRoot) {
         contractSurfaces: loadContractSurfaces(repoRoot, products),
         productWorkspaces: loadProductWorkspaces(repoRoot, products),
         backendDetachedProducts: loadBackendDetachedProducts(repoRoot, products, tachGraph),
+        tachDeclaredProducts: listTachDeclaredProducts(products, tachGraph),
         semgrepDomains: loadSemgrepDomains(repoRoot),
         rustGraph: loadRustGraph(repoRoot),
         tachGraph,

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -43,11 +43,11 @@
 //
 //      Which of the product's own files seed that cascade is the narrower
 //      question isolation does govern. An isolated product declares a contract
-//      surface as its `backend:contract-check` inputs in
-//      products/<name>/turbo.json — the same declaration turbo-discover reads
-//      to decide whether dependent test suites run, so the two mechanisms
-//      cannot drift apart — and a change confined to its internals keeps its
-//      own lane without cascading. This makes the declaration load-bearing for
+//      surface as its `backend:contract-check` inputs in products/<name>/turbo.json.
+//      This is the same declaration turbo-discover reads to decide whether dependent
+//      test suites run, so the two mechanisms cannot drift apart. A change confined
+//      to its internals keeps its own lane without cascading. This makes the
+//      declaration load-bearing for
 //      correctness: an input list that omits a file other products import puts
 //      those products in a parallel lane. A product that declares no narrowed
 //      inputs, isolated or not, cascades on every backend file.

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -64,6 +64,32 @@ const CONTEXT = {
 // What a widening decision now uploads in place of the "ALL" sentinel.
 const EVERYTHING = allKnownTargets(CONTEXT)
 
+// A graph that declares all three products, so their importer sets are bounded.
+// The base CONTEXT deliberately declares none, which covers the case where a
+// product sits outside `tach check` and has to keep widening.
+const TACH_DECLARED_CONTEXT = {
+    ...CONTEXT,
+    tachGraph: {
+        graph: parseTachModules(`
+[[modules]]
+path = "products.alpha"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.beta"
+depends_on = ["products.gamma"]
+layer = "modules"
+
+[[modules]]
+path = "products.gamma"
+depends_on = []
+layer = "modules"
+`),
+        tachDependents,
+    },
+}
+
 // gamma vendors its own pnpm workspace; alpha and beta keep the conventional
 // backend/ + frontend/ layout, so the cases above stay on the old behavior.
 const WORKSPACE_CONTEXT = {
@@ -541,12 +567,50 @@ layer = "modules"
     ])
 })
 
-test('a non-isolated product change widens to every backend target', () => {
+// The base CONTEXT keeps an empty tach graph, so no product is declared in it.
+// A product `tach check` does not constrain has no bounded importer set: any
+// module may import it, so its change still has to reach every backend lane.
+test('a product absent from the tach graph widens to every backend target', () => {
     const targets = computeTargets(['products/gamma/backend/api.py'], CONTEXT)
     assert.equal(targets.includes('py:core'), true)
     for (const product of CONTEXT.products) {
         assert.equal(targets.includes(`py:product:${product}`), true, `expected py:product:${product}`)
     }
+})
+
+// The lane only has to answer whether another PR can reference the symbols this
+// one changed, and tach.toml answers exactly that. Isolation is the stronger,
+// separate claim that the product's own suite is sufficient — which lets CI
+// skip the full Django suite, and which products/architecture.md says tach
+// cannot prove. A product can be too unsealed for that and still be bounded
+// here, which is why gamma (non-isolated) narrows the same way alpha does.
+test('a non-isolated product tach declares claims its own lane and its importers', () => {
+    assert.deepEqual(computeTargets(['products/gamma/backend/api.py'], TACH_DECLARED_CONTEXT), [
+        'py:product:beta',
+        'py:product:gamma',
+    ])
+    // Every backend file seeds, because a product with no declared contract
+    // surface has no way to say a file is internal.
+    assert.deepEqual(
+        computeTargets(['products/gamma/backend/internal/helper.py'], TACH_DECLARED_CONTEXT),
+        computeTargets(['products/gamma/backend/api.py'], TACH_DECLARED_CONTEXT)
+    )
+})
+
+// Isolation still governs the narrower question of which of a product's own
+// files seed the cascade at all, which is what a contract surface declares.
+test('isolation still buys a narrowed contract surface on top of the lane', () => {
+    const context = {
+        ...TACH_DECLARED_CONTEXT,
+        isolatedProducts: new Set([...CONTEXT.isolatedProducts, 'gamma']),
+        contractSurfaces: new Map([['gamma', compileContractMatcher(['backend/facade/**'])]]),
+    }
+    // Internals keep the product's own lane, with no cascade to beta.
+    assert.deepEqual(computeTargets(['products/gamma/backend/internal/helper.py'], context), ['py:product:gamma'])
+    assert.deepEqual(computeTargets(['products/gamma/backend/facade/api.py'], context), [
+        'py:product:beta',
+        'py:product:gamma',
+    ])
 })
 
 // 63 of the products are non-isolated, and their package.json carries the
@@ -571,9 +635,10 @@ test("a non-isolated product's declarations still seed the dependent cascade", (
     ])
 })
 
-// The narrowing is scoped to the declarations. Backend code in a non-isolated
-// product has no declared boundary, which is the whole reason it widens.
-test('a non-isolated product keeps widening on everything that is not a declaration', () => {
+// Declarations narrow even for a product tach does not declare, because they
+// configure only this product's own tasks. Its other files have neither a
+// declared boundary nor a bounded importer set, so they still widen.
+test('an undeclared product keeps widening on everything that is not a declaration', () => {
     for (const file of ['products/gamma/backend/api.py', 'products/gamma/mcp/tools.yaml']) {
         assert.equal(computeTargets([file], CONTEXT).includes('py:product:alpha'), true, file)
     }

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -580,7 +580,7 @@ test('a product absent from the tach graph widens to every backend target', () =
 
 // The lane only has to answer whether another PR can reference the symbols this
 // one changed, and tach.toml answers exactly that. Isolation is the stronger,
-// separate claim that the product's own suite is sufficient — which lets CI
+// separate claim that the product's own suite is sufficient, which lets CI
 // skip the full Django suite, and which products/architecture.md says tach
 // cannot prove. A product can be too unsealed for that and still be bounded
 // here, which is why gamma (non-isolated) narrows the same way alpha does.


### PR DESCRIPTION
> Stacked on #76904.

## Problem

A backend change in a non-isolated product claims **every** backend lane - `py:core` plus all 81 `py:product:*`. The reasoning in the code was that such a product "has no declared boundary".

It does have one. `tach.toml` declares it, and `tach check` enforces it in CI, so for any product tach declares, the modules that may import it are exactly the ones listing it in `depends_on`.

This is the single biggest source of lane overlap. From a day of telemetry (212 PRs):

| | PRs |
| --- | --- |
| Claimed every Python lane | 75 |
| of those, because they touch `posthog/` | 44 |
| of those, because they touch **only** `products/` | 28 |

Those 28 never go near core. They widen purely because their product is not isolated. Only 15 of 81 products are.

## Changes

One branch. A non-isolated product that tach declares now claims its own lane and seeds the cascade to its direct importers, exactly as an isolated product without a narrowed contract surface already does.

```diff
- } else if (isContractDeclaration(product, file)) {
+ } else if (isContractDeclaration(product, file) || tachDeclaredProducts.has(product)) {
      targets.add(pyProduct(product))
      cascadeSeeds.add(product)
  } else {
      allPyProducts()
  }
```

Effect across all 81 products, measured against the real repo: **70 narrow, 11 keep widening.**

| Product | Lanes before | after |
| --- | --- | --- |
| `web_analytics` | 82 | 1 |
| `signals` | 82 | 9 |
| `ai_observability` | 82 | 9 |
| `cohorts` | 82 | 14 |
| `product_analytics` (widest) | 82 | 17 |

Median across the narrowed set is 3.

### Why isolation is not required for this

Isolation is a strictly stronger claim, and this PR does not touch it.

Isolation says *a change inside the product can only break the product's own tests*, which is what lets CI skip the full Django suite. `products/architecture.md` is explicit that tach cannot prove it: cross-cutting tests (permissions, schema, activity-log) reach a product's endpoints **by URL, in process, with no import** for any graph to see. "No importers is necessary, not sufficient." That is why the doc says non-isolated products must not declare `backend:contract-check`.

A lane asks a weaker question: can another PR reference the symbols this one changed? That is the import half, which tach does enforce. So a product can be too unsealed to skip the suite and still have a bounded importer set.

Nothing here changes test selection. `backend:contract-check` still means what it meant, `turbo-discover` still reads it the same way, and no product becomes isolated.

### What still widens

The 11 products absent from `tach.toml` - `core_events`, `games`, `groups`, `ingestion`, `integrations`, `persons`, `session_replay`, `session_summaries`, `subscriptions`, `support`, `toolbar`. Nothing constrains what may import them, so they keep claiming every backend lane. That is the fail-safe, and adding them to `tach.toml` is the fix, in their own PRs.

`posthog/` and `ee/` are unchanged: 44 of the 75 widening PRs touch core, and core genuinely can break anything.

## How did you test this code?

I (actually Claude) ran these. No manual testing - CI script, no UI.

- `node --test` across all four affected suites: **92 pass, 0 fail**.
- Swept every one of the 81 real products through `computeTargets` and asserted every emitted target exists in `allKnownTargets`: **0 violations**. This matters because #76904 replaced the `ALL` sentinel with the enumerated universe, so a cascade emitting a target outside it would make a widened PR *disjoint* from the PR claiming it.
- Verified `tach.toml` name mapping: every dependency name in the graph is itself a module, and every module maps to a real `py:product:*` lane. So the cascade cannot invent a target.
- `oxfmt` on both changed files.

New tests, and the regression each catches:

- **`a non-isolated product tach declares claims its own lane and its importers`** - the change itself, asserted in both directions. Also pins that every backend file seeds, since a product with no contract surface cannot call a file internal.
- **`isolation still buys a narrowed contract surface on top of the lane`** - guards against collapsing the two concepts. Isolation still decides *which* files seed; this PR only decides the fallback when nothing is declared.
- **`a product absent from the tach graph widens to every backend target`** - the fail-safe. This is the renamed old test: the base test context deliberately keeps an empty tach graph, which is exactly the undeclared case.

> [!WARNING]
> This extends the cascade's existing accepted risk from 15 products to 69. The script's header documents it: the cascade names direct importers, not the transitive closure, so a conflict routed through an intermediate product is not serialized and master's post-merge run is the only net. The transitive closure is not an option - a 31-product cycle in `tach.toml` means any seed inside it expands to the whole backend. Widening the exposure is the deliberate trade here and the main thing to push back on in review.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `products/architecture.md` is unchanged and still governs isolation, which this PR does not alter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This came out of reading the lane telemetry from #76904. The tripwire split in that PR attacks the 79 PRs that widen to `ALL`; this one attacks the 75 that claim every Python lane, which the data showed is the larger and more structural source of overlap.

Worth recording the wrong turn, because I nearly shipped it. My first suggestion was to declare `backend:contract-check` on the high-traffic non-isolated products, framed as a one-line config change. That is wrong, and `products/architecture.md` says so directly: the key causes selective testing to skip the full Django suite, so adding it to unsealed products would have switched off coverage for 66 products rather than narrowing lanes. Claude caught it on the read-through of the soundness section. The correction is what produced this PR: separate the two questions, and use tach for the one it can actually answer.

Also considered and rejected: building a real AST-level import graph. It would be sparser than tach's declarations, since a declared dependency can linger after its last import. But the edge that matters - "does product X import `posthog`" - is true for 60 of the 74 module blocks, so it buys nothing where the cost is. And tach models `posthog` as a single module, so it has no resolution inside core, which is where the remaining 44 PRs would need it.

Tools: Claude Code (Opus 5), PostHog MCP for the telemetry queries, `gh stack` for the stack. Skills invoked: `/stacking-prs`.
