### PR TITLE
fix(data-warehouse): route materialization run logs to log_entries

### DIFF
--- a/posthog/temporal/data_modeling/activities/create_data_modeling_job.py
+++ b/posthog/temporal/data_modeling/activities/create_data_modeling_job.py
@@ -5,6 +5,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.data_modeling.activities.utils import bind_data_modeling_log_context
 
 from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobEngine, Node
 
@@ -20,8 +21,16 @@ class CreateDataModelingJobInputs:
     parent_workflow_id: str | None = None
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CreatedDataModelingJob:
+    job_id: str
+    saved_query_id: str | None
+
+
 @database_sync_to_async_pool
-def _create_data_modeling_job(inputs: CreateDataModelingJobInputs, workflow_id: str, workflow_run_id: str) -> str:
+def _create_data_modeling_job(
+    inputs: CreateDataModelingJobInputs, workflow_id: str, workflow_run_id: str
+) -> CreatedDataModelingJob:
     node = Node.objects.prefetch_related("saved_query").get(
         id=inputs.node_id, team_id=inputs.team_id, dag_id=inputs.dag_id
     )
@@ -35,7 +44,10 @@ def _create_data_modeling_job(inputs: CreateDataModelingJobInputs, workflow_id: 
         parent_workflow_id=inputs.parent_workflow_id,
         created_by_id=node.saved_query.created_by_id if node.saved_query else None,
     )
-    return str(job.id)
+    return CreatedDataModelingJob(
+        job_id=str(job.id),
+        saved_query_id=str(node.saved_query.id) if node.saved_query else None,
+    )
 
 
 @activity.defn
@@ -51,6 +63,8 @@ async def create_data_modeling_job_activity(inputs: CreateDataModelingJobInputs)
     assert workflow_id
     assert workflow_run_id
 
-    job_id = await _create_data_modeling_job(inputs, workflow_id, workflow_run_id)
-    await logger.ainfo(f"Created DataModelingJob {job_id} for node {inputs.node_id}")
-    return job_id
+    created = await _create_data_modeling_job(inputs, workflow_id, workflow_run_id)
+    if created.saved_query_id is not None:
+        bind_data_modeling_log_context(inputs.team_id, created.saved_query_id)
+    await logger.ainfo(f"Created DataModelingJob {created.job_id} for node {inputs.node_id}")
+    return created.job_id

--- a/posthog/temporal/data_modeling/activities/fail_materialization.py
+++ b/posthog/temporal/data_modeling/activities/fail_materialization.py
@@ -23,6 +23,7 @@ from products.data_warehouse.backend.facade.api import pause_saved_query_schedul
 from ..metrics import get_node_suspended_metric
 from .utils import (
     CONSECUTIVE_FAILURES_TO_SUSPEND,
+    bind_data_modeling_log_context,
     maybe_suspend_node_for_engine,
     strip_hostname_from_error,
     update_node_system_properties,
@@ -148,6 +149,8 @@ async def fail_materialization_activity(inputs: FailMaterializationInputs) -> No
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
     _, job = await _fail_node_and_data_modeling_job(inputs)
+    if job.saved_query_id is not None:
+        bind_data_modeling_log_context(inputs.team_id, job.saved_query_id)
     await logger.aerror(
         f"Failed materialization job: node={inputs.node_id} dag={inputs.dag_id} job={job.id} "
         f"workflow={job.workflow_id} workflow_run={job.workflow_run_id} error={inputs.error}"

--- a/posthog/temporal/data_modeling/activities/fail_materialization.py
+++ b/posthog/temporal/data_modeling/activities/fail_materialization.py
@@ -151,10 +151,14 @@ async def fail_materialization_activity(inputs: FailMaterializationInputs) -> No
     _, job = await _fail_node_and_data_modeling_job(inputs)
     if job.saved_query_id is not None:
         bind_data_modeling_log_context(inputs.team_id, job.saved_query_id)
-    await logger.aerror(
-        f"Failed materialization job: node={inputs.node_id} dag={inputs.dag_id} job={job.id} "
-        f"workflow={job.workflow_id} workflow_run={job.workflow_run_id} error={inputs.error}"
+    job_context = (
+        f"node={inputs.node_id} dag={inputs.dag_id} job={job.id} "
+        f"workflow={job.workflow_id} workflow_run={job.workflow_run_id}"
     )
+    # The bound context above puts this line in front of users, so it carries the same sanitized
+    # error the job row does. The raw one stays write-only, where only internal logging sees it.
+    await logger.aerror(f"Failed materialization job: {job_context} error={strip_hostname_from_error(inputs.error)}")
+    await logger.aerror(f"Failed materialization job: {job_context} error={inputs.error}", write_only=True)
     # error-specific recovery: pause schedule on timeout, revert on unknown table, else suspend after repeated failures
     if not inputs.update_node:
         return
@@ -196,4 +200,6 @@ async def fail_materialization_activity(inputs: FailMaterializationInputs) -> No
                 )
     except Exception as e:
         capture_exception(e)
-        await logger.aexception(f"Failed to run error-specific recovery for node {inputs.node_id}: {str(e)}")
+        await logger.aexception(
+            f"Failed to run error-specific recovery for node {inputs.node_id}: {strip_hostname_from_error(str(e))}"
+        )

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -395,7 +395,9 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
         arrow_prepared_hogql_query, context=context, dialect="clickhouse", stack=[], settings=settings
     )
 
-    await logger.adebug(f"Running clickhouse query: {arrow_printed}")
+    # The query goes in a field rather than the message: only the message is copied into the
+    # log_entries row users can read, and the compiled query is the saved query's own SQL.
+    await logger.adebug("Running clickhouse query", query=arrow_printed)
 
     async with (
         _clickhouse_query_semaphore,

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -29,6 +29,7 @@ from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.clickhouse import get_client as get_clickhouse_client
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger
+from posthog.temporal.data_modeling.activities.utils import bind_data_modeling_log_context
 
 from products.data_modeling.backend.facade.modeling import bounded_resolver_factory_for_view
 from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery, Node, NodeType
@@ -487,6 +488,7 @@ async def materialize_view_activity(inputs: MaterializeViewInputs) -> Materializ
     tag_queries(team_id=inputs.team_id, product=Product.WAREHOUSE, feature=Feature.DATA_MODELING)
 
     objects = await _get_matview_input_objects(inputs)
+    bind_data_modeling_log_context(inputs.team_id, objects.saved_query.id)
     await logger.ainfo(f"Starting materialization for node {objects.node.name}")
 
     table_uri = _build_model_table_uri(objects.team.pk, objects.saved_query.id.hex, objects.saved_query.normalized_name)

--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -28,7 +28,12 @@ from products.managed_warehouse.backend.facade.api import (
 )
 
 from ..metrics import get_node_suspended_metric
-from .utils import CONSECUTIVE_FAILURES_TO_SUSPEND, clear_node_suspension_for_engine, maybe_suspend_node_for_engine
+from .utils import (
+    CONSECUTIVE_FAILURES_TO_SUSPEND,
+    bind_data_modeling_log_context,
+    clear_node_suspension_for_engine,
+    maybe_suspend_node_for_engine,
+)
 
 LOGGER = get_logger(__name__)
 
@@ -163,6 +168,7 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
     logger = LOGGER.bind()
 
     team, node, saved_query = await _get_shadow_input_objects(inputs)
+    bind_data_modeling_log_context(inputs.team_id, saved_query.id)
     hogql_query = typing.cast(dict, saved_query.query)["query"]
     schema_name = duckgres_data_modeling_schema(team.pk)
     table_name = saved_query.normalized_name

--- a/posthog/temporal/data_modeling/activities/prepare_queryable_table.py
+++ b/posthog/temporal/data_modeling/activities/prepare_queryable_table.py
@@ -1,10 +1,10 @@
 import dataclasses
 
 from structlog import get_logger
-from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.data_modeling.activities.utils import bind_data_modeling_log_context
 
 from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
 from products.data_warehouse.backend.facade.api import create_table_from_saved_query
@@ -58,7 +58,7 @@ async def prepare_queryable_table_activity(inputs: PrepareQueryableTableInputs) 
 
     Returns storage metrics (delta and total MiB) for the materialized table.
     """
-    bind_contextvars(team_id=inputs.team_id)
+    bind_data_modeling_log_context(inputs.team_id, inputs.saved_query_id)
     logger = LOGGER.bind()
 
     saved_query = await _get_saved_query_with_table(inputs)

--- a/posthog/temporal/data_modeling/activities/succeed_materialization.py
+++ b/posthog/temporal/data_modeling/activities/succeed_materialization.py
@@ -18,7 +18,7 @@ from products.data_modeling.backend.facade.models import (
     Node,
 )
 
-from .utils import clear_node_suspension, update_node_system_properties
+from .utils import bind_data_modeling_log_context, clear_node_suspension, update_node_system_properties
 
 LOGGER = get_logger(__name__)
 
@@ -153,6 +153,8 @@ async def succeed_materialization_activity(inputs: SucceedMaterializationInputs)
 
     outcome = await _succeed_node_and_data_modeling_job(inputs)
 
+    if outcome.job.saved_query_id is not None:
+        bind_data_modeling_log_context(inputs.team_id, outcome.job.saved_query_id)
     await logger.ainfo(
         f"Succeeded materialization job: node={inputs.node_id} dag={inputs.dag_id} job={outcome.job.id} "
         f"workflow={outcome.job.workflow_id} workflow_run={outcome.job.workflow_run_id}"

--- a/posthog/temporal/data_modeling/activities/utils.py
+++ b/posthog/temporal/data_modeling/activities/utils.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from django.db import transaction
 
+from structlog.contextvars import bind_contextvars
+
 from posthog.sync import database_sync_to_async_pool
 
 from products.data_modeling.backend.facade.api import (
@@ -25,6 +27,7 @@ from products.data_modeling.backend.facade.models import (
 # API and DAG-sync paths that clear it. Re-exported so the activities keep importing from here.
 __all__ = [
     "CONSECUTIVE_FAILURES_TO_SUSPEND",
+    "bind_data_modeling_log_context",
     "clear_node_suspension",
     "clear_node_suspension_for_engine",
     "is_node_suspended",
@@ -36,6 +39,17 @@ __all__ = [
 
 # Consecutive failed jobs (per engine) before a node is suspended from future DAG runs.
 CONSECUTIVE_FAILURES_TO_SUSPEND = 5
+
+
+def bind_data_modeling_log_context(team_id: int, saved_query_id: UUID | str) -> None:
+    """Route this activity's log lines to `log_entries` under the saved query's id.
+
+    The v2 workflow types aren't mapped in `resolve_log_source` (their workflow ids carry a node
+    id, not the saved query id the UI queries by), so without this event-level override every
+    produced line lands with a NULL log_source and the run-history modal shows no logs.
+    """
+    bind_contextvars(team_id=team_id, log_source="data_modeling_run", log_source_id=str(saved_query_id))
+
 
 # Regex patterns for stripping hostnames from ClickHouse error messages
 # Matches patterns like: "(from chi-xxx.svc.cluster.local:9000)" or "(from 10.0.0.1:9000)"

--- a/posthog/temporal/data_modeling/run_workflow.py
+++ b/posthog/temporal/data_modeling/run_workflow.py
@@ -420,7 +420,7 @@ async def handle_error(
     error_str = str(error)
     if job:
         await logger.ainfo("Marking job %s as failed", job.id)
-        await logger.aerror(f"handle_error: error={error_str}. error_message={error_message}")
+        await logger.aerror(f"handle_error: error={error_str}. error_message={error_message}", write_only=True)
         job.status = DataModelingJob.Status.FAILED
         job.rows_materialized = 0
         job.error = strip_hostname_from_error(error_str)
@@ -440,7 +440,7 @@ async def handle_cancelled(
 ):
     error_str = str(error)
     if job:
-        await logger.aerror(f"handle_cancelled: error={error_str}. error_message={error_message}")
+        await logger.aerror(f"handle_cancelled: error={error_str}. error_message={error_message}", write_only=True)
         job.status = DataModelingJob.Status.CANCELLED
         job.rows_materialized = 0
         job.error = strip_hostname_from_error(error_str)
@@ -605,7 +605,7 @@ async def materialize_model(
         raise
     except Exception as e:
         error_message = str(e)
-        await logger.aerror(f"Error materializing model {model_label}: {error_message}")
+        await logger.aerror(f"Error materializing model {model_label}: {strip_hostname_from_error(error_message)}")
         if "Query exceeds memory limits" in error_message:
             error_message = f"Query exceeded memory limit. Try reducing its scope by changing the time range."
             saved_query.latest_error = error_message
@@ -761,7 +761,7 @@ async def mark_job_as_failed(job: DataModelingJob, error_message: str, logger: F
     but the user-facing error has hostnames stripped to avoid exposing infrastructure details.
     """
 
-    await logger.aerror(f"mark_job_as_failed: {error_message}")
+    await logger.aerror(f"mark_job_as_failed: {error_message}", write_only=True)
     await logger.ainfo("Marking job %s as failed", job.id)
     job.status = DataModelingJob.Status.FAILED
     job.rows_materialized = 0

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -810,6 +810,39 @@ def test_log_messages_renderer_event_level_log_source_override():
     assert payload["instance_id"] == "abc-run-id"
 
 
+def test_log_messages_renderer_keeps_structured_fields_out_of_the_produce_message():
+    """Only the message text reaches `log_entries`; other event keys stay in the written log.
+
+    Callers rely on this to keep sensitive values (compiled SQL, credentials) out of the rows
+    users can read, by passing them as fields instead of interpolating them into the message.
+    """
+    from posthog.temporal.common.logger import Logger, LogMessagesRenderer
+
+    renderer = LogMessagesRenderer(event_key="msg")
+    event_dict = {
+        "msg": "Running clickhouse query",
+        "query": "SELECT secret_column FROM some_private_table",
+        "level": "debug",
+        "team_id": 2,
+        "timestamp": "2024-01-01 00:00:00.000000",
+        "workflow_type": "data-modeling-materialize-view",
+        "workflow_id": "materialize-view-abc-def",
+        "workflow_run_id": "abc-run-id",
+        "log_source": "data_modeling_run",
+        "log_source_id": "019df430-79ff-0000-4434-e9fc02f7216b",
+    }
+
+    rendered = renderer(logger=cast(Logger, None), name="debug", event_dict=event_dict)
+
+    assert rendered["produce_message"] is not None
+    assert rendered["write_message"] is not None
+
+    produced = rendered["produce_message"].decode("utf-8")
+    assert json.loads(produced)["message"] == "Running clickhouse query"
+    assert "secret_column" not in produced
+    assert "secret_column" in rendered["write_message"]
+
+
 def test_log_messages_renderer_appends_resource_to_message():
     """`resource_name` / `resource` in the event dict gets appended to the produce message text.
 

--- a/posthog/temporal/tests/data_modeling/conftest.py
+++ b/posthog/temporal/tests/data_modeling/conftest.py
@@ -15,6 +15,9 @@ import pytest_asyncio
 # fixture setup. Importing the chain here — while structlog is still the default config —
 # runs that module-level code safely and caches it, so the signal's lazy import is a no-op.
 import posthog.api.advanced_activity_logs  # noqa: F401, E402 — warm import; see comment above
+from posthog.sync import database_sync_to_async
+
+from products.data_modeling.backend.facade.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Node, NodeType
 
 TEST_ROOT_BUCKET = "test-data-modeling"
 SESSION = aioboto3.Session()
@@ -42,3 +45,47 @@ async def minio_client(bucket_name):
             await client.create_bucket(Bucket=bucket_name)
 
         yield client
+
+
+@pytest_asyncio.fixture
+async def asaved_query(ateam, auser):
+    query = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
+        team=ateam,
+        name="test_model",
+        query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        created_by=auser,
+    )
+    yield query
+    await database_sync_to_async(query.delete)()
+
+
+@pytest_asyncio.fixture
+async def adag(ateam):
+    dag = await database_sync_to_async(DAG.objects.create)(team=ateam, name="test-dag")
+    yield dag
+    await database_sync_to_async(dag.delete)()
+
+
+@pytest_asyncio.fixture
+async def anode(ateam, asaved_query, adag):
+    node = await database_sync_to_async(Node.objects.create)(
+        team=ateam,
+        saved_query=asaved_query,
+        dag=adag,
+        name="test_model",
+        type=NodeType.MAT_VIEW,
+    )
+    yield node
+    await database_sync_to_async(node.delete)()
+
+
+@pytest_asyncio.fixture
+async def ajob(ateam, asaved_query):
+    job = await database_sync_to_async(DataModelingJob.objects.create)(
+        team=ateam,
+        saved_query=asaved_query,
+        status=DataModelingJob.Status.RUNNING,
+        workflow_id="test-workflow",
+    )
+    yield job
+    await database_sync_to_async(job.delete)()

--- a/posthog/temporal/tests/data_modeling/test_log_routing.py
+++ b/posthog/temporal/tests/data_modeling/test_log_routing.py
@@ -1,0 +1,155 @@
+import json
+import uuid
+import asyncio
+import dataclasses
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from django.test import override_settings
+
+import pytest_asyncio
+import temporalio.testing
+
+from posthog.temporal.common.logger import BACKGROUND_LOGGER_TASKS, configure_logger
+from posthog.temporal.data_modeling.activities import (
+    CreateDataModelingJobInputs,
+    FailMaterializationInputs,
+    SucceedMaterializationInputs,
+    create_data_modeling_job_activity,
+    fail_materialization_activity,
+    succeed_materialization_activity,
+)
+
+if TYPE_CHECKING:
+    from posthog.kafka_client.client import _AsyncKafkaProducer
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+class QueueCapture(asyncio.Queue[bytes]):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.entries: list[bytes] = []
+
+    def put_nowait(self, item: bytes) -> None:
+        self.entries.append(item)
+        super().put_nowait(item)
+
+
+class NoopKafkaProducer:
+    """Consumes produced log messages without a Kafka broker; capture happens at the queue."""
+
+    async def produce(self, *, topic, data, key=None, value_serializer=None) -> None:
+        return None
+
+    async def flush(self, timeout=None) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+@dataclasses.dataclass
+class ActivityInfo:
+    activity_id: str
+    activity_type: str
+    attempt: int
+    task_queue: str
+    workflow_id: str
+    workflow_namespace: str
+    workflow_run_id: str
+    workflow_type: str
+
+
+@pytest_asyncio.fixture
+async def queue():
+    return QueueCapture(maxsize=0)
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def configure_produce_capture(queue):
+    loop = asyncio.get_running_loop()
+    with override_settings(TEST=False, DEBUG=False):
+        configure_logger(
+            queue=queue,
+            producer=cast("_AsyncKafkaProducer", NoopKafkaProducer()),
+            cache_logger_on_first_use=False,
+            loop=loop,
+            raise_on_producer_error=True,
+        )
+
+    yield
+
+    for task in BACKGROUND_LOGGER_TASKS.values():
+        task.cancel()
+    if BACKGROUND_LOGGER_TASKS:
+        await asyncio.wait(BACKGROUND_LOGGER_TASKS.values())
+
+
+@pytest.fixture
+def v2_activity_environment():
+    env = temporalio.testing.ActivityEnvironment()
+    env.info = ActivityInfo(  # type: ignore[assignment]
+        activity_id=str(uuid.uuid4()),
+        activity_type="test-activity",
+        attempt=1,
+        task_queue="data-modeling-task-queue",
+        workflow_id=f"materialize-view-{uuid.uuid4()}-{uuid.uuid4()}",
+        workflow_namespace="test",
+        workflow_type="data-modeling-materialize-view",
+        workflow_run_id=str(uuid.uuid4()),
+    )
+    return env
+
+
+async def _wait_for_queue_entries(queue: QueueCapture) -> None:
+    for _ in range(100):
+        if queue.entries:
+            return
+        await asyncio.sleep(0)
+    raise TimeoutError("Timed out waiting for produced log messages")
+
+
+@pytest.mark.parametrize("activity_case", ["create_job", "succeed", "fail"])
+async def test_v2_activity_log_lines_are_routed_to_the_saved_query(
+    activity_case, v2_activity_environment, queue, ateam, adag, anode, asaved_query, ajob
+):
+    if activity_case == "create_job":
+        await v2_activity_environment.run(
+            create_data_modeling_job_activity,
+            CreateDataModelingJobInputs(team_id=ateam.pk, node_id=str(anode.id), dag_id=str(adag.id)),
+        )
+    elif activity_case == "succeed":
+        await v2_activity_environment.run(
+            succeed_materialization_activity,
+            SucceedMaterializationInputs(
+                team_id=ateam.pk,
+                node_id=str(anode.id),
+                dag_id=str(adag.id),
+                job_id=str(ajob.id),
+                row_count=1,
+                duration_seconds=1.0,
+            ),
+        )
+    else:
+        await v2_activity_environment.run(
+            fail_materialization_activity,
+            FailMaterializationInputs(
+                team_id=ateam.pk,
+                node_id=str(anode.id),
+                dag_id=str(adag.id),
+                job_id=str(ajob.id),
+                error="Something broke",
+                update_node=False,
+            ),
+        )
+    await _wait_for_queue_entries(queue)
+
+    messages = [json.loads(entry.decode("utf-8")) for entry in queue.entries]
+    routed_messages = [m for m in messages if m["log_source"] == "data_modeling_run"]
+    assert len(routed_messages) >= 1
+    for message in routed_messages:
+        assert message["log_source_id"] == str(asaved_query.id)
+        assert message["instance_id"] == v2_activity_environment.info.workflow_run_id
+        assert message["team_id"] == ateam.pk

--- a/posthog/temporal/tests/data_modeling/test_log_routing.py
+++ b/posthog/temporal/tests/data_modeling/test_log_routing.py
@@ -153,3 +153,28 @@ async def test_v2_activity_log_lines_are_routed_to_the_saved_query(
         assert message["log_source_id"] == str(asaved_query.id)
         assert message["instance_id"] == v2_activity_environment.info.workflow_run_id
         assert message["team_id"] == ateam.pk
+
+
+async def test_failure_logs_do_not_expose_clickhouse_hostnames(
+    v2_activity_environment, queue, ateam, adag, anode, asaved_query, ajob
+):
+    await v2_activity_environment.run(
+        fail_materialization_activity,
+        FailMaterializationInputs(
+            team_id=ateam.pk,
+            node_id=str(anode.id),
+            dag_id=str(adag.id),
+            job_id=str(ajob.id),
+            error="Code 241. Memory limit exceeded (from chi-posthog-data-0-0.svc.cluster.local:9000)",
+            update_node=False,
+        ),
+    )
+    await _wait_for_queue_entries(queue)
+
+    routed_messages = [
+        json.loads(entry.decode("utf-8")) for entry in queue.entries if json.loads(entry.decode("utf-8"))["log_source"]
+    ]
+    assert len(routed_messages) >= 1
+    for message in routed_messages:
+        assert "svc.cluster.local" not in message["message"]
+    assert any("Memory limit exceeded" in message["message"] for message in routed_messages)

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -12,7 +12,6 @@ from django.test import override_settings
 
 import pyarrow as pa
 import deltalake
-import pytest_asyncio
 import pyarrow.parquet as pq
 
 from posthog.hogql.resolver import ResolverFactory
@@ -41,7 +40,6 @@ from posthog.temporal.data_modeling.activities.materialize_view import (
 from products.data_modeling.backend.facade.api import compute_enrichment_hash
 from products.data_modeling.backend.facade.modeling import bounded_resolver_factory_for_view
 from products.data_modeling.backend.facade.models import (
-    DAG,
     DataModelingJob,
     DataModelingJobEngine,
     DataModelingJobStatus,
@@ -53,50 +51,6 @@ from products.data_warehouse.backend.facade.api import CreateTableResult
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
-
-
-@pytest_asyncio.fixture
-async def asaved_query(ateam, auser):
-    query = await database_sync_to_async(DataWarehouseSavedQuery.objects.create)(
-        team=ateam,
-        name="test_model",
-        query={"query": "SELECT 1", "kind": "HogQLQuery"},
-        created_by=auser,
-    )
-    yield query
-    await database_sync_to_async(query.delete)()
-
-
-@pytest_asyncio.fixture
-async def adag(ateam):
-    dag = await database_sync_to_async(DAG.objects.create)(team=ateam, name="test-dag")
-    yield dag
-    await database_sync_to_async(dag.delete)()
-
-
-@pytest_asyncio.fixture
-async def anode(ateam, asaved_query, adag):
-    node = await database_sync_to_async(Node.objects.create)(
-        team=ateam,
-        saved_query=asaved_query,
-        dag=adag,
-        name="test_model",
-        type=NodeType.MAT_VIEW,
-    )
-    yield node
-    await database_sync_to_async(node.delete)()
-
-
-@pytest_asyncio.fixture
-async def ajob(ateam, asaved_query):
-    job = await database_sync_to_async(DataModelingJob.objects.create)(
-        team=ateam,
-        saved_query=asaved_query,
-        status=DataModelingJob.Status.RUNNING,
-        workflow_id="test-workflow",
-    )
-    yield job
-    await database_sync_to_async(job.delete)()
 
 
 async def _make_job(ateam, saved_query, status, *, engine=DataModelingJobEngine.CLICKHOUSE, error=None):

--- a/products/data_modeling/backend/logic/node_materialization.py
+++ b/products/data_modeling/backend/logic/node_materialization.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import asdict
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 from django.conf import settings
@@ -41,7 +41,10 @@ def start_node_materialization(node: Node, *, is_v2: bool) -> None:
             select=[Selector(label=str(node.saved_query_id), ancestors=0, descendants=0)],
         )
         workflow_name = "data-modeling-run"
-        workflow_id = f"data-modeling-run-{node.id}-{uuid4()}"
+        # Mirror the scheduled-run id shape ({saved_query_id}-{iso timestamp}) so
+        # resolve_log_source can recover the saved query id and the run's logs show up
+        # in the materialization history UI.
+        workflow_id = f"{node.saved_query_id}-{datetime.now(UTC).isoformat()}"
 
     temporal = sync_connect()
     asyncio.run(

--- a/products/data_modeling/backend/tests/api/test_node_api.py
+++ b/products/data_modeling/backend/tests/api/test_node_api.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import Team
+from posthog.temporal.common.logger import resolve_log_source
 
 from products.data_modeling.backend.logic.node_frequency import set_declared_target
 from products.data_modeling.backend.logic.node_suspension import mark_node_suspended, suspension_state
@@ -237,6 +238,14 @@ class TestNodeViewSet(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         mock_client.start_workflow.assert_called_once()
+
+        # The workflow id must resolve back to the saved query id, or the run's log lines
+        # detach from the materialization history UI (which queries by saved query id).
+        workflow_id = mock_client.start_workflow.call_args.kwargs["id"]
+        self.assertEqual(
+            resolve_log_source("data-modeling-run", workflow_id),
+            ("data_modeling_run", str(self.saved_query.id)),
+        )
 
     def _suspend(self, node: Node) -> None:
         mark_node_suspended(node, engine="clickhouse", reason="boom", job_id=str(uuid4()), fingerprint=None)


### PR DESCRIPTION
## Problem

The materialization run history UI (the runs modal on endpoints, the SQL editor Info tab, and the `/models` node detail page) shows an expandable log section per run, but for most runs it is empty:

- Every **v2** materialization run writes its log lines with a NULL `log_source`. The v2 workflow types (`data-modeling-materialize-view`, `data-modeling-execute-dag`) were never mapped in `resolve_log_source`, and their workflow ids carry a node id, not the saved query id the UI queries `log_entries` by, so the mapping can't be derived from the id at all. The logs are produced, they just land under a key nobody can query.
- **v1 ad-hoc** runs ("Sync now" on a single node) use workflow id `data-modeling-run-{node.id}-{uuid4}`, which breaks the `rsplit("-", 3)` heuristic in `resolve_log_source`, filing their logs under a garbage id. Only v1 scheduled runs show logs today.

## Changes

- New `bind_data_modeling_log_context(team_id, saved_query_id)` helper in the v2 activities' `utils.py` binds `log_source="data_modeling_run"` / `log_source_id=<saved_query_id>` into the structlog contextvars. The renderer already supports event-level overrides (same mechanism the CDC pipeline uses), so every subsequent produced line lands where the UI queries it.
- Called it in each v2 activity as soon as the saved query id is known: `materialize_view`, `materialize_view_duckgres`, `prepare_queryable_table`, `create_data_modeling_job`, `succeed_materialization`, `fail_materialization`.
- Changed the v1 ad-hoc workflow id in `start_node_materialization` to the scheduled-run shape `{saved_query_id}-{iso timestamp}`, which the existing `data-modeling-run` branch of `resolve_log_source` parses correctly. No consumer parses the old ad-hoc shape (verified: the v2 filters use `workflow_id__startswith="materialize"`, and the legacy cancel path reconstructs a different shape).

No new log lines were added. A successful v2 run already emits ~7 INFO lines and a failed one emits the ERROR line, they were just unqueryable.

## How did you test this code?

- New `test_log_routing.py`: parameterized produce-path test running the create/succeed/fail activities in an `ActivityEnvironment` with a v2-shaped workflow context, asserting the produced Kafka messages carry `log_source="data_modeling_run"`, the saved query id, and the workflow run id as `instance_id`. Catches any activity dropping the context binding, which silently empties the log section again.
- Extended `test_materialize_starts_workflow` to assert the v1 ad-hoc workflow id resolves back to the saved query id through `resolve_log_source`. Catches the id shape and the parser drifting apart, which is exactly the bug being fixed.
- Moved the shared `asaved_query`/`adag`/`anode`/`ajob` fixtures to the data-modeling tests' `conftest.py` so both test modules use them.
- Ran the full `test_materialize_view_activities.py` and `test_node_api.py` suites locally (all green).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed, no user-facing workflow change; the existing log UI starts working.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-tests, /writing-code-comments, /stacking-prs. The alternative of adding v2 branches to `resolve_log_source` was investigated and rejected: `Node.id` is not the saved query id (nullable FK with its own PK), and `resolve_log_source` is a pure string function, so id parsing could only ever yield an id the UI never queries. Context binding in the activities is the only mechanism that can attach the right id, and has precedent in the CDC extraction activities.
