### PR TITLE
fix(managed-warehouse): gate ducklake registration on a provisioned duckgres server

### DIFF
--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -132,7 +132,7 @@ async def ducklake_register_data_imports_gate_activity(inputs: DuckLakeRegisterD
         return False
 
     try:
-        return feature_enabled_or_false(
+        flag_enabled = feature_enabled_or_false(
             DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG,
             str(team.uuid),
             groups={
@@ -150,6 +150,26 @@ async def ducklake_register_data_imports_gate_activity(inputs: DuckLakeRegisterD
         await logger.awarning("Failed to evaluate DuckLake data imports registration feature flag", error=str(error))
         capture_exception(error)
         return False
+
+    if not flag_enabled:
+        return False
+
+    # The flag alone is not sufficient: registration resolves the team's schema through
+    # the duckgres control plane, which only knows orgs with a provisioned server, so a
+    # flag-enabled team in an unprovisioned org would fail the prepare activity with a
+    # spurious "control plane unreachable" error. Dev mode has no DuckgresServer rows
+    # (connections come from env vars), so the check applies only to real deployments.
+    if is_dev_mode():
+        return True
+
+    server = await database_sync_to_async(get_duckgres_server_by_team_org)(inputs.team_id)
+    if server is None:
+        await logger.ainfo(
+            "No DuckgresServer provisioned for team's organization; skipping DuckLake data imports registration"
+        )
+        return False
+
+    return True
 
 
 @activity.defn
@@ -525,7 +545,7 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
         if not should_register:
-            logger.info("DuckLake data imports registration workflow disabled by feature flag")
+            logger.info("DuckLake data imports registration gated off (flag disabled or no DuckgresServer)")
             return
 
         schema_id = str(inputs.schema_id)

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
@@ -73,6 +73,23 @@ async def test_registration_gate_uses_independent_feature_flag(monkeypatch, atea
 
 @pytest.mark.asyncio
 @pytest.mark.django_db
+@pytest.mark.parametrize("server_provisioned", [True, False])
+async def test_registration_gate_requires_provisioned_duckgres_server(monkeypatch, ateam, server_provisioned):
+    monkeypatch.setattr(registration_module, "feature_enabled_or_false", lambda *args, **kwargs: True)
+    monkeypatch.setattr(registration_module, "is_dev_mode", lambda: False)
+    monkeypatch.setattr(
+        registration_module,
+        "get_duckgres_server_by_team_org",
+        lambda team_id: MagicMock() if server_provisioned else None,
+    )
+
+    result = await ducklake_register_data_imports_gate_activity(DuckLakeRegisterDataImportsGateInputs(team_id=ateam.id))
+
+    assert result is server_provisioned
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
 async def test_prepare_registration_pins_the_import_jobs_prepared_generation(ateam):
     credential = await database_sync_to_async(DataWarehouseCredential.objects.create)(
         team=ateam,


### PR DESCRIPTION
## Problem

The `ducklake-register.data-imports` workflow's gate activity only checks the `ducklake-data-imports-registration-workflow` feature flag. When the flag is enabled for a team whose org has no provisioned `DuckgresServer`, the workflow passes the gate and then fails in the prepare activity: resolving the team's data-imports schema goes through the duckgres control plane, which returns a non-success status for orgs it has never provisioned. That response is indistinguishable from an unreachable control plane in `_teams_from_response`, so the activity raises `CPUnavailableError` ("duckgres control plane unreachable reading team state for team ...") and retries pointlessly, failing the workflow.

We hit exactly this in production after enabling the flag for orgs that had no duckgres server yet.

## Changes

- `ducklake_register_data_imports_gate_activity` now also requires `get_duckgres_server_by_team_org(team_id)` to return a server, mirroring the check `_connect_to_duckgres_for_team` already does at the end of the workflow (where it's too late). Skipped in dev mode, where there are no `DuckgresServer` rows and connections come from env vars.
- Updated the workflow's gated-off log line to reflect both reasons.

> [!NOTE]
> Activity implementation change only, so no new workflow commands and no `workflow.patched()` gate needed. In-flight histories replay unchanged.

Not addressed here (possible follow-up): `_teams_from_response` conflates "org unknown to the control plane" with "control plane unreachable". Distinguishing a 404-shaped response from a 5xx/timeout would de-noise every `team_state` consumer.

## How did you test this code?

Added `test_registration_gate_requires_provisioned_duckgres_server` (parameterized over server present/absent): it catches a regression where the gate stops requiring a provisioned server outside dev mode, which no existing test covered - the existing gate test only exercises the flag. Ran the new test plus the pre-existing `test_registration_gate_uses_independent_feature_flag`; all 4 cases pass locally. `ruff check` and `ruff format --check` clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Internal workflow behavior, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) in a session driven by Eric, after tracing a production workflow failure to the missing gate. Skills invoked: /writing-tests, /writing-code-comments. Considered adding the check at the trigger sites (v3 load consumer, v2 child-workflow start) instead, but the gate activity is the single choke point both paths already go through, and the check there is deterministic-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)