### PR TITLE
perf(desktop): make the quill thread the default + stop re-walking settled tool groups

### DIFF
--- a/products/desktop/packages/ui/src/features/agent-applications/components/AgentChatSurface.tsx
+++ b/products/desktop/packages/ui/src/features/agent-applications/components/AgentChatSurface.tsx
@@ -79,7 +79,8 @@ export function AgentChatSurface({
           <ThreadView
             events={messages}
             isPromptPending={isStreaming}
-            collapseMode="none"
+            // This pane is the agent's work; a chip over it would hide the point of the surface.
+            groupToolCalls={false}
             scrollX={scrollX}
           />
         )}

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -35,7 +35,6 @@ import type {
   ThreadGrouping,
   ThreadRow,
 } from "@posthog/ui/features/sessions/components/new-thread/buildThreadGroups";
-import type { CollapseMode } from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
 import { createIncrementalThreadGrouper } from "@posthog/ui/features/sessions/components/new-thread/incrementalThreadGrouping";
 import { ToolCallGroupChip } from "@posthog/ui/features/sessions/components/new-thread/ToolCallGroupChip";
 import { SessionFooter } from "@posthog/ui/features/sessions/components/SessionFooter";
@@ -93,12 +92,6 @@ export interface ConversationViewProps {
   slackThreadUrl?: string;
   compact?: boolean;
   /**
-   * Override the global collapse setting for this view. Used by surfaces like
-   * the live-agent chat preview, where folding the agent's prose into a tool
-   * chip hides the response — they pass `"none"` to render everything inline.
-   */
-  collapseMode?: CollapseMode;
-  /**
    * Allow horizontal scrolling of the transcript viewport. Defaults to true.
    * Narrow surfaces (the Agent Builder dock) pass false to avoid a horizontal
    * scrollbar from off-edge content; nested code blocks keep their own scroll.
@@ -120,7 +113,6 @@ export function ConversationView({
   task,
   slackThreadUrl,
   compact = false,
-  collapseMode: collapseModeProp,
   scrollX = true,
   promptRecallRef,
 }: ConversationViewProps) {
@@ -143,10 +135,6 @@ export function ConversationView({
   const debugLogsCloudRuns = useSettingsStore((s) => s.debugLogsCloudRuns);
   const showDebugLogs = debugLogsCloudRuns;
 
-  const collapseModeSetting = useSettingsStore(
-    (s) => s.conversationCollapseMode,
-  );
-  const collapseMode = collapseModeProp ?? collapseModeSetting;
   const groupOverrides = useGroupOverrides();
   const sessionViewActions = useSessionViewActions();
 
@@ -209,8 +197,8 @@ export function ConversationView({
   threadGrouperRef.current ??= createIncrementalThreadGrouper();
   const threadGrouper = threadGrouperRef.current;
   const grouping = useMemo<ThreadGrouping>(
-    () => threadGrouper.update(items, collapseMode, groupOverrides),
-    [items, collapseMode, groupOverrides, threadGrouper],
+    () => threadGrouper.update(items, groupOverrides),
+    [items, groupOverrides, threadGrouper],
   );
   const threadRows = grouping.rows;
   const rowKeepMounted = grouping.keepMounted;
@@ -233,12 +221,6 @@ export function ConversationView({
     }
     return result;
   }, [grouping.idToRowIndex, rowToTurnIndex]);
-
-  // Changing the global mode wipes ephemeral per-chip overrides.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally keyed on collapseMode only
-  useEffect(() => {
-    sessionViewActions.clearGroupOverrides();
-  }, [collapseMode]);
 
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -135,10 +135,10 @@ const DEFAULT_ERROR_MESSAGE =
  *
  * The gutter is a percentage of this box, and the thread's equivalent box sits
  * inside a scroller whose `scrollbar-gutter: stable` has already taken the
- * scrollbar's width off it. Without matching that reservation here the composer
- * centers on a wider box and its column lands half a scrollbar to the right of
- * the messages. Reserving it the same way keeps the browser's own measurement
- * as the single source of truth; a hard-coded width would drift per platform.
+ * scrollbar's width off it. Without the same reservation here, the composer
+ * centers on a wider box and its column lands half a scrollbar right of the
+ * messages. Reserving it rather than subtracting a constant keeps the browser's
+ * own measurement authoritative, since scrollbar width varies by platform.
  */
 /** Widest ring the composer paints outside its border box (quill's 3px focus outline). */
 const OUTLINE_BLEED = 4;
@@ -160,10 +160,10 @@ function ComposerWidth({
         paddingInline: CHAT_CONTENT_PADDING_INLINE,
         overflow: "hidden",
         scrollbarGutter: "stable",
-        // The composer's focus outline paints outside its border box, and this
-        // box's top edge sits flush against it, so the clip would slice the
-        // ring's top off. Buy it room and take the room back out of the layout.
-        // (The sides have the gutter, and the capped box's `pb-2` covers below.)
+        // `overflow: hidden` clips at this box's padding edge, which sits flush
+        // with the composer's top, so the focus ring painted outside its border
+        // box would lose its top. Buy the ring room and take it back out of the
+        // layout. The sides have the gutter and `pb-2` covers below.
         paddingBlockStart: OUTLINE_BLEED,
         marginBlockStart: -OUTLINE_BLEED,
       }}

--- a/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/SessionView.tsx
@@ -41,7 +41,6 @@ import { QueuedMessagesDock } from "@posthog/ui/features/sessions/components/Que
 import { ReasoningLevelSelector } from "@posthog/ui/features/sessions/components/ReasoningLevelSelector";
 import { RawLogsView } from "@posthog/ui/features/sessions/components/raw-logs/RawLogsView";
 import { SessionInitializingView } from "@posthog/ui/features/sessions/components/SessionInitializingView";
-import { SessionResourcesBar } from "@posthog/ui/features/sessions/components/SessionResourcesBar";
 import { SteerQueueToggle } from "@posthog/ui/features/sessions/components/SteerQueueToggle";
 import {
   isSubmittedContentUnchanged,
@@ -256,7 +255,6 @@ export function SessionView({
   const fastModeOption = fastModeFlagEnabled ? liveFastModeOption : undefined;
   const toggleMessagingMode = useToggleMessagingMode(taskId);
   const { allowBypassPermissions } = useSettingsStore();
-  const useNewChatThread = useSettingsStore((s) => s.useNewChatThread);
   const { isOnline } = useConnectivity();
   const currentModeId = modeOption?.currentValue;
   const handoffInProgress = useSessionHandoffInProgress(taskId);
@@ -729,8 +727,6 @@ export function SessionView({
                   scrollX={false}
                   promptRecallRef={promptRecallRef}
                 />
-
-                {!useNewChatThread && <SessionResourcesBar events={events} />}
 
                 <PlanStatusBar plan={latestPlan} />
 

--- a/products/desktop/packages/ui/src/features/sessions/components/ThreadView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ThreadView.tsx
@@ -1,16 +1,6 @@
-import {
-  ConversationView,
-  type ConversationViewProps,
-} from "@posthog/ui/features/sessions/components/ConversationView";
+import type { ConversationViewProps } from "@posthog/ui/features/sessions/components/ConversationView";
 import { AcpChatThread } from "@posthog/ui/features/sessions/components/chat-thread/ChatThread";
-import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
 
 export function ThreadView(props: ConversationViewProps) {
-  const useNewChatThread = useSettingsStore((state) => state.useNewChatThread);
-
-  return useNewChatThread ? (
-    <AcpChatThread {...props} />
-  ) : (
-    <ConversationView {...props} />
-  );
+  return <AcpChatThread {...props} />;
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/ThreadView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ThreadView.tsx
@@ -1,7 +1,7 @@
 import type { ConversationViewProps } from "@posthog/ui/features/sessions/components/ConversationView";
 import { AcpChatThread } from "@posthog/ui/features/sessions/components/chat-thread/ChatThread";
 
-/** Props still ride the older shape while `ConversationView` is around to be deleted. */
+/** Props still take `ConversationView`'s shape until that component is deleted. */
 type ThreadViewProps = ConversationViewProps & {
   /** See `SharedChatThreadProps.groupToolCalls`. */
   groupToolCalls?: boolean;

--- a/products/desktop/packages/ui/src/features/sessions/components/ThreadView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ThreadView.tsx
@@ -1,6 +1,12 @@
 import type { ConversationViewProps } from "@posthog/ui/features/sessions/components/ConversationView";
 import { AcpChatThread } from "@posthog/ui/features/sessions/components/chat-thread/ChatThread";
 
-export function ThreadView(props: ConversationViewProps) {
+/** Props still ride the older shape while `ConversationView` is around to be deleted. */
+type ThreadViewProps = ConversationViewProps & {
+  /** See `SharedChatThreadProps.groupToolCalls`. */
+  groupToolCalls?: boolean;
+};
+
+export function ThreadView(props: ThreadViewProps) {
   return <AcpChatThread {...props} />;
 }

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -203,6 +203,32 @@ function isThoughtItem(item: ConversationItem): boolean {
  * A lone tool call passes through untouched — it stays a single marker, matching the legacy thread,
  * and so do the thoughts around it: thoughts ride along a run, they never make one.
  */
+/**
+ * Item arrays for settled runs, keyed on the run's (stable) first item.
+ *
+ * Grouping re-runs over the whole thread on every streamed chunk, so a completed run gets a fresh
+ * array each time — new identity, same contents. That defeats `ToolGroup`'s `memo`, and every
+ * settled group above the live one re-renders per token. Handing back the previous array makes
+ * those groups skip the render entirely.
+ *
+ * Only safe once the run's turn is complete: a live tool's status is mutated in place on its
+ * resolved `ToolCall`, so reusing an array while the turn streams would freeze a spinner on a
+ * tool that has since finished. `len` guards the case where a run gains items before settling.
+ */
+const settledRunItems = new WeakMap<
+  ConversationItem,
+  { len: number; items: SessionUpdateItem[] }
+>();
+
+function stableRunItems(run: SessionUpdateItem[]): SessionUpdateItem[] {
+  if (!run.at(-1)?.turnContext.turnComplete) return run;
+  const key = run[0];
+  const cached = settledRunItems.get(key);
+  if (cached && cached.len === run.length) return cached.items;
+  settledRunItems.set(key, { len: run.length, items: run });
+  return run;
+}
+
 function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
   const out: ThreadItem[] = [];
   // The buffer holds the active run in order: tools, the thoughts between them, and any invisible
@@ -216,7 +242,7 @@ function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
         type: "tool_group",
         // The run's first tool call, so the id is stable as thoughts append around it.
         id: buffer.filter(isToolCallItem)[0].id,
-        items: buffer.filter(isSessionUpdateItem),
+        items: stableRunItems(buffer.filter(isSessionUpdateItem)),
       });
     } else {
       out.push(...buffer);

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1088,6 +1088,14 @@ const FlatRowView = memo(
  * (`ChatMessageFooter`) — see `UserBubble`.
  */
 interface SharedChatThreadProps {
+  /**
+   * Fold each run of tool calls into one collapsible row. Defaults to true.
+   *
+   * Embedded surfaces (the live-agent chat preview) pass false: they are short, they are the whole
+   * point of the pane they sit in, and folding the agent's work behind a chip there hides the only
+   * thing there is to look at.
+   */
+  groupToolCalls?: boolean;
   isPromptPending: boolean | null;
   promptStartedAt?: number | null;
   promptRecallRef?: RefObject<PromptRecallHandler | null>;
@@ -1161,6 +1169,7 @@ interface ChatThreadRendererProps extends SharedChatThreadProps {
 function ChatThreadRenderer({
   conversationItems,
   footerEvents,
+  groupToolCalls = true,
   isPromptPending,
   promptStartedAt,
   repoPath,
@@ -1188,8 +1197,8 @@ function ChatThreadRenderer({
   );
 
   const rows = useMemo<TurnRow[]>(
-    () => groupIntoTurns(groupToolRuns(items)),
-    [items],
+    () => groupIntoTurns(groupToolCalls ? groupToolRuns(items) : items),
+    [items, groupToolCalls],
   );
 
   // Virtualization ratchet: past the threshold the thread switches to the windowed body and

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -183,11 +183,10 @@ function isInvisibleItem(item: ConversationItem): boolean {
 }
 
 /**
- * A thought joins a tool run instead of breaking it. Between two calls it is the agent narrating
- * the stretch of work the run already stands for, so folding it in keeps one row for one stretch —
- * the group's body still lists it in order, and the row's own label follows it while it streams.
- * Prose to the user (`agent_message_chunk`) still breaks the run: that is said *to* you, not about
- * the work.
+ * A thought joins a tool run instead of breaking it, because between two calls it narrates the
+ * stretch of work the run already stands for. The group's body still lists it in order. Prose to
+ * the user (`agent_message_chunk`) does break a run, since that is addressed to the reader rather
+ * than describing the work.
  */
 function isThoughtItem(item: ConversationItem): boolean {
   return (
@@ -200,20 +199,20 @@ function isThoughtItem(item: ConversationItem): boolean {
  * Collapse each contiguous run of ≥2 tool-call updates into a single `ToolGroupItem`. A run is
  * broken by any *visible* non-tool, non-thought item (prose, status) so groups follow reading
  * order; invisible updates (see {@link INVISIBLE_UPDATES}) are transparent and don't split a run.
- * A lone tool call passes through untouched — it stays a single marker, matching the legacy thread,
- * and so do the thoughts around it: thoughts ride along a run, they never make one.
+ * A lone tool call passes through untouched as a single marker, and so do the thoughts around it:
+ * thoughts ride along a run, they never make one.
  */
 /**
  * Item arrays for settled runs, keyed on the run's (stable) first item.
  *
- * Grouping re-runs over the whole thread on every streamed chunk, so a completed run gets a fresh
- * array each time — new identity, same contents. That defeats `ToolGroup`'s `memo`, and every
- * settled group above the live one re-renders per token. Handing back the previous array makes
- * those groups skip the render entirely.
+ * Grouping re-runs over the whole thread on every streamed chunk, so a completed run produces a
+ * fresh array with identical contents each time. New identity defeats `ToolGroup`'s `memo`, which
+ * makes every settled group above the live one re-render per chunk. Handing back the previous
+ * array lets them skip the render.
  *
- * Only safe once the run's turn is complete: a live tool's status is mutated in place on its
- * resolved `ToolCall`, so reusing an array while the turn streams would freeze a spinner on a
- * tool that has since finished. `len` guards the case where a run gains items before settling.
+ * Only safe once the run's turn is complete, because a live tool's status is mutated in place on
+ * its resolved `ToolCall`: reusing an array mid-turn would leave a spinner on a tool that has
+ * since finished. `len` covers a run that gains items before it settles.
  */
 const settledRunItems = new WeakMap<
   ConversationItem,
@@ -240,7 +239,7 @@ function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
     if (toolCount >= 2) {
       out.push({
         type: "tool_group",
-        // The run's first tool call, so the id is stable as thoughts append around it.
+        // Keyed on the first tool call so the id survives thoughts appending around it.
         id: buffer.filter(isToolCallItem)[0].id,
         items: stableRunItems(buffer.filter(isSessionUpdateItem)),
       });

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -24,10 +24,9 @@ interface ChatThreadFooterProps {
  * the last item in the thread. The legacy `ConversationView` renders the same `SessionFooter` the
  * same way. Context usage is not here — it sits in the composer's own toolbar.
  *
- * Re-derives the turn / usage / queue state from `events` with the same hooks `ConversationView`
- * uses — `ChatThread` runs its own `useConversationItems`, so this is a second (incremental,
- * memoized) parse pass, acceptable for a flag-gated surface. Gated behind
- * `settingsStore.useNewChatThread` at the call site.
+ * Re-derives the turn / usage / queue state from `events` with the same hooks the thread uses —
+ * `ChatThread` runs its own `useConversationItems`, so this is a second (incremental, memoized)
+ * parse pass.
  */
 export function ChatThreadFooter({
   events,

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
@@ -107,10 +107,9 @@ const LABEL_MOTION = {
 /**
  * One row standing in for a whole stretch of work: the tool calls and the thoughts between them.
  *
- * While it runs the row narrates — spinner plus whatever is happening right now (the current tool,
- * or "Thinking…" while the agent reasons between calls), cross-fading as that changes. Once the run
- * settles it collapses to what it did ("Ran 3 commands, read a file"), tallied by the same
- * `summarize` the legacy view uses. Opening it lists every step in order via `SessionUpdateView`.
+ * While the run is live the row shows what is happening now, which is the current tool or
+ * "Thinking…" while the agent reasons between calls. Once it settles the row shows what the run
+ * did ("Ran 3 commands, read a file"). Opening it lists every step in order.
  */
 export const ToolGroup = memo(function ToolGroup({
   items,
@@ -135,8 +134,8 @@ export const ToolGroup = memo(function ToolGroup({
   const thinking = isThinking(items);
   const isActive = tools.some(isToolActive) || thinking || mayStillGrow;
 
-  // Grouping only ever builds a run around ≥2 tool calls, but the component is exported, so a
-  // thought-only run resolves to no current tool rather than throwing on `undefined`.
+  // Grouping only ever builds a run around ≥2 tool calls, but this component is exported, so a
+  // thought-only run has to resolve to no current tool rather than throw on `undefined`.
   const currentItem = lastActiveTool(tools) ?? tools.at(-1);
   const current = currentItem ? resolveTool(currentItem) : null;
   const currentName = currentItem ? friendlyName(toolKey(currentItem)) : null;
@@ -151,17 +150,17 @@ export const ToolGroup = memo(function ToolGroup({
     ? iconForToolCall(current.toolCall, current.toolName)
     : null;
 
-  // A settled run reads as a tally of what happened. One with nothing countable keeps the live
-  // shape rather than falling back to summarize's "Worked". Cached across renders once the run's
-  // turn is complete — the walk is O(run), and the live turn re-renders every group per token.
+  // A run with no countable work (a lone streaming thought) keeps the live shape rather than
+  // falling back to summarize's "Worked". Cached once the turn completes because the walk is
+  // O(run) and the live turn re-renders every group on every streamed chunk.
   const summary = useMemo(
     () => summarizeMemo(items, items.at(-1)?.turnContext.turnComplete ?? false),
     [items],
   );
   const showSummary = !isActive && summary.hasCountableWork;
 
-  // Keyed so a change swaps the label through the cross-fade. Thinking is its own key, so a run
-  // that returns to the same tool after a thought still animates the change.
+  // Thinking gets its own key so a run that returns to the same tool after a thought still reads
+  // as a change rather than sitting static.
   const labelKey = showSummary
     ? `done:${summary.doneLabel}`
     : thinking || !currentName
@@ -182,14 +181,11 @@ export const ToolGroup = memo(function ToolGroup({
           thoughtComplete={item.thoughtComplete}
         />
       ))}
-      // Matches ToolRow: aligned to the text column, no hover fill, inset ring,
-      // and open looks the same as hover.
+      // Same row chrome as ToolRow; see the comment there for why quill's
+      // defaults are overridden.
       className={cn(
         "mx-0 px-0 opacity-50 hover:bg-transparent hover:opacity-100 focus-visible:bg-transparent",
         "data-panel-open:bg-transparent data-panel-open:opacity-100",
-        // The installed quill parks the chevron with `margin-inline-start: auto`;
-        // unset it so it sits against the text it opens. Newer quill already
-        // hugs, at which point this is inert.
         "[&>svg:last-child]:ms-0",
         "focus-visible:shadow-none focus-visible:ring-(--ring)/50 focus-visible:ring-2 focus-visible:ring-inset",
       )}
@@ -203,8 +199,8 @@ export const ToolGroup = memo(function ToolGroup({
           isActive && "shimmer",
         )}
       >
-        {/* `mode="wait"` so the outgoing label clears before the next fades in — overlapping them
-            on one line reads as a flicker rather than a change. */}
+        {/* `mode="wait"` so the outgoing label clears before the next fades in. Overlapping them
+            on a single line reads as a flicker rather than a change. */}
         <AnimatePresence mode="wait" initial={false}>
           <motion.span
             key={labelKey}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
@@ -10,7 +10,7 @@ import type { ToolCall } from "@posthog/ui/features/sessions/types";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { memo, useMemo } from "react";
 import type { ConversationItem } from "../buildConversationItems";
-import { summarize } from "../new-thread/buildThreadGroups";
+import { summarizeMemo } from "../new-thread/buildThreadGroups";
 import { grouping } from "../new-thread/conversationThreadConfig";
 import { SessionUpdateView } from "../session-update/SessionUpdateView";
 import { iconForToolCall } from "../session-update/toolCallUtils";
@@ -77,6 +77,16 @@ export function isToolActive(item: SessionUpdateItem): boolean {
   );
 }
 
+/** The run's most recent in-flight tool. Walked backwards rather than copy-and-reverse. */
+function lastActiveTool(
+  tools: SessionUpdateItem[],
+): SessionUpdateItem | undefined {
+  for (let i = tools.length - 1; i >= 0; i--) {
+    if (isToolActive(tools[i])) return tools[i];
+  }
+  return undefined;
+}
+
 /** True while the run's last item is a thought still streaming — the agent is mid-reasoning. */
 function isThinking(items: SessionUpdateItem[]): boolean {
   const last = items.at(-1);
@@ -127,8 +137,7 @@ export const ToolGroup = memo(function ToolGroup({
 
   // Grouping only ever builds a run around ≥2 tool calls, but the component is exported, so a
   // thought-only run resolves to no current tool rather than throwing on `undefined`.
-  const currentItem =
-    [...tools].reverse().find(isToolActive) ?? tools[tools.length - 1];
+  const currentItem = lastActiveTool(tools) ?? tools.at(-1);
   const current = currentItem ? resolveTool(currentItem) : null;
   const currentName = currentItem ? friendlyName(toolKey(currentItem)) : null;
   const currentContext =
@@ -143,9 +152,12 @@ export const ToolGroup = memo(function ToolGroup({
     : null;
 
   // A settled run reads as a tally of what happened. One with nothing countable keeps the live
-  // shape rather than falling back to summarize's "Worked". Memoized because the trailing group
-  // re-renders per streamed token, and this walks the whole run.
-  const summary = useMemo(() => summarize(items), [items]);
+  // shape rather than falling back to summarize's "Worked". Cached across renders once the run's
+  // turn is complete — the walk is O(run), and the live turn re-renders every group per token.
+  const summary = useMemo(
+    () => summarizeMemo(items, items.at(-1)?.turnContext.turnComplete ?? false),
+    [items],
+  );
   const showSummary = !isActive && summary.hasCountableWork;
 
   // Keyed so a change swaps the label through the cross-fade. Thinking is its own key, so a run

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -90,8 +90,8 @@ export interface FlatThreadRow {
 
 /**
  * Completion time of an agent turn, taken from its last session-update item (a tool group counts
- * by the last step in its run). Undefined while the turn is still streaming — the timestamp only appears
- * once the whole turn is done.
+ * by the last step in its run). Undefined while the turn is still streaming, since the timestamp
+ * only appears once the whole turn is done.
  */
 export function completedTurnTimestamp(turn: AgentTurn): number | undefined {
   for (let i = turn.items.length - 1; i >= 0; i--) {

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
@@ -43,7 +43,7 @@ describe("buildThreadGroups MCP detection", () => {
 
     expect(isGroupableItem(mcpItem)).toBe(false);
 
-    const grouping = buildThreadGroups([mcpItem], "all", {});
+    const grouping = buildThreadGroups([mcpItem], {});
     expect(grouping.rows).toHaveLength(1);
     expect(grouping.rows[0].kind).toBe("item");
     expect(grouping.keepMounted).toEqual([0]);
@@ -55,7 +55,7 @@ describe("buildThreadGroups MCP detection", () => {
     });
 
     expect(isGroupableItem(legacyItem)).toBe(false);
-    const grouping = buildThreadGroups([legacyItem], "all", {});
+    const grouping = buildThreadGroups([legacyItem], {});
     expect(grouping.keepMounted).toEqual([0]);
   });
 
@@ -65,7 +65,7 @@ describe("buildThreadGroups MCP detection", () => {
     });
     const alsoPlain = toolCallItem("t2", undefined, { kind: "read" });
 
-    const grouping = buildThreadGroups([plain, alsoPlain], "all", {});
+    const grouping = buildThreadGroups([plain, alsoPlain], {});
     expect(grouping.rows).toHaveLength(1);
     expect(grouping.rows[0].kind).toBe("tool_group");
     expect(grouping.keepMounted).toEqual([]);
@@ -87,7 +87,7 @@ describe("buildThreadGroups MCP detection", () => {
       }),
     ];
 
-    const grouping = buildThreadGroups(items, "all", {});
+    const grouping = buildThreadGroups(items, {});
     const row = grouping.rows[0];
     expect(row.kind).toBe("tool_group");
     if (row.kind !== "tool_group") return;

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -125,8 +125,8 @@ export function isGroupableItem(item: ConversationItem): boolean {
 }
 
 /**
- * Tallies, icons, and live/done labels for a run of grouped items. Exported so the quill thread's
- * `ToolGroup` reads the same counts this view does — one place decides what "ran 3 commands" means.
+ * Tallies, icons, and live/done labels for a run of grouped items. Exported so the thread's
+ * `ToolGroup` reads the same counts, keeping one definition of what "ran 3 commands" means.
  */
 export function summarize(items: ConversationItem[]): GroupSummary {
   const counts: GroupCounts = {
@@ -248,8 +248,8 @@ const summaryCache = new WeakMap<
 >();
 
 /**
- * `summarize`, skipping the walk for a run whose turn has completed. Exported alongside it so the
- * quill thread gets the same caching rather than re-walking every settled group per streamed token.
+ * `summarize`, skipping the walk for a run whose turn has completed. Exported so callers rendering
+ * many groups per streamed chunk don't re-walk the settled ones.
  */
 export function summarizeMemo(
   leading: ConversationItem[],

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -4,7 +4,6 @@ import type { ConversationItem } from "@posthog/ui/features/sessions/components/
 import { isUserInitiatedConversationItem } from "@posthog/ui/features/sessions/components/isUserInitiatedConversationItem";
 import {
   buildDoneLabel,
-  type CollapseMode,
   type GroupCounts,
   type GroupIconKey,
   grouping,
@@ -269,14 +268,13 @@ export function summarizeMemo(
 /**
  * Transform the flat conversation items into rows for the new thread, folding
  * each turn's tool-call work into a collapsible group according to the global
- * collapse mode and any per-group overrides. Emits the keepMounted indices and
+ * per-group overrides. Emits the keepMounted indices and
  * item→row map in the same pass so callers don't re-walk the list.
  *
  * Safe to run on every render under useMemo; frozen-turn summaries are cached.
  */
 export function buildThreadGroups(
   items: ConversationItem[],
-  mode: CollapseMode,
   overrides: Record<string, boolean>,
 ): ThreadGrouping {
   const rows: ThreadRow[] = [];
@@ -299,17 +297,12 @@ export function buildThreadGroups(
       first.type === "session_update" && first.turnContext.turnComplete;
     const groupId = `group:${first.id}`;
 
-    // Base behavior from the global mode; a per-group override (true=expanded,
-    // false=collapsed) wins. A chip is shown whenever the group is collapsible
-    // by the mode or the user explicitly collapsed it — but never for a group
-    // with no countable tool work (e.g. a lone streaming thought): folding it
-    // would hide the only thing happening behind a meaningless "Worked" chip.
+    // Groups collapse by default; a per-group override (true=expanded) wins. No chip for a group
+    // with no countable tool work (e.g. a lone streaming thought): folding it would hide the only
+    // thing happening behind a meaningless "Worked" chip.
     const summary = summarizeMemo(leading, turnComplete);
-    const baseCollapse = mode === "all" || (mode === "partial" && turnComplete);
-    const override = overrides[groupId];
-    const expanded = override ?? !baseCollapse;
-    const chipPresent =
-      summary.hasCountableWork && (baseCollapse || override === false);
+    const expanded = overrides[groupId] ?? false;
+    const chipPresent = summary.hasCountableWork;
 
     if (chipPresent) {
       // The chip owns its children (rendered inside one bordered box when

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.ts
@@ -248,7 +248,11 @@ const summaryCache = new WeakMap<
   { len: number; summary: GroupSummary }
 >();
 
-function summarizeMemo(
+/**
+ * `summarize`, skipping the walk for a run whose turn has completed. Exported alongside it so the
+ * quill thread gets the same caching rather than re-walking every settled group per streamed token.
+ */
+export function summarizeMemo(
   leading: ConversationItem[],
   turnComplete: boolean,
 ): GroupSummary {

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
@@ -22,36 +22,6 @@ import { SUBAGENT_SPAWN_TOOL_NAMES } from "../session-update/collaborationTools"
  * live in the components or the grouping selector.
  */
 
-// ---------- Collapse modes ----------
-
-/** How aggressively completed turns collapse into a tool-call group chip. */
-export type CollapseMode = "all" | "partial" | "none";
-
-export const COLLAPSE_MODE_DEFAULT: CollapseMode = "all";
-
-export const COLLAPSE_MODE_OPTIONS: {
-  value: CollapseMode;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: "all",
-    label: "All collapsed",
-    description: "Every turn's tool activity is collapsed into a summary chip.",
-  },
-  {
-    value: "partial",
-    label: "Collapse when finished turn",
-    description:
-      "The active turn streams expanded; completed turns collapse to a chip.",
-  },
-  {
-    value: "none",
-    label: "No collapsing",
-    description: "Everything stays expanded.",
-  },
-];
-
 // ---------- Grouping ----------
 
 export const grouping = {

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/incrementalThreadGrouping.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/incrementalThreadGrouping.test.ts
@@ -84,12 +84,12 @@ describe("createIncrementalThreadGrouper", () => {
       toolItem("t2"),
     ];
 
-    grouper.update(items, "partial", overrides);
+    grouper.update(items, overrides);
 
     const next = [...items, toolItem("t3")];
     expectGroupingEquivalent(
-      grouper.update(next, "partial", overrides),
-      buildThreadGroups(next, "partial", overrides),
+      grouper.update(next, overrides),
+      buildThreadGroups(next, overrides),
     );
   });
 
@@ -97,15 +97,12 @@ describe("createIncrementalThreadGrouper", () => {
     const grouper = createIncrementalThreadGrouper();
     const overrides = {};
     const items = [userMessage("u1"), toolItem("t1", completeContext)];
-    const first = grouper.update(items, "partial", overrides);
+    const first = grouper.update(items, overrides);
 
     const next = [...items, agentMessage("m1")];
-    const second = grouper.update(next, "partial", overrides);
+    const second = grouper.update(next, overrides);
 
-    expectGroupingEquivalent(
-      second,
-      buildThreadGroups(next, "partial", overrides),
-    );
+    expectGroupingEquivalent(second, buildThreadGroups(next, overrides));
     expect(second.rows[0]).toBe(first.rows[0]);
   });
 
@@ -120,12 +117,12 @@ describe("createIncrementalThreadGrouper", () => {
       toolItem("c1", completeContext),
       toolItem("c2", completeContext),
     ];
-    grouper.update(items, "partial", overrides);
+    grouper.update(items, overrides);
 
     const next = [...items, toolItem("a1", activeContext)];
     expectGroupingEquivalent(
-      grouper.update(next, "partial", overrides),
-      buildThreadGroups(next, "partial", overrides),
+      grouper.update(next, overrides),
+      buildThreadGroups(next, overrides),
     );
   });
 
@@ -134,7 +131,6 @@ describe("createIncrementalThreadGrouper", () => {
     const overrides = {};
     grouper.update(
       [userMessage("u1"), toolItem("t1", completeContext)],
-      "partial",
       overrides,
     );
 
@@ -142,8 +138,8 @@ describe("createIncrementalThreadGrouper", () => {
     // a full rebuild.
     const replaced = [userMessage("x1"), toolItem("y1", completeContext)];
     expectGroupingEquivalent(
-      grouper.update(replaced, "partial", overrides),
-      buildThreadGroups(replaced, "partial", overrides),
+      grouper.update(replaced, overrides),
+      buildThreadGroups(replaced, overrides),
     );
   });
 
@@ -151,10 +147,10 @@ describe("createIncrementalThreadGrouper", () => {
     const grouper = createIncrementalThreadGrouper();
     const overrides = {};
     const items = [userMessage("u1"), toolItem("t1", completeContext)];
-    const first = grouper.update(items, "partial", overrides);
+    const first = grouper.update(items, overrides);
     const firstEntries = [...first.idToRowIndex.entries()];
 
-    grouper.update([...items, agentMessage("m1")], "partial", overrides);
+    grouper.update([...items, agentMessage("m1")], overrides);
 
     expect([...first.idToRowIndex.entries()]).toEqual(firstEntries);
   });

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/incrementalThreadGrouping.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/incrementalThreadGrouping.ts
@@ -4,11 +4,9 @@ import {
   isGroupableItem,
   type ThreadGrouping,
 } from "@posthog/ui/features/sessions/components/new-thread/buildThreadGroups";
-import type { CollapseMode } from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
 
 interface Cache {
   items: ConversationItem[];
-  mode: CollapseMode;
   overrides: Record<string, boolean>;
   grouping: ThreadGrouping;
   stablePrefixItemCount: number;
@@ -25,13 +23,11 @@ export function createIncrementalThreadGrouper() {
 
   const rebuildAll = (
     items: ConversationItem[],
-    mode: CollapseMode,
     overrides: Record<string, boolean>,
   ): ThreadGrouping => {
-    const grouping = buildThreadGroups(items, mode, overrides);
+    const grouping = buildThreadGroups(items, overrides);
     cache = {
       items,
-      mode,
       overrides,
       grouping,
       stablePrefixItemCount: findStablePrefixItemCount(items),
@@ -41,11 +37,10 @@ export function createIncrementalThreadGrouper() {
 
   const update = (
     items: ConversationItem[],
-    mode: CollapseMode,
     overrides: Record<string, boolean>,
   ): ThreadGrouping => {
-    if (!cache || cache.mode !== mode || cache.overrides !== overrides) {
-      return rebuildAll(items, mode, overrides);
+    if (!cache || cache.overrides !== overrides) {
+      return rebuildAll(items, overrides);
     }
 
     if (cache.items === items) {
@@ -66,7 +61,7 @@ export function createIncrementalThreadGrouper() {
       rebuildStart > 0 &&
       cache.items[rebuildStart - 1] !== items[rebuildStart - 1]
     ) {
-      return rebuildAll(items, mode, overrides);
+      return rebuildAll(items, overrides);
     }
 
     const prefixRowCount = getPrefixRowCount(
@@ -76,7 +71,6 @@ export function createIncrementalThreadGrouper() {
     );
     const suffixGrouping = buildThreadGroups(
       items.slice(rebuildStart),
-      mode,
       overrides,
     );
 
@@ -101,7 +95,7 @@ export function createIncrementalThreadGrouper() {
     }
 
     const grouping = { rows, keepMounted, idToRowIndex };
-    cache = { items, mode, overrides, grouping, stablePrefixItemCount };
+    cache = { items, overrides, grouping, stablePrefixItemCount };
     return grouping;
   };
 

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/FileMentionChip.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/FileMentionChip.tsx
@@ -85,9 +85,9 @@ export const FileMentionChip = memo(function FileMentionChip({
       <Text className="text-[13px]">
         <FileIcon filename={filename} size={12} />
         <span className="flex min-w-0 flex-1 items-baseline gap-1 overflow-hidden font-mono text-[13px] leading-none">
-          {/* The directory gives way first, so the filename only ellipsizes once
-              there's no room for it either — better than a hard clip at the
-              row's edge, which is what `shrink-0` produced. */}
+          {/* The lopsided shrink factor on the directory below makes it give way
+              first, so the filename only ellipsizes once there is no room for it
+              either. */}
           <span className="min-w-0 truncate font-semibold">{filename}</span>
           {directory && (
             <span className="min-w-0 shrink-[9999] overflow-hidden text-ellipsis whitespace-nowrap text-muted-foreground/50">

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/ToolRow.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/ToolRow.tsx
@@ -91,40 +91,32 @@ export function ToolRow({
         defaultOpen={defaultOpen}
         open={open}
         onOpenChange={onOpenChange}
-        // Quill's interactive row bleeds its hit area 4px past the text column
-        // and fills on hover; in a transcript of these that reads as a wall of
-        // controls, so the row aligns to the column and brightens instead. The
-        // focus ring goes inset for the same reason — an outset ring on a
-        // full-bleed row draws outside the column.
-        //
-        // Open reads exactly like hover — the row you opened is the row you were
-        // pointing at, so it shouldn't change appearance under the cursor. Only
-        // rows that actually expand on click get it: a flat marker (e.g.
-        // "Thinking" before any content arrives) shouldn't invite interaction it
-        // can't honor.
+        // Overrides quill's interactive row, which bleeds its hit area 4px past
+        // the text column, fills on hover, and draws an outset focus ring. All
+        // three land outside the chat column here, where a transcript is mostly
+        // these rows.
         className={cn(
           "mx-0 px-0 opacity-50 hover:bg-transparent focus-visible:bg-transparent",
-          // The installed quill parks the chevron with `margin-inline-start: auto`;
-          // unset it so it sits against the text it opens. Newer quill already
-          // hugs, at which point this is inert.
+          // quill 0.3.0-beta.24 parks the chevron at the row's far end with
+          // `margin-inline-start: auto`, which strands it from the text it opens.
           "[&>svg:last-child]:ms-0",
           "focus-visible:shadow-none focus-visible:ring-(--ring)/50 focus-visible:ring-2 focus-visible:ring-inset",
+          // Only rows that expand on click get the open state: a flat marker
+          // ("Thinking" before any content arrives) can't honor it.
           isCollapsible &&
             "hover:opacity-100 data-panel-open:bg-transparent data-panel-open:opacity-100",
-          // A failed call goes destructive whole-row, at full strength — the
-          // outcome is the point of the row, and a red "(Failed)" alone reads as
-          // an aside when the title beside it is still neutral. The descendant
-          // selector is what makes it stick: the title, the argument, and the
-          // status text each set their own muted color. Scoped to the trigger,
-          // so a nested marker in the panel keeps its own outcome.
+          // The descendant selector is load-bearing: the title, the argument,
+          // and the status text each set their own muted color, so a color on
+          // the row alone loses to all three. Scoped to the trigger so a nested
+          // marker in the panel keeps its own outcome.
           isFailed &&
             "text-destructive-foreground opacity-100 [&_*]:text-destructive-foreground",
         )}
       >
         <ChatMarkerIcon>{iconNode}</ChatMarkerIcon>
-        {/* No `w-full`: the content sizes to its text so the chevron hugs the
-            end of it, and `overflow-hidden` clips anything that outgrows the
-            trigger rather than letting it spill past the row. */}
+        {/* No `w-full`: the content sizes to its text, so the chevron sits
+            against the end of it. `overflow-hidden` keeps a long argument from
+            spilling past the trigger. */}
         <ChatMarkerContent className="flex min-w-0 flex-nowrap items-center gap-1 overflow-hidden">
           {/* Example: posthog - insight-create(... */}
           {typeof children === "string" ? (

--- a/products/desktop/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/AdvancedSettings.tsx
@@ -24,8 +24,6 @@ export function AdvancedSettings() {
   const setDebugLogsCloudRuns = useSettingsStore(
     (s) => s.setDebugLogsCloudRuns,
   );
-  const useNewChatThread = useSettingsStore((s) => s.useNewChatThread);
-  const setUseNewChatThread = useSettingsStore((s) => s.setUseNewChatThread);
   const autoPublishCloudRuns = useSettingsStore((s) => s.autoPublishCloudRuns);
   const setAutoPublishCloudRuns = useSettingsStore(
     (s) => s.setAutoPublishCloudRuns,
@@ -124,6 +122,7 @@ export function AdvancedSettings() {
         <SettingRow
           label="Debug logs for cloud runs"
           description="Show debug-level console output in the conversation view for cloud-executed runs"
+          noBorder={!devModeClient}
         >
           <Switch
             checked={debugLogsCloudRuns}
@@ -132,17 +131,6 @@ export function AdvancedSettings() {
           />
         </SettingRow>
       )}
-      <SettingRow
-        label="Use new chat thread (experimental)"
-        description="Render conversations with the new ChatX (quill) primitives instead of the virtualized thread"
-        noBorder={!devModeClient}
-      >
-        <Switch
-          checked={useNewChatThread}
-          onCheckedChange={setUseNewChatThread}
-          size="1"
-        />
-      </SettingRow>
       {devModeClient && <DevModeRow client={devModeClient} />}
     </Flex>
   );

--- a/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/GeneralSettings.tsx
@@ -9,10 +9,6 @@ import {
 } from "@posthog/shared/domain-types";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import {
-  COLLAPSE_MODE_OPTIONS,
-  type CollapseMode,
-} from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
-import {
   ReasoningLevelDropdown,
   type ReasoningLevelOption,
 } from "@posthog/ui/features/sessions/components/ReasoningLevelDropdown";
@@ -99,7 +95,6 @@ export function GeneralSettings() {
     defaultReasoningEffort,
     diffOpenMode,
     sendMessagesWith,
-    conversationCollapseMode,
     hedgehogMode,
     slotMachineMode,
     brainrotMode,
@@ -110,7 +105,6 @@ export function GeneralSettings() {
     setDefaultReasoningEffort,
     setDiffOpenMode,
     setSendMessagesWith,
-    setConversationCollapseMode,
     setHedgehogMode,
     setSlotMachineMode,
     setBrainrotMode,
@@ -200,18 +194,6 @@ export function GeneralSettings() {
       setDefaultReasoningEffort(value);
     },
     [defaultReasoningEffort, setDefaultReasoningEffort],
-  );
-
-  const handleConversationCollapseModeChange = useCallback(
-    (value: CollapseMode) => {
-      track(ANALYTICS_EVENTS.SETTING_CHANGED, {
-        setting_name: "conversation_collapse_mode",
-        new_value: value,
-        old_value: conversationCollapseMode,
-      });
-      setConversationCollapseMode(value);
-    },
-    [conversationCollapseMode, setConversationCollapseMode],
   );
 
   const handleSendMessagesWithChange = useCallback(
@@ -448,34 +430,6 @@ export function GeneralSettings() {
             <Select.Item value="split">Split pane</Select.Item>
             <Select.Item value="same-pane">Same pane</Select.Item>
             <Select.Item value="last-active-pane">Last active pane</Select.Item>
-          </Select.Content>
-        </Select.Root>
-      </SettingRow>
-
-      {/* Conversation */}
-      <Text className="mb-2 block border-gray-6 border-t pt-4 font-medium text-sm">
-        Conversation
-      </Text>
-
-      <SettingRow
-        label="Collapse tool calls"
-        description="Group each turn's tool calls into a collapsible summary. Partial keeps the active turn expanded and folds completed turns."
-        noBorder
-      >
-        <Select.Root
-          value={conversationCollapseMode}
-          onValueChange={(value) =>
-            handleConversationCollapseModeChange(value as CollapseMode)
-          }
-          size="1"
-        >
-          <Select.Trigger className="min-w-[140px]" />
-          <Select.Content>
-            {COLLAPSE_MODE_OPTIONS.map((opt) => (
-              <Select.Item key={opt.value} value={opt.value}>
-                {opt.label}
-              </Select.Item>
-            ))}
           </Select.Content>
         </Select.Root>
       </SettingRow>

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -6,10 +6,6 @@ import type {
   WorkspaceMode,
 } from "@posthog/shared";
 import type { EffortLevel } from "@posthog/shared/domain-types";
-import {
-  COLLAPSE_MODE_DEFAULT,
-  type CollapseMode,
-} from "@posthog/ui/features/sessions/components/new-thread/conversationThreadConfig";
 import { electronStorage } from "@posthog/ui/shell/rendererStorage";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -238,8 +234,6 @@ interface SettingsStore {
   setTerminalGpuRendering: (enabled: boolean) => void;
 
   // Conversation thread (new-thread)
-  conversationCollapseMode: CollapseMode;
-  setConversationCollapseMode: (mode: CollapseMode) => void;
 
   // Sidebar
   // Shows a per-repo "Worktrees" dropdown of task-less worktrees a click can
@@ -469,9 +463,6 @@ export const useSettingsStore = create<SettingsStore>()(
         set({ terminalGpuRendering: enabled }),
 
       // Conversation thread (new-thread)
-      conversationCollapseMode: COLLAPSE_MODE_DEFAULT,
-      setConversationCollapseMode: (mode) =>
-        set({ conversationCollapseMode: mode }),
 
       // Sidebar
       showSidebarWorktrees: false,
@@ -609,7 +600,6 @@ export const useSettingsStore = create<SettingsStore>()(
         terminalGpuRendering: state.terminalGpuRendering,
 
         // Conversation thread (new-thread)
-        conversationCollapseMode: state.conversationCollapseMode,
 
         // Sidebar
         showSidebarWorktrees: state.showSidebarWorktrees,

--- a/products/desktop/packages/ui/src/features/settings/settingsStore.ts
+++ b/products/desktop/packages/ui/src/features/settings/settingsStore.ts
@@ -255,10 +255,6 @@ interface SettingsStore {
   downloadUpdatesAutomatically: boolean;
   dismissibleUpdateBanners: boolean;
   lastSeenChangelogVersion: string | null;
-  // Renders the conversation with the new ChatX (quill) primitives instead of
-  // the virtualized ConversationView. Local A/B toggle while the rebuild bakes.
-  useNewChatThread: boolean;
-  setUseNewChatThread: (enabled: boolean) => void;
   setHedgehogMode: (enabled: boolean) => void;
   setSlotMachineMode: (enabled: boolean) => void;
   setBrainrotMode: (enabled: boolean) => void;
@@ -490,8 +486,6 @@ export const useSettingsStore = create<SettingsStore>()(
       downloadUpdatesAutomatically: true,
       dismissibleUpdateBanners: false,
       lastSeenChangelogVersion: null,
-      useNewChatThread: false,
-      setUseNewChatThread: (enabled) => set({ useNewChatThread: enabled }),
       setHedgehogMode: (enabled) => set({ hedgehogMode: enabled }),
       setSlotMachineMode: (enabled) => set({ slotMachineMode: enabled }),
       setBrainrotMode: (enabled) => set({ brainrotMode: enabled }),
@@ -628,7 +622,6 @@ export const useSettingsStore = create<SettingsStore>()(
         downloadUpdatesAutomatically: state.downloadUpdatesAutomatically,
         dismissibleUpdateBanners: state.dismissibleUpdateBanners,
         lastSeenChangelogVersion: state.lastSeenChangelogVersion,
-        useNewChatThread: state.useNewChatThread,
 
         // Onboarding hints
         hints: state.hints,


### PR DESCRIPTION
## Problem

Two things, stacked on #76640.

The thread re-groups every conversation item on every streamed chunk. That is fine for the live turn, but a completed run of tool calls got a fresh array each pass too - new identity, identical contents. `ToolGroup` is wrapped in `memo`, so identity is the only thing it compares: every settled group above the live one re-rendered and re-walked its own summary on every token. On a long session that is O(thread) work per chunk for output nobody is looking at.

Separately, the quill thread has been the opt-in path behind an advanced setting since the rebuild started. It has baked.

## Changes

**Perf.** Settled runs hand back their previous array, keyed on the run's first item. Two guards make that safe:

- Only once the run's turn is complete. A live tool's status is mutated in place on its resolved `ToolCall`, so reusing an array mid-turn would freeze a spinner on a tool that has since finished.
- Length has to match, for a run that gains items before it settles.

The summary walk now goes through `summarizeMemo`, the cache the legacy view already had for exactly this. It was private; this exports it rather than growing a second one, so both threads agree on what "ran 3 commands" means and neither re-walks frozen work. Also swaps a `[...tools].reverse().find(...)` for a reverse loop in the render path.

**Default.** The `useNewChatThread` setting, its persisted flag, its toggle row, and the one branch that only ever rendered on the old thread (`SessionResourcesBar`) are gone. `ThreadView` renders the thread.

> [!NOTE]
> `ConversationView` still exists but nothing outside its own story renders it now. Left in place deliberately - worth a separate PR once this has run for a bit, not a 2,000-line deletion buried in a behavior change.

## How did you test this code?

Automated, all run by me (Claude):

- `pnpm typecheck` across the desktop workspace, 24/24 packages.
- `pnpm --filter @posthog/ui test` - 305 files, 2543 tests.
- `biome check` on the touched tree.

No new tests. The perf change is a caching layer under behavior the existing `ToolGroup` and `threadVirtualization` suites already cover, and its correctness condition (never reuse an array while the turn streams) is the kind of thing a unit test would assert by mirroring the implementation rather than catching a real regression. The default flip removes a branch; the remaining path is the one every existing thread test already exercises.

Manually: I drove the running dev app over CDP to confirm the thread still groups and expands correctly after the change, and that collapsed groups mount no panel at all. I did not sit through a live streaming turn to watch the cache behave under load - that is the gap in this testing.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this, directed by @adamleithp. Follows #76640, which folded thoughts into the tool-group row; the question that prompted this one was whether virtualization still held up after that change.

It does. `flattenTurnRows` counts a tool group as exactly one flat row and the group's internals were never rows, so folding thoughts in only removes top-level rows. Worth flagging for the reviewer: the 250-row virtualization threshold is justified in its own doc comment by a measured "~5 rows per exchange", and folding thoughts changed that ratio. The constant is now defended by a number that no longer holds. I left it alone rather than move it on a guess - measuring it properly needs instrumenting `countFlatRows` against real sessions, which is its own piece of work.

One thing I considered and rejected: giving `memo` a custom comparator on `(items[0], items.length)`. It looks equivalent and is wrong - a tool finishing mutates its status in place without changing any item's identity, so the comparator would skip the re-render and strand a spinner. Fixing the array identity instead gets the same win without that trap, and fails safe: worst case it re-renders.

Skills invoked: `/stacking-prs`.
