### PR TITLE
fix(posthog_ai): stop an open SSE stream from wedging local hot reload

### DIFF
--- a/bin/start-backend
+++ b/bin/start-backend
@@ -23,6 +23,11 @@ fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# --workers-kill-timeout bounds the reload. Granian defaults it to disabled, which means it joins
+# the old worker with no timeout and only escalates to a hard kill when the flag is set. An open SSE
+# stream (an agent run log held by a browser tab) never finishes on its own, so without this the
+# worker never exits, the replacement is never spawned, and port 8000 stays dead until it is killed
+# by hand. A worker with nothing in flight still exits immediately, so normal reloads are unaffected.
 python ${DEBUG:+ -m debugpy --listen 127.0.0.1:5678} -m granian \
     --interface asgi \
     posthog.asgi:application \
@@ -33,4 +38,5 @@ python ${DEBUG:+ -m debugpy --listen 127.0.0.1:5678} -m granian \
     --reload-paths ./frontend/src/products.json \
     --host $HOST_BIND \
     --log-level debug \
-    --workers 1
+    --workers 1 \
+    --workers-kill-timeout 5

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -183,6 +183,10 @@ const config: Config = {
         // `new URL("./x.png", import.meta.url)` — import.meta is unavailable under Sucrase/CJS,
         // so mock them to the styleMock string instead of executing them.
         '^@posthog/brand/.*/png/.*$': '<rootDir>/src/test/mocks/styleMock.js',
+        // devHmrStreamAbort subscribes to Vite HMR events via import.meta, which Sucrase passes
+        // through into CJS and Jest then cannot compile ("Cannot use 'import.meta' outside a module").
+        // It is dev-server-only behavior, so stub it out rather than transform it.
+        devHmrStreamAbort$: '<rootDir>/src/test/mocks/emptyMock.js',
         '^.+\\.sql\\?raw$': '<rootDir>/src/test/mocks/rawFileMock.js',
         '^(.+)\\.yaml\\?raw$': '$1.yaml',
         '^~/(.*)$': '<rootDir>/src/$1',

--- a/products/posthog_ai/frontend/logics/devHmrStreamAbort.ts
+++ b/products/posthog_ai/frontend/logics/devHmrStreamAbort.ts
@@ -1,0 +1,79 @@
+import type { LiveStreamEntry } from './runStreamLogic'
+
+interface LiveStreamRegistryHost {
+    __posthogAiLiveStreamControllers?: Set<LiveStreamEntry>
+}
+
+// Vite injects `import.meta.hot` in dev and replaces it with undefined in production builds. Typed
+// locally because `vite/client` only resolves from the frontend workspace, not from this product.
+interface ViteHotContext {
+    on: (event: 'vite:afterUpdate' | 'vite:beforeFullReload' | 'vite:beforeUpdate', cb: () => void) => void
+}
+
+let registered = false
+
+/**
+ * Closes live SSE readers before Vite applies an HMR update, so a dev reload never waits on them.
+ *
+ * An open SSE response keeps a granian dev worker alive, and granian's reload joins the old worker
+ * before spawning its replacement, so a stream nobody closes stalls the whole backend until the kill
+ * timeout in bin/start-backend fires. Vite awaits `vite:beforeUpdate` listeners before applying an
+ * update, which makes it the one hook early enough to release the worker rather than race it.
+ *
+ * Every update fires this, including updates that leave `runStreamLogic` itself untouched. Those
+ * logics survive the swap with a live thread still on screen, and an aborted signal is the silent
+ * teardown path that schedules no reconnect, so aborting alone would stall the run with no way back.
+ * They are reopened on `vite:afterUpdate` instead.
+ *
+ * Registry membership is what decides who gets reopened, because an entry is removed only when its
+ * 'event-source' disposable tears down. An entry still present after the swap therefore has a logic
+ * that is mounted and still wants a stream. Entries that vanished belong either to a logic that
+ * unmounted mid-swap or to a build the swap discarded (re-evaluating `runStreamLogic` installs a
+ * fresh registry), and both must stay closed.
+ *
+ * This lives outside `runStreamLogic` because `import.meta` cannot appear in any module Jest
+ * compiles: Sucrase passes it through into CJS and the script then fails to compile with "Cannot use
+ * 'import.meta' outside a module", which no runtime environment check can prevent. Jest maps this
+ * path to an empty module (see `moduleNameMapper` in frontend/jest.config.ts), so the caller must
+ * keep the call itself behind a development check.
+ */
+export function registerHmrStreamAbort(): void {
+    const hot = (import.meta as ImportMeta & { hot?: ViteHotContext }).hot
+    // An HMR swap that re-evaluates only the caller would otherwise stack a second set of listeners
+    // on this module's still-live hot context.
+    if (!hot || registered) {
+        return
+    }
+    registered = true
+
+    const registryHost = globalThis as LiveStreamRegistryHost
+    let pendingReopen: LiveStreamEntry[] = []
+
+    const abortAll = (): LiveStreamEntry[] => {
+        const entries = [...(registryHost.__posthogAiLiveStreamControllers ?? [])]
+        entries.forEach((entry) => entry.controller.abort())
+        return entries
+    }
+
+    hot.on('vite:beforeUpdate', () => {
+        pendingReopen = abortAll()
+    })
+
+    hot.on('vite:afterUpdate', () => {
+        const entries = pendingReopen
+        pendingReopen = []
+        const current = registryHost.__posthogAiLiveStreamControllers
+        entries.forEach((entry) => {
+            if (current?.has(entry)) {
+                entry.reopen()
+            }
+        })
+    })
+
+    // A full reload discards the page anyway, but releasing the worker before it starts means the new
+    // page's first requests aren't queued behind a backend still waiting on the old connection.
+    hot.on('vite:beforeFullReload', () => {
+        pendingReopen = []
+        abortAll()
+    })
+}

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -72,27 +72,38 @@ import { extractContextBlockLines } from '../utils/posthogContextBlock'
 import { getClaudeCodeMeta, resolveToolCall } from '../utils/toolResolver'
 import { attachedContextLogic } from './attachedContextLogic'
 import { debugLogsLogic } from './debugLogsLogic'
+import { registerHmrStreamAbort } from './devHmrStreamAbort'
 import { foregroundStreamLogic } from './foregroundStreamLogic'
 import { hasReplayListener, toolStreamEventsLogic } from './toolStreamEventsLogic'
 import type { ToolStreamSubscription } from './toolStreamEventsLogic'
 
+export interface LiveStreamEntry {
+    controller: AbortController
+    /** Reopens this stream after an HMR swap its logic survived. See `devHmrStreamAbort`. */
+    reopen: () => void
+}
+
 interface LiveStreamRegistryHost {
-    __posthogAiLiveStreamControllers?: Set<AbortController>
+    __posthogAiLiveStreamControllers?: Set<LiveStreamEntry>
 }
 
 // Dev-only guard against orphaned SSE readers: an HMR swap re-evaluates this module in the same page,
-// and the old build's logic gets discarded with a fresh kea `cache` — its 'event-source' disposable
-// never runs teardown, so its reader keeps the connection open (pinning a granian dev worker) until
-// the tab closes. A fresh evaluation finding controllers in the page-global registry therefore means
-// an HMR swap just replaced their build — abort them (an aborted signal is the silent teardown path,
-// so the old logic won't schedule a reconnect). On first load the registry is empty, and a full page
-// load needs none of this: the browser aborts in-flight fetches itself. `import.meta.hot.dispose`
-// would be the idiomatic hook, but `import.meta` is a parse error in Jest's CJS transform.
-const liveStreamControllers = new Set<AbortController>()
+// and the old build's logic gets discarded with a fresh kea `cache`, so its 'event-source' disposable
+// never runs teardown and its reader keeps the connection open (pinning a granian dev worker) until
+// the tab closes. A fresh evaluation finding entries in the page-global registry therefore means
+// an HMR swap just replaced their build, so abort them (an aborted signal is the silent teardown path,
+// which is why the old logic won't schedule a reconnect). On first load the registry is empty, and a
+// full page load needs none of this because the browser aborts in-flight fetches itself.
+//
+// This only covers swaps that re-evaluate this module. `devHmrStreamAbort` covers the rest, where the
+// logic survives and its stream has to be reopened rather than left closed.
+const liveStreamControllers = new Set<LiveStreamEntry>()
 if (process.env.NODE_ENV === 'development') {
     const registryHost = globalThis as LiveStreamRegistryHost
-    registryHost.__posthogAiLiveStreamControllers?.forEach((controller) => controller.abort())
+    registryHost.__posthogAiLiveStreamControllers?.forEach((entry) => entry.controller.abort())
     registryHost.__posthogAiLiveStreamControllers = liveStreamControllers
+    // Jest maps this module to an empty stub, so the call has to stay inside this check.
+    registerHmrStreamAbort()
 }
 
 export type RunSseStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
@@ -2626,10 +2637,17 @@ export const runStreamLogic = kea<runStreamLogicType>([
             cache.disposables.add(
                 (): (() => void) => {
                     const controller = new AbortController()
-                    liveStreamControllers.add(controller)
+                    // `startLatest: true` mirrors the reconnect path below: the resume actually happens
+                    // off `cache.lastEventId` via Last-Event-ID, so this only matters if no frame has
+                    // arrived yet.
+                    const entry: LiveStreamEntry = {
+                        controller,
+                        reopen: () => actions.openSseForRun({ taskId, runId, startLatest: true }),
+                    }
+                    liveStreamControllers.add(entry)
                     void streamRun(controller.signal)
                     return () => {
-                        liveStreamControllers.delete(controller)
+                        liveStreamControllers.delete(entry)
                         controller.abort()
                     }
                 },


### PR DESCRIPTION
## Problem

If you have a PostHog AI agent run open in a browser tab, the local backend stops hot reloading. You edit a file, the log prints `Changes detected, reloading workers..`, and then nothing. Port 8000 stays dead until you find the granian worker pid and `kill -9` it, or close the tab.

The agent-run SSE stream is the culprit, but the reason it is fatal rather than merely slow is in granian. The reload loop calls `_stop_workers()` before `_spawn_workers()`, and `_stop_workers` does:

```python
timeout = self.workers_kill_timeout if self.workers_kill_timeout else None
for wrk in self.wrks:
    wrk.join(timeout)                 # timeout=None, so this blocks forever
    if self.workers_kill_timeout:     # the kill escalation is gated on the same flag
        ...
        wrk.kill()
```

`--workers-kill-timeout` defaults to disabled and `bin/start-backend` never set it. An SSE response never finishes on its own, so `join(None)` waits forever and the replacement worker is never spawned. `--workers 1` means one pinned stream takes down the whole dev backend. phrocs `autorestart` cannot help either, since it only fires when a process exits and the wedged parent is still alive.

```mermaid
flowchart TD
    A[File change] --> B[_stop_workers]
    B --> C{"join(timeout)"}
    C -->|timeout disabled| D[Blocks forever on the open SSE]
    D --> E[Replacement never spawned]
    E --> F[Port 8000 dead]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class D,E,F phRed;
```

## Changes

**Bound the reload.** Set `--workers-kill-timeout 5` in `bin/start-backend`. A worker with nothing in flight still exits immediately, so normal reloads are unaffected. The 5s is only ever paid when something is genuinely pinned.

```mermaid
flowchart TD
    A[File change] --> B[_stop_workers]
    B --> C{"join(5s)"}
    C -->|worker idle| D[Exits immediately]
    C -->|SSE still open| E[SIGKILL after 5s]
    D --> F[Replacement spawned]
    E --> F
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A,F phYellow;
    class D,E phBlue;
```

**Release the stream on HMR.** `runStreamLogic` already keeps a page-global `AbortController` registry, but it only aborts orphans when a swap re-evaluates that module, so readers from every other update keep pinning a worker. Vite awaits `vite:beforeUpdate` listeners before it applies an update, which makes that the one hook early enough to release the worker instead of racing it.

Logics that survive the swap are reopened on `vite:afterUpdate`. Registry membership is what decides who gets reopened: an entry is removed only when its `event-source` disposable tears down, so anything still present has a mounted logic that still wants a stream. Without that half, an unrelated component edit would silently kill a live run, because an aborted signal is the silent teardown path and schedules no reconnect.

That listener lives in its own module for a non-obvious reason. `import.meta` cannot appear in any module Jest compiles: Sucrase passes it straight through into CJS and the script then fails with `Cannot use 'import.meta' outside a module`. That is a compile error for the whole file, so a runtime `NODE_ENV` check does not save it. Jest maps the path to an empty stub, and the caller keeps the call itself behind the existing development check.

> [!NOTE]
> The two halves are independent. The flag alone fixes the hang, including for backend edits, which the HMR listener cannot see at all since Vite watches no Python. The listener is orphaned-reader hygiene and can be reverted on its own.

I also considered `--reload-ignore-patterns` so frontend edits stop restarting Django at all, and dropped it: it assumes Vite is running, and without that watcher some `.tsx`-derived inputs never reach granian.

## How did you test this code?

Automated, all run by me (the agent):

- `products/posthog_ai/frontend` suite: 715 tests, 48 suites, passing. This is what confirms the Jest stub keeps `runStreamLogic` compiling.
- `frontend/src/scenes/max` suite: 473 tests, 22 suites, passing. Verifies the `moduleNameMapper` entry resolves from a second root, since the Max scene imports these logics.
- Typecheck via a scoped tsconfig extending the root one: no errors in either touched TS file.
- `oxlint` and `oxfmt --check` clean on the changed files, `bash -n` clean on `bin/start-backend`.

> [!WARNING]
> I could not exercise the runtime behavior, since that needs a running dev stack with a live agent run. Two things are worth a human check before this leaves draft:
> 1. Edit a backend file with a run open. Expect `Killing worker-1 after it refused to gracefully stop` within ~5s, then a respawn, then `/_health` returning 200.
> 2. Edit an unrelated `.tsx` during a live run. The run must keep streaming after the swap rather than silently stalling. That is the `vite:afterUpdate` reopen path, and it is the one piece with real regression surface.

No new tests. The flag is dev-only launcher config, and the listener sits behind `import.meta.hot`, which is stubbed out under Jest by construction, so there is nothing a unit test could meaningfully assert.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. Nothing user-facing changes, and no documented workflow moves.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Georgiy pointed at the symptom (an open stream blocking hot reload) and steered scope through several rounds. I invoked `/writing-code-comments` for the comment work.

Most of the effort went into ruling things out. I first proposed a purely client-side abort, which does not work: a backend edit produces no browser-visible event at all, and the existing re-evaluation guard is chicken-and-egg, since the HMR swap that would trigger it is downstream of the wedge. I then proposed a SIGTERM handler in the shared SSE helper, which Georgiy pushed back on, correctly: it would race granian's own Rust-side handlers across every SSE endpoint in production and buys nothing the kill timeout does not already deliver.

Two things I had wrong and caught before they shipped. Georgiy suggested gating the Vite code behind the existing dev block, so I checked it rather than assuming, and a runtime gate cannot work here for the parse-vs-compile reason described above. Separately I had written `/// <reference types="vite/client" />`, which would have failed CI with TS2688, since vite only resolves from the `frontend` workspace and never from `products/`. `import.meta.hot` is typed locally instead.
