### PR TITLE
fix(warehouse): parallelize DuckLake registration copies

### DIFF
--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -64,6 +64,7 @@ LOGGER = get_logger(__name__)
 DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG = "ducklake-data-imports-registration-workflow"
 DATA_IMPORTS_GENERATIONS_PREFIX = "_imports"
 DUCKLAKE_REGISTER_STAGE_DURATION_METRIC = "ducklake_register_data_imports_stage_duration"
+S3_COPY_BATCH_SIZE = 16
 _SOURCE_JOB_STATE_PATCH_ID = "ducklake-register-source-job-state-2026-08"
 
 
@@ -436,6 +437,8 @@ def _copy_prepared_parquet_files(source_uri: str, landing_uri: str) -> tuple[lis
     if not parquet_paths:
         raise ApplicationError(f"No prepared Parquet files found under {source_uri}", non_retryable=True)
 
+    source_copy_paths: list[str] = []
+    landing_copy_paths: list[str] = []
     landing_paths: list[str] = []
     for source_path_value in parquet_paths:
         source_path = source_path_value.removeprefix("s3://")
@@ -443,8 +446,11 @@ def _copy_prepared_parquet_files(source_uri: str, landing_uri: str) -> tuple[lis
         if relative_path == source_path or relative_path.startswith("../"):
             raise ApplicationError(f"Prepared file escaped source prefix: {source_path}", non_retryable=True)
         landing_path = f"{landing_prefix}/{relative_path}"
-        s3.copy(source_path, landing_path)
+        source_copy_paths.append(source_path)
+        landing_copy_paths.append(landing_path)
         landing_paths.append(f"s3://{landing_path}")
+
+    s3.copy(source_copy_paths, landing_copy_paths, batch_size=S3_COPY_BATCH_SIZE)
 
     copied_bytes = 0
     if isinstance(found, dict):

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
@@ -14,6 +14,7 @@ from products.managed_warehouse.backend.facade.contracts import ManagedWarehouse
 from products.managed_warehouse.backend.temporal import ducklake_register_data_imports_workflow as registration_module
 from products.managed_warehouse.backend.temporal.ducklake_register_data_imports_workflow import (
     DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG,
+    S3_COPY_BATCH_SIZE,
     DuckLakeRegisterDataImportsActivityInputs,
     DuckLakeRegisterDataImportsGateInputs,
     DuckLakeRegisterDataImportsInputs,
@@ -144,7 +145,7 @@ async def test_prepare_registration_pins_the_import_jobs_prepared_generation(ate
 def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monkeypatch):
     class FakeS3:
         def __init__(self) -> None:
-            self.copies: list[tuple[str, str]] = []
+            self.copy_calls: list[tuple[list[str], list[str], int]] = []
 
         def find(self, prefix: str, detail: bool = False):
             files = {
@@ -153,8 +154,8 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
             }
             return files if detail else list(files)
 
-        def copy(self, source: str, destination: str) -> None:
-            self.copies.append((source, destination))
+        def copy(self, sources: list[str], destinations: list[str], *, batch_size: int) -> None:
+            self.copy_calls.append((sources, destinations, batch_size))
 
     s3 = FakeS3()
     monkeypatch.setattr(registration_module, "get_s3_client", lambda: s3)
@@ -191,17 +192,20 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
 
     assert applied is True
     connect.assert_called_once_with("postgresql://duckgres", autocommit=True)
-    assert s3.copies == [
+    assert s3.copy_calls == [
         (
-            "source/team/customers__query/_ph_partition_key=2026-07/a.parquet",
-            "ducklake/posthog_data_imports_team_1/postgres_customers/_imports/schema/job/"
-            "_ph_partition_key=2026-07/a.parquet",
-        ),
-        (
-            "source/team/customers__query/_ph_partition_key=2026-08/b.parquet",
-            "ducklake/posthog_data_imports_team_1/postgres_customers/_imports/schema/job/"
-            "_ph_partition_key=2026-08/b.parquet",
-        ),
+            [
+                "source/team/customers__query/_ph_partition_key=2026-07/a.parquet",
+                "source/team/customers__query/_ph_partition_key=2026-08/b.parquet",
+            ],
+            [
+                "ducklake/posthog_data_imports_team_1/postgres_customers/_imports/schema/job/"
+                "_ph_partition_key=2026-07/a.parquet",
+                "ducklake/posthog_data_imports_team_1/postgres_customers/_imports/schema/job/"
+                "_ph_partition_key=2026-08/b.parquet",
+            ],
+            S3_COPY_BATCH_SIZE,
+        )
     ]
     executed = [str(call.args[0]) for call in conn.execute.call_args_list]
     registration_indexes = [index for index, query in enumerate(executed) if "ducklake_add_data_files" in query]


### PR DESCRIPTION
## Problem

DuckLake data import registration copies each prepared Parquet object with a separate synchronous `s3.copy` call. Although S3 performs the object copy server-side, serializing every request makes registration latency scale with both file count and object size and can exhaust the activity timeout.

## Changes

- Submit the complete paired source and destination path lists to one `s3fs.copy` call.
- Bound s3fs copy concurrency to 16 objects.
- Extend the existing activity test to guard against returning to per-object serial copy calls.

## How did you test this code?

- `bin/hogli test products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py::test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection` passed. This catches a regression where multiple Parquet objects are sent through separate serial S3 calls instead of one bounded bulk call.
- The complete test file executed all 17 tests successfully, then the command failed during global ClickHouse teardown because the local `channel_definition` replica was read-only.
- `bin/hogli ci:preflight --fix` passed.
- Commit hooks passed Python lint, formatting, and type checking.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this only changes the internal concurrency of an existing registration step.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated this change. Invoked the repository `/writing-tests` skill and the GitHub `/yeet` publishing skill. I chose s3fs's built-in bounded batch copy instead of adding a separate executor so the existing server-side copy behavior and source-to-destination mapping stay unchanged.