### PR TITLE
feat(signals): bring back Review PR and Dismiss on inbox Slack cards

### DIFF
--- a/products/signals/backend/management/AGENTS.md
+++ b/products/signals/backend/management/AGENTS.md
@@ -38,7 +38,7 @@ python manage.py list_signal_reports --team-id 1 --signals --json
    - `pending_input` — needs human judgment before acting
    - `failed` — failed safety review (possible prompt injection)
    - `potential` (reset, weight zeroed) — deemed not actionable
-7. On reaching `ready`, the summary workflow starts `signal-report-inbox-notification` to post the Slack inbox notification. If the report auto-started an implementation task, that workflow waits for the PR to open (bounded by `SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS`) so the card can show a "Review PR" button; if that task never opens a PR (fails, is cancelled, or the wait times out) no notification is sent. Reports with no auto-start task notify immediately.
+7. On reaching `ready`, the summary workflow starts `signal-report-inbox-notification` to post the Slack inbox notification. If the report auto-started an implementation task, that workflow waits for the PR to open (bounded by `SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS`) so the card can show a "Review PR" button; if that task never opens a PR (fails, is cancelled, or the wait times out) the notification still goes out, just without that button. Reports with no auto-start task notify immediately.
 8. `ready` reports accumulate new signals silently. After enough new signals (`signal_count >= signals_at_run`), the report is re-promoted and the summary workflow runs again — reusing the previous repo selection and lightly validating previous findings instead of re-researching from scratch.
 
 Reports that aren't `ready` still appear in the output with their `error` field explaining why they were filtered, plus `artefacts` containing the full judge reasoning.

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -25,6 +25,7 @@ from posthog.models import User
 from posthog.models.integration import Integration, SlackIntegration
 
 from products.signals.backend.enums import SIGNAL_SOURCE_PRODUCT_LABELS
