### PR TITLE
refactor(lazy-loader): cache omitted keys as null at the point of load

### DIFF
--- a/nodejs/src/common/utils/lazy-loader.test.ts
+++ b/nodejs/src/common/utils/lazy-loader.test.ts
@@ -380,6 +380,14 @@ describe('LazyLoader', () => {
             // so this observes a scheduled reload without waiting out the buffer for it to surface.
             expect(loadSpy).toHaveBeenCalledTimes(0)
             expect(loader).toHaveBeenCalledTimes(0)
+
+            // Past where the background deadline would sit if the null were stamped with
+            // refreshBackgroundAgeMs (start+3.5min), still inside the null TTL that runs to
+            // start+4.5min.
+            jest.spyOn(Date, 'now').mockReturnValue(start + 1000 * 60 * 4)
+            expect(await lazyLoader.get('key1')).toBeNull()
+            expect(loadSpy).toHaveBeenCalledTimes(0)
+            expect(loader).toHaveBeenCalledTimes(0)
         })
 
         it('re-caches a key that reloads from null to null', async () => {
@@ -481,6 +489,21 @@ describe('LazyLoader', () => {
             expect(Object.keys(cache).length).toBe(2)
             // When all have the same lastUsed time, eviction order depends on iteration order
             // Just verify we have exactly 2 entries
+        })
+
+        it('evicts down to maxSize when the loader omits every requested key', async () => {
+            const customLoader = new LazyLoader({
+                name: 'test',
+                loader,
+                maxSize: 2,
+                refreshJitterMs: 0,
+            })
+
+            // Nulls for omitted keys are cached like any other value, so they count against maxSize.
+            loader.mockResolvedValueOnce({})
+            await customLoader.getMany(['key1', 'key2', 'key3'])
+
+            expect(Object.keys(customLoader.getCache()).length).toBe(2)
         })
     })
 

--- a/nodejs/src/common/utils/lazy-loader.ts
+++ b/nodejs/src/common/utils/lazy-loader.ts
@@ -324,10 +324,11 @@ export class LazyLoader<T> {
     }
 
     /**
-     * Invoke the loader and normalize its result into a map this class owns: no prototype, one
-     * entry per requested key, and `undefined` collapsed to `null`. The loader hands back a plain
-     * object, where a key like `__proto__` resolves up the prototype chain instead of reading as
-     * absent.
+     * Invoke the loader and normalize its result into a map this class owns: no prototype, an entry
+     * for every requested key, and `undefined` collapsed to `null`. Keys the loader returns beyond
+     * those requested are kept, so a loader can warm the cache with extras. The loader hands back a
+     * plain object, where a key like `__proto__` resolves up the prototype chain instead of reading
+     * as absent.
      */
     private async invokeLoader(keys: string[]): Promise<Record<string, T | null>> {
         const loaded = await this.invokeLoaderWithRetry(keys)

--- a/nodejs/src/common/utils/lazy-loader.ts
+++ b/nodejs/src/common/utils/lazy-loader.ts
@@ -102,7 +102,7 @@ type CacheEntry<T> = {
 
 export class LazyLoader<T> {
     private cache: Record<string, CacheEntry<T> | undefined>
-    private pendingLoads: Record<string, Promise<T | null> | undefined>
+    private pendingLoads: Record<string, Promise<void> | undefined>
 
     private refreshAgeMs: number
     private refreshNullAgeMs: number
@@ -114,7 +114,7 @@ export class LazyLoader<T> {
     private buffer:
         | {
               keys: Set<string>
-              promise: Promise<LazyLoaderMap<T>>
+              promise: Promise<void>
           }
         | undefined
 
@@ -272,10 +272,12 @@ export class LazyLoader<T> {
     /**
      * Schedules the keys to be loaded with a buffer to allow batching multiple keys
      * This is somewhat complex but simplifies the usage around the codebase as you can safely do multiple gets without worrying about firing off duplicate DB requests
+     *
+     * Loaded values land in `this.cache` via `setValues`; callers read them back from there.
      */
-    private async load(keys: string[]): Promise<LazyLoaderMap<T>> {
+    private async load(keys: string[]): Promise<void> {
         const bufferMs = this.options.bufferMs ?? defaultConfig.LAZY_LOADER_DEFAULT_BUFFER_MS
-        const keyPromises: Promise<T | null>[] = []
+        const keyPromises: Promise<void>[] = []
 
         for (const key of keys) {
             let pendingLoad = this.pendingLoads[key]
@@ -298,78 +300,43 @@ export class LazyLoader<T> {
                             this.buffer = undefined
                             resolve(keys)
                         }, bufferMs)
-                    })
-                        .then((keys) => {
-                            // Pull out the keys to load and clear the buffer
-                            logger.debug('[LazyLoader]', this.options.name, 'Loading: ', keys)
-                            return this.invokeLoader(keys)
-                        })
-                        .then((map) => {
-                            this.setValues(map)
-                            return map
-                        }),
+                    }).then(async (bufferedKeys) => {
+                        logger.debug('[LazyLoader]', this.options.name, 'Loading: ', bufferedKeys)
+                        this.setValues(await this.invokeLoader(bufferedKeys))
+                    }),
                 }
                 lazyLoaderBufferUsage.labels({ name: this.options.name, hit: 'miss' }).inc()
             } else {
                 lazyLoaderBufferUsage.labels({ name: this.options.name, hit: 'hit' }).inc()
             }
 
-            // Add the key to the buffer and add a pendingLoad that waits for the buffer to resolve
-            // and then picks out its value
+            // Add the key to the buffer and add a pendingLoad that waits for the buffer to resolve.
+            // The values land in the cache via setValues, so callers read them from there.
             this.buffer.keys.add(key)
-            pendingLoad = this.buffer.promise
-                .then((map) => map[key] ?? null)
-                .finally(() => {
-                    delete this.pendingLoads[key]
-                })
+            pendingLoad = this.buffer.promise.finally(() => {
+                delete this.pendingLoads[key]
+            })
             this.pendingLoads[key] = pendingLoad
             keyPromises.push(pendingLoad)
         }
 
