### PR TITLE
feat(experiments): highlight the full row of significant variants

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5895,7 +5895,7 @@ snapshots:
     scenes-app-experiments--experiment-frequentist-five-variants--light:
         hash: v1.k794b7964.ca65930ed4fba58aa886be84c0489a0702ef118abac3516ed530db42a772ad71.fp95LwvCUvwV1spa0Back9q7nUlZVypBoc4UMXJh9qc
     scenes-app-experiments--experiment-frequentist-two-variants--dark:
-        hash: v1.k794b7964.fbf1df2e60a7a9bf7aaadb8a463b4bffb7bcc3ac1fda3526d3354c5224b6d9ae.GAeCKzstYDp9qrQI3OU-83C-NDDTM__YuSgKBZxRK64
+        hash: v1.k794b7964.045c33562841fedac0650c2b70ad4fda3b5bac5a2f43fc01310759ba3347a24f.ZwvpM3E6g3mcUx0ZrbltZHnAWoaSX7wlgu79kfGkRb8
     scenes-app-experiments--experiment-frequentist-two-variants--light:
         hash: v1.k794b7964.b349b1f26f7d80b19b9772a0b011dfb52f23470ad04cf37b051ee3ff4ad9fdda.b7dOvKFXgBwnaUoLtGjiaVaT6ai_j3-UXDxx3IRcOzw
     scenes-app-experiments--experiment-with-funnel-metric--dark:

--- a/frontend/src/scenes/experiments/MetricsView/hooks/useColumnWidthSync.ts
+++ b/frontend/src/scenes/experiments/MetricsView/hooks/useColumnWidthSync.ts
@@ -9,7 +9,7 @@ interface UseColumnWidthSyncParams {
 
 // Constants for table structure validation
 const BASELINE_ROW_CELL_COUNT = 7
-const VARIANT_ROW_CELL_COUNT = 5
+const VARIANT_ROW_CELL_COUNT = 6
 const EXPECTED_COLUMN_COUNT = 7
 const WIDTH_COMPARISON_TOLERANCE = 0.5 // Tolerance for sub-pixel rendering differences
 
@@ -33,11 +33,8 @@ const getParentColumnIndex = (cellIndex: number, cellCount: number): number | nu
     }
 
     if (cellCount === VARIANT_ROW_CELL_COUNT) {
-        // Variant row: skip breakdown label (col 0) and details (col 5)
-        if (cellIndex < 4) {
-            return cellIndex + 1 // Columns 1-4
-        }
-        return cellIndex + 2 // Column 6 (chart)
+        // Variant row: skip breakdown label (col 0), then map 1:1 to columns 1-6
+        return cellIndex + 1
     }
 
     return null

