### PR TITLE
fix(data-imports): don't re-report transient object-store errors from the idempotency fallback

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/idempotency.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/idempotency.py
@@ -7,6 +7,7 @@ from asgiref.sync import async_to_sync
 
 from posthog.exceptions_capture import capture_exception
 from posthog.redis import get_client
+from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.writer import DeltaWriter
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import DeltaTableHelper
@@ -89,7 +90,11 @@ def is_batch_already_processed(
             batch_index=batch_index,
             error=str(e),
         )
-        capture_exception(e)
+        # get_delta_table already re-raises known-transient object-store blips as
+        # NonReportableError (see delta_table_helper._capture_unless_transient) and
+        # intentionally skips reporting them itself — don't undo that here.
+        if not isinstance(e, NonReportableError):
+            capture_exception(e)
         raise
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_idempotency.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_idempotency.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from parameterized import parameterized
 
+from posthog.temporal.common.errors import NonReportableError
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.idempotency import (
     get_idempotency_key,
     is_batch_already_processed,
@@ -142,6 +144,31 @@ class TestIsBatchAlreadyProcessed:
                 is_batch_already_processed(
                     team_id=1, schema_id="s", run_uuid="r", batch_index=0, delta_table_helper=helper
                 )
+
+    @parameterized.expand(
+        [
+            # (name, error, expect_captured)
+            ("non_transient_error_is_reported", RuntimeError("delta blew up"), True),
+            ("non_reportable_error_is_not_reported", NonReportableError("transient object-store blip"), False),
+        ]
+    )
+    def test_capture_exception_respects_non_reportable_errors(self, _name, error, expect_captured):
+        """get_delta_table already classifies transient object-store blips as NonReportableError
+        and skips reporting them itself; this call site must not undo that by reporting again."""
+        client = _redis_client(0)
+        helper = _delta_helper(error)
+
+        with (
+            patch(REDIS_CLIENT_PATH) as mock_get_client,
+            patch(f"{_IDEMPOTENCY_MODULE}.capture_exception") as mock_capture,
+        ):
+            mock_get_client.return_value.__enter__.return_value = client
+            with pytest.raises(type(error)):
+                is_batch_already_processed(
+                    team_id=1, schema_id="s", run_uuid="r", batch_index=0, delta_table_helper=helper
+                )
+
+        assert mock_capture.called is expect_captured
 
 
 class TestMarkBatchAsProcessed:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `TransientObjectStoreError` ("Generic S3 error … operation timed out") originating from `is_batch_already_processed`'s delta-history fallback in the data-imports pipeline: https://us.posthog.com/project/2/error_tracking/019fcb92-5f2a-7f92-852f-0bd0d83b5a06

Tracing the stack: `is_batch_already_processed` (idempotency.py) calls `DeltaWriter.has_batch_been_committed` → `has_commit_with_metadata` → `get_delta_table`. When the underlying S3 list call for `DeltaTable.is_deltatable()` times out, `get_delta_table`'s `_capture_unless_transient` helper already recognizes this as a known-transient object-store blip and deliberately re-raises it as `TransientObjectStoreError` (a `NonReportableError` subclass) specifically so it's *not* reported to error tracking — a retry clears it, it isn't a defect.

`is_batch_already_processed`'s own `except` block undoes that: it calls `capture_exception(e)` on *any* exception before re-raising, with no check for `NonReportableError`/transient classification. This is the only call site in this pipeline that skips that check — every sibling call site (`delta_table_helper.py`, `common/extract.py`, `common/load.py`, `repartition_table.py`, `import_data_sync.py`) guards its `capture_exception` call the same way. Because this code path runs inside the Temporal activity that drives the whole batch loop, the double-report happens regardless of whether the activity interceptor would otherwise have filtered it.

## Changes

- `idempotency.py`: skip `capture_exception` when the error is a `NonReportableError` (which `TransientObjectStoreError` already is), matching the convention used elsewhere in this pipeline. Genuine (non-transient) errors are still reported and still re-raised either way, so retry behavior is unchanged.

## How did you test this code?

Added a parameterized regression test to `test_idempotency.py`: `test_capture_exception_respects_non_reportable_errors` asserts `capture_exception` is called for an ordinary `RuntimeError` from the delta fallback but *not* called for a `NonReportableError` — this fails if the guard is removed and the unconditional `capture_exception` call comes back.

Ran locally:
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_idempotency.py` — 16 passed
- `ruff check` / `ruff format --check` on the changed files — clean
- `tach check --dependencies --interfaces` — clean
- `uv run mypy --cache-fine-grained .` (repo-wide) — no issues
- `hogli ci:preflight --fix` — 0 failures

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a live error-tracking issue.
- Investigated via PostHog's error-tracking MCP tools (issue detail + event stack trace) to find the exact raise site, then read `delta_table_helper.py`'s `_capture_unless_transient` and `delta/errors.py`'s `TransientObjectStoreError`/`NonReportableError` machinery to understand the intended non-reporting behavior, and confirmed every sibling call site in this pipeline already guards on it — `idempotency.py` was the outlier.
- Ruled out swallowing the error or changing retry behavior — `NonReportableError` only suppresses reporting, Temporal's retry policy for the activity is untouched.
- Searched open PRs (by exception type, module path, and the maintainer's own open PRs) for a duplicate fix; found none touching this file's error-reporting logic.