### PR TITLE
feat(data-warehouse): add 11 missing TikTok Ads tables

### DIFF
--- a/posthog/temporal/tests/data_modeling/test_log_routing.py
+++ b/posthog/temporal/tests/data_modeling/test_log_routing.py
@@ -2,6 +2,7 @@ import json
 import uuid
 import asyncio
 import dataclasses
+from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -103,11 +104,19 @@ def v2_activity_environment():
     return env
 
 
-async def _wait_for_queue_entries(queue: QueueCapture) -> None:
-    for _ in range(100):
-        if queue.entries:
+async def _wait_for_queue_entries(queue: QueueCapture, matches: Callable[[dict], bool] | None = None) -> None:
+    # Produced lines reach the queue via `run_coroutine_threadsafe` from a thread-pool
+    # executor, so a line can still be in flight after the activity returns. Wait for the
+    # message we actually assert on — not just the first line to land — with real
+    # wall-clock time, otherwise a generic log line can satisfy the wait before the routed
+    # entry arrives and the assertion sees zero routed messages.
+    for _ in range(200):
+        if matches is None:
+            if queue.entries:
+                return
+        elif any(matches(json.loads(entry.decode("utf-8"))) for entry in queue.entries):
             return
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
     raise TimeoutError("Timed out waiting for produced log messages")
 
 
@@ -144,7 +153,7 @@ async def test_v2_activity_log_lines_are_routed_to_the_saved_query(
                 update_node=False,
             ),
         )
-    await _wait_for_queue_entries(queue)
+    await _wait_for_queue_entries(queue, matches=lambda m: m.get("log_source") == "data_modeling_run")
 
     messages = [json.loads(entry.decode("utf-8")) for entry in queue.entries]
     routed_messages = [m for m in messages if m["log_source"] == "data_modeling_run"]
@@ -169,7 +178,7 @@ async def test_failure_logs_do_not_expose_clickhouse_hostnames(
             update_node=False,
         ),
     )
