### PR TITLE
fix(surveys): sanitize newlines in HogQL comment to prevent query parse failure on non-ASCII characters (Fixes #75804)

### DIFF
--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -993,7 +993,13 @@ export function getExpressionCommentForQuestion(
     questionIndex: number
 ): string {
     if (q.question.trim().length > 0) {
-        return q.question
+        // Sanitize the question text for use as a HogQL single-line comment.
+        // HogQL comments end at the first newline, so any embedded newlines
+        // would break the query and cause "unexpected character" parse errors
+        // on non-ASCII characters (e.g. é, á, ó, ú) that appear after the
+        // newline. Replace newlines with spaces to keep the comment on one line.
+        return q.question.replaceAll(/[
+]+/g, ' ').trim()
     }
     return `Question ${questionIndex + 1}`
 }


### PR DESCRIPTION
## Summary

The survey responses tab fails with an "unexpected character 'é' (U+00E9)" error when survey questions contain non-ASCII characters (e.g. Spanish accented letters like á, é, í, ó, ú).

## Root cause

`getExpressionCommentForQuestion` in `frontend/src/scenes/surveys/utils.ts` returns the raw question text for use as a HogQL single-line comment (`--`). When a question contains embedded newlines (common in multi-line question text), the HogQL comment ends at the first newline, and the remaining text is parsed as HogQL code. Non-ASCII characters in that text produce the "unexpected character" error.

## Fix

Sanitize the question text by replacing newlines with spaces before using it as a HogQL comment. This keeps the comment on a single line as required by the HogQL `SINGLE_LINE_COMMENT` lexer rule.

## Related issue

Fixes #75804