### PR TITLE
fix(gitlab): guide users to group/project when a URL or bare name is entered

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/gitlab.py
@@ -190,6 +190,16 @@ def validate_credentials(
     if not project or not project.strip():
         return False, "Missing project id or path"
 
+    # GitLab addresses a project by its numeric id or a group/project path. A pasted URL or a bare
+    # group name otherwise URL-encodes into a nonsense path, 404s, and gets reported as "not found
+    # or not accessible with this token" — which points the user at the token rather than the format.
+    project_ref = project.strip()
+    if "://" in project_ref or ("/" not in project_ref and not project_ref.isdigit()):
+        return (
+            False,
+            "Enter the project as group/project (for example, mygroup/myproject) or its numeric project ID, not a full URL.",
+        )
+
     host_only = _host_only(host)
     if not host_only:
         return False, "Invalid GitLab host"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gitlab/tests/test_gitlab.py
@@ -280,6 +280,29 @@ class TestValidateCredentials:
         assert valid is False
         assert msg == expected_msg
 
+    @pytest.mark.parametrize(
+        "project",
+        [
+            "https://gitlab.com/mygroup/",  # pasted URL
+            "mygroup",  # bare group, no project and not a numeric id
+            "some-dashboard",  # bare name
+        ],
+    )
+    def test_malformed_project_gets_format_guidance(self, project):
+        # Guards the pre-request format check: without it these URL-encode into a nonsense path,
+        # 404, and get the misleading "not found or not accessible" message.
+        valid, msg = validate_credentials("https://gitlab.com", "tok", project)
+        assert valid is False
+        assert "group/project" in (msg or "")
+
+    def test_numeric_project_id_is_not_rejected_as_malformed(self):
+        # A bare numeric id is a valid GitLab project reference, so it must reach the API rather
+        # than trip the format check for bare names.
+        with self._patch_session(_response(status_code=200)) as patched:
+            valid, _ = validate_credentials("https://gitlab.com", "tok", "114682853")
+            assert valid is True
+            patched.return_value.get.assert_called_once()
+
     def test_request_exception_returns_failure(self):
         import requests
 


### PR DESCRIPTION
## Problem

When creating a GitLab data warehouse source, users sometimes paste a full URL or just a group name into the project field instead of `group/project` or a numeric project id. That value got URL-encoded into a nonsense project path, returned a 404, and surfaced as `Project '<value>' not found or not accessible with this token`. That message sends people to check their token when the real problem is the identifier format.

A numeric project id and a valid `group/project` that genuinely 404 (token lacks access) still get the existing message.

## Changes

`validate_credentials` now checks the project shape before making the request. A value containing `://`, or a bare name with no `/` that isn't a numeric id, returns a message naming the expected format instead of probing the API and echoing a misleading not-found error.

## How did you test this code?

Added a parameterized case to `test_gitlab.py` covering a pasted URL and two bare group names, plus a case asserting a numeric project id still reaches the API rather than tripping the format check (guards against over-rejecting valid ids). Ran the GitLab source suite locally, all green. I (Claude) did not do manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) as part of a triage pass over data warehouse source-creation failures. Invoked skills: `/writing-user-facing-copy` (message wording), `/writing-tests` (test value gate), `/writing-code-comments`. The parallel GitHub source had the same failure shape and is fixed in a separate PR. The check deliberately lets a bare all-digits value through, since GitLab addresses a project by numeric id as well as `group/project`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