--- a/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/ChartCell.tsx
@@ -44,6 +44,8 @@ interface ChartCellProps {
     onTimeseriesClick?: () => void
     /** Extra suffix to disambiguate SVG gradient IDs (e.g. breakdown value) */
     gradientSuffix?: string
+    /** Row-level tint for significant results; replaces the alternating background */
+    highlightBackgroundColor?: string
 }
 
 export function ChartCell({
@@ -57,6 +59,7 @@ export function ChartCell({
     isSecondary = false,
     onTimeseriesClick,
     gradientSuffix,
+    highlightBackgroundColor,
 }: ChartCellProps): JSX.Element {
     const colors = useChartColors()
     const scale = useAxisScale(axisRange, VIEW_BOX_WIDTH, SVG_EDGE_MARGIN)
@@ -94,7 +97,12 @@ export function ChartCell({
             className={`p-0 align-top text-center relative overflow-hidden ${
                 isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
             } ${isLastRow ? 'border-b' : ''}`}
-            style={CHART_CELL_HEIGHT_STYLE}
+            style={{
+                ...CHART_CELL_HEIGHT_STYLE,
+                backgroundImage: highlightBackgroundColor
+                    ? `linear-gradient(${highlightBackgroundColor}, ${highlightBackgroundColor})`
+                    : undefined,
+            }}
         >
             <div className="relative h-full">
                 <svg

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -1103,7 +1103,7 @@ export function MetricRowGroup({
                         {/* Variant name */}
                         <td
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
-                                significant ? '' : isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                                isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
@@ -1113,7 +1113,7 @@ export function MetricRowGroup({
                         {/* Value */}
                         <td
                             className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
-                                significant ? '' : isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                                isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
@@ -1126,7 +1126,7 @@ export function MetricRowGroup({
                         {/* Delta */}
                         <td
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
-                                significant ? '' : isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                                isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
                             style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -61,6 +61,8 @@ import {
     CHART_CELL_VIEW_BOX_HEIGHT,
     EMPTY_STATE_ROW_MIN_HEIGHT,
     GRID_LINES_OPACITY,
+    SIGNIFICANT_CELL_BG_ALPHA,
+    SIGNIFICANT_ROW_BG_ALPHA,
     SVG_EDGE_MARGIN,
     VIEW_BOX_WIDTH,
 } from './constants'
@@ -314,11 +316,10 @@ function CollapsibleBreakdownSection({
                                                                     <div />
                                                                 </td>
 
-                                                                {/* Empty Details column for alignment */}
+                                                                {/* Empty Details column for alignment (per-row; variant rows render their own) */}
                                                                 <td
-                                                                    className={`w-20 pt-3 align-top relative overflow-hidden border-b ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                                                                    rowSpan={totalRows}
-                                                                    style={totalRowsHeightStyle}
+                                                                    className={`w-20 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
+                                                                    style={FIXED_HEIGHT_STYLE}
                                                                 />
 
                                                                 <td
@@ -366,6 +367,14 @@ function CollapsibleBreakdownSection({
                                                                     const deltaPositive = isDeltaPositive(variant)
                                                                     const winning = isWinning(variant, metric.goal)
                                                                     const deltaText = formatDeltaPercent(variant)
+                                                                    const rowBackgroundColor = significant
+                                                                        ? winning
+                                                                            ? `${colors.BAR_POSITIVE}${SIGNIFICANT_ROW_BG_ALPHA}`
+                                                                            : `${colors.BAR_NEGATIVE}${SIGNIFICANT_ROW_BG_ALPHA}`
+                                                                        : undefined
+                                                                    const rowBackgroundImage = rowBackgroundColor
+                                                                        ? `linear-gradient(${rowBackgroundColor}, ${rowBackgroundColor})`
+                                                                        : undefined
 
                                                                     return (
                                                                         <tr
@@ -382,14 +391,20 @@ function CollapsibleBreakdownSection({
                                                                         >
                                                                             <td
                                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
-                                                                                style={FIXED_HEIGHT_STYLE}
+                                                                                style={{
+                                                                                    ...FIXED_HEIGHT_STYLE,
+                                                                                    backgroundImage: rowBackgroundImage,
+                                                                                }}
                                                                             >
                                                                                 <VariantTag variantKey={variant.key} />
                                                                             </td>
 
                                                                             <td
                                                                                 className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
-                                                                                style={FIXED_HEIGHT_STYLE}
+                                                                                style={{
+                                                                                    ...FIXED_HEIGHT_STYLE,
+                                                                                    backgroundImage: rowBackgroundImage,
+                                                                                }}
                                                                             >
                                                                                 <div className="metric-cell">
                                                                                     <div>
@@ -404,7 +419,10 @@ function CollapsibleBreakdownSection({
 
                                                                             <td
                                                                                 className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
-                                                                                style={FIXED_HEIGHT_STYLE}
+                                                                                style={{
+                                                                                    ...FIXED_HEIGHT_STYLE,
+                                                                                    backgroundImage: rowBackgroundImage,
+                                                                                }}
                                                                             >
                                                                                 <div className="flex items-center gap-1">
                                                                                     <span
@@ -443,8 +461,8 @@ function CollapsibleBreakdownSection({
                                                                                     ...FIXED_HEIGHT_STYLE,
                                                                                     backgroundColor: significant
                                                                                         ? winning
-                                                                                            ? `${colors.BAR_POSITIVE}30`
-                                                                                            : `${colors.BAR_NEGATIVE}30`
+                                                                                            ? `${colors.BAR_POSITIVE}${SIGNIFICANT_CELL_BG_ALPHA}`
+                                                                                            : `${colors.BAR_NEGATIVE}${SIGNIFICANT_CELL_BG_ALPHA}`
                                                                                         : undefined,
                                                                                 }}
                                                                             >
@@ -460,6 +478,15 @@ function CollapsibleBreakdownSection({
                                                                                 </span>
                                                                             </td>
 
+                                                                            {/* Details (empty, for alignment) */}
+                                                                            <td
+                                                                                className={`w-20 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${isLastRow ? 'border-b' : ''}`}
+                                                                                style={{
+                                                                                    ...FIXED_HEIGHT_STYLE,
+                                                                                    backgroundImage: rowBackgroundImage,
+                                                                                }}
+                                                                            />
+
                                                                             <ChartCell
                                                                                 variantResult={variant}
                                                                                 metric={metric}
@@ -471,6 +498,9 @@ function CollapsibleBreakdownSection({
                                                                                 gradientSuffix={String(
                                                                                     breakdownResult.breakdown_value
                                                                                 )}
+                                                                                highlightBackgroundColor={
+                                                                                    rowBackgroundColor
+                                                                                }
                                                                             />
                                                                         </tr>
                                                                     )
@@ -989,13 +1019,12 @@ export function MetricRowGroup({
                     <div />
                 </td>
 
-                {/* Details column - with rowspan */}
+                {/* Details column (per-row cells so significant-row tints align pixel-perfectly; variant rows render their own) */}
                 <td
                     className={`w-20 pt-3 align-top relative overflow-hidden ${
-                        !isLastMetric ? 'border-b' : ''
-                    } ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
-                    rowSpan={variantResults.length + 1}
-                    style={totalRowsHeightStyle}
+                        isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                    } ${variantResults.length === 0 ? 'border-b' : ''}`}
+                    style={FIXED_HEIGHT_STYLE}
                 >
                     {showDetailsModal && (
                         <>
@@ -1053,6 +1082,14 @@ export function MetricRowGroup({
                 const deltaPositive = isDeltaPositive(variant)
                 const winning = isWinning(variant, metric.goal)
                 const deltaText = formatDeltaPercent(variant)
+                const rowBackgroundColor = significant
+                    ? winning
+                        ? `${colors.BAR_POSITIVE}${SIGNIFICANT_ROW_BG_ALPHA}`
+                        : `${colors.BAR_NEGATIVE}${SIGNIFICANT_ROW_BG_ALPHA}`
+                    : undefined
+                const rowBackgroundImage = rowBackgroundColor
+                    ? `linear-gradient(${rowBackgroundColor}, ${rowBackgroundColor})`
+                    : undefined
 
                 return (
                     <tr
@@ -1066,9 +1103,9 @@ export function MetricRowGroup({
                         {/* Variant name */}
                         <td
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
-                                isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                                significant ? '' : isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
-                            style={FIXED_HEIGHT_STYLE}
+                            style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
                             <VariantTag variantKey={variant.key} />
                         </td>
@@ -1076,9 +1113,9 @@ export function MetricRowGroup({
                         {/* Value */}
                         <td
                             className={`w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
-                                isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                                significant ? '' : isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
-                            style={FIXED_HEIGHT_STYLE}
+                            style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
                             <div className="metric-cell">
                                 <div>{formatMetricValue(variant, metric)}</div>
@@ -1089,9 +1126,9 @@ export function MetricRowGroup({
                         {/* Delta */}
                         <td
                             className={`w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden ${
-                                isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+                                significant ? '' : isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
                             } ${isLastRow ? 'border-b' : ''}`}
-                            style={FIXED_HEIGHT_STYLE}
+                            style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
                         >
                             <div className="flex items-center gap-1">
                                 <span
@@ -1120,8 +1157,8 @@ export function MetricRowGroup({
                                 ...FIXED_HEIGHT_STYLE,
                                 backgroundColor: significant
                                     ? winning
-                                        ? `${colors.BAR_POSITIVE}30`
-                                        : `${colors.BAR_NEGATIVE}30`
+                                        ? `${colors.BAR_POSITIVE}${SIGNIFICANT_CELL_BG_ALPHA}`
+                                        : `${colors.BAR_NEGATIVE}${SIGNIFICANT_CELL_BG_ALPHA}`
                                     : undefined,
                             }}
                         >
@@ -1134,6 +1171,14 @@ export function MetricRowGroup({
                             </span>
                         </td>
 
+                        {/* Details (button lives in the baseline row's cell) */}
+                        <td
+                            className={`w-20 ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
+                                isLastRow ? 'border-b' : ''
+                            }`}
+                            style={{ ...FIXED_HEIGHT_STYLE, backgroundImage: rowBackgroundImage }}
+                        />
+
                         {/* Chart */}
                         <ChartCell
                             variantResult={variant}
@@ -1144,6 +1189,7 @@ export function MetricRowGroup({
                             isLastRow={isLastRow}
                             isSecondary={isSecondary}
                             onTimeseriesClick={() => handleTimeseriesClick(variant)}
+                            highlightBackgroundColor={rowBackgroundColor}
                         />
                     </tr>
                 )

--- a/frontend/src/scenes/experiments/MetricsView/new/constants.ts
+++ b/frontend/src/scenes/experiments/MetricsView/new/constants.ts
@@ -10,6 +10,11 @@ export const EMPTY_STATE_ROW_MIN_HEIGHT = 80
 export const CHART_BAR_OPACITY = 0.9
 export const GRID_LINES_OPACITY = 0.8
 
+// Significant-result highlight: hex alpha suffixes appended to BAR_POSITIVE / BAR_NEGATIVE.
+// The row tint must stay dimmer than the win probability / p-value cell so that cell still stands out.
+export const SIGNIFICANT_CELL_BG_ALPHA = '30'
+export const SIGNIFICANT_ROW_BG_ALPHA = '14'
+
 // Axis
 export const TICK_PANEL_HEIGHT = 20
 export const TICK_FONT_SIZE = 9


### PR DESCRIPTION
## Problem

In the experiment results table, only the win probability / p-value cell gets a colored background when a variant reaches significance. I saw a competitor tint the entire variant row and think it highlights variant significance much better.

## Changes

Significant variant rows now get a dimmed green/red tint across all cells (variant, value, delta, details, and the interval bar chart). The win probability / p-value cell keeps its stronger highlight on top.

<img width="1239" height="355" alt="image" src="https://github.com/user-attachments/assets/75629f96-7fa4-4044-9dec-9deca6623664" />

<img width="1239" height="355" alt="image" src="https://github.com/user-attachments/assets/aca20c38-13ea-438a-ac27-a1a46a2e6fa2" />


Implementation notes:

- The tint is layered as a `linear-gradient` background image over each cell's existing background class, so it composites identically everywhere (a plain `backgroundColor` replaced the base class and produced visible shade mismatches between columns).
- The details column was one tall `rowSpan` cell per metric group, which can't take a per-row background. It's now a regular per-row cell, with the details button staying in the baseline row. This also required updating `useColumnWidthSync`'s cell-count mapping for nested breakdown tables (variant rows went from 5 to 6 cells).

## How did you test this code?

Verified manually in the local app: row tints align pixel-perfectly across metric groups (an earlier absolute-positioning approach drifted 1px on some rows due to `border-collapse` row-height rounding), details button unaffected, win% cell unchanged. Ran frontend typecheck and lint. No tests added - purely visual change.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by me throughout. Notable decisions along the way: an initial version painted the row tint with `backgroundColor` while dropping the cells' background classes, which composited over the page background and made columns visibly mismatched - replaced with gradient layering. A second iteration rendered the details-column highlight as absolutely positioned bands inside the `rowSpan` cell at fixed 51px offsets; that drifted 1px against real row heights under `border-collapse` rounding, so the column was restructured to per-row cells. A variant where the win% cell matched the interval bar's solid fill was tried and rejected as too heavy.
