### PR TITLE
feat(signals): make the Self-driving switch stop signals and scouts

### DIFF
--- a/frontend/src/scenes/inbox/components/config/SelfDrivingSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/SelfDrivingSection.tsx
@@ -221,10 +221,11 @@ function BaseBranchOverrides(): JSX.Element {
 }
 
 /**
- * Team-wide PR-generation control, backed by `autostart_enabled` and `default_autostart_priority`
- * on `signalTeamConfigLogic`. The inline switch is the master opt-out for autonomous inbox PRs;
- * reports keep generating and notifying either way. The threshold is the team default; a teammate's
- * personal threshold takes precedence for reports suggesting them as reviewer.
+ * Team-wide Self-driving control, backed by `autostart_enabled` and `default_autostart_priority` on
+ * `signalTeamConfigLogic`. The inline switch turns the whole pipeline off, not just the PRs at the
+ * end of it: the backend drops the team's signals at emission and stops dispatching scheduled
+ * scouts, so no reports arrive either. The threshold is the team default; a teammate's personal
+ * threshold takes precedence for reports suggesting them as reviewer.
  *
  * A standalone card rather than a `SetupWidgetCard` because it hosts inline controls (the switch and
  * threshold) that can't live inside that card's single button/link wrapper.
@@ -246,15 +247,17 @@ export function SelfDrivingSection(): JSX.Element {
                 </span>
                 <div className="flex flex-col gap-0.5 min-w-0 flex-1">
                     <div className="flex items-center justify-between gap-2">
-                        <span className="text-[13px] font-semibold text-default">PR generation</span>
+                        <span className="text-[13px] font-semibold text-default">Self-driving</span>
                         <LemonSwitch
                             checked={autostartEnabled}
                             loading={teamConfigUpdating}
                             onChange={(enabled) => patchTeamConfig({ autostart_enabled: enabled })}
-                            aria-label="Generate PRs for actionable reports automatically"
+                            aria-label="Run Self-driving for this team"
                         />
                     </div>
-                    <p className="text-xs text-tertiary leading-snug mb-0">Agents open PRs for actionable reports.</p>
+                    <p className="text-xs text-tertiary leading-snug mb-0">
+                        Agents watch your product, write reports, and open PRs.
+                    </p>
                 </div>
             </div>
 
@@ -277,7 +280,8 @@ export function SelfDrivingSection(): JSX.Element {
                     </>
                 ) : (
                     <p className="text-xs text-secondary mb-0 px-2.5 py-1.5">
-                        Reports still arrive and notify your team.
+                        Nothing runs while this is off. Your scouts are paused and no new reports arrive. To keep the
+                        reports and get fewer PRs, switch this back on and raise the threshold.
                     </p>
                 )}
             </div>

--- a/frontend/src/scenes/inbox/logics/signalTeamConfigLogic.ts
+++ b/frontend/src/scenes/inbox/logics/signalTeamConfigLogic.ts
@@ -213,8 +213,8 @@ export const signalTeamConfigLogic = kea<signalTeamConfigLogicType>([
         ],
     }),
     selectors({
-        // Master switch for autonomous inbox PRs: only an explicit false disables
-        // auto-start, so a team that never touched the setting stays on.
+        // Master switch for Self-driving as a whole (signals, scouts, reports and the PRs at the end
+        // of it): only an explicit false switches it off, so a team that never touched it stays on.
         autostartEnabled: [
             (s) => [s.teamConfig],
             (teamConfig: SignalTeamConfig | null): boolean => teamConfig?.autostart_enabled !== false,

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -257,9 +257,9 @@ export interface SignalUserAutonomyConfig {
 
 export interface SignalTeamConfig {
     id?: string
-    /** Master switch for autonomous inbox PRs. Only an explicit false disables auto-start; null (never set) leaves it on. */
+    /** Master switch for Self-driving as a whole: with an explicit false the pipeline consumes no signals and runs no scouts, so no reports or PRs are produced. Null (never set) leaves it on. */
     autostart_enabled?: boolean | null
-    /** Team-wide default PR auto-start threshold (P0–P4, non-null from the API). "Never" is expressed via autostart_enabled instead. */
+    /** Team-wide default PR auto-start threshold (P0–P4, non-null from the API). There is no "never" threshold; switching Self-driving off via autostart_enabled is the way to stop PRs. */
     default_autostart_priority: SignalReportPriority | null
     /** Default Slack channel for this team's inbox notifications. */
     default_slack_notification_channel?: string | null

--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -478,6 +478,7 @@ Per-team singleton config for Signals settings, including the default autonomy p
 | ---------------------------- | --------------- | ---------------------------------------------------------------------------- |
 | `id`                         | UUID (PK)       | Primary key (UUIDModel)                                                      |
 | `team`                       | OneToOne → Team | Owning team (`related_name="signal_team_config"`)                            |
+| `autostart_enabled`          | BooleanField    | Master switch for Self-driving (nullable; only an explicit `False` is off)    |
 | `default_autostart_priority` | CharField       | Default severity threshold for auto-start (`P0`–`P4`, where `P0` is highest) |
 | `created_at`                 | DateTime        | Auto-set on creation                                                         |
 | `updated_at`                 | DateTime        | Auto-set on save                                                             |
@@ -487,6 +488,12 @@ Notes:
 - Auto-created as a team extension via `register_team_extension_signal`
 - `default_autostart_priority` defaults to `P4` (every report priority auto-starts). The threshold is no longer user-configurable in the inbox UI; everyone runs on this default.
 - `SignalUserAutonomyConfig.autostart_priority` can still hold a per-user override at the data layer (`null` = use the team default), but there is no UI to set it.
