### PR TITLE
fix(warehouse): keep registration heartbeat through metrics

### DIFF
--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -343,23 +343,23 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
             logger.info("Skipping stale prepared Parquet generation before catalog swap")
             return False
 
-    get_ducklake_register_data_imports_files_metric(team_id=inputs.team_id, schema_id=schema_id).record(
-        float(len(landing_paths))
-    )
-    get_ducklake_register_data_imports_rows_metric(team_id=inputs.team_id, schema_id=schema_id).record(
-        float(registered_rows)
-    )
-    get_ducklake_register_data_imports_bytes_metric(team_id=inputs.team_id, schema_id=schema_id).record(
-        float(copied_bytes)
-    )
+        get_ducklake_register_data_imports_files_metric(team_id=inputs.team_id, schema_id=schema_id).record(
+            float(len(landing_paths))
+        )
+        get_ducklake_register_data_imports_rows_metric(team_id=inputs.team_id, schema_id=schema_id).record(
+            float(registered_rows)
+        )
+        get_ducklake_register_data_imports_bytes_metric(team_id=inputs.team_id, schema_id=schema_id).record(
+            float(copied_bytes)
+        )
 
-    logger.info(
-        "Copied, verified, and registered prepared Parquet files in DuckLake",
-        ducklake_table=f"{inputs.metadata.ducklake_schema_name}.{inputs.metadata.ducklake_table_name}",
-        file_count=len(landing_paths),
-        landing_uri=inputs.metadata.landing_uri,
-    )
-    return True
+        logger.info(
+            "Copied, verified, and registered prepared Parquet files in DuckLake",
+            ducklake_table=f"{inputs.metadata.ducklake_schema_name}.{inputs.metadata.ducklake_table_name}",
+            file_count=len(landing_paths),
+            landing_uri=inputs.metadata.landing_uri,
+        )
+        return True
 
 
 def _is_valid_queryable_folder(queryable_folder: str) -> bool:

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
@@ -180,11 +180,19 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     connect = MagicMock(return_value=conn)
     monkeypatch.setattr(registration_module.psycopg, "connect", connect)
     monkeypatch.setattr(registration_module, "setup_duckgres_session", MagicMock())
+    heartbeat_state = {"active": False}
     heartbeater = MagicMock()
-    heartbeater.__enter__ = MagicMock(return_value=heartbeater)
-    heartbeater.__exit__ = MagicMock(return_value=False)
+    heartbeater.__enter__ = MagicMock(side_effect=lambda: heartbeat_state.update(active=True))
+    heartbeater.__exit__ = MagicMock(side_effect=lambda *args: heartbeat_state.update(active=False))
     monkeypatch.setattr(registration_module, "HeartbeaterSync", MagicMock(return_value=heartbeater))
     workload_metrics = _mock_activity_workload_metrics(monkeypatch)
+
+    def assert_heartbeat_active(_value: float) -> None:
+        assert heartbeat_state["active"] is True
+
+    workload_metrics.files.record.side_effect = assert_heartbeat_active
+    workload_metrics.rows.record.side_effect = assert_heartbeat_active
+    workload_metrics.bytes.record.side_effect = assert_heartbeat_active
 
     inputs = _activity_inputs()
     applied = copy_and_register_ducklake_data_imports_activity(inputs)


### PR DESCRIPTION
## Problem

A DuckLake data import registration can finish its durable catalog work and then stop heartbeating before it records terminal workload metrics and writes the success log. If that terminal work is delayed, Temporal can classify the successful activity as a heartbeat timeout and retry the full copy and registration.

## Changes

The heartbeat now remains active through terminal metric recording and the success log. The activity stops heartbeating only as it returns its result to Temporal.

```mermaid
flowchart LR
    A["Copy and register"] --> B["Stop heartbeat"] --> C["Record metrics"] --> D["Return result"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B,C phGray;
    class D phYellow;
```

```mermaid
flowchart LR
    A["Copy and register"] --> B["Record metrics"] --> C["Stop heartbeat"] --> D["Return result"]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phBlue;
    class B,C phGray;
    class D phYellow;
```

## How did you test this code?

- `hogli ci:preflight --fix` passed lint, formatting, and preflight checks.
- The registration workflow test file ran all 17 tests successfully. The command then exited nonzero during package teardown because the local ClickHouse replica was read-only.
- Extended the existing copy activity test to assert terminal file, row, and byte metrics are recorded while the heartbeat context is active. This catches the regression where terminal telemetry runs after heartbeats stop.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. This changes an internal Temporal activity lifecycle without changing its interface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop authored the change in an isolated worktree. I used the `/writing-tests` skill to keep the regression coverage focused and the `github:yeet` skill for the publish workflow. The patch deliberately keeps the scope to heartbeat lifetime; copy parallelism and activity splitting remain separate follow-up work.
