### PR TITLE
chore(ci): keep product skill markdown off the frontend lanes

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -1258,8 +1258,14 @@ function computeTargets(changedFiles, context) {
             // is still backend: the workspace says the directory holds a JS
             // package, not that Python cannot be checked into it.
             const isWorkspaceOnly = !isBackend && !isFrontend && isInProductWorkspace(product, file, productWorkspaces)
+            // Markdown reaches this branch only as a product skill, which the
+            // prose rule exempts above because the skill build and the
+            // product's own backend read those files. Both readers are Python,
+            // so it takes the backend half of the "neither" default below and
+            // not the frontend one: no frontend suite reads a skill.
+            const isMarkdown = /\.mdx?$/.test(file)
 
-            if (isFrontend || (!isBackend && !isFrontend)) {
+            if (isFrontend || (!isBackend && !isFrontend && !isMarkdown)) {
                 targets.add(feProduct(product))
             }
             if (isBackend || (!isBackend && !isFrontend && !isWorkspaceOnly)) {

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -850,11 +850,23 @@ test('markdown alongside code contributes no lane of its own', () => {
 
 // hogli build:skills zips products/*/skills/*, and ci-agent-skills.yml gates on
 // those paths and on .agents/, so this markdown is a build input, not prose.
+// Both readers of a product skill are Python — the skill build and, for some
+// products, their own backend — so it claims the backend lane and not the
+// frontend one. A four-file docs PR was claiming every frontend product lane
+// off two SKILL.md files this way.
 test('skill markdown keeps the lane of the tree that builds it', () => {
     assert.deepEqual(computeTargets(['.agents/skills/merging-prs/SKILL.md'], CONTEXT), ['agents'])
     const productSkill = computeTargets(['products/beta/skills/creating-experiments/SKILL.md'], CONTEXT)
     assert.equal(productSkill.includes('py:product:beta'), true)
-    assert.equal(productSkill.includes('fe:product:beta'), true)
+    assert.equal(productSkill.includes('fe:product:beta'), false)
+})
+
+// The carve-out is for markdown, not for everything under skills/. A non-prose
+// file there is as unclassifiable as before and keeps both halves.
+test('a non-markdown skill file still claims both halves', () => {
+    const script = computeTargets(['products/beta/skills/creating-experiments/scripts/run.sh'], CONTEXT)
+    assert.equal(script.includes('py:product:beta'), true)
+    assert.equal(script.includes('fe:product:beta'), true)
 })
 
 // docs/onboarding is the @posthog/docs-onboarding workspace package that

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -850,10 +850,8 @@ test('markdown alongside code contributes no lane of its own', () => {
 
 // hogli build:skills zips products/*/skills/*, and ci-agent-skills.yml gates on
 // those paths and on .agents/, so this markdown is a build input, not prose.
-// Both readers of a product skill are Python — the skill build and, for some
-// products, their own backend — so it claims the backend lane and not the
-// frontend one. A four-file docs PR was claiming every frontend product lane
-// off two SKILL.md files this way.
+// Skill markdown is a build input for the Python skill build (and sometimes the product backend).
+// No frontend suite reads these files, so they should claim the backend lane but not the frontend lane.
 test('skill markdown keeps the lane of the tree that builds it', () => {
     assert.deepEqual(computeTargets(['.agents/skills/merging-prs/SKILL.md'], CONTEXT), ['agents'])
     const productSkill = computeTargets(['products/beta/skills/creating-experiments/SKILL.md'], CONTEXT)


### PR DESCRIPTION
> Stacked on #76951.

## Problem

A four-file docs PR (#76155) uploaded 165 impacted targets. Two of those files were `products/ingestion/skills/**/*.md`, and between them they claimed **every frontend product lane**.

The chain:

1. `products/*/skills/**` is deliberately exempt from the prose rule, because those files really are a build input - `products/posthog_ai/scripts/build_skills.py` reads `products/*/skills/*`, `ci-agent-skills.yml` gates on that path, and some products read their own skills at runtime (`products/signals/backend/management/commands/sync_signals_scout_skills.py`, `products/review_hog/backend/reviewer/lazy_seed.py`).
2. Having escaped the prose rule, the file lands in the `products/` branch.
3. There, `isBackend` is `segments[2] === 'backend' || endsWith('.py')` and `isFrontend` is `segments[2] === 'frontend' || /\.tsx?$/`. A file under `skills/` is neither, and the "neither" case is conservatively treated as **both**.

Step 3 is right for an unclassifiable file in general. It is wrong for markdown specifically: every reader of a product skill is Python. No frontend suite reads one.

## Changes

```diff
+ const isMarkdown = /\.mdx?$/.test(file)
+
- if (isFrontend || (!isBackend && !isFrontend)) {
+ if (isFrontend || (!isBackend && !isFrontend && !isMarkdown)) {
      targets.add(feProduct(product))
  }
```

Markdown now takes only the backend half of the default. The backend half is kept because it is real - the skill build and, for some products, their own backend are both Python.

Markdown is the only file type this can affect. Everything else under a product is either prose (and never reaches this branch), `backend/`, `frontend/`, `.py`, or `.tsx`. The one remaining path is `products/*/skills/**` non-markdown, which keeps both halves.

## How did you test this code?

I (actually Claude) ran these. No manual testing - CI script, no UI.

- `node --test` across all four affected suites: **93 pass, 0 fail**.
- Recomputed #76155's real four-file diff. The two skill files drop from 83 targets each to 1.
- `oxfmt` on both changed files.

Tests:

- **`skill markdown keeps the lane of the tree that builds it`** - existing test, flipped to assert the frontend lane is now absent. It was already asserting the pair, so it pins the change in both directions.
- **`a non-markdown skill file still claims both halves`** - new. The carve-out is for markdown, not for `skills/`. Without this, someone tightening the rule to the whole directory would not fail a test.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while tracing why #76155 uploaded 165 targets for four files. That number turned out to have two unrelated causes: this one, and `products/ingestion` being absent from `tach.toml` (fixed in #77019 on top).

The remaining 82 after both fixes come from `frontend/src/**/IngestionWarningsView.tsx`, which is the `frontend/src/` core fan-out working as designed - a core frontend change can break any product's frontend, and set intersection is the only way Trunk can express that.

One thing I looked at and deliberately did not change: the skill build reads every product's skills, so a PR editing `build_skills.py` and a PR adding a skill that violates a new check are not serialized against each other. That is the same class as a lint-rule change and arguably wants its own rule. It is a separate question from this one - dropping the frontend claim does not make it worse, since the frontend lane was never protecting the skill build - so I left it alone rather than bundling a second behavior change into a one-line fix.

Tools: Claude Code (Opus 5). Skills invoked: `/stacking-prs`.
