### PR TITLE
fix(dashboards): let card edge zones yield to scrollbars underneath

### DIFF
--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -121,6 +121,9 @@ mockResizeObserver.mockReturnValue({
 })
 ;(globalThis as any).ResizeObserver = mockResizeObserver
 
+// jsdom has no layout, so hit-testing at a point can't return anything
+document.elementsFromPoint = document.elementsFromPoint ?? ((): Element[] => [])
+
 // Tell React Testing Library to use "data-attr" as the test ID attribute
 configure({ testIdAttribute: 'data-attr' })
 

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -2,12 +2,73 @@ import '@testing-library/jest-dom'
 
 import { cleanup, fireEvent, render } from '@testing-library/react'
 
-import { EditModeEdgeOverlay } from './EditModeEdgeOverlay'
+import { EditModeEdgeOverlay, isPointInScrollbarGutter } from './EditModeEdgeOverlay'
+
+type FakeElementConfig = {
+    rect: { left: number; top: number; right: number; bottom: number }
+    offsetWidth: number
+    offsetHeight: number
+    clientWidth: number
+    clientHeight: number
+    scrollWidth: number
+    scrollHeight: number
+    border?: number
+    direction?: 'ltr' | 'rtl'
+}
+
+// A 400x300 element with classic 15px scrollbars: clientWidth/Height shrink by the scrollbar
+// (and borders, when set), and content overflows on both axes unless a case says otherwise.
+const SCROLLABLE_BASE: FakeElementConfig = {
+    rect: { left: 0, top: 0, right: 400, bottom: 300 },
+    offsetWidth: 400,
+    offsetHeight: 300,
+    clientWidth: 385,
+    clientHeight: 285,
+    scrollWidth: 800,
+    scrollHeight: 600,
+}
 
 describe('EditModeEdgeOverlay', () => {
+    const styleConfig = new WeakMap<Element, { border: number; direction: string }>()
+    const realGetComputedStyle = window.getComputedStyle
+
     beforeEach(() => {
         cleanup()
+        jest.spyOn(window, 'getComputedStyle').mockImplementation((el: Element): CSSStyleDeclaration => {
+            const config = styleConfig.get(el)
+            if (!config) {
+                return realGetComputedStyle(el)
+            }
+            return {
+                borderTopWidth: `${config.border}px`,
+                borderBottomWidth: `${config.border}px`,
+                borderLeftWidth: `${config.border}px`,
+                borderRightWidth: `${config.border}px`,
+                direction: config.direction,
+            } as CSSStyleDeclaration
+        })
     })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    function fakeScrollableElement({
+        rect,
+        border = 0,
+        direction = 'ltr',
+        ...dimensions
+    }: FakeElementConfig): HTMLElement {
+        const el = document.createElement('div')
+        Object.defineProperties(
+            el,
+            Object.fromEntries(Object.entries(dimensions).map(([key, value]) => [key, { value }]))
+        )
+        el.getBoundingClientRect = () =>
+            ({ ...rect, width: rect.right - rect.left, height: rect.bottom - rect.top }) as DOMRect
+        styleConfig.set(el, { border, direction })
+        return el
+    }
 
     it('renders eight edge and corner hit areas with data attr', () => {
         const { getAllByTitle } = render(<EditModeEdgeOverlay onEnterEditMode={() => {}} />)
@@ -61,5 +122,79 @@ describe('EditModeEdgeOverlay', () => {
         fireEvent.mouseEnter(zones[4])
         fireEvent.mouseLeave(zones[0])
         expect(container.querySelectorAll('.handle')).toHaveLength(8)
+    })
+
+    describe('scrollbar pass-through', () => {
+        // A table tile's horizontal scrollbar renders in the card's bottom pixels, right under the
+        // "s" zone. Presses aimed at it must scroll, not throw the user into edit mode.
+        function renderWithScrollableUnderneath(): {
+            onEnterEditMode: jest.Mock
+            zones: HTMLElement[]
+            scrollable: HTMLElement
+        } {
+            const onEnterEditMode = jest.fn()
+            const { container, getAllByTitle } = render(<EditModeEdgeOverlay onEnterEditMode={onEnterEditMode} />)
+            const zones = getAllByTitle('Click to edit layout')
+            const scrollable = fakeScrollableElement(SCROLLABLE_BASE)
+            container.appendChild(scrollable)
+            jest.spyOn(document, 'elementsFromPoint').mockImplementation((x: number, y: number) =>
+                x >= 0 && x <= 400 && y >= 0 && y <= 300 ? [zones[1], scrollable] : []
+            )
+            return { onEnterEditMode, zones, scrollable }
+        }
+
+        it('does not enter edit mode when the press lands on a scrollbar under the zone', () => {
+            const { onEnterEditMode, zones } = renderWithScrollableUnderneath()
+
+            fireEvent.mouseDown(zones[1], { clientX: 200, clientY: 292 })
+            expect(onEnterEditMode).not.toHaveBeenCalled()
+
+            fireEvent.mouseDown(zones[1], { clientX: 200, clientY: 150 })
+            expect(onEnterEditMode).toHaveBeenCalledTimes(1)
+        })
+
+        it('lets pointer events through while hovering a scrollbar and recaptures them after', () => {
+            const { zones } = renderWithScrollableUnderneath()
+
+            fireEvent.mouseMove(zones[1], { clientX: 200, clientY: 292 })
+            expect(zones[1]).toHaveStyle({ pointerEvents: 'none' })
+
+            fireEvent.mouseMove(document, { clientX: 200, clientY: 150 })
+            expect(zones[1]).not.toHaveStyle({ pointerEvents: 'none' })
+        })
+    })
+
+    describe('isPointInScrollbarGutter', () => {
+        test.each<[string, Partial<FakeElementConfig>, [number, number], boolean]>([
+            ['point on the horizontal scrollbar', {}, [200, 292], true],
+            ['point on the vertical scrollbar (ltr: right edge)', {}, [392, 150], true],
+            ['point in the content area', {}, [200, 150], false],
+            ['point outside the element', {}, [200, 310], false],
+            [
+                'horizontal gutter reserved but content does not overflow',
+                { scrollWidth: 385, scrollHeight: 285 },
+                [200, 292],
+                false,
+            ],
+            ['overlay scrollbars occupy no layout space', { clientWidth: 400, clientHeight: 300 }, [200, 292], false],
+            [
+                'point on the bottom border, just below the gutter',
+                { border: 2, clientWidth: 381, clientHeight: 281 },
+                [200, 299],
+                false,
+            ],
+            [
+                'point on the horizontal scrollbar of a bordered element',
+                { border: 2, clientWidth: 381, clientHeight: 281 },
+                [200, 290],
+                true,
+            ],
+            ['rtl: vertical scrollbar sits on the left edge', { direction: 'rtl' }, [7, 150], true],
+            ['rtl: right edge is plain content', { direction: 'rtl' }, [392, 150], false],
+        ])('%s', (_name, overrides, [x, y], expected) => {
+            expect(isPointInScrollbarGutter(fakeScrollableElement({ ...SCROLLABLE_BASE, ...overrides }), x, y)).toBe(
+                expected
+            )
+        })
     })
 })

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -2,7 +2,11 @@ import '@testing-library/jest-dom'
 
 import { cleanup, fireEvent, render } from '@testing-library/react'
 
-import { EditModeEdgeOverlay, isPointInScrollbarGutter } from './EditModeEdgeOverlay'
+import {
+    EditModeEdgeOverlay,
+    isPointInScrollbarGutter,
+    useResizeHandleScrollbarPassThrough,
+} from './EditModeEdgeOverlay'
 
 type FakeElementConfig = {
     rect: { left: number; top: number; right: number; bottom: number }
@@ -189,6 +193,72 @@ describe('EditModeEdgeOverlay', () => {
 
             expect(zones[6]).toHaveStyle({ pointerEvents: 'none' })
             expect(zones[1]).toHaveStyle({ pointerEvents: 'none' })
+        })
+    })
+
+    describe('useResizeHandleScrollbarPassThrough', () => {
+        // In edit mode react-grid-layout's south resize handle covers a table tile's horizontal
+        // scrollbar, so presses there resized the tile instead of scrolling.
+        function Harness(): null {
+            useResizeHandleScrollbarPassThrough(true)
+            return null
+        }
+
+        function mountEditModeTile(): { gridItem: HTMLElement; handle: HTMLElement; scrollable: HTMLElement } {
+            const gridItem = document.createElement('div')
+            gridItem.className = 'react-grid-item'
+            const scrollable = fakeScrollableElement(SCROLLABLE_BASE)
+            const handle = document.createElement('span')
+            handle.className = 'react-resizable-handle react-resizable-handle-s'
+            handle.getBoundingClientRect = () =>
+                ({ left: 0, top: 276, right: 368, bottom: 308, width: 368, height: 32 }) as DOMRect
+            gridItem.append(scrollable, handle)
+            document.body.appendChild(gridItem)
+            jest.spyOn(document, 'elementsFromPoint').mockImplementation((x: number, y: number) =>
+                x >= 0 && x <= 400 && y >= 0 && y <= 300 ? [handle, scrollable, gridItem] : []
+            )
+            render(<Harness />)
+            return { gridItem, handle, scrollable }
+        }
+
+        afterEach(() => {
+            document.querySelectorAll('.react-grid-item').forEach((el) => el.remove())
+        })
+
+        it('yields a resize handle while over a scrollbar and re-arms it after', () => {
+            const { handle } = mountEditModeTile()
+
+            fireEvent.mouseMove(handle, { clientX: 200, clientY: 292 })
+            expect(handle.style.pointerEvents).toBe('none')
+
+            fireEvent.mouseMove(document, { clientX: 200, clientY: 150 })
+            expect(handle.style.pointerEvents).toBe('')
+        })
+
+        it('yields every handle stacked on the point, not just the hovered one', () => {
+            const { gridItem, handle } = mountEditModeTile()
+            const cornerHandle = document.createElement('span')
+            cornerHandle.className = 'react-resizable-handle react-resizable-handle-sw'
+            cornerHandle.getBoundingClientRect = () =>
+                ({ left: -8, top: 276, right: 24, bottom: 308, width: 32, height: 32 }) as DOMRect
+            gridItem.appendChild(cornerHandle)
+
+            fireEvent.mouseMove(cornerHandle, { clientX: 8, clientY: 292 })
+
+            expect(cornerHandle.style.pointerEvents).toBe('none')
+            expect(handle.style.pointerEvents).toBe('none')
+        })
+
+        it('stops a press over a scrollbar from reaching the grid item, but not one elsewhere', () => {
+            const { gridItem, scrollable } = mountEditModeTile()
+            const gridItemPress = jest.fn()
+            gridItem.addEventListener('mousedown', gridItemPress)
+
+            fireEvent.mouseDown(scrollable, { clientX: 200, clientY: 292 })
+            expect(gridItemPress).not.toHaveBeenCalled()
+
+            fireEvent.mouseDown(scrollable, { clientX: 200, clientY: 150 })
+            expect(gridItemPress).toHaveBeenCalledTimes(1)
         })
     })
 

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -162,6 +162,25 @@ describe('EditModeEdgeOverlay', () => {
             fireEvent.mouseMove(document, { clientX: 200, clientY: 150 })
             expect(zones[1]).not.toHaveStyle({ pointerEvents: 'none' })
         })
+
+        it('yields every zone stacked on the point, not just the hovered one', () => {
+            const { zones } = renderWithScrollableUnderneath()
+            // Corner zones paint above edge zones near card corners. jsdom has no layout, so give the
+            // sw corner and s edge zones their real overlapping geometry at the card's bottom-left.
+            const rects: Array<[number, { left: number; top: number; right: number; bottom: number }]> = [
+                [1, { left: 0, top: 288, right: 400, bottom: 302 }],
+                [6, { left: -2, top: 284, right: 16, bottom: 302 }],
+            ]
+            for (const [index, rect] of rects) {
+                zones[index].getBoundingClientRect = () =>
+                    ({ ...rect, width: rect.right - rect.left, height: rect.bottom - rect.top }) as DOMRect
+            }
+
+            fireEvent.mouseMove(zones[6], { clientX: 8, clientY: 292 })
+
+            expect(zones[6]).toHaveStyle({ pointerEvents: 'none' })
+            expect(zones[1]).toHaveStyle({ pointerEvents: 'none' })
+        })
     })
 
     describe('isPointInScrollbarGutter', () => {

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.test.tsx
@@ -14,6 +14,8 @@ type FakeElementConfig = {
     scrollHeight: number
     border?: number
     direction?: 'ltr' | 'rtl'
+    overflowX?: string
+    overflowY?: string
 }
 
 // A 400x300 element with classic 15px scrollbars: clientWidth/Height shrink by the scrollbar
@@ -29,7 +31,10 @@ const SCROLLABLE_BASE: FakeElementConfig = {
 }
 
 describe('EditModeEdgeOverlay', () => {
-    const styleConfig = new WeakMap<Element, { border: number; direction: string }>()
+    const styleConfig = new WeakMap<
+        Element,
+        { border: number; direction: string; overflowX: string; overflowY: string }
+    >()
     const realGetComputedStyle = window.getComputedStyle
 
     beforeEach(() => {
@@ -45,6 +50,8 @@ describe('EditModeEdgeOverlay', () => {
                 borderLeftWidth: `${config.border}px`,
                 borderRightWidth: `${config.border}px`,
                 direction: config.direction,
+                overflowX: config.overflowX,
+                overflowY: config.overflowY,
             } as CSSStyleDeclaration
         })
     })
@@ -57,6 +64,8 @@ describe('EditModeEdgeOverlay', () => {
         rect,
         border = 0,
         direction = 'ltr',
+        overflowX = 'auto',
+        overflowY = 'auto',
         ...dimensions
     }: FakeElementConfig): HTMLElement {
         const el = document.createElement('div')
@@ -66,7 +75,7 @@ describe('EditModeEdgeOverlay', () => {
         )
         el.getBoundingClientRect = () =>
             ({ ...rect, width: rect.right - rect.left, height: rect.bottom - rect.top }) as DOMRect
-        styleConfig.set(el, { border, direction })
+        styleConfig.set(el, { border, direction, overflowX, overflowY })
         return el
     }
 
@@ -195,7 +204,23 @@ describe('EditModeEdgeOverlay', () => {
                 [200, 292],
                 false,
             ],
-            ['overlay scrollbars occupy no layout space', { clientWidth: 400, clientHeight: 300 }, [200, 292], false],
+            // Overlay scrollbars (macOS default): no layout gutter, so the edge band of a genuinely
+            // scrollable element counts as scrollbar territory.
+            ['overlay: point in the bottom scroll band', { clientWidth: 400, clientHeight: 300 }, [200, 292], true],
+            ['overlay: point above the bottom scroll band', { clientWidth: 400, clientHeight: 300 }, [200, 283], false],
+            ['overlay: point in the right scroll band', { clientWidth: 400, clientHeight: 300 }, [392, 150], true],
+            [
+                'overlay rtl: scroll band sits on the left edge',
+                { clientWidth: 400, clientHeight: 300, direction: 'rtl' as const },
+                [7, 150],
+                true,
+            ],
+            [
+                'overflow hidden clips without a scrollbar',
+                { clientWidth: 400, clientHeight: 300, overflowX: 'hidden', overflowY: 'hidden' },
+                [200, 292],
+                false,
+            ],
             [
                 'point on the bottom border, just below the gutter',
                 { border: 2, clientWidth: 381, clientHeight: 281 },

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -39,10 +39,24 @@ const zones: { edge: EditModeEdge; style: React.CSSProperties; cursor: React.CSS
 ]
 
 /**
- * Whether the viewport point (x, y) lies on a visible, functional scrollbar of `el`.
+ * Overlay scrollbars (macOS default, and Chromium headless) occupy no layout space, so their exact
+ * bounds cannot be measured. They render inside the scroll container along its bottom/right edge;
+ * 16px matches the macOS hover-expanded track and comfortably covers Chromium's overlay thumb.
+ */
+const OVERLAY_SCROLLBAR_BAND = 16
+
+const isScrollableOverflow = (overflow: string): boolean =>
+    // 'overlay' is legacy WebKit; Chrome computes it to 'auto' but include it for safety.
+    overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay'
+
+/**
+ * Whether the viewport point (x, y) lies on a functional scrollbar of `el`.
  * "Functional" means the content actually overflows on that axis, so a press there would grab the
- * scrollbar rather than hit an empty reserved gutter. Overlay scrollbars (macOS default) occupy no
- * layout space, so `offsetHeight - clientHeight` is 0 and they are never matched.
+ * scrollbar rather than hit an empty reserved gutter. Classic scrollbars occupy layout space
+ * (`offsetHeight - clientHeight`), which gives their exact bounds. Overlay scrollbars (macOS
+ * default) occupy none, so for a scrollable element without a gutter the edge band where the
+ * overlay scrollbar materializes counts as scrollbar territory even while the thumb is hidden;
+ * a press there while it's hidden just falls through to the content, matching native behavior.
  */
 export function isPointInScrollbarGutter(el: HTMLElement, x: number, y: number): boolean {
     const style = window.getComputedStyle(el)
@@ -55,11 +69,18 @@ export function isPointInScrollbarGutter(el: HTMLElement, x: number, y: number):
     // offsetHeight spans the border box; clientHeight excludes borders and the horizontal scrollbar,
     // so the difference minus borders is the scrollbar's rendered height (0 for overlay scrollbars).
     // The > 1 threshold absorbs the integer rounding of offset/client dimensions.
-    const horizontalScrollbarHeight = el.offsetHeight - el.clientHeight - borderTop - borderBottom
-    if (horizontalScrollbarHeight > 1 && el.scrollWidth > el.clientWidth) {
-        const gutterTop = rect.bottom - borderBottom - horizontalScrollbarHeight
+    const horizontalGutter = el.offsetHeight - el.clientHeight - borderTop - borderBottom
+    const canScrollX = el.scrollWidth - el.clientWidth > 1
+    const horizontalBand =
+        horizontalGutter > 1 && canScrollX
+            ? horizontalGutter
+            : canScrollX && isScrollableOverflow(style.overflowX)
+              ? OVERLAY_SCROLLBAR_BAND
+              : 0
+    if (horizontalBand > 0) {
+        const bandTop = rect.bottom - borderBottom - horizontalBand
         if (
-            y >= gutterTop &&
+            y >= bandTop &&
             y <= rect.bottom - borderBottom &&
             x >= rect.left + borderLeft &&
             x <= rect.right - borderRight
@@ -68,13 +89,19 @@ export function isPointInScrollbarGutter(el: HTMLElement, x: number, y: number):
         }
     }
 
-    const verticalScrollbarWidth = el.offsetWidth - el.clientWidth - borderLeft - borderRight
-    if (verticalScrollbarWidth > 1 && el.scrollHeight > el.clientHeight) {
-        const gutterLeft =
-            style.direction === 'rtl' ? rect.left + borderLeft : rect.right - borderRight - verticalScrollbarWidth
+    const verticalGutter = el.offsetWidth - el.clientWidth - borderLeft - borderRight
+    const canScrollY = el.scrollHeight - el.clientHeight > 1
+    const verticalBand =
+        verticalGutter > 1 && canScrollY
+            ? verticalGutter
+            : canScrollY && isScrollableOverflow(style.overflowY)
+              ? OVERLAY_SCROLLBAR_BAND
+              : 0
+    if (verticalBand > 0) {
+        const bandLeft = style.direction === 'rtl' ? rect.left + borderLeft : rect.right - borderRight - verticalBand
         if (
-            x >= gutterLeft &&
-            x <= gutterLeft + verticalScrollbarWidth &&
+            x >= bandLeft &&
+            x <= bandLeft + verticalBand &&
             y >= rect.top + borderTop &&
             y <= rect.bottom - borderBottom
         ) {

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -125,6 +125,94 @@ function pointIsOverScrollbarInside(container: HTMLElement, x: number, y: number
         )
 }
 
+/**
+ * In edit mode react-grid-layout's resize handles cover the card edges — the south handle is 32px
+ * tall and reaches 24px into the tile (see DashboardItems.scss), fully burying a table's horizontal
+ * scrollbar — so they must yield to scrollbars the same way the view-mode zones above do. One
+ * document-level watcher covers every tile: it hands a hovered handle's pixels to the scrollbar via
+ * `pointer-events: none` and re-arms it once the pointer leaves. The capture-phase mousedown guard
+ * covers what the hover hand-off can't: a press that lands before any mousemove, or a press on the
+ * scrollbar itself, which would otherwise bubble into react-grid-layout and start a resize or tile
+ * drag. Stopping propagation (without preventDefault) keeps the native scrollbar interaction alive.
+ */
+export function useResizeHandleScrollbarPassThrough(enabled: boolean): void {
+    useEffect(() => {
+        if (!enabled) {
+            return
+        }
+        const yielded = new Set<HTMLElement>()
+
+        const rearm = (event: MouseEvent): void => {
+            for (const handle of yielded) {
+                const gridItem = handle.closest('.react-grid-item')
+                const rect = handle.getBoundingClientRect()
+                const inHandle =
+                    handle.isConnected &&
+                    event.clientX >= rect.left &&
+                    event.clientX <= rect.right &&
+                    event.clientY >= rect.top &&
+                    event.clientY <= rect.bottom
+                if (
+                    !inHandle ||
+                    !(gridItem instanceof HTMLElement) ||
+                    !pointIsOverScrollbarInside(gridItem, event.clientX, event.clientY)
+                ) {
+                    handle.style.pointerEvents = ''
+                    yielded.delete(handle)
+                }
+            }
+        }
+
+        const handleMove = (event: MouseEvent): void => {
+            if (event.buttons !== 0) {
+                return // don't re-target pixels mid-drag or mid-resize
+            }
+            rearm(event)
+            const hovered = event.target instanceof Element ? event.target.closest('.react-resizable-handle') : null
+            const gridItem = hovered?.closest('.react-grid-item')
+            if (
+                !(hovered instanceof HTMLElement) ||
+                !(gridItem instanceof HTMLElement) ||
+                yielded.has(hovered) ||
+                !pointIsOverScrollbarInside(gridItem, event.clientX, event.clientY)
+            ) {
+                return
+            }
+            // Corner handles overlap the edge handles at the ends, so yield every handle stacked on
+            // the point at once — otherwise the one beneath swallows a press until its own mousemove.
+            for (const handle of gridItem.querySelectorAll<HTMLElement>('.react-resizable-handle')) {
+                const rect = handle.getBoundingClientRect()
+                if (
+                    event.clientX >= rect.left &&
+                    event.clientX <= rect.right &&
+                    event.clientY >= rect.top &&
+                    event.clientY <= rect.bottom
+                ) {
+                    handle.style.pointerEvents = 'none'
+                    yielded.add(handle)
+                }
+            }
+        }
+
+        const handlePressCapture = (event: MouseEvent): void => {
+            const gridItem = event.target instanceof Element ? event.target.closest('.react-grid-item') : null
+            if (gridItem instanceof HTMLElement && pointIsOverScrollbarInside(gridItem, event.clientX, event.clientY)) {
+                event.stopPropagation()
+            }
+        }
+
+        document.addEventListener('mousemove', handleMove)
+        document.addEventListener('mousedown', handlePressCapture, true)
+        return () => {
+            document.removeEventListener('mousemove', handleMove)
+            document.removeEventListener('mousedown', handlePressCapture, true)
+            for (const handle of yielded) {
+                handle.style.pointerEvents = ''
+            }
+        }
+    }, [enabled])
+}
+
 export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnterEditMode }) => {
     const [hovering, setHovering] = useState(false)
     // Count entered zones rather than toggling a boolean, so following the border across overlapping

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -123,11 +123,32 @@ export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnte
         if (!container || scrollbarPassThroughEdges.has(edge)) {
             return
         }
-        if (pointIsOverScrollbarInside(container, event.clientX, event.clientY)) {
-            setScrollbarPassThroughEdges((prev) => new Set(prev).add(edge))
-            // The zone's own mouseleave won't fire once it ignores pointer events, so release here.
-            releaseHover()
+        const { clientX, clientY } = event
+        if (!pointIsOverScrollbarInside(container, clientX, clientY)) {
+            return
         }
+        // Corner zones paint above edge zones, so several zones can stack on these pixels. Yield every
+        // zone whose rect contains the point, not just the hovered one: a zone beneath only receives its
+        // own mousemove after the one above yields, and until then it would swallow a press aimed at the
+        // scrollbar (handlePress keeps it out of edit mode, but the press reaches no scrollbar either).
+        setScrollbarPassThroughEdges((prev) => {
+            let next: Set<EditModeEdge> | null = null
+            for (const [zoneEdge, zone] of zoneRefs.current) {
+                if (!zone || prev.has(zoneEdge)) {
+                    continue
+                }
+                const rect = zone.getBoundingClientRect()
+                const containsPoint =
+                    clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+                if (zoneEdge === edge || containsPoint) {
+                    next = next ?? new Set(prev)
+                    next.add(zoneEdge)
+                }
+            }
+            return next ?? prev
+        })
+        // The zone's own mouseleave won't fire once it ignores pointer events, so release here.
+        releaseHover()
     }
 
     useEffect(() => {

--- a/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/EditModeEdgeOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 
 import { DashboardResizeHandles } from 'lib/components/Cards/handles'
 
@@ -7,6 +7,8 @@ export type EditModeEdge = 'n' | 's' | 'w' | 'e' | 'nw' | 'ne' | 'sw' | 'se'
 interface EditModeEdgeOverlayProps {
     onEnterEditMode: (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge) => void
 }
+
+const EDGE_ZONE_DATA_ATTR = 'dashboard-edit-mode-from-card-edge'
 
 const edgeOverlayBaseStyle: React.CSSProperties = {
     position: 'absolute',
@@ -36,13 +38,137 @@ const zones: { edge: EditModeEdge; style: React.CSSProperties; cursor: React.CSS
     { edge: 'se', style: { ...cornerZoneStyle, bottom: -2, right: -2 }, cursor: 'se-resize' },
 ]
 
+/**
+ * Whether the viewport point (x, y) lies on a visible, functional scrollbar of `el`.
+ * "Functional" means the content actually overflows on that axis, so a press there would grab the
+ * scrollbar rather than hit an empty reserved gutter. Overlay scrollbars (macOS default) occupy no
+ * layout space, so `offsetHeight - clientHeight` is 0 and they are never matched.
+ */
+export function isPointInScrollbarGutter(el: HTMLElement, x: number, y: number): boolean {
+    const style = window.getComputedStyle(el)
+    const borderTop = parseFloat(style.borderTopWidth) || 0
+    const borderBottom = parseFloat(style.borderBottomWidth) || 0
+    const borderLeft = parseFloat(style.borderLeftWidth) || 0
+    const borderRight = parseFloat(style.borderRightWidth) || 0
+    const rect = el.getBoundingClientRect()
+
+    // offsetHeight spans the border box; clientHeight excludes borders and the horizontal scrollbar,
+    // so the difference minus borders is the scrollbar's rendered height (0 for overlay scrollbars).
+    // The > 1 threshold absorbs the integer rounding of offset/client dimensions.
+    const horizontalScrollbarHeight = el.offsetHeight - el.clientHeight - borderTop - borderBottom
+    if (horizontalScrollbarHeight > 1 && el.scrollWidth > el.clientWidth) {
+        const gutterTop = rect.bottom - borderBottom - horizontalScrollbarHeight
+        if (
+            y >= gutterTop &&
+            y <= rect.bottom - borderBottom &&
+            x >= rect.left + borderLeft &&
+            x <= rect.right - borderRight
+        ) {
+            return true
+        }
+    }
+
+    const verticalScrollbarWidth = el.offsetWidth - el.clientWidth - borderLeft - borderRight
+    if (verticalScrollbarWidth > 1 && el.scrollHeight > el.clientHeight) {
+        const gutterLeft =
+            style.direction === 'rtl' ? rect.left + borderLeft : rect.right - borderRight - verticalScrollbarWidth
+        if (
+            x >= gutterLeft &&
+            x <= gutterLeft + verticalScrollbarWidth &&
+            y >= rect.top + borderTop &&
+            y <= rect.bottom - borderBottom
+        ) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/** Whether any element of the card under the viewport point shows a functional scrollbar there. */
+function pointIsOverScrollbarInside(container: HTMLElement, x: number, y: number): boolean {
+    return document
+        .elementsFromPoint(x, y)
+        .some(
+            (el) =>
+                el instanceof HTMLElement &&
+                el.dataset.attr !== EDGE_ZONE_DATA_ATTR &&
+                container.contains(el) &&
+                isPointInScrollbarGutter(el, x, y)
+        )
+}
+
 export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnterEditMode }) => {
     const [hovering, setHovering] = useState(false)
     // Count entered zones rather than toggling a boolean, so following the border across overlapping
     // edge/corner zones never dips to "not hovering" for a frame and flickers the handles.
     const hoverCount = useRef(0)
+    // Zones whose pixels currently sit on top of a scrollbar of the tile's content. They get
+    // `pointer-events: none` so presses and wheel events reach the scrollbar natively: a native
+    // scrollbar drag only engages when the browser hit-tests the pointer to the scrollable element
+    // itself, so an intercept-then-forward approach cannot work. The main case is a table insight
+    // whose horizontal scrollbar renders in the card's bottom pixels, exactly under the "s" zone.
+    const [scrollbarPassThroughEdges, setScrollbarPassThroughEdges] = useState<ReadonlySet<EditModeEdge>>(new Set())
+    const zoneRefs = useRef(new Map<EditModeEdge, HTMLDivElement | null>())
+
+    const releaseHover = (): void => {
+        hoverCount.current = Math.max(0, hoverCount.current - 1)
+        if (hoverCount.current === 0) {
+            setHovering(false)
+        }
+    }
+
+    const evaluateScrollbarPassThrough = (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge): void => {
+        const container = event.currentTarget.parentElement
+        if (!container || scrollbarPassThroughEdges.has(edge)) {
+            return
+        }
+        if (pointIsOverScrollbarInside(container, event.clientX, event.clientY)) {
+            setScrollbarPassThroughEdges((prev) => new Set(prev).add(edge))
+            // The zone's own mouseleave won't fire once it ignores pointer events, so release here.
+            releaseHover()
+        }
+    }
+
+    useEffect(() => {
+        if (scrollbarPassThroughEdges.size === 0) {
+            return
+        }
+        // While any zone is letting events through, watch the pointer at the document level and
+        // re-enable the zone once the pointer is no longer over the scrollbar beneath it.
+        const handleMove = (event: MouseEvent): void => {
+            setScrollbarPassThroughEdges((prev) => {
+                let next: Set<EditModeEdge> | null = null
+                for (const edge of prev) {
+                    const zone = zoneRefs.current.get(edge)
+                    const container = zone?.parentElement
+                    const rect = zone?.getBoundingClientRect()
+                    const inZone =
+                        !!rect &&
+                        event.clientX >= rect.left &&
+                        event.clientX <= rect.right &&
+                        event.clientY >= rect.top &&
+                        event.clientY <= rect.bottom
+                    if (!inZone || !container || !pointIsOverScrollbarInside(container, event.clientX, event.clientY)) {
+                        next = next ?? new Set(prev)
+                        next.delete(edge)
+                    }
+                }
+                return next ?? prev
+            })
+        }
+        document.addEventListener('mousemove', handleMove)
+        return () => document.removeEventListener('mousemove', handleMove)
+    }, [scrollbarPassThroughEdges])
 
     const handlePress = (event: React.MouseEvent<HTMLDivElement>, edge: EditModeEdge): void => {
+        // A fast press can land before any mousemove had a chance to hand the zone's pixels over to
+        // the scrollbar below. The press is lost either way (it targeted the zone), but it must not
+        // throw the user into edit mode when they were aiming at a scrollbar.
+        const container = event.currentTarget.parentElement
+        if (container && pointIsOverScrollbarInside(container, event.clientX, event.clientY)) {
+            return
+        }
         // Treat any press (click or drag attempt) as intent to edit
         event.preventDefault()
         event.stopPropagation()
@@ -55,22 +181,27 @@ export const EditModeEdgeOverlay: React.FC<EditModeEdgeOverlayProps> = ({ onEnte
             {zones.map(({ edge, style, cursor }) => (
                 <div
                     key={edge}
+                    ref={(el) => {
+                        zoneRefs.current.set(edge, el)
+                    }}
                     onMouseDown={(event) => handlePress(event, edge)}
-                    onMouseEnter={() => {
+                    onMouseMove={(event) => evaluateScrollbarPassThrough(event, edge)}
+                    onMouseEnter={(event) => {
                         hoverCount.current += 1
                         setHovering(true)
+                        evaluateScrollbarPassThrough(event, edge)
                     }}
-                    onMouseLeave={() => {
-                        hoverCount.current = Math.max(0, hoverCount.current - 1)
-                        if (hoverCount.current === 0) {
-                            setHovering(false)
-                        }
-                    }}
+                    onMouseLeave={() => releaseHover()}
                     aria-hidden="true"
                     title="Click to edit layout"
-                    data-attr="dashboard-edit-mode-from-card-edge"
+                    data-attr={EDGE_ZONE_DATA_ATTR}
                     // eslint-disable-next-line react/forbid-dom-props
-                    style={{ ...edgeOverlayBaseStyle, ...style, cursor }}
+                    style={{
+                        ...edgeOverlayBaseStyle,
+                        ...style,
+                        cursor,
+                        ...(scrollbarPassThroughEdges.has(edge) ? { pointerEvents: 'none' } : {}),
+                    }}
                 />
             ))}
         </>

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -12,7 +12,7 @@ import { getDashboardWidgetFetchDisplayError } from '@posthog/products-dashboard
 
 import { ApiError } from 'lib/api'
 import { InsightCard } from 'lib/components/Cards/InsightCard'
-import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
+import { EditModeEdge, useResizeHandleScrollbarPassThrough } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
 import { DashboardEventSource, eventUsageLogic } from 'lib/utils/eventUsageLogic'
@@ -290,6 +290,8 @@ export function DashboardItems({ showCreateAnomalyAlertButton }: DashboardItemsP
         }),
         [layoutEditMode, isMobileView, isLayoutZoomToggled]
     )
+
+    useResizeHandleScrollbarPassThrough(layoutEditMode && !isMobileView)
 
     const onEnterEditModeFromEdge = useMemo(
         () =>


### PR DESCRIPTION
## TL;DR

On a dashboard, both the invisible edge strips (view mode) and react-grid-layout's resize handles (edit mode) sat on top of table scrollbars, so grabbing a table's scrollbar resized the tile or threw you into edit mode instead of scrolling. Now both step aside when the cursor is over scrollbar territory — a real scrollbar gutter, or the edge band where macOS-style overlay scrollbars live — so the scrollbar wins.

## Problem

A customer reported (via support, [internal thread](https://posthog.slack.com/archives/C0368RPHLQH/p1785839134257029)) that horizontal scrolling on dashboards is "nearly impossible". Their session telemetry shows the mechanism: repeated `dashboard mode toggled` events with `source: card_edge_hover`, each followed by a discard within seconds. They were trying to drag a table tile's horizontal scrollbar.

Two layers cover the scrollbar's pixels:

- View mode: `EditModeEdgeOverlay` renders invisible press-capture zones over card edges (the bottom zone is 14px tall, 12px into the card, above tile content). A press aimed at the scrollbar entered edit mode and started a resize gesture.
- Edit mode: react-grid-layout's resize handles cover the edges — the south handle is 32px tall and reaches 24px into the tile, fully burying a table's horizontal scrollbar. A press there resized the tile; the scrollbar stayed dead even after entering edit mode.

## Changes

- View-mode edge zones detect scrollbar territory beneath the cursor (`document.elementsFromPoint` + offset/client dimension math) and set `pointer-events: none` on themselves while the cursor is over it, so presses and wheel events reach the scrollbar natively. A document-level mousemove watcher re-arms a zone once the cursor leaves. Zones stack near corners, so a scrollbar hit yields every zone covering the point at once (raised in Greptile review), and `handlePress` re-checks at press time so a fast click doesn't hijack into edit mode.
- Edit-mode resize handles yield the same way via a new `useResizeHandleScrollbarPassThrough` hook: one document-level watcher hands a hovered handle's pixels to the scrollbar and re-arms it after, yielding stacked corner+edge handles together. A capture-phase mousedown guard stops fast presses (and presses on the scrollbar itself, which would bubble into react-grid-layout) from starting a resize or tile drag — stopping propagation without preventing default keeps the native scrollbar interaction alive.
- Scrollbar territory covers both scrollbar modes. Classic scrollbars occupy layout space, giving exact gutter bounds. Overlay scrollbars (macOS default) occupy none, so for an element that genuinely scrolls on an axis the 16px edge band where the overlay scrollbar materializes counts too. This matters: PostHog's stylesheet uses standard `scrollbar-width`/`scrollbar-color` properties, whose presence makes Chromium ignore all `::-webkit-scrollbar` styling document-wide and render native platform scrollbars — overlay on macOS.
- jsdom lacks `elementsFromPoint`, so `jest.setup.ts` shims it to return `[]`, consistent with jsdom having no layout.

> [!NOTE]
> Native scrollbar drags only engage when the browser hit-tests the pointer to the scrollable element itself, so an intercept-and-forward approach can't work. Yielding the pixels via `pointer-events: none` is the only way to let the scrollbar win. For overlay scrollbars this means the edge band over a scrollable element no longer enters edit mode or resizes even while the thumb is hidden; a press there falls through to the tile content, matching native behavior.

## How did you test this code?

Runtime verification against the Storybook dashboard scene driven by Playwright Chromium on the real DOM, in both scrollbar modes, both dashboard modes:

- Edit mode, classic scrollbars: before this revision, a press+drag on a table tile's scrollbar started a resize (`.resizing` class, no scroll). After: the handle yields on hover, the same drag scrolls the table (`scrollLeft` 0 → 263), wheel over the band scrolls too, and a press on the handle outside scrollbar territory (below the card border) still resizes.
- Edit mode, overlay scrollbars (headless Chromium, same zero-gutter geometry as macOS): press+drag in the band no longer resizes; a horizontal wheel gesture over the band scrolls the table (`scrollLeft` 0 → 120); resize still engages outside the band.
- View mode, both scrollbar modes: scrollbar drags and wheel scroll the table without entering edit mode; a press on a scrollbar-free edge still enters edit mode.

Unit tests: `EditModeEdgeOverlay.test.tsx` (31 pass) — parameterized gutter/band math (borders, rtl, overlay bands, `overflow: hidden`, reserved-but-non-overflowing gutters) plus behavioral tests for zone press suppression, pointer-events hand-off and restore, corner-stack yielding, and the edit-mode hook (handle yield + re-arm, stacked-handle yield, press-capture guard). All 12 Cards/DashboardItems suites pass (123 tests). Frontend typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by Thomas Obermueller

Investigated with PostHog Code (Claude) from a support report; revised twice after feedback. The first revision missed overlay scrollbars (found by bisecting the live page's stylesheets to explain why custom scrollbar styling doesn't render in Chromium); the second missed edit mode entirely — a devtools screenshot showed react-grid-layout's south resize handle covering the scrollbar, reproduced and verified before/after in Storybook (the Edit story needs a layout-edit `DashboardEventSource` for handles to arm). Skills invoked: /writing-tests, /writing-code-comments, /verify. Considered and rejected: shrinking the zones/handles (hurts the resize targets), press-time detection alone (a press that hits an overlay can't be forwarded to a native scrollbar), and reserving layout space under tables in cards (visual regression for every table tile).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
