### PR TITLE
fix(data-imports): stop double-classifying transient object-store errors as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -44,7 +44,11 @@ def is_transient_object_store_error(error: BaseException) -> bool:
     match), but hitting our own instance-role-authenticated bucket always means the same transient
     resolution hiccup, so it's recognized by type rather than by message.
     """
-    if isinstance(error, botocore.exceptions.NoCredentialsError):
+    if isinstance(error, TransientObjectStoreError | botocore.exceptions.NoCredentialsError):
+        # Already classified and wrapped by a prior call to this same function (see
+        # `_capture_unless_transient`) — a caller further up the stack that catches broadly and
+        # re-runs this classifier on the wrapper, rather than the original OSError/DeltaError it
+        # wraps, must still treat it as transient.
         return True
     return isinstance(error, OSError | deltalake.exceptions.DeltaError) and any(
         needle in str(error) for needle in TRANSIENT_OBJECT_STORE_ERRORS

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -5,6 +5,7 @@ import botocore.exceptions
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TransientObjectStoreError,
     is_transient_delta_maintenance_error,
     is_transient_maintenance_error,
     is_transient_object_store_error,
@@ -32,6 +33,11 @@ class TestIsTransientObjectStoreError:
                 True,
             ),
             ("unrelated_exception_type", ValueError("some other unrelated failure"), False),
+            # `get_delta_table` re-raises a recognized transient blip as this wrapper (see
+            # `_capture_unless_transient`) instead of the original OSError/DeltaError. A caller
+            # further up the stack that catches broadly and re-runs this classifier on the caught
+            # exception sees the wrapper, not the original — it must still read as transient.
+            ("already_wrapped_transient_error", TransientObjectStoreError("Please reduce your request rate"), True),
         ]
     )
     def test_classifies_transient_errors(self, _name: str, error: Exception, expected: bool):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -5,6 +5,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from parameterized import parameterized
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    TransientObjectStoreError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.repartition_table import (
     RepartitionActivityInputs,
     _maybe_flag_pre_extraction,
@@ -93,27 +96,27 @@ class TestMaybeFlagPreExtraction:
         [
             (
                 "generic_s3_error",
-                OSError(
-                    "Generic S3 error: Error getting list response body: HTTP error: "
-                    "request or response body error: operation timed out"
-                ),
+                "Generic S3 error: Error getting list response body: HTTP error: "
+                "request or response body error: operation timed out",
             ),
             (
                 "credential_provider_timeout",
-                OSError(
-                    "Operation not supported: an error occurred while loading credentials: "
-                    "dispatch failure: timeout: client error (Connect): HTTP connect timeout occurred: timed out"
-                ),
+                "Operation not supported: an error occurred while loading credentials: "
+                "dispatch failure: timeout: client error (Connect): HTTP connect timeout occurred: timed out",
             ),
         ]
     )
     @patch(f"{MODULE}.capture_exception")
     def test_transient_object_store_error_is_not_reported(
-        self, _name: str, error: OSError, mock_capture: MagicMock
+        self, _name: str, message: str, mock_capture: MagicMock
     ) -> None:
+        # `get_delta_table` never lets the raw OSError/DeltaError escape for a recognized transient
+        # blip — it re-raises `TransientObjectStoreError` instead (see `_capture_unless_transient`).
+        # Mocking the raw error here would miss the exact bug this test guards: a caller re-running
+        # `is_transient_object_store_error` on the wrapper it actually receives, not on the original.
         schema = _schema(name="stripe_charge", s3_folder_name=None)
         helper = MagicMock()
-        helper.get_delta_table = AsyncMock(side_effect=error)
+        helper.get_delta_table = AsyncMock(side_effect=TransientObjectStoreError(message))
 
         result = _maybe_flag_pre_extraction(schema, MagicMock(), helper, MagicMock(), enabled=True)
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `TransientObjectStoreError` issue from the data warehouse import pipeline's repartition activity. The underlying cause was an S3 `SlowDown` (503) response while opening a Delta table — a transient, self-recovering blip, not a defect.

`DeltaTableRef.get_delta_table()` already has logic to avoid reporting these: when it recognizes a transient object-store error (via `is_transient_object_store_error`), it re-raises it wrapped as `TransientObjectStoreError` (a `NonReportableError` subclass) instead of letting the original `OSError`/`DeltaError` escape.

The bug is one layer up. `_maybe_flag_pre_extraction` (the pre-extraction repartition-size check) catches the exception from that call chain and re-runs `is_transient_object_store_error` itself to decide whether to call `capture_exception`. But by that point the exception it receives is the `TransientObjectStoreError` wrapper, not the original `OSError`/`DeltaError` — and the classifier only matched those two original types. So it always fell into the "report it" branch, minting a fresh error-tracking issue for something already known to be transient.

## Changes

- `is_transient_object_store_error` now also recognizes its own `TransientObjectStoreError` wrapper type, so a caller that catches broadly and re-checks the same predicate on what it actually receives still classifies it correctly.
- This fixes `_maybe_flag_pre_extraction` and, as a side effect, the delta maintenance call sites too, since `is_transient_maintenance_error` delegates to the same function.

## How did you test this code?

Added a case to `TestIsTransientObjectStoreError` asserting the classifier returns `True` for an already-wrapped `TransientObjectStoreError` — this is the exact regression: without the fix, this case fails.

Also fixed `test_transient_object_store_error_is_not_reported` in `test_repartition_table.py`, which mocked `get_delta_table` raising a raw `OSError` directly. That never happens in production (`get_delta_table` always wraps a recognized transient blip before it escapes), so the test was masking the bug by giving the classifier the type it actually expects instead of what it really receives. Changed it to raise `TransientObjectStoreError`, matching production behavior — confirmed this fails without the fix and passes with it.

Ran the full backend `mypy` check (clean) and the touched test modules locally.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from an error-tracking alert for the `products/warehouse_sources` data-imports pipeline. Traced the stack trace to `_capture_unless_transient`/`get_delta_table` in `pipelines/core/delta/table.py`, then to the actual bug in `_maybe_flag_pre_extraction` in `workflow_activities/repartition_table.py`, which re-classifies an already-wrapped exception using a predicate that doesn't recognize the wrapper type. Verified the regression reproduces by temporarily reverting the fix and confirming the new/updated tests fail, then confirmed they pass with the fix applied.

Checked open PRs (including the maintainer's own queue) for overlap — #75240 and #75242 touch the same `errors.py` file but classify different error signatures (a racy missing `_delta_log` commit file), not this wrapper re-classification bug, so this isn't a duplicate.