### PR TITLE
fix(experiments): shorten exposures header fade-out

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Exposures.tsx
@@ -286,12 +286,14 @@ export function Exposures(): JSX.Element {
                 </span>
 
                 {!isExperimentDraft && (
-                    // Transitioning visibility delays the hidden flip until the fade-out finishes
+                    // Transitioning visibility delays the hidden flip until the fade-out finishes.
+                    // The fade-out is shorter so it ends before the 200ms panel slide does; at equal
+                    // durations the exit reads as sluggish.
                     <div
-                        className={`flex items-center gap-3 transition-[opacity,visibility] duration-300 ease-in-out ${
+                        className={`flex items-center gap-3 transition-[opacity,visibility] ease-in-out ${
                             isCollapsed
-                                ? 'visible opacity-100 pointer-events-auto'
-                                : 'invisible opacity-0 pointer-events-none'
+                                ? 'visible opacity-100 pointer-events-auto duration-300'
+                                : 'invisible opacity-0 pointer-events-none duration-150'
                         }`}
                     >
                         {exposuresLoading ? (


### PR DESCRIPTION
## Problem

Follow-up to #76590. The header summary fade-out (300ms) outlasts the panel slide (200ms), so expanding the section feels sluggish.

## Changes

Fade-out is now 150ms. Fade-in stays at 300ms.

## How did you test this code?

Tested in the local app: expanding feels snappy, collapsing keeps the slow ease-in.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code, verified visually by the author in the local app.
