### PR TITLE
fix(cymbal): persist exception chain ids from SDK mechanisms

### DIFF
--- a/rust/cymbal/src/core/types/mod.rs
+++ b/rust/cymbal/src/core/types/mod.rs
@@ -24,4 +24,12 @@ pub struct Mechanism {
     pub source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub synthetic: Option<bool>,
+    /// Position of this exception in the `$exception_list` chain the SDK emitted,
+    /// `0` being the outermost error. Only set for multi-exception chains.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exception_id: Option<u32>,
+    /// `exception_id` of the exception this one is the cause of. Ids stay attached
+    /// to their exception, so wire-order normalization does not invalidate them.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_id: Option<u32>,
 }

--- a/rust/cymbal/tests/event.rs
+++ b/rust/cymbal/tests/event.rs
@@ -505,6 +505,8 @@ async fn extracts_metadata_from_exceptions(db: PgPool) {
         mechanism_type: None,
         source: None,
         synthetic: None,
+        exception_id: None,
+        parent_id: None,
     });
     let input = make_event_with_options(vec![exception], None, Some(true));
 
@@ -529,6 +531,48 @@ async fn extracts_metadata_from_exceptions(db: PgPool) {
         .functions()
         .iter()
         .any(|function| function == "onClick"));
+}
+
+#[sqlx::test(migrations = "./tests/test_migrations")]
+async fn preserves_exception_chain_ids(db: PgPool) {
+    let harness = TestHarness::new(db);
+    // (type, message, mechanism type, exception_id, parent_id)
+    let chain: [(&str, &str, &str, u32, Option<u32>); 3] = [
+        ("RuntimeException", "outermost", "generic", 0, None),
+        ("IllegalStateException", "the cause", "chained", 1, Some(0)),
+        ("IOException", "also thrown", "suppressed", 2, Some(0)),
+    ];
+    let exceptions = chain
+        .iter()
+        .map(|(kind, message, mechanism_type, exception_id, parent_id)| {
+            let mut exception = make_exception(kind, message);
+            exception.mechanism = Some(Mechanism {
+                handled: Some(false),
+                mechanism_type: Some(mechanism_type.to_string()),
+                source: None,
+                synthetic: None,
+                exception_id: Some(*exception_id),
+                parent_id: *parent_id,
+            });
+            exception
+        })
+        .collect();
+
+    let (status, body): (_, SuccessResponse) = harness.post_event(&make_event(exceptions)).await;
+
+    assert!(status.is_success());
+    let stored = &body.first_event().as_ref().unwrap().properties["$exception_list"];
+    for (index, (_, _, mechanism_type, exception_id, parent_id)) in chain.iter().enumerate() {
+        let mechanism = &stored[index]["mechanism"];
+        assert_eq!(mechanism["type"], json!(mechanism_type));
+        assert_eq!(mechanism["handled"], json!(false));
+        assert_eq!(mechanism["exception_id"], json!(exception_id));
+        // An unset parent_id must stay absent rather than serialize as null.
+        assert_eq!(
+            mechanism.get("parent_id"),
+            parent_id.map(Into::into).as_ref()
+        );
+    }
 }
 
 // Frame resolution tests

--- a/rust/cymbal/tests/types.rs
+++ b/rust/cymbal/tests/types.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use common_types::ClickHouseEvent;
 use cymbal::{
     frames::{Frame, RawFrame},
-    types::{RawExceptionProperties, Stacktrace},
+    types::{Mechanism, RawExceptionProperties, Stacktrace},
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 
 #[test]
 fn serde_passthrough() {
@@ -143,4 +143,27 @@ fn php_exceptions() {
     assert_eq!(context.after[1].line, "    return [$e, $throwLine];");
     assert_eq!(frames[1].mangled_name, "<unknown>");
     assert_eq!(frames[1].resolved_name, None);
+}
+
+#[test]
+fn mechanism_chain_ids_round_trip() {
+    let chained = json!({
+        "handled": false,
+        "type": "chained",
+        "exception_id": 1,
+        "parent_id": 0,
+    });
+    let parsed: Mechanism = serde_json::from_value(chained.clone()).unwrap();
+    assert_eq!(parsed.exception_id, Some(1));
+    assert_eq!(parsed.parent_id, Some(0));
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), chained);
+}
+
+#[test]
+fn mechanism_without_chain_ids_stays_absent() {
+    let unchained = json!({ "handled": true, "type": "generic" });
+    let parsed: Mechanism = serde_json::from_value(unchained.clone()).unwrap();
+    assert_eq!(parsed.exception_id, None);
+    assert_eq!(parsed.parent_id, None);
+    assert_eq!(serde_json::to_value(&parsed).unwrap(), unchained);
 }


