### PR TITLE
fix(replay): store an integer id in session_recording_linked_flag

### DIFF
--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -920,7 +920,18 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
                 "Must provide a dictionary with only 'id' and 'key' keys. _or_ only 'id', 'key', and 'variant' keys."
             )
 
-        return value
+        # jsonb containment (`__contains={"id": <int>}`) is type-sensitive, so a non-integer id
+        # makes the flag-delete guard miss this row and delete a flag the team still advertises.
+        # A numeric string is normalized instead of rejected, so a client sending "123" stores a
+        # usable row rather than a broken one. Bools and floats are excluded because
+        # isinstance(True, int) is True, and int(12.5) would silently link flag 12.
+        flag_id = value["id"]
+        if isinstance(flag_id, bool) or not isinstance(flag_id, int | str):
+            raise exceptions.ValidationError("Must provide an integer 'id'.")
+        try:
+            return {**value, "id": int(flag_id)}
+        except ValueError:
+            raise exceptions.ValidationError("Must provide an integer 'id'.")
 
     @staticmethod
     def validate_session_recording_trigger_match_type_config(value) -> Literal["all", "any"] | None:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from parameterized import parameterized
 from rest_framework import status, test
 
+from posthog.api.project import ProjectBackwardCompatSerializer
 from posthog.api.team import (
     TEAM_CONFIG_FIELDS_SET,
     TEAM_CONFIG_MEMBER_FIELDS_SET,
@@ -3518,10 +3519,33 @@ class TestTeamSerializerValidationNoDB(SimpleTestCase):
                 {"wat": "wat"},
                 "Must provide a dictionary with only 'id' and 'key' keys. _or_ only 'id', 'key', and 'variant' keys.",
             ],
+            ["non-numeric string id", {"id": "abc", "key": "flag-key"}, "Must provide an integer 'id'."],
+            ["float id", {"id": 12.5, "key": "flag-key"}, "Must provide an integer 'id'."],
+            ["null id", {"id": None, "key": None}, "Must provide an integer 'id'."],
+            ["boolean id", {"id": True, "key": "flag-key"}, "Must provide an integer 'id'."],
         ]
     )
     def test_invalid_session_recording_linked_flag(self, _name: str, value: Any, expected_detail: str) -> None:
         self._assert_field_error("session_recording_linked_flag", value, "invalid", expected_detail)
+
+    # Object-level validate() needs self.context["view"], so a value that passes field validation
+    # can't go through is_valid() here. The static validator is the shared entry point anyway:
+    # ProjectBackwardCompatSerializer.validate_session_recording_linked_flag delegates straight to it.
+    @parameterized.expand(
+        [
+            ["none", None, None],
+            ["integer id", {"id": 123, "key": "flag-key"}, {"id": 123, "key": "flag-key"}],
+            ["numeric string id", {"id": "123", "key": "flag-key"}, {"id": 123, "key": "flag-key"}],
+            [
+                "variant survives normalization",
+                {"id": "123", "key": "flag-key", "variant": "test"},
+                {"id": 123, "key": "flag-key", "variant": "test"},
+            ],
+        ]
+    )
+    def test_valid_session_recording_linked_flag(self, _name: str, value: dict | None, expected: dict | None) -> None:
+        assert TeamSerializer.validate_session_recording_linked_flag(value) == expected
+        assert ProjectBackwardCompatSerializer.validate_session_recording_linked_flag(value) == expected
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

`Team.session_recording_linked_flag` is a JSONField that accepted any JSON, including a stringified id.

jsonb containment is type sensitive, so a row holding `{"id": "123"}` does not match a `session_recording_linked_flag__contains={"id": 123}` lookup. That lookup is what stops you deleting a feature flag replay depends on. With a string id the guard misses the row, so the flag deletes cleanly while the team keeps advertising the flag key to SDKs. Both the browser and React Native SDKs treat a linked flag they can't resolve as "do not record", so recording stops with nothing logged and no error surfaced to the team.

The same containment lookup backs the `is_used_in_replay_settings` field, and it's the lookup used to keep the stored key in step when a flag is renamed. Storing an integer is a prerequisite for any of those to see the affected rows.

## Changes

`TeamSerializer.validate_session_recording_linked_flag` now normalizes the id to an int instead of storing whatever arrived. A numeric string is coerced rather than rejected, which is what `serializers.IntegerField` does everywhere else in the API, so a client sending `{"id": "123"}` keeps working and stores a row that the delete guard can actually see.

Bools and floats are rejected. `isinstance(True, int)` is true in Python, so `{"id": true}` would otherwise link flag 1, and `int(12.5)` is 12, so a float would silently link a real but wrong flag.

`ProjectBackwardCompatSerializer` delegates to the same static method, so both API surfaces are covered by the one change.

The UI never sent a string here. `FlagSelector` types its `onChange` as `(id: number, key: string)` and the value originates from the flags API, where Django emits an integer. The affected rows came from direct API clients, which is also why coercing beats rejecting: those clients are currently getting a 200 and a broken row, and this turns that into a 200 and a correct one.

This only fixes new writes. Rows already holding a bad id need a repair pass, which I'm keeping separate.

## How did you test this code?

Automated tests only, no manual run against a live project.

`TestTeamSerializerValidationNoDB` covers the normalization and the rejections as parameterized cases:

- `numeric string id` asserts `{"id": "123"}` comes back as `{"id": 123}`. This is the case the PR exists for, and it fails if anyone reverts to storing the input as-is.
- `variant survives normalization` guards rebuilding the dict field by field instead of spreading it, which would silently drop `variant` and change which sessions get recorded.
- `float id` and `boolean id` guard the two coercions that produce a real but wrong flag id rather than an error.
- `non-numeric string id` is the only case exercising the `ValueError` branch, so it fails if the `try` is refactored away.

The valid cases assert through both `TeamSerializer` and `ProjectBackwardCompatSerializer`, pinning the delegation so the project surface can't drift onto its own copy of the rules.

```
hogli test posthog/api/test/test_team.py -k session_recording_linked_flag
21 passed
```

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed. The field's shape reaches the frontend through the generated API schema, which regenerates from the serializer.