### PR TITLE
fix(notebooks): order sql node refs before the ctes that read them

### DIFF
--- a/products/notebooks/backend/sql_v2_references.py
+++ b/products/notebooks/backend/sql_v2_references.py
@@ -78,7 +78,7 @@ class _TableReferenceCollector(TraversingVisitor):
         super().visit_join_expr(node)
 
 
-def _references(query: ast.SelectQuery | ast.SelectSetQuery, candidates: set[str]) -> set[str]:
+def _references(query: ast.Expr, candidates: set[str]) -> set[str]:
     collector = _TableReferenceCollector(candidates)
     collector.visit(query)
     # A name the query defines as its own CTE shadows the ref — don't pull it in.
@@ -152,11 +152,33 @@ def resolve_sql_v2_references(code: str, refs: dict[str, str | None]) -> str:
     root = main if isinstance(main, ast.SelectQuery) else parse_select(f"select * from ({code}\n)")
     if not isinstance(root, ast.SelectQuery):  # narrow for the type checker; the wrap is always a SelectQuery
         return code
-    ctes: dict[str, ast.CTE] = dict(root.ctes or {})
-    for name in order:
-        # setdefault so the user's own CTE of the same name always wins over a node ref.
-        ctes.setdefault(name, ast.CTE(name=name, expr=parse_ref(name), cte_type="subquery"))
-    root.ctes = ctes
+    user_ctes: dict[str, ast.CTE] = dict(root.ctes or {})
+    # The user's own CTE of the same name always wins over a node ref.
+    injected = {
+        name: ast.CTE(name=name, expr=parse_ref(name), cte_type="subquery") for name in order if name not in user_ctes
+    }
+
+    # A CTE must be printed before every CTE that reads it, and the user's own WITH clauses
+    # can read node refs just as node definitions can read a shadowing user CTE. So the two
+    # sides get merged in one dependency order rather than concatenated — appending the refs
+    # after a `with … as (select … from df1)` leaves df1 an unknown table.
+    all_names = set(injected) | set(user_ctes)
+    merged: dict[str, ast.CTE] = {}
+    emitting: set[str] = set()
+
+    def emit(name: str) -> None:
+        if name in merged or name in emitting:  # already placed, or a cycle — let HogQL report it
+            return
+        emitting.add(name)
+        cte = injected.get(name) or user_ctes[name]
+        for dependency in sorted(_references(cte.expr, all_names)):
+            emit(dependency)
+        emitting.discard(name)
+        merged[name] = cte
+
+    for name in [*injected, *user_ctes]:
+        emit(name)
+    root.ctes = merged
 
     return print_prepared_ast(root, context=HogQLContext(team_id=None), dialect="hogql")
 

--- a/products/notebooks/backend/sql_v2_references.py
+++ b/products/notebooks/backend/sql_v2_references.py
@@ -58,16 +58,20 @@ class SQLV2Ref:
     last_run_code: str | None = None
 
 
-class _TableReferenceCollector(TraversingVisitor):
+class _ReferenceCollector(TraversingVisitor):
+    """Base for the two scans below: both gather the names of `candidates` a query reaches."""
+
+    def __init__(self, candidates: set[str]) -> None:
+        self.candidates = candidates
+        self.found: set[str] = set()
+
+
+class _TableReferenceCollector(_ReferenceCollector):
     """Collect the FROM/JOIN targets of a query that name one of `candidates`.
 
     Only bare single-identifier tables count — ``from df1`` matches, a column called
     ``df1`` does not — so a reference is a genuine table position, not any mention.
     """
-
-    def __init__(self, candidates: set[str]) -> None:
-        self.candidates = candidates
-        self.found: set[str] = set()
 
     def visit_join_expr(self, node: ast.JoinExpr) -> None:
         table = node.table
@@ -78,12 +82,36 @@ class _TableReferenceCollector(TraversingVisitor):
         super().visit_join_expr(node)
 
 
-def _references(query: ast.Expr, candidates: set[str]) -> set[str]:
-    collector = _TableReferenceCollector(candidates)
+class _NameReferenceCollector(_ReferenceCollector):
+    """Collect every bare identifier naming one of `candidates`, in any position.
+
+    A superset of `_TableReferenceCollector`: a scalar CTE (``with 5 as cutoff``) is read as a
+    column, not a table, so FROM/JOIN positions alone can't see that dependency. Only safe for
+    ordering an already-chosen set of CTEs — never for deciding what to inline, where a column
+    that merely shares a node's name must not pull that node in.
+    """
+
+    def visit_field(self, node: ast.Field) -> None:
+        if len(node.chain) == 1 and node.chain[0] in self.candidates:
+            name = node.chain[0]
+            if isinstance(name, str):
+                self.found.add(name)
+        super().visit_field(node)
+
+
+def _collect(collector: _ReferenceCollector, query: ast.Expr) -> set[str]:
     collector.visit(query)
     # A name the query defines as its own CTE shadows the ref — don't pull it in.
     own_ctes = set(query.ctes.keys()) if isinstance(query, ast.SelectQuery) and query.ctes else set()
     return collector.found - own_ctes