+- `autostart_enabled` is the whole product's master switch, surfaced as the inbox's **Self-driving** toggle, not a PR-only opt-out. `False` means the team consumes no signals and runs no scheduled scouts, so no reports are generated either. Read through `SignalTeamConfig.is_self_driving_enabled(team_id)` (fail-open: no row, or a null value, is on) and enforced in five places:
+  - `facade/api.py:emit_signal` — the funnel every signal passes through, so it covers the paths with no gate of their own (error-tracking backfill, eval signals, reingestion)
+  - `emission/gate.py:emit_signals_enabled` — stops the data-import pipeline from spawning the emission child workflow, whose LLM summarization/actionability passes would otherwise run first
+  - `emission/conversations_coordinator.py` — excludes the team from the hourly conversations fan-out
+  - `temporal/agentic/scout_coordinator.py:_participating_teams` — drops the team from tick planning (via `self_driving_disabled_team_ids`, folded into the enrollment skip set), so no scout child workflow, tick budget, or breaker recovery probe
+  - `scout_harness/views.py:_reject_if_manual_run_suppressed` — 403s a manual scout trigger, whose findings the emit gate would drop anyway (surfaced to an in-flight scout as the `self_driving_disabled` emit skip reason)
 
 ### `SignalUserAutonomyConfig`
 
