### PR TITLE
chore(desktop): rename release label to create desktop release

### DIFF
--- a/.github/workflows/desktop-tag.yml
+++ b/.github/workflows/desktop-tag.yml
@@ -26,7 +26,7 @@ jobs:
             github.event_name == 'schedule' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event.pull_request.merged == true &&
-             contains(github.event.pull_request.labels.*.name, 'Create release'))
+             contains(github.event.pull_request.labels.*.name, 'create desktop release'))
         permissions:
             contents: write
             actions: write
@@ -67,11 +67,11 @@ jobs:
                   }
 
                   LABELER=$(gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/events" --paginate \
-                    --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create release") | "\(.id) \(.actor.login)"' \
+                    --jq '.[] | select(.event == "labeled" and (.label.name | ascii_downcase) == "create desktop release") | "\(.id) \(.actor.login)"' \
                     | sort -n | tail -1 | cut -d" " -f2)
 
                   if [ -z "$LABELER" ]; then
-                    skip "Could not determine who added the 'Create release' label."
+                    skip "Could not determine who added the 'create desktop release' label."
                     exit 0
                   fi
 
@@ -81,10 +81,10 @@ jobs:
                   fi
 
                   if echo "$MEMBERS" | grep -qixF "$LABELER"; then
-                    echo "'Create release' was added by ${LABELER}, a member of ${TEAM_SLUG}."
+                    echo "'create desktop release' was added by ${LABELER}, a member of ${TEAM_SLUG}."
                     echo "authorized=true" >> "$GITHUB_OUTPUT"
                   else
-                    skip "'Create release' was added by @${LABELER}, who is not on ${TEAM_SLUG}."
+                    skip "'create desktop release' was added by @${LABELER}, who is not on ${TEAM_SLUG}."
                   fi
 
             - name: Check quiet period

--- a/products/desktop/apps/code/README.md
+++ b/products/desktop/apps/code/README.md
@@ -73,7 +73,7 @@ PostHog auto-updates on macOS and Windows. Current builds use `electron-updater`
 There are three ways a release can fire:
 
 1. **Scheduled (default)** — automatic at 17:00 and 01:00 UTC.
-2. **Hotfix** — add the `Create release` label to a PR before it merges. On merge, the tag workflow runs immediately and ships whatever is on `main`.
+2. **Hotfix** — add the `create desktop release` label to a PR before it merges. On merge, the tag workflow runs immediately and ships whatever is on `master`.
 3. **Manual** — run `Tag PostHog Release` via `workflow_dispatch` from the Actions tab.
 
 Local prep (only needed for one-off manual builds):


### PR DESCRIPTION
## Problem

The desktop app reused a generic `create release` label to trigger an auto-release on PR merge. In the monorepo that name is ambiguous next to other products and the `release-*` cherry-pick labels, and it doesn't say what it releases.

## Changes

- Renamed the label to `create desktop release` in `desktop-tag.yml` (trigger check, labeler audit query and its log/comment strings). Also normalized the casing to match the actual label, which the old workflow only matched because GitHub expression comparisons are case-insensitive.
- Renamed the GitHub label itself in place, so any already-labeled PRs keep it.
- Updated the mention in `products/desktop/apps/code/README.md`, plus fixed its stale reference to `main` (now `master`).

> [!NOTE]
> Until this merges, the workflow on master still checks the old name while the live label already has the new one. A PR labeled and merged in that window won't auto-release and just falls back to the twice-daily scheduled release.

## How did you test this code?

`bin/hogli lint:workflows` and `actionlint` pass locally. No automated tests apply, this is a string rename in a workflow trigger plus docs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A, the only doc mentioning the label is the README updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable). Skills invoked: /authoring-ci-workflows. We picked `create desktop release` over `desktop release` to keep the trigger-verb semantics (adding the label performs an action, like `automerge`), and renamed the existing label in place rather than creating a new one so labeled PRs carry over.
