### PR TITLE
fix(desktop): generate release notes from monorepo tags

### DIFF
--- a/.github/scripts/desktop/generate-release-notes.mjs
+++ b/.github/scripts/desktop/generate-release-notes.mjs
@@ -1,0 +1,118 @@
+import { execFileSync } from "node:child_process";
+
+const REPOSITORY = "PostHog/posthog";
+const DESKTOP_LABEL = "feature/desktop";
+const DESKTOP_PATH = "products/desktop/";
+
+export function selectReleaseChanges(commits, pullRequests) {
+    return commits.filter((commit) => {
+        if (commit.files.some((file) => file.startsWith(DESKTOP_PATH))) {
+            return true;
+        }
+        const pullRequest = pullRequests.get(commit.pullRequestNumber);
+        return pullRequest?.labels.includes(DESKTOP_LABEL) ?? false;
+    });
+}
+
+export function renderReleaseNotes(previousTag, currentTag, commits, pullRequests) {
+    const lines = ["## What's Changed"];
+    for (const commit of selectReleaseChanges(commits, pullRequests)) {
+        const pullRequest = pullRequests.get(commit.pullRequestNumber);
+        if (pullRequest) {
+            lines.push(`* ${pullRequest.title} by @${pullRequest.author} in ${pullRequest.url}`);
+        } else {
+            lines.push(`* ${commit.subject} ([commit](https://github.com/${REPOSITORY}/commit/${commit.sha}))`);
+        }
+    }
+    lines.push(
+        "",
+        `**Full Changelog**: https://github.com/${REPOSITORY}/compare/${previousTag}...${currentTag}`,
+    );
+    return `${lines.join("\n")}\n`;
+}
+
+function git(...args) {
+    return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function readCommits(previousTag, currentTag) {
+    const log = git("log", "--format=%H%x09%s", `${previousTag}..${currentTag}`);
+    if (!log) return [];
+    return log.split("\n").map((line) => {
+        const tab = line.indexOf("\t");
+        const sha = line.slice(0, tab);
+        const subject = line.slice(tab + 1);
+        const match = subject.match(/\(#(\d+)\)$/);
+        const files = git("diff-tree", "--no-commit-id", "--name-only", "-r", sha)
+            .split("\n")
+            .filter(Boolean);
+        return {
+            sha,
+            subject,
+            files,
+            pullRequestNumber: match ? Number(match[1]) : null,
+        };
+    });
+}
+
+async function readPullRequests(numbers) {
+    const pullRequests = new Map();
+    for (let index = 0; index < numbers.length; index += 50) {
+        const chunk = numbers.slice(index, index + 50);
+        const fields = chunk
+            .map(
+                (number) => `pr${number}: pullRequest(number: ${number}) {
+                    title url author { login } labels(first: 100) { nodes { name } }
+                }`,
+            )
+            .join("\n");
+        const response = await fetch("https://api.github.com/graphql", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${process.env.GH_TOKEN}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ query: `query { repository(owner: "PostHog", name: "posthog") { ${fields} } }` }),
+        });
+        if (!response.ok) throw new Error(`GitHub GraphQL request failed: ${response.status}`);
+        const payload = await response.json();
+        if (payload.errors) throw new Error(`GitHub GraphQL request failed: ${JSON.stringify(payload.errors)}`);
+        for (const number of chunk) {
+            const pullRequest = payload.data.repository[`pr${number}`];
+            if (!pullRequest) continue;
+            pullRequests.set(number, {
+                title: pullRequest.title,
+                url: pullRequest.url,
+                author: pullRequest.author?.login ?? "ghost",
+                labels: pullRequest.labels.nodes.map((label) => label.name),
+            });
+        }
+    }
+    return pullRequests;
+}
+
+async function main() {
+    const currentTag = process.argv[2];
+    if (!currentTag) throw new Error("Usage: generate-release-notes.mjs <desktop-tag>");
+    if (!process.env.GH_TOKEN) throw new Error("GH_TOKEN is required");
+
+    const previousTag = git(
+        "describe",
+        "--tags",
+        "--match",
+        "desktop-v*",
+        "--abbrev=0",
+        `${currentTag}^`,
+    );
+    const commits = readCommits(previousTag, currentTag);
+    const numbers = [...new Set(commits.map((commit) => commit.pullRequestNumber).filter(Boolean))];
+    const pullRequests = await readPullRequests(numbers);
+    process.stdout.write(renderReleaseNotes(previousTag, currentTag, commits, pullRequests));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main().catch((error) => {
+        console.error(error.message);
+        process.exit(1);
+    });
+}

