### PR TITLE
fix(mysql): stop retrying an SSH tunnel host that fails safety checks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -224,6 +224,18 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # retries forever. `connect` re-raises it as `_SSH_HANDSHAKE_EOF_ERROR` — same
             # gateway-configuration class as "Could not establish session to SSH gateway" above.
             _SSH_HANDSHAKE_EOF_ERROR: "Could not connect to your SSH tunnel — the gateway accepted the connection but closed it during the SSH handshake. Check that the SSH host and port point to an SSH server (not the database port), that the bastion is running and reachable, and that PostHog's IP addresses are allowed through its firewall, then re-enable the sync.",
+            # `_pinned_ssh_host` (common/mixins.py) re-checks the SSH tunnel host on every connect,
+            # since a host that resolved to a public address at setup can drift (DNS change, or a
+            # short-TTL record). It rejects the host if it doesn't resolve or resolves to a
+            # private/internal address, which is a config problem only the customer can fix, so
+            # retrying just re-hits the same rejection. Match the stable prefix and exclude the
+            # volatile host/IP details that follow it in `resolution.error`.
+            "SSH tunnel host not allowed": (
+                "PostHog rejected the SSH tunnel host for this source because it either couldn't "
+                "be resolved, or resolves to a private/internal address. Check that the SSH tunnel "
+                "host is spelled correctly and reachable from the public internet, then re-enable "
+                "the sync."
+            ),
             # MySQL/MariaDB error 1129 (ER_HOST_IS_BLOCKED): the server has blocked our import
             # host because aborted/interrupted connections from it exceeded `max_connect_errors`.
             # The block is server-side state that only a DB admin can clear (FLUSH HOSTS /

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1868,6 +1868,27 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # DNS resolution failure for the configured SSH tunnel host (`_pinned_ssh_host` in
+            # common/mixins.py).
+            "SSH tunnel host not allowed: Couldn't resolve the host 'bastion.example.com'. Check "
+            "that it's spelled correctly and reachable from the public internet.",
+            # Temporal-wrapped form carrying the exception class name.
+            "Exception: SSH tunnel host not allowed: Couldn't resolve the host 'bastion.example.com'. "
+            "Check that it's spelled correctly and reachable from the public internet.",
+            # The other rejection `_pinned_ssh_host` can raise: the host resolves to a private/internal address.
+            "SSH tunnel host not allowed: This host points to an internal or private IP address, "
+            "which PostHog can't reach. Use a host that's reachable from the public internet.",
+        ],
+    )
+    def test_ssh_tunnel_host_not_allowed_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        assert "SSH tunnel host not allowed" in non_retryable
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"SSH tunnel host rejection should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Raw pymysql str(error) form (classified in `_handle_import_error`).
             str(pymysql.err.OperationalError(1054, "Unknown column 'favoritor_id' in 'where clause'")),
             # Temporal-wrapped str(e.cause) form (classified in external_data_job).


### PR DESCRIPTION
## Problem

PostHog's MySQL source revalidates a configured SSH tunnel host on every connect attempt, rejecting it if it can't be resolved via DNS or resolves to a private/internal address (raising `SSH tunnel host not allowed: ...`). This showed up in [error tracking](https://us.posthog.com/project/2/error_tracking/019fca23-8fc5-7621-aca8-a25adec06682) as a recurring exception on a source whose SSH tunnel host had stopped resolving.

That condition only clears once the customer fixes their SSH tunnel host config, so retrying never helps, but the message wasn't in this source's non-retryable error list, so schema discovery kept retrying and re-reporting it as error-tracking noise on every scheduled run instead of stopping.

## Changes

Added the stable `"SSH tunnel host not allowed"` prefix to `MySQLSource.get_non_retryable_errors()`, following the same pattern already used for this source's other SSH tunnel failures (gateway session errors, handshake EOF). This mirrors the identical fix already shipped for the Postgres source in [#76966](https://github.com/PostHog/posthog/pull/76966), which doesn't touch MySQL.

## How did you test this code?

Added 3 parameterized cases to `TestMySQLSourceNonRetryableErrors` (`test_ssh_tunnel_host_not_allowed_is_non_retryable`) covering the raw message, the Temporal-wrapped form, and the private-IP variant of the same rejection. This guards the exact regression that prompted this fix: without the new entry, this error would keep retrying instead of stopping. Ran the full `TestMySQLSourceNonRetryableErrors` class locally (49 tests passed).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a live error-tracking issue for the MySQL warehouse source.
- Confirmed the failure's stack trace originates in `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py` (`connect`, `_ssh_tunnel_endpoint`) calling into the shared SSH tunnel helper (`common/mixins.py`'s `_pinned_ssh_host`), which raises this exact message.
- Classified as a user/upstream config error (not a code bug): the host either doesn't resolve or resolves to a disallowed private address, and nothing on PostHog's side can fix that.
- Searched open PRs (by message, module path, and the maintainer's own open PRs) for a duplicate fix; found [#76966](https://github.com/PostHog/posthog/pull/76966), which fixes the identical root cause but only for the Postgres source, so this PR is not a duplicate.
- Skill invoked: `/writing-tests` before adding the new test cases.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*