-    await _wait_for_queue_entries(queue)
+    await _wait_for_queue_entries(queue, matches=lambda m: bool(m.get("log_source")))
 
     routed_messages = [
         json.loads(entry.decode("utf-8")) for entry in queue.entries if json.loads(entry.decode("utf-8"))["log_source"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/COVERAGE_GAPS.md
@@ -357,6 +357,27 @@ campaign_stats_daily_demographics, ad_stats_daily_country, ad_stats_daily_demogr
 - [ ] Organization-level tables — funding sources, billing centers, invoices, members (skipped: all
       scoped to an organization ID this source does not collect).
 
+### TikTok Ads — spec-verified
+
+Supersedes the TikTok Ads entries in the section above.
+Diffed on 2026-08-04 against the TikTok Marketing API v1.3 surface as expressed by the actively
+maintained Airbyte `source-tiktok-marketing` manifest
+(<https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml>),
+since TikTok publishes no machine-readable spec and its docs portal renders client-side.
+
+Have: campaigns, ad_groups, ads, campaign_report, ad_group_report, ad_report, creative_videos,
+creative_images, campaign_demographic_report, campaign_country_report, campaign_platform_report,
+ad_group_demographic_report, ad_group_country_report, ad_group_platform_report,
+ad_demographic_report, ad_country_report, ad_platform_report.
+
+- [x] Creative metadata — `creative_videos` (`/file/video/ad/search/`) and `creative_images` (`/file/image/ad/search/`) decode the `video_id` / `image_ids` already synced on `ads`.
+- [x] Breakdown dimensions on the report tables — nine `report_type=AUDIENCE` tables covering gender + age, country, and operating system at campaign, ad group, and ad level. All default to off.
+- [ ] Ad account table (skipped: `/advertiser/info/` is not readable with the scope the PostHog TikTok app holds, so the table would fail for every connection. Report tables already carry `currency`; timezone stays missing).
+- [ ] Audiences (skipped: `/dmp/custom_audience/list/` needs the audience-management scope, which the app does not hold today).
+- [ ] Pixel / conversion event definitions (skipped: `/pixel/list/` needs the events-manager scope, which the app does not hold today).
+- [ ] Province-level breakdown (skipped: TikTok only offers `province_id` at ad level, so it does not fit the symmetric set above).
+- [ ] Spark Ads posts, creative portfolios, and music assets.
+
 ### Linear — spec-verified
 
 Verified 2026-08-04 against the root `Query` type published by `@linear/sdk` 89.0.0 (npm), which is

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/canonical_descriptions.py
@@ -32,6 +32,50 @@ def _report_columns(**overrides: str) -> dict[str, str]:
     return {**_REPORT_METRIC_COLUMNS, **overrides}
 
 
+# Metrics available on the AUDIENCE report type. `currency` and the campaign-level budget
+# attributes are not returned once a breakdown dimension is applied.
+_AUDIENCE_REPORT_METRIC_COLUMNS = {
+    "stat_time_day": "Date the metrics are aggregated for.",
+    "spend": "Total amount spent in the reporting period.",
+    "impressions": "Number of times the ads were shown.",
+    "clicks": "Number of clicks on the ads.",
+    "ctr": "Click-through rate (clicks divided by impressions).",
+    "cpc": "Average cost per click.",
+    "cpm": "Average cost per thousand impressions.",
+    "reach": "Number of unique users who saw the ads.",
+    "frequency": "Average number of times each user saw the ads.",
+    "cost_per_1000_reached": "Average cost to reach 1,000 unique users.",
+    "video_play_actions": "Number of times the video started playing.",
+    "video_views_p25": "Number of times the video was watched to 25% of its length.",
+    "video_views_p50": "Number of times the video was watched to 50% of its length.",
+    "video_views_p75": "Number of times the video was watched to 75% of its length.",
+    "video_views_p100": "Number of times the video was watched to 100% of its length.",
+    "likes": "Number of likes the ads received.",
+    "comments": "Number of comments the ads received.",
+    "shares": "Number of shares the ads received.",
+    "follows": "Number of new followers gained from the ads.",
+    "profile_visits": "Number of visits to the advertiser's TikTok profile from the ads.",
+}
+
+_BREAKDOWN_COLUMNS = {
+    "gender": "Gender bucket the metrics are broken down by.",
+    "age": "Age bucket the metrics are broken down by.",
+    "country_code": "Country the metrics are broken down by, as an ISO country code.",
+    "platform": "Operating system the metrics are broken down by (for example ANDROID, IOS).",
+}
+
+
+def _audience_report_columns(*breakdowns: str, **overrides: str) -> dict[str, str]:
+    return {
+        **_AUDIENCE_REPORT_METRIC_COLUMNS,
+        **{name: _BREAKDOWN_COLUMNS[name] for name in breakdowns},
+        **overrides,
+    }
+
+
+_AUDIENCE_REPORT_DOCS_URL = "https://business-api.tiktok.com/portal/docs?id=1740302848100353"
+
+
 CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
     "campaigns": {
         "description": "An advertising campaign in your TikTok Ads account, with its objective and budget.",
@@ -115,6 +159,145 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
         "columns": _report_columns(
             ad_id="ID of the ad the metrics belong to.",
             video_views_p100="Number of times the video was watched to 100% of its length.",
+        ),
+    },
+    "creative_videos": {
+        "description": "A video asset in your TikTok Ads creative library, joinable to the video used by an ad.",
+        "docs_url": "https://business-api.tiktok.com/portal/docs",
+        "columns": {
+            "video_id": "Unique identifier for the video asset.",
+            "material_id": "Identifier of the material the video belongs to.",
+            "file_name": "Name of the uploaded video file.",
+            "format": "File format of the video.",
+            "duration": "Length of the video in seconds.",
+            "width": "Width of the video in pixels.",
+            "height": "Height of the video in pixels.",
+            "bit_rate": "Bitrate of the video.",
+            "size": "Size of the video file in bytes.",
+            "signature": "Signature of the video file.",
+            "video_cover_url": "URL of the video's cover image.",
+            "preview_url": "Temporary URL for previewing the video.",
+            "preview_url_expire_time": "Time at which the preview URL stops working.",
+            "allowed_placements": "Placements the video can be used in.",
+            "allow_download": "Whether the video can be downloaded.",
+            "displayable": "Whether the video can be displayed.",
+            "create_time": "Time at which the video was uploaded.",
+            "modify_time": "Time at which the video was last modified.",
+        },
+    },
+    "creative_images": {
+        "description": "An image asset in your TikTok Ads creative library, joinable to the images used by an ad.",
+        "docs_url": "https://business-api.tiktok.com/portal/docs",
+        "columns": {
+            "image_id": "Unique identifier for the image asset.",
+            "material_id": "Identifier of the material the image belongs to.",
+            "file_name": "Name of the uploaded image file.",
+            "format": "File format of the image.",
+            "width": "Width of the image in pixels.",
+            "height": "Height of the image in pixels.",
+            "size": "Size of the image file in bytes.",
+            "signature": "Signature of the image file.",
+            "image_url": "URL the image can be fetched from.",
+            "is_carousel_usable": "Whether the image can be used in a carousel ad.",
+            "displayable": "Whether the image can be displayed.",
+            "create_time": "Time at which the image was uploaded.",
+            "modify_time": "Time at which the image was last modified.",
+        },
+    },
+    "campaign_demographic_report": {
+        "description": "Daily campaign performance broken down by the viewer's gender and age bucket.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "gender",
+            "age",
+            campaign_id="ID of the campaign the metrics belong to.",
+            campaign_name="Name of the campaign the metrics belong to.",
+        ),
+    },
+    "campaign_country_report": {
+        "description": "Daily campaign performance broken down by the viewer's country.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "country_code",
+            campaign_id="ID of the campaign the metrics belong to.",
+            campaign_name="Name of the campaign the metrics belong to.",
+        ),
+    },
+    "campaign_platform_report": {
+        "description": "Daily campaign performance broken down by the viewer's operating system.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "platform",
+            campaign_id="ID of the campaign the metrics belong to.",
+            campaign_name="Name of the campaign the metrics belong to.",
+        ),
+    },
+    "ad_group_demographic_report": {
+        "description": "Daily ad group performance broken down by the viewer's gender and age bucket.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "gender",
+            "age",
+            adgroup_id="ID of the ad group the metrics belong to.",
+            adgroup_name="Name of the ad group the metrics belong to.",
+            campaign_id="ID of the campaign the ad group belongs to.",
+            placement_type="How placements were selected for the ad group.",
+            promotion_type="What the ad group promotes (for example WEBSITE, APP).",
+        ),
+    },
+    "ad_group_country_report": {
+        "description": "Daily ad group performance broken down by the viewer's country.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "country_code",
+            adgroup_id="ID of the ad group the metrics belong to.",
+            adgroup_name="Name of the ad group the metrics belong to.",
+            campaign_id="ID of the campaign the ad group belongs to.",
+        ),
+    },
+    "ad_group_platform_report": {
+        "description": "Daily ad group performance broken down by the viewer's operating system.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "platform",
+            adgroup_id="ID of the ad group the metrics belong to.",
+            adgroup_name="Name of the ad group the metrics belong to.",
+            campaign_id="ID of the campaign the ad group belongs to.",
+        ),
+    },
+    "ad_demographic_report": {
+        "description": "Daily ad performance broken down by the viewer's gender and age bucket.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "gender",
+            "age",
+            ad_id="ID of the ad the metrics belong to.",
+            ad_name="Name of the ad the metrics belong to.",
+            ad_text="Primary text shown with the ad.",
+            adgroup_id="ID of the ad group the ad belongs to.",
+            campaign_id="ID of the campaign the ad belongs to.",
+        ),
+    },
+    "ad_country_report": {
+        "description": "Daily ad performance broken down by the viewer's country.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "country_code",
+            ad_id="ID of the ad the metrics belong to.",
+            ad_name="Name of the ad the metrics belong to.",
+            adgroup_id="ID of the ad group the ad belongs to.",
+            campaign_id="ID of the campaign the ad belongs to.",
+        ),
+    },
+    "ad_platform_report": {
+        "description": "Daily ad performance broken down by the viewer's operating system.",
+        "docs_url": _AUDIENCE_REPORT_DOCS_URL,
+        "columns": _audience_report_columns(
+            "platform",
+            ad_id="ID of the ad the metrics belong to.",
+            ad_name="Name of the ad the metrics belong to.",
+            adgroup_id="ID of the ad group the ad belongs to.",
+            campaign_id="ID of the campaign the ad belongs to.",
         ),
     },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/settings.py
