### PR TITLE
fix(mcp): preserve Grafana service account tokens

### DIFF
--- a/tools/infra-scripts/mcp/grafana-token
+++ b/tools/infra-scripts/mcp/grafana-token
@@ -86,8 +86,19 @@ case "${1:-}" in
             # Delete existing token if present (security add doesn't update)
             security delete-generic-password -a "$USER" -s "$SERVICE" 2>/dev/null || true
 
-            # Add new token (use stdin to avoid token appearing in process list)
-            printf '%s' "$TOKEN" | security add-generic-password -a "$USER" -s "$SERVICE" -w
+            # security reads password input from the TTY, so use expect to keep the token out of process arguments.
+            printf '%s\n' "$TOKEN" | KEYCHAIN_ACCOUNT="$USER" KEYCHAIN_SERVICE="$SERVICE" expect -c '
+                set token [gets stdin]
+                log_user 0
+                spawn security add-generic-password -a $env(KEYCHAIN_ACCOUNT) -s $env(KEYCHAIN_SERVICE) -w
+                expect "password data for new item:"
+                send -- "$token\r"
+                expect "retype password for new item:"
+                send -- "$token\r"
+                expect eof
+                set wait_status [wait]
+                exit [lindex $wait_status 3]
+            '
 
             echo "Token for $REGION saved to Keychain."
             echo ""


### PR DESCRIPTION
## Problem

The Grafana token helper pipes each service account token to macOS Keychain, but `security add-generic-password -w` reads password input from the controlling TTY in an interactive shell. The pipe is ignored, so users are prompted and can store the wrong credential.

## Changes

Use macOS's bundled `expect` command to supply the token to both Keychain TTY prompts. The token remains on stdin and does not appear in process arguments.

## How did you test this code?

- Ran the actual helper in an allocated TTY with a 65-character dummy token and no manual input, retrieved the token from Keychain, and verified an exact match before deleting the temporary entry.
- Ran Bash syntax checking and ShellCheck.
- Ran `hogli ci:preflight --fix`; no known CI failure class applies to the diff.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation change is needed. The fix makes the helper behave as its existing usage documentation describes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex first reproduced the Keychain behavior without a TTY, where stdin appeared to work. Testing from an interactive terminal showed that `security` reads from the controlling TTY instead. The final implementation uses the macOS-bundled `expect` command to preserve stdin-based secret handling in both environments. No repository skills were invoked, as requested, and no real token values were printed or added to the repository.