### PR DESCRIPTION
## Problem

SDKs already emit exception chain relationships inside each `$exception_list[].mechanism`: `exception_id` (0-based position in the chain) and `parent_id` (the id of the exception this one is the cause of), alongside mechanism `type` values like `chained` and `suppressed`.

Cymbal's `Mechanism` struct is closed over four fields (`handled`, `type`, `source`, `synthetic`), so serde silently drops the two id fields on deserialization.
Processed events are re-serialized from that same struct, which means the chain relationships never make it into stored events.
Nothing warns, the data just disappears.

This affects posthog-rs today, which has emitted these ids since v0.15, and it blocks [PostHog/posthog-android#669](https://github.com/PostHog/posthog-android/pull/669), which adds the same metadata for Java and Android throwable chains (including suppressed exceptions).

## Changes

Additive only.
`Mechanism` gains `exception_id: Option<u32>` and `parent_id: Option<u32>`, both `skip_serializing_if = "Option::is_none"` to match the struct's existing style.

The same `Mechanism` type is used for both input parsing (`RawExceptionProperties`) and output serialization (`ProcessedExceptionPropertiesWire`), since the processing model re-exports it from `crate::core::types`.
So preserving the fields on the struct is enough, no extra wiring needed.

Two notes for reviewers:

- Ids travel with their exception, they are not indices into the stored array.
  Wire-order normalization reverses `$exception_list` for some SDKs, and that does not invalidate anything: `parent_id` still resolves by matching a sibling's `exception_id`.
- This is unrelated to the top-level `Exception.id` that the parser assigns as a fresh UUID. That field is untouched.

## How did you test this code?

Automated tests only, all run locally by me (Claude). No manual end-to-end run against a live stack.

Added three tests:

- `mechanism_chain_ids_round_trip` (`rust/cymbal/tests/types.rs`) - a mechanism with `type: "chained"` plus both ids parses and re-serializes identically.
  Catches the exact regression this PR fixes: a closed struct dropping wire fields.
- `mechanism_without_chain_ids_stays_absent` (same file) - absent ids stay absent on output rather than becoming `null`.
  Catches a wrong or missing `skip_serializing_if`, which would spam nulls into every single-exception event.
- `preserves_exception_chain_ids` (`rust/cymbal/tests/event.rs`) - a 3-item chain (generic, chained, suppressed with ids) posted through `/process`, asserting the stored `$exception_list` mechanisms verbatim.
  Catches loss anywhere in the pipeline between parse and store, which a pure serde test would miss.

Gates, from `rust/`:

```
cargo fmt -p cymbal --check                           ok
cargo clippy -p cymbal --all-targets -- -D warnings   ok
cargo test -p cymbal                                  ok, 0 failed
```

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed. No user-visible surface changes, this only stops dropping data that SDKs already send.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude, directed by me.
`/autoreview` (Codex, read-only) ran against the branch and came back clean.

I grepped for downstream consumers that enumerate allowed mechanism keys, since additive JSON fields are only safe if nothing validates the shape:

- Frontend `ErrorTrackingException.mechanism` in `frontend/src/lib/components/Errors/types.ts` is a structural TS type, not a runtime validator, so extra keys pass through fine.
  Worth noting separately that its `type: 'generic'` literal is already too narrow for what SDKs send today (`chained`, `suppressed`), which is a pre-existing frontend typing gap rather than something this PR introduces. Left alone to keep the diff surgical.
- The only frontend runtime reads of mechanism are `mechanism?.synthetic` and `mechanism?.handled` in `frontend/src/lib/components/Errors/utils.ts`. Both unaffected.
- No Python or plugin-server code touches exception mechanisms.
- `$exception_list` lands in ClickHouse as a JSON property blob, so there is no column list to extend.
- Issue grouping and fingerprinting never read mechanism ids.

One decision worth flagging: I used `u32` rather than `usize`.
posthog-rs types these as `usize` on the SDK side and android emits plain ints, but chains are short (posthog-rs caps at 50), so a fixed 32-bit width is the right choice for a wire type.

Not stacked on the in-flight Java error tracking PRs (#76829, #76832), this is independent off master.
