### PR TITLE
feat(data-imports): raise batcher default chunk size to 500k rows

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/batcher.py
@@ -13,7 +13,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.tab
 )
 
 DEFAULT_CHUNK_SIZE_BYTES: int = 200 * 1024 * 1024  # 200 MiB
-DEFAULT_CHUNK_SIZE: int = 5000
+DEFAULT_CHUNK_SIZE: int = 500_000
 
 # string/binary/list use 32-bit offsets and overflow ("Offset overflow error") once a column's
 # offsets cross 2^31 (~2.1 GB); delta-rs hits this when it concatenates merge-source chunks.


### PR DESCRIPTION
## Problem

The pipeline v3 batcher cuts a batch at 5,000 rows by default.
For narrow tables that produces many small batches (and small parquet files), adding per-batch overhead in S3 writes, queue rows, and loader merges.

## Changes

Raises `DEFAULT_CHUNK_SIZE` in `pipelines/core/batcher.py` from 5,000 to 500,000 rows.

> [!NOTE]
> Memory stays bounded by the byte limits, which now become the governing threshold for most tables: the batcher still flushes at ~200 MiB of buffered data (`DEFAULT_CHUNK_SIZE_BYTES`) and still splits any materialized table above 256 MiB of Arrow payload (`DEFAULT_MAX_TABLE_BYTES`). Sources that set their own `chunk_size` are unaffected.

## How did you test this code?

Constant-only change. Existing e2e tests that exercise batching patch `DEFAULT_CHUNK_SIZE` to explicit values, so they are unaffected by the default. `hogli ci:preflight --strict` passed on push (ruff lint/format).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed, internal tuning constant.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. I asked Claude to trace how pipeline v3 batch sizes are decided, then to raise the default row threshold to 500k. Claude verified no test depends on the old default value before changing it.
