### PR TITLE
fix(klaviyo): skip values report when conversion metric is ineligible

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -28,6 +28,11 @@ DEFAULT_CONVERSION_METRIC_NAME = "Placed Order"
 # Accounts have tens of metrics, so the fallback lookup stays bounded rather than walking forever.
 MAX_CONVERSION_METRIC_PAGES = 20
 
+# Klaviyo's exact detail string when a metric (configured or auto-resolved) can't be used as a
+# values report's conversion metric, e.g. a system metric Klaviyo doesn't allow for conversion
+# statistics. The same metric would be re-resolved on every retry, so this can never self-heal.
+CONVERSION_METRIC_INELIGIBLE_DETAIL = "does not support querying for values data"
+
 
 class KlaviyoRetryableError(Exception):
     pass
@@ -457,26 +462,39 @@ def _get_values_report_rows(
     post_headers = {**headers, "Content-Type": "application/vnd.api+json"}
     url = f"{KLAVIYO_BASE_URL}{config.path}"
 
-    while True:
-        data = _fetch_page(session, url, post_headers, logger, json_body=body)
-        attributes = data.get("data", {}).get("attributes", {})
+    try:
+        while True:
+            data = _fetch_page(session, url, post_headers, logger, json_body=body)
+            attributes = data.get("data", {}).get("attributes", {})
 
-        for result in attributes.get("results", []):
-            batcher.batch(
-                {
-                    **result.get("groupings", {}),
-                    **result.get("statistics", {}),
-                    "timeframe_key": report.timeframe_key,
-                    "conversion_metric_id": metric_id,
-                }
+            for result in attributes.get("results", []):
+                batcher.batch(
+                    {
+                        **result.get("groupings", {}),
+                        **result.get("statistics", {}),
+                        "timeframe_key": report.timeframe_key,
+                        "conversion_metric_id": metric_id,
+                    }
+                )
+                if batcher.should_yield():
+                    yield batcher.get_table()
+
+            next_url = data.get("links", {}).get("next")
+            if not next_url:
+                break
+            url = next_url
+    except requests.HTTPError as exc:
+        if (
+            exc.response is not None
+            and exc.response.status_code == 400
+            and CONVERSION_METRIC_INELIGIBLE_DETAIL in exc.response.text
+        ):
+            logger.warning(
+                f"Klaviyo: conversion metric {metric_id} isn't eligible for values reporting on "
+                f"{config.name}; set a different conversion metric ID on the source, skipping"
             )
-            if batcher.should_yield():
-                yield batcher.get_table()
-
-        next_url = data.get("links", {}).get("next")
-        if not next_url:
-            break
-        url = next_url
+            return
+        raise
 
 
 def get_rows(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -763,6 +763,37 @@ class TestValuesReports:
 
         assert rows[0]["conversion_metric_id"] == "M_FIRST"
 
+    def test_ineligible_conversion_metric_skips_the_report_instead_of_failing_the_sync(self, monkeypatch: Any) -> None:
+        # Klaviyo rejects some metrics (e.g. system metrics) as conversion metrics for values
+        # reports; the same metric would be re-resolved on every retry, so this can never self-heal
+        # and must not fail the whole sync.
+        response = _response_with_status(400)
+        response._content = (
+            b'{"errors":[{"status":400,"code":"invalid","title":"Invalid input.",'
+            b'"detail":"Passed in conversion metric does not support querying for values data",'
+            b'"source":{"pointer":"/data/attributes/conversion_metric_id"}}]}'
+        )
+
+        def fake_fetch(
+            session: Any, url: str, headers: dict[str, str], logger: Any, json_body: dict | None = None
+        ) -> dict:
+            if json_body is not None:
+                raise requests.HTTPError(response=response)
+            return {"data": [{"id": "M_FIRST", "attributes": {"name": "Viewed Product"}}], "links": {}}
+
+        monkeypatch.setattr(klaviyo, "_fetch_page", fake_fetch)
+        assert (
+            list(
+                get_rows(
+                    api_key="pk_test",
+                    endpoint="campaign_values_reports",
+                    logger=MagicMock(),
+                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+                )
+            )
+            == []
+        )
+
     def test_account_with_no_metrics_yields_nothing_instead_of_posting_an_invalid_report(
         self, monkeypatch: Any
     ) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -794,6 +794,30 @@ class TestValuesReports:
             == []
         )
 
+    def test_unrelated_http_error_still_propagates(self, monkeypatch: Any) -> None:
+        # Only the specific ineligible-conversion-metric 400 should be swallowed; any other HTTP
+        # failure (e.g. a transient 500) must still fail the sync loudly rather than go silent.
+        response = _response_with_status(500)
+        response._content = b'{"errors":[{"status":500,"title":"Internal Server Error"}]}'
+
+        def fake_fetch(
+            session: Any, url: str, headers: dict[str, str], logger: Any, json_body: dict | None = None
+        ) -> dict:
+            if json_body is not None:
+                raise requests.HTTPError(response=response)
+            return {"data": [{"id": "M_FIRST", "attributes": {"name": "Viewed Product"}}], "links": {}}
+
+        monkeypatch.setattr(klaviyo, "_fetch_page", fake_fetch)
+        with pytest.raises(requests.HTTPError):
+            list(
+                get_rows(
+                    api_key="pk_test",
+                    endpoint="campaign_values_reports",
+                    logger=MagicMock(),
+                    resumable_source_manager=_FakeResumableManager(),  # type: ignore[arg-type]
+                )
+            )
+
     def test_account_with_no_metrics_yields_nothing_instead_of_posting_an_invalid_report(
         self, monkeypatch: Any
     ) -> None:


### PR DESCRIPTION
## Problem

Error tracking flagged a recurring `HTTPError` from the Klaviyo data warehouse source: [400 Client Error: Bad Request for url: https://a.klaviyo.com/api/campaign-values-reports](https://us.posthog.com/project/2/error_tracking/019fcc94-5bbc-73b0-ad84-4f470abdc2fd) (same failure also hit `flow-values-reports`).

The stack trace lands in `_fetch_page` in [`klaviyo.py`](products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py), called from `_get_values_report_rows`. The Klaviyo response body explains the actual cause:

```
"detail":"Passed in conversion metric does not support querying for values data"
```

Klaviyo restricts which metrics are eligible as a conversion metric for these reporting endpoints. `_resolve_conversion_metric_id` falls back to "Placed Order" if present, otherwise to whichever metric the account defines first — and that first metric isn't guaranteed to be conversion-eligible. Since the same metric gets re-resolved on every retry, this can never self-heal: the schema just kept failing on every sync attempt instead of the rest of the source syncing normally.

## Changes

- Catch this specific, stable Klaviyo error detail in `_get_values_report_rows` and skip the table with a warning log, mirroring the existing graceful-skip behavior already in place for accounts with no metrics at all.
- Left the rest of the retry behavior untouched — this isn't a credential/permission issue, so it doesn't belong in `get_non_retryable_errors`, and it isn't a transient error either.

## How did you test this code?

Added one regression test, `test_ineligible_conversion_metric_skips_the_report_instead_of_failing_the_sync`, that simulates Klaviyo returning this exact 400 detail and asserts the sync now yields no rows instead of raising. No existing test covered this failure shape (the existing tests cover "no metrics at all" and "successful fallback to the first metric", but not "the resolved metric gets rejected by Klaviyo").

Ran the full Klaviyo test suite locally (100 passed) and full-repo `mypy` (no issues).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error tracking issue end-to-end (pulled the issue, stack trace, and underlying Klaviyo log payload via the PostHog MCP tools; read Klaviyo's API docs to rule out a statistics/group_by validation bug before finding the real cause in logs).
- Skill invoked: `/writing-tests` before adding the regression test.
- Decision: considered adding this error string to `get_non_retryable_errors` instead, but the root cause is our own fallback metric-selection logic occasionally picking an ineligible metric (not a user credential problem), so a graceful skip is the more correct fix — it also covers the case where a user explicitly configures an ineligible metric ID.