### PR TITLE
feat(slack_app): add workspace activity stats to the App Home tab

### DIFF
--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -30,6 +30,7 @@ logger = structlog.get_logger(__name__)
 
 SLACK_APP_OAUTH_FLAG = "slack-app-oauth"
 SLACK_APP_HOME_FLAG = "slack-app-home"
+SLACK_APP_HOME_STATS_FLAG = "slack-app-home-stats"
 SLACK_APP_AGENT_DESIGN_FLAG = "slack-app-agent-design"
 SLACK_APP_ASSISTANT_FLAG = "slack-app-assistant"
 SLACK_APP_BOT_PRS_FLAG = "slack-app-bot-prs"
@@ -87,6 +88,29 @@ def is_slack_app_home_enabled(integration: Integration) -> bool:
     except Exception:
         logger.exception(
             "slack_app_home_feature_flag_check_failed",
+            integration_id=integration.id,
+        )
+        return False
+
+
+def is_slack_app_home_stats_enabled(integration: Integration) -> bool:
+    """Gate for the workspace-activity stats card on the App Home tab. Separate from
+    ``is_slack_app_home_enabled`` so the aggregates can go dark without taking the whole
+    Home tab with them. Keyed on the Slack workspace + PostHog org."""
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                SLACK_APP_HOME_STATS_FLAG,
+                f"slack_workspace:{integration.integration_id}",
+                groups={"organization": str(integration.team.organization_id)},
+                person_properties=_region_properties(),
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception:
+        logger.exception(
+            "slack_app_home_stats_feature_flag_check_failed",
             integration_id=integration.id,
         )
         return False

--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -30,7 +30,6 @@ logger = structlog.get_logger(__name__)
 
 SLACK_APP_OAUTH_FLAG = "slack-app-oauth"
 SLACK_APP_HOME_FLAG = "slack-app-home"
-SLACK_APP_HOME_STATS_FLAG = "slack-app-home-stats"
 SLACK_APP_AGENT_DESIGN_FLAG = "slack-app-agent-design"
 SLACK_APP_ASSISTANT_FLAG = "slack-app-assistant"
 SLACK_APP_BOT_PRS_FLAG = "slack-app-bot-prs"
@@ -88,29 +87,6 @@ def is_slack_app_home_enabled(integration: Integration) -> bool:
     except Exception:
         logger.exception(
             "slack_app_home_feature_flag_check_failed",
-            integration_id=integration.id,
-        )
-        return False
-
-
-def is_slack_app_home_stats_enabled(integration: Integration) -> bool:
-    """Gate for the workspace-activity stats card on the App Home tab. Separate from
-    ``is_slack_app_home_enabled`` so the aggregates can go dark without taking the whole
-    Home tab with them. Keyed on the Slack workspace + PostHog org."""
-    try:
-        return bool(
-            posthoganalytics.feature_enabled(
-                SLACK_APP_HOME_STATS_FLAG,
-                f"slack_workspace:{integration.integration_id}",
-                groups={"organization": str(integration.team.organization_id)},
-                person_properties=_region_properties(),
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
-    except Exception:
-        logger.exception(
-            "slack_app_home_stats_feature_flag_check_failed",
             integration_id=integration.id,
         )
         return False

--- a/products/slack_app/backend/migrations/0012_slackthreadtaskmapping_workspace_created_idx.py
+++ b/products/slack_app/backend/migrations/0012_slackthreadtaskmapping_workspace_created_idx.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # CONCURRENTLY so the build takes no ACCESS EXCLUSIVE lock on the mapping table.
+    # Concurrent builds can't run in a transaction, so this migration is non-atomic.
+    atomic = False
+
+    dependencies = [
+        ("slack_app", "0011_slacksettings_permission_modes"),
+    ]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="slackthreadtaskmapping",
+            index=models.Index(fields=["slack_workspace_id", "created_at"], name="slack_thr_map_ws_created_idx"),
+        ),
+    ]

--- a/products/slack_app/backend/migrations/0012_slackthreadtaskmapping_workspace_created_idx.py
+++ b/products/slack_app/backend/migrations/0012_slackthreadtaskmapping_workspace_created_idx.py
@@ -15,6 +15,10 @@ class Migration(migrations.Migration):
     operations = [
         SafeAddIndexConcurrently(
             model_name="slackthreadtaskmapping",
-            index=models.Index(fields=["slack_workspace_id", "created_at"], name="slack_thr_map_ws_created_idx"),
+            index=models.Index(
+                fields=["slack_workspace_id", "created_at"],
+                include=["team_id"],
+                name="slack_thr_map_ws_created_idx",
+            ),
         ),
     ]

--- a/products/slack_app/backend/migrations/max_migration.txt
+++ b/products/slack_app/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0011_slacksettings_permission_modes
+0012_slackthreadtaskmapping_workspace_created_idx

--- a/products/slack_app/backend/models.py
+++ b/products/slack_app/backend/models.py
@@ -47,6 +47,11 @@ class SlackThreadTaskMapping(UUIDModel):
                 name="uniq_slack_thread_task_mapping",
             )
         ]
+        indexes = [
+            # Serves the workspace-wide activity aggregates on the App Home tab, which scan a
+            # whole workspace over a date window rather than a single thread.
+            models.Index(fields=["slack_workspace_id", "created_at"], name="slack_thr_map_ws_created_idx"),
+        ]
 
 
 class SlackUserProfileCache(UUIDModel):

