### PR TITLE
fix(data-warehouse): add public-host guidance to MySQL and MSSQL source host fields

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -194,7 +194,13 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
                         label="Host",
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
-                        placeholder="localhost",
+                        placeholder="db.example.com",
+                        caption=(
+                            "Must be reachable from the public internet. Add PostHog's egress IP addresses to your "
+                            "firewall allowlist (see the docs above) and use a public host. `localhost` and private "
+                            "IPs (10.x, 172.16-31.x, 192.168.x) can't be reached. For a database that can't be "
+                            "exposed publicly, enable the SSH tunnel below."
+                        ),
                         secret=False,
                     ),
                     SourceFieldInputConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -107,7 +107,13 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
                         label="Host",
                         type=SourceFieldInputConfigType.TEXT,
                         required=True,
-                        placeholder="localhost",
+                        placeholder="db.example.com",
+                        caption=(
+                            "Must be reachable from the public internet. Add PostHog's egress IP addresses to your "
+                            "firewall allowlist (see the docs above) and use a public host. `localhost` and private "
+                            "IPs (10.x, 172.16-31.x, 192.168.x) can't be reached. For a database that can't be "
+                            "exposed publicly, enable the SSH tunnel below."
+                        ),
                         secret=False,
                     ),
                     SourceFieldInputConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -250,8 +250,8 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                         placeholder="db.example.com",
                         caption=(
                             "Must be reachable from the public internet. Add PostHog's egress IP addresses to your "
-                            "firewall allowlist (see the docs above) and use a public host — `localhost` and private "
-                            "IPs (10.x, 172.16–31.x, 192.168.x) can't be reached. For a database that can't be "
+                            "firewall allowlist (see the docs above) and use a public host. `localhost` and private "
+                            "IPs (10.x, 172.16-31.x, 192.168.x) can't be reached. For a database that can't be "
                             "exposed publicly, enable the SSH tunnel below."
                         ),
                         secret=False,


### PR DESCRIPTION
## Problem

The Postgres warehouse source host field spells out that the database has to be reachable from the public internet, that PostHog's egress IPs need allowlisting, that `localhost` and private IPs can't be reached, and that an SSH tunnel is the fallback for a database you can't expose. The MySQL and MSSQL host fields had none of that guidance, and their placeholder was `localhost` — the one value that's actually blocked on cloud.

Onboarding-session reviews of the new-source flow show users pointing a database source at a private or internal host, hitting the connection error with no in-form hint about why, and giving up. The fix that already works for Postgres just wasn't carried over to the other two direct-database sources.

## Changes

Add the same guidance caption to the MySQL and MSSQL host fields, and change the placeholder from `localhost` to `db.example.com` to match Postgres. The caption is reworded to avoid an em-dash (splitting the clause into a separate sentence), which is also how it should read.

No behavior, validation, or sync change — this is field help text and a placeholder only.

## How did you test this code?

Ran `ruff check` and `ruff format --check` over both touched files (clean), and confirmed `caption` / `placeholder` are valid fields on `SourceFieldInputConfig` in `posthog/schema.py` (Postgres already sets `caption` identically). No automated test asserts the host placeholder or caption, so none needed changing. I (Claude) was not able to render the wizard in this environment (dev stack not bootstrapped), so I did not manually verify the caption in the browser.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) from a review of anonymized new-source onboarding session summaries. The friction theme: direct-database sources whose host field gave no reachability guidance and whose `localhost` placeholder points at a host that's blocked on cloud. I checked the other SQL sources — Postgres already has this caption, Redshift's placeholder already steers to a public host — so the gap was MySQL and MSSQL. Invoked the `/writing-user-facing-copy` skill and dropped the em-dash from the Postgres wording while reusing it. Checked open PRs (including the maintainer's own) for a duplicate and found none touching these captions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
