### PR TITLE
feat(capture): kafka-manager prototype — capture health telemetry

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2176,6 +2176,7 @@ dependencies = [
  "httparse",
  "hyper 1.9.0",
  "hyper-util",
+ "kafka-manager-types",
  "lifecycle",
  "limiters",
  "lz-str",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -6610,6 +6610,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "kafka-manager"
+version = "0.1.0"
+dependencies = [
+ "axum 0.7.9",
+ "axum-test-helper",
+ "common-alloc",
+ "common-metrics",
+ "envconfig",
+ "health",
+ "kafka-manager-types",
+ "metrics",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "kafka-manager-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "keyed-stash"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -58,6 +58,8 @@ members = [
   "ingestion-consumer",
   "ingestion-control-plane",
   "kafka-deduplicator",
+  "kafka-manager",
+  "kafka-manager-types",
   "personhog-common",
   "personhog-coordination",
   "personhog-identity",

--- a/rust/capture/Cargo.toml
+++ b/rust/capture/Cargo.toml
@@ -33,6 +33,7 @@ common-ingestion-warnings = { path = "../common/ingestion_warnings" }
 common-kafka = { path = "../common/kafka" }
 common-redis = { path = "../common/redis" }
 common-types = { path = "../common/types" }
+kafka-manager-types = { path = "../kafka-manager-types" }
 limiters = { path = "../common/limiters" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
@@ -44,6 +45,7 @@ prost = { workspace = true }
 rand = { workspace = true }
 rdkafka = { workspace = true }
 redis = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_urlencoded = { workspace = true }

--- a/rust/capture/src/config.rs
+++ b/rust/capture/src/config.rs
@@ -321,6 +321,18 @@ pub struct Config {
     #[envconfig(default = "false")]
     pub is_mirror_deploy: bool,
 
+    /// Base URL of the kafka-manager service. Unset (the default) disables the
+    /// telemetry reporter entirely — no task is spawned and the produce path
+    /// runs exactly as before. The reporter is fire-and-forget: a down or slow
+    /// manager only ever costs dropped reports, never capture behavior.
+    pub capture_kafka_manager_url: Option<String>,
+
+    #[envconfig(default = "10")]
+    pub capture_kafka_manager_report_interval_secs: u64,
+
+    #[envconfig(default = "2000")]
+    pub capture_kafka_manager_request_timeout_ms: u64,
+
     #[envconfig(default = "info")]
     pub log_level: Level,
 

--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -9,6 +9,7 @@ pub mod extractors;
 pub mod global_rate_limiter;
 pub mod ingestion_warnings;
 pub mod log_util;
+pub mod manager_reporter;
 pub mod metrics_middleware;
 pub mod otel;
 pub mod payload;

--- a/rust/capture/src/manager_reporter.rs
+++ b/rust/capture/src/manager_reporter.rs
@@ -1,0 +1,255 @@
+//! Fail-open telemetry reporter to the kafka-manager service.
+//!
+//! Pushes periodic [`HealthReport`]s (delivery outcome counts, producer queue
+//! pressure, broker connectivity) to an external kafka-manager, which
+//! aggregates them fleet-wide as groundwork for a Kafka circuit breaker. The
+//! channel is strictly one-way: nothing the manager does — including being
+//! down — can influence the produce path.
+//!
+//! Fail-open by construction:
+//! - Without [`init`] (the `CAPTURE_KAFKA_MANAGER_URL` env var unset), the
+//!   record hooks are no-ops behind a single atomic load and no task runs.
+//! - When enabled, the produce path only bumps relaxed atomics; serialization
+//!   and HTTP happen on a background task with a short request timeout.
+//! - Send failures increment a counter and are otherwise dropped.
+//!
+//! Scope: the v0 sink path. Delivery counts cover every producer built on
+//! `sinks::producer`, so on deployments with a secondary sink the counts are
+//! a pod-wide blend; producer stats come only from the liveness-gating
+//! (primary) producer. Per-sink attribution and the v1 sink stack are next
+//! steps once per-cluster breakers need them.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use kafka_manager_types::{DeliveryCounts, HealthReport, ProducerStats};
+use metrics::counter;
+use tracing::log::{debug, warn};
+
+static COLLECTOR: OnceLock<Arc<Collector>> = OnceLock::new();
+
+/// Terminal outcome of one produce attempt, as classified by the delivery
+/// report handling in `sinks::producer`.
+#[derive(Debug, Clone, Copy)]
+pub enum DeliveryOutcome {
+    Delivered,
+    BrokerError,
+    TimedOut,
+    TooLarge,
+    Abandoned,
+    EnqueueError,
+}
+
+#[derive(Default)]
+pub struct Collector {
+    ok: AtomicU64,
+    broker_error: AtomicU64,
+    timed_out: AtomicU64,
+    too_large: AtomicU64,
+    abandoned: AtomicU64,
+    enqueue_error: AtomicU64,
+    producer_stats: Mutex<Option<ProducerStats>>,
+}
+
+impl Collector {
+    fn record(&self, outcome: DeliveryOutcome) {
+        let cell = match outcome {
+            DeliveryOutcome::Delivered => &self.ok,
+            DeliveryOutcome::BrokerError => &self.broker_error,
+            DeliveryOutcome::TimedOut => &self.timed_out,
+            DeliveryOutcome::TooLarge => &self.too_large,
+            DeliveryOutcome::Abandoned => &self.abandoned,
+            DeliveryOutcome::EnqueueError => &self.enqueue_error,
+        };
+        cell.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn delivery_counts(&self) -> DeliveryCounts {
+        DeliveryCounts {
+            ok: self.ok.load(Ordering::Relaxed),
+            broker_error: self.broker_error.load(Ordering::Relaxed),
+            timed_out: self.timed_out.load(Ordering::Relaxed),
+            too_large: self.too_large.load(Ordering::Relaxed),
+            abandoned: self.abandoned.load(Ordering::Relaxed),
+            enqueue_error: self.enqueue_error.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Whether a reporter is installed. Callers use this to skip assembling
+/// snapshots that would go nowhere (the stats callback builds a per-broker
+/// Vec only when this is true).
+pub fn enabled() -> bool {
+    COLLECTOR.get().is_some()
+}
+
+/// No-op unless [`init`] ran: one atomic load, then one relaxed increment.
+pub fn record_delivery_outcome(outcome: DeliveryOutcome) {
+    if let Some(collector) = COLLECTOR.get() {
+        collector.record(outcome);
+    }
+}
+
+/// Store the latest librdkafka statistics snapshot (10s cadence, not per
+/// event). No-op unless [`init`] ran.
+pub fn record_producer_stats(stats: ProducerStats) {
+    if let Some(collector) = COLLECTOR.get() {
+        *collector.producer_stats.lock().unwrap() = Some(stats);
+    }
+}
+
+pub struct ReporterConfig {
+    pub url: String,
+    pub deployment: String,
+    pub interval: Duration,
+    pub request_timeout: Duration,
+}
+
+/// Install the global collector and spawn the report loop. Called once at
+/// startup when `CAPTURE_KAFKA_MANAGER_URL` is set; a second call is ignored.
+pub fn init(config: ReporterConfig) {
+    let collector = Arc::new(Collector::default());
+    if COLLECTOR.set(collector.clone()).is_err() {
+        return;
+    }
+    let client = match reqwest::Client::builder()
+        .timeout(config.request_timeout)
+        .build()
+    {
+        Ok(client) => client,
+        Err(e) => {
+            // Reporter stays a no-op collector; capture is unaffected.
+            warn!("kafka-manager reporter disabled, could not build HTTP client: {e:#}");
+            return;
+        }
+    };
+    tokio::spawn(report_loop(collector, client, config));
+}
+
+async fn report_loop(collector: Arc<Collector>, client: reqwest::Client, config: ReporterConfig) {
+    let pod = std::env::var("HOSTNAME").unwrap_or_else(|_| "unknown".to_string());
+    let endpoint = format!("{}/v1/health-reports", config.url.trim_end_matches('/'));
+    let mut interval = tokio::time::interval(config.interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    loop {
+        interval.tick().await;
+        let report = build_report(&collector, &pod, &config.deployment);
+        send_report(&client, &endpoint, &report).await;
+    }
+}
+
+fn build_report(collector: &Collector, pod: &str, deployment: &str) -> HealthReport {
+    HealthReport {
+        pod: pod.to_string(),
+        deployment: deployment.to_string(),
+        delivery: collector.delivery_counts(),
+        producer: collector.producer_stats.lock().unwrap().clone(),
+    }
+}
+
+async fn send_report(client: &reqwest::Client, endpoint: &str, report: &HealthReport) {
+    match client.post(endpoint).json(report).send().await {
+        Ok(response) if response.status().is_success() => {
+            counter!("capture_manager_reports_sent_total").increment(1);
+        }
+        Ok(response) => {
+            counter!("capture_manager_report_failures_total", "reason" => "http_status")
+                .increment(1);
+            debug!(
+                "kafka-manager rejected health report: {}",
+                response.status()
+            );
+        }
+        Err(e) => {
+            counter!("capture_manager_report_failures_total", "reason" => "unreachable")
+                .increment(1);
+            debug!("kafka-manager unreachable: {e:#}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+    use axum::routing::post;
+    use axum::{Json, Router};
+
+    #[test]
+    fn record_hooks_are_noops_without_init() {
+        // No test in this binary calls init(), so the hot-path hooks must
+        // silently do nothing — this is the flag-off production state.
+        assert!(!enabled());
+        record_delivery_outcome(DeliveryOutcome::Delivered);
+        record_producer_stats(ProducerStats::default());
+    }
+
+    #[test]
+    fn build_report_snapshots_cumulative_counts() {
+        let collector = Collector::default();
+        collector.record(DeliveryOutcome::Delivered);
+        collector.record(DeliveryOutcome::Delivered);
+        collector.record(DeliveryOutcome::TimedOut);
+        collector.record(DeliveryOutcome::TooLarge);
+
+        let report = build_report(&collector, "pod-1", "capture");
+        assert_eq!(report.delivery.ok, 2);
+        assert_eq!(report.delivery.timed_out, 1);
+        assert_eq!(report.delivery.too_large, 1);
+        assert!(report.producer.is_none());
+
+        collector.record(DeliveryOutcome::Delivered);
+        let report = build_report(&collector, "pod-1", "capture");
+        assert_eq!(report.delivery.ok, 3, "counts are cumulative");
+    }
+
+    #[tokio::test]
+    async fn send_report_round_trips_to_manager() {
+        let received: Arc<Mutex<Vec<HealthReport>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = received.clone();
+        let app = Router::new()
+            .route(
+                "/v1/health-reports",
+                post(
+                    |State(sink): State<Arc<Mutex<Vec<HealthReport>>>>,
+                     Json(report): Json<HealthReport>| async move {
+                        sink.lock().unwrap().push(report);
+                        axum::http::StatusCode::NO_CONTENT
+                    },
+                ),
+            )
+            .with_state(sink);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await });
+
+        let collector = Collector::default();
+        collector.record(DeliveryOutcome::Delivered);
+        let report = build_report(&collector, "pod-1", "capture");
+        let client = reqwest::Client::new();
+        send_report(
+            &client,
+            &format!("http://{addr}/v1/health-reports"),
+            &report,
+        )
+        .await;
+
+        let received = received.lock().unwrap();
+        assert_eq!(received.len(), 1);
+        assert_eq!(received[0].pod, "pod-1");
+        assert_eq!(received[0].delivery.ok, 1);
+    }
+
+    #[tokio::test]
+    async fn send_report_to_unreachable_manager_is_harmless() {
+        let collector = Collector::default();
+        let report = build_report(&collector, "pod-1", "capture");
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_millis(200))
+            .build()
+            .unwrap();
+        // Reserved port with nothing listening: must return, not panic or hang.
+        send_report(&client, "http://127.0.0.1:1/v1/health-reports", &report).await;
+    }
+}

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -171,6 +171,19 @@ pub async fn build_components(
         )
     });
 
+    // Fire-and-forget health telemetry to the kafka-manager service. Unset
+    // URL (the default) means no reporter task and untouched produce paths.
+    if let Some(url) = &config.capture_kafka_manager_url {
+        crate::manager_reporter::init(crate::manager_reporter::ReporterConfig {
+            url: url.clone(),
+            deployment: config.otel_service_name.clone(),
+            interval: Duration::from_secs(config.capture_kafka_manager_report_interval_secs.max(1)),
+            request_timeout: Duration::from_millis(
+                config.capture_kafka_manager_request_timeout_ms.max(100),
+            ),
+        });
+    }
+
     let redis_client = Arc::new(
         RedisClient::with_config(
             config.redis_url.clone(),

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -91,6 +91,30 @@ impl rdkafka::ClientContext for KafkaContext {
         let down_brokers = total_brokers.saturating_sub(up_brokers);
         gauge!("capture_kafka_any_brokers_down").set(if down_brokers > 0 { 1.0 } else { 0.0 });
 
+        // Snapshot for the kafka-manager reporter, from the liveness-gating
+        // (primary) producer only — a secondary producer sharing this context
+        // type would otherwise overwrite the primary's view. Guarded so the
+        // per-broker Vec is only built when a reporter is installed.
+        if self.liveness.is_some() && crate::manager_reporter::enabled() {
+            crate::manager_reporter::record_producer_stats(kafka_manager_types::ProducerStats {
+                queue_depth: stats.msg_cnt,
+                queue_capacity: stats.msg_max,
+                brokers_up: up_brokers as u32,
+                brokers_total: total_brokers as u32,
+                brokers: stats
+                    .brokers
+                    .values()
+                    .map(|broker| kafka_manager_types::BrokerStats {
+                        id: broker.nodeid.to_string(),
+                        up: broker.state == "UP",
+                        rtt_p99_us: broker.rtt.as_ref().map(|rtt| rtt.p99).unwrap_or(0),
+                        tx_errors: broker.txerrs,
+                        request_timeouts: broker.req_timeouts,
+                    })
+                    .collect(),
+            });
+        }
+
         // Update exported metrics
         gauge!("capture_kafka_callback_queue_depth",).set(stats.replyq as f64);
         gauge!("capture_kafka_producer_queue_depth",).set(stats.msg_cnt as f64);

--- a/rust/capture/src/sinks/producer.rs
+++ b/rust/capture/src/sinks/producer.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use tracing::error;
 
 use crate::api::CaptureError;
+use crate::manager_reporter::{self, DeliveryOutcome};
 use crate::prometheus::report_dropped_events;
 
 /// A record to be produced to Kafka
@@ -64,6 +65,7 @@ impl Future for DeliveryAckFuture {
                         // Cancelled due to timeout while retrying
                         metrics::counter!("capture_kafka_produce_errors_total").increment(1);
                         error!("failed to produce to Kafka before write timeout");
+                        manager_reporter::record_delivery_outcome(DeliveryOutcome::TimedOut);
                         ("cancelled", Err(CaptureError::RetryableSinkError))
                     }
                     Ok(Err((
@@ -71,6 +73,7 @@ impl Future for DeliveryAckFuture {
                         _,
                     ))) => {
                         report_dropped_events("kafka_message_size", 1);
+                        manager_reporter::record_delivery_outcome(DeliveryOutcome::TooLarge);
                         (
                             "too_large",
                             Err(CaptureError::EventTooBig(
@@ -81,10 +84,12 @@ impl Future for DeliveryAckFuture {
                     Ok(Err((err, _))) => {
                         metrics::counter!("capture_kafka_produce_errors_total").increment(1);
                         error!("failed to produce to Kafka: {err:#}");
+                        manager_reporter::record_delivery_outcome(DeliveryOutcome::BrokerError);
                         ("broker_err", Err(CaptureError::RetryableSinkError))
                     }
                     Ok(Ok(_)) => {
                         metrics::counter!("capture_events_ingested_total").increment(1);
+                        manager_reporter::record_delivery_outcome(DeliveryOutcome::Delivered);
                         ("ok", Ok(()))
                     }
                 };
@@ -107,6 +112,7 @@ impl Drop for DeliveryAckFuture {
         // wait so tail-latency dashboards don't lose the slowest samples.
         if !self.recorded {
             let elapsed_ms = self.started.elapsed().as_secs_f64() * 1000.0;
+            manager_reporter::record_delivery_outcome(DeliveryOutcome::Abandoned);
             histogram!(
                 "capture_kafka_produce_ack_duration_ms",
                 "outcome" => "dropped",
@@ -152,6 +158,7 @@ impl<C: rdkafka::ClientContext + Send + Sync + 'static> KafkaProducer for RdKafk
             Err((e, _)) => match e.rdkafka_error_code() {
                 Some(RDKafkaErrorCode::MessageSizeTooLarge) => {
                     report_dropped_events("kafka_message_size", 1);
+                    manager_reporter::record_delivery_outcome(DeliveryOutcome::TooLarge);
                     Err(CaptureError::EventTooBig(
                         "Event rejected by kafka during send".to_string(),
                     ))
@@ -160,6 +167,7 @@ impl<C: rdkafka::ClientContext + Send + Sync + 'static> KafkaProducer for RdKafk
                     // Use error counter, not dropped counter - this is retryable
                     counter!("capture_kafka_produce_errors_total").increment(1);
                     error!("failed to produce event: {e:#}");
+                    manager_reporter::record_delivery_outcome(DeliveryOutcome::EnqueueError);
                     Err(CaptureError::RetryableSinkError)
                 }
             },

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -153,6 +153,9 @@ mod tests {
             enable_historical_rerouting: false,
             historical_rerouting_threshold_days: 1,
             is_mirror_deploy: false,
+            capture_kafka_manager_url: None,
+            capture_kafka_manager_report_interval_secs: 10,
+            capture_kafka_manager_request_timeout_ms: 2000,
             log_level: Level::INFO,
             verbose_sample_percent: 0.0,
             kafka: KafkaConfig {

--- a/rust/capture/tests/common/utils.rs
+++ b/rust/capture/tests/common/utils.rs
@@ -69,6 +69,9 @@ pub static DEFAULT_CONFIG: Lazy<Config> = Lazy::new(|| Config {
     enable_historical_rerouting: false,
     historical_rerouting_threshold_days: 1_i64,
     is_mirror_deploy: false,
+    capture_kafka_manager_url: None,
+    capture_kafka_manager_report_interval_secs: 10,
+    capture_kafka_manager_request_timeout_ms: 2000,
     log_level: Level::INFO,
     verbose_sample_percent: 0.0_f32,
     kafka: KafkaConfig {

--- a/rust/ingestion-control-plane/README.md
+++ b/rust/ingestion-control-plane/README.md
@@ -15,6 +15,10 @@ Discovers ingestion topics and consumer groups from the cluster by prefix (a gro
 
 Results are broken down per token (resolved to `team_id` via Postgres when `DATABASE_URL` is set), with events and distinct_ids nested under each token, plus a message-size distribution and header-flag counts. Analyses use a dedicated consumer group (`ingestion-control-plane-inspector`) and never touch the real group's offsets.
 
+### Kafka fleet
+
+Live producer-health view backed by the `kafka-manager` service (see `rust/kafka-manager`): capture pods push delivery outcome counts, producer queue pressure, and broker connectivity there; this tool reads its `/v1/fleet` snapshot through `GET /api/kafka-fleet` and renders per-deployment pod tables (staleness, queue fill, brokers down, last-interval failure ratio and throughput). Requires `KAFKA_MANAGER_URL`; unset disables the tool with a clear error.
+
 ### Consumer debug
 
 Lists live ingestion-consumer pods and serves the consumer's routing debug UI per pod at `/pods/<namespace>/<name>/` (static pods use the `static` pseudo-namespace), backed by a proxy to the pod's debug API (`/debug/state`, `/debug/load`, SSE `/debug/events`). The UI lives here; the consumer only exposes the JSON/SSE API (gated behind `DEBUG_UI_ENABLED` on the consumer side).
@@ -29,6 +33,7 @@ Lists live ingestion-consumer pods and serves the consumer's routing debug UI pe
 | `TOPIC_PREFIX` | `ingestion-` | Topics are discovered from cluster metadata by prefix |
 | `GROUP_PREFIX` | `ingestion-` | Consumer groups are discovered by prefix; a group maps to the topics it has committed offsets on |
 | `DISCOVERY_CACHE_TTL_SECS` | `300` | Discovered targets are cached; topology changes rarely |
+| `KAFKA_MANAGER_URL` | empty | Base URL of the kafka-manager service; empty disables the Kafka fleet tool |
 | `OVERVIEW_CACHE_TTL_SECS` | `15` | Overview scans are cached with single-flight refresh, bounding broker load from repeated requests |
 | `DATABASE_URL` | empty | Read replica; empty disables token → team resolution |
 | `ANALYSIS_MESSAGE_COUNT` | `10000` | Messages per analysis |

--- a/rust/ingestion-control-plane/src/api.rs
+++ b/rust/ingestion-control-plane/src/api.rs
@@ -195,6 +195,45 @@ async fn cancel_analysis(
     }
 }
 
+/// Read-through to the kafka-manager's fleet snapshot. The body is passed
+/// along as opaque JSON so this service doesn't track the manager's schema;
+/// the UI renders whatever the manager reports.
+async fn get_kafka_fleet(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Some(base) = state
+        .config
+        .kafka_manager_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+    else {
+        return Err(ApiError::unavailable(
+            "KAFKA_MANAGER_URL not set; the Kafka fleet tool is disabled",
+        ));
+    };
+
+    let url = format!("{}/v1/fleet", base.trim_end_matches('/'));
+    let response = state
+        .http
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+        .map_err(|e| ApiError::upstream(format!("kafka-manager unreachable: {e}")))?;
+    if !response.status().is_success() {
+        return Err(ApiError::upstream(format!(
+            "kafka-manager returned {}",
+            response.status()
+        )));
+    }
+    let snapshot = response
+        .json()
+        .await
+        .map_err(|e| ApiError::upstream(format!("invalid kafka-manager response: {e}")))?;
+    Ok(Json(snapshot))
+}
+
 #[derive(Serialize)]
 struct PodsResponse {
     pods: Vec<DiscoveredPod>,
@@ -220,6 +259,7 @@ pub fn router(state: AppState) -> Router {
             get(get_analysis).delete(cancel_analysis),
         )
         .route("/api/pods", get(list_pods))
+        .route("/api/kafka-fleet", get(get_kafka_fleet))
         // The consumer debug UI is served per pod; its relative `debug/...`
         // fetches resolve to the proxy route below. Pods are addressed by
         // namespace + name so identical names across lanes cannot collide.

--- a/rust/ingestion-control-plane/src/config.rs
+++ b/rust/ingestion-control-plane/src/config.rs
@@ -54,6 +54,12 @@ pub struct Config {
     #[envconfig(default = "ingestion-")]
     pub group_prefix: String,
 
+    /// Base URL of the kafka-manager service backing the "Kafka fleet" tool.
+    /// Unset (or empty) hides the tool's data behind a clear "not configured"
+    /// error instead of failing requests.
+    #[envconfig(from = "KAFKA_MANAGER_URL")]
+    pub kafka_manager_url: Option<String>,
+
     /// Topology (topics, groups, partitions) changes rarely; discovered
     /// targets are cached this long.
     #[envconfig(default = "300")]

--- a/rust/ingestion-control-plane/src/ui/index.html
+++ b/rust/ingestion-control-plane/src/ui/index.html
@@ -593,8 +593,80 @@
         },
       };
 
+      // ---------- section: kafka fleet ----------
+      const fleetSection = {
+        id: "fleet",
+        title: "Kafka fleet",
+        description:
+          "Producer health pushed by capture pods to the kafka-manager service: queue pressure, broker connectivity, and delivery failure rates per deployment.",
+        timers: [],
+        unmount() {
+          this.timers.forEach(clearInterval);
+          this.timers = [];
+        },
+        mount(root) {
+          const body = el("div", {}, el("div", { class: "empty" }, "Loading fleet view…"));
+          const fetchedAt = el("span", { class: "muted mono", style: "text-transform: none; letter-spacing: 0" });
+          this.ui = { body, fetchedAt };
+          root.append(
+            el("div", { class: "panel" },
+              el("h2", {}, "Reporting pods", fetchedAt,
+                el("button", { class: "small", onclick: () => this.refresh() }, "Refresh")),
+              body)
+          );
+          this.refresh();
+          this.timers.push(setInterval(() => this.refresh(), 15000));
+        },
+
+        async refresh() {
+          const { body, fetchedAt } = this.ui;
+          try {
+            const data = await fetchJSON("api/kafka-fleet");
+            fetchedAt.textContent = `fetched ${new Date().toLocaleTimeString()}`;
+            if (!data.deployments || !data.deployments.length) {
+              body.replaceChildren(el("div", { class: "empty" }, "No pods reporting. Capture pods publish here when CAPTURE_KAFKA_MANAGER_URL is set."));
+              return;
+            }
+            const fmtRatio = (r) => (r === null || r === undefined ? "–" : `${(r * 100).toFixed(2)}%`);
+            body.replaceChildren(
+              ...data.deployments.map((deployment) =>
+                el("div", {},
+                  el("h3", { class: "ns-head" },
+                    el("span", { class: "ns" }, deployment.deployment),
+                    el("span", {}, `${deployment.pods.length} pod${deployment.pods.length === 1 ? "" : "s"}`)),
+                  el("table", {},
+                    el("thead", {}, el("tr", {},
+                      el("th", {}, "pod"), el("th", {}, "last report"), el("th", {}, "queue fill"),
+                      el("th", {}, "brokers down"), el("th", {}, "failure ratio"), el("th", {}, "acks/s"),
+                      el("th", {}, "delivered"), el("th", {}, "failed"))),
+                    el("tbody", {}, deployment.pods.map((pod) => {
+                      const delivery = pod.delivery || {};
+                      const failed = (delivery.broker_error || 0) + (delivery.timed_out || 0) + (delivery.enqueue_error || 0);
+                      const failing = (pod.interval && pod.interval.failure_ratio > 0) || false;
+                      const stale = pod.seconds_since_report > 30;
+                      return el("tr", {},
+                        el("td", { class: "mono" }, pod.pod),
+                        el("td", {}, el("span", { class: `pill ${stale ? "warn" : "good"}` }, `${pod.seconds_since_report}s ago`)),
+                        el("td", { class: "mono" }, fmtRatio(pod.queue_fill_ratio)),
+                        el("td", {}, el("span", { class: `pill ${pod.brokers_down > 0 ? "warn" : "good"}` }, fmtInt(pod.brokers_down))),
+                        el("td", {}, el("span", { class: `pill ${failing ? "warn" : "good"}` }, fmtRatio(pod.interval && pod.interval.failure_ratio))),
+                        el("td", { class: "mono" }, pod.interval ? pod.interval.acks_per_second.toFixed(1) : "–"),
+                        el("td", { class: "mono" }, fmtInt(delivery.ok)),
+                        el("td", { class: "mono" }, fmtInt(failed)));
+                    }))
+                  )
+                )
+              )
+            );
+          } catch (e) {
+            fetchedAt.textContent = "";
+            body.replaceChildren(el("div", { class: "error-box" }, String(e)));
+          }
+        },
+      };
+
       // ---------- boot ----------
-      SECTIONS.push(lagSection, debugSection);
+      SECTIONS.push(lagSection, debugSection, fleetSection);
       const nav = document.getElementById("nav");
       for (const section of SECTIONS) {
         nav.append(el("span", { class: "nav-item", "data-id": section.id, onclick: () => navigate(section.id) }, section.title));

--- a/rust/kafka-manager-types/Cargo.toml
+++ b/rust/kafka-manager-types/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "kafka-manager-types"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+
+[lints]
+workspace = true

--- a/rust/kafka-manager-types/src/lib.rs
+++ b/rust/kafka-manager-types/src/lib.rs
@@ -1,0 +1,93 @@
+//! Wire types for the kafka-manager telemetry channel.
+//!
+//! Shared by producers of health reports (capture) and the kafka-manager
+//! service. Reports flow one way — client to manager — and carry the produce
+//! health signals a Kafka circuit breaker needs: delivery outcome counts,
+//! producer queue pressure, and broker connectivity. The manager never sends
+//! anything back on this channel; clients must keep working identically when
+//! it is absent.
+
+use serde::{Deserialize, Serialize};
+
+/// One reporting interval's view of a single pod's produce health.
+///
+/// Counters are cumulative since process start, not per-interval deltas: the
+/// manager computes rates from consecutive reports, which makes the channel
+/// tolerant to lost or duplicated reports and makes pod restarts detectable
+/// (a counter going backwards).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthReport {
+    /// Pod identity, unique within a deployment (Kubernetes pod name).
+    pub pod: String,
+    /// Logical group the pod belongs to (e.g. `capture`, `capture-replay`).
+    /// Fleet aggregation happens per deployment.
+    pub deployment: String,
+    /// Cumulative delivery outcome counts since process start.
+    pub delivery: DeliveryCounts,
+    /// Latest librdkafka statistics snapshot, if one has been observed yet
+    /// (the stats callback fires on an interval, so the first report after
+    /// boot may not carry one).
+    pub producer: Option<ProducerStats>,
+}
+
+/// Cumulative delivery report outcomes, classified the way a breaker needs
+/// them: successes, retriable transport failures, local timeouts, and the
+/// permanent per-message errors that must never count toward tripping.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveryCounts {
+    /// Broker acknowledged the write.
+    pub ok: u64,
+    /// Broker or transport returned a retriable produce error.
+    pub broker_error: u64,
+    /// Message expired in the producer before the broker acked it
+    /// (librdkafka `message.timeout.ms` including retries).
+    pub timed_out: u64,
+    /// Rejected as too large — permanent, excluded from breaker error ratios.
+    pub too_large: u64,
+    /// Ack future dropped before completion (batch fail-fast aborted the
+    /// wait); outcome unknown, message may or may not have been delivered.
+    pub abandoned: u64,
+    /// Rejected synchronously at enqueue time (queue full, unknown topic).
+    pub enqueue_error: u64,
+}
+
+impl DeliveryCounts {
+    /// Attempts with a known terminal outcome.
+    pub fn total(&self) -> u64 {
+        self.ok + self.broker_error + self.timed_out + self.too_large + self.enqueue_error
+    }
+
+    /// Outcomes a breaker should count as failures. `too_large` is excluded
+    /// (permanent per-message error, not cluster health) and `abandoned` is
+    /// excluded (unknown outcome).
+    pub fn failures(&self) -> u64 {
+        self.broker_error + self.timed_out + self.enqueue_error
+    }
+}
+
+/// Producer-level pressure and connectivity from the librdkafka statistics
+/// callback.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ProducerStats {
+    /// Messages currently buffered in the producer queue.
+    pub queue_depth: u64,
+    /// Producer queue capacity (`queue.buffering.max.messages`). The fill
+    /// ratio `queue_depth / queue_capacity` is the leading indicator of a
+    /// produce stall.
+    pub queue_capacity: u64,
+    pub brokers_up: u32,
+    pub brokers_total: u32,
+    pub brokers: Vec<BrokerStats>,
+}
+
+/// Per-broker connectivity and error counters (cumulative).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct BrokerStats {
+    pub id: String,
+    pub up: bool,
+    /// Producer-observed round-trip p99 in microseconds. Under `acks=all`
+    /// this includes follower replication, making it an early ISR-lag signal.
+    pub rtt_p99_us: i64,
+    pub tx_errors: u64,
+    pub request_timeouts: u64,
+}

--- a/rust/kafka-manager/Cargo.toml
+++ b/rust/kafka-manager/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "kafka-manager"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+axum = { workspace = true }
+common-alloc = { path = "../common/alloc" }
+common-metrics = { path = "../common/metrics" }
+envconfig = { workspace = true }
+health = { path = "../common/health" }
+kafka-manager-types = { path = "../kafka-manager-types" }
+metrics = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+axum-test-helper = { git = "https://github.com/posthog/axum-test-helper.git" }
+# axum-test-helper needs tower's `make` feature; enable it for this crate's
+# build graph (elsewhere it arrives via workspace feature unification).
+tower = { workspace = true, features = ["make"] }
+
+[lints]
+workspace = true

--- a/rust/kafka-manager/README.md
+++ b/rust/kafka-manager/README.md
@@ -15,6 +15,7 @@ Losing this service loses telemetry, nothing else.
 
 - `POST /v1/health-reports` — one `HealthReport` (see `kafka-manager-types`) per pod per interval. Counters are cumulative since process start; the manager derives interval rates and detects restarts from counter resets.
 - `GET /v1/fleet` — JSON snapshot: per deployment, per pod — staleness, queue fill ratio, brokers down, last-interval failure ratio and throughput.
+  The ingestion-control-plane's "Kafka fleet" tool renders this snapshot (set `KAFKA_MANAGER_URL` there).
 - `/metrics`, `/_liveness`, `/_readiness`.
 
 ## Metrics

--- a/rust/kafka-manager/README.md
+++ b/rust/kafka-manager/README.md
@@ -1,0 +1,54 @@
+# Kafka manager (prototype)
+
+Observe-only control-plane prototype for Kafka producer health.
+Capture pods push periodic health reports (delivery outcome counts, producer queue pressure, broker connectivity);
+this service aggregates them into a live fleet view.
+It is the first step toward the Kafka circuit breaker: gather the signals, watch them fleet-wide, tune trip conditions in shadow — before any component acts on them.
+
+**This service makes no decisions and sends nothing back to its reporters.**
+Clients treat it as a fire-and-forget telemetry target and must behave identically when it is down (see `capture`'s `manager_reporter` module).
+Losing this service loses telemetry, nothing else.
+
+> **⚠️ Purely internal service — never expose publicly.** No authentication of its own; deploy only behind the internal ingress.
+
+## API
+
+- `POST /v1/health-reports` — one `HealthReport` (see `kafka-manager-types`) per pod per interval. Counters are cumulative since process start; the manager derives interval rates and detects restarts from counter resets.
+- `GET /v1/fleet` — JSON snapshot: per deployment, per pod — staleness, queue fill ratio, brokers down, last-interval failure ratio and throughput.
+- `/metrics`, `/_liveness`, `/_readiness`.
+
+## Metrics
+
+Per `deployment` label, refreshed every sweep:
+
+- `kafka_manager_pods_reporting` — pods with a live (non-expired) report. `0` means the fleet went silent; the other gauges are meaningless then.
+- `kafka_manager_queue_fill_ratio_max` — worst pod's producer queue fill (the leading stall indicator).
+- `kafka_manager_brokers_down_max` — worst pod's count of non-UP brokers.
+- `kafka_manager_delivery_failure_ratio_max` — worst pod's failures / attempts over its last report interval (excludes permanent per-message errors).
+- `kafka_manager_delivery_acks_per_second` — fleet-wide delivery attempt throughput.
+- `kafka_manager_reports_received_total`, `kafka_manager_pods_expired_total`.
+
+## Configuration
+
+| Env var | Default | Notes |
+| --- | --- | --- |
+| `BIND_HOST` / `BIND_PORT` | `0.0.0.0` / `3308` | Single listener: API, `/_liveness`, `/_readiness`, `/metrics` |
+| `POD_TTL_SECONDS` | `60` | Reports older than this evict the pod from fleet state |
+| `SWEEP_INTERVAL_SECONDS` | `5` | Eviction + gauge refresh cadence |
+
+## Local development
+
+```sh
+cargo run -p kafka-manager
+
+# Point a local capture at it:
+CAPTURE_KAFKA_MANAGER_URL=http://127.0.0.1:3308 cargo run -p capture
+
+# Watch the fleet view:
+curl -s http://127.0.0.1:3308/v1/fleet | jq .
+```
+
+## Deployment notes
+
+- Single replica is fine: state is in-memory and rebuilt from the report stream within one report interval.
+- Needs a matrix entry in `.github/workflows/rust-docker-build.yml` plus a charts-repo app to deploy (not wired up yet — prototype).

--- a/rust/kafka-manager/src/api.rs
+++ b/rust/kafka-manager/src/api.rs
@@ -1,0 +1,77 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use kafka_manager_types::HealthReport;
+use metrics::counter;
+
+use crate::state::{FleetSnapshot, FleetState};
+
+pub fn router(state: Arc<FleetState>) -> Router {
+    Router::new()
+        .route("/v1/health-reports", post(ingest_report))
+        .route("/v1/fleet", get(fleet_snapshot))
+        .with_state(state)
+}
+
+async fn ingest_report(
+    State(state): State<Arc<FleetState>>,
+    Json(report): Json<HealthReport>,
+) -> StatusCode {
+    let deployment: Arc<str> = Arc::from(report.deployment.as_str());
+    counter!("kafka_manager_reports_received_total", "deployment" => deployment).increment(1);
+    state.ingest(report);
+    StatusCode::NO_CONTENT
+}
+
+async fn fleet_snapshot(State(state): State<Arc<FleetState>>) -> Json<FleetSnapshot> {
+    Json(state.snapshot())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum_test_helper::TestClient;
+    use kafka_manager_types::DeliveryCounts;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn report_round_trips_into_fleet_snapshot() {
+        let state = Arc::new(FleetState::new(Duration::from_secs(60)));
+        let client = TestClient::new(router(state));
+
+        let report = HealthReport {
+            pod: "capture-abc".to_string(),
+            deployment: "capture".to_string(),
+            delivery: DeliveryCounts {
+                ok: 42,
+                ..Default::default()
+            },
+            producer: None,
+        };
+        let response = client.post("/v1/health-reports").json(&report).send().await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let response = client.get("/v1/fleet").send().await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let snapshot: serde_json::Value = response.json().await;
+        assert_eq!(snapshot["deployments"][0]["pods"][0]["pod"], "capture-abc");
+        assert_eq!(snapshot["deployments"][0]["pods"][0]["delivery"]["ok"], 42);
+    }
+
+    #[tokio::test]
+    async fn malformed_report_is_rejected_not_fatal() {
+        let state = Arc::new(FleetState::new(Duration::from_secs(60)));
+        let client = TestClient::new(router(state));
+
+        let response = client
+            .post("/v1/health-reports")
+            .header("content-type", "application/json")
+            .body("{\"nope\": true}")
+            .send()
+            .await;
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    }
+}

--- a/rust/kafka-manager/src/config.rs
+++ b/rust/kafka-manager/src/config.rs
@@ -1,0 +1,19 @@
+use envconfig::Envconfig;
+
+#[derive(Envconfig, Clone)]
+pub struct Config {
+    #[envconfig(from = "BIND_HOST", default = "0.0.0.0")]
+    pub host: String,
+
+    #[envconfig(from = "BIND_PORT", default = "3308")]
+    pub port: u16,
+
+    /// A pod that has not reported for this long is evicted from fleet state.
+    /// Must comfortably exceed the clients' report interval (default 10s) so
+    /// a single lost report does not flap the fleet view.
+    #[envconfig(from = "POD_TTL_SECONDS", default = "60")]
+    pub pod_ttl_seconds: u64,
+
+    #[envconfig(from = "SWEEP_INTERVAL_SECONDS", default = "5")]
+    pub sweep_interval_seconds: u64,
+}

--- a/rust/kafka-manager/src/lib.rs
+++ b/rust/kafka-manager/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod api;
+pub mod config;
+pub mod state;

--- a/rust/kafka-manager/src/main.rs
+++ b/rust/kafka-manager/src/main.rs
@@ -1,0 +1,86 @@
+use std::future::ready;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::routing::get;
+use common_metrics::setup_metrics_routes;
+use envconfig::Envconfig;
+use health::{readiness_handler, HealthRegistry};
+use kafka_manager::api;
+use kafka_manager::config::Config;
+use kafka_manager::state::FleetState;
+use tokio::signal;
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+
+common_alloc::used!();
+
+async fn shutdown() {
+    let mut term = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .expect("failed to register SIGTERM handler");
+    let mut interrupt = signal::unix::signal(signal::unix::SignalKind::interrupt())
+        .expect("failed to register SIGINT handler");
+
+    tokio::select! {
+        _ = term.recv() => {},
+        _ = interrupt.recv() => {},
+    };
+
+    info!("Shutting down gracefully...");
+}
+
+fn setup_tracing() {
+    let log_layer = tracing_subscriber::fmt::layer().json().with_filter(
+        EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .from_env_lossy(),
+    );
+    tracing_subscriber::registry().with(log_layer).init();
+}
+
+#[tokio::main]
+async fn main() {
+    setup_tracing();
+    info!("Starting kafka-manager...");
+
+    let config = Config::init_from_env().expect("failed to load config");
+    let bind = format!("{}:{}", config.host, config.port);
+
+    // No long-running pipeline to healthcheck; the sweep loop doubles as the
+    // liveness heartbeat so a wedged state lock fails the probe.
+    let health_registry = HealthRegistry::new("liveness");
+    let sweeper_health = health_registry
+        .register("sweeper".to_string(), Duration::from_secs(30))
+        .await;
+
+    let state = Arc::new(FleetState::new(Duration::from_secs(config.pod_ttl_seconds)));
+
+    let sweep_state = state.clone();
+    let sweep_interval = Duration::from_secs(config.sweep_interval_seconds.max(1));
+    tokio::spawn(async move {
+        loop {
+            sweep_state.sweep();
+            sweeper_health.report_healthy().await;
+            tokio::time::sleep(sweep_interval).await;
+        }
+    });
+
+    let router = api::router(state)
+        .route("/_readiness", get(readiness_handler))
+        .route(
+            "/_liveness",
+            get(move || ready(health_registry.get_status())),
+        );
+    let router = setup_metrics_routes(router);
+
+    info!("Listening on {}", bind);
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .expect("could not bind port");
+
+    axum::serve(listener, router)
+        .with_graceful_shutdown(shutdown())
+        .await
+        .expect("server failed");
+}

--- a/rust/kafka-manager/src/state.rs
+++ b/rust/kafka-manager/src/state.rs
@@ -1,0 +1,321 @@
+//! In-memory fleet state: the last reports per pod, TTL eviction, and the
+//! derived per-deployment aggregates exported as Prometheus gauges.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use kafka_manager_types::{DeliveryCounts, HealthReport};
+use metrics::{counter, gauge};
+use serde::Serialize;
+
+pub struct FleetState {
+    ttl: Duration,
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    pods: HashMap<PodKey, PodEntry>,
+    /// Deployments ever seen this process lifetime. Gauges are re-emitted for
+    /// all of them on every sweep, so a deployment going fully silent reads
+    /// as `pods_reporting == 0` instead of a frozen last value.
+    deployments: BTreeSet<String>,
+}
+
+type PodKey = (String, String);
+
+struct PodEntry {
+    report: HealthReport,
+    received_at: Instant,
+    /// The previous report's arrival time and cumulative counts, kept so
+    /// interval rates survive between sweeps.
+    prev: Option<(Instant, DeliveryCounts)>,
+}
+
+/// Interval rates derived from two consecutive cumulative reports.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct IntervalRates {
+    /// Failures over attempts with a known outcome in the interval. `None`
+    /// when the interval saw no attempts.
+    pub failure_ratio: Option<f64>,
+    pub acks_per_second: f64,
+}
+
+#[derive(Serialize)]
+pub struct FleetSnapshot {
+    pub deployments: Vec<DeploymentSnapshot>,
+}
+
+#[derive(Serialize)]
+pub struct DeploymentSnapshot {
+    pub deployment: String,
+    pub pods: Vec<PodSnapshot>,
+}
+
+#[derive(Serialize)]
+pub struct PodSnapshot {
+    pub pod: String,
+    pub seconds_since_report: u64,
+    pub queue_fill_ratio: Option<f64>,
+    pub brokers_down: Option<u32>,
+    pub interval: Option<IntervalRates>,
+    pub delivery: DeliveryCounts,
+}
+
+impl FleetState {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            ttl,
+            inner: Mutex::new(Inner::default()),
+        }
+    }
+
+    pub fn ingest(&self, report: HealthReport) {
+        self.ingest_at(report, Instant::now());
+    }
+
+    pub fn ingest_at(&self, report: HealthReport, now: Instant) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.deployments.insert(report.deployment.clone());
+        let key = (report.deployment.clone(), report.pod.clone());
+        match inner.pods.entry(key) {
+            std::collections::hash_map::Entry::Occupied(mut occupied) => {
+                let entry = occupied.get_mut();
+                entry.prev = Some((entry.received_at, entry.report.delivery));
+                entry.report = report;
+                entry.received_at = now;
+            }
+            std::collections::hash_map::Entry::Vacant(vacant) => {
+                vacant.insert(PodEntry {
+                    report,
+                    received_at: now,
+                    prev: None,
+                });
+            }
+        }
+    }
+
+    /// Evict pods past the TTL and re-emit the per-deployment gauges.
+    pub fn sweep(&self) {
+        self.sweep_at(Instant::now());
+    }
+
+    pub fn sweep_at(&self, now: Instant) {
+        let mut inner = self.inner.lock().unwrap();
+        let ttl = self.ttl;
+        inner.pods.retain(|(deployment, _), entry| {
+            let alive = now.duration_since(entry.received_at) <= ttl;
+            if !alive {
+                let deployment: Arc<str> = Arc::from(deployment.as_str());
+                counter!("kafka_manager_pods_expired_total", "deployment" => deployment)
+                    .increment(1);
+            }
+            alive
+        });
+
+        let mut per_deployment: BTreeMap<&str, DeploymentAggregates> = inner
+            .deployments
+            .iter()
+            .map(|d| (d.as_str(), DeploymentAggregates::default()))
+            .collect();
+        for ((deployment, _), entry) in &inner.pods {
+            let aggregates = per_deployment
+                .get_mut(deployment.as_str())
+                .expect("pod deployment missing from seen-deployment set");
+            aggregates.observe(entry);
+        }
+
+        for (deployment, aggregates) in per_deployment {
+            let deployment: Arc<str> = Arc::from(deployment);
+            gauge!("kafka_manager_pods_reporting", "deployment" => deployment.clone())
+                .set(aggregates.pods as f64);
+            gauge!("kafka_manager_queue_fill_ratio_max", "deployment" => deployment.clone())
+                .set(aggregates.queue_fill_ratio_max);
+            gauge!("kafka_manager_brokers_down_max", "deployment" => deployment.clone())
+                .set(aggregates.brokers_down_max as f64);
+            gauge!("kafka_manager_delivery_failure_ratio_max", "deployment" => deployment.clone())
+                .set(aggregates.failure_ratio_max);
+            gauge!("kafka_manager_delivery_acks_per_second", "deployment" => deployment)
+                .set(aggregates.acks_per_second);
+        }
+    }
+
+    pub fn snapshot(&self) -> FleetSnapshot {
+        self.snapshot_at(Instant::now())
+    }
+
+    pub fn snapshot_at(&self, now: Instant) -> FleetSnapshot {
+        let inner = self.inner.lock().unwrap();
+        let mut deployments: BTreeMap<&str, Vec<PodSnapshot>> = BTreeMap::new();
+        for ((deployment, pod), entry) in &inner.pods {
+            deployments
+                .entry(deployment.as_str())
+                .or_default()
+                .push(PodSnapshot {
+                    pod: pod.clone(),
+                    seconds_since_report: now.duration_since(entry.received_at).as_secs(),
+                    queue_fill_ratio: entry.queue_fill_ratio(),
+                    brokers_down: entry
+                        .report
+                        .producer
+                        .as_ref()
+                        .map(|p| p.brokers_total.saturating_sub(p.brokers_up)),
+                    interval: entry.interval_rates(),
+                    delivery: entry.report.delivery,
+                });
+        }
+        FleetSnapshot {
+            deployments: deployments
+                .into_iter()
+                .map(|(deployment, mut pods)| {
+                    pods.sort_by(|a, b| a.pod.cmp(&b.pod));
+                    DeploymentSnapshot {
+                        deployment: deployment.to_string(),
+                        pods,
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct DeploymentAggregates {
+    pods: usize,
+    queue_fill_ratio_max: f64,
+    brokers_down_max: u32,
+    failure_ratio_max: f64,
+    acks_per_second: f64,
+}
+
+impl DeploymentAggregates {
+    fn observe(&mut self, entry: &PodEntry) {
+        self.pods += 1;
+        if let Some(ratio) = entry.queue_fill_ratio() {
+            self.queue_fill_ratio_max = self.queue_fill_ratio_max.max(ratio);
+        }
+        if let Some(producer) = &entry.report.producer {
+            self.brokers_down_max = self
+                .brokers_down_max
+                .max(producer.brokers_total.saturating_sub(producer.brokers_up));
+        }
+        if let Some(rates) = entry.interval_rates() {
+            if let Some(ratio) = rates.failure_ratio {
+                self.failure_ratio_max = self.failure_ratio_max.max(ratio);
+            }
+            self.acks_per_second += rates.acks_per_second;
+        }
+    }
+}
+
+impl PodEntry {
+    fn queue_fill_ratio(&self) -> Option<f64> {
+        let producer = self.report.producer.as_ref()?;
+        if producer.queue_capacity == 0 {
+            return None;
+        }
+        Some(producer.queue_depth as f64 / producer.queue_capacity as f64)
+    }
+
+    /// Rates over the last inter-report interval. `None` until two reports
+    /// have arrived, or when the counters went backwards (process restart —
+    /// the next interval will be clean).
+    fn interval_rates(&self) -> Option<IntervalRates> {
+        let (prev_at, prev) = self.prev.as_ref()?;
+        let current = &self.report.delivery;
+        if current.total() < prev.total() || current.failures() < prev.failures() {
+            return None;
+        }
+        let elapsed = self.received_at.duration_since(*prev_at).as_secs_f64();
+        if elapsed <= 0.0 {
+            return None;
+        }
+        let attempts = current.total() - prev.total();
+        let failures = current.failures() - prev.failures();
+        Some(IntervalRates {
+            failure_ratio: (attempts > 0).then(|| failures as f64 / attempts as f64),
+            acks_per_second: attempts as f64 / elapsed,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kafka_manager_types::ProducerStats;
+
+    fn report(pod: &str, ok: u64, broker_error: u64) -> HealthReport {
+        HealthReport {
+            pod: pod.to_string(),
+            deployment: "capture".to_string(),
+            delivery: DeliveryCounts {
+                ok,
+                broker_error,
+                ..Default::default()
+            },
+            producer: Some(ProducerStats {
+                queue_depth: 100,
+                queue_capacity: 1000,
+                brokers_up: 3,
+                brokers_total: 3,
+                brokers: vec![],
+            }),
+        }
+    }
+
+    #[test]
+    fn interval_rates_need_two_reports() {
+        let state = FleetState::new(Duration::from_secs(60));
+        let t0 = Instant::now();
+        state.ingest_at(report("pod-a", 100, 0), t0);
+        let snapshot = state.snapshot_at(t0);
+        assert!(snapshot.deployments[0].pods[0].interval.is_none());
+
+        state.ingest_at(report("pod-a", 190, 10), t0 + Duration::from_secs(10));
+        let snapshot = state.snapshot_at(t0 + Duration::from_secs(10));
+        let rates = snapshot.deployments[0].pods[0].interval.unwrap();
+        assert_eq!(rates.failure_ratio, Some(0.1));
+        assert_eq!(rates.acks_per_second, 10.0);
+    }
+
+    #[test]
+    fn counter_reset_suppresses_rates_for_one_interval() {
+        let state = FleetState::new(Duration::from_secs(60));
+        let t0 = Instant::now();
+        state.ingest_at(report("pod-a", 1000, 5), t0);
+        // Pod restarted: cumulative counters start over below previous values.
+        state.ingest_at(report("pod-a", 50, 0), t0 + Duration::from_secs(10));
+        let snapshot = state.snapshot_at(t0 + Duration::from_secs(10));
+        assert!(snapshot.deployments[0].pods[0].interval.is_none());
+
+        state.ingest_at(report("pod-a", 150, 0), t0 + Duration::from_secs(20));
+        let snapshot = state.snapshot_at(t0 + Duration::from_secs(20));
+        assert!(snapshot.deployments[0].pods[0].interval.is_some());
+    }
+
+    #[test]
+    fn sweep_evicts_stale_pods() {
+        let state = FleetState::new(Duration::from_secs(60));
+        let t0 = Instant::now();
+        state.ingest_at(report("pod-a", 1, 0), t0);
+        state.ingest_at(report("pod-b", 1, 0), t0 + Duration::from_secs(50));
+
+        state.sweep_at(t0 + Duration::from_secs(70));
+        let snapshot = state.snapshot_at(t0 + Duration::from_secs(70));
+        let pods: Vec<_> = snapshot.deployments[0]
+            .pods
+            .iter()
+            .map(|p| p.pod.as_str())
+            .collect();
+        assert_eq!(pods, vec!["pod-b"]);
+    }
+
+    #[test]
+    fn queue_fill_ratio_from_latest_stats() {
+        let state = FleetState::new(Duration::from_secs(60));
+        state.ingest(report("pod-a", 1, 0));
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.deployments[0].pods[0].queue_fill_ratio, Some(0.1));
+    }
+}


### PR DESCRIPTION
## Problem

Building the Kafka circuit breaker for capture (see the [Kafka management vision](https://github.com/PostHog/runbooks/pull/551) and the capture outputs refactor #72691) needs real production signal first. The trigger design calls for tuning trip conditions against our actual baselines rather than picking thresholds up front, and the eventual decision topology is per-pod detection feeding a centralized decision. Neither exists yet: today the produce health signals live only in per-pod Prometheus metrics, with no fleet-level view and no service positioned to become the decision maker.

This PR is the observe-only first step: a kafka-manager service that ingests health reports pushed by capture pods, and a capture-side reporter that pushes them.

## Changes

```mermaid
flowchart LR
    A[capture pod] -->|"POST /v1/health-reports (10s)"| M{{kafka-manager}}
    B[capture pod] -->|"POST /v1/health-reports (10s)"| M
    M --> P[Prometheus gauges per deployment]
    M --> F["GET /v1/fleet JSON snapshot"]
    F --> C{{"ingestion-control-plane — Kafka fleet tool"}}
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class M,C phBlue;
    class A,B phYellow;
    class P,F phGray;
```

> [!NOTE]
> The channel is strictly one way. The manager makes no decisions and sends nothing back. Losing it loses telemetry, nothing else.

**`rust/kafka-manager`** (new service crate): axum service with `POST /v1/health-reports`, a `GET /v1/fleet` JSON snapshot, and per-deployment Prometheus gauges refreshed by a sweep loop (pods reporting, max queue fill ratio, max brokers down, max delivery failure ratio over the last interval, fleet acks/s). Reports carry cumulative counters, so the manager derives interval rates from consecutive reports, tolerates lost reports, and detects pod restarts as counter resets.

**`rust/kafka-manager-types`** (new): the serde wire types shared by both sides, including the breaker-oriented outcome classification (permanent per-message errors like too-large are excluded from failure ratios).

**`rust/capture`**: a `manager_reporter` module, fail open by construction:

- `CAPTURE_KAFKA_MANAGER_URL` unset (the default): no task spawns and the record hooks are no-ops behind a single atomic load. Produce paths are untouched.
- Enabled: the hot path only bumps relaxed atomics at the existing delivery-report classification sites (`sinks/producer.rs`) and stores a snapshot from the existing 10s librdkafka stats callback (`sinks/kafka.rs`, primary producer only). Serialization and HTTP happen on a background task with a 2s request timeout. Send failures increment `capture_manager_report_failures_total` and are dropped.
- Kill switch is unsetting the env var. No restart ordering, no data dependency.

**`rust/ingestion-control-plane`**: a third sidebar tool, "Kafka fleet". `GET /api/kafka-fleet` reads the manager's `/v1/fleet` through the control plane (opaque JSON passthrough so it doesn't track the manager's schema; 5s timeout; a clear "not configured" error when the new `KAFKA_MANAGER_URL` env var is unset) and the UI renders per-deployment pod tables: report staleness, queue fill, brokers down, last-interval failure ratio, acks/s, cumulative delivered/failed. The manager stays a standalone service; the control plane is just a read-only viewer of it.

Scope notes: delivery counts are pod-wide (a secondary sink's outcomes blend in), producer stats come only from the liveness-gating producer, and the v1 sink stack is not instrumented. Per-sink attribution comes when per-cluster breakers need it.

Not in this PR: deploy wiring (`rust-docker-build.yml` matrix entry, charts app), shadow breaker evaluation in the manager, anything on the control path.

## How did you test this code?

Automated (all run by the agent):

- `cargo test -p kafka-manager -p kafka-manager-types`: fleet state (interval rates need two reports, counter-reset suppression, TTL eviction, queue fill derivation) and API round-trip plus malformed-report rejection.
- `cargo test -p capture --lib`: 1096 tests green, including the new reporter tests: hooks are no-ops without init (the flag-off production state), cumulative snapshot building, report round-trip to an in-process server, and send to an unreachable manager returning harmlessly.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` on all three crates.
- `cargo test -p ingestion-control-plane`: 29 tests green with the new endpoint wired in.
- Local smoke run: booted `kafka-manager`, POSTed two consecutive reports, verified `/v1/fleet` derived the interval failure ratio and `/metrics` exported the per-deployment gauges. Then booted `ingestion-control-plane` with `KAFKA_MANAGER_URL` pointed at it and verified `/api/kafka-fleet` returns the same snapshot through the proxy.

Not done: no staging/production run yet; the reporter has not been exercised against a real capture deployment.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`rust/kafka-manager/README.md` documents the service, its API, metrics, and config. Design context lives in the runbooks vision PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Decisions of note:

- New standalone crate rather than a tool inside `ingestion-control-plane`: the manager is a long-running aggregation service that later grows decision logic, not an ops UI; the control-plane crate stays the human-facing tool.
- Push from capture rather than the manager scraping Prometheus: fresher per-pod signal, and it establishes the reporting channel the breaker's control plane will later use (the `ControlPlane` seam in #72691 can wrap this reporter).
- Cumulative counters plus atomics instead of a report channel: the hot path never allocates or blocks, and the manager handles lost reports and restarts without protocol machinery.
- HTTP/JSON for the prototype; the transport gets revisited when the acked config-push channel (the `KafkaManagerService` shape prototyped in #72691) lands.