+
+
+def _references(query: ast.Expr, candidates: set[str]) -> set[str]:
+    return _collect(_TableReferenceCollector(candidates), query)
+
+
+def _ordering_dependencies(query: ast.Expr, candidates: set[str]) -> set[str]:
+    return _collect(_NameReferenceCollector(candidates), query)
 
 
 def resolve_sql_v2_references(code: str, refs: dict[str, str | None]) -> str:
@@ -167,11 +195,21 @@ def resolve_sql_v2_references(code: str, refs: dict[str, str | None]) -> str:
     emitting: set[str] = set()
 
     def emit(name: str) -> None:
-        if name in merged or name in emitting:  # already placed, or a cycle — let HogQL report it
+        if name in merged or name in emitting:
             return
         emitting.add(name)
         cte = injected.get(name) or user_ctes[name]
-        for dependency in sorted(_references(cte.expr, all_names)):
+        # Ordering has to see expression-position reads too: an inlined definition reading the
+        # user's `with 5 as cutoff` depends on it even though no FROM/JOIN names it.
+        table_dependencies = _references(cte.expr, all_names)
+        for dependency in sorted(_ordering_dependencies(cte.expr, all_names) - {name}):
+            # The node-ref cycle check above only walks node names, so a cycle running through
+            # one of the user's own CTEs reaches here instead. No ordering satisfies it, so fail
+            # with a 400 rather than dispatch a query that can't resolve. Only a real table
+            # position counts: the broader scan above also matches columns, where a name shared
+            # with a CTE is not a dependency at all.
+            if dependency in emitting and dependency in table_dependencies:
+                raise SQLV2ReferenceError(f"Reference cycle through '{dependency}'.")
             emit(dependency)
         emitting.discard(name)
         merged[name] = cte

--- a/products/notebooks/backend/test/test_sql_v2_references.py
+++ b/products/notebooks/backend/test/test_sql_v2_references.py
@@ -1,5 +1,7 @@
 from django.test import SimpleTestCase
 
+from parameterized import parameterized
+
 from products.notebooks.backend.sql_v2_references import (
     SQLV2Ref,
     SQLV2ReferenceError,
@@ -171,6 +173,23 @@ class TestResolveSQLV2References(SimpleTestCase):
         )
         self.assertIn("mine AS", resolved)
         self.assertIn("df1 AS", resolved)
+
+    @parameterized.expand(
+        [
+            # The user's own WITH reads a node frame, so the injected CTE has to precede it.
+            ("user_cte_reads_a_ref", "with mine as (select id from df1) select * from mine", "df1 AS", "mine AS"),
+            # And the reverse: the node's definition reads a name the user's WITH shadows.
+            ("ref_reads_a_shadowed_cte", "with df1 as (select 5 as id) select * from df2", "df1 AS", "df2 AS"),
+        ]
+    )
+    def test_ctes_are_merged_in_dependency_order(self, _name, code, first, second):
+        # Whichever side a CTE comes from, it must be printed before the one that reads it —
+        # appending the refs after the user's WITH leaves them unknown tables.
+        resolved = resolve_sql_v2_references(
+            code,
+            {"df1": "select uuid as id from events", "df2": "select id from df1 where id > 0"},
+        )
+        self.assertLess(resolved.index(first), resolved.index(second))
 
     def test_union_query_with_a_trailing_line_comment_still_resolves(self):
         # The UNION wrap embeds the raw text in `select * from (…)`; without a newline before

--- a/products/notebooks/backend/test/test_sql_v2_references.py
+++ b/products/notebooks/backend/test/test_sql_v2_references.py
@@ -1,6 +1,12 @@
+from posthog.test.base import BaseTest
+
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
 
 from products.notebooks.backend.sql_v2_references import (
     SQLV2Ref,
@@ -180,6 +186,8 @@ class TestResolveSQLV2References(SimpleTestCase):
             ("user_cte_reads_a_ref", "with mine as (select id from df1) select * from mine", "df1 AS", "mine AS"),
             # And the reverse: the node's definition reads a name the user's WITH shadows.
             ("ref_reads_a_shadowed_cte", "with df1 as (select 5 as id) select * from df2", "df1 AS", "df2 AS"),
+            # A scalar CTE is read as a column, so this dependency appears in no FROM/JOIN at all.
+            ("ref_reads_a_scalar_cte", "with 5 as cutoff select id from df3", "5 AS cutoff", "df3 AS"),
         ]
     )
     def test_ctes_are_merged_in_dependency_order(self, _name, code, first, second):
