### PR TITLE
fix(warehouse-sources): fan out klaviyo coupon codes over coupons

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/canonical_descriptions.py
@@ -356,9 +356,10 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
     },
     "coupon_codes": {
         "description": "A unique coupon code assigned to a profile.",
-        "docs_url": "https://developers.klaviyo.com/en/reference/get_coupon_codes",
+        "docs_url": "https://developers.klaviyo.com/en/reference/get_coupon_coupon_codes",
         "columns": {
             "id": "Unique identifier for the coupon code.",
+            "coupon_id": "Identifier of the coupon this code was issued from.",
             "unique_code": "The code assigned to the profile.",
             "expires_at": "The datetime when the code expires.",
             "status": "Current status of the code (e.g. unassigned, assigned_to_profile, used).",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/settings.py
@@ -569,11 +569,18 @@ KLAVIYO_ENDPOINTS: dict[str, KlaviyoEndpointConfig] = {
         page_size=100,
         incremental_fields=[],
     ),
+    # Klaviyo requires a filter on coupon.id or profile.id on the flat /coupon-codes collection, so
+    # it can't be listed directly; fan out over /coupons and pull each coupon's codes instead.
     "coupon_codes": KlaviyoEndpointConfig(
         name="coupon_codes",
-        path="/coupon-codes",
+        path="/coupons/{coupon_id}/coupon-codes",
         page_size=100,
         incremental_fields=[],
+        fan_out=KlaviyoFanOutConfig(
+            parent_path="/coupons",
+            parent_page_size=100,
+            parent_id_column="coupon_id",
+        ),
     ),
     "tags": KlaviyoEndpointConfig(
         name="tags",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -574,6 +574,36 @@ class TestGeneralizedFanOut:
             }
         ]
 
+    def test_coupon_codes_fan_out_over_coupons_instead_of_the_unfiltered_collection(self, monkeypatch: Any) -> None:
+        # Klaviyo's flat /coupon-codes list requires a coupon.id or profile.id filter and 400s
+        # without one; fanning out per coupon avoids ever calling that unfiltered endpoint.
+        pages = {
+            "https://a.klaviyo.com/api/coupons?page[size]=100": {
+                "data": [{"id": "C1"}],
+                "links": {"next": None},
+            },
+            "https://a.klaviyo.com/api/coupons/C1/coupon-codes?page[size]=100": {
+                "data": [
+                    {
+                        "type": "coupon-code",
+                        "id": "C1-CODE1",
+                        "attributes": {"unique_code": "CODE1", "status": "UNASSIGNED"},
+                    }
+                ],
+                "links": {"next": None},
+            },
+        }
+        rows = _collect_rows("coupon_codes", monkeypatch, pages)
+        assert rows == [
+            {
+                "type": "coupon-code",
+                "id": "C1-CODE1",
+                "unique_code": "CODE1",
+                "status": "UNASSIGNED",
+                "coupon_id": "C1",
+            }
+        ]
+
     def test_flow_messages_walk_flows_then_actions_and_carry_both_ancestors(self, monkeypatch: Any) -> None:
         # Two-level fan-out: the intermediate path must be formatted with the grandparent id, and
         # each row must carry both ancestors or the flow -> action -> message chain can't be rebuilt.


### PR DESCRIPTION
## Problem

The Klaviyo `coupon_codes` data warehouse import was failing on every sync with:

```
HTTPError: 400 Client Error: Bad Request for url: https://a.klaviyo.com/api/coupon-codes?page[size]=100
```

Klaviyo's [flat `GET /api/coupon-codes` list endpoint](https://developers.klaviyo.com/en/reference/get_coupon_codes) requires a `filter` on `coupon.id` or `profile.id` — it can't be listed without one. Our source config was calling it as an unfiltered, top-level collection, so it 400ed unconditionally.

This is an app-side bug, not a credential/config issue, so it needed a code fix rather than a `NonRetryableErrors` entry.

## Changes

- Reconfigured the `coupon_codes` endpoint to fan out over `/coupons` and pull each coupon's codes via the per-coupon [`GET /api/coupons/{id}/coupon-codes`](https://developers.klaviyo.com/en/reference/get_coupon_coupon_codes) endpoint, which requires no filter. This mirrors the existing one-level fan-out pattern already used for `flow_actions`.
- Each coupon code row now carries a `coupon_id` column identifying the coupon it fanned out from; updated the canonical column descriptions to match.

## How did you test this code?

- Added `test_coupon_codes_fan_out_over_coupons_instead_of_the_unfiltered_collection` in `test_klaviyo.py`, which asserts the sync now calls `/coupons` then `/coupons/{coupon_id}/coupon-codes` and never touches the unfiltered `/coupon-codes` endpoint that 400s — this locks in the fix and would catch a regression back to the flat collection.
- Ran the full `test_klaviyo.py` suite locally (100 passed) and `mypy --cache-fine-grained .` repo-wide (no issues).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs reference this endpoint's request shape.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a PostHog error tracking issue for the Klaviyo warehouse source.
- Skills invoked: `/writing-tests` before adding the regression test.
- Confirmed via PostHog error tracking that the stack trace originates in `products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py` (`_fetch_page` → `raise_for_status()`), then verified against Klaviyo's public API reference that the flat `/coupon-codes` endpoint requires a filter param our config never supplied — a genuine app bug, not a credential/config problem, so no `NonRetryableErrors` change was warranted.
- Searched open PRs (by keyword and by the source maintainer) for a prior fix; found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*