### PR TITLE
fix(github): guide users to owner/repo when a URL or bare name is entered

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -312,6 +312,17 @@ def validate_credentials(
     personal_access_token: str, repository: str, api_version: str = GITHUB_DEFAULT_API_VERSION
 ) -> tuple[bool, str | None]:
     """Validate GitHub API credentials by making a test request to the repository."""
+    # A pasted clone URL (github.com/owner/repo.git) or a bare owner name otherwise reaches the API
+    # as a nonsense path, 404s, and gets reported as "not found or not accessible" — which points the
+    # user at permissions rather than the real problem, the identifier format. Catch the wrong shape
+    # before the request so the message names the fix.
+    repo = repository.strip()
+    if repo.count("/") != 1 or not all(repo.split("/")):
+        return (
+            False,
+            "Enter the repository as owner/repo (for example, posthog/posthog), not a full URL or just the owner name.",
+        )
+
     url = f"{GITHUB_BASE_URL}/repos/{repository}"
     headers = _get_headers(personal_access_token, api_version=api_version)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_validate_credentials.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_validate_credentials.py
@@ -44,3 +44,21 @@ def test_json_error_message_is_surfaced():
     is_valid, message = _validate_with(_response(422, json_body={"message": "Validation failed"}))
     assert is_valid is False
     assert message == "Validation failed"
+
+
+@pytest.mark.parametrize(
+    "repository",
+    [
+        "https://github.com/owner/repo.git",  # pasted clone URL
+        "owner",  # bare owner, no repo
+        "owner/repo/extra",  # too many path segments
+        "/repo",  # missing owner
+    ],
+)
+def test_malformed_repository_gets_format_guidance(repository):
+    # Guards the pre-request format check: without it these reach the API, 404, and get the
+    # misleading "not found or not accessible" message instead of format guidance.
+    is_valid, message = github.validate_credentials("token", repository)
+    assert is_valid is False
+    assert message is not None
+    assert "owner/repo" in message


### PR DESCRIPTION
## Problem

When creating a GitHub data warehouse source, users sometimes paste a full clone URL (`https://github.com/owner/repo.git`) or just an owner name into the repository field instead of `owner/repo`. That value reached the GitHub API as a nonsense path, returned a 404, and surfaced as `Repository '<value>' not found or not accessible`. That message sends people to check repository permissions when the real problem is the identifier format, so they get stuck.

Valid `owner/repo` inputs that genuinely 404 (private repo, no access) still get the existing message.

## Changes

`validate_credentials` now checks the repository shape before making the request. If it isn't `owner/repo` (a URL, a bare owner, empty halves, or extra path segments), it returns a message naming the expected format instead of probing the API and echoing a misleading not-found error.

## How did you test this code?

Added a parameterized case to `test_github_validate_credentials.py` covering a pasted clone URL, a bare owner, an over-segmented path, and a missing owner. It guards the regression where removing the pre-request format check sends malformed identifiers to the API and back to the misleading "not found or not accessible" message. Ran the file plus the existing GitHub validate suite locally, all green. I (Claude) did not do manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) as part of a triage pass over data warehouse source-creation failures. Invoked skills: `/writing-user-facing-copy` (message wording), `/writing-tests` (test value gate), `/writing-code-comments`. The parallel GitLab source had the same failure shape and is fixed in a separate PR. Considered auto-normalizing the input (stripping a URL prefix / `.git`) but rejected it: the wrong value is what gets persisted, so recovering only at validation time would mask a later sync failure. A clear rejection makes the user fix the stored value.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