@@ -187,9 +195,28 @@ class TestResolveSQLV2References(SimpleTestCase):
         # appending the refs after the user's WITH leaves them unknown tables.
         resolved = resolve_sql_v2_references(
             code,
-            {"df1": "select uuid as id from events", "df2": "select id from df1 where id > 0"},
+            {
+                "df1": "select uuid as id from events",
+                "df2": "select id from df1 where id > 0",
+                "df3": "select uuid as id from events where 1 > cutoff",
+            },
         )
         self.assertLess(resolved.index(first), resolved.index(second))
+
+    @parameterized.expand(
+        [
+            ("subquery_in_from", "select id from (select id from df1)"),
+            ("subquery_in_where", "select uuid from events where uuid in (select id from df1)"),
+            ("scalar_subquery_in_select_list", "select (select count() from df1) as c"),
+            ("union_inside_a_user_cte", "with u as (select id from df1 union all select 1 as id) select id from u"),
+        ]
+    )
+    def test_refs_nested_below_the_top_level_are_still_inlined(self, _name, code):
+        # Every other case here reads the ref from a top-level FROM/JOIN, so a collector that
+        # stopped descending into subqueries would still pass them while silently dropping the
+        # CTE — the query then fails in ClickHouse with an unknown table.
+        resolved = resolve_sql_v2_references(code, {"df1": "select uuid as id from events"})
+        self.assertIn("df1 AS (", resolved)
 
     def test_union_query_with_a_trailing_line_comment_still_resolves(self):
         # The UNION wrap embeds the raw text in `select * from (…)`; without a newline before
@@ -217,6 +244,25 @@ class TestResolveSQLV2References(SimpleTestCase):
                 {"a": "select * from b", "b": "select * from a"},
             )
 
+    def test_cycle_through_a_user_cte_raises(self):
+        # The cycle check above only walks node names, so a cycle closed by the user's own CTE
+        # reaches the merge instead. Naming a CTE after a table the node reads is an easy
+        # collision to hit, and it must fail here as a 400 rather than as a ClickHouse error.
+        with self.assertRaises(SQLV2ReferenceError):
+            resolve_sql_v2_references(
+                "with events as (select * from df1) select * from df1",
+                {"df1": "select * from events"},
+            )
+
+    def test_columns_sharing_a_cte_name_are_not_a_cycle(self):
+        # Ordering scans every identifier, not just table positions, so two CTEs selecting a
+        # column named after each other look circular. They aren't, and must still resolve.
+        resolved = resolve_sql_v2_references(
+            "with a as (select b from df1), b as (select a from df1) select * from a",
+            {"df1": "select uuid as a, uuid as b from events"},
+        )
+        self.assertIn("df1 AS (", resolved)
+
     def test_invalid_referenced_definition_raises(self):
         with self.assertRaises(SQLV2ReferenceError):
             resolve_sql_v2_references("select * from df1", {"df1": "select from where ("})
@@ -229,3 +275,33 @@ class TestResolveSQLV2References(SimpleTestCase):
     def test_unreferenced_never_run_node_is_ignored(self):
         # A never-run node nobody references must not block the run.
         self.assertEqual(resolve_sql_v2_references("select 1", {"df1": None}), "select 1")
+
+
+class TestResolvedQueryIsValidHogQL(BaseTest):
+    # Every other assertion in this file matches a substring of the resolved SQL, which cannot see
+    # a query that is well-formed but unresolvable: the CTE-ordering bug emitted a perfectly good
+    # `df1 AS (…)` *after* the CTE reading it, so every substring check passed while ClickHouse
+    # rejected the query. Resolving it for real is the only assertion that catches that class.
+    @parameterized.expand(
+        [
+            ("user_cte_reads_a_ref", "with mine as (select id from df1) select id from mine"),
+            ("ref_reads_a_shadowed_cte", "with df1 as (select 5 as id) select id from df2"),
+            (
+                "chained_user_ctes_over_a_ref",
+                "with a as (select id from df1), b as (select id from a) select id from b",
+            ),
+            ("nested_subquery", "select id from (select id from df1)"),
+            ("ref_reads_a_scalar_cte", "with 5 as cutoff select id from df3"),
+        ]
+    )
+    def test_resolved_query_typechecks(self, _name, code):
+        resolved = resolve_sql_v2_references(
+            code,
+            {
+                "df1": "select uuid as id from events",
+                "df2": "select id from df1 where id > 0",
+                "df3": "select uuid as id from events where 1 > cutoff",
+            },
+        )
+        context = HogQLContext(team_id=self.team.pk, team=self.team, enable_select_queries=True)
+        prepare_and_print_ast(parse_select(resolved), context=context, dialect="clickhouse")