@@ -813,7 +820,7 @@ Team-scoped singleton config for the default autonomy priority threshold. Uses `
 | Method | Path              | Description                            |
 | ------ | ----------------- | -------------------------------------- |
 | GET    | `signals/config/` | Retrieve the team's `SignalTeamConfig` |
-| POST   | `signals/config/` | Update `default_autostart_priority`    |
+| POST   | `signals/config/` | Update `autostart_enabled` / `default_autostart_priority` |
 
 #### User Autonomy Config (action on `UserViewSet`)
 
@@ -1078,7 +1085,7 @@ The autonomy system allows Signals to automatically start a Tasks coding run whe
 
 Autonomy is configured at two levels:
 
-1. **Team level** (`SignalTeamConfig`): Sets the `default_autostart_priority` threshold (`P0`–`P4`). Auto-created as a team extension via `register_team_extension_signal`. Managed via `GET/POST /api/projects/:team_id/signals/config/`.
+1. **Team level** (`SignalTeamConfig`): Sets the `default_autostart_priority` threshold (`P0`–`P4`), and `autostart_enabled`, the master switch for Self-driving as a whole (see the model's notes above — `False` also stops signal consumption and scout runs, so it is not a PR-only opt-out). Auto-created as a team extension via `register_team_extension_signal`. Managed via `GET/POST /api/projects/:team_id/signals/config/`.
 
 2. **User level** (`SignalUserAutonomyConfig`): Per-user opt-in. A row existing means the user is opted in. Each user can optionally override the team priority threshold with `autostart_priority`. Managed via `GET/PUT/DELETE /api/users/@me/signal_autonomy/`.
 

--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -478,7 +478,7 @@ Per-team singleton config for Signals settings, including the default autonomy p
 | ---------------------------- | --------------- | ---------------------------------------------------------------------------- |
 | `id`                         | UUID (PK)       | Primary key (UUIDModel)                                                      |
 | `team`                       | OneToOne → Team | Owning team (`related_name="signal_team_config"`)                            |
-| `autostart_enabled`          | BooleanField    | Master switch for Self-driving (nullable; only an explicit `False` is off)    |
+| `autostart_enabled`          | BooleanField    | Master switch for Self-driving (nullable; only an explicit `False` is off)   |
 | `default_autostart_priority` | CharField       | Default severity threshold for auto-start (`P0`–`P4`, where `P0` is highest) |
 | `created_at`                 | DateTime        | Auto-set on creation                                                         |
 | `updated_at`                 | DateTime        | Auto-set on save                                                             |
@@ -817,9 +817,9 @@ Important side effects:
 
 Team-scoped singleton config for the default autonomy priority threshold. Uses `IsAuthenticated` + `APIScopePermission` (scope: `task`). Returns 404 if no config exists for the team.
 
-| Method | Path              | Description                            |
-| ------ | ----------------- | -------------------------------------- |
-| GET    | `signals/config/` | Retrieve the team's `SignalTeamConfig` |
+| Method | Path              | Description                                               |
+| ------ | ----------------- | --------------------------------------------------------- |
+| GET    | `signals/config/` | Retrieve the team's `SignalTeamConfig`                    |
 | POST   | `signals/config/` | Update `autostart_enabled` / `default_autostart_priority` |
 
 #### User Autonomy Config (action on `UserViewSet`)

--- a/products/signals/backend/auto_start.py
+++ b/products/signals/backend/auto_start.py
@@ -595,7 +595,8 @@ async def maybe_autostart_implementation_task(
     if team_config and team_config.autostart_enabled is False:
         # Master switch: an explicit opt-out means no path (reviewer, user-triggered, or reviewer-less
         # fallback) may auto-start. Null (never set) leaves autostart on, so only False disables here.
-        # Reports still generate and notify.
+        # A team that switched Self-driving off shouldn't reach this at all — the same switch drops
+        # its signals at emission — so this is the backstop for reports that predate the flip.
         logger.info(
             "signals auto-start skipped", report_id=report_id, team_id=team_id, reason="autostart disabled for team"
         )

--- a/products/signals/backend/emission/conversations_coordinator.py
+++ b/products/signals/backend/emission/conversations_coordinator.py
@@ -56,7 +56,12 @@ async def get_conversations_signals_enabled_teams_activity() -> list[int]:
             enabled=True,
             # Tiny bit paranoid, as signals enabled should require AI consent by design
             team__organization__is_ai_data_processing_approved=True,
-        ).values_list("team_id", flat=True)
+        )
+        # Teams that switched Self-driving off consume no signals at all, so skip them before the
+        # per-team child workflow (which runs LLM passes over every ticket) is even spawned. `exclude`
+        # on the reverse one-to-one keeps the gate fail-open for teams with no config row.
+        .exclude(team__signal_team_config__autostart_enabled=False)
+        .values_list("team_id", flat=True)
     ]
 
 

--- a/products/signals/backend/emission/gate.py
+++ b/products/signals/backend/emission/gate.py
@@ -4,11 +4,16 @@ warehouse_sources calls it without importing signals (which depends on warehouse
 """
 
 from products.signals.backend.emission.registry import get_signal_source_identity
-from products.signals.backend.models import SignalSourceConfig
+from products.signals.backend.models import SignalSourceConfig, SignalTeamConfig
 
 
 def emit_signals_enabled(team_id: int, source_type: str, schema_name: str, ai_data_processing_approved: bool) -> bool:
     if not ai_data_processing_approved:
+        return False
+    # `emit_signal` drops the team's signals anyway when Self-driving is off, but the child workflow
+    # this gate spawns runs LLM summarization and actionability filtering on every imported record
+    # first. Checking here keeps an opted-out team's imports from paying for output nothing reads.
+    if not SignalTeamConfig.is_self_driving_enabled(team_id):
         return False
     identity = get_signal_source_identity(source_type, schema_name)
     if identity is None:

--- a/products/signals/backend/emission/tests/test_gate.py
+++ b/products/signals/backend/emission/tests/test_gate.py
@@ -1,0 +1,38 @@
+import pytest
+from posthog.test.base import BaseTest
+
+from parameterized import parameterized
+
+from products.signals.backend.emission.gate import emit_signals_enabled
+from products.signals.backend.models import SignalSourceConfig, SignalTeamConfig
+
+ZENDESK_SOURCE_TYPE = "Zendesk"
+ZENDESK_SCHEMA_NAME = "tickets"
+
+
+@pytest.mark.django_db
+class TestEmitSignalsGate(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        SignalSourceConfig.objects.create(
+            team=self.team,
+            source_product=SignalSourceConfig.SourceProduct.ZENDESK,
+            source_type=SignalSourceConfig.SourceType.TICKET,
+            enabled=True,
+        )
+
+    def _gate(self) -> bool:
+        return emit_signals_enabled(
+            self.team.id, ZENDESK_SOURCE_TYPE, ZENDESK_SCHEMA_NAME, ai_data_processing_approved=True
+        )
+
+    @parameterized.expand([(True,), (False,), (None,)])
+    def test_self_driving_switch_gates_data_import_emission(self, autostart_enabled: bool | None) -> None:
+        # The gate runs before the emission child workflow is spawned, and that workflow pays for LLM
+        # summarization and actionability filtering on every imported record — so an opted-out team
+        # has to be turned away here, not only later at `emit_signal`.
+        # `None` is the shape every team starts in: the team extension signal creates the row with
+        # the switch unset, and that has to read as on.
+        SignalTeamConfig.objects.update_or_create(team=self.team, defaults={"autostart_enabled": autostart_enabled})
+
+        assert self._gate() is (autostart_enabled is not False)

--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -19,7 +19,7 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.client import async_connect
 
 from products.signals.backend.contracts import SIGNAL_VARIANT_LOOKUP, SignalRemediation
-from products.signals.backend.models import SignalSourceConfig
+from products.signals.backend.models import SignalSourceConfig, SignalTeamConfig
 
 if TYPE_CHECKING:
     from products.tasks.backend.facade.repo_selection import RepoSelectionResult
@@ -392,6 +392,16 @@ async def emit_signal(
 
     organization = await database_sync_to_async(lambda: team.organization)()
     if not organization.is_ai_data_processing_approved:
+        return
+
+    # Self-driving's master switch. Every signal in the product funnels through here, so this is the
+    # one check that holds for the paths with no gate of their own (error-tracking backfill, eval
+    # signals, reingestion) — the emission and scout paths gate earlier too, to skip the LLM work
+    # ahead of this point.
+    self_driving_enabled = await database_sync_to_async(
+        SignalTeamConfig.is_self_driving_enabled, thread_sensitive=False
+    )(team.id)
+    if not self_driving_enabled:
         return
 
     is_enabled = await database_sync_to_async(SignalSourceConfig.is_source_enabled, thread_sensitive=False)(

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -134,9 +134,12 @@ class SignalTeamConfig(UUIDModel):
         on_delete=models.CASCADE,
         related_name="signal_team_config",
     )
-    # Master switch for autonomous inbox PRs. Null means the team never set it (autostart stays on
-    # by default); only an explicit False disables it, leaving reports to still generate and notify
-    # while the team reviews and opens PRs manually.
+    # Master switch for the whole Self-driving pipeline, not only the PRs at the end of it. Null
+    # means the team never set it (Self-driving stays on by default); only an explicit False turns it
+    # off, which drops the team's signals at emission and stops scheduled scout runs, so no reports
+    # are generated either. A narrower "reports keep arriving, PRs don't" reading isn't offered: the
+    # report research is the expensive half, and a team that wants to stay in the loop lowers
+    # `default_autostart_priority` instead of switching the pipeline off.
     autostart_enabled = models.BooleanField(null=True, blank=True)
     default_autostart_priority = models.CharField(max_length=2, choices=AutonomyPriority, default=AutonomyPriority.P4)
     default_slack_notification_channel = models.CharField(max_length=255, null=True, blank=True)
@@ -147,6 +150,21 @@ class SignalTeamConfig(UUIDModel):
     class Meta:
         verbose_name = "Signal team config"
         verbose_name_plural = "Signal team configs"
+
+    @classmethod
+    def is_self_driving_enabled(cls, team_id: int) -> bool:
+        """Whether the team's Self-driving master switch is on.
+
+        Fail-open, matching the field's null-means-never-set default: a team with no config row, or
+        one that never touched the switch, is on. Only an explicit opt-out turns the pipeline off.
+        """
+        return not cls.objects.filter(team_id=team_id, autostart_enabled=False).exists()
+
+    @classmethod
+    def self_driving_disabled_team_ids(cls) -> set[int]:
+        """Every team that explicitly switched Self-driving off, for callers that filter a fleet-wide
+        candidate set rather than checking one team (the scout coordinator's tick planning)."""
+        return set(cls.objects.filter(autostart_enabled=False).values_list("team_id", flat=True))
 
 
 register_team_extension_signal(SignalTeamConfig, logger=logger)

--- a/products/signals/backend/scout_harness/profile/builders.py
+++ b/products/signals/backend/scout_harness/profile/builders.py
@@ -59,7 +59,13 @@ from products.dashboards.backend.models.dashboard import Dashboard
 from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.notebooks.backend.facade import api as notebooks
-from products.signals.backend.models import SignalReport, SignalScoutConfig, SignalScoutRun, SignalSourceConfig
+from products.signals.backend.models import (
+    SignalReport,
+    SignalScoutConfig,
+    SignalScoutRun,
+    SignalSourceConfig,
+    SignalTeamConfig,
+)
 from products.signals.backend.scout_harness.config_registry import live_scout_skill_names
 from products.signals.backend.scout_harness.profile.schema import Inventory
 from products.signals.backend.scout_harness.team_limits import withheld_skills_for_team
@@ -285,10 +291,13 @@ def _emit_eligibility(team: Team) -> dict[str, Any]:
 
     Mirrors the team/org-level half of the shared emit preflight (`_preflight_emit_gates`) so a
     scout can read it at cold start and quick-close before doing throwaway work whose output would
-    be silently dropped. Both the signal and report channels gate on the same two conditions: the
-    org must have approved AI data processing, and the `signals_scout` source must be enabled.
-    `remediation` reuses the emit path's authoritative pointers so the profile and the skip
-    response never drift.
+    be silently dropped. Both the signal and report channels gate on the same three conditions: the
+    org must have approved AI data processing, the team's Self-driving switch must be on, and the
+    `signals_scout` source must be enabled. `remediation` reuses the emit path's authoritative
+    pointers so the profile and the skip response never drift.
+
+    The Self-driving switch folds into `can_emit` and `remediation` rather than adding a key of its
+    own, so the section's shape (and `INVENTORY_SOURCE_VERSION` with it) is unchanged.
     """
     # Deferred to break the profile↔tools import cycle: `tools/__init__` eagerly imports
     # `tools.profile`, which imports this `profile` package, so a module-level import here would
@@ -300,12 +309,18 @@ def _emit_eligibility(team: Team) -> dict[str, Any]:
     )
 
     ai_processing_approved = bool(team.organization.is_ai_data_processing_approved)
+    self_driving_enabled = SignalTeamConfig.is_self_driving_enabled(team.id)
     source_enabled = SignalSourceConfig.is_source_enabled(team.id, SOURCE_PRODUCT, SOURCE_TYPE)
-    can_emit = ai_processing_approved and source_enabled
+    can_emit = ai_processing_approved and self_driving_enabled and source_enabled
     # Point at the first failing gate, matching the preflight's check order.
-    blocking_reason = (
-        None if can_emit else ("ai_processing_not_approved" if not ai_processing_approved else "source_disabled")
-    )
+    blocking_reason: str | None = None
+    if not can_emit:
+        if not ai_processing_approved:
+            blocking_reason = "ai_processing_not_approved"
+        elif not self_driving_enabled:
+            blocking_reason = "self_driving_disabled"
+        else:
+            blocking_reason = "source_disabled"
     return {
         "ai_processing_approved": ai_processing_approved,
         "source_enabled": source_enabled,

--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -818,7 +818,7 @@ class EmitFindingResponseSerializer(serializers.Serializer):
     emitted = serializers.BooleanField(help_text="Whether `emit_signal` was actually fired.")
     skipped_reason = serializers.CharField(
         allow_null=True,
-        help_text="`ai_processing_not_approved` | `source_disabled` | null when emitted normally.",
+        help_text="`ai_processing_not_approved` | `self_driving_disabled` | `source_disabled` | null when emitted normally.",
     )
     remediation = serializers.CharField(
         allow_null=True,
@@ -998,7 +998,7 @@ class EmitReportResponseSerializer(serializers.Serializer):
     )
     skipped_reason = serializers.CharField(
         allow_null=True,
-        help_text="`scout_config_missing` | `scout_emit_disabled` | `ai_processing_not_approved` | `source_disabled` | null when not gate-skipped.",
+        help_text="`scout_config_missing` | `scout_emit_disabled` | `ai_processing_not_approved` | `self_driving_disabled` | `source_disabled` | null when not gate-skipped.",
     )
     safety_explanation = serializers.CharField(
         allow_null=True,

--- a/products/signals/backend/scout_harness/tools/emit.py
+++ b/products/signals/backend/scout_harness/tools/emit.py
@@ -36,7 +36,13 @@ from django.db import transaction
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 
-from products.signals.backend.models import SignalScoutConfig, SignalScoutEmission, SignalScoutRun, SignalSourceConfig
+from products.signals.backend.models import (
+    SignalScoutConfig,
+    SignalScoutEmission,
+    SignalScoutRun,
+    SignalSourceConfig,
+    SignalTeamConfig,
+)
 from products.signals.backend.scout_harness.slack_delivery_queue import queue_configured_scout_slack_delivery
 from products.tasks.backend.facade import api as tasks_facade
 
@@ -102,6 +108,7 @@ class EmitResult:
       - "scout_config_missing": the run's dispatch-time config FK is null/gone — fail closed
       - "scout_emit_disabled": the scout's config has emit=False (dry-run)
       - "ai_processing_not_approved": team's organization has not approved AI processing
+      - "self_driving_disabled": the team switched Self-driving off, so the pipeline is idle
       - "source_disabled": SignalSourceConfig disables the signals_scout source for this team
 
     `remediation` carries a one-line, scout-actionable next step whenever the skip is one the
@@ -516,7 +523,8 @@ def _preflight_emit_gates(team: Team, run: SignalScoutRun) -> str | None:
     """Return the matching skipped_reason if a gate would drop the emit; else None.
 
     `emit_signal()` returns silently when the team's organization has not approved
-    AI processing or when `SignalSourceConfig.is_source_enabled(...)` is False.
+    AI processing, when the team switched Self-driving off, or when
+    `SignalSourceConfig.is_source_enabled(...)` is False.
     Surfacing the gate result here lets the view return a useful skipped_reason
     instead of "emitted" for an emit the pipeline silently dropped. The per-scout
     `emit` toggle is checked first: a dry-run scout runs and logs but emits nothing.
@@ -542,6 +550,8 @@ def _preflight_emit_gates(team: Team, run: SignalScoutRun) -> str | None:
     organization = team.organization
     if not organization.is_ai_data_processing_approved:
         return "ai_processing_not_approved"
+    if not SignalTeamConfig.is_self_driving_enabled(team.id):
+        return "self_driving_disabled"
     if not SignalSourceConfig.is_source_enabled(team.id, SOURCE_PRODUCT, SOURCE_TYPE):
         return "source_disabled"
     return None
@@ -562,6 +572,11 @@ EMIT_SKIP_REMEDIATION: dict[str, str | None] = {
         "This organization has not approved AI data processing, so no scout finding can reach the "
         "inbox. An org admin must turn on the 'Enable PostHog features that use third-party AI "
         "services' toggle in Organization settings → AI service providers."
+    ),
+    "self_driving_disabled": (
+        "This team has switched Self-driving off, so the whole pipeline is idle and no finding can "
+        "reach the inbox. Someone on the team must switch Self-driving back on in the inbox setup "
+        "panel."
     ),
     "source_disabled": (
         "The signals_scout source is disabled for this team, so findings are dropped before the "

--- a/products/signals/backend/scout_harness/tools/report.py
+++ b/products/signals/backend/scout_harness/tools/report.py
@@ -639,12 +639,15 @@ CUSTOMER_REPORT_EDITED_EVENT = "$scout_report_edited"
 _REPORT_EVENT_SOURCE = "signals_scout_report"
 
 # Gate-skip reasons that mean the scout isn't active — deliberately off (`scout_emit_disabled` /
-# `source_disabled`) or fail-closed because its dispatch-time config is gone (`scout_config_missing`,
-# from a deleted/nulled `SignalScoutConfig`). See `_preflight_emit_gates`. An inactive scout must produce
+# `source_disabled` / `self_driving_disabled`, the team-wide switch) or fail-closed because its
+# dispatch-time config is gone (`scout_config_missing`, from a deleted/nulled `SignalScoutConfig`). See
+# `_preflight_emit_gates`. An inactive scout must produce
 # no side effects, so its attempt is still recorded on the internal stream but is NOT fanned out as a
 # customer-facing, automation-driving event. Other gate-skips that represent a real, customer-controlled
 # condition (e.g. `ai_processing_not_approved`) still forward the raw event.
-_INACTIVE_SKIP_REASONS = frozenset({"scout_emit_disabled", "source_disabled", "scout_config_missing"})
+_INACTIVE_SKIP_REASONS = frozenset(
+    {"scout_emit_disabled", "source_disabled", "self_driving_disabled", "scout_config_missing"}
+)
 
 
 @dataclass

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -60,6 +60,7 @@ from products.signals.backend.models import (
     SignalScoutEmission,
     SignalScoutNote,
     SignalScoutRun,
+    SignalTeamConfig,
 )
 from products.signals.backend.quota import is_team_signals_quota_limited
 from products.signals.backend.report_charts import ChartSize
@@ -290,6 +291,9 @@ def _reject_if_manual_run_suppressed(team_id: int) -> None:
       coordinator counts, so they share the tally: once the budget is spent the trigger is
       throttled (429) until the window rolls, instead of letting repeated manual runs blow past
       the per-team daily cap the scheduled path enforces.
+    - **The team's own Self-driving switch**, the one gate here that is the customer's rather than
+      an operator's. With it off nothing the run emits survives `emit_signal`, so the trigger is
+      forbidden (403) instead of burning a sandbox on findings the pipeline drops on arrival.
 
     `team_id` is the canonical (parent) project id, matching how the coordinator plans; team
     config keys are canonicalized the same way so a child-env override still lines up.
@@ -297,6 +301,9 @@ def _reject_if_manual_run_suppressed(team_id: int) -> None:
     payload = _read_flag_payload()
     if not _resolve_enrolled(team_id, _parse_enrollment(payload)):
         raise exceptions.PermissionDenied(detail="Signals scouts are not enabled for this project.")
+
+    if not SignalTeamConfig.is_self_driving_enabled(team_id):
+        raise exceptions.PermissionDenied(detail="Self-driving is switched off for this project.")
 
     team_configs = _canonicalize_team_config_keys(_team_configs(payload))
     per_day = _resolve_max_runs_per_day(team_id, team_configs, _default_team_config(payload))

--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -189,9 +189,10 @@ class SignalTeamConfigSerializer(serializers.ModelSerializer):
         extra_kwargs = {
             "autostart_enabled": {
                 "help_text": (
-                    "Master switch for autonomous inbox PRs. Null (never set) leaves autostart on; set "
-                    "false to opt out, so actionable reports still generate and notify but the team "
-                    "never auto-starts an implementation task or opens a PR — reviewers open PRs manually."
+                    "Master switch for Self-driving. Null (never set) leaves it on; set false to switch "
+                    "the whole pipeline off, so the team's signals are dropped at emission, scheduled "
+                    "scouts stop running, and no reports or PRs are produced. To keep reports coming but "
+                    "review them before a PR opens, raise `default_autostart_priority` instead."
                 )
             },
             "default_slack_notification_channel": {

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -18,7 +18,7 @@ from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.heartbeat import Heartbeater
 
-from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.models import SignalScoutConfig, SignalTeamConfig
 from products.signals.backend.scout_harness.config_registry import live_scout_skill_names, register_missing_configs
 from products.signals.backend.scout_harness.lazy_seed import sync_canonical_skills
 from products.signals.backend.scout_harness.limits import AUTO_PAUSE_PROBE_INTERVAL_S
@@ -374,8 +374,14 @@ def _participating_teams(enrollment: Enrollment) -> list[tuple[Team, bool]]:
     Skip is subtracted AFTER canonicalizing both sides, so listing a child env in `guaranteed_team_ids`
     and its parent project in `skip_team_ids` (or the reverse) still hard-excludes the project — the
     raw ids differ but their canonical parent matches.
+
+    A team that switched Self-driving off joins the skip set: dropping it here, before the plan is
+    built, is what keeps the tick from seeding its skills, spending budget on it, or firing the
+    breaker recovery probe its paused lanes would otherwise be owed (`_collect_probe_runs` only runs
+    for participating teams). The switch lives on a raw team, so it canonicalizes with everything
+    else — setting it on a child env drains the whole project, same as `skip_team_ids` does.
     """
-    skip_canonical = _canonicalize_team_ids(enrollment.skip)
+    skip_canonical = _canonicalize_team_ids(enrollment.skip | SignalTeamConfig.self_driving_disabled_team_ids())
     explicit = _canonicalize_team_ids(enrollment.explicit) - skip_canonical
 
     wildcard_ids: set[int] = set()

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -14,7 +14,7 @@ from products.signals.backend.facade.api import (
     _telemetry_props_from_extra,
     emit_signal,
 )
-from products.signals.backend.models import SignalSourceConfig
+from products.signals.backend.models import SignalSourceConfig, SignalTeamConfig
 from products.signals.backend.temporal.buffer import BufferSignalsWorkflow
 from products.signals.backend.temporal.emitter import SignalEmitterWorkflow
 
@@ -28,6 +28,17 @@ def team_stub() -> MagicMock:
     team.uuid = uuid.UUID("00000000-0000-0000-0000-000000000001")
     team.organization = org
     return team
+
+
+@pytest.fixture(autouse=True)
+def self_driving_on():
+    """Keep the Self-driving master switch on without a database.
+
+    `emit_signal` reads it per call, and these tests run on a `MagicMock` team with no DB access,
+    so an unpatched read raises instead of falling through to the fail-open default.
+    """
+    with patch.object(SignalTeamConfig, "is_self_driving_enabled", return_value=True):
+        yield
 
 
 SESSION_PROBLEM_EXTRA = {
@@ -208,6 +219,28 @@ class TestEmitSignalValidation:
             team_stub.id, "github:issue:notification-1"
         )
         assert emitter_call.kwargs["id_reuse_policy"] == WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
+
+    async def test_emit_signal_skips_when_self_driving_is_off(self, team_stub):
+        # The master switch has to hold here, not only at the pipeline entry points: this is the one
+        # gate the paths with no check of their own (error-tracking backfill, eval signals,
+        # reingestion) pass through, so an opted-out team consumes nothing.
+        client = AsyncMock()
+
+        with (
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
+            patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
+            patch.object(SignalTeamConfig, "is_self_driving_enabled", return_value=False),
+        ):
+            await emit_signal(
+                team=team_stub,
+                source_product="github",
+                source_type="issue",
+                source_id="test-id-1",
+                description="A valid signal",
+                extra=GITHUB_ISSUE_EXTRA,
+            )
+
+        client.start_workflow.assert_not_awaited()
 
     @pytest.mark.parametrize("idempotency_key", ["", "   "])
     async def test_emit_signal_rejects_empty_idempotency_keys(self, team_stub, idempotency_key):

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -313,9 +313,9 @@ async def test_wildcard_keeps_a_fully_breaker_paused_team_enrolled_for_probes(at
 @pytest.mark.flag_off
 @pytest.mark.parametrize("autostart_enabled", [True, False, None])
 async def test_self_driving_switch_drains_a_team(ateam, autostart_enabled):
-    # The inbox's Self-driving switch stops the whole pipeline, so an off team must plan no runs at
-    # all: its findings would be dropped at emission, and a probe for a breaker-paused lane would
-    # burn a sandbox for nothing. Only an explicit False is off (null means never set).
+    # The inbox's Self-driving switch stops the whole pipeline, so a team that switched it off drops
+    # out of participation entirely — anything its scouts emitted would be dropped at emission
+    # anyway. Only an explicit False is off; null means never set.
     await database_sync_to_async(_create_skill)(ateam, "signals-scout-errors")
     await database_sync_to_async(_create_config)(ateam, "signals-scout-errors", enabled=True)
     await database_sync_to_async(SignalTeamConfig.objects.update_or_create)(

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -21,7 +21,7 @@ from posthog.models import Organization, Team
 from posthog.models.scoping import team_scope
 from posthog.sync import database_sync_to_async
 
-from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.models import SignalScoutConfig, SignalTeamConfig
 from products.signals.backend.scout_harness.config_registry import register_missing_configs
 from products.signals.backend.scout_harness.lazy_seed import HARNESS_SEEDED_BY, sync_canonical_skills
 from products.signals.backend.scout_harness.limits import AUTO_PAUSE_PROBE_INTERVAL_S
@@ -306,6 +306,26 @@ async def test_wildcard_keeps_a_fully_breaker_paused_team_enrolled_for_probes(at
         planned = await _run_activity()
 
     assert any(p.team_id == ateam.id and p.skill_name == "signals-scout-errors" for p in planned)
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.flag_off
+@pytest.mark.parametrize("autostart_enabled", [True, False, None])
+async def test_self_driving_switch_drains_a_team(ateam, autostart_enabled):
+    # The inbox's Self-driving switch stops the whole pipeline, so an off team must plan no runs at
+    # all: its findings would be dropped at emission, and a probe for a breaker-paused lane would
+    # burn a sandbox for nothing. Only an explicit False is off (null means never set).
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-errors")
+    await database_sync_to_async(_create_config)(ateam, "signals-scout-errors", enabled=True)
+    await database_sync_to_async(SignalTeamConfig.objects.update_or_create)(
+        team=ateam, defaults={"autostart_enabled": autostart_enabled}
+    )
+
+    with patch(_PAYLOAD_PATH, return_value={"guaranteed_team_ids": ["*"]}):
+        planned = await _run_activity()
+
+    assert any(p.team_id == ateam.id for p in planned) is (autostart_enabled is not False)
 
 
 @pytest.mark.asyncio

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -3323,7 +3323,7 @@ export interface EmitReportResponseApi {
     /** True when the report actually surfaced in the inbox (READY or PENDING_INPUT). */
     emitted: boolean
     /**
-     * `scout_config_missing` | `scout_emit_disabled` | `ai_processing_not_approved` | `source_disabled` | null when not gate-skipped.
+     * `scout_config_missing` | `scout_emit_disabled` | `ai_processing_not_approved` | `self_driving_disabled` | `source_disabled` | null when not gate-skipped.
      * @nullable
      */
     skipped_reason: string | null
@@ -3423,7 +3423,7 @@ export interface EmitFindingResponseApi {
     /** Whether `emit_signal` was actually fired. */
     emitted: boolean
     /**
-     * `ai_processing_not_approved` | `source_disabled` | null when emitted normally.
+     * `ai_processing_not_approved` | `self_driving_disabled` | `source_disabled` | null when emitted normally.
      * @nullable
      */
     skipped_reason: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -24811,7 +24811,7 @@ export namespace Schemas {
       /** Whether `emit_signal` was actually fired. */
       emitted: boolean;
       /**
-         * `ai_processing_not_approved` | `source_disabled` | null when emitted normally.
+         * `ai_processing_not_approved` | `self_driving_disabled` | `source_disabled` | null when emitted normally.
          * @nullable
          */
       skipped_reason: string | null;
@@ -24907,7 +24907,7 @@ export namespace Schemas {
       /** True when the report actually surfaced in the inbox (READY or PENDING_INPUT). */
       emitted: boolean;
       /**
-         * `scout_config_missing` | `scout_emit_disabled` | `ai_processing_not_approved` | `source_disabled` | null when not gate-skipped.
+         * `scout_config_missing` | `scout_emit_disabled` | `ai_processing_not_approved` | `self_driving_disabled` | `source_disabled` | null when not gate-skipped.
          * @nullable
          */
       skipped_reason: string | null;


### PR DESCRIPTION
## Problem

The inbox's team-level toggle was labelled "PR generation" and only did what the label said: `SignalTeamConfig.autostart_enabled=False` stopped auto-start of implementation tasks, and nothing else. A team that switched it off still consumed signals, still ran scheduled scouts, and still generated reports, which is the expensive half of the pipeline. So the only control a team had over volume didn't reduce the work being done on its behalf, and the card's copy promised "reports still arrive and notify your team" as if that were the point.

The switch should mean what a customer reads into it: Self-driving off, nothing running.

## Changes

`autostart_enabled` becomes the master switch for the whole product rather than a PR-only opt-out. Reads go through two new helpers on `SignalTeamConfig`, both fail-open so only an explicit `False` is off (`null`, the state every team starts in, stays on):

- `is_self_driving_enabled(team_id)` for the single-team checks
- `self_driving_disabled_team_ids()` for the coordinator, which filters a fleet-wide candidate set

Enforced in five places, each chosen so the work stops before it is paid for rather than after:

| Where | Why there |
| --- | --- |
| `facade/api.py:emit_signal` | Every signal funnels through it, so it covers the paths with no gate of their own (error-tracking backfill, eval signals, reingestion) |
| `emission/gate.py` | The data-import pipeline asks before spawning the emission child workflow, which runs LLM summarization and actionability filtering over every imported record |
| `emission/conversations_coordinator.py` | Excludes the team from the hourly fan-out, same reasoning |
| `temporal/agentic/scout_coordinator.py:_participating_teams` | Folded into the enrollment skip set, so an off team gets no child workflow, no tick budget, and no breaker recovery probe |
| `scout_harness/views.py` | A manual scout trigger 403s instead of burning a sandbox on findings the emit gate would drop |

An in-flight scout that emits after the switch flips now gets `self_driving_disabled` as its skip reason, with remediation pointing at the toggle, instead of a silent drop.

The card is relabelled **Self-driving**, and the off-state copy says what actually happens and how to get fewer PRs without stopping the pipeline (raise the threshold).

Model comment, serializer help text, `frontend/src/scenes/inbox/types.ts`, and `products/signals/ARCHITECTURE.md` are updated to describe the broadened contract, including the list of enforcement points above.

Note for review: [#75576](https://github.com/PostHog/posthog/pull/75576) touches the same component (splitting the threshold into project and personal). Whichever lands second will need a small conflict fix in `SelfDrivingSection.tsx`; the two changes are otherwise independent.

## How did you test this code?

I am the PostHog Slack app (Claude), working from a sandbox with Postgres only: no ClickHouse, no `sqlx` for the persons database, and no dev stack. (I got Postgres migrated and shimmed past the `sqlx` dependency, but the standalone ClickHouse binary won't start under gVisor — its executable self-checksum comes out different on every run.) So one of the three test groups actually ran, and **the two Django-DB-backed tests below are still unverified.**

CI has not covered them either: draft PRs run a narrowed matrix, so the Django test jobs were skipped and `Django Tests Pass` went green on skips alone. I have added the `run-ci-backend` label, which takes effect on the next push or when this is marked ready for review — that run is what will actually exercise them. Everything else is green: Python code quality (ruff + mypy), frontend typechecking, formatting, Jest, and OpenAPI type validation.

Ran and passing:

- `products/signals/backend/test/test_api.py` — 18 tests. Includes a new `test_emit_signal_skips_when_self_driving_is_off`: catches the master switch being dropped from the funnel, which is what covers the emit paths with no gate of their own. This file needs no database, which is why it ran here.

Written but not executed:

- `products/signals/backend/emission/tests/test_gate.py` (new) — parameterized over `True` / `False` / `None`: catches the data-import gate letting an opted-out team's records through to the LLM passes, and locks in that the `null` state every team starts in reads as on.
- `products/signals/backend/test/test_scout_coordinator.py::test_self_driving_switch_drains_a_team` (new) — parameterized the same way: catches scheduled scouts still being planned for an off team, including the breaker-probe path that bypasses the enabled-config filter.

The visual review run is red by design: 4 snapshots changed, all of them the inbox scene stories that contain this card (`scenes-app-inbox-scene--empty` and `--self-driving-paused`, light and dark). I checked the diff list to confirm nothing else moved, and left the approval to a human rather than approving my own change.

Everything else is verified only by reading: no manual run of the app, no screenshots of the relabelled card, and no test for the manual-run 403 or the `self_driving_disabled` emit skip reason. The existing `TestEmitEligibility` tests in `test_scout_harness_profile.py` should still pass unchanged (a default team's config row has `autostart_enabled=None`, which reads as on), but I could not run them either.

The DRF help-text edits on the two scout response serializers feed `products/signals/frontend/generated/api.schemas.ts`; I could not run `hogli build:openapi` here, so CI's OpenAPI codegen step should regenerate and auto-commit that file.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

This changes what an existing customer-facing toggle does, so it is worth a changelog line.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a request in [#team-signals](https://posthog.slack.com/archives/C09SK2PAGKF/p1785840775991489?thread_ts=1785840775.991489&cid=C09SK2PAGKF), where the discussion concluded that "no PRs" as a setting is really "don't bill me", and that without a pricing change the honest option is to make the switch disable Self-driving and rename it.

Decisions worth flagging for review:

- **Reused `autostart_enabled` rather than adding a `signals_enabled` field.** Broadening an existing field's contract is the thing to be suspicious about here, and the field name now undersells what it does. A rename would ripple through the serializer, the generated frontend types, the desktop client, and the MCP surface for no behavioral gain, so the contract is documented at the model, the serializer, and in `ARCHITECTURE.md` instead. Worth a second opinion.
- **Gated in five places instead of only `emit_signal`.** The funnel alone is sufficient for correctness, but the emission paths run LLM summarization and actionability filtering *before* reaching it, so gating only there would have kept paying for output nobody reads.
- **Manual scout runs are blocked too.** They are user-initiated, so leaving them working was defensible, but their findings cannot land while the switch is off.
- **The coordinator's disabled set is canonicalized with the enrollment skip set**, so flipping the switch on a child environment drains the whole project. That matches how `skip_team_ids` already behaves, and scout configs live on the parent, but it is a deliberate choice rather than a forced one.
- Skills invoked while producing this PR: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments` (read from `.agents/skills/`).

Not done here, and worth its own follow-up: the thread also proposed repurposing `SignalUserAutonomyConfig.autostart_priority` into a per-user Slack-ping threshold, and floated a minimum threshold of P2 pending how well pre-research priority correlates with post-research priority.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785840775991489?thread_ts=1785840775.991489&cid=C09SK2PAGKF)*