--- a/products/slack_app/backend/models.py
+++ b/products/slack_app/backend/models.py
@@ -49,8 +49,14 @@ class SlackThreadTaskMapping(UUIDModel):
         ]
         indexes = [
             # Serves the workspace-wide activity aggregates on the App Home tab, which scan a
-            # whole workspace over a date window rather than a single thread.
-            models.Index(fields=["slack_workspace_id", "created_at"], name="slack_thr_map_ws_created_idx"),
+            # whole workspace over a date window rather than a single thread. `team_id` rides
+            # along as an INCLUDE column so the accessible-projects filter is evaluated off the
+            # index instead of a heap fetch per candidate row.
+            models.Index(
+                fields=["slack_workspace_id", "created_at"],
+                include=["team_id"],
+                name="slack_thr_map_ws_created_idx",
+            ),
         ]
 
 

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -15,8 +15,8 @@ in `products/slack_app/backend/api.py` are the ones that actually call
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
@@ -46,8 +46,8 @@ from products.slack_app.backend.services.slack_app_home_stats import (
     STATS_WINDOW_OPTIONS,
     ModelUsage,
     StatsState,
+    build_stats_state,
     coerce_window_days,
-    resolve_stats_state,
 )
 from products.slack_app.backend.services.slack_settings import (
     AIPreferences,
@@ -347,6 +347,35 @@ class TasksState:
 
 
 @dataclass(frozen=True)
+class HomeViewState:
+    """The Home tab's control settings, as they stood when the user clicked.
+
+    Slack holds no server-side state for a published Home tab; each `block_actions`
+    payload instead carries the whole view's inputs. Reading them into one object means
+    an action on any card republishes the others exactly as they were, instead of
+    resetting them to their defaults.
+    """
+
+    selected_repo: str | None = None
+    selected_status: str | None = None
+    tasks_page: int = 0
+    stats_window_days: int = DEFAULT_STATS_WINDOW_DAYS
+    stats_force_refresh: bool = False
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> HomeViewState:
+        # Block Kit only persists state under blocks carrying a `block_id`, so each
+        # card's controls row shares one key. Absent blocks (a card the viewer doesn't
+        # get) simply fall back to defaults.
+        values = (payload.get("view") or {}).get("state", {}).get("values", {}) or {}
+        return cls(
+            selected_repo=_selected_value(values, BLOCK_TASKS_CONTROLS, ACTION_TASKS_FILTER_REPO),
+            selected_status=_selected_value(values, BLOCK_TASKS_CONTROLS, ACTION_TASKS_FILTER_STATUS),
+            stats_window_days=coerce_window_days(_selected_value(values, BLOCK_STATS_CONTROLS, ACTION_STATS_WINDOW)),
+        )
+
+
+@dataclass(frozen=True)
 class AccountState:
     """Inputs the renderer needs to draw the optional account-link card.
 
@@ -428,6 +457,60 @@ def _section_title(title: str, subtitle: str | None = None) -> dict:
 def _subsection_label(text: str) -> dict:
     """Bold mrkdwn line in a `context` block — smaller than a section title."""
     return {"type": "context", "elements": [{"type": "mrkdwn", "text": f"*{text}*"}]}
+
+
+def _refreshed_at_blocks(epoch: int) -> list[dict]:
+    """ "Last refreshed" line, rendered in the viewer's own timezone by Slack.
+
+    Empty when the card has never been resolved, so callers can `extend` unconditionally.
+    """
+    if not epoch:
+        return []
+    return [
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f"_Last refreshed <!date^{epoch}^{{date_short_pretty}} at {{time}}|just now>_",
+                }
+            ],
+        }
+    ]
+
+
+def _static_select(
+    *,
+    action_id: str,
+    placeholder: str,
+    pairs: Iterable[tuple[str, str]],
+    selected: str | None = None,
+) -> dict[str, Any]:
+    """A `static_select` built from `(value, label)` pairs.
+
+    `selected` is honoured only when it matches one of the pairs, so a stale value from a
+    cached view can't produce an `initial_option` Slack rejects.
+    """
+    options = [{"text": {"type": "plain_text", "text": label, "emoji": True}, "value": value} for value, label in pairs]
+    element: dict[str, Any] = {
+        "type": "static_select",
+        "action_id": action_id,
+        "placeholder": {"type": "plain_text", "text": placeholder},
+        "options": options,
+    }
+    initial = next((o for o in options if o["value"] == selected), None)
+    if initial:
+        element["initial_option"] = initial
+    return element
+
+
+def _provider_for_runtime_adapter(runtime_adapter: str | None) -> str:
+    """The gateway `owned_by` a runtime adapter implies — the inverse of
+    `_PROVIDER_TO_RUNTIME_ADAPTER`, so the two can't drift when an adapter is added."""
+    for provider, adapter in _PROVIDER_TO_RUNTIME_ADAPTER.items():
+        if adapter == runtime_adapter:
+            return provider
+    return "anthropic"
 
 
 def _header_blocks() -> list[dict]:
@@ -703,21 +786,7 @@ def _tasks_section_blocks(state: TasksState) -> list[dict]:
 
     if state.has_any_tasks:
         blocks.append(_tasks_controls_block(state))
-        if state.refreshed_at_epoch:
-            blocks.append(
-                {
-                    "type": "context",
-                    "elements": [
-                        {
-                            "type": "mrkdwn",
-                            "text": (
-                                f"_Last refreshed <!date^{state.refreshed_at_epoch}"
-                                "^{date_short_pretty} at {time}|just now>_"
-                            ),
-                        }
-                    ],
-                }
-            )
+        blocks.extend(_refreshed_at_blocks(state.refreshed_at_epoch))
 
     if not state.items:
         empty_text = (
@@ -867,7 +936,6 @@ def _tasks_controls_block(state: TasksState) -> dict:
 # Block Kit caps on the stats card. These live with the renderer rather than the resolver
 # because they describe what Slack will draw, not what the workspace did.
 _STATS_MAX_PIE_SEGMENTS = 12
-_STATS_MAX_CHART_POINTS = 20
 _STATS_MAX_LABEL_CHARS = 20
 _STATS_TABLE_PAGE_SIZE = 5
 
@@ -899,43 +967,31 @@ def _stats_section_blocks(state: StatsState) -> list[dict]:
         return blocks
 
     blocks.append(_stats_headline_block(state))
-
-    outcomes_block = _stats_outcomes_block(state)
-    if outcomes_block:
-        blocks.append(outcomes_block)
-
-    for chart in (_stats_trend_chart(state), _stats_models_chart(state)):
-        if chart:
-            blocks.append(chart)
-
-    people_table = _stats_people_table(state)
-    if people_table:
-        blocks.append(people_table)
-
+    blocks.extend(
+        block
+        for block in (
+            _stats_outcomes_block(state),
+            _stats_trend_chart(state),
+            _stats_models_chart(state),
+            _stats_people_table(state),
+        )
+        if block
+    )
     blocks.extend(_stats_footnote_blocks(state))
     return blocks
 
 
 def _stats_controls_block(state: StatsState) -> dict:
-    options = [
-        {"text": {"type": "plain_text", "text": label, "emoji": True}, "value": str(days)}
-        for days, label in STATS_WINDOW_OPTIONS
-    ]
-    window_select: dict[str, Any] = {
-        "type": "static_select",
-        "action_id": ACTION_STATS_WINDOW,
-        "placeholder": {"type": "plain_text", "text": "Pick a window"},
-        "options": options,
-    }
-    selected = next((o for o in options if o["value"] == str(state.window_days)), None)
-    if selected:
-        window_select["initial_option"] = selected
-
     return {
         "type": "actions",
         "block_id": BLOCK_STATS_CONTROLS,
         "elements": [
-            window_select,
+            _static_select(
+                action_id=ACTION_STATS_WINDOW,
+                placeholder="Pick a window",
+                pairs=((str(days), label) for days, label in STATS_WINDOW_OPTIONS),
+                selected=str(state.window_days),
+            ),
             {
                 "type": "button",
                 "action_id": ACTION_STATS_REFRESH,
@@ -973,7 +1029,7 @@ def _stats_trend_chart(state: StatsState) -> dict | None:
 
     Skipped entirely when the window produced no PRs — an all-zero chart is noise.
     """
-    buckets = state.trend[-_STATS_MAX_CHART_POINTS:]
+    buckets = state.trend
     if not buckets or not state.tasks_with_pr:
         return None
     return {
@@ -999,15 +1055,12 @@ def _stats_models_chart(state: StatsState) -> dict | None:
     if not state.models:
         return None
 
-    head: tuple[ModelUsage, ...]
-    tail: tuple[ModelUsage, ...]
-    if len(state.models) <= _STATS_MAX_PIE_SEGMENTS:
-        head, tail = state.models, ()
-    else:
-        head, tail = state.models[: _STATS_MAX_PIE_SEGMENTS - 1], state.models[_STATS_MAX_PIE_SEGMENTS - 1 :]
+    fits = len(state.models) <= _STATS_MAX_PIE_SEGMENTS
+    head = state.models if fits else state.models[: _STATS_MAX_PIE_SEGMENTS - 1]
+    tail = () if fits else state.models[_STATS_MAX_PIE_SEGMENTS - 1 :]
 
     segments: list[dict[str, Any]] = [
-        {"label": _stats_label(_stats_model_label(usage)), "value": usage.value} for usage in head if usage.value > 0
+        {"label": _stats_model_label(usage), "value": usage.value} for usage in head if usage.value > 0
     ]
     other = sum(usage.value for usage in tail)
     if other > 0:
@@ -1019,15 +1072,11 @@ def _stats_models_chart(state: StatsState) -> dict | None:
 
 
 def _stats_model_label(usage: ModelUsage) -> str:
-    owned_by = "openai" if usage.runtime_adapter == "codex" else "anthropic"
-    return _format_model_id(usage.model, owned_by=owned_by)
-
-
-def _stats_label(text: str) -> str:
-    """Fit a chart label into Slack's 20-character cap."""
-    if len(text) <= _STATS_MAX_LABEL_CHARS:
-        return text
-    return text[: _STATS_MAX_LABEL_CHARS - 1] + "…"
+    """Display label for a model, truncated to Slack's 20-character chart-label cap."""
+    label = _format_model_id(usage.model, owned_by=_provider_for_runtime_adapter(usage.runtime_adapter))
+    if len(label) <= _STATS_MAX_LABEL_CHARS:
+        return label
+    return label[: _STATS_MAX_LABEL_CHARS - 1] + "…"
 
 
 def _stats_people_table(state: StatsState) -> dict | None:
@@ -1059,22 +1108,30 @@ def _stats_people_table(state: StatsState) -> dict | None:
 
 
 def _stats_footnote_blocks(state: StatsState) -> list[dict]:
-    notes: list[str] = []
+    blocks: list[dict] = []
     if state.truncated:
-        notes.append(f"Counting the {STATS_MAX_TASKS} most recent tasks — older activity in this window is excluded.")
-    if state.refreshed_at_epoch:
-        notes.append(
-            f"Last refreshed <!date^{state.refreshed_at_epoch}^{{date_short_pretty}} at {{time}}|just now>",
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            f"_Counting the {STATS_MAX_TASKS} most recent tasks — "
+                            "older activity in this window is excluded._"
+                        ),
+                    }
+                ],
+            }
         )
-    if not notes:
-        return []
-    return [{"type": "context", "elements": [{"type": "mrkdwn", "text": f"_{' · '.join(notes)}_"}]}]
+    blocks.extend(_refreshed_at_blocks(state.refreshed_at_epoch))
+    return blocks
 
 
 def _row_summary(row: SlackSettings | None) -> str:
     if not row or not row.runtime_adapter or not row.model:
         return "_(none)_"
-    owned_by = "openai" if row.runtime_adapter == "codex" else "anthropic"
+    owned_by = _provider_for_runtime_adapter(row.runtime_adapter)
     parts = [
         f"*Model:* {_format_model_id(row.model, owned_by=owned_by)}",
         f"*Runtime:* {_label(row.runtime_adapter, RUNTIME_ADAPTER_DISPLAY_NAMES)}",
@@ -1277,10 +1334,11 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
 
     slack = SlackIntegration(integration)
     is_admin = _is_admin(slack, integration, slack_user_id)
+    accessible = _accessible_integrations(integration, slack_user_id)
     account_state = _resolve_account_state(integration, slack_user_id)
-    project_state = _resolve_project_state(integration, slack_user_id)
-    tasks_state = _resolve_tasks_state(integration, slack_user_id)
-    stats_state = _resolve_stats_state(integration, slack_user_id, is_admin=is_admin)
+    project_state = _resolve_project_state(integration, slack_user_id, accessible=accessible)
+    tasks_state = _resolve_tasks_state(integration, slack_user_id, accessible=accessible)
+    stats_state = _resolve_stats_state(integration, accessible=accessible, is_admin=is_admin)
 
     view = render_home_view(
         effective=effective,
@@ -1320,27 +1378,13 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
     if not is_slack_app_home_enabled(integration):
         return HttpResponse(status=200)
 
-    # The Home tab keeps no server-side view state, so the stats window has to be read
-    # back off every payload and re-applied — otherwise an unrelated click (a task
-    # filter, a project pick) would silently snap the card back to its default window.
-    stats_window_days = _read_stats_window_from_payload(payload)
+    # The Home tab keeps no server-side view state — every payload carries the whole
+    # view's inputs instead. Read them all back once so any action republishes with the
+    # controls the user had dialled in, rather than resetting its neighbours' cards.
+    view_state = HomeViewState.from_payload(payload)
 
-    def republish(
-        *,
-        selected_repo: str | None = None,
-        selected_status: str | None = None,
-        page: int = 0,
-        stats_force_refresh: bool = False,
-    ) -> None:
-        _republish_home(
-            integration,
-            slack_user_id,
-            selected_repo=selected_repo,
-            selected_status=selected_status,
-            page=page,
-            stats_window_days=stats_window_days,
-            stats_force_refresh=stats_force_refresh,
-        )
+    def republish(state: HomeViewState = view_state) -> None:
+        _republish_home(integration, slack_user_id, view_state=state)
 
     if action_id == ACTION_EDIT_PERSONAL and trigger_id:
         _open_edit_modal(integration, slack_user_id, scope="personal", trigger_id=trigger_id)
@@ -1394,7 +1438,6 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
         ACTION_TASKS_PAGE_PREV,
         ACTION_TASKS_PAGE_NEXT,
     ):
-        selected_repo, selected_status = _read_tasks_filters_from_payload(payload)
         # Filter changes snap back to page 0; Refresh / Prev / Next carry the
         # target page as the button value so the Home tab stays stateless.
         if action_id in (ACTION_TASKS_REFRESH, ACTION_TASKS_PAGE_PREV, ACTION_TASKS_PAGE_NEXT):
@@ -1404,13 +1447,13 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
                 page = 0
         else:
             page = 0
-        republish(selected_repo=selected_repo, selected_status=selected_status, page=page)
+        republish(replace(view_state, tasks_page=page))
         return HttpResponse(status=200)
 
     if action_id in (ACTION_STATS_WINDOW, ACTION_STATS_REFRESH):
-        # The window pick is already reflected in the view state `stats_window_days`
-        # was read from; only Refresh needs to bypass the aggregate cache.
-        republish(stats_force_refresh=action_id == ACTION_STATS_REFRESH)
+        # The window pick already rode in on the view state; only Refresh additionally
+        # needs to bypass the aggregate cache.
+        republish(replace(view_state, stats_force_refresh=action_id == ACTION_STATS_REFRESH))
         return HttpResponse(status=200)
 
     if action_id in (MODAL_ACTION_RUNTIME_ADAPTER, MODAL_ACTION_MODEL):
@@ -1654,31 +1697,30 @@ def _republish_home(
     integration: Integration,
     slack_user_id: str,
     *,
-    selected_repo: str | None = None,
-    selected_status: str | None = None,
-    page: int = 0,
-    stats_window_days: int = DEFAULT_STATS_WINDOW_DAYS,
-    stats_force_refresh: bool = False,
+    view_state: HomeViewState | None = None,
 ) -> None:
+    view_state = view_state or HomeViewState()
     user_row, workspace_row = _load_rows(integration, slack_user_id)
     effective = resolve_ai_preferences(integration, slack_user_id)
     slack = SlackIntegration(integration)
     is_admin = _is_admin(slack, integration, slack_user_id)
+    accessible = _accessible_integrations(integration, slack_user_id)
     account_state = _resolve_account_state(integration, slack_user_id)
-    project_state = _resolve_project_state(integration, slack_user_id)
+    project_state = _resolve_project_state(integration, slack_user_id, accessible=accessible)
     tasks_state = _resolve_tasks_state(
         integration,
         slack_user_id,
-        selected_repo=selected_repo,
-        selected_status=selected_status,
-        page=page,
+        accessible=accessible,
+        selected_repo=view_state.selected_repo,
+        selected_status=view_state.selected_status,
+        page=view_state.tasks_page,
     )
     stats_state = _resolve_stats_state(
         integration,
-        slack_user_id,
+        accessible=accessible,
         is_admin=is_admin,
-        window_days=stats_window_days,
-        force_refresh=stats_force_refresh,
+        window_days=view_state.stats_window_days,
+        force_refresh=view_state.stats_force_refresh,
     )
     view = render_home_view(
         effective=effective,
@@ -1708,6 +1750,7 @@ def _resolve_tasks_state(
     integration: Integration,
     slack_user_id: str,
     *,
+    accessible: list[Integration],
     selected_repo: str | None = None,
     selected_status: str | None = None,
     page: int = 0,
@@ -1742,12 +1785,7 @@ def _resolve_tasks_state(
     if not mappings:
         return TasksState()
 
-    candidates = list(
-        Integration.objects.filter(kind="slack", integration_id=slack_team_id)
-        .select_related("team", "team__organization")
-        .order_by("id")
-    )
-    accessible_team_ids = {c.team_id for c in _filter_accessible_integrations(integration, slack_user_id, candidates)}
+    accessible_team_ids = {c.team_id for c in accessible}
     if not accessible_team_ids:
         return TasksState()
 
@@ -1851,35 +1889,6 @@ def _format_relative(when: datetime | None, *, now: datetime) -> str:
     return when.strftime("%b %d")
 
 
-def _read_tasks_filters_from_payload(payload: dict) -> tuple[str | None, str | None]:
-    """Pull current filter selections off the Home tab view state.
-
-    The Home tab is stateless — each pick triggers a `block_actions` payload
-    that carries the *whole* view's input state, so the handler can re-publish
-    honouring whatever the user has dialled in. Block Kit only persists
-    state under blocks that carry a `block_id`, so the controls row uses
-    a single fixed `BLOCK_TASKS_CONTROLS` key for every select inside it.
-    """
-    values = (payload.get("view") or {}).get("state", {}).get("values", {}) or {}
-    controls = values.get(BLOCK_TASKS_CONTROLS, {})
-    repo = (controls.get(ACTION_TASKS_FILTER_REPO, {}).get("selected_option") or {}).get("value")
-    status = (controls.get(ACTION_TASKS_FILTER_STATUS, {}).get("selected_option") or {}).get("value")
-    return repo, status
-
-
-def _read_stats_window_from_payload(payload: dict) -> int:
-    """Pull the selected stats window off the Home tab view state.
-
-    Same mechanism as `_read_tasks_filters_from_payload` — Block Kit only persists state
-    under blocks carrying a `block_id`, so the whole controls row shares one key. Falls
-    back to the default window when the card isn't rendered for this user.
-    """
-    values = (payload.get("view") or {}).get("state", {}).get("values", {}) or {}
-    controls = values.get(BLOCK_STATS_CONTROLS, {})
-    selected = (controls.get(ACTION_STATS_WINDOW, {}).get("selected_option") or {}).get("value")
-    return coerce_window_days(selected)
-
-
 def _resolve_account_state(integration: Integration, slack_user_id: str) -> AccountState:
     slack_team_id = integration.integration_id
     if not is_slack_app_oauth_enabled(integration, slack_team_id):
@@ -1912,10 +1921,31 @@ def _resolve_account_state(integration: Integration, slack_user_id: str) -> Acco
     return AccountState(enabled=True, linked_email=None, link_url=link_url)
 
 
+def _workspace_integrations(slack_team_id: str) -> list[Integration]:
+    """Every PostHog project this Slack workspace is connected to."""
+    return list(
+        Integration.objects.filter(kind="slack", integration_id=slack_team_id)
+        .select_related("team", "team__organization")
+        .order_by("id")
+    )
+
+
+def _accessible_integrations(integration: Integration, slack_user_id: str) -> list[Integration]:
+    """The workspace's projects this Slack user can actually reach in PostHog.
+
+    Resolved once per publish and handed to every card: it costs a `UserPermissions`
+    build plus three queries, and all three cards want the same answer. It is also the
+    authorization boundary for the whole tab, so it should have exactly one definition.
+    """
+    return _filter_accessible_integrations(
+        integration, slack_user_id, _workspace_integrations(integration.integration_id)
+    )
+
+
 def _resolve_stats_state(
     integration: Integration,
-    slack_user_id: str,
     *,
+    accessible: list[Integration],
     is_admin: bool,
     window_days: int = DEFAULT_STATS_WINDOW_DAYS,
     force_refresh: bool = False,
@@ -1929,19 +1959,13 @@ def _resolve_stats_state(
     if not is_admin or not is_slack_app_home_stats_enabled(integration):
         return None
 
-    slack_team_id = integration.integration_id
-    candidates = list(
-        Integration.objects.filter(kind="slack", integration_id=slack_team_id)
-        .select_related("team", "team__organization")
-        .order_by("id")
-    )
-    accessible_team_ids = {c.team_id for c in _filter_accessible_integrations(integration, slack_user_id, candidates)}
+    accessible_team_ids = {c.team_id for c in accessible}
     if not accessible_team_ids:
         return None
 
     try:
-        return resolve_stats_state(
-            slack_workspace_id=slack_team_id,
+        return build_stats_state(
+            slack_workspace_id=integration.integration_id,
             accessible_team_ids=accessible_team_ids,
             window_days=window_days,
             force_refresh=force_refresh,
@@ -1949,24 +1973,16 @@ def _resolve_stats_state(
     except Exception:
         # The card is supplementary — a failed aggregate shouldn't cost the user their
         # settings and task list too.
-        logger.exception(
-            "slack_app_home_stats_resolve_failed",
-            integration_id=integration.id,
-            slack_user_id=slack_user_id,
-        )
+        logger.exception("slack_app_home_stats_resolve_failed", integration_id=integration.id)
         return None
 
 
-def _resolve_project_state(integration: Integration, slack_user_id: str) -> ProjectState:
-    candidates = list(
-        Integration.objects.filter(kind="slack", integration_id=integration.integration_id)
-        .select_related("team", "team__organization")
-        .order_by("id")
-    )
+def _resolve_project_state(
+    integration: Integration, slack_user_id: str, *, accessible: list[Integration]
+) -> ProjectState:
+    candidates = _workspace_integrations(integration.integration_id)
     if not candidates:
         return ProjectState()
-
-    accessible = _filter_accessible_integrations(integration, slack_user_id, candidates)
 
     user_row = (
         SlackSettings.objects.filter(

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -30,8 +30,25 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
-from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
+from products.slack_app.backend.feature_flags import (
+    is_slack_app_home_enabled,
+    is_slack_app_home_stats_enabled,
+    is_slack_app_oauth_enabled,
+)
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
+from products.slack_app.backend.services.slack_app_home_stats import (
+    DEFAULT_STATS_WINDOW_DAYS,
+    OUTCOME_CANCELLED,
+    OUTCOME_DONE,
+    OUTCOME_FAILED,
+    OUTCOME_RUNNING,
+    STATS_MAX_TASKS,
+    STATS_WINDOW_OPTIONS,
+    ModelUsage,
+    StatsState,
+    coerce_window_days,
+    resolve_stats_state,
+)
 from products.slack_app.backend.services.slack_settings import (
     AIPreferences,
     build_ai_preferences_payload,
@@ -61,12 +78,15 @@ ACTION_TASKS_REFRESH = "slack_app_home:tasks_refresh"
 # can't share one id — they both carry the target page as `value`.
 ACTION_TASKS_PAGE_PREV = "slack_app_home:tasks_page_prev"
 ACTION_TASKS_PAGE_NEXT = "slack_app_home:tasks_page_next"
+ACTION_STATS_WINDOW = "slack_app_home:stats_window"
+ACTION_STATS_REFRESH = "slack_app_home:stats_refresh"
 
 # Single block_id for the whole controls row. Block Kit only persists
 # state in `view.state.values` under blocks that carry a `block_id`, so
 # both the repo and the status dropdowns live under the same key here and
 # the handler can read them back on each pick.
 BLOCK_TASKS_CONTROLS = "block_tasks_controls"
+BLOCK_STATS_CONTROLS = "block_stats_controls"
 
 # Sentinel value the "All …" options carry — Slack rejects empty `value`
 # strings, so the resolver treats this as "no filter".
@@ -349,6 +369,7 @@ def render_home_view(
     account_state: AccountState | None = None,
     project_state: ProjectState | None = None,
     tasks_state: TasksState | None = None,
+    stats_state: StatsState | None = None,
 ) -> dict:
     """Render the Block Kit payload for `views.publish` on the App Home tab."""
 
@@ -383,6 +404,13 @@ def render_home_view(
     if tasks_state is not None:
         blocks.append({"type": "divider"})
         blocks.extend(_tasks_section_blocks(tasks_state))
+
+    # Section 5 — workspace activity: aggregates across everyone's Slack-started work,
+    # rather than the calling user's own. Last because it answers a different question
+    # than the rest of the tab, and only admins get it at all.
+    if stats_state is not None:
+        blocks.append({"type": "divider"})
+        blocks.extend(_stats_section_blocks(stats_state))
 
     blocks.append({"type": "divider"})
     blocks.extend(_footer_blocks())
@@ -836,6 +864,213 @@ def _tasks_controls_block(state: TasksState) -> dict:
     return {"type": "actions", "block_id": BLOCK_TASKS_CONTROLS, "elements": elements}
 
 
+# Block Kit caps on the stats card. These live with the renderer rather than the resolver
+# because they describe what Slack will draw, not what the workspace did.
+_STATS_MAX_PIE_SEGMENTS = 12
+_STATS_MAX_CHART_POINTS = 20
+_STATS_MAX_LABEL_CHARS = 20
+_STATS_TABLE_PAGE_SIZE = 5
+
+_OUTCOME_EMOJI: dict[str, str] = {
+    OUTCOME_DONE: "🦔",
+    OUTCOME_FAILED: "❌",
+    OUTCOME_CANCELLED: "🚫",
+    OUTCOME_RUNNING: "🔄",
+}
+
+
+def _stats_section_blocks(state: StatsState) -> list[dict]:
+    """Render the workspace-activity card: headline counts, two charts, a leaderboard."""
+    blocks: list[dict] = [
+        _section_title(
+            "📊 Workspace activity",
+            "What your team shipped with @PostHog. Only workspace admins see this.",
+        ),
+        _stats_controls_block(state),
+    ]
+
+    if not state.has_data:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": "_Nobody has started a task from Slack in this window._"},
+            }
+        )
+        return blocks
+
+    blocks.append(_stats_headline_block(state))
+
+    outcomes_block = _stats_outcomes_block(state)
+    if outcomes_block:
+        blocks.append(outcomes_block)
+
+    for chart in (_stats_trend_chart(state), _stats_models_chart(state)):
+        if chart:
+            blocks.append(chart)
+
+    people_table = _stats_people_table(state)
+    if people_table:
+        blocks.append(people_table)
+
+    blocks.extend(_stats_footnote_blocks(state))
+    return blocks
+
+
+def _stats_controls_block(state: StatsState) -> dict:
+    options = [
+        {"text": {"type": "plain_text", "text": label, "emoji": True}, "value": str(days)}
+        for days, label in STATS_WINDOW_OPTIONS
+    ]
+    window_select: dict[str, Any] = {
+        "type": "static_select",
+        "action_id": ACTION_STATS_WINDOW,
+        "placeholder": {"type": "plain_text", "text": "Pick a window"},
+        "options": options,
+    }
+    selected = next((o for o in options if o["value"] == str(state.window_days)), None)
+    if selected:
+        window_select["initial_option"] = selected
+
+    return {
+        "type": "actions",
+        "block_id": BLOCK_STATS_CONTROLS,
+        "elements": [
+            window_select,
+            {
+                "type": "button",
+                "action_id": ACTION_STATS_REFRESH,
+                "value": str(state.window_days),
+                "text": {"type": "plain_text", "text": "Refresh", "emoji": True},
+            },
+        ],
+    }
+
+
+def _stats_headline_block(state: StatsState) -> dict:
+    parts = [
+        f"*{state.tasks_started}* tasks",
+        f"*{state.tasks_with_pr}* opened a PR",
+        f"*{state.tasks_merged}* merged",
+    ]
+    merge_rate = state.merge_rate_percent
+    if merge_rate is not None:
+        parts.append(f"*{merge_rate}%* merge rate")
+    return {"type": "section", "text": {"type": "mrkdwn", "text": "  ·  ".join(parts)}}
+
+
+def _stats_outcomes_block(state: StatsState) -> dict | None:
+    """Outcome split as a muted text line — it's the least interesting of the four
+    breakdowns, and giving up its chart keeps the card inside Slack's per-surface
+    data-visualization budget."""
+    if not state.outcomes:
+        return None
+    parts = [f"{_OUTCOME_EMOJI.get(s.label, '')} {s.value} {s.label.lower()}".strip() for s in state.outcomes]
+    return {"type": "context", "elements": [{"type": "mrkdwn", "text": " · ".join(parts)}]}
+
+
+def _stats_trend_chart(state: StatsState) -> dict | None:
+    """Grouped bars of PRs opened vs merged per bucket.
+
+    Skipped entirely when the window produced no PRs — an all-zero chart is noise.
+    """
+    buckets = state.trend[-_STATS_MAX_CHART_POINTS:]
+    if not buckets or not state.tasks_with_pr:
+        return None
+    return {
+        "type": "data_visualization",
+        "title": "PRs opened and merged",
+        "chart": {
+            "type": "bar",
+            "series": [
+                {"name": "Opened", "data": [{"label": b.label, "value": b.opened} for b in buckets]},
+                {"name": "Merged", "data": [{"label": b.label, "value": b.merged} for b in buckets]},
+            ],
+            "axis_config": {"categories": [b.label for b in buckets], "y_label": "PRs"},
+        },
+    }
+
+
+def _stats_models_chart(state: StatsState) -> dict | None:
+    """Share of runs per pinned model, with the long tail folded into "Other".
+
+    Slack rejects pie segments whose value isn't positive, so zero counts are dropped
+    rather than drawn as empty slices.
+    """
+    if not state.models:
+        return None
+
+    head: tuple[ModelUsage, ...]
+    tail: tuple[ModelUsage, ...]
+    if len(state.models) <= _STATS_MAX_PIE_SEGMENTS:
+        head, tail = state.models, ()
+    else:
+        head, tail = state.models[: _STATS_MAX_PIE_SEGMENTS - 1], state.models[_STATS_MAX_PIE_SEGMENTS - 1 :]
+
+    segments: list[dict[str, Any]] = [
+        {"label": _stats_label(_stats_model_label(usage)), "value": usage.value} for usage in head if usage.value > 0
+    ]
+    other = sum(usage.value for usage in tail)
+    if other > 0:
+        segments.append({"label": "Other", "value": other})
+
+    if not segments:
+        return None
+    return {"type": "data_visualization", "title": "Models used", "chart": {"type": "pie", "segments": segments}}
+
+
+def _stats_model_label(usage: ModelUsage) -> str:
+    owned_by = "openai" if usage.runtime_adapter == "codex" else "anthropic"
+    return _format_model_id(usage.model, owned_by=owned_by)
+
+
+def _stats_label(text: str) -> str:
+    """Fit a chart label into Slack's 20-character cap."""
+    if len(text) <= _STATS_MAX_LABEL_CHARS:
+        return text
+    return text[: _STATS_MAX_LABEL_CHARS - 1] + "…"
+
+
+def _stats_people_table(state: StatsState) -> dict | None:
+    """Sortable leaderboard. `raw_number` cells carry both the rendered `text` and the
+    numeric `value` Slack sorts on."""
+    if not state.people:
+        return None
+    rows: list[list[dict[str, Any]]] = [
+        [
+            {"type": "raw_text", "text": "Person"},
+            {"type": "raw_text", "text": "Tasks"},
+            {"type": "raw_text", "text": "PRs merged"},
+        ]
+    ]
+    rows.extend(
+        [
+            {"type": "raw_text", "text": person.name},
+            {"type": "raw_number", "text": str(person.tasks), "value": person.tasks},
+            {"type": "raw_number", "text": str(person.merged), "value": person.merged},
+        ]
+        for person in state.people
+    )
+    return {
+        "type": "data_table",
+        "caption": "Most active people",
+        "page_size": _STATS_TABLE_PAGE_SIZE,
+        "rows": rows,
+    }
+
+
+def _stats_footnote_blocks(state: StatsState) -> list[dict]:
+    notes: list[str] = []
+    if state.truncated:
+        notes.append(f"Counting the {STATS_MAX_TASKS} most recent tasks — older activity in this window is excluded.")
+    if state.refreshed_at_epoch:
+        notes.append(
+            f"Last refreshed <!date^{state.refreshed_at_epoch}^{{date_short_pretty}} at {{time}}|just now>",
+        )
+    if not notes:
+        return []
+    return [{"type": "context", "elements": [{"type": "mrkdwn", "text": f"_{' · '.join(notes)}_"}]}]
+
+
 def _row_summary(row: SlackSettings | None) -> str:
     if not row or not row.runtime_adapter or not row.model:
         return "_(none)_"
@@ -1045,6 +1280,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     account_state = _resolve_account_state(integration, slack_user_id)
     project_state = _resolve_project_state(integration, slack_user_id)
     tasks_state = _resolve_tasks_state(integration, slack_user_id)
+    stats_state = _resolve_stats_state(integration, slack_user_id, is_admin=is_admin)
 
     view = render_home_view(
         effective=effective,
@@ -1054,6 +1290,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
         account_state=account_state,
         project_state=project_state,
         tasks_state=tasks_state,
+        stats_state=stats_state,
     )
     try:
         slack.client.views_publish(user_id=slack_user_id, view=view)
@@ -1083,6 +1320,28 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
     if not is_slack_app_home_enabled(integration):
         return HttpResponse(status=200)
 
+    # The Home tab keeps no server-side view state, so the stats window has to be read
+    # back off every payload and re-applied — otherwise an unrelated click (a task
+    # filter, a project pick) would silently snap the card back to its default window.
+    stats_window_days = _read_stats_window_from_payload(payload)
+
+    def republish(
+        *,
+        selected_repo: str | None = None,
+        selected_status: str | None = None,
+        page: int = 0,
+        stats_force_refresh: bool = False,
+    ) -> None:
+        _republish_home(
+            integration,
+            slack_user_id,
+            selected_repo=selected_repo,
+            selected_status=selected_status,
+            page=page,
+            stats_window_days=stats_window_days,
+            stats_force_refresh=stats_force_refresh,
+        )
+
     if action_id == ACTION_EDIT_PERSONAL and trigger_id:
         _open_edit_modal(integration, slack_user_id, scope="personal", trigger_id=trigger_id)
         return HttpResponse(status=200)
@@ -1097,17 +1356,17 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
 
     if action_id == ACTION_RESET_PERSONAL:
         _clear_personal_override(integration, slack_user_id)
-        _republish_home(integration, slack_user_id)
+        republish()
         return HttpResponse(status=200)
 
     if action_id == ACTION_SET_PROJECT_PERSONAL:
         _apply_project_pick(integration, slack_user_id=slack_user_id, action=action, scope="personal")
-        _republish_home(integration, slack_user_id)
+        republish()
         return HttpResponse(status=200)
 
     if action_id == ACTION_RESET_PROJECT_PERSONAL:
         _clear_project_personal(integration, slack_user_id)
-        _republish_home(integration, slack_user_id)
+        republish()
         return HttpResponse(status=200)
 
     if action_id == ACTION_SET_PROJECT_WORKSPACE:
@@ -1116,7 +1375,7 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
             _post_ephemeral_admin_only(slack, payload)
             return HttpResponse(status=200)
         _apply_project_pick(integration, slack_user_id=None, action=action, scope="workspace")
-        _republish_home(integration, slack_user_id)
+        republish()
         return HttpResponse(status=200)
 
     if action_id == ACTION_UNLINK_ACCOUNT:
@@ -1125,7 +1384,7 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
         # cached view shouldn't be allowed to drive deletes.
         if is_slack_app_oauth_enabled(integration, integration.integration_id):
             _unlink_user_account(integration, slack_user_id)
-        _republish_home(integration, slack_user_id)
+        republish()
         return HttpResponse(status=200)
 
     if action_id in (
@@ -1145,13 +1404,13 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
                 page = 0
         else:
             page = 0
-        _republish_home(
-            integration,
-            slack_user_id,
-            selected_repo=selected_repo,
-            selected_status=selected_status,
-            page=page,
-        )
+        republish(selected_repo=selected_repo, selected_status=selected_status, page=page)
+        return HttpResponse(status=200)
+
+    if action_id in (ACTION_STATS_WINDOW, ACTION_STATS_REFRESH):
+        # The window pick is already reflected in the view state `stats_window_days`
+        # was read from; only Refresh needs to bypass the aggregate cache.
+        republish(stats_force_refresh=action_id == ACTION_STATS_REFRESH)
         return HttpResponse(status=200)
 
     if action_id in (MODAL_ACTION_RUNTIME_ADAPTER, MODAL_ACTION_MODEL):
@@ -1398,6 +1657,8 @@ def _republish_home(
     selected_repo: str | None = None,
     selected_status: str | None = None,
     page: int = 0,
+    stats_window_days: int = DEFAULT_STATS_WINDOW_DAYS,
+    stats_force_refresh: bool = False,
 ) -> None:
     user_row, workspace_row = _load_rows(integration, slack_user_id)
     effective = resolve_ai_preferences(integration, slack_user_id)
@@ -1412,6 +1673,13 @@ def _republish_home(
         selected_status=selected_status,
         page=page,
     )
+    stats_state = _resolve_stats_state(
+        integration,
+        slack_user_id,
+        is_admin=is_admin,
+        window_days=stats_window_days,
+        force_refresh=stats_force_refresh,
+    )
     view = render_home_view(
         effective=effective,
         user_row=user_row,
@@ -1420,6 +1688,7 @@ def _republish_home(
         account_state=account_state,
         project_state=project_state,
         tasks_state=tasks_state,
+        stats_state=stats_state,
     )
     try:
         slack.client.views_publish(user_id=slack_user_id, view=view)
@@ -1598,6 +1867,19 @@ def _read_tasks_filters_from_payload(payload: dict) -> tuple[str | None, str | N
     return repo, status
 
 
+def _read_stats_window_from_payload(payload: dict) -> int:
+    """Pull the selected stats window off the Home tab view state.
+
+    Same mechanism as `_read_tasks_filters_from_payload` — Block Kit only persists state
+    under blocks carrying a `block_id`, so the whole controls row shares one key. Falls
+    back to the default window when the card isn't rendered for this user.
+    """
+    values = (payload.get("view") or {}).get("state", {}).get("values", {}) or {}
+    controls = values.get(BLOCK_STATS_CONTROLS, {})
+    selected = (controls.get(ACTION_STATS_WINDOW, {}).get("selected_option") or {}).get("value")
+    return coerce_window_days(selected)
+
+
 def _resolve_account_state(integration: Integration, slack_user_id: str) -> AccountState:
     slack_team_id = integration.integration_id
     if not is_slack_app_oauth_enabled(integration, slack_team_id):
@@ -1628,6 +1910,51 @@ def _resolve_account_state(integration: Integration, slack_user_id: str) -> Acco
         )
         link_url = None
     return AccountState(enabled=True, linked_email=None, link_url=link_url)
+
+
+def _resolve_stats_state(
+    integration: Integration,
+    slack_user_id: str,
+    *,
+    is_admin: bool,
+    window_days: int = DEFAULT_STATS_WINDOW_DAYS,
+    force_refresh: bool = False,
+) -> StatsState | None:
+    """Workspace activity aggregates, or None when the card shouldn't render at all.
+
+    Scoped to the projects this admin can already reach: being a Slack workspace admin
+    says nothing about PostHog org membership, so the card must never widen what its
+    viewer could otherwise see.
+    """
+    if not is_admin or not is_slack_app_home_stats_enabled(integration):
+        return None
+
+    slack_team_id = integration.integration_id
+    candidates = list(
+        Integration.objects.filter(kind="slack", integration_id=slack_team_id)
+        .select_related("team", "team__organization")
+        .order_by("id")
+    )
+    accessible_team_ids = {c.team_id for c in _filter_accessible_integrations(integration, slack_user_id, candidates)}
+    if not accessible_team_ids:
+        return None
+
+    try:
+        return resolve_stats_state(
+            slack_workspace_id=slack_team_id,
+            accessible_team_ids=accessible_team_ids,
+            window_days=window_days,
+            force_refresh=force_refresh,
+        )
+    except Exception:
+        # The card is supplementary — a failed aggregate shouldn't cost the user their
+        # settings and task list too.
+        logger.exception(
+            "slack_app_home_stats_resolve_failed",
+            integration_id=integration.id,
+            slack_user_id=slack_user_id,
+        )
+        return None
 
 
 def _resolve_project_state(integration: Integration, slack_user_id: str) -> ProjectState:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -403,13 +403,20 @@ def render_home_view(
 
     blocks.extend(_header_blocks())
 
-    # Section 1 — project routing. Personal pick on top; admins get an
+    # Section 1 — workspace activity: aggregates across everyone's Slack-started work,
+    # rather than the calling user's own. Admin-only, and first because it's the reason
+    # an admin opens the tab at all — the settings below are set once and rarely revisited.
+    if stats_state is not None:
+        blocks.append({"type": "divider"})
+        blocks.extend(_stats_section_blocks(stats_state))
+
+    # Section 2 — project routing. Personal pick on top; admins get an
     # editable workspace default below, others see it as read-only context.
     if project_state and project_state.has_anything_to_show:
         blocks.append({"type": "divider"})
         blocks.extend(_project_section_blocks(project_state, is_admin=is_admin))
 
-    # Section 2 — AI model settings: which model handles those mentions.
+    # Section 3 — AI model settings: which model handles those mentions.
     # Headline shows the effective triple (and its source); personal /
     # workspace controls underneath mirror the project routing layout.
     blocks.append({"type": "divider"})
@@ -417,25 +424,18 @@ def render_home_view(
     blocks.extend(_personal_section_blocks(user_row))
     blocks.extend(_workspace_section_blocks(workspace_row, is_admin=is_admin))
 
-    # Section 3 — account linking: shown before Tasks so the connect
+    # Section 4 — account linking: shown before Tasks so the connect
     # prompt is visible while the Tasks list is still empty. Flag-gated.
     if account_state and account_state.enabled:
         blocks.append({"type": "divider"})
         blocks.extend(_account_section_blocks(account_state))
 
-    # Section 4 — your tasks: a quiet list of tasks the calling user
+    # Section 5 — your tasks: a quiet list of tasks the calling user
     # started via @PostHog mentions, so they can see status without
     # the bot pinging the activity feed for every transition.
     if tasks_state is not None:
         blocks.append({"type": "divider"})
         blocks.extend(_tasks_section_blocks(tasks_state))
-
-    # Section 5 — workspace activity: aggregates across everyone's Slack-started work,
-    # rather than the calling user's own. Last because it answers a different question
-    # than the rest of the tab, and only admins get it at all.
-    if stats_state is not None:
-        blocks.append({"type": "divider"})
-        blocks.extend(_stats_section_blocks(stats_state))
 
     blocks.append({"type": "divider"})
     blocks.extend(_footer_blocks())

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -935,13 +935,13 @@ def _tasks_controls_block(state: TasksState) -> dict:
 # Charts are drawn as text. Block Kit does have a native `data_visualization` block, but
 # `views.publish` rejects it on the App Home surface with "Unsupported block type" — note
 # that `blocks.validate` accepts it, so the schema check is not proof a surface takes it.
-# `data_table` is fine on Home, hence the real table below the bars.
-_STATS_MAX_MODEL_ROWS = 6
-_STATS_MAX_LABEL_CHARS = 20
-_STATS_BAR_WIDTH = 12
+_STATS_MAX_BREAKDOWN_ROWS = 6
+# Breakdown labels and bars share a half-width column, so both are tighter than the
+# full-width sparkline row above them.
+_STATS_COLUMN_LABEL_CHARS = 14
+_STATS_BAR_WIDTH = 8
 # Slack renders `section.fields` in two columns and rejects more than 10 cells.
 _STATS_MAX_FIELDS = 10
-_STATS_TABLE_PAGE_SIZE = 5
 
 # Eight levels of block-fill, so a sparkline reads as a shape rather than a row of dots.
 _SPARK_LEVELS = "▁▂▃▄▅▆▇█"
@@ -979,8 +979,7 @@ def _stats_section_blocks(state: StatsState) -> list[dict]:
         for block in (
             _stats_outcomes_block(state),
             _stats_trend_block(state),
-            _stats_models_block(state),
-            _stats_people_table(state),
+            _stats_breakdowns_block(state),
         )
         if block
     )
@@ -1077,18 +1076,27 @@ def _stats_trend_block(state: StatsState) -> dict | None:
     }
 
 
-def _stats_models_block(state: StatsState) -> dict | None:
-    """Share of runs per model, as a bar column with the long tail folded into "Other".
+def _stats_breakdowns_block(state: StatsState) -> dict | None:
+    """Models and people side by side.
 
-    Rendered inside a fenced block so the bars and counts line up — proportional text
-    would leave the columns ragged.
+    `section.fields` is Block Kit's only two-column layout, so the two breakdowns share
+    one block instead of stacking. Each column is fenced: the counts only line up under a
+    monospace font, and proportional text leaves them ragged.
     """
+    columns = [column for column in (_stats_models_column(state), _stats_people_column(state)) if column]
+    if not columns:
+        return None
+    return {"type": "section", "fields": [{"type": "mrkdwn", "text": column} for column in columns]}
+
+
+def _stats_models_column(state: StatsState) -> str | None:
+    """Share of runs per model, with the long tail folded into "Other"."""
     if not state.models:
         return None
 
-    fits = len(state.models) <= _STATS_MAX_MODEL_ROWS
-    head = state.models if fits else state.models[: _STATS_MAX_MODEL_ROWS - 1]
-    tail = () if fits else state.models[_STATS_MAX_MODEL_ROWS - 1 :]
+    fits = len(state.models) <= _STATS_MAX_BREAKDOWN_ROWS
+    head = state.models if fits else state.models[: _STATS_MAX_BREAKDOWN_ROWS - 1]
+    tail = () if fits else state.models[_STATS_MAX_BREAKDOWN_ROWS - 1 :]
 
     rows = [(_stats_model_label(usage), usage.value) for usage in head if usage.value > 0]
     other = sum(usage.value for usage in tail)
@@ -1099,8 +1107,24 @@ def _stats_models_block(state: StatsState) -> dict | None:
 
     peak = max(value for _, value in rows)
     width = max(len(label) for label, _ in rows)
-    lines = "\n".join(f"{label:<{width}}  {_bar(value, peak)} {value:>3}" for label, value in rows)
-    return {"type": "section", "text": {"type": "mrkdwn", "text": f"*Models*\n```\n{lines}\n```"}}
+    lines = "\n".join(f"{label:<{width}} {_bar(value, peak)} {value:>3}" for label, value in rows)
+    return f"*Models*\n```\n{lines}\n```"
+
+
+def _stats_people_column(state: StatsState) -> str | None:
+    """Leaderboard as text: who started how many, and how many of those merged."""
+    people = state.people[:_STATS_MAX_BREAKDOWN_ROWS]
+    if not people:
+        return None
+
+    names = [_truncate(person.name, _STATS_COLUMN_LABEL_CHARS) for person in people]
+    width = max(len(name) for name in names)
+    lines = "\n".join(f"{name:<{width}} {person.tasks:>3} {person.merged:>4}" for name, person in zip(names, people))
+    return f"*Most active* _tasks · merged_\n```\n{lines}\n```"
+
+
+def _truncate(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[: limit - 1] + "…"
 
 
 def _sparkline(values: list[int], peak: int) -> str:
@@ -1123,37 +1147,7 @@ def _bar(value: int, peak: int, width: int = _STATS_BAR_WIDTH) -> str:
 def _stats_model_label(usage: ModelUsage) -> str:
     """Display label for a model, truncated so the bar column stays aligned."""
     label = _format_model_id(usage.model, owned_by=_provider_for_runtime_adapter(usage.runtime_adapter))
-    if len(label) <= _STATS_MAX_LABEL_CHARS:
-        return label
-    return label[: _STATS_MAX_LABEL_CHARS - 1] + "…"
-
-
-def _stats_people_table(state: StatsState) -> dict | None:
-    """Sortable leaderboard. `raw_number` cells carry both the rendered `text` and the
-    numeric `value` Slack sorts on."""
-    if not state.people:
-        return None
-    rows: list[list[dict[str, Any]]] = [
-        [
-            {"type": "raw_text", "text": "Person"},
-            {"type": "raw_text", "text": "Tasks"},
-            {"type": "raw_text", "text": "PRs merged"},
-        ]
-    ]
-    rows.extend(
-        [
-            {"type": "raw_text", "text": person.name},
-            {"type": "raw_number", "text": str(person.tasks), "value": person.tasks},
-            {"type": "raw_number", "text": str(person.merged), "value": person.merged},
-        ]
-        for person in state.people
-    )
-    return {
-        "type": "data_table",
-        "caption": "Most active people",
-        "page_size": _STATS_TABLE_PAGE_SIZE,
-        "rows": rows,
-    }
+    return _truncate(label, _STATS_COLUMN_LABEL_CHARS)
 
 
 def _stats_footnote_blocks(state: StatsState) -> list[dict]:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -30,11 +30,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user_integration import UserIntegration
 from posthog.user_permissions import UserPermissions
 
-from products.slack_app.backend.feature_flags import (
-    is_slack_app_home_enabled,
-    is_slack_app_home_stats_enabled,
-    is_slack_app_oauth_enabled,
-)
+from products.slack_app.backend.feature_flags import is_slack_app_home_enabled, is_slack_app_oauth_enabled
 from products.slack_app.backend.models import SlackSettings, SlackUserProfileCache
 from products.slack_app.backend.services.slack_app_home_stats import (
     DEFAULT_STATS_WINDOW_DAYS,
@@ -1952,11 +1948,14 @@ def _resolve_stats_state(
 ) -> StatsState | None:
     """Workspace activity aggregates, or None when the card shouldn't render at all.
 
+    Admin-only, and rides the same `slack-app-home` gate as the rest of the tab — the
+    callers already returned early when that flag is off.
+
     Scoped to the projects this admin can already reach: being a Slack workspace admin
     says nothing about PostHog org membership, so the card must never widen what its
     viewer could otherwise see.
     """
-    if not is_admin or not is_slack_app_home_stats_enabled(integration):
+    if not is_admin:
         return None
 
     accessible_team_ids = {c.team_id for c in accessible}

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -929,13 +929,22 @@ def _tasks_controls_block(state: TasksState) -> dict:
     return {"type": "actions", "block_id": BLOCK_TASKS_CONTROLS, "elements": elements}
 
 
-# Block Kit caps on the stats card. These live with the renderer rather than the resolver
-# because they describe what Slack will draw, not what the workspace did.
-_STATS_MAX_PIE_SEGMENTS = 12
+# Display caps for the stats card. These live with the renderer rather than the resolver
+# because they describe what gets drawn, not what the workspace did.
+#
+# Charts are drawn as text. Block Kit does have a native `data_visualization` block, but
+# `views.publish` rejects it on the App Home surface with "Unsupported block type" — note
+# that `blocks.validate` accepts it, so the schema check is not proof a surface takes it.
+# `data_table` is fine on Home, hence the real table below the bars.
+_STATS_MAX_MODEL_ROWS = 6
 _STATS_MAX_LABEL_CHARS = 20
+_STATS_BAR_WIDTH = 12
 # Slack renders `section.fields` in two columns and rejects more than 10 cells.
 _STATS_MAX_FIELDS = 10
 _STATS_TABLE_PAGE_SIZE = 5
+
+# Eight levels of block-fill, so a sparkline reads as a shape rather than a row of dots.
+_SPARK_LEVELS = "▁▂▃▄▅▆▇█"
 
 _OUTCOME_EMOJI: dict[str, str] = {
     OUTCOME_DONE: "🦔",
@@ -946,7 +955,7 @@ _OUTCOME_EMOJI: dict[str, str] = {
 
 
 def _stats_section_blocks(state: StatsState) -> list[dict]:
-    """Render the workspace-activity card: headline counts, two charts, a leaderboard."""
+    """Render the workspace-activity card: a KPI grid, two text charts, a leaderboard."""
     blocks: list[dict] = [
         _section_title(
             "📊 Workspace activity",
@@ -969,8 +978,8 @@ def _stats_section_blocks(state: StatsState) -> list[dict]:
         block
         for block in (
             _stats_outcomes_block(state),
-            _stats_trend_chart(state),
-            _stats_models_chart(state),
+            _stats_trend_block(state),
+            _stats_models_block(state),
             _stats_people_table(state),
         )
         if block
@@ -1043,55 +1052,76 @@ def _stats_outcomes_block(state: StatsState) -> dict | None:
     return {"type": "context", "elements": [{"type": "mrkdwn", "text": " · ".join(parts)}]}
 
 
-def _stats_trend_chart(state: StatsState) -> dict | None:
-    """Grouped bars of PRs opened vs merged per bucket.
+def _stats_trend_block(state: StatsState) -> dict | None:
+    """PRs opened vs merged per bucket, as two sparklines on one line.
 
-    Skipped entirely when the window produced no PRs — an all-zero chart is noise.
+    Skipped when the window produced no PRs — a flat line of minima is noise.
     """
     buckets = state.trend
     if not buckets or not state.tasks_with_pr:
         return None
+
+    # One shared peak so the two lines are read against each other, not each rescaled.
+    peak = max(max(b.opened, b.merged) for b in buckets)
+    opened = _sparkline([b.opened for b in buckets], peak)
+    merged = _sparkline([b.merged for b in buckets], peak)
+    span = f"{buckets[0].label} → {buckets[-1].label}"
     return {
-        "type": "data_visualization",
-        "title": "PRs opened and merged",
-        "chart": {
-            "type": "bar",
-            "series": [
-                {"name": "Opened", "data": [{"label": b.label, "value": b.opened} for b in buckets]},
-                {"name": "Merged", "data": [{"label": b.label, "value": b.merged} for b in buckets]},
-            ],
-            "axis_config": {"categories": [b.label for b in buckets], "y_label": "PRs"},
-        },
+        "type": "context",
+        "elements": [
+            {
+                "type": "mrkdwn",
+                "text": f"*PRs* `{opened}` opened · `{merged}` merged   _{span}_",
+            }
+        ],
     }
 
 
-def _stats_models_chart(state: StatsState) -> dict | None:
-    """Share of runs per pinned model, with the long tail folded into "Other".
+def _stats_models_block(state: StatsState) -> dict | None:
+    """Share of runs per model, as a bar column with the long tail folded into "Other".
 
-    Slack rejects pie segments whose value isn't positive, so zero counts are dropped
-    rather than drawn as empty slices.
+    Rendered inside a fenced block so the bars and counts line up — proportional text
+    would leave the columns ragged.
     """
     if not state.models:
         return None
 
-    fits = len(state.models) <= _STATS_MAX_PIE_SEGMENTS
-    head = state.models if fits else state.models[: _STATS_MAX_PIE_SEGMENTS - 1]
-    tail = () if fits else state.models[_STATS_MAX_PIE_SEGMENTS - 1 :]
+    fits = len(state.models) <= _STATS_MAX_MODEL_ROWS
+    head = state.models if fits else state.models[: _STATS_MAX_MODEL_ROWS - 1]
+    tail = () if fits else state.models[_STATS_MAX_MODEL_ROWS - 1 :]
 
-    segments: list[dict[str, Any]] = [
-        {"label": _stats_model_label(usage), "value": usage.value} for usage in head if usage.value > 0
-    ]
+    rows = [(_stats_model_label(usage), usage.value) for usage in head if usage.value > 0]
     other = sum(usage.value for usage in tail)
     if other > 0:
-        segments.append({"label": "Other", "value": other})
-
-    if not segments:
+        rows.append(("Other", other))
+    if not rows:
         return None
-    return {"type": "data_visualization", "title": "Models used", "chart": {"type": "pie", "segments": segments}}
+
+    peak = max(value for _, value in rows)
+    width = max(len(label) for label, _ in rows)
+    lines = "\n".join(f"{label:<{width}}  {_bar(value, peak)} {value:>3}" for label, value in rows)
+    return {"type": "section", "text": {"type": "mrkdwn", "text": f"*Models*\n```\n{lines}\n```"}}
+
+
+def _sparkline(values: list[int], peak: int) -> str:
+    """Render counts as block-fill characters, scaled against `peak`."""
+    if peak <= 0:
+        return _SPARK_LEVELS[0] * len(values)
+    top = len(_SPARK_LEVELS) - 1
+    return "".join(_SPARK_LEVELS[min(top, value * top // peak)] for value in values)
+
+
+def _bar(value: int, peak: int, width: int = _STATS_BAR_WIDTH) -> str:
+    """Fixed-width bar. Any non-zero value keeps at least one filled cell, so a small
+    count reads as present rather than absent."""
+    if peak <= 0 or value <= 0:
+        return "░" * width
+    filled = min(width, max(1, round(value * width / peak)))
+    return "█" * filled + "░" * (width - filled)
 
 
 def _stats_model_label(usage: ModelUsage) -> str:
-    """Display label for a model, truncated to Slack's 20-character chart-label cap."""
+    """Display label for a model, truncated so the bar column stays aligned."""
     label = _format_model_id(usage.model, owned_by=_provider_for_runtime_adapter(usage.runtime_adapter))
     if len(label) <= _STATS_MAX_LABEL_CHARS:
         return label

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -933,6 +933,8 @@ def _tasks_controls_block(state: TasksState) -> dict:
 # because they describe what Slack will draw, not what the workspace did.
 _STATS_MAX_PIE_SEGMENTS = 12
 _STATS_MAX_LABEL_CHARS = 20
+# Slack renders `section.fields` in two columns and rejects more than 10 cells.
+_STATS_MAX_FIELDS = 10
 _STATS_TABLE_PAGE_SIZE = 5
 
 _OUTCOME_EMOJI: dict[str, str] = {
@@ -999,15 +1001,36 @@ def _stats_controls_block(state: StatsState) -> dict:
 
 
 def _stats_headline_block(state: StatsState) -> dict:
-    parts = [
-        f"*{state.tasks_started}* tasks",
-        f"*{state.tasks_with_pr}* opened a PR",
-        f"*{state.tasks_merged}* merged",
-    ]
     merge_rate = state.merge_rate_percent
-    if merge_rate is not None:
-        parts.append(f"*{merge_rate}%* merge rate")
-    return {"type": "section", "text": {"type": "mrkdwn", "text": "  ·  ".join(parts)}}
+    cells = [
+        ("Tasks", str(state.tasks_started)),
+        ("Opened a PR", str(state.tasks_with_pr)),
+        ("Merged", str(state.tasks_merged)),
+        ("Merge rate", "—" if merge_rate is None else f"{merge_rate}%"),
+        ("Median run", _format_duration(state.median_cycle_seconds)),
+        ("People", str(state.active_people)),
+    ]
+    # `fields` lays out in two columns, so six KPIs cost three rows instead of the six
+    # lines a stack of sections would take. Slack caps this at 10 cells.
+    return {
+        "type": "section",
+        "fields": [{"type": "mrkdwn", "text": f"*{label}*\n{value}"} for label, value in cells[:_STATS_MAX_FIELDS]],
+    }
+
+
+def _format_duration(seconds: int | None) -> str:
+    """Compact wall-clock label — `45s`, `12m`, `2h 5m`, `3d`."""
+    if seconds is None:
+        return "—"
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, mins = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h {mins}m" if mins else f"{hours}h"
+    return f"{hours // 24}d"
 
 
 def _stats_outcomes_block(state: StatsState) -> dict | None:

--- a/products/slack_app/backend/services/slack_app_home_stats.py
+++ b/products/slack_app/backend/services/slack_app_home_stats.py
@@ -1,0 +1,360 @@
+"""Workspace activity aggregates behind the App Home stats card.
+
+This module is deliberately free of Block Kit: it answers "what did this workspace ship
+with @PostHog over the last N days" and returns plain dataclasses. The renderer in
+`slack_app_home.py` decides how much of that fits into Slack's chart and table limits,
+because those caps (12 pie segments, 20 chart points, 20-character labels) are
+presentation constraints rather than facts about the data.
+
+Everything is scoped to the tasks a Slack workspace started *and* the caller can already
+see: the mapping query filters on `team_id__in=accessible_team_ids`, which the caller
+derives from the same accessible-integration check the rest of the Home tab uses. A Slack
+workspace admin is not automatically a PostHog org member, so the aggregates must never
+widen what the viewer could otherwise reach.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from django.core.cache import cache
+from django.utils import timezone as django_timezone
+
+import structlog
+
+from products.slack_app.backend.models import SlackThreadTaskMapping, SlackUserProfileCache
+
+logger = structlog.get_logger(__name__)
+
+# Window choices offered by the card's picker, in render order.
+STATS_WINDOW_OPTIONS: tuple[tuple[int, str], ...] = (
+    (7, "Last 7 days"),
+    (30, "Last 30 days"),
+    (90, "Last 90 days"),
+)
+DEFAULT_STATS_WINDOW_DAYS = 30
+_VALID_WINDOW_DAYS = frozenset(days for days, _ in STATS_WINDOW_OPTIONS)
+
+# Aggregation happens in Python over fetched rows rather than in SQL, so the row set is
+# bounded. Hitting the cap is surfaced in the UI instead of silently under-reporting.
+STATS_MAX_TASKS = 2000
+
+# The Home tab republishes on open and on every interaction, all inside Slack's 3s SLA,
+# so the same aggregate is recomputed far more often than the underlying data changes.
+_STATS_CACHE_TTL_SECONDS = 300
+
+# Below this the trend is bucketed by day; at or above it, by week. Keeps every window
+# under Slack's 20-points-per-series cap while still giving a 7-day window daily detail.
+_DAILY_BUCKET_MAX_DAYS = 20
+
+# The leaderboard is a top-N, not a directory — bounding it here also keeps the cached
+# aggregate small on workspaces with hundreds of people.
+_MAX_PEOPLE_ROWS = 20
+
+# Display order for the outcome breakdown, and the labels the renderer decorates.
+OUTCOME_DONE = "Done"
+OUTCOME_FAILED = "Failed"
+OUTCOME_CANCELLED = "Cancelled"
+OUTCOME_RUNNING = "In progress"
+_OUTCOME_ORDER: tuple[str, ...] = (OUTCOME_DONE, OUTCOME_FAILED, OUTCOME_CANCELLED, OUTCOME_RUNNING)
+
+
+@dataclass(frozen=True)
+class Slice:
+    """One labelled count — an outcome bucket or a model's share of runs."""
+
+    label: str
+    value: int
+
+
+@dataclass(frozen=True)
+class ModelUsage:
+    """How many runs a given pinned model handled.
+
+    Carries the raw model id and its runtime so the renderer can format a display label
+    without guessing the provider.
+    """
+
+    model: str
+    runtime_adapter: str | None
+    value: int
+
+
+@dataclass(frozen=True)
+class TrendBucket:
+    """PRs opened and merged within one day or week of the window."""
+
+    label: str
+    opened: int
+    merged: int
+
+
+@dataclass(frozen=True)
+class PersonRow:
+    """One row of the most-active-people table."""
+
+    name: str
+    tasks: int
+    merged: int
+
+
+@dataclass(frozen=True)
+class StatsState:
+    """Everything the stats card renders, already aggregated.
+
+    ``tasks_with_pr`` counts tasks whose latest PR-bearing run produced a pull request,
+    matching how ``tasks_merged`` is counted, so the two describe the same runs and the
+    merge rate between them is meaningful.
+    """
+
+    window_days: int = DEFAULT_STATS_WINDOW_DAYS
+    tasks_started: int = 0
+    tasks_with_pr: int = 0
+    tasks_merged: int = 0
+    outcomes: tuple[Slice, ...] = ()
+    trend: tuple[TrendBucket, ...] = ()
+    models: tuple[ModelUsage, ...] = ()
+    people: tuple[PersonRow, ...] = ()
+    truncated: bool = False
+    refreshed_at_epoch: int = 0
+
+    @property
+    def has_data(self) -> bool:
+        return self.tasks_started > 0
+
+    @property
+    def merge_rate_percent(self) -> int | None:
+        """Merged as a percentage of tasks that opened a PR. None when nothing opened one."""
+        if not self.tasks_with_pr:
+            return None
+        return round(self.tasks_merged * 100 / self.tasks_with_pr)
+
+
+def coerce_window_days(raw: str | int | None) -> int:
+    """Clamp an untrusted window value from a Slack payload to one we offer."""
+    try:
+        days = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return DEFAULT_STATS_WINDOW_DAYS
+    return days if days in _VALID_WINDOW_DAYS else DEFAULT_STATS_WINDOW_DAYS
+
+
+def resolve_stats_state(
+    *,
+    slack_workspace_id: str,
+    accessible_team_ids: Iterable[int],
+    window_days: int = DEFAULT_STATS_WINDOW_DAYS,
+    force_refresh: bool = False,
+) -> StatsState:
+    """Aggregate Slack-started task activity for a workspace over the given window.
+
+    Cached for `_STATS_CACHE_TTL_SECONDS`; the card's Refresh button bypasses the cache.
+    """
+    team_ids = sorted(set(accessible_team_ids))
+    window_days = coerce_window_days(window_days)
+    if not slack_workspace_id or not team_ids:
+        return StatsState(window_days=window_days)
+
+    cache_key = _cache_key(slack_workspace_id, team_ids, window_days)
+    if not force_refresh:
+        cached = cache.get(cache_key)
+        if isinstance(cached, StatsState):
+            return cached
+
+    state = _compute_stats_state(
+        slack_workspace_id=slack_workspace_id,
+        team_ids=team_ids,
+        window_days=window_days,
+    )
+    try:
+        cache.set(cache_key, state, _STATS_CACHE_TTL_SECONDS)
+    except Exception:
+        # A cache backend outage should slow the Home tab down, not break it.
+        logger.warning("slack_app_home_stats_cache_write_failed", slack_workspace_id=slack_workspace_id)
+    return state
+
+
+def _cache_key(slack_workspace_id: str, team_ids: list[int], window_days: int) -> str:
+    teams = ",".join(str(t) for t in team_ids)
+    return f"slack_app_home_stats:{slack_workspace_id}:{window_days}:{teams}"
+
+
+def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window_days: int) -> StatsState:
+    # Deferred to keep the tasks facade off this module's import path, matching how the
+    # rest of the Home tab reaches it.
+    from products.tasks.backend.facade import api as tasks_facade  # noqa: PLC0415
+
+    now = django_timezone.now()
+    cutoff = now - timedelta(days=window_days)
+
+    # One extra row tells us the cap was hit without a second COUNT query.
+    rows = list(
+        SlackThreadTaskMapping.objects.filter(
+            slack_workspace_id=slack_workspace_id,
+            team_id__in=team_ids,
+            created_at__gte=cutoff,
+        )
+        .order_by("-created_at")
+        .values("task_id", "mentioning_slack_user_id", "created_at")[: STATS_MAX_TASKS + 1]
+    )
+    truncated = len(rows) > STATS_MAX_TASKS
+    rows = rows[:STATS_MAX_TASKS]
+    if not rows:
+        return StatsState(window_days=window_days, refreshed_at_epoch=int(now.timestamp()))
+
+    # A task is mapped once per thread, but dedupe anyway so a task can't be double-counted.
+    first_row_by_task: dict[str, Mapping[str, Any]] = {}
+    for row in rows:
+        first_row_by_task.setdefault(str(row["task_id"]), row)
+
+    task_ids = list(first_row_by_task)
+    runs_by_task = tasks_facade.get_latest_run_by_task(task_ids)
+    merged_task_ids = tasks_facade.get_merged_pr_task_ids(task_ids)
+
+    outcome_counts: dict[str, int] = defaultdict(int)
+    model_counts: dict[tuple[str, str | None], int] = defaultdict(int)
+    tasks_by_person: dict[str, int] = defaultdict(int)
+    merged_by_person: dict[str, int] = defaultdict(int)
+    opened_by_bucket: dict[date, int] = defaultdict(int)
+    merged_by_bucket: dict[date, int] = defaultdict(int)
+    tasks_with_pr = 0
+
+    bucket_by_week = window_days >= _DAILY_BUCKET_MAX_DAYS
+
+    for task_id, mapping_row in first_row_by_task.items():
+        run = runs_by_task.get(task_id)
+        person = mapping_row["mentioning_slack_user_id"] or ""
+        bucket = _bucket_start(mapping_row["created_at"], by_week=bucket_by_week)
+
+        outcome_counts[_outcome_label(run.status if run else None)] += 1
+
+        if run is not None:
+            model = (run.state or {}).get("model")
+            if model:
+                model_counts[(str(model), (run.state or {}).get("runtime_adapter"))] += 1
+
+        tasks_by_person[person] += 1
+
+        has_pr = bool(run and run.pr_url)
+        if has_pr:
+            tasks_with_pr += 1
+            opened_by_bucket[bucket] += 1
+        if task_id in merged_task_ids:
+            merged_by_bucket[bucket] += 1
+            merged_by_person[person] += 1
+
+    return StatsState(
+        window_days=window_days,
+        tasks_started=len(first_row_by_task),
+        tasks_with_pr=tasks_with_pr,
+        tasks_merged=len(merged_task_ids),
+        outcomes=tuple(
+            Slice(label=label, value=outcome_counts[label]) for label in _OUTCOME_ORDER if outcome_counts.get(label)
+        ),
+        trend=_build_trend(
+            opened_by_bucket,
+            merged_by_bucket,
+            now=now,
+            window_days=window_days,
+            by_week=bucket_by_week,
+        ),
+        models=tuple(
+            ModelUsage(model=model, runtime_adapter=runtime_adapter, value=count)
+            for (model, runtime_adapter), count in sorted(model_counts.items(), key=lambda kv: (-kv[1], kv[0][0]))
+        ),
+        people=_build_people(tasks_by_person, merged_by_person, slack_workspace_id),
+        truncated=truncated,
+        refreshed_at_epoch=int(now.timestamp()),
+    )
+
+
+def _outcome_label(status: str | None) -> str:
+    """Map a run status onto a card bucket.
+
+    A task with no run yet, and any status we don't recognise, counts as in flight —
+    every task started in the window has to land in exactly one bucket for the outcome
+    counts to add up to the headline total.
+    """
+    if status == "completed":
+        return OUTCOME_DONE
+    if status == "failed":
+        return OUTCOME_FAILED
+    if status == "cancelled":
+        return OUTCOME_CANCELLED
+    return OUTCOME_RUNNING
+
+
+def _bucket_start(when: datetime | None, *, by_week: bool) -> date:
+    """The day, or the Monday of the week, a task belongs to."""
+    day = (when or django_timezone.now()).date()
+    if not by_week:
+        return day
+    return day - timedelta(days=day.weekday())
+
+
+def _build_trend(
+    opened_by_bucket: dict[date, int],
+    merged_by_bucket: dict[date, int],
+    *,
+    now: datetime,
+    window_days: int,
+    by_week: bool,
+) -> tuple[TrendBucket, ...]:
+    """Every bucket in the window, including empty ones.
+
+    Slack requires each series to carry a point for every axis category, so gaps have to
+    be materialised as zeroes rather than skipped.
+    """
+    end = _bucket_start(now, by_week=by_week)
+    start = _bucket_start(now - timedelta(days=window_days - 1), by_week=by_week)
+    step = timedelta(days=7 if by_week else 1)
+
+    buckets: list[TrendBucket] = []
+    current = start
+    while current <= end:
+        buckets.append(
+            TrendBucket(
+                label=current.strftime("%b %d"),
+                opened=opened_by_bucket.get(current, 0),
+                merged=merged_by_bucket.get(current, 0),
+            )
+        )
+        current += step
+    return tuple(buckets)
+
+
+def _build_people(
+    tasks_by_person: dict[str, int],
+    merged_by_person: dict[str, int],
+    slack_workspace_id: str,
+) -> tuple[PersonRow, ...]:
+    """The leaderboard, resolved to human names where the profile cache knows them."""
+    if not tasks_by_person:
+        return ()
+
+    ranked = sorted(tasks_by_person.items(), key=lambda kv: (-kv[1], kv[0]))[:_MAX_PEOPLE_ROWS]
+    slack_user_ids = [slack_user_id for slack_user_id, _ in ranked if slack_user_id]
+
+    # The cache is per-integration and a workspace can be connected to several projects,
+    # so match on the workspace and keep the first profile found for each Slack user.
+    names: dict[str, str] = {}
+    for profile in SlackUserProfileCache.objects.filter(
+        integration__integration_id=slack_workspace_id,
+        slack_user_id__in=slack_user_ids,
+    ).values("slack_user_id", "real_name", "display_name"):
+        name = profile["real_name"] or profile["display_name"]
+        if name:
+            names.setdefault(profile["slack_user_id"], name)
+
+    return tuple(
+        PersonRow(
+            name=names.get(slack_user_id) or slack_user_id or "Unknown",
+            tasks=task_count,
+            merged=merged_by_person.get(slack_user_id, 0),
+        )
+        for slack_user_id, task_count in ranked
+    )

--- a/products/slack_app/backend/services/slack_app_home_stats.py
+++ b/products/slack_app/backend/services/slack_app_home_stats.py
@@ -3,8 +3,12 @@
 This module is deliberately free of Block Kit: it answers "what did this workspace ship
 with @PostHog over the last N days" and returns plain dataclasses. The renderer in
 `slack_app_home.py` decides how much of that fits into Slack's chart and table limits,
-because those caps (12 pie segments, 20 chart points, 20-character labels) are
-presentation constraints rather than facts about the data.
+because caps like the 12 pie segments and 20-character labels are presentation
+constraints rather than facts about the data.
+
+Two caps are the exception and live here, because they change what gets *computed* rather
+than what gets drawn: `MAX_TREND_POINTS` picks daily-vs-weekly bucketing, and
+`_MAX_PEOPLE_ROWS` bounds the leaderboard so the cached aggregate stays small.
 
 Everything is scoped to the tasks a Slack workspace started *and* the caller can already
 see: the mapping query filters on `team_id__in=accessible_team_ids`, which the caller
@@ -47,9 +51,10 @@ STATS_MAX_TASKS = 2000
 # so the same aggregate is recomputed far more often than the underlying data changes.
 _STATS_CACHE_TTL_SECONDS = 300
 
-# Below this the trend is bucketed by day; at or above it, by week. Keeps every window
-# under Slack's 20-points-per-series cap while still giving a 7-day window daily detail.
-_DAILY_BUCKET_MAX_DAYS = 20
+# Slack rejects a chart series carrying more than 20 points. The trend is bucketed by day
+# while a window fits under that, and by week beyond it, so the cap is enforced where the
+# buckets are chosen rather than by truncating a too-long series at render time.
+MAX_TREND_POINTS = 20
 
 # The leaderboard is a top-N, not a directory — bounding it here also keeps the cached
 # aggregate small on workspaces with hundreds of people.
@@ -61,6 +66,14 @@ OUTCOME_FAILED = "Failed"
 OUTCOME_CANCELLED = "Cancelled"
 OUTCOME_RUNNING = "In progress"
 _OUTCOME_ORDER: tuple[str, ...] = (OUTCOME_DONE, OUTCOME_FAILED, OUTCOME_CANCELLED, OUTCOME_RUNNING)
+
+# Terminal run statuses get their own bucket; everything else — including a task with no
+# run row yet — is still in flight.
+_TERMINAL_OUTCOMES: dict[str, str] = {
+    "completed": OUTCOME_DONE,
+    "failed": OUTCOME_FAILED,
+    "cancelled": OUTCOME_CANCELLED,
+}
 
 
 @dataclass(frozen=True)
@@ -106,9 +119,9 @@ class PersonRow:
 class StatsState:
     """Everything the stats card renders, already aggregated.
 
-    ``tasks_with_pr`` counts tasks whose latest PR-bearing run produced a pull request,
-    matching how ``tasks_merged`` is counted, so the two describe the same runs and the
-    merge rate between them is meaningful.
+    ``tasks_with_pr`` and ``tasks_merged`` are both counted off each task's latest
+    *PR-bearing* run, so they describe the same runs and the merge rate between them
+    cannot exceed 100%.
     """
 
     window_days: int = DEFAULT_STATS_WINDOW_DAYS
@@ -143,7 +156,7 @@ def coerce_window_days(raw: str | int | None) -> int:
     return days if days in _VALID_WINDOW_DAYS else DEFAULT_STATS_WINDOW_DAYS
 
 
-def resolve_stats_state(
+def build_stats_state(
     *,
     slack_workspace_id: str,
     accessible_team_ids: Iterable[int],
@@ -160,21 +173,16 @@ def resolve_stats_state(
         return StatsState(window_days=window_days)
 
     cache_key = _cache_key(slack_workspace_id, team_ids, window_days)
-    if not force_refresh:
-        cached = cache.get(cache_key)
-        if isinstance(cached, StatsState):
-            return cached
+    cached = _cache_get(cache_key) if not force_refresh else None
+    if cached is not None:
+        return cached
 
     state = _compute_stats_state(
         slack_workspace_id=slack_workspace_id,
         team_ids=team_ids,
         window_days=window_days,
     )
-    try:
-        cache.set(cache_key, state, _STATS_CACHE_TTL_SECONDS)
-    except Exception:
-        # A cache backend outage should slow the Home tab down, not break it.
-        logger.warning("slack_app_home_stats_cache_write_failed", slack_workspace_id=slack_workspace_id)
+    _cache_set(cache_key, state)
     return state
 
 
@@ -183,12 +191,31 @@ def _cache_key(slack_workspace_id: str, team_ids: list[int], window_days: int) -
     return f"slack_app_home_stats:{slack_workspace_id}:{window_days}:{teams}"
 
 
+def _cache_get(cache_key: str) -> StatsState | None:
+    # A cache backend outage should slow the Home tab down, not make the card vanish, so
+    # both sides of the cache swallow their errors.
+    try:
+        cached = cache.get(cache_key)
+    except Exception:
+        logger.warning("slack_app_home_stats_cache_read_failed", cache_key=cache_key)
+        return None
+    return cached if isinstance(cached, StatsState) else None
+
+
+def _cache_set(cache_key: str, state: StatsState) -> None:
+    try:
+        cache.set(cache_key, state, _STATS_CACHE_TTL_SECONDS)
+    except Exception:
+        logger.warning("slack_app_home_stats_cache_write_failed", cache_key=cache_key)
+
+
 def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window_days: int) -> StatsState:
     # Deferred to keep the tasks facade off this module's import path, matching how the
     # rest of the Home tab reaches it.
     from products.tasks.backend.facade import api as tasks_facade  # noqa: PLC0415
 
     now = django_timezone.now()
+    refreshed_at_epoch = int(now.timestamp())
     cutoff = now - timedelta(days=window_days)
 
     # One extra row tells us the cap was hit without a second COUNT query.
@@ -204,7 +231,7 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
     truncated = len(rows) > STATS_MAX_TASKS
     rows = rows[:STATS_MAX_TASKS]
     if not rows:
-        return StatsState(window_days=window_days, refreshed_at_epoch=int(now.timestamp()))
+        return StatsState(window_days=window_days, refreshed_at_epoch=refreshed_at_epoch)
 
     # A task is mapped once per thread, but dedupe anyway so a task can't be double-counted.
     first_row_by_task: dict[str, Mapping[str, Any]] = {}
@@ -213,6 +240,10 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
 
     task_ids = list(first_row_by_task)
     runs_by_task = tasks_facade.get_latest_run_by_task(task_ids)
+    # `get_latest_pr_url_by_task` and `get_merged_pr_task_ids` resolve the same run for a
+    # given task, so "opened a PR" and "merged" always describe one run. The latest run
+    # overall — which carries the status and model — may well be a later, PR-less one.
+    pr_urls_by_task = tasks_facade.get_latest_pr_url_by_task(task_ids)
     merged_task_ids = tasks_facade.get_merged_pr_task_ids(task_ids)
 
     outcome_counts: dict[str, int] = defaultdict(int)
@@ -223,7 +254,7 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
     merged_by_bucket: dict[date, int] = defaultdict(int)
     tasks_with_pr = 0
 
-    bucket_by_week = window_days >= _DAILY_BUCKET_MAX_DAYS
+    bucket_by_week = window_days > MAX_TREND_POINTS
 
     for task_id, mapping_row in first_row_by_task.items():
         run = runs_by_task.get(task_id)
@@ -239,8 +270,7 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
 
         tasks_by_person[person] += 1
 
-        has_pr = bool(run and run.pr_url)
-        if has_pr:
+        if task_id in pr_urls_by_task:
             tasks_with_pr += 1
             opened_by_bucket[bucket] += 1
         if task_id in merged_task_ids:
@@ -268,7 +298,7 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
         ),
         people=_build_people(tasks_by_person, merged_by_person, slack_workspace_id),
         truncated=truncated,
-        refreshed_at_epoch=int(now.timestamp()),
+        refreshed_at_epoch=refreshed_at_epoch,
     )
 
 
@@ -279,21 +309,13 @@ def _outcome_label(status: str | None) -> str:
     every task started in the window has to land in exactly one bucket for the outcome
     counts to add up to the headline total.
     """
-    if status == "completed":
-        return OUTCOME_DONE
-    if status == "failed":
-        return OUTCOME_FAILED
-    if status == "cancelled":
-        return OUTCOME_CANCELLED
-    return OUTCOME_RUNNING
+    return _TERMINAL_OUTCOMES.get(status or "", OUTCOME_RUNNING)
 
 
-def _bucket_start(when: datetime | None, *, by_week: bool) -> date:
+def _bucket_start(when: datetime, *, by_week: bool) -> date:
     """The day, or the Monday of the week, a task belongs to."""
-    day = (when or django_timezone.now()).date()
-    if not by_week:
-        return day
-    return day - timedelta(days=day.weekday())
+    day = when.date()
+    return day - timedelta(days=day.weekday()) if by_week else day
 
 
 def _build_trend(
@@ -341,12 +363,14 @@ def _build_people(
 
     # The cache is per-integration and a workspace can be connected to several projects,
     # so match on the workspace and keep the first profile found for each Slack user.
+    # Name precedence matches `slack_messages`, so one person reads the same on the
+    # leaderboard as in forwarded thread context.
     names: dict[str, str] = {}
     for profile in SlackUserProfileCache.objects.filter(
         integration__integration_id=slack_workspace_id,
         slack_user_id__in=slack_user_ids,
     ).values("slack_user_id", "real_name", "display_name"):
-        name = profile["real_name"] or profile["display_name"]
+        name = profile["display_name"] or profile["real_name"]
         if name:
             names.setdefault(profile["slack_user_id"], name)
 

--- a/products/slack_app/backend/services/slack_app_home_stats.py
+++ b/products/slack_app/backend/services/slack_app_home_stats.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
+from statistics import median
 from typing import Any
 
 from django.core.cache import cache
@@ -128,6 +129,11 @@ class StatsState:
     tasks_started: int = 0
     tasks_with_pr: int = 0
     tasks_merged: int = 0
+    # Everyone who started something, not just the leaderboard's top rows.
+    active_people: int = 0
+    # Median wall-clock of runs that finished successfully. Failed and cancelled runs are
+    # excluded — they stop at an arbitrary point and would drag the figure toward noise.
+    median_cycle_seconds: int | None = None
     outcomes: tuple[Slice, ...] = ()
     trend: tuple[TrendBucket, ...] = ()
     models: tuple[ModelUsage, ...] = ()
@@ -252,6 +258,7 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
     merged_by_person: dict[str, int] = defaultdict(int)
     opened_by_bucket: dict[date, int] = defaultdict(int)
     merged_by_bucket: dict[date, int] = defaultdict(int)
+    cycle_seconds: list[int] = []
     tasks_with_pr = 0
 
     bucket_by_week = window_days > MAX_TREND_POINTS
@@ -267,6 +274,10 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
             model = (run.state or {}).get("model")
             if model:
                 model_counts[(str(model), (run.state or {}).get("runtime_adapter"))] += 1
+            if run.status == "completed" and run.completed_at and run.created_at:
+                elapsed = int((run.completed_at - run.created_at).total_seconds())
+                if elapsed >= 0:
+                    cycle_seconds.append(elapsed)
 
         tasks_by_person[person] += 1
 
@@ -282,6 +293,8 @@ def _compute_stats_state(*, slack_workspace_id: str, team_ids: list[int], window
         tasks_started=len(first_row_by_task),
         tasks_with_pr=tasks_with_pr,
         tasks_merged=len(merged_task_ids),
+        active_people=len(tasks_by_person),
+        median_cycle_seconds=int(median(cycle_seconds)) if cycle_seconds else None,
         outcomes=tuple(
             Slice(label=label, value=outcome_counts[label]) for label in _OUTCOME_ORDER if outcome_counts.get(label)
         ),

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -184,6 +184,18 @@ class TestStatsCardRendering:
         counted = sum(int(line.rsplit(" ", 1)[-1]) for line in lines)
         assert counted == sum(m.value for m in models)
 
+    def test_card_sits_below_the_welcome_and_above_the_settings(self):
+        view = _render(StatsState(tasks_started=1))
+        rendered = [str(block) for block in view["blocks"]]
+
+        welcome_at = next(i for i, b in enumerate(rendered) if "Welcome to PostHog" in b)
+        stats_at = next(i for i, b in enumerate(rendered) if "Workspace activity" in b)
+        model_at = next(i for i, b in enumerate(rendered) if "AI model" in b)
+
+        # An admin opens the tab for the activity; routing and model are set once and
+        # rarely revisited, so they must not push it below the fold.
+        assert welcome_at < stats_at < model_at
+
     def test_headline_renders_as_a_two_column_field_grid(self):
         view = _render(
             StatsState(

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 
 import pytest
@@ -31,7 +32,7 @@ SLACK_USER = "U_ADMIN"
 
 # Slack's documented Block Kit caps. Exceeding any of them makes `views.publish` fail with
 # `invalid_blocks`, which takes down the whole Home tab and not just this card.
-MAX_PIE_SEGMENTS = 12
+MAX_MODEL_ROWS = 6
 MAX_CHART_POINTS = 20
 MAX_LABEL_CHARS = 20
 MAX_SECTION_FIELDS = 10
@@ -160,30 +161,28 @@ class TestWindowCoercion:
 class TestStatsCardRendering:
     def test_card_omitted_when_state_is_none(self):
         view = _render(None)
-        assert not _blocks_of_type(view, "data_visualization")
         assert not _blocks_of_type(view, "data_table")
         assert "Workspace activity" not in str(view)
 
     def test_empty_window_renders_controls_without_charts(self):
         view = _render(StatsState(window_days=30))
         assert "Workspace activity" in str(view)
-        # An empty window has no series to plot; a chart with no data is invalid.
-        assert not _blocks_of_type(view, "data_visualization")
+        # An empty window has nothing to plot and nobody to list.
         assert not _blocks_of_type(view, "data_table")
+        assert "*Models*" not in str(view)
 
-    def test_model_pie_folds_the_tail_and_stays_within_slack_caps(self):
+    def test_model_bars_fold_the_tail_without_losing_counts(self):
         models = tuple(ModelUsage(model=f"model-{i}", runtime_adapter="claude", value=20 - i) for i in range(15))
         view = _render(StatsState(tasks_started=100, models=models))
 
-        pie = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "pie")
-        segments = pie["chart"]["segments"]
+        block = next(b for b in view["blocks"] if b["type"] == "section" and "*Models*" in str(b.get("text")))
+        lines = [line for line in block["text"]["text"].splitlines() if line and not line.startswith(("*", "`"))]
 
-        assert len(segments) <= MAX_PIE_SEGMENTS
-        assert segments[-1]["label"] == "Other"
-        # Nothing may be dropped: the folded tail carries the models that didn't fit.
-        assert sum(s["value"] for s in segments) == sum(m.value for m in models)
-        # Slack rejects a segment whose value isn't positive.
-        assert all(s["value"] > 0 for s in segments)
+        assert len(lines) <= MAX_MODEL_ROWS
+        assert lines[-1].startswith("Other")
+        # The folded tail carries the models that didn't get their own row.
+        counted = sum(int(line.rsplit(" ", 1)[-1]) for line in lines)
+        assert counted == sum(m.value for m in models)
 
     def test_headline_renders_as_a_two_column_field_grid(self):
         view = _render(
@@ -235,24 +234,35 @@ class TestStatsCardRendering:
                 ),
             )
         )
-        pie = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "pie")
-        assert all(len(s["label"]) <= MAX_LABEL_CHARS for s in pie["chart"]["segments"])
+        block = next(b for b in view["blocks"] if b["type"] == "section" and "*Models*" in str(b.get("text")))
+        labels = [
+            line.split("  ")[0]
+            for line in block["text"]["text"].splitlines()
+            if line and not line.startswith(("*", "`"))
+        ]
+        # A long label would push the bar column out of alignment inside the fenced block.
+        assert all(len(label) <= MAX_LABEL_CHARS for label in labels)
 
-    def test_every_trend_series_carries_a_point_per_axis_category(self):
-        trend = tuple(TrendBucket(label=f"Day {i:02d}", opened=1, merged=1) for i in range(4))
-        view = _render(StatsState(tasks_started=4, tasks_with_pr=4, trend=trend))
+    def test_trend_sparklines_scale_both_series_against_one_peak(self):
+        trend = (
+            TrendBucket(label="Jul 07", opened=8, merged=0),
+            TrendBucket(label="Jul 14", opened=0, merged=4),
+        )
+        view = _render(StatsState(tasks_started=12, tasks_with_pr=8, trend=trend))
 
-        bar = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "bar")
-        categories = bar["chart"]["axis_config"]["categories"]
+        text = next(b["elements"][0]["text"] for b in view["blocks"] if b["type"] == "context" and "*PRs*" in str(b))
+        opened, merged = re.findall(r"`([^`]+)`", text)
 
-        for series in bar["chart"]["series"]:
-            # Slack rejects a series that skips any axis category.
-            assert [p["label"] for p in series["data"]] == categories
+        assert len(opened) == len(merged) == len(trend)
+        # Shared peak: merged's 4 must read as half of opened's 8, not as its own maximum.
+        assert opened[0] == "█" and merged[0] == "▁"
+        assert merged[1] < opened[0]
+        assert "Jul 07 → Jul 14" in text
 
-    def test_trend_chart_omitted_when_the_window_produced_no_prs(self):
+    def test_trend_omitted_when_the_window_produced_no_prs(self):
         trend = (TrendBucket(label="Jul 07", opened=0, merged=0),)
         view = _render(StatsState(tasks_started=3, tasks_with_pr=0, trend=trend))
-        assert not [c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "bar"]
+        assert not [b for b in view["blocks"] if b["type"] == "context" and "*PRs*" in str(b)]
 
     def test_leaderboard_numbers_carry_both_display_text_and_sort_value(self):
         view = _render(StatsState(tasks_started=9, people=(PersonRow(name="Vojta", tasks=9, merged=6),)))

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -21,8 +21,8 @@ from products.slack_app.backend.services.slack_app_home_stats import (
     PersonRow,
     StatsState,
     TrendBucket,
+    build_stats_state,
     coerce_window_days,
-    resolve_stats_state,
 )
 from products.slack_app.backend.services.slack_settings import AIPreferences
 
@@ -200,17 +200,15 @@ class TestStatsCardRendering:
         pie = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "pie")
         assert all(len(s["label"]) <= MAX_LABEL_CHARS for s in pie["chart"]["segments"])
 
-    def test_trend_chart_is_capped_to_the_slack_point_limit(self):
-        trend = tuple(TrendBucket(label=f"Day {i:02d}", opened=1, merged=1) for i in range(40))
-        view = _render(StatsState(tasks_started=40, tasks_with_pr=40, trend=trend))
+    def test_every_trend_series_carries_a_point_per_axis_category(self):
+        trend = tuple(TrendBucket(label=f"Day {i:02d}", opened=1, merged=1) for i in range(4))
+        view = _render(StatsState(tasks_started=4, tasks_with_pr=4, trend=trend))
 
         bar = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "bar")
         categories = bar["chart"]["axis_config"]["categories"]
 
-        assert len(categories) <= MAX_CHART_POINTS
         for series in bar["chart"]["series"]:
-            assert len(series["data"]) == len(categories)
-            # Slack requires every series to carry a point for each axis category.
+            # Slack rejects a series that skips any axis category.
             assert [p["label"] for p in series["data"]] == categories
 
     def test_trend_chart_omitted_when_the_window_produced_no_prs(self):
@@ -237,18 +235,47 @@ class TestResolveStatsState:
         _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.2", pr_url="u/2", pr_merged=False)
         _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.3", pr_url=None)
 
-        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
 
         assert state.tasks_started == 3
         assert state.tasks_with_pr == 2
         assert state.tasks_merged == 1
         assert state.merge_rate_percent == 50
 
+    def test_merge_rate_survives_a_later_run_that_produced_no_pr(self, slack_integration):
+        team = slack_integration.team
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        mapping = _mk_task_with_run(
+            team=team, integration=slack_integration, pr_url="u/1", pr_merged=True, status="completed"
+        )
+        # A follow-up run on the same task that never opened a PR. Counting "opened a PR"
+        # off the latest run of any kind would drop this task from the denominator while
+        # the merge helper still counts it, pushing the rate above 100%.
+        TaskRun.objects.create(team=team, task=mapping.task, status="failed", output={}, state={})
+
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        assert state.tasks_with_pr == 1
+        assert state.tasks_merged == 1
+        assert state.merge_rate_percent == 100
+
+    def test_model_usage_is_aggregated_from_the_latest_run_state(self, slack_integration):
+        team = slack_integration.team
+        for index, model in enumerate(["claude-opus-5", "claude-opus-5", "gpt-5-codex"]):
+            _mk_task_with_run(team=team, integration=slack_integration, thread_ts=f"1.{index}", model=model)
+
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        assert [(usage.model, usage.value) for usage in state.models] == [
+            ("claude-opus-5", 2),
+            ("gpt-5-codex", 1),
+        ]
+
     def test_merge_rate_is_none_when_nothing_opened_a_pr(self, slack_integration):
         team = slack_integration.team
         _mk_task_with_run(team=team, integration=slack_integration, pr_url=None)
 
-        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
 
         assert state.tasks_with_pr == 0
         assert state.merge_rate_percent is None
@@ -265,7 +292,7 @@ class TestResolveStatsState:
         _mk_task_with_run(team=slack_integration.team, integration=slack_integration, thread_ts="1.1")
         _mk_task_with_run(team=other_team, integration=other_integration, thread_ts="2.1", channel="C2")
 
-        state = resolve_stats_state(
+        state = build_stats_state(
             slack_workspace_id=WORKSPACE,
             accessible_team_ids={slack_integration.team_id},
         )
@@ -282,21 +309,16 @@ class TestResolveStatsState:
             created_at=timezone.now() - timedelta(days=45),
         )
 
-        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id}, window_days=30)
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id}, window_days=30)
 
         assert state.tasks_started == 1
 
-    @pytest.mark.parametrize("window_days", [7, 30, 90])
-    def test_every_started_task_lands_in_exactly_one_outcome_bucket(self, slack_integration, window_days):
+    def test_every_started_task_lands_in_exactly_one_outcome_bucket(self, slack_integration):
         team = slack_integration.team
         for index, status in enumerate(["completed", "failed", "cancelled", "in_progress", "queued"]):
             _mk_task_with_run(team=team, integration=slack_integration, thread_ts=f"1.{index}", status=status)
 
-        state = resolve_stats_state(
-            slack_workspace_id=WORKSPACE,
-            accessible_team_ids={team.id},
-            window_days=window_days,
-        )
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
 
         assert sum(outcome.value for outcome in state.outcomes) == state.tasks_started
 
@@ -305,7 +327,7 @@ class TestResolveStatsState:
         team = slack_integration.team
         _mk_task_with_run(team=team, integration=slack_integration, pr_url="u/1", pr_merged=True)
 
-        state = resolve_stats_state(
+        state = build_stats_state(
             slack_workspace_id=WORKSPACE,
             accessible_team_ids={team.id},
             window_days=window_days,
@@ -323,7 +345,7 @@ class TestResolveStatsState:
         _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.1", pr_url="u/1", pr_merged=True)
         _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.2", slack_user_id="U_UNKNOWN")
 
-        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
 
         by_name = {person.name: person for person in state.people}
         assert by_name["Vojta Bartos"].tasks == 1
@@ -334,29 +356,35 @@ class TestResolveStatsState:
     def test_no_accessible_teams_yields_an_empty_card(self, slack_integration):
         _mk_task_with_run(team=slack_integration.team, integration=slack_integration)
 
-        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids=set())
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids=set())
 
         assert not state.has_data
 
 
 class TestStatsCardGating:
-    def _published_view(self, mock_slack_client) -> dict:
-        handle_app_home_opened({"user": SLACK_USER}, WORKSPACE)
-        return mock_slack_client.views_publish.call_args.kwargs["view"]
-
-    def test_admin_sees_the_card(self, slack_integration, mock_slack_client, flag_on, admin_user):
-        assert "Workspace activity" in str(self._published_view(mock_slack_client))
-
-    def test_non_admins_never_see_the_card(self, slack_integration, mock_slack_client, flag_on):
-        with patch(
-            "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
-            return_value=False,
+    @pytest.mark.parametrize(
+        "is_admin, stats_flag_on, expected_visible",
+        [
+            (True, True, True),
+            (False, True, False),
+            (True, False, False),
+            (False, False, False),
+        ],
+    )
+    def test_card_needs_both_admin_and_its_own_flag(
+        self, slack_integration, mock_slack_client, flag_on, is_admin, stats_flag_on, expected_visible
+    ):
+        with (
+            patch(
+                "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
+                return_value=is_admin,
+            ),
+            patch(
+                "products.slack_app.backend.services.slack_app_home.is_slack_app_home_stats_enabled",
+                return_value=stats_flag_on,
+            ),
         ):
-            assert "Workspace activity" not in str(self._published_view(mock_slack_client))
+            handle_app_home_opened({"user": SLACK_USER}, WORKSPACE)
 
-    def test_card_is_dark_when_its_own_flag_is_off(self, slack_integration, mock_slack_client, flag_on, admin_user):
-        with patch(
-            "products.slack_app.backend.services.slack_app_home.is_slack_app_home_stats_enabled",
-            return_value=False,
-        ):
-            assert "Workspace activity" not in str(self._published_view(mock_slack_client))
+        view = mock_slack_client.views_publish.call_args.kwargs["view"]
+        assert ("Workspace activity" in str(view)) is expected_visible

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -362,27 +362,11 @@ class TestResolveStatsState:
 
 
 class TestStatsCardGating:
-    @pytest.mark.parametrize(
-        "is_admin, stats_flag_on, expected_visible",
-        [
-            (True, True, True),
-            (False, True, False),
-            (True, False, False),
-            (False, False, False),
-        ],
-    )
-    def test_card_needs_both_admin_and_its_own_flag(
-        self, slack_integration, mock_slack_client, flag_on, is_admin, stats_flag_on, expected_visible
-    ):
-        with (
-            patch(
-                "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
-                return_value=is_admin,
-            ),
-            patch(
-                "products.slack_app.backend.services.slack_app_home.is_slack_app_home_stats_enabled",
-                return_value=stats_flag_on,
-            ),
+    @pytest.mark.parametrize("is_admin, expected_visible", [(True, True), (False, False)])
+    def test_card_is_admin_only(self, slack_integration, mock_slack_client, flag_on, is_admin, expected_visible):
+        with patch(
+            "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
+            return_value=is_admin,
         ):
             handle_app_home_opened({"user": SLACK_USER}, WORKSPACE)
 

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -34,6 +34,7 @@ SLACK_USER = "U_ADMIN"
 MAX_PIE_SEGMENTS = 12
 MAX_CHART_POINTS = 20
 MAX_LABEL_CHARS = 20
+MAX_SECTION_FIELDS = 10
 
 
 @pytest.fixture(autouse=True)
@@ -184,6 +185,43 @@ class TestStatsCardRendering:
         # Slack rejects a segment whose value isn't positive.
         assert all(s["value"] > 0 for s in segments)
 
+    def test_headline_renders_as_a_two_column_field_grid(self):
+        view = _render(
+            StatsState(
+                tasks_started=24,
+                tasks_with_pr=18,
+                tasks_merged=11,
+                active_people=5,
+                median_cycle_seconds=840,
+            )
+        )
+        grid = next(b for b in view["blocks"] if b["type"] == "section" and "fields" in b)
+
+        # Slack lays `fields` out in two columns and rejects more than 10 cells; a stack of
+        # sections instead would cost one full-width row per KPI.
+        assert len(grid["fields"]) <= MAX_SECTION_FIELDS
+        rendered = [f["text"] for f in grid["fields"]]
+        assert "*Tasks*\n24" in rendered
+        assert "*Merge rate*\n61%" in rendered
+        assert "*Median run*\n14m" in rendered
+        assert "*People*\n5" in rendered
+
+    @pytest.mark.parametrize(
+        "seconds, expected",
+        [
+            (None, "—"),
+            (45, "45s"),
+            (840, "14m"),
+            (3600, "1h"),
+            (7500, "2h 5m"),
+            (259200, "3d"),
+        ],
+    )
+    def test_durations_render_compactly(self, seconds, expected):
+        view = _render(StatsState(tasks_started=1, median_cycle_seconds=seconds))
+        grid = next(b for b in view["blocks"] if b["type"] == "section" and "fields" in b)
+        assert f"*Median run*\n{expected}" in [f["text"] for f in grid["fields"]]
+
     def test_long_model_ids_are_truncated_to_the_label_cap(self):
         view = _render(
             StatsState(
@@ -258,6 +296,35 @@ class TestResolveStatsState:
         assert state.tasks_with_pr == 1
         assert state.tasks_merged == 1
         assert state.merge_rate_percent == 100
+
+    def test_median_run_time_ignores_runs_that_did_not_complete(self, slack_integration):
+        team = slack_integration.team
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        # Completed runs of 10 and 30 minutes, plus a failed one that ran for a week. The
+        # failed run stopped at an arbitrary point, so letting it in would swamp the median.
+        for index, (status, minutes) in enumerate([("completed", 10), ("completed", 30), ("failed", 10080)]):
+            mapping = _mk_task_with_run(team=team, integration=slack_integration, thread_ts=f"1.{index}", status=status)
+            TaskRun.objects.filter(pk=mapping.task_run_id).update(
+                completed_at=mapping.task_run.created_at + timedelta(minutes=minutes)
+            )
+
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        assert state.median_cycle_seconds == 20 * 60
+
+    def test_active_people_counts_everyone_not_just_the_leaderboard(self, slack_integration):
+        team = slack_integration.team
+        for index in range(3):
+            _mk_task_with_run(
+                team=team,
+                integration=slack_integration,
+                thread_ts=f"1.{index}",
+                slack_user_id=f"U_PERSON_{index}",
+            )
+
+        state = build_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        assert state.active_people == 3
 
     def test_model_usage_is_aggregated_from_the_latest_run_state(self, slack_integration):
         team = slack_integration.team

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from django.apps import apps
+from django.core.cache import cache
+from django.utils import timezone
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team.team import Team
+
+from products.slack_app.backend.models import SlackThreadTaskMapping, SlackUserProfileCache
+from products.slack_app.backend.services.slack_app_home import handle_app_home_opened, render_home_view
+from products.slack_app.backend.services.slack_app_home_stats import (
+    DEFAULT_STATS_WINDOW_DAYS,
+    ModelUsage,
+    PersonRow,
+    StatsState,
+    TrendBucket,
+    coerce_window_days,
+    resolve_stats_state,
+)
+from products.slack_app.backend.services.slack_settings import AIPreferences
+
+WORKSPACE = "T_STATS"
+SLACK_USER = "U_ADMIN"
+
+# Slack's documented Block Kit caps. Exceeding any of them makes `views.publish` fail with
+# `invalid_blocks`, which takes down the whole Home tab and not just this card.
+MAX_PIE_SEGMENTS = 12
+MAX_CHART_POINTS = 20
+MAX_LABEL_CHARS = 20
+
+
+@pytest.fixture(autouse=True)
+def _clear_stats_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def slack_integration(db):
+    organization = Organization.objects.create(name="Org")
+    team = Team.objects.create(organization=organization, name="Team")
+    return Integration.objects.create(
+        team=team,
+        kind="slack",
+        integration_id=WORKSPACE,
+        sensitive_config={"access_token": "xoxb"},
+    )
+
+
+@pytest.fixture
+def mock_slack_client():
+    fake_client = MagicMock()
+    with patch("products.slack_app.backend.services.slack_app_home.SlackIntegration") as cls:
+        instance = MagicMock()
+        instance.client = fake_client
+        cls.return_value = instance
+        yield fake_client
+
+
+@pytest.fixture
+def flag_on():
+    with patch(
+        "products.slack_app.backend.feature_flags.posthoganalytics.feature_enabled",
+        return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture
+def admin_user():
+    with patch(
+        "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
+        return_value=True,
+    ):
+        yield
+
+
+def _mk_task_with_run(
+    *,
+    team,
+    integration,
+    slack_user_id: str = SLACK_USER,
+    channel: str = "C1",
+    thread_ts: str = "1.1",
+    status: str = "completed",
+    pr_url: str | None = None,
+    pr_merged: bool = False,
+    model: str | None = "claude-opus-5",
+    created_at=None,
+) -> SlackThreadTaskMapping:
+    Task = apps.get_model("tasks", "Task")
+    TaskRun = apps.get_model("tasks", "TaskRun")
+
+    task = Task.objects.create(team=team, title="t")
+    output: dict = {}
+    if pr_url:
+        output["pr_url"] = pr_url
+        output["pr_merged"] = pr_merged
+    state = {"model": model, "runtime_adapter": "claude"} if model else {}
+    task_run = TaskRun.objects.create(team=team, task=task, status=status, output=output, state=state)
+
+    mapping = SlackThreadTaskMapping.objects.create(
+        team=team,
+        integration=integration,
+        slack_workspace_id=WORKSPACE,
+        channel=channel,
+        thread_ts=thread_ts,
+        task=task,
+        task_run=task_run,
+        mentioning_slack_user_id=slack_user_id,
+    )
+    if created_at is not None:
+        # `created_at` is auto_now_add, so backdating has to bypass the model save.
+        SlackThreadTaskMapping.objects.filter(pk=mapping.pk).update(created_at=created_at)
+        mapping.refresh_from_db()
+    return mapping
+
+
+def _blocks_of_type(view: dict, block_type: str) -> list[dict]:
+    return [b for b in view["blocks"] if b["type"] == block_type]
+
+
+def _render(state: StatsState | None) -> dict:
+    return render_home_view(
+        effective=AIPreferences(),
+        user_row=None,
+        workspace_row=None,
+        is_admin=True,
+        stats_state=state,
+    )
+
+
+class TestWindowCoercion:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("7", 7),
+            ("30", 30),
+            ("90", 90),
+            (90, 90),
+            ("99999", DEFAULT_STATS_WINDOW_DAYS),
+            ("-1", DEFAULT_STATS_WINDOW_DAYS),
+            ("nonsense", DEFAULT_STATS_WINDOW_DAYS),
+            (None, DEFAULT_STATS_WINDOW_DAYS),
+        ],
+    )
+    def test_untrusted_window_is_clamped_to_an_offered_option(self, raw, expected):
+        assert coerce_window_days(raw) == expected
+
+
+class TestStatsCardRendering:
+    def test_card_omitted_when_state_is_none(self):
+        view = _render(None)
+        assert not _blocks_of_type(view, "data_visualization")
+        assert not _blocks_of_type(view, "data_table")
+        assert "Workspace activity" not in str(view)
+
+    def test_empty_window_renders_controls_without_charts(self):
+        view = _render(StatsState(window_days=30))
+        assert "Workspace activity" in str(view)
+        # An empty window has no series to plot; a chart with no data is invalid.
+        assert not _blocks_of_type(view, "data_visualization")
+        assert not _blocks_of_type(view, "data_table")
+
+    def test_model_pie_folds_the_tail_and_stays_within_slack_caps(self):
+        models = tuple(ModelUsage(model=f"model-{i}", runtime_adapter="claude", value=20 - i) for i in range(15))
+        view = _render(StatsState(tasks_started=100, models=models))
+
+        pie = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "pie")
+        segments = pie["chart"]["segments"]
+
+        assert len(segments) <= MAX_PIE_SEGMENTS
+        assert segments[-1]["label"] == "Other"
+        # Nothing may be dropped: the folded tail carries the models that didn't fit.
+        assert sum(s["value"] for s in segments) == sum(m.value for m in models)
+        # Slack rejects a segment whose value isn't positive.
+        assert all(s["value"] > 0 for s in segments)
+
+    def test_long_model_ids_are_truncated_to_the_label_cap(self):
+        view = _render(
+            StatsState(
+                tasks_started=1,
+                models=(
+                    ModelUsage(
+                        model="anthropic/claude-sonnet-4-5-with-an-absurdly-long-name",
+                        runtime_adapter="claude",
+                        value=1,
+                    ),
+                ),
+            )
+        )
+        pie = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "pie")
+        assert all(len(s["label"]) <= MAX_LABEL_CHARS for s in pie["chart"]["segments"])
+
+    def test_trend_chart_is_capped_to_the_slack_point_limit(self):
+        trend = tuple(TrendBucket(label=f"Day {i:02d}", opened=1, merged=1) for i in range(40))
+        view = _render(StatsState(tasks_started=40, tasks_with_pr=40, trend=trend))
+
+        bar = next(c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "bar")
+        categories = bar["chart"]["axis_config"]["categories"]
+
+        assert len(categories) <= MAX_CHART_POINTS
+        for series in bar["chart"]["series"]:
+            assert len(series["data"]) == len(categories)
+            # Slack requires every series to carry a point for each axis category.
+            assert [p["label"] for p in series["data"]] == categories
+
+    def test_trend_chart_omitted_when_the_window_produced_no_prs(self):
+        trend = (TrendBucket(label="Jul 07", opened=0, merged=0),)
+        view = _render(StatsState(tasks_started=3, tasks_with_pr=0, trend=trend))
+        assert not [c for c in _blocks_of_type(view, "data_visualization") if c["chart"]["type"] == "bar"]
+
+    def test_leaderboard_numbers_carry_both_display_text_and_sort_value(self):
+        view = _render(StatsState(tasks_started=9, people=(PersonRow(name="Vojta", tasks=9, merged=6),)))
+
+        table = _blocks_of_type(view, "data_table")[0]
+        data_row = table["rows"][1]
+
+        assert data_row[0] == {"type": "raw_text", "text": "Vojta"}
+        # Slack sorts on `value` and renders `text`; omitting either is rejected.
+        assert data_row[1] == {"type": "raw_number", "text": "9", "value": 9}
+        assert data_row[2] == {"type": "raw_number", "text": "6", "value": 6}
+
+
+class TestResolveStatsState:
+    def test_counts_prs_and_merges_off_the_same_tasks(self, slack_integration):
+        team = slack_integration.team
+        _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.1", pr_url="u/1", pr_merged=True)
+        _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.2", pr_url="u/2", pr_merged=False)
+        _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.3", pr_url=None)
+
+        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        assert state.tasks_started == 3
+        assert state.tasks_with_pr == 2
+        assert state.tasks_merged == 1
+        assert state.merge_rate_percent == 50
+
+    def test_merge_rate_is_none_when_nothing_opened_a_pr(self, slack_integration):
+        team = slack_integration.team
+        _mk_task_with_run(team=team, integration=slack_integration, pr_url=None)
+
+        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        assert state.tasks_with_pr == 0
+        assert state.merge_rate_percent is None
+
+    def test_excludes_tasks_from_teams_the_viewer_cannot_access(self, slack_integration):
+        other_org = Organization.objects.create(name="Other org")
+        other_team = Team.objects.create(organization=other_org, name="Other team")
+        other_integration = Integration.objects.create(
+            team=other_team,
+            kind="slack",
+            integration_id=WORKSPACE,
+            sensitive_config={"access_token": "xoxb"},
+        )
+        _mk_task_with_run(team=slack_integration.team, integration=slack_integration, thread_ts="1.1")
+        _mk_task_with_run(team=other_team, integration=other_integration, thread_ts="2.1", channel="C2")
+
+        state = resolve_stats_state(
+            slack_workspace_id=WORKSPACE,
+            accessible_team_ids={slack_integration.team_id},
+        )
+
+        assert state.tasks_started == 1
+
+    def test_excludes_activity_older_than_the_window(self, slack_integration):
+        team = slack_integration.team
+        _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.1")
+        _mk_task_with_run(
+            team=team,
+            integration=slack_integration,
+            thread_ts="1.2",
+            created_at=timezone.now() - timedelta(days=45),
+        )
+
+        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id}, window_days=30)
+
+        assert state.tasks_started == 1
+
+    @pytest.mark.parametrize("window_days", [7, 30, 90])
+    def test_every_started_task_lands_in_exactly_one_outcome_bucket(self, slack_integration, window_days):
+        team = slack_integration.team
+        for index, status in enumerate(["completed", "failed", "cancelled", "in_progress", "queued"]):
+            _mk_task_with_run(team=team, integration=slack_integration, thread_ts=f"1.{index}", status=status)
+
+        state = resolve_stats_state(
+            slack_workspace_id=WORKSPACE,
+            accessible_team_ids={team.id},
+            window_days=window_days,
+        )
+
+        assert sum(outcome.value for outcome in state.outcomes) == state.tasks_started
+
+    @pytest.mark.parametrize("window_days", [7, 30, 90])
+    def test_trend_buckets_stay_within_the_chart_point_cap(self, slack_integration, window_days):
+        team = slack_integration.team
+        _mk_task_with_run(team=team, integration=slack_integration, pr_url="u/1", pr_merged=True)
+
+        state = resolve_stats_state(
+            slack_workspace_id=WORKSPACE,
+            accessible_team_ids={team.id},
+            window_days=window_days,
+        )
+
+        assert 0 < len(state.trend) <= MAX_CHART_POINTS
+
+    def test_leaderboard_resolves_slack_ids_to_cached_names(self, slack_integration):
+        team = slack_integration.team
+        SlackUserProfileCache.objects.create(
+            integration=slack_integration,
+            slack_user_id=SLACK_USER,
+            real_name="Vojta Bartos",
+        )
+        _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.1", pr_url="u/1", pr_merged=True)
+        _mk_task_with_run(team=team, integration=slack_integration, thread_ts="1.2", slack_user_id="U_UNKNOWN")
+
+        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids={team.id})
+
+        by_name = {person.name: person for person in state.people}
+        assert by_name["Vojta Bartos"].tasks == 1
+        assert by_name["Vojta Bartos"].merged == 1
+        # No cached profile — falling back to the raw id beats dropping the row.
+        assert by_name["U_UNKNOWN"].tasks == 1
+
+    def test_no_accessible_teams_yields_an_empty_card(self, slack_integration):
+        _mk_task_with_run(team=slack_integration.team, integration=slack_integration)
+
+        state = resolve_stats_state(slack_workspace_id=WORKSPACE, accessible_team_ids=set())
+
+        assert not state.has_data
+
+
+class TestStatsCardGating:
+    def _published_view(self, mock_slack_client) -> dict:
+        handle_app_home_opened({"user": SLACK_USER}, WORKSPACE)
+        return mock_slack_client.views_publish.call_args.kwargs["view"]
+
+    def test_admin_sees_the_card(self, slack_integration, mock_slack_client, flag_on, admin_user):
+        assert "Workspace activity" in str(self._published_view(mock_slack_client))
+
+    def test_non_admins_never_see_the_card(self, slack_integration, mock_slack_client, flag_on):
+        with patch(
+            "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
+            return_value=False,
+        ):
+            assert "Workspace activity" not in str(self._published_view(mock_slack_client))
+
+    def test_card_is_dark_when_its_own_flag_is_off(self, slack_integration, mock_slack_client, flag_on, admin_user):
+        with patch(
+            "products.slack_app.backend.services.slack_app_home.is_slack_app_home_stats_enabled",
+            return_value=False,
+        ):
+            assert "Workspace activity" not in str(self._published_view(mock_slack_client))

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -34,7 +34,7 @@ SLACK_USER = "U_ADMIN"
 # `invalid_blocks`, which takes down the whole Home tab and not just this card.
 MAX_MODEL_ROWS = 6
 MAX_CHART_POINTS = 20
-MAX_LABEL_CHARS = 20
+MAX_LABEL_CHARS = 14
 MAX_SECTION_FIELDS = 10
 
 
@@ -130,6 +130,22 @@ def _blocks_of_type(view: dict, block_type: str) -> list[dict]:
     return [b for b in view["blocks"] if b["type"] == block_type]
 
 
+def _fields_blocks(view: dict) -> list[dict]:
+    return [b for b in view["blocks"] if b["type"] == "section" and "fields" in b]
+
+
+def _kpi_grid(view: dict) -> dict:
+    return next(b for b in _fields_blocks(view) if any(f["text"].startswith("*Tasks*") for f in b["fields"]))
+
+
+def _breakdowns_block(view: dict) -> dict:
+    return next(b for b in _fields_blocks(view) if any(f["text"].startswith("*Models*") for f in b["fields"]))
+
+
+def _column(view: dict, heading: str) -> str:
+    return next(f["text"] for b in _fields_blocks(view) for f in b["fields"] if f["text"].startswith(heading))
+
+
 def _render(state: StatsState | None) -> dict:
     return render_home_view(
         effective=AIPreferences(),
@@ -161,22 +177,21 @@ class TestWindowCoercion:
 class TestStatsCardRendering:
     def test_card_omitted_when_state_is_none(self):
         view = _render(None)
-        assert not _blocks_of_type(view, "data_table")
         assert "Workspace activity" not in str(view)
 
     def test_empty_window_renders_controls_without_charts(self):
         view = _render(StatsState(window_days=30))
         assert "Workspace activity" in str(view)
         # An empty window has nothing to plot and nobody to list.
-        assert not _blocks_of_type(view, "data_table")
         assert "*Models*" not in str(view)
+        assert "*Most active*" not in str(view)
 
     def test_model_bars_fold_the_tail_without_losing_counts(self):
         models = tuple(ModelUsage(model=f"model-{i}", runtime_adapter="claude", value=20 - i) for i in range(15))
         view = _render(StatsState(tasks_started=100, models=models))
 
-        block = next(b for b in view["blocks"] if b["type"] == "section" and "*Models*" in str(b.get("text")))
-        lines = [line for line in block["text"]["text"].splitlines() if line and not line.startswith(("*", "`"))]
+        column = _column(view, "*Models*")
+        lines = [line for line in column.splitlines() if line and not line.startswith(("*", "`"))]
 
         assert len(lines) <= MAX_MODEL_ROWS
         assert lines[-1].startswith("Other")
@@ -206,7 +221,7 @@ class TestStatsCardRendering:
                 median_cycle_seconds=840,
             )
         )
-        grid = next(b for b in view["blocks"] if b["type"] == "section" and "fields" in b)
+        grid = _kpi_grid(view)
 
         # Slack lays `fields` out in two columns and rejects more than 10 cells; a stack of
         # sections instead would cost one full-width row per KPI.
@@ -230,8 +245,7 @@ class TestStatsCardRendering:
     )
     def test_durations_render_compactly(self, seconds, expected):
         view = _render(StatsState(tasks_started=1, median_cycle_seconds=seconds))
-        grid = next(b for b in view["blocks"] if b["type"] == "section" and "fields" in b)
-        assert f"*Median run*\n{expected}" in [f["text"] for f in grid["fields"]]
+        assert f"*Median run*\n{expected}" in [f["text"] for f in _kpi_grid(view)["fields"]]
 
     def test_long_model_ids_are_truncated_to_the_label_cap(self):
         view = _render(
@@ -246,10 +260,9 @@ class TestStatsCardRendering:
                 ),
             )
         )
-        block = next(b for b in view["blocks"] if b["type"] == "section" and "*Models*" in str(b.get("text")))
         labels = [
-            line.split("  ")[0]
-            for line in block["text"]["text"].splitlines()
+            line.split(" ")[0]
+            for line in _column(view, "*Models*").splitlines()
             if line and not line.startswith(("*", "`"))
         ]
         # A long label would push the bar column out of alignment inside the fenced block.
@@ -276,16 +289,35 @@ class TestStatsCardRendering:
         view = _render(StatsState(tasks_started=3, tasks_with_pr=0, trend=trend))
         assert not [b for b in view["blocks"] if b["type"] == "context" and "*PRs*" in str(b)]
 
-    def test_leaderboard_numbers_carry_both_display_text_and_sort_value(self):
-        view = _render(StatsState(tasks_started=9, people=(PersonRow(name="Vojta", tasks=9, merged=6),)))
+    def test_models_and_people_render_as_two_columns_of_one_block(self):
+        view = _render(
+            StatsState(
+                tasks_started=9,
+                models=(ModelUsage(model="claude-opus-5", runtime_adapter="claude", value=9),),
+                people=(PersonRow(name="Vojta", tasks=9, merged=6), PersonRow(name="Anna", tasks=4, merged=1)),
+            )
+        )
 
-        table = _blocks_of_type(view, "data_table")[0]
-        data_row = table["rows"][1]
+        # `section.fields` is the only two-column layout Block Kit offers, so both
+        # breakdowns have to share one block to sit side by side.
+        block = _breakdowns_block(view)
+        columns = [f["text"] for f in block["fields"]]
 
-        assert data_row[0] == {"type": "raw_text", "text": "Vojta"}
-        # Slack sorts on `value` and renders `text`; omitting either is rejected.
-        assert data_row[1] == {"type": "raw_number", "text": "9", "value": 9}
-        assert data_row[2] == {"type": "raw_number", "text": "6", "value": 6}
+        assert len(columns) == 2
+        assert columns[0].startswith("*Models*")
+        assert columns[1].startswith("*Most active*")
+        assert "Vojta" in columns[1] and "Anna" in columns[1]
+
+    def test_leaderboard_columns_stay_aligned_under_a_long_name(self):
+        people = (PersonRow(name="A", tasks=9, merged=6), PersonRow(name="Bartholomew Wigglesworth", tasks=4, merged=1))
+        view = _render(StatsState(tasks_started=13, people=people))
+
+        column = _column(view, "*Most active*")
+        rows = [line for line in column.splitlines() if line and not line.startswith(("*", "`"))]
+
+        # Names are padded to a common width inside the fenced block, so the count
+        # columns line up rather than drifting with each name's length.
+        assert len({len(row) for row in rows}) == 1
 
 
 class TestResolveStatsState:


### PR DESCRIPTION
## Problem

Slack workspace admins can't see what their team is shipping through @PostHog. The Home tab only shows the caller's own settings and tasks.

## Changes

An admin-only "Workspace activity" card at the top of the App Home tab, under the existing `slack-app-home` flag.

<img width="1246" height="692" alt="Screenshot 2026-08-04 at 14 36 23" src="https://github.com/user-attachments/assets/628aef65-8647-4d1f-935f-f6a7af70cb9a" />


Also: a concurrent index on `SlackThreadTaskMapping (slack_workspace_id, created_at)`, and the tab's controls now read into one `HomeViewState` so cards stop resetting each other's filters.

> [!WARNING]
> Block Kit's native `data_visualization` block is rejected by `views.publish` on App Home, even though `blocks.validate` accepts it. Hence text charts.

## How did you test this code?

753 tests pass (40 new), repo-wide mypy clean, no migration drift. Seeded 20 tasks locally and published the card to a live App Home — that's how the `data_visualization` rejection surfaced, since `blocks.validate` had passed.

New tests cover the display caps (field grid, model tail folding, sparklines sharing one peak) and the aggregation invariants (team scoping, outcome bucketing, median ignoring incomplete runs, window clamping). One pins a bug review caught: "opened a PR" was counted off the latest run while "merged" came off the latest *PR-bearing* run, so merge rate could exceed 100%.

Manually tested

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Skills: `/django-migrations`, `/writing-tests`, Slack `block-kit`, `/simplify`.

Deferred: token/cost spend (ClickHouse, too heavy for a 3s handler), PR merge latency (the webhook stores `pr_merged` with no timestamp), failure-reason and per-channel breakdowns.
