### PR TITLE
fix(desktop): refresh markdown preview when file contents change (Fixes #76280)

### DIFF
--- a/products/desktop/packages/ui/src/features/code-editor/hooks/useFileContent.ts
+++ b/products/desktop/packages/ui/src/features/code-editor/hooks/useFileContent.ts
@@ -18,7 +18,7 @@ export function useRepoFileContent(
       { repoPath, filePath },
       {
         enabled,
-        staleTime: Number.POSITIVE_INFINITY,
+        staleTime: 0,
         gcTime: FILE_CONTENT_GC_MS,
       },
     ),
@@ -32,7 +32,7 @@ export function useAbsoluteFileContent(filePath: string, enabled: boolean) {
       { filePath },
       {
         enabled,
-        staleTime: Number.POSITIVE_INFINITY,
+        staleTime: 0,
         gcTime: FILE_CONTENT_GC_MS,
       },
     ),


### PR DESCRIPTION
## Problem

The markdown document preview does not refresh when the file contents change on disk. Steps to reproduce:

1. Open a markdown file in preview mode
2. Edit the file in an external editor or the source view
3. The preview still shows the old content

## Root cause

The `useAbsoluteFileContent` and `useRepoFileContent` hooks in `useFileContent.ts` use `staleTime: Number.POSITIVE_INFINITY` for their React Query configuration. This means the query cache is never considered stale, so React Query never refetches the file content even when the underlying file has changed.

Since file content is read from local disk (which is cheap), there is no benefit to keeping the cache fresh forever.

## Fix

Changed `staleTime` from `Number.POSITIVE_INFINITY` to `0` in both `useAbsoluteFileContent` and `useRepoFileContent`. This ensures React Query refetches the file content on every mount, so the preview always reflects the current file contents.

## Verification

- [x] Fixes the reproduction steps in the issue
- [x] No performance concern since file reads from local disk are cheap
- [x] Only affects file content hooks; base64 image queries keep their `POSITIVE_INFINITY` staleTime since images are memoized via `useMemo`

Fixes #76280