### PR TITLE
fix(warehouse): return 400 when source create schema discovery raises a known credential error

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -2214,15 +2214,21 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 data={"message": f"Source type '{source_type}' does not support schema discovery."},
             )
         except Exception as e:
-            # Credentials can still fail here even after passing live validation above (e.g. a
-            # BigQuery service account key rotated/revoked in the moment between the two calls).
-            # Classify via the source's own non-retryable-error map, same as `database_schema` and
-            # `refresh_schemas`, so an expected source error returns a clean 400 instead of the
-            # uncaught 500 this would otherwise raise, and roll back the row so it doesn't linger
-            # half-created.
+            # `get_schemas` opens its own connection, so credentials validated above can still fail
+            # here (e.g. a BigQuery service account key rotated/revoked in between). Classify via
+            # the source's own non-retryable-error map, same as `database_schema` and
+            # `refresh_schemas`, and roll back the row so a source that can't discover its schema
+            # doesn't linger half-created.
             error_message, is_expected_source_error = _classify_refresh_schemas_error(source, e)
             if not is_expected_source_error:
-                capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
+                capture_exception(
+                    e,
+                    {
+                        "source_type": source_type,
+                        "team_id": self.team_id,
+                        "source_id": str(new_source_model.id),
+                    },
+                )
             new_source_model.delete()
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,

--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -2213,6 +2213,21 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": f"Source type '{source_type}' does not support schema discovery."},
             )
+        except Exception as e:
+            # Credentials can still fail here even after passing live validation above (e.g. a
+            # BigQuery service account key rotated/revoked in the moment between the two calls).
+            # Classify via the source's own non-retryable-error map, same as `database_schema` and
+            # `refresh_schemas`, so an expected source error returns a clean 400 instead of the
+            # uncaught 500 this would otherwise raise, and roll back the row so it doesn't linger
+            # half-created.
+            error_message, is_expected_source_error = _classify_refresh_schemas_error(source, e)
+            if not is_expected_source_error:
+                capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
+            new_source_model.delete()
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={"message": error_message},
+            )
         if is_direct_query:
             new_source_model.connection_metadata = get_direct_connection_metadata(
                 source_impl=source,

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -2063,6 +2063,61 @@ class TestExternalDataSource(APIBaseTest):
         assert "'private_key'" in response.json()["message"]
         assert "'private_key_id'" in response.json()["message"]
 
+    @patch("products.warehouse_sources.backend.presentation.views.external_data_source.capture_exception")
+    def test_create_external_data_source_bigquery_returns_400_on_credentials_rejected_during_schema_discovery(
+        self, mock_capture_exception
+    ):
+        # Credentials can pass the live validation above and still be rejected moments later when
+        # `get_schemas` opens its own BigQuery connection (e.g. a key rotated/revoked in between).
+        # That used to escape `_create_external_data_source` as an uncaught 500 and leave the row
+        # behind; it must now return a clean 400 with the row rolled back, without flooding error
+        # tracking for this expected, already-classified source error.
+        from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
+            BIGQUERY_CREDENTIALS_REJECTED_ERROR,
+            BigQueryCredentialsRejectedError,
+        )
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source.BigQuerySource.validate_credentials",
+                return_value=(True, None),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source.BigQuerySource.get_schemas",
+                # Mirrors the real message `get_columns` raises: it keeps the `invalid_grant` marker
+                # inline so `get_non_retryable_errors` ("invalid_grant" -> BIGQUERY_CREDENTIALS_REJECTED_ERROR)
+                # still matches it, unlike the plain BIGQUERY_CREDENTIALS_REJECTED_ERROR constant.
+                side_effect=BigQueryCredentialsRejectedError(
+                    "Your BigQuery service account credentials were rejected by Google (invalid_grant). "
+                    "The key may have been rotated or revoked, or the service account deleted. "
+                    "Please upload a new Google Cloud JSON key file."
+                ),
+            ),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/",
+                data={
+                    "source_type": "BigQuery",
+                    "created_via": "web",
+                    "payload": {
+                        "schemas": [],
+                        "dataset_id": "my_project.my_dataset",
+                        "key_file": {
+                            "project_id": "my_project",
+                            "private_key": "my_private_key",
+                            "private_key_id": "my_private_key_id",
+                            "token_uri": "https://google.com",
+                            "client_email": "test@posthog.com",
+                        },
+                    },
+                },
+            )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == BIGQUERY_CREDENTIALS_REJECTED_ERROR
+        assert ExternalDataSource.objects.count() == 0
+        mock_capture_exception.assert_not_called()
+
     def test_list_external_data_source_query_count_does_not_scale_with_sources(self):
         # N+1 regression guard: created_by, revenue_analytics_config, schemas and the latest job are
         # all fetched up front, so listing must cost the same number of queries regardless of how many

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -2067,11 +2067,8 @@ class TestExternalDataSource(APIBaseTest):
     def test_create_external_data_source_bigquery_returns_400_on_credentials_rejected_during_schema_discovery(
         self, mock_capture_exception
     ):