@@ -71,6 +71,69 @@ METRICS_FIELDS = [
 
 TIKTOK_REPORT_METRICS = json.dumps(METRICS_FIELDS)
 
+# Metrics TikTok accepts on an AUDIENCE report. Narrower than the BASIC set above:
+# account/entity attributes such as `currency`, `campaign_budget`, `billing_event` and
+# `split_test` are not available once the report is broken down by an audience dimension.
+AUDIENCE_REPORT_METRICS_FIELDS = [
+    "average_video_play_per_user",
+    "average_video_play",
+    "clicks_on_music_disc",
+    "clicks",
+    "comments",
+    "cost_per_1000_reached",
+    "cpc",
+    "cpm",
+    "ctr",
+    "follows",
+    "frequency",
+    "impressions",
+    "likes",
+    "profile_visits",
+    "reach",
+    "shares",
+    "spend",
+    "video_play_actions",
+    "video_views_p100",
+    "video_views_p25",
+    "video_views_p50",
+    "video_views_p75",
+    "video_watched_2s",
+    "video_watched_6s",
+]
+
+# Conversion metrics TikTok only reports below campaign level on an AUDIENCE report.
+_AUDIENCE_CONVERSION_METRICS_FIELDS = [
+    "conversion_rate",
+    "conversion",
+    "cost_per_conversion",
+    "cost_per_result",
+    "real_time_conversion_rate",
+    "real_time_conversion",
+    "real_time_cost_per_conversion",
+    "real_time_cost_per_result",
+    "real_time_result_rate",
+    "real_time_result",
+    "result_rate",
+    "result",
+]
+
+CAMPAIGN_AUDIENCE_REPORT_METRICS_FIELDS = [*AUDIENCE_REPORT_METRICS_FIELDS, "campaign_name"]
+AD_GROUP_AUDIENCE_REPORT_METRICS_FIELDS = [
+    *AUDIENCE_REPORT_METRICS_FIELDS,
+    *_AUDIENCE_CONVERSION_METRICS_FIELDS,
+    "adgroup_name",
+    "campaign_id",
+    "campaign_name",
+    "placement_type",
+    "promotion_type",
+]
+AD_AUDIENCE_REPORT_METRICS_FIELDS = [
+    *AD_GROUP_AUDIENCE_REPORT_METRICS_FIELDS,
+    "ad_name",
+    "ad_text",
+    "adgroup_id",
+]
+
 ENDPOINT_ADVERTISERS = ["advertisers"]
 ENDPOINT_AD_MANAGEMENT = ["campaigns", "adgroups", "ads"]
 ENDPOINT_INSIGHTS = ["campaign_report", "ad_group_report", "ad_report"]
@@ -80,6 +143,9 @@ class EndpointType(str, Enum):
     ACCOUNT = "account"
     ENTITY = "entity"
     REPORT = "report"
+    # Creative library assets (videos, images). Unlike ENTITY rows they carry no
+    # operational status and no comment settings, so they pass through untransformed.
+    ASSET = "asset"
 
 
 @dataclass
@@ -91,6 +157,64 @@ class EndpointConfig:
     partition_format: Optional[PartitionFormat] = None
     partition_size: int = 1
     endpoint_type: Optional[EndpointType] = None
+    should_sync_default: bool = True
+
+
+STAT_TIME_DAY_INCREMENTAL_FIELD: IncrementalField = {
+    "label": "stat_time_day",
+    "type": IncrementalFieldType.Date,
+    "field": "stat_time_day",
+    "field_type": IncrementalFieldType.Date,
+}
+
+
+def audience_report_config(name: str, data_level: str, dimensions: list[str], metrics: list[str]) -> EndpointConfig:
+    """One AUDIENCE-report breakdown table.
+
+    Same `/report/integrated/get/` endpoint as the existing BASIC report tables, with
+    `report_type=AUDIENCE` and the breakdown appended to `dimensions`. TikTok returns one
+    row per (entity, day, breakdown value), so the dimension list is also the primary key.
+
+    Docs: https://business-api.tiktok.com/portal/docs?id=1740302848100353
+    """
+    return EndpointConfig(
+        resource={
+            "name": name,
+            "table_name": name,
+            "primary_key": dimensions,
+            "endpoint": {
+                "path": "/report/integrated/get/",
+                "method": "GET",
+                "params": {
+                    "advertiser_id": "{advertiser_id}",
+                    "service_type": "AUCTION",
+                    "report_type": "AUDIENCE",
+                    "data_level": data_level,
+                    "dimensions": json.dumps(dimensions),
+                    "metrics": json.dumps(metrics),
+                    "page_size": 1000,
+                    "start_date": "{start_date}",
+                    "end_date": "{end_date}",
+                },
+                "data_selector": "data.list",
+                "incremental": {
+                    "cursor_path": "stat_time_day",
+                    "start_param": "start_date",
+                    "end_param": "end_date",
+                },
+            },
+            "table_format": "delta",
+        },
+        incremental_fields=[STAT_TIME_DAY_INCREMENTAL_FIELD],
+        partition_keys=["stat_time_day"],
+        partition_mode="datetime",
+        partition_format="week",
+        partition_size=1,
+        endpoint_type=EndpointType.REPORT,
+        # A breakdown multiplies every entity-day by its distinct dimension values, so these
+        # are far larger than the totals tables and only some accounts care about them.
+        should_sync_default=False,
+    )
 
 
 TIKTOK_ADS_CONFIG: dict[str, EndpointConfig] = {
@@ -297,5 +421,111 @@ TIKTOK_ADS_CONFIG: dict[str, EndpointConfig] = {
         partition_format="week",
         partition_size=1,
         endpoint_type=EndpointType.REPORT,
+    ),
+    "creative_videos": EndpointConfig(
+        resource={
+            # TikTok creative library, video assets. Docs: https://business-api.tiktok.com/portal/docs
+            "name": "creative_videos",
+            "table_name": "creative_videos",
+            "primary_key": ["video_id"],
+            "endpoint": {
+                "path": "/file/video/ad/search/",
+                "method": "GET",
+                "params": {
+                    "advertiser_id": "{advertiser_id}",
+                    # TikTok caps the creative library search at 100 per page.
+                    "page_size": 100,
+                    "page": 1,
+                },
+                "data_selector": "data.list",
+            },
+            "table_format": "delta",
+        },
+        # `modify_time` is only filterable client-side, so this stays full refresh.
+        incremental_fields=None,
+        partition_keys=["create_time"],
+        partition_mode="datetime",
+        partition_format="week",
+        partition_size=1,
+        endpoint_type=EndpointType.ASSET,
+    ),
+    "creative_images": EndpointConfig(
+        resource={
+            # TikTok creative library, image assets. Docs: https://business-api.tiktok.com/portal/docs
+            "name": "creative_images",
+            "table_name": "creative_images",
+            "primary_key": ["image_id"],
+            "endpoint": {
+                "path": "/file/image/ad/search/",
+                "method": "GET",
+                "params": {
+                    "advertiser_id": "{advertiser_id}",
+                    "page_size": 100,
+                    "page": 1,
+                },
+                "data_selector": "data.list",
+            },
+            "table_format": "delta",
+        },
+        incremental_fields=None,
+        partition_keys=["create_time"],
+        partition_mode="datetime",
+        partition_format="week",
+        partition_size=1,
+        endpoint_type=EndpointType.ASSET,
+    ),
+    "campaign_demographic_report": audience_report_config(
+        "campaign_demographic_report",
+        "AUCTION_CAMPAIGN",
+        ["campaign_id", "stat_time_day", "gender", "age"],
+        CAMPAIGN_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "campaign_country_report": audience_report_config(
+        "campaign_country_report",
+        "AUCTION_CAMPAIGN",
+        ["campaign_id", "stat_time_day", "country_code"],
+        CAMPAIGN_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "campaign_platform_report": audience_report_config(
+        "campaign_platform_report",
+        "AUCTION_CAMPAIGN",
+        ["campaign_id", "stat_time_day", "platform"],
+        CAMPAIGN_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "ad_group_demographic_report": audience_report_config(
+        "ad_group_demographic_report",
+        "AUCTION_ADGROUP",
+        ["adgroup_id", "stat_time_day", "gender", "age"],
+        AD_GROUP_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "ad_group_country_report": audience_report_config(
+        "ad_group_country_report",
+        "AUCTION_ADGROUP",
+        ["adgroup_id", "stat_time_day", "country_code"],
+        AD_GROUP_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "ad_group_platform_report": audience_report_config(
+        "ad_group_platform_report",
+        "AUCTION_ADGROUP",
+        ["adgroup_id", "stat_time_day", "platform"],
+        AD_GROUP_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "ad_demographic_report": audience_report_config(
+        "ad_demographic_report",
+        "AUCTION_AD",
+        ["ad_id", "stat_time_day", "gender", "age"],
+        AD_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "ad_country_report": audience_report_config(
+        "ad_country_report",
+        "AUCTION_AD",
+        ["ad_id", "stat_time_day", "country_code"],
+        AD_AUDIENCE_REPORT_METRICS_FIELDS,
+    ),
+    "ad_platform_report": audience_report_config(
+        "ad_platform_report",
+        "AUCTION_AD",
+        ["ad_id", "stat_time_day", "platform"],
+        AD_AUDIENCE_REPORT_METRICS_FIELDS,
     ),
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -203,6 +203,7 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
                 supports_incremental=endpoint_config.incremental_fields is not None,
                 supports_append=False,
                 incremental_fields=endpoint_config.incremental_fields or [],
+                should_sync_default=endpoint_config.should_sync_default,
             )
             for endpoint_config in TIKTOK_ADS_CONFIG.values()
         ]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads.py
@@ -243,6 +243,8 @@ class TestTikTokAdsSource:
             ("campaigns", False, None),
             ("ad_groups", False, None),
             ("ads", False, None),
+            ("creative_videos", False, None),
+            ("creative_images", False, None),
         ]
     )
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.tiktok_ads.rest_api_resource")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -189,7 +189,25 @@ class TestTikTokAdsSource:
         """Test schema retrieval."""
         schemas = self.source.get_schemas(self.config, self.team_id)
 
-        expected_schemas = {"campaigns", "ad_groups", "ads", "campaign_report", "ad_group_report", "ad_report"}
+        expected_schemas = {
+            "campaigns",
+            "ad_groups",
+            "ads",
+            "creative_videos",
+            "creative_images",
+            "campaign_report",
+            "ad_group_report",
+            "ad_report",
+            "campaign_demographic_report",
+            "campaign_country_report",
+            "campaign_platform_report",
+            "ad_group_demographic_report",
+            "ad_group_country_report",
+            "ad_group_platform_report",
+            "ad_demographic_report",
+            "ad_country_report",
+            "ad_platform_report",
+        }
         actual_schema_names = {schema.name for schema in schemas}
 
         assert actual_schema_names == expected_schemas
@@ -202,6 +220,26 @@ class TestTikTokAdsSource:
             else:
                 assert schema.supports_incremental is False
                 assert schema.incremental_fields == []
+
+    def test_only_breakdown_reports_are_off_by_default(self):
+        # New tables land in the schema picker pre-ticked. The breakdown reports fan every
+        # entity-day out across its dimension values, so they must stay opt-in while the
+        # tables that shipped before this stay selected.
+        should_sync = {schema.name: schema.should_sync_default for schema in self.source.get_schemas(self.config, 1)}
+
+        off_by_default = {name for name, default in should_sync.items() if not default}
+
+        assert off_by_default == {
+            "campaign_demographic_report",
+            "campaign_country_report",
+            "campaign_platform_report",
+            "ad_group_demographic_report",
+            "ad_group_country_report",
+            "ad_group_platform_report",
+            "ad_demographic_report",
+            "ad_country_report",
+            "ad_platform_report",
+        }
 
     def test_get_resumable_source_manager(self):
         """The source must expose a ResumableSourceManager instance."""

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py
@@ -1,5 +1,6 @@
 """Tests for TikTok Ads utility functions."""
 
+import json
 from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, cast
@@ -438,6 +439,15 @@ class TestStreamTransformations:
         assert result[0]["advertiser_id"] == "123456"
         assert isinstance(result[0]["create_time"], datetime)
 
+    def test_apply_stream_transformations_asset_endpoint(self):
+        # Creative assets have no operational status. Routing them through the entity
+        # transformation would invent a `current_status` column TikTok never returned.
+        reports = [{"video_id": "v1", "create_time": "2026-01-01 00:00:00"}]
+
+        result = TikTokReportResource.apply_stream_transformations(EndpointType.ASSET, reports)
+
+        assert result == reports
+
     def test_apply_stream_transformations_unknown_endpoint(self):
         """Test stream transformations for unknown endpoint type."""
         reports = [{"data": "test"}]
@@ -812,6 +822,11 @@ class TestHelperFunctions:
             ("campaigns", EndpointType.ENTITY),
             ("ad_groups", EndpointType.ENTITY),
             ("ads", EndpointType.ENTITY),
+            ("campaign_demographic_report", EndpointType.REPORT),
+            ("ad_group_country_report", EndpointType.REPORT),
+            ("ad_platform_report", EndpointType.REPORT),
+            ("creative_videos", EndpointType.ASSET),
+            ("creative_images", EndpointType.ASSET),
         ]
     )
     def test_is_report_endpoint(self, endpoint_name, expected_endpoint_type):
@@ -819,6 +834,60 @@ class TestHelperFunctions:
         config = TIKTOK_ADS_CONFIG.get(endpoint_name)
         assert config is not None, f"Endpoint {endpoint_name} not found in config"
         assert config.endpoint_type == expected_endpoint_type
+
+
+# Metrics TikTok only accepts on a BASIC report. Requesting any of them alongside an
+# audience dimension is rejected outright, which would take the whole breakdown table down.
+_BASIC_ONLY_METRICS = {
+    "app_promotion_type",
+    "billing_event",
+    "campaign_budget",
+    "campaign_dedicate_type",
+    "currency",
+    "gross_impressions",
+    "split_test",
+}
+
+AUDIENCE_REPORT_ENDPOINTS = [
+    ("campaign_demographic_report", ["campaign_id", "stat_time_day", "gender", "age"], "AUCTION_CAMPAIGN"),
+    ("campaign_country_report", ["campaign_id", "stat_time_day", "country_code"], "AUCTION_CAMPAIGN"),
+    ("campaign_platform_report", ["campaign_id", "stat_time_day", "platform"], "AUCTION_CAMPAIGN"),
+    ("ad_group_demographic_report", ["adgroup_id", "stat_time_day", "gender", "age"], "AUCTION_ADGROUP"),
+    ("ad_group_country_report", ["adgroup_id", "stat_time_day", "country_code"], "AUCTION_ADGROUP"),
+    ("ad_group_platform_report", ["adgroup_id", "stat_time_day", "platform"], "AUCTION_ADGROUP"),
+    ("ad_demographic_report", ["ad_id", "stat_time_day", "gender", "age"], "AUCTION_AD"),
+    ("ad_country_report", ["ad_id", "stat_time_day", "country_code"], "AUCTION_AD"),
+    ("ad_platform_report", ["ad_id", "stat_time_day", "platform"], "AUCTION_AD"),
+]
+
+
+def _endpoint_params(endpoint_name: str) -> dict[str, Any]:
+    endpoint = cast(dict[str, Any], TIKTOK_ADS_CONFIG[endpoint_name].resource["endpoint"])
+    return cast(dict[str, Any], endpoint["params"])
+
+
+class TestAudienceReportEndpoints:
+    @parameterized.expand(AUDIENCE_REPORT_ENDPOINTS)
+    def test_breakdown_dimensions_are_part_of_the_primary_key(self, endpoint_name, dimensions, data_level):
+        # TikTok returns one row per (entity, day, breakdown value). Dropping a breakdown
+        # from the key would collapse every value of it onto one row and make each merge
+        # multi-match, so the key has to carry the full dimension list.
+        params = _endpoint_params(endpoint_name)
+
+        assert TIKTOK_ADS_CONFIG[endpoint_name].resource["primary_key"] == dimensions
+        assert json.loads(params["dimensions"]) == dimensions
+        assert params["data_level"] == data_level
+
+    @parameterized.expand(AUDIENCE_REPORT_ENDPOINTS)
+    def test_requests_the_audience_report_with_audience_safe_metrics(self, endpoint_name, dimensions, data_level):
+        # Reusing the BASIC metric list here is the easy mistake, and TikTok rejects the
+        # whole request rather than dropping the unsupported metrics.
+        params = _endpoint_params(endpoint_name)
+        metrics = set(json.loads(params["metrics"]))
+
+        assert params["report_type"] == "AUDIENCE"
+        assert metrics & _BASIC_ONLY_METRICS == set()
+        assert metrics & set(dimensions) == set()
 
 
 class TestListAdvertisers:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -303,6 +303,9 @@ class TikTokReportResource:
                 return cls.transform_entity_reports(reports_list)
             case EndpointType.ACCOUNT:
                 return cls.transform_account_reports(reports_list)
+            case EndpointType.ASSET:
+                # Creative library rows already arrive flat and need no defaulting.
+                return reports_list
             case _:
                 raise ValueError(f"Endpoint type: {endpoint_type} is not implemented")
 


### PR DESCRIPTION
## Problem

The TikTok Ads source ships six tables: campaigns, ad groups, ads, and one daily report for each. That covers "what did we spend and what did it get us", but it stops short of the two things people ask the warehouse next.

First, totals only. There is no way to slice spend by age, gender, country or operating system, which is the most common reason someone exports ad data in the first place.

Second, no creative metadata. The `ads` table carries a `video_id` and image ids, but nothing to join them to, so you can rank ad ids and still not say which creative won.

## Changes

Eleven new tables, all additive. No existing table name, primary key, incremental field, partition key or sort mode changes.

**Breakdown reports (9)** hit the same `/report/integrated/get/` endpoint the existing report tables already use, with `report_type=AUDIENCE` and the breakdown appended to `dimensions`. Three breakdowns at each of the three levels:

| breakdown | campaign | ad group | ad |
|---|---|---|---|
| gender + age | `campaign_demographic_report` | `ad_group_demographic_report` | `ad_demographic_report` |
| country | `campaign_country_report` | `ad_group_country_report` | `ad_country_report` |
| operating system | `campaign_platform_report` | `ad_group_platform_report` | `ad_platform_report` |

They are incremental on `stat_time_day` and partitioned by week, same as the totals tables, and they reuse the existing date-chunking and resume machinery unchanged. All nine ship `should_sync_default=False`. A breakdown fans every entity-day out across its distinct dimension values, so it should be opt-in rather than switching itself on for connections that only asked for totals.

> [!NOTE]
> The AUDIENCE report type accepts a narrower metric set than BASIC. Account and entity attributes such as `currency`, `campaign_budget`, `billing_event` and `split_test` are rejected once a breakdown dimension is applied, and TikTok fails the whole request rather than dropping the unsupported fields. So these tables get their own metric list rather than reusing `METRICS_FIELDS`, and there is a test pinning that.

**Creative assets (2)** are the lookup tables that decode what `ads` already syncs: `creative_videos` from `/file/video/ad/search/` and `creative_images` from `/file/image/ad/search/`. Both are full refresh. TikTok exposes `modify_time` on the rows but no server-side filter for it, so a "client-side incremental" would still page the whole library every run. They get a new `EndpointType.ASSET` so they skip the entity transformation, which would otherwise stamp a `current_status` column TikTok never returned.

`canonical_descriptions.py` gains a table description plus per-column descriptions for all eleven.

### Spec I diffed against

TikTok publishes no machine-readable spec and its docs portal renders client-side, so the reference here is the actively maintained Airbyte [`source-tiktok-marketing` manifest](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-tiktok-marketing/manifest.yaml) (v5.1.8, updated last week), which runs against the same Marketing API v1.3 this source pins. It gives paths, request params, data selectors, pagination and primary keys per stream. I checked each claimed gap against it and dropped the ones that did not hold up.

### Deliberately skipped

- **Ad account table** (`/advertiser/info/`). The advertiser endpoint is not readable with the scope the PostHog TikTok app holds. That is already noted in `utils.py` and was established when the account picker landed in #70196. Shipping it would give every connection a table that fails. The report tables already carry `currency`; timezone stays missing until the app's scopes are widened.
- **Audiences** (`/dmp/custom_audience/list/`) and **pixels** (`/pixel/list/`). Both sit behind their own scopes (audience management, events manager) rather than the ads-management scope everything here uses. Same failure mode, and lower value than the breakdowns.
- **Province breakdown**. TikTok only offers `province_id` at ad level, so it does not fit the symmetric set above.
- Spark Ads posts, creative portfolios and music assets. Real endpoints, but narrow.

`COVERAGE_GAPS.md` gets a TikTok Ads section recording all of this.

## How did you test this code?

The new tables were built against published API references and **not** exercised against a live TikTok account. Treat the metric lists as doc-derived.

Checks I ran:

- `pytest .../sources/tiktok_ads/` - 165 passed, up from 138 on master. Every pre-existing test still passes.
- `pytest .../sources/tests/` - 3865 passed, covering the cross-source registry, category and version checks.
- `ruff check --fix` and `ruff format` over the source directory.
- `mypy --cache-fine-grained` over the source directory including tests - clean apart from the pre-existing `managed_migrations.py: Cannot determine type of "OBJECT_STORAGE_REGION"` that shows up whenever mypy is scoped to a subset.

New tests and the regression each catches:

- Two parameterized cases per breakdown table in `test_tiktok_ads_utils.py`. One pins the breakdown dimensions into the primary key: TikTok returns one row per (entity, day, dimension value), so dropping `gender` from the key would collapse them onto one row and make every merge multi-match. The other pins `report_type=AUDIENCE` and asserts the metric list carries none of the BASIC-only fields, which is the easy mistake here and takes the whole table down when made.
- `test_only_breakdown_reports_are_off_by_default` in `test_tiktok_ads_source.py` asserts through `get_schemas` that exactly the nine breakdowns are unticked. Guards against a future expensive table auto-enabling on existing connections, and against `should_sync_default` not being propagated.
- One case for `EndpointType.ASSET` in the transformation router: creative rows must pass through untouched, not pick up a fabricated `current_status`.
- Existing parameterized lists extended with the new endpoints rather than copied, so endpoint-type and source-response coverage grows without new test bodies.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No doc change needed. The source already sets `lists_tables_without_credentials`, so the Supported tables section on posthog.com renders from `get_schemas` and picks the new tables up automatically.