--- a/.github/scripts/desktop/generate-release-notes.test.mjs
+++ b/.github/scripts/desktop/generate-release-notes.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { renderReleaseNotes, selectReleaseChanges } from "./generate-release-notes.mjs";
+
+const commits = [
+    { sha: "desktop", subject: "fix: desktop", files: ["products/desktop/app.ts"], pullRequestNumber: 1 },
+    { sha: "backend", subject: "feat: backend", files: ["posthog/api.py"], pullRequestNumber: 2 },
+    { sha: "other", subject: "feat: other", files: ["frontend/index.ts"], pullRequestNumber: 3 },
+];
+const pullRequests = new Map([
+    [1, { title: "fix: desktop", author: "one", url: "https://example.test/1", labels: [] }],
+    [2, { title: "feat: backend", author: "two", url: "https://example.test/2", labels: ["feature/desktop"] }],
+    [3, { title: "feat: other", author: "three", url: "https://example.test/3", labels: [] }],
+]);
+
+describe("selectReleaseChanges", () => {
+    it("includes desktop paths and feature/desktop labels", () => {
+        assert.deepEqual(selectReleaseChanges(commits, pullRequests).map(({ sha }) => sha), ["desktop", "backend"]);
+    });
+});
+
+describe("renderReleaseNotes", () => {
+    it("renders only selected pull requests and the monorepo comparison", () => {
+        const notes = renderReleaseNotes("desktop-v1", "desktop-v2", commits, pullRequests);
+        assert.match(notes, /fix: desktop by @one/);
+        assert.match(notes, /feat: backend by @two/);
+        assert.doesNotMatch(notes, /feat: other/);
+        assert.match(notes, /PostHog\/posthog\/compare\/desktop-v1\.\.\.desktop-v2/);
+    });
+});

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -666,6 +666,8 @@ jobs:
             - name: Checkout release scripts
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
+                  fetch-depth: 0
+                  filter: blob:none
                   sparse-checkout: |
                       products/desktop/apps/code/scripts/merge-mac-manifests.mjs
                       products/desktop/apps/code/scripts/generate-release-download-tables.mjs
@@ -720,7 +722,34 @@ jobs:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   APP_VERSION: ${{ steps.version.outputs.version }}
               run: |
