### PR TITLE
chore(ci): declare the remaining products as tach modules

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -215,6 +215,11 @@ depends_on = [
 layer = "modules"
 
 [[modules]]
+path = "products.core_events"
+depends_on = []
+layer = "modules"
+
+[[modules]]
 path = "products.dashboards"
 depends_on = [
     "ee",
@@ -246,6 +251,56 @@ layer = "modules"
 [[modules]]
 path = "products.data_tools"
 depends_on = ["posthog"]
+layer = "modules"
+
+[[modules]]
+path = "products.games"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.groups"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.ingestion"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.integrations"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.persons"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.session_replay"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.session_summaries"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.subscriptions"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.support"
+depends_on = []
+layer = "modules"
+
+[[modules]]
+path = "products.toolbar"
+depends_on = []
 layer = "modules"
 
 [[modules]]


### PR DESCRIPTION
> Stacked on #77018.

## Problem

Eleven products are absent from `tach.toml`: `core_events`, `games`, `groups`, `ingestion`, `integrations`, `persons`, `session_replay`, `session_summaries`, `subscriptions`, `support`, `toolbar`.

Nothing bounds what may import an undeclared product, so #76951 deliberately leaves them widening: any file in one that is neither `backend/` nor `frontend/` claims every backend lane. `products/ingestion` is the extreme case - the directory contains nothing but `skills/`, so **every** change to that product claimed all 82 Python lanes.

## Changes

Eleven `[[modules]]` blocks with `depends_on = []`, inserted alphabetically among the existing product modules. Additions only, no existing block touched. 74 modules to 85.

> [!NOTE]
> The empty `depends_on` is accurate, not a placeholder. None of these products has importable Python today - eight have zero `.py` files, `core_events` and `subscriptions` have only an empty `__init__.py`, and `support`'s six files are standalone scripts under `products/support/scripts/`. That is why they were never declared. The declaration is a statement that they expose nothing, and `tach check` enforces it from now on: the moment someone adds Python that another module imports, the build fails until the edge is declared.

Effect on real files in those products, with #76951 in place:

| Product | Widening files | Lanes before | after |
| --- | --- | --- | --- |
| `ingestion` | 15 | 82 | **1** |
| `core_events` | 3 | 82 | **1** |
| `subscriptions` | 6 | 82 | **1** |
| `support` | 6 | 82 | **1** |
| `games` | 6 | 83 | **2** |
| `integrations` | 1 | 83 | **2** |
| `groups`, `persons`, `session_summaries`, `toolbar` | 1 each | 254 | 254 |
| `session_replay` | 0 | - | - |

The last four gain nothing today: their only widening file is `manifest.tsx`, which is a tripwire (`products/*/manifest.tsx`) and universal regardless. They are declared anyway for consistency and for the forward-looking enforcement above, not because they move a number.

End to end on #76155's real diff, with this PR and the two below it: **165 targets to 84**. The two ingestion skill files go from 83 each to a single shared `py:product:ingestion`. The residual 82 is the `frontend/src/` core fan-out, which is correct.

## How did you test this code?

I (actually Claude) ran these. No manual testing - this is a config file plus its enforcement.

- `tach check --dependencies --interfaces` (the exact command `ci-backend.yml` runs): **all modules validated**, same as the baseline before the change.
- Confirmed tach actually resolves these paths rather than silently ignoring them: adding a deliberately fake `products.definitely_not_a_real_product` produces `[WARN] Module containing ... not found in project`, and none of the eleven does.
- Parsed the file with `tomllib` and counted: 85 modules, 23 interfaces, no block lost or reordered.
- Swept every real file in the eleven products through `computeTargets` before and after to produce the table above.
- Re-ran the four script suites: **93 pass, 0 fail**.

No new tests. This PR adds no logic - the behavior it unlocks is already covered by #76951's `a product absent from the tach graph widens to every backend target`, which pins the fail-safe these declarations move the products out of.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `products/architecture.md` describes tach as the import boundary enforcer, which is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked for these eleven to be added after #76951 left them widening. Worth recording that my framing of the problem was off, and Claude corrected it while measuring.

I had sized the gap by running `products/<name>/backend/api.py` through the rules for each product - a synthetic path. It reported all eleven claiming 82 lanes. But none of these products has a `backend/` directory, so that file could never appear in a diff. Re-measuring against the files that actually exist gave the table above: six products gain, four are blocked by the `manifest.tsx` tripwire instead, one had nothing widening.

That also reframed what "add them to tach" means. The instinct was that they were missing an entry someone forgot. They are missing an entry because they have no Python - so the honest declaration is the empty one, and its value is enforcement going forward rather than any edge it describes today.

Alternative considered: detect "product contains no `.py` files" from disk and treat it as having no backend, in the same spirit as the existing `backendDetachedProducts` rule. That needs no `tach.toml` change and would cover the four `manifest.tsx` products too, since it applies before the product rules. Rejected for now because it adds a second, weaker isolation mechanism next to the enforced one, and because a disk snapshot is a softer guarantee than `tach check`. Worth revisiting if more frontend-only products appear.

Tools: Claude Code (Opus 5), `tach` locally. Skills invoked: `/stacking-prs`.
