### PR TITLE
fix(error-tracking): support scoped auth for all endpoints

### DIFF
--- a/products/error_tracking/backend/presentation/views/assignment_rules.py
+++ b/products/error_tracking/backend/presentation/views/assignment_rules.py
@@ -129,6 +129,7 @@ class ErrorTrackingAssignmentRuleSerializer(serializers.Serializer):
 
 class ErrorTrackingAssignmentRuleViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "error_tracking"
+    scope_object_write_actions = ["create", "update", "partial_update", "destroy", "reorder"]
     serializer_class = ErrorTrackingAssignmentRuleSerializer
 
     def list(self, request, *args, **kwargs) -> Response:

--- a/products/error_tracking/backend/presentation/views/bypass_rules.py
+++ b/products/error_tracking/backend/presentation/views/bypass_rules.py
@@ -83,6 +83,7 @@ class ErrorTrackingBypassRuleUpdateRequestSerializer(serializers.Serializer):
 
 class ErrorTrackingBypassRuleViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "error_tracking"
+    scope_object_write_actions = ["create", "update", "partial_update", "destroy", "reorder"]
     serializer_class = ErrorTrackingBypassRuleSerializer
 
     def list(self, request, *args, **kwargs) -> Response:

--- a/products/error_tracking/backend/presentation/views/git_provider_file_link_resolver.py
+++ b/products/error_tracking/backend/presentation/views/git_provider_file_link_resolver.py
@@ -259,6 +259,7 @@ def get_gitlab_file_url(
 
 class GitProviderFileLinksViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "error_tracking"
+    scope_object_read_actions = ["resolve_github", "resolve_gitlab"]
 
     @extend_schema(
         parameters=[GitProviderFileLinkResolveQuerySerializer],

--- a/products/error_tracking/backend/presentation/views/grouping_rules.py
+++ b/products/error_tracking/backend/presentation/views/grouping_rules.py
@@ -141,6 +141,7 @@ class ErrorTrackingGroupingRuleListResponseSerializer(serializers.Serializer):
 
 class ErrorTrackingGroupingRuleViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "error_tracking"
+    scope_object_write_actions = ["create", "update", "partial_update", "destroy", "reorder"]
     serializer_class = ErrorTrackingGroupingRuleSerializer
     # The list endpoint returns all rules unpaginated ({"results": [...]}); without this the
     # default paginator makes the schema advertise limit/offset params the view doesn't honor.

--- a/products/error_tracking/backend/presentation/views/spike_detection_config.py
+++ b/products/error_tracking/backend/presentation/views/spike_detection_config.py
@@ -25,6 +25,7 @@ class ErrorTrackingSpikeDetectionConfigSerializer(serializers.Serializer):
 
 class ErrorTrackingSpikeDetectionConfigViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
     scope_object = "error_tracking"
+    scope_object_write_actions = ["update_config"]
 
     @extend_schema(responses={200: ErrorTrackingSpikeDetectionConfigSerializer})
     def list(self, request, *args, **kwargs):

--- a/products/error_tracking/backend/presentation/views/suppression_rules.py
+++ b/products/error_tracking/backend/presentation/views/suppression_rules.py
@@ -90,6 +90,7 @@ class ErrorTrackingSuppressionRuleUpdateRequestSerializer(serializers.Serializer
 
 class ErrorTrackingSuppressionRuleViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     scope_object = "error_tracking"
+    scope_object_write_actions = ["create", "update", "partial_update", "destroy", "reorder"]
     serializer_class = ErrorTrackingSuppressionRuleSerializer
 
     def list(self, request, *args, **kwargs) -> Response:

--- a/products/error_tracking/backend/presentation/views/symbol_sets.py
+++ b/products/error_tracking/backend/presentation/views/symbol_sets.py
@@ -137,6 +137,8 @@ class ErrorTrackingSymbolSetViewSet(TeamAndOrgViewSetMixin, viewsets.GenericView
         "bulk_finish_upload",
         "start_upload",
         "finish_upload",
+        "update",
+        "partial_update",
         "destroy",
         "bulk_delete",
         "create",

--- a/products/error_tracking/backend/tests/api/test_api_scopes.py
+++ b/products/error_tracking/backend/tests/api/test_api_scopes.py
@@ -1,0 +1,45 @@
+from typing import Any, cast
+
+from django.test import SimpleTestCase
+
+from rest_framework.viewsets import ViewSetMixin
+
+from posthog.api.forbid_destroy_model import ForbidDestroyModel
+from posthog.permissions import ScopeBasePermission
+
+from products.error_tracking.backend.routes import register_routes
+
+
+class _RouteCollector:
+    def __init__(self) -> None:
+        self.projects = self
+        self.viewsets: list[type[ViewSetMixin]] = []
+
+    def register(self, _prefix: str, viewset: type[ViewSetMixin], _basename: str, _parents: list[str]) -> None:
+        self.viewsets.append(viewset)
+
+
+class TestErrorTrackingAPIScopes(SimpleTestCase):
+    def test_all_registered_actions_support_scoped_authentication(self) -> None:
+        routes = _RouteCollector()
+        register_routes(cast(Any, routes))
+
+        missing_actions: list[str] = []
+        standard_actions = set(ScopeBasePermission.read_actions + ScopeBasePermission.write_actions)
+
+        for viewset in routes.viewsets:
+            actions = {action.__name__ for action in viewset.get_extra_actions()}
+            actions.update(action for action in standard_actions if callable(getattr(viewset, action, None)))
+
+            read_actions = set(getattr(viewset, "scope_object_read_actions", ScopeBasePermission.read_actions))
+            write_actions = set(getattr(viewset, "scope_object_write_actions", ScopeBasePermission.write_actions))
+
+            for action in actions:
+                action_method: Any = getattr(viewset, action)
+                if action_method is ForbidDestroyModel.destroy:
+                    continue
+                required_scopes = getattr(action_method, "kwargs", {}).get("required_scopes")
+                if action not in read_actions | write_actions and not required_scopes:
+                    missing_actions.append(f"{viewset.__name__}.{action}")
+
+        self.assertEqual(missing_actions, [])


### PR DESCRIPTION
## Problem

Local OAuth and personal API key requests were rejected for several Error Tracking actions because those actions had no read or write scope declaration.

**Why:** Scoped authentication should have the same supported Error Tracking surface as session authentication.

## Changes

- Declare `error_tracking` scopes for every supported registered action.
- Add a product-wide regression test that detects unscoped routes.

## How did you test this code?

- `uv run pytest products/error_tracking/backend/tests/api/test_api_scopes.py -q` – passes and guards against registered actions missing scope coverage.
- `ruff check` and `ruff format` – pass through `hogli ci:preflight --fix`.
- `uv run mypy --cache-fine-grained .` – no issues in 17,541 source files.
- The database-backed OAuth permission suite and OpenAPI generation could not initialize because Postgres was not running. The change does not alter API schemas.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed because this restores existing endpoint behavior for scoped authentication.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code (Codex) implemented and audited the scoped-auth surface. I used `/improving-drf-endpoints`, `/writing-tests`, and `/writing-code-comments`; the audit excludes intentionally forbidden delete actions that return 405.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*