-                  gh api repos/PostHog/code/releases/generate-notes -f tag_name="v$APP_VERSION" --jq '.body' > /tmp/release-notes.md
+                  CURRENT_TAG="desktop-v$APP_VERSION"
+                  PREVIOUS_TAG=$(git tag --merged "$CURRENT_TAG" --list 'desktop-v*' --sort=-v:refname \
+                    | grep -Fxv "$CURRENT_TAG" | head -1)
+
+                  if [ -z "$PREVIOUS_TAG" ]; then
+                    echo "No previous desktop release tag found for $CURRENT_TAG"
+                    exit 1
+                  fi
+
+                  echo "## What's Changed" > /tmp/release-notes.md
+                  while IFS=$'\t' read -r SHA SUBJECT; do
+                    if [[ "$SUBJECT" =~ ^(.*)\ \(#([0-9]+)\)$ ]]; then
+                      TITLE="${BASH_REMATCH[1]}"
+                      PR_NUMBER="${BASH_REMATCH[2]}"
+                      AUTHOR=$(gh api "repos/PostHog/posthog/pulls/$PR_NUMBER" --jq '.user.login' 2>/dev/null || true)
+                      if [ -n "$AUTHOR" ]; then
+                        printf '* %s by @%s in https://github.com/PostHog/posthog/pull/%s\n' \
+                          "$TITLE" "$AUTHOR" "$PR_NUMBER" >> /tmp/release-notes.md
+                        continue
+                      fi
+                    fi
+                    printf '* %s ([commit](https://github.com/PostHog/posthog/commit/%s))\n' \
+                      "$SUBJECT" "$SHA" >> /tmp/release-notes.md
+                  done < <(git log --format=$'%H\t%s' "$PREVIOUS_TAG..$CURRENT_TAG" -- products/desktop/)
+
+                  printf '\n' >> /tmp/release-notes.md
+                  printf '**Full Changelog**: https://github.com/PostHog/posthog/compare/%s...%s\n' \
+                    "$PREVIOUS_TAG" "$CURRENT_TAG" >> /tmp/release-notes.md
                   printf '\n' >> /tmp/release-notes.md
                   node products/desktop/apps/code/scripts/generate-release-download-tables.mjs "$APP_VERSION" /tmp/checksums >> /tmp/release-notes.md
                   gh release edit "v$APP_VERSION" --repo PostHog/code --draft=false --notes-file /tmp/release-notes.md

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -673,6 +673,7 @@ jobs:
                       products/desktop/apps/code/scripts/generate-release-download-tables.mjs
                       products/desktop/apps/code/scripts/build-releases-feed.mjs
                       products/desktop/apps/code/scripts/inject-release-notes.mjs
+                      .github/scripts/desktop/generate-release-notes.mjs
                   sparse-checkout-cone-mode: false
 
             - name: Setup Node.js
@@ -723,34 +724,7 @@ jobs:
                   APP_VERSION: ${{ steps.version.outputs.version }}
               run: |
                   CURRENT_TAG="desktop-v$APP_VERSION"
-                  PREVIOUS_TAG=$(git tag --merged "$CURRENT_TAG" --list 'desktop-v*' --sort=-v:refname \
-                    | grep -Fxv "$CURRENT_TAG" | head -1)
-
-                  if [ -z "$PREVIOUS_TAG" ]; then
-                    echo "No previous desktop release tag found for $CURRENT_TAG"
-                    exit 1
-                  fi
-
-                  echo "## What's Changed" > /tmp/release-notes.md
-                  while IFS=$'\t' read -r SHA SUBJECT; do
-                    if [[ "$SUBJECT" =~ ^(.*)\ \(#([0-9]+)\)$ ]]; then
-                      TITLE="${BASH_REMATCH[1]}"
-                      PR_NUMBER="${BASH_REMATCH[2]}"
-                      AUTHOR=$(gh api "repos/PostHog/posthog/pulls/$PR_NUMBER" --jq '.user.login' 2>/dev/null || true)
-                      if [ -n "$AUTHOR" ]; then
-                        printf '* %s by @%s in https://github.com/PostHog/posthog/pull/%s\n' \
-                          "$TITLE" "$AUTHOR" "$PR_NUMBER" >> /tmp/release-notes.md
-                        continue
-                      fi
-                    fi
-                    printf '* %s ([commit](https://github.com/PostHog/posthog/commit/%s))\n' \
-                      "$SUBJECT" "$SHA" >> /tmp/release-notes.md
-                  done < <(git log --format=$'%H\t%s' "$PREVIOUS_TAG..$CURRENT_TAG" -- products/desktop/)
-
-                  printf '\n' >> /tmp/release-notes.md
-                  printf '**Full Changelog**: https://github.com/PostHog/posthog/compare/%s...%s\n' \
-                    "$PREVIOUS_TAG" "$CURRENT_TAG" >> /tmp/release-notes.md
-                  printf '\n' >> /tmp/release-notes.md
+                  node .github/scripts/desktop/generate-release-notes.mjs "$CURRENT_TAG" > /tmp/release-notes.md
                   node products/desktop/apps/code/scripts/generate-release-download-tables.mjs "$APP_VERSION" /tmp/checksums >> /tmp/release-notes.md
                   gh release edit "v$APP_VERSION" --repo PostHog/code --draft=false --notes-file /tmp/release-notes.md
 


### PR DESCRIPTION
## Problem

Desktop releases are built from `desktop-v*` tags in the monorepo, but release notes are generated against tags in the archived repository. Those legacy tags all point at the repository migration commit, so every in-app changelog repeats the migration note.

**Why:** Release notes should describe the desktop-related changes included in each update without pulling in unrelated monorepo work.

```mermaid
flowchart LR
    A[desktop-v tag] --> B[Legacy repository tags]
    B --> C[Repeated migration note]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phRed;
    class C phYellow;
```

## Changes

Generate release notes from commits between consecutive monorepo `desktop-v*` tags. Include a PR when it either changes `products/desktop/**` or carries the `feature/desktop` label, allowing related backend changes to opt in without including unrelated monorepo work.

| | Before | After |
| --- | --- | --- |
| Release source | Archived `PostHog/code` tags | Consecutive monorepo `desktop-v*` tags |
| Included changes | The archived repository migration commit | PRs changing `products/desktop/**` |
| Cross-product changes | Not represented | Included when labeled `feature/desktop` |
| Unrelated monorepo work | Could not be selected correctly | Excluded |
| In-app changelog | Repeated migration note | Actual desktop-related PR titles and links |

```mermaid
flowchart LR
    A[desktop-v tag] --> B{Desktop path or label?}
    B -->|Yes| C[Include change]
    B -->|No| D[Exclude change]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phBlue;
    class B phGray;
    class C phYellow;
    class D phGray;
```

## How did you test this code?

Added Node tests covering inclusion by desktop path, inclusion by `feature/desktop`, and exclusion of unrelated changes. Ran:

- `node --test .github/scripts/desktop/generate-release-notes.test.mjs`
- A live preview for `desktop-v0.60.7...desktop-v0.60.11`, which produced the four expected desktop changes
- `git diff --check`

The repository workflow linter could not run because this fresh checkout has no Python environment.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed. This corrects the existing release workflow behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex diagnosed and implemented this change without invoking a repository skill. The generator combines path-based detection with the existing desktop label so cross-product work can opt in explicitly.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*