+from products.signals.backend.implementation_pr import fetch_implementation_pr_urls_for_reports
 from products.signals.backend.models import (
     AutonomyPriority,
     SignalReport,
@@ -62,6 +63,9 @@ _MAX_REVIEWER_MENTIONS = 5
 
 # Deep link opened by the PostHog Desktop app. Override via env for dev (`posthog-code-dev`).
 POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME = getattr(settings, "POSTHOG_CODE_INBOX_DEEP_LINK_SCHEME", "posthog-code")
+
+# Wire contract with products/slack_app/backend/api.py — keep this action_id in sync.
+SIGNALS_DISMISS_REPORT_ACTION_ID = "signals_dismiss_report"
 
 # Priority ranking — lower index is higher priority. Index used for threshold comparison.
 _PRIORITY_ORDER: tuple[str, ...] = (
@@ -315,6 +319,8 @@ def _build_message_blocks(
     source_products: list[str],
     reviewer_mentions: list[str],
     repository: str | None = None,
+    implementation_pr_url: str | None = None,
+    dismiss_button_value: str | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New report"
     header_text = (
@@ -362,13 +368,42 @@ def _build_message_blocks(
             }
         )
 
-    action_elements: list[dict] = [
+    action_elements: list[dict] = []
+    # Validated before it reaches Slack: a malformed URL fails the whole `chat_postMessage`, so a bad
+    # PR link would cost the notification rather than just its button.
+    if _is_safe_http_url(implementation_pr_url):
+        action_elements.append(
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Review PR", "emoji": True},
+                "url": implementation_pr_url,
+            }
+        )
+    action_elements.append(
         {
             "type": "button",
             "text": {"type": "plain_text", "text": "Review in PostHog", "emoji": True},
             "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
         }
-    ]
+    )
+    if dismiss_button_value:
+        action_elements.append(
+            {
+                "type": "button",
+                "action_id": SIGNALS_DISMISS_REPORT_ACTION_ID,
+                "text": {"type": "plain_text", "text": "Dismiss", "emoji": True},
+                "value": dismiss_button_value,
+                "confirm": {
+                    "title": {"type": "plain_text", "text": "Dismiss this report?"},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "This will dismiss the report for everyone. You can still find it in PostHog.",
+                    },
+                    "confirm": {"type": "plain_text", "text": "Dismiss"},
+                    "deny": {"type": "plain_text", "text": "Cancel"},
+                },
+            }
+        )
     blocks.append({"type": "actions", "elements": action_elements})
 
     priority_suffix = f" ({priority})" if priority else ""
@@ -592,6 +627,7 @@ def _deliver_route_notification(
     priority: str | None,
     source_products: list[str],
     repository: str | None,
+    implementation_pr_url: str | None = None,
     signals: list[dict] | None = None,
 ) -> bool:
     """Post one report notification to a route's channel (with optional evidence thread).
@@ -609,12 +645,23 @@ def _deliver_route_notification(
     try:
         slack = SlackIntegration(route.integration)
         mentions = _resolve_reviewer_mentions(slack, route.users)
+        # The Dismiss handler in slack_app can't infer the destination from the interaction payload,
+        # so the button carries the routing ids it needs to act on the right report.
+        dismiss_button_value = json.dumps(
+            {
+                "integration_id": route.integration.id,
+                "report_id": str(report.id),
+                "team_id": report.team_id,
+            }
+        )
         blocks, text = _build_message_blocks(
             report,
             priority=priority,
             source_products=source_products,
             reviewer_mentions=mentions,
             repository=repository,
+            implementation_pr_url=implementation_pr_url,
+            dismiss_button_value=dismiss_button_value,
         )
         response = slack.client.chat_postMessage(channel=channel_id, blocks=blocks, text=text)
         thread_ts = response.get("ts") if hasattr(response, "get") else None
@@ -689,6 +736,7 @@ def dispatch_inbox_item_notifications(
 
     sources = source_products or []
     repository = _report_repository(report)
+    implementation_pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
 
     sent = 0
     for route in routes:
@@ -698,6 +746,7 @@ def dispatch_inbox_item_notifications(
             priority=priority,
             source_products=sources,
             repository=repository,
+            implementation_pr_url=implementation_pr_url,
             signals=signals,
         ):
             sent += 1
@@ -791,6 +840,7 @@ def dispatch_reviewer_added_notifications(
 
     sources = source_products or []
     repository = _report_repository(report)
+    implementation_pr_url = fetch_implementation_pr_urls_for_reports([str(report.id)]).get(str(report.id))
 
     sent = 0
     for route in routes.values():
@@ -800,6 +850,7 @@ def dispatch_reviewer_added_notifications(
             priority=priority,
             source_products=sources,
             repository=repository,
+            implementation_pr_url=implementation_pr_url,
         ):
             sent += 1
     logger.info(

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.apps import apps
 from django.conf import settings
 
 from social_django.models import UserSocialAuth
@@ -31,6 +32,7 @@ from products.signals.backend.slack_inbox_notifications import (
     dispatch_inbox_item_notifications,
     dispatch_reviewer_added_notifications,
 )
+from products.signals.backend.task_run_artefacts import record_implementation_task
 from products.signals.backend.tasks import send_reviewer_added_slack_notifications
 
 from ee.models.rbac.access_control import AccessControl
@@ -116,6 +118,50 @@ def test_build_message_blocks_includes_recipient_and_open_in_posthog_button() ->
     assert buttons[0]["text"]["text"] == "Review in PostHog"
     assert buttons[0]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
     assert text == "Report (P1): Checkout errors spiked"
+
+
+def test_build_message_blocks_orders_pr_posthog_and_dismiss_buttons() -> None:
+    report = SignalReport(id="report-uuid", team_id=42, title="Checkout errors spiked")
+    dismiss_value = '{"integration_id": 2, "report_id": "report-uuid", "team_id": 42}'
+    blocks, _ = _build_message_blocks(
+        report,
+        priority="P1",
+        source_products=["error_tracking"],
+        reviewer_mentions=["<@U123>"],
+        implementation_pr_url="https://github.com/org/repo/pull/42",
+        dismiss_button_value=dismiss_value,
+    )
+
+    buttons = blocks[3]["elements"]
+    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Review in PostHog", "Dismiss"]
+    assert buttons[0]["url"] == "https://github.com/org/repo/pull/42"
+    assert buttons[1]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
+    dismiss = buttons[-1]
+    # action_id is the wire contract with the handler in products/slack_app/backend/api.py.
+    assert dismiss["action_id"] == "signals_dismiss_report"
+    assert dismiss["value"] == dismiss_value
+    assert "url" not in dismiss
+    assert dismiss["confirm"]["confirm"]["text"] == "Dismiss"
+    assert dismiss["confirm"]["deny"]["text"] == "Cancel"
+
+
+@pytest.mark.parametrize(
+    "pr_url",
+    [None, "", "javascript:alert(1)", "https://github.com/org/repo/pull/1|evil"],
+)
+def test_build_message_blocks_omits_pr_button_for_missing_or_unsafe_url(pr_url: str | None) -> None:
+    # An unusable URL must cost only the button — Slack rejects the whole chat_postMessage otherwise.
+    report = SignalReport(id="report-uuid", team_id=42, title="No PR yet")
+    blocks, _ = _build_message_blocks(
+        report,
+        priority=None,
+        source_products=[],
+        reviewer_mentions=[],
+        implementation_pr_url=pr_url,
+    )
+
+    buttons = next(block for block in blocks if block["type"] == "actions")["elements"]
+    assert [b["text"]["text"] for b in buttons] == ["Review in PostHog"]
 
 
 def test_build_message_blocks_mentions_every_routed_reviewer() -> None:
@@ -287,6 +333,33 @@ def _make_ready_report(
             content=json.dumps([{"github_login": login} for login in suggested_logins]),
         )
     return report
+
+
+def _create_implementation_task_with_run(
+    team: Team,
+    report: SignalReport,
+    *,
+    pr_url: str | None = None,
+) -> None:
+    Task = apps.get_model("tasks", "Task")
+    TaskRun = apps.get_model("tasks", "TaskRun")
+    task = Task.objects.create(
+        team=team,
+        title="Implementation task",
+        description="Fix the bug",
+        origin_product=Task.OriginProduct.SIGNAL_REPORT,
+    )
+    record_implementation_task(
+        team_id=team.id,
+        report_id=str(report.id),
+        task_id=str(task.id),
+    )
+    TaskRun.objects.create(
+        team=team,
+        task=task,
+        status=TaskRun.Status.COMPLETED,
+        output={"pr_url": pr_url},
+    )
 
 
 @pytest.mark.django_db
@@ -604,6 +677,41 @@ def test_dispatch_includes_repository_from_repo_selection_artefact(org_and_team)
     assert sent == 1
     blocks = fake_client.chat_postMessage.call_args.kwargs["blocks"]
     assert "PostHog/posthog" in blocks[1]["text"]["text"]
+
+
+@pytest.mark.django_db
+def test_dispatch_links_pr_of_implementation_task_and_routes_dismiss(org_and_team):
+    org, team = org_and_team
+    user = _make_reviewer_user(org, "reviewer-pr@example.com", "pr-bot")
+    integration = _make_slack_integration(team, user)
+    SignalUserAutonomyConfig.objects.create(
+        user=user,
+        slack_notification_integration=integration,
+        slack_notification_channel="C123|#inbox",
+    )
+    report = _make_ready_report(team, priority=AutonomyPriority.P1, suggested_logins=["pr-bot"])
+    _create_implementation_task_with_run(team, report, pr_url="https://github.com/org/repo/pull/99")
+
+    fake_client = MagicMock()
+    with (
+        patch("products.signals.backend.slack_inbox_notifications.SlackIntegration") as slack_cls,
+        patch(
+            "products.signals.backend.slack_inbox_notifications.lookup_slack_user_id_by_email",
+            return_value=None,
+        ),
+    ):
+        slack_cls.return_value.client = fake_client
+        sent = dispatch_inbox_item_notifications(str(report.id), team.id)
+
+    assert sent == 1
+    buttons = fake_client.chat_postMessage.call_args.kwargs["blocks"][3]["elements"]
+    assert [b["text"]["text"] for b in buttons] == ["Review PR", "Review in PostHog", "Dismiss"]
+    assert buttons[0]["url"] == "https://github.com/org/repo/pull/99"
+    assert json.loads(buttons[-1]["value"]) == {
+        "integration_id": integration.id,
+        "report_id": str(report.id),
+        "team_id": team.id,
+    }
 
 
 @pytest.mark.django_db

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -3606,7 +3606,7 @@ def _handle_channel_approval_deny(payload: dict) -> HttpResponse:
     return HttpResponse(status=200)
 
 
-# Handles the Dismiss button on inbox notifications delivered before that button was removed.
+# Wire contract with products/signals/backend/slack_inbox_notifications.py (SIGNALS_DISMISS_REPORT_ACTION_ID).
 SIGNALS_DISMISS_REPORT_ACTION_ID = "signals_dismiss_report"
 
 
@@ -3720,11 +3720,9 @@ def _post_signals_dismiss_feedback(payload: dict, *, dismissed: bool, slack_user
     else:
         text = "This report could not be dismissed — it may already be resolved or removed."
 
-    # keep_link_buttons=False: historical dismiss-capable messages carried "Review PR"/"Open in
-    # PostHog" link buttons in the same actions block as Dismiss (see the pre-removal
-    # slack_inbox_notifications.py block construction), so dropping the whole block here matches
-    # existing behavior rather than the default.
-    _replace_message_stripping_actions(payload, text, keep_link_buttons=False)
+    # A dismissed report is still worth opening, so the default keeps the "Review PR" and "Review in
+    # PostHog" links and only Dismiss itself is replaced by the context line.
+    _replace_message_stripping_actions(payload, text)
 
 
 # Snoozes an insight alert from the button on its firing Slack message.


### PR DESCRIPTION
## Problem

Inbox report notifications in Slack lost their "Review PR" button. When a report's implementation task has already opened a pull request, there was no way to get to that PR from the Slack card - you had to open the report in PostHog first and find it there. The "Dismiss" action was gone too, so triaging a report from Slack meant leaving Slack.

Both were removed in #71136 to cut the card down to a single action. In practice the PR link is the most useful thing on the card: it is the whole point of the notification workflow waiting for the PR to open before it posts.

## Changes

- "Review PR" is back as the first button, shown when the report has an implementation PR, followed by "Review in PostHog" and then "Dismiss".
- The PR URL is validated with the existing `is_safe_slack_http_url` guard before it becomes a button. Slack rejects an entire `chat_postMessage` on a malformed URL, so without the check one bad PR link would cost the whole notification instead of just its button. This mirrors the `safeHttpUrl` guard the web inbox card already applies to the same field.
- Both dispatchers resolve the PR (report-ready and reviewer-added), so a reviewer added to a report after the fact gets the same card.
- Dismissing a report now keeps the link buttons and replaces only the Dismiss action, rather than stripping the whole actions block. A dismissed report is still worth opening.
- Corrected a line in the signals management doc that claimed no notification is sent when the implementation task never opens a PR. That stopped being true a while back - the notification goes out either way, just without the button.

## How did you test this code?

I (Claude, via the PostHog Slack app) ran these locally. No manual Slack testing - I did not post a real message to a workspace.

- `products/signals/backend/test/test_slack_inbox_notifications.py` - 80 passed
- `products/slack_app/backend/tests/test_posthog_code_interactivity.py` - 61 passed
- `uv run mypy --cache-fine-grained .` - clean across 17,540 files
- `hogli ci:preflight --strict` - clean

Three groups of tests, and what each catches that nothing else did:

- `test_build_message_blocks_orders_pr_posthog_and_dismiss_buttons` - the button set and order, plus the Dismiss `action_id` and payload. The `action_id` is a wire contract with the handler in `slack_app`; nothing else pinned it from the sending side, so a rename on either end would have shipped a dead button.
- `test_build_message_blocks_omits_pr_button_for_missing_or_unsafe_url` - parameterized over missing, empty, `javascript:`, and pipe-bearing URLs. Guards the fail-soft behavior: an unusable URL must cost the button, not the notification.
- `test_dispatch_links_pr_of_implementation_task_and_routes_dismiss` - the end-to-end wiring from an implementation task run's `pr_url` through to the posted button, and that Dismiss carries the routing ids. This is the regression that prompted the PR: the button-building code can be correct while nothing feeds it a PR URL.

The environment had no dev stack (no docker), so to run the DB-backed tests I stood up a local Postgres 16 and temporarily overrode `django_db_setup` to skip the ClickHouse and persons-DB setup these tests do not touch. Both overrides are reverted and not in the diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Doc change is in this PR (`products/signals/backend/management/AGENTS.md`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Josh asked why reports arriving in a Slack channel had no "Review PR" button when there used to be one. I traced it to #71136, which intentionally simplified the card to one button, and reported that back; the follow-up was to restore them.

Two leftovers from that removal made this look like a bug rather than a decision, and both are worth knowing when reviewing. The notification workflow still waits (up to `SIGNALS_INBOX_PR_NOTIFICATION_TIMEOUT_SECONDS`) for the implementation PR to open before posting, which only ever existed to get the link onto the card - so for the last while that wait bought nothing. Restoring the button makes it meaningful again. The alternative was to drop the wait and notify immediately; I did not take it, since the PR link is what was asked for, but it is a real option if we ever remove the button again.

I also restored Dismiss, reading "those buttons" as the pair that #71136 removed. Its handler in `slack_app` was left intact at the time, so this is only the sending side. Say the word if you want Dismiss left off and I will drop it.

Skills invoked: `/writing-tests` (before touching the test file), plus the repo conventions in CLAUDE.md for commits and PR shape. Tools: Read/Edit/Grep/Bash, `gh` for the history archaeology on #71136.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1785841046600289)*