-        # Credentials can pass the live validation above and still be rejected moments later when
-        # `get_schemas` opens its own BigQuery connection (e.g. a key rotated/revoked in between).
-        # That used to escape `_create_external_data_source` as an uncaught 500 and leave the row
-        # behind; it must now return a clean 400 with the row rolled back, without flooding error
-        # tracking for this expected, already-classified source error.
+        # `get_schemas` opens its own BigQuery connection, so credentials that passed the earlier
+        # live validation can still be rejected here (e.g. a key rotated/revoked in between).
         from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
             BIGQUERY_CREDENTIALS_REJECTED_ERROR,
             BigQueryCredentialsRejectedError,
@@ -2100,7 +2097,9 @@ class TestExternalDataSource(APIBaseTest):
                     "source_type": "BigQuery",
                     "created_via": "web",
                     "payload": {
-                        "schemas": [],
+                        "schemas": [
+                            {"name": "my_table", "should_sync": True, "sync_type": "full_refresh"},
+                        ],
                         "dataset_id": "my_project.my_dataset",
                         "key_file": {
                             "project_id": "my_project",


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `BigQueryCredentialsRejectedError` ("Your BigQuery service account credentials were rejected by Google (invalid_grant)...") raised from `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py`'s `get_columns`, uncaught, from the two-step source-creation endpoint (`_create_external_data_source`).

That endpoint only wraps its `get_schemas()` call in `except NotImplementedError`. Live credential validation runs earlier in the same request and had passed, but `get_schemas()` opens its own independent BigQuery connection — if the service account key is rejected in that narrow window (e.g. rotated/revoked right after validation, or a transient token-endpoint hiccup), the exception escapes uncaught: the request 500s, the just-created `ExternalDataSource` row is never rolled back (left in `status="Running"` with no schemas), and the exception floods error tracking even though it's a well-understood, already-classified user/credential error (`BigQueryCredentialsRejectedError` and the `invalid_grant` string are both already mapped to a friendly message via `BigQuerySource.get_non_retryable_errors()`).

Two sibling code paths in the same file already handle this correctly: the `database_schema` and `refresh_schemas` actions both classify a `get_schemas()` failure via `_classify_refresh_schemas_error(source, e)` (which checks the source's own `get_non_retryable_errors()` map) before deciding whether to capture the exception. The create endpoint was the one path missing this.

This isn't BigQuery-specific — the same gap would surface for any source whose credentials are independently re-checked between validation and schema discovery — but this specific error tracking issue was reported for BigQuery, is the one with reproducing evidence, and the fix lives at the shared call site all sources go through.

## Changes

- `_create_external_data_source` now also catches `Exception` (in addition to the existing `NotImplementedError` branch) around its `get_schemas()` call, classifies it via the existing `_classify_refresh_schemas_error` helper, rolls back the half-created source row, and returns a clean 400 — capturing to error tracking only when the error isn't already a known/expected source error, mirroring `database_schema`'s existing handling.

## How did you test this code?

- Added `test_create_external_data_source_bigquery_returns_400_on_credentials_rejected_during_schema_discovery`: mocks `BigQuerySource.validate_credentials` to succeed (as it did for the real report) and `get_schemas` to raise the real `BigQueryCredentialsRejectedError` message. Asserts a 400 with the friendly message, the source row rolled back, and no error-tracking capture — this is the exact regression the fix addresses; no existing test covered a `get_schemas` failure in the two-step create flow.
- Ran the full `TestExternalDataSource` create-related test suite (90 tests) locally — all pass, no regressions.
- Ran `uv run mypy --cache-fine-grained .` repo-wide — clean.
- Ran `ruff check`/`ruff format` on changed files — clean.
- Did not do any manual/browser testing of this change.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged a live PostHog error-tracking issue for the BigQuery import source (`BigQueryCredentialsRejectedError`, invalid_grant), confirmed the stack trace originates in `bigquery.py`, and initially assumed the fix was to extend `BigQuerySource.get_non_retryable_errors()` — but that mapping already exists on master. Tracing the actual failing call path (`_create_external_data_source` → `get_schemas`) showed the real gap: that endpoint doesn't consult the non-retryable-error classification at all, unlike its sibling `database_schema`/`refresh_schemas` actions. I found and reviewed an existing draft PR (#71040) that patches the same call site for a different (Postgres connection) failure mode — it doesn't cover this credentials case and is stale/conflicting after a product directory rename, so this isn't a duplicate.

No skills were invoked for this change (no migration, DRF schema, or copy changes were needed — the response shape and viewset schema are unchanged).