-        const results = await Promise.all(keyPromises)
-
-        // Values are already in the cache via the buffer's setValues call.
-        // For keys the loader omitted (resolved to null), update the cache
-        // so deleted/disabled items don't serve stale data.
-        const now = Date.now()
-        // Keys are caller-supplied: on a plain object, assigning `__proto__` would reassign this
-        // map's prototype instead of storing the value under that key.
-        const result: LazyLoaderMap<T> = Object.create(null)
-        for (let i = 0; i < keys.length; i++) {
-            const key = keys[i]
-            const entry = this.cache[key]
-            // An entry already holding null is rewritten once its deadline has lapsed. Nothing else
-            // would refresh it, since `setValues` only touches keys the loader returned, so leaving
-            // it alone would strand it permanently expired and make every later lookup block.
-            if (results[i] === null && (!entry || entry.value !== null || entry.cacheUntil <= now)) {
-                if (!entry) {
-                    this.cacheSize++
-                }
-                // Replace the entry rather than patching the previous value's fields. A
-                // backgroundRefreshAfter left over from when this key held a real value is
-                // necessarily in the past, because refreshBackgroundAgeMs is smaller than the
-                // refreshAgeMs the key just exceeded. Keeping it would background-refresh the key
-                // on every lookup for the whole null TTL.
-                const jitter = Math.floor(Math.random() * this.refreshJitterMs)
-                this.cache[key] = {
-                    value: null,
-                    lastUsed: now,
-                    cacheUntil: now + this.refreshNullAgeMs + jitter,
-                }
-            }
-            result[key] = this.cache[key]?.value ?? null
-        }
-        return result
+        await Promise.all(keyPromises)
     }
 
     /**
-     * Invoke the loader and normalize its result into a map this class owns: no prototype, and
-     * `undefined` collapsed to `null`. The loader hands back a plain object, where a key like
-     * `__proto__` resolves up the prototype chain instead of reading as absent.
+     * Invoke the loader and normalize its result into a map this class owns: no prototype, one
+     * entry per requested key, and `undefined` collapsed to `null`. The loader hands back a plain
+     * object, where a key like `__proto__` resolves up the prototype chain instead of reading as
+     * absent.
      */
     private async invokeLoader(keys: string[]): Promise<Record<string, T | null>> {
         const loaded = await this.invokeLoaderWithRetry(keys)
         const map: Record<string, T | null> = Object.create(null)
+        // A key the loader omits means "no value", not "no answer", so seed every requested key
+        // before overlaying what came back.
+        for (const key of keys) {
+            map[key] = null
+        }
         for (const [key, value] of Object.entries(loaded)) {
             map[key] = value ?? null
         }


### PR DESCRIPTION
## Problem

A key the loader omits means "no value", not "no answer", so it has to be cached as null. #76935 made that work, but it did it in a pass that ran after the load resolved, separate from `setValues`. That pass had to reason about which stale deadlines an existing entry might still be carrying in order to decide whether to rewrite it, and it wrote cache entries directly, bypassing `evictLRU` and the size gauge.

## Changes

`invokeLoader` now seeds every requested key with null before overlaying what the loader returned. Omitted keys reach `setValues` like any other value, so they get their refresh deadlines from the one path that stamps them. The post-load pass is gone, and `load()` no longer returns a map because callers read values back out of the cache.

Cache lifetimes are unchanged: a null still takes `refreshNullAgeMs` for both deadlines.

> [!NOTE]
> Omitted keys already counted toward `maxSize`, but the old pass wrote them without calling `evictLRU` or the size gauge, so both waited for the next `setValues`. Routing them through `setValues` closes that gap: a batch that overflows `maxSize` evicts at the point of load instead of a cycle later, and the size gauge no longer lags a cycle behind.

## How did you test this code?

Ran `pnpm jest src/common/utils/lazy-loader.test.ts` in `nodejs/`. 29 passed.

Two test changes, each covering a regression the existing suite missed:

- `evicts down to maxSize when the loader omits every requested key` is new. Nothing covered eviction for omitted keys, because the old path never called `evictLRU` for them.
- `does not background-refresh a key whose value has become null` gets an assertion at `start + 4min`, past where the background deadline would sit if the null were stamped with `refreshBackgroundAgeMs`, but still inside the null TTL. The existing assertions only looked before that point, so a null carrying a `refreshBackgroundAgeMs` deadline would have passed.

## Automatic notifications

- [ ] Publish to changelog?
