### PR TITLE
fix(ingestion): retry transient person fetch and group type loads

### DIFF
--- a/nodejs/src/common/groups/group-type-manager.ts
+++ b/nodejs/src/common/groups/group-type-manager.ts
@@ -2,7 +2,7 @@ import { DateTime } from 'luxon'
 
 import { GroupRepository } from '~/common/groups/repositories/group-repository.interface'
 import { timeoutGuard } from '~/common/utils/db/utils'
-import { LazyLoader } from '~/common/utils/lazy-loader'
+import { LazyLoader, LoaderRetryOptions } from '~/common/utils/lazy-loader'
 import { captureTeamEvent } from '~/common/utils/posthog'
 import { TeamManager } from '~/common/utils/team-manager'
 import { GroupTypeIndex, GroupTypeToColumnIndex, GroupTypesByProjectId, ProjectId, Team, TeamId } from '~/types'
@@ -10,17 +10,24 @@ import { GroupTypeIndex, GroupTypeToColumnIndex, GroupTypesByProjectId, ProjectI
 /** How many unique group types to allow per team */
 export const MAX_GROUP_TYPES_PER_TEAM = 5
 
+export interface GroupTypeManagerOptions {
+    /** Retry transient group-type-load failures (e.g. a Postgres pooler blip) instead of letting them propagate. */
+    loaderRetry?: LoaderRetryOptions
+}
+
 export class GroupTypeManager {
     private loader: LazyLoader<GroupTypeToColumnIndex>
 
     constructor(
         private groupRepository: GroupRepository,
-        private teamManager: TeamManager
+        private teamManager: TeamManager,
+        options?: GroupTypeManagerOptions
     ) {
         this.loader = new LazyLoader({
             name: 'GroupTypeManager',
             refreshAgeMs: 30_000, // 30 seconds
             refreshJitterMs: 0,
+            loaderRetry: options?.loaderRetry,
             loader: async (projectIds: string[]) => {
                 const response: Record<string, GroupTypeToColumnIndex> = {}
                 const timeout = timeoutGuard(`Still running "fetchGroupTypes". Timeout warning after 30 sec!`)

--- a/nodejs/src/common/personhog/grpc-retry.test.ts
+++ b/nodejs/src/common/personhog/grpc-retry.test.ts
@@ -64,35 +64,36 @@ describe('withRetry', () => {
         ['Canceled', Code.Canceled],
     ])('does not retry on %s', async (_name, code) => {
         let callCount = 0
-        await expect(
-            withRetry(
-                () => {
-                    callCount++
-                    throw new ConnectError('non-retryable', code)
-                },
-                'test-client',
-                'test-method'
-            )
-        ).rejects.toThrow(ConnectError)
+        const error: unknown = await withRetry(
+            () => {
+                callCount++
+                throw new ConnectError('non-retryable', code)
+            },
+            'test-client',
+            'test-method'
+        ).catch((e: unknown) => e)
+        expect(error).toBeInstanceOf(ConnectError)
+        // Not tagged retriable: outer retry layers must not absorb these.
+        expect(error).not.toHaveProperty('isRetriable')
         expect(callCount).toBe(1)
     })
 
     it('does not retry non-ConnectError errors', async () => {
         let callCount = 0
-        await expect(
-            withRetry(
-                () => {
-                    callCount++
-                    throw new Error('plain error')
-                },
-                'test-client',
-                'test-method'
-            )
-        ).rejects.toThrow('plain error')
+        const error: unknown = await withRetry(
+            () => {
+                callCount++
+                throw new Error('plain error')
+            },
+            'test-client',
+            'test-method'
+        ).catch((e: unknown) => e)
+        expect(error).toBeInstanceOf(Error)
+        expect(error).not.toHaveProperty('isRetriable')
         expect(callCount).toBe(1)
     })
 
-    it('throws after max retries exhausted', async () => {
+    it('throws after max retries exhausted, tagged retriable for outer retry layers', async () => {
         let callCount = 0
         await expect(
             withRetry(
@@ -103,7 +104,7 @@ describe('withRetry', () => {
                 'test-client',
                 'test-method'
             )
-        ).rejects.toThrow(ConnectError)
+        ).rejects.toMatchObject({ code: Code.Unavailable, isRetriable: true })
         // 1 initial + 2 retries = 3 total (default maxRetries=2)
         expect(callCount).toBe(3)
     })

--- a/nodejs/src/common/personhog/grpc-retry.ts
+++ b/nodejs/src/common/personhog/grpc-retry.ts
@@ -13,8 +13,18 @@ const RETRYABLE_CODES = new Set([
     Code.Unknown,
 ])
 
-function isRetryable(error: unknown): boolean {
+function isRetryable(error: unknown): error is ConnectError {
     return error instanceof ConnectError && RETRYABLE_CODES.has(error.code)
+}
+
+/**
+ * Tag a terminal transient error as retriable so outer retry layers (pipeline
+ * chunk retry, LazyLoader loaderRetry) can keep retrying after the client-level
+ * budget here is exhausted. Non-transient errors are left untagged so
+ * unexpected failures surface loudly instead of being absorbed.
+ */
+function tagRetriable(error: ConnectError): ConnectError & { isRetriable: true } {
+    return Object.assign(error, { isRetriable: true as const })
 }
 
 function sleep(ms: number): Promise<void> {
@@ -48,7 +58,7 @@ export async function withRetry<T>(
                 logger.error(`[${client}/${method}] gRPC call failed`, {
                     error: String(error),
                 })
-                throw error
+                throw isRetryable(error) ? tagRetriable(error) : error
             }
             personhogRetriesTotal.inc({ method, client, error_type: grpcErrorType(error) })
             logger.warn(`[${client}/${method}] Retryable gRPC error, retrying`, {

--- a/nodejs/src/ingestion/pipelines/ai/pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ai/pipeline.ts
@@ -178,8 +178,8 @@ export function createAiIngestionPipeline<
             .pipeChunk(createOverflowLaneTTLRefreshStep(overflowLaneTTLRefreshService))
             // Read-only batch person fetch (no person writes). The personhog
             // client retries transient gRPC errors for ~150ms; this outer
-            // retry absorbs longer blips (persons DB failover) that would
-            // otherwise crash the worker via an unhandled rejection.
+            // retry absorbs longer blips that would otherwise crash the
+            // worker via an unhandled rejection.
             .pipeChunk(createFetchPersonChunkStep(personRepository), {
                 retry: { tries: 5, sleepMs: 100, name: 'fetch_person_chunk' },
             })

--- a/nodejs/src/ingestion/pipelines/ai/pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ai/pipeline.ts
@@ -176,8 +176,13 @@ export function createAiIngestionPipeline<
             .pipeChunk(createApplyCookielessProcessingStep(cookielessManager))
             .pipeChunk(createOnlyCookielessRateLimitToOverflowStep(preservePartitionLocality, overflowRedirectService))
             .pipeChunk(createOverflowLaneTTLRefreshStep(overflowLaneTTLRefreshService))
-            // Read-only batch person fetch (no person writes).
-            .pipeChunk(createFetchPersonChunkStep(personRepository))
+            // Read-only batch person fetch (no person writes). The personhog
+            // client retries transient gRPC errors for ~150ms; this outer
+            // retry absorbs longer blips (persons DB failover) that would
+            // otherwise crash the worker via an unhandled rejection.
+            .pipeChunk(createFetchPersonChunkStep(personRepository), {
+                retry: { tries: 5, sleepMs: 100, name: 'fetch_person_chunk' },
+            })
             // Prefetch hog functions for the batch's teams so the transformer
             // honors Hog watcher's disabled-function state (mirrors analytics).
             .pipeChunk(createPrefetchHogFunctionsStep(hogTransformer, cdpHogWatcherSampleRate))

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.ts
@@ -190,8 +190,8 @@ export function createErrorTrackingPipeline(config: ErrorTrackingPipelineConfig)
         afterCymbal
             // Batch fetch person (read-only, no updates). The personhog client
             // retries transient gRPC errors for ~150ms; this outer retry
-            // absorbs longer blips (persons DB failover) that would otherwise
-            // crash the worker via an unhandled rejection.
+            // absorbs longer blips that would otherwise crash the worker via
+            // an unhandled rejection.
             .pipeChunk(createFetchPersonChunkStep(personRepository), {
                 retry: { tries: 5, sleepMs: 100, name: 'fetch_person_chunk' },
             })

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-pipeline.ts
@@ -188,8 +188,13 @@ export function createErrorTrackingPipeline(config: ErrorTrackingPipelineConfig)
 
     return (
         afterCymbal
-            // Batch fetch person (read-only, no updates)
-            .pipeChunk(createFetchPersonChunkStep(personRepository))
+            // Batch fetch person (read-only, no updates). The personhog client
+            // retries transient gRPC errors for ~150ms; this outer retry
+            // absorbs longer blips (persons DB failover) that would otherwise
+            // crash the worker via an unhandled rejection.
+            .pipeChunk(createFetchPersonChunkStep(personRepository), {
+                retry: { tries: 5, sleepMs: 100, name: 'fetch_person_chunk' },
+            })
             // Run Hog transformations (including GeoIP if team has it enabled)
             .pipe(createHogTransformEventStep(hogTransformer))
             // Prepare event for emission

--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -237,7 +237,12 @@ export class IngestionGeneralServer implements NodeServer {
         const integrationManager = new IntegrationManagerService(this.pubsub, this.postgres, encryptedFields)
 
         // 3. Ingestion-specific services
-        const groupTypeManager = new GroupTypeManager(groupRepository, teamManager)
+        // Same rationale as the team manager's loaderRetry above: group-type loads run
+        // detached in the LazyLoader buffer, so an un-retried transient failure can
+        // surface as an unhandled rejection and restart the worker.
+        const groupTypeManager = new GroupTypeManager(groupRepository, teamManager, {
+            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+        })
 
         const serviceLoaders: (() => Promise<PluginServerService>)[] = []
 


### PR DESCRIPTION
## Problem

Ingestion workers in the AI and error tracking pipelines shut down whenever a read-only person fetch hits a transient personhog gRPC failure (for example a persons DB failover). The personhog client retries for only ~150ms, and the rethrown `ConnectError` then escapes the unwrapped pipeline step as an unhandled rejection, killing the worker. Because the dependency is shared, one blip can take out many pods at once.

Group type loads have the same failure shape one layer down. They run detached in the `LazyLoader` buffer, so a transient Postgres pooler error (`ECONNREFUSED` during a scale-down) surfaces as an unhandled rejection and restarts analytics workers. `TeamManager` already opted into `loaderRetry` for exactly this reason, but `GroupTypeManager` never did.

## Changes

The retry policy lives at the pipeline edges, matching how the neighboring steps already behave. The personhog client keeps its fast ~150ms budget for micro-blips.

- `withRetry` in `grpc-retry.ts` now tags terminal transient errors (`Unavailable`, `DeadlineExceeded`, etc.) with `isRetriable: true` before rethrowing. Outer retry layers key off this flag: `loaderRetry` only retries errors explicitly marked retriable, and the chunk retry wrapper uses it to distinguish transient failures from bugs. Non-transient codes stay untagged so genuine bugs keep failing loudly.
- `createFetchPersonChunkStep` in the AI and error tracking pipelines is now wrapped with `retry: { tries: 5, sleepMs: 100 }`, the same config as the sibling `hog_transform_event`, `readonly_process_groups`, and `emit_event` steps. Worst case adds ~1.5s of backoff, far below the liveness interval.
- `GroupTypeManager` accepts a `loaderRetry` option (mirroring `TeamManagerOptions`), and the ingestion server opts in with the same config as `TeamManager` (`250ms` interval, `5s` deadline). This covers both backends, since the Postgres path already throws `DependencyUnavailableError` with `isRetriable = true` and the personhog path is now tagged by the client.

Cymbal retry semantics are intentionally untouched.

> [!NOTE]
> Behavior change on exhaustion is unchanged: if a blip outlasts the edge budget the worker still shuts down as before. This PR only widens the window transient failures can be absorbed in.

## How did you test this code?

- Extended `grpc-retry.test.ts` with assertions that exhausted transient errors carry `isRetriable: true` and that non-transient and non-ConnectError failures stay untagged. This catches the regression where the tag is dropped and outer retry layers silently stop engaging (or start absorbing genuine bugs). No existing test asserted the flag.
- Ran `grpc-retry.test.ts` (21 passed), `group-type-manager.test.ts` (16 passed), `ai/pipeline.test.ts` + `error-tracking-pipeline.test.ts` (41 passed), plus `pnpm build` and `pnpm lint`.
- No manual testing against a live environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal reliability change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The session started as a Grafana MCP review of ingestion worker crash logs across environments, which found that all recent AI pipeline worker crashes shared one signature (transient personhog unavailability escaping the unwrapped person fetch step) and that analytics workers crash the same way via the group type `LazyLoader`. Skills used: the ingestion monitoring skill for the investigation and `/writing-tests` before extending tests.

Decisions along the way: I (Paweł) chose to keep one consistent retry policy at the pipeline edges rather than strengthening the gRPC client budget, since the client is shared by callers with different latency tolerances and the edge configs were already uniform. Tagging every terminal error as retriable was considered and rejected so unexpected errors keep crashing loudly. Cymbal exhaustion handling was deliberately left out of scope.
