### PR TITLE
fix(notebooks): keep cmd+a inside embedded code cell editors

### DIFF
--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -5248,6 +5248,44 @@ Tail paragraph`),
         expect(window.getSelection()?.toString()).not.toContain('Tail paragraph')
     })
 
+    it('leaves Cmd+A alone inside a component code editor', () => {
+        const registry = createMarkdownNotebookRegistry([
+            {
+                tagName: 'Embed',
+                label: 'Embed',
+                category: 'Media',
+                // Stands in for the Monaco editor of an SQLV2 or PythonV2 cell. With EditContext on,
+                // Monaco takes focus on a plain div rather than a hidden textarea, so the notebook can
+                // only tell it apart by the `monaco-editor` container.
+                ViewComponent: () =>
+                    createElement(
+                        'div',
+                        { className: 'monaco-editor' },
+                        createElement('div', { className: 'native-edit-context', tabIndex: 0 })
+                    ),
+            },
+        ])
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                value: withNotebookTitle(`Before component
+
+<Embed />
+
+After component`),
+                registry,
+            })
+        )
+        const component = container.querySelector('.MarkdownNotebook__component-shell') as HTMLElement
+        const editorInputHost = container.querySelector('.native-edit-context') as HTMLElement
+        window.getSelection()?.removeAllRanges()
+
+        editorInputHost.focus()
+        fireSelectAllShortcut(editorInputHost)
+
+        expect(window.getSelection()?.toString()).toEqual('')
+        expect(component.classList.contains('MarkdownNotebook__component-shell--selected')).toBe(false)
+    })
+
     it('selects text and components with Cmd+A from a focused component', () => {
         const onChange = jest.fn()
         const registry = createMarkdownNotebookRegistry([

--- a/frontend/src/lib/components/MarkdownNotebook/domSelection.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/domSelection.ts
@@ -648,8 +648,16 @@ export function rangeIntersectsNode(range: Range, node: Node): boolean {
     }
 }
 
+// Monaco belongs in this list because an embedded editor (SQLV2 and PythonV2 cells, the debug drawer)
+// owns its own editing and key handling, so the notebook has to leave Cmd+A, Backspace, copy and paste
+// to it rather than acting on the whole document. Tag names alone don't find it: with EditContext
+// enabled, which is Monaco's default on Chromium, the focused input host is a plain
+// `div.native-edit-context` instead of the legacy hidden textarea, and the DOM selection stays wherever
+// it was before the editor took focus.
+const NATIVE_EDITABLE_SELECTOR = 'input, textarea, select, .monaco-editor'
+
 export function isNativeEditableElement(element: HTMLElement): boolean {
-    return Boolean(element.closest('input, textarea, select'))
+    return Boolean(element.closest(NATIVE_EDITABLE_SELECTOR))
 }
 
 export function isFormattingToolbarFocused(): boolean {


### PR DESCRIPTION
## Problem

In a markdown notebook, put the cursor in the code editor of a SQLV2 or PythonV2 cell and press cmd+a. Instead of selecting the code in that cell, it selects the entire notebook.

The notebook editor is a bespoke contenteditable surface, so it hand-rolls cmd+a. `handleNotebookKeyDown` escalates through text block, then code block, then whole notebook, and it bails out early when the event came from something that does its own editing:

https://github.com/PostHog/posthog/blob/e1858c1cc687df5064bf6b8dd6c8a2f74ad70c9b/frontend/src/lib/components/MarkdownNotebook/domSelection.ts#L651-L653

That guard misses Monaco. We're on monaco-editor 0.55, where `editContext` defaults to on, and `effectiveEditContext` resolves to `editContextSupported && editContext`. Chromium supports EditContext, so Monaco puts focus on a plain `div.native-edit-context` appended into `.overflow-guard`, not the legacy hidden `textarea.inputarea`. No `input`, `textarea` or `select` in the ancestor chain means the guard returns false, the handler runs, both scoped branches miss (Monaco has neither `.MarkdownNotebook__text-block` nor `.MarkdownNotebook__code-block`), and it lands on `selectNotebookContents()` with `preventDefault()`. Monaco never sees the keystroke.

Same guard is reused for `beforeinput`, copy, cut, paste and the root keydown handler, so this was not only cmd+a. Copying a selection out of a SQL cell was also going through the notebook's own copy handler.

> [!NOTE]
> Chromium only. Firefox and Safari have no EditContext, so Monaco falls back to the hidden textarea there and the old guard happened to work.

## Changes

Added `.monaco-editor` to the guard's selector. The container class covers both the EditContext div and the legacy textarea, so it holds regardless of which input path Monaco picks.

```diff
-    return Boolean(element.closest('input, textarea, select'))
+    return Boolean(element.closest(NATIVE_EDITABLE_SELECTOR))
```

No visual change, so no screenshots.

## How did you test this code?

I (actually Claude) could not run the app: this needs a real Chromium with EditContext plus a running dev stack and a sandbox kernel for the cells, and jsdom has no EditContext to reproduce it against. So the premise is verified against the installed monaco-editor 0.55.1 source instead: `editContext` defaults to `true`, `effectiveEditContext` is `typeof globalThis.EditContext === 'function' && editContext`, and `native-edit-context` is a `div` appended to the `.overflow-guard` inside `.monaco-editor`.

Automated:

- New jest case in `MarkdownNotebook.test.ts`, next to the existing cmd+a escalation tests. It registers a component whose view renders the Monaco DOM contract (`div.monaco-editor > div.native-edit-context[tabindex]`) and fires cmd+a from that host. Catches the regression where a select-all inside a component's code editor escalates to the whole notebook. No existing test fires cmd+a from inside a component node, which is exactly why the gap shipped. Confirmed it fails on master's guard with `Received: "Notebook titleBefore componentEmbedAdd a titleAfter component"` and passes with the fix.
- Full `frontend/src/lib/components/MarkdownNotebook/` suite: 617 passed, 15 suites.
- `pnpm --filter=@posthog/frontend typescript:check` clean, oxlint and oxfmt clean.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, working in a git worktree off master. Skills invoked: `/writing-code-comments` and `/writing-tests`.

The first hypothesis was a TipTap keymap binding `Mod-a`, since that is where notebook cells used to live. Dead end: the revamped notebooks dropped ProseMirror, and select-all is hand-rolled on a contenteditable canvas. The second dead end was assuming Monaco focuses a `textarea`, which is what the guard already assumed and what made the bug look impossible on paper. Reading the monaco-editor 0.55.1 source is what settled it.

Considered scoping the fix to `.native-edit-context`, but `.monaco-editor` is the better anchor: it survives the EditContext fallback and any future change to the input host's class. Also considered renaming `isNativeEditableElement`, since Monaco is not a native editable element, but every one of the six call sites wants the same thing (this target owns its own editing, keep the notebook out of it), and a rename would churn a file several other notebook branches are touching right now. Left the name and wrote down the why instead.

The `.MarkdownNotebook__debug-drawer` special case at two of the call sites is now redundant for its Monaco instance, but it may cover non-Monaco parts of the drawer, so I left it.
