### PR TITLE
fix(data-warehouse): exclude direct sources from readiness

### DIFF
--- a/products/data_warehouse/backend/logic/managed_warehouse_data_status.py
+++ b/products/data_warehouse/backend/logic/managed_warehouse_data_status.py
@@ -194,7 +194,7 @@ def source_table_readiness(state: ManagedWarehouseSourceJobRecord | None) -> tup
     if state.status == ManagedWarehouseSourceJobStatus.RUNNING:
         return "backfilling", f"The {workflow_name} workflow is applying the latest source import."
     if state.status == ManagedWarehouseSourceJobStatus.COMPLETED:
-        return "up_to_date", f"The latest source import was applied by the {workflow_name} workflow."
+        return "up_to_date", "The latest source import was applied."
     if state.status == ManagedWarehouseSourceJobStatus.STALE:
         return "waiting", "A newer source import replaced this register workflow."
     return "waiting", f"The {workflow_name} workflow did not apply this source import."

--- a/products/data_warehouse/backend/logic/managed_warehouse_data_status.py
+++ b/products/data_warehouse/backend/logic/managed_warehouse_data_status.py
@@ -209,7 +209,11 @@ def _schema_table_statuses(
     per-source detail lookup (one source's schemas, for the drill-down modal) so the readiness
     computation and the visibility rules never drift between the two views.
     """
-    source_filter: dict[str, object] = {"team_id": team_id, "deleted": False}
+    source_filter: dict[str, object] = {
+        "team_id": team_id,
+        "deleted": False,
+        "access_method": ExternalDataSource.AccessMethod.WAREHOUSE,
+    }
     if source_id is not None:
         source_filter["id"] = source_id
     sources = user_access_control.filter_queryset_by_access_level(ExternalDataSource.objects.filter(**source_filter))

--- a/products/data_warehouse/backend/tests/api/test_misc_warehouse_viewsets_access_control.py
+++ b/products/data_warehouse/backend/tests/api/test_misc_warehouse_viewsets_access_control.py
@@ -95,7 +95,7 @@ class TestDataWarehouseViewSetAccessControl(WarehouseAccessControlTestMixin):
         response = self.client.get(self._path("total_rows_stats/"))
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_managed_warehouse_status_excludes_blocked_sources(self):
+    def test_managed_warehouse_status_excludes_blocked_and_direct_sources(self):
         self._create_access_control(self.viewer_user, access_level="viewer")
         self._create_access_control(self.viewer_user, resource="external_data_source", access_level="viewer")
         allowed_source = ExternalDataSource.objects.create(
@@ -112,8 +112,20 @@ class TestDataWarehouseViewSetAccessControl(WarehouseAccessControlTestMixin):
             source_type="Postgres",
             status="Running",
         )
+        managed_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="managed",
+            connection_id="managed-connection",
+            source_type="Postgres",
+            status="Running",
+            prefix="managed_warehouse",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            direct_query_enabled=True,
+            connection_metadata={"engine": "duckdb", "system_managed": True, "credential_kind": "org_root"},
+        )
         allowed_schema = ExternalDataSchema.objects.create(team=self.team, source=allowed_source, name="charges")
         ExternalDataSchema.objects.create(team=self.team, source=blocked_source, name="customers")
+        ExternalDataSchema.objects.create(team=self.team, source=managed_source, name="events")
         self._create_access_control(
             self.viewer_user,
             resource="external_data_source",


### PR DESCRIPTION
## Problem

The Data ops warehouse readiness response currently considers every external data source that has schemas. Direct-query connections do not run copy or register workflows, so the auto-provisioned managed warehouse connection appears as a circular source and stays in a waiting state.

## Changes

- Limit source readiness to warehouse import connections.
- Preserve the existing source access-control filtering.
- Extend the existing API regression to cover the auto-provisioned managed warehouse direct connection.

## How did you test this code?

- The focused API test assertion passed and confirmed only the import source is returned. The local command later exited during global teardown because the local ClickHouse replica is read-only.
- Ruff lint and format checks passed for both changed files.
- Strict CI preflight passed against current master.
- OpenAPI generation completed and produced no additional diff.

The regression coverage catches the managed warehouse direct connection being added back to the readiness response.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed. This corrects which existing connections appear in the dashboard.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop implemented this follow-up after the source workflow-state PR merged. Skills invoked: /implementing-warehouse-sources and /writing-tests.

I filtered by the existing warehouse import access method instead of matching the reserved managed warehouse name or JSON metadata. This excludes all direct-query connections, which cannot produce copy or register workflow state, while keeping ordinary imported sources visible.