### PR TITLE
fix(postgres): stop retrying an SSH tunnel host that fails safety checks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -555,12 +555,12 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # `_pinned_ssh_host` (common/mixins.py) re-checks the SSH tunnel host on every connect,
             # since a host that resolved to a public address at setup can drift (DNS change, or a
             # short-TTL record). It rejects the host if it doesn't resolve or resolves to a
-            # private/internal address — a config problem only the customer can fix, so retrying
-            # just re-hits the same rejection. Match the stable prefix and exclude the volatile
-            # host/IP details that follow it in `resolution.error`.
+            # private/internal address, which is a config problem only the customer can fix, so
+            # retrying just re-hits the same rejection. Match the stable prefix and exclude the
+            # volatile host/IP details that follow it in `resolution.error`.
             "SSH tunnel host not allowed": (
-                "PostHog rejected the SSH tunnel host for this source — it either couldn't be "
-                "resolved, or resolves to a private/internal address. Check that the SSH tunnel "
+                "PostHog rejected the SSH tunnel host for this source because it either couldn't "
+                "be resolved, or resolves to a private/internal address. Check that the SSH tunnel "
                 "host is spelled correctly and reachable from the public internet, then re-enable "
                 "the sync."
             ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -552,6 +552,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "SSH server (not the database port), that the bastion is running and reachable, and "
                 "that PostHog's IP addresses are allowed through its firewall, then re-enable the sync."
             ),
+            # `_pinned_ssh_host` (common/mixins.py) re-checks the SSH tunnel host on every connect,
+            # since a host that resolved to a public address at setup can drift (DNS change, or a
+            # short-TTL record). It rejects the host if it doesn't resolve or resolves to a
+            # private/internal address — a config problem only the customer can fix, so retrying
+            # just re-hits the same rejection. Match the stable prefix and exclude the volatile
+            # host/IP details that follow it in `resolution.error`.
+            "SSH tunnel host not allowed": (
+                "PostHog rejected the SSH tunnel host for this source — it either couldn't be "
+                "resolved, or resolves to a private/internal address. Check that the SSH tunnel "
+                "host is spelled correctly and reachable from the public internet, then re-enable "
+                "the sync."
+            ),
             # Raised by `SSHTunnel.get_tunnel` when `is_auth_valid()` fails — the SSH tunnel private
             # key can't be parsed, or password auth is missing a username/password. The auth config
             # is fixed, so retrying just replays the same invalid credentials. The streaming path

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -462,6 +462,27 @@ class TestPostgresSourceNonRetryableErrors:
         assert friendly, "Invalid SSH tunnel auth error should surface an actionable message"
         assert "SSH authentication details" in friendly[0]
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # DNS resolution failure for the configured SSH tunnel host (`_pinned_ssh_host` in
+            # common/mixins.py).
+            "SSH tunnel host not allowed: Couldn't resolve the host 'bastion.example.com'. Check "
+            "that it's spelled correctly and reachable from the public internet.",
+            # Temporal-wrapped form carrying the exception class name.
+            "Exception: SSH tunnel host not allowed: Couldn't resolve the host 'bastion.example.com'. "
+            "Check that it's spelled correctly and reachable from the public internet.",
+            # The other rejection `_pinned_ssh_host` can raise: the host resolves to a private/internal address.
+            "SSH tunnel host not allowed: This host points to an internal or private IP address, "
+            "which PostHog can't reach. Use a host that's reachable from the public internet.",
+        ],
+    )
+    def test_ssh_tunnel_host_not_allowed_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        assert "SSH tunnel host not allowed" in non_retryable
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"SSH tunnel host rejection should be non-retryable: {error_msg}"
+
     def test_tls_no_application_protocol_returns_friendly_message(self, source):
         non_retryable = source.get_non_retryable_errors()
         error_msg = (


### PR DESCRIPTION
## Problem

PostHog's Postgres source revalidates a configured SSH tunnel host on every connect attempt, rejecting it if it can't be resolved via DNS or resolves to a private/internal address (raising `SSH tunnel host not allowed: ...`). This showed up in error tracking as a recurring exception on a source whose SSH tunnel host had stopped resolving.

That condition only clears once the customer fixes their SSH tunnel host config, so retrying never helps – but the message wasn't in this source's non-retryable error list, so schema discovery kept retrying and re-reporting it as error-tracking noise on every scheduled run instead of stopping.

## Changes

Added the stable `"SSH tunnel host not allowed"` prefix to `PostgresSource.get_non_retryable_errors()`, following the same pattern already used for this source's other SSH tunnel failures (gateway session errors, handshake EOF, invalid auth). This covers both underlying causes (unresolvable host, private/internal address) since both are raised with the same prefix.

## How did you test this code?

Added 3 parameterized cases to `TestPostgresSourceNonRetryableErrors` (`test_ssh_tunnel_host_not_allowed_is_non_retryable`) covering the raw message, the Temporal-wrapped form, and the private-IP variant of the same rejection. This guards the exact regression that prompted this fix: without the new entry, this error would keep retrying instead of stopping after a few attempts. Ran the full `TestPostgresSourceNonRetryableErrors` class locally (124 tests passed).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a live error-tracking issue for the Postgres warehouse source.
- Confirmed the failure's stack trace originates in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py` (`get_schemas`) calling into the shared SSH tunnel helper (`common/mixins.py`'s `_pinned_ssh_host`), which raises this exact message.
- Classified as a user/upstream config error (not a code bug): the host either doesn't resolve or resolves to a disallowed private address, and nothing on PostHog's side can fix that.
- Searched open PRs (by message, module path, and the maintainer's own open PRs) for a duplicate fix; found none.
- Skill invoked: `/writing-tests` before adding the new test cases.