### PR TITLE
fix(ui): add scrollable code block for long command approval content (Fixes #76233)

### DIFF
--- a/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
+++ b/products/desktop/packages/ui/src/primitives/CodeBlock.tsx
@@ -49,7 +49,7 @@ export function CodeBlock({
   return (
     <div className="group relative">
       <pre
-        className={`m-0 mb-3 overflow-x-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
+        className={`m-0 mb-3 max-h-[50vh] overflow-x-auto overflow-y-auto whitespace-pre rounded-(--radius-2) border border-(--gray-6) bg-(--gray-3) p-3 pr-10 font-[var(--code-font-family)] text-(--gray-12) ${sizeClass}`}
       >
         {children}
       </pre>


### PR DESCRIPTION
## Description

When a command approval has long arguments (e.g., a large JSON payload), the `CodeBlock` component's `<pre>` element grows without bound, causing the entire bottom container to overflow instead of the code block itself being scrollable.

## Changes

Added `max-h-[50vh]` and `overflow-y-auto` to the `CodeBlock` component's `<pre>` element so that long content scrolls inside the code block rather than overflowing the container.

## Screenshots

Before: Long command args overflow the bottom container
After: Code block is independently scrollable

Fixes #76233