### PR DESCRIPTION
## Problem

```sql
WITH top_events      AS (SELECT event FROM event_breakdown ...),  -- reads it
     shares          AS (... FROM event_breakdown b ...),         -- reads it
     event_breakdown AS (...),                                    -- declared here, too late
     person_activity AS (...)
SELECT ...
```
Queries like above weren't able to resolve the dataframe successfully (`event_breakdown`).

A SQLV2 node is a query definition, not a materialized table. When another node references it, the backend inlines the upstream definition as a CTE and recomputes in ClickHouse. Those injected CTEs were appended *after* the query's own `WITH` clauses, which produces a forward reference:

HogQL resolves CTEs in declaration order, so `top_events` cannot see `event_breakdown`.
The module docstring already promised dependency ordering, but that only held among injected refs, never across the user's own `WITH`.

> [!NOTE]
> Workaround until this ships: move the CTEs into `FROM`-position subqueries.
> The injected refs land at the top level, where subqueries can see them.

## Changes

Merge the user's CTEs and the injected node refs into one dependency order instead of concatenating them.

The dependency can point either way, which is why simply flipping the order does not work:

- a user CTE can read a node ref (the bug above)
- a node definition can read a name the user's `WITH` shadows (existing behavior, where the user's CTE wins)

So the merge walks both sides as a single graph and emits each CTE after everything it reads.

Two follow-ups from review, both in `f41f878`:

**Ordering counts expression reads, not just `FROM`/`JOIN`.**
An inlined definition reading the query's own scalar CTE (`with 5 as cutoff`) reads it as a column, so the table-position scan saw no dependency and emitted the definition first.
Ordering now uses a wider scan over any bare identifier.
That scan over-approximates by design, so it stays out of the decision about *which* refs to inline, where a column merely sharing a node's name must not pull that node in.

**A cycle closed through a user CTE now raises instead of being silently broken.**
The pre-existing cycle check only walks node names, so `with events as (select * from df1) select * from df1` against `df1 = select * from events` never reached it.
It now raises `SQLV2ReferenceError`, so the endpoint returns a 400 rather than dispatching a query that cannot resolve.
Only a back edge through a real table position counts, so the wider ordering scan cannot turn two CTEs selecting columns named after each other into a false cycle.

No API or schema change.
This only affects the ClickHouse lane: queries referencing a Python-created frame route to DuckDB, where refs are materialized as real tables and no CTE injection happens.

## How did you test this code?

I (actually Claude) did all verification locally.
No manual testing in a running app and no ClickHouse execution, since the failure is in query construction and reproduces at the resolver and printer level.

Reproduced the bug first, then confirmed the fix.
I ran the reported query through `resolve_sql_v2_references` and printed the result with the HogQL printer against real team schema.
Before, it failed with `QueryError: Unknown table event_breakdown`.
After, it resolves to `event_breakdown, person_activity, top_events, shares` and typechecks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs affected. The behavior here was already documented in the module docstring, which this change makes true.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) diagnosed and fixed this after I hit the error while dogfooding v2 notebooks.
Skills invoked: `/writing-tests` before adding the regression tests.

Diagnosis path worth knowing about: the error string traces to HogQL's resolver, which proved the query had been routed to ClickHouse with the ref never inlined, rather than failing at routing.
The first hypothesis was that the reference collector does not descend into CTEs. That turned out to be false, since `TraversingVisitor` does visit `node.ctes`. Ordering was the real cause.

The one-line fix of emitting injected refs before the user's CTEs was tried and rejected.
It fixes the reported case but breaks the shadowing case, where a node definition reads a name the user's `WITH` overrides.
The topological merge handles both directions.

Both review findings were reproduced before being accepted, and both are answered inline.
The scalar-CTE one was a genuine regression from the first commit.
The cycle one was not a regression (master produces the same broken query) but the fix is still right, and it correctly caught that a comment I wrote rested on a false premise: `print_prepared_ast` does not resolve names, so nothing was going to report that error at dispatch.
I did not take the suggested cycle fix verbatim, since raising on every back edge would false-positive against the wider ordering scan added in the same commit.
