### PR TITLE
chore(persons): return explicit person columns instead of *

### DIFF
--- a/nodejs/src/common/persons/repositories/postgres-person-repository.ts
+++ b/nodejs/src/common/persons/repositories/postgres-person-repository.ts
@@ -44,6 +44,25 @@ import { RawPostgresPersonRepository } from './raw-postgres-person-repository'
 const DEFAULT_PERSON_PROPERTIES_TRIM_TARGET_BYTES = 512 * 1024
 const DEFAULT_PERSON_PROPERTIES_DB_CONSTRAINT_LIMIT_BYTES = 655360
 
+// Person write paths return these explicit columns instead of *: the persons
+// schema carries personhog-only columns (is_deleted) that must not leak into
+// ingestion's InternalPerson objects.
+const PERSON_COLUMN_NAMES = [
+    'id',
+    'uuid',
+    'created_at',
+    'team_id',
+    'properties',
+    'properties_last_updated_at',
+    'properties_last_operation',
+    'is_user_id',
+    'version',
+    'is_identified',
+    'last_seen_at',
+]
+export const PERSON_COLUMNS = PERSON_COLUMN_NAMES.join(', ')
+const PERSON_COLUMNS_PREFIXED = PERSON_COLUMN_NAMES.map((column) => `p.${column}`).join(', ')
+
 function queryTag(base: string, callerTag?: string): string {
     return callerTag ? `${base}:${callerTag}` : base
 }
@@ -581,7 +600,7 @@ export class PostgresPersonRepository
                 `WITH inserted_person AS (
                         INSERT INTO posthog_person (${columns.join(', ')})
                         VALUES (${valuePlaceholders})
-                        RETURNING *
+                        RETURNING ${PERSON_COLUMNS}
                     )` +
                 distinctIdsCTE +
                 ` SELECT * FROM inserted_person;`
@@ -1151,14 +1170,14 @@ export class PostgresPersonRepository
         ).map(
             (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
         )} WHERE id = $${idParamIndex} AND team_id = $${teamIdParamIndex}
-        RETURNING *, COALESCE(pg_column_size(properties)::bigint, 0::bigint) as properties_size_bytes
+        RETURNING ${PERSON_COLUMNS}, COALESCE(pg_column_size(properties)::bigint, 0::bigint) as properties_size_bytes
         /* operation='updatePersonWithPropertiesSize',purpose='${tag || 'update'}' */`
 
         // Potentially overriding values badly if there was an update to the person after computing updateValues above
         const queryString = `UPDATE posthog_person SET version = ${versionString}, ${Object.keys(update).map(
             (field, index) => `"${sanitizeSqlIdentifier(field)}" = $${index + 1}`
         )} WHERE id = $${idParamIndex} AND team_id = $${teamIdParamIndex}
-        RETURNING *
+        RETURNING ${PERSON_COLUMNS}
         /* operation='updatePerson',purpose='${tag || 'update'}' */`
 
         const shouldCalculatePropertiesSize =
@@ -1238,7 +1257,7 @@ export class PostgresPersonRepository
                     last_seen_at = $5,
                     version = COALESCE(version, 0)::numeric + 1
                 WHERE team_id = $6 AND uuid = $7 AND version = $8
-                RETURNING *
+                RETURNING ${PERSON_COLUMNS}
                 `,
                 [
                     JSON.stringify(finalProperties),
@@ -1364,7 +1383,7 @@ export class PostgresPersonRepository
                     $8::text[]
                 ) AS batch(batch_uuid, batch_team_id, new_properties, new_properties_last_updated_at, new_properties_last_operation, new_is_identified, new_created_at, new_last_seen_at)
                 WHERE p.uuid = batch.batch_uuid AND p.team_id = batch.batch_team_id
-                RETURNING p.*
+                RETURNING ${PERSON_COLUMNS_PREFIXED}
                 `,
                 [
                     uuids,

--- a/nodejs/src/common/persons/repositories/test-helpers.ts
+++ b/nodejs/src/common/persons/repositories/test-helpers.ts
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon'
 
+import { PERSON_COLUMNS } from '~/common/persons/repositories/postgres-person-repository'
 import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
 import { InternalPerson, PersonDistinctId, PersonUpdateFields, RawPerson, Team } from '~/types'
 
@@ -22,7 +23,9 @@ export async function getFirstTeam(postgres: PostgresRouter): Promise<Team> {
 
 export async function fetchPersons(postgres: PostgresRouter, teamId?: number): Promise<InternalPerson[]> {
     const query =
-        teamId !== undefined ? 'SELECT * FROM posthog_person WHERE team_id = $1' : 'SELECT * FROM posthog_person'
+        teamId !== undefined
+            ? `SELECT ${PERSON_COLUMNS} FROM posthog_person WHERE team_id = $1`
+            : `SELECT ${PERSON_COLUMNS} FROM posthog_person`
     const params = teamId !== undefined ? [teamId] : undefined
     return await postgres
         .query<RawPerson>(PostgresUse.PERSONS_WRITE, query, params, 'fetchPersons')

--- a/nodejs/tests/helpers/sql.ts
+++ b/nodejs/tests/helpers/sql.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon'
 
 import { defaultConfig } from '~/common/config/config'
+import { PERSON_COLUMNS } from '~/common/persons/repositories/postgres-person-repository'
 import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
 import { UUIDT } from '~/common/utils/utils'
 
@@ -475,7 +476,7 @@ export const createOrganizationMembership = async (pg: PostgresRouter, organizat
 }
 
 export async function fetchPostgresPersons(postgres: PostgresRouter, teamId: number) {
-    const query = `SELECT * FROM posthog_person WHERE team_id = ${teamId} ORDER BY id`
+    const query = `SELECT ${PERSON_COLUMNS} FROM posthog_person WHERE team_id = ${teamId} ORDER BY id`
     return (await postgres.query(PostgresUse.PERSONS_READ, query, undefined, 'persons')).rows.map(
         // NOTE: we map to update some values here to maintain
         // compatibility with `hub.fetchPersons`.


### PR DESCRIPTION
## Problem

Split out of #74124 so the code change can land ahead of the schema change.

The persons schema is about to grow personhog-only columns (`is_deleted`, from the lifecycle saga work in #74124). The nodejs person write paths use `RETURNING *` and `SELECT *`, so any new column immediately leaks into ingestion's `InternalPerson` objects and breaks deep-equality tests the moment the migration merges.

## Changes

- Person write paths in `PostgresPersonRepository` return an explicit `PERSON_COLUMNS` list instead of `RETURNING *`.
- Test helpers (`test-helpers.ts`, `tests/helpers/sql.ts`) select the same explicit columns so fetched rows stay comparable with write-path results.
- No behavior change on the current schema, since the explicit list matches today's `posthog_person` columns exactly. Once the schema PR merges, new columns stay invisible to ingestion.

## How did you test this code?

- On the combined branch (#74124 stack), `postgres-person-repository.test.ts` passed with 108 tests against the migrated schema. Without this change, two deep-equality tests fail there, which is the regression this guards.
- Verified the explicit column list matches the current `posthog_person` schema (information_schema check against a migrated local persons DB, where the only extra column is the upcoming `is_deleted`).
- I could not run the jest integration suite standalone in this session (the local runner was killed by the environment before starting), so relying on CI for the suite run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Internal refactor, no docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Extracted by Claude Code, directed by @jose-sequeira, from #74124 (the nodejs hunks applied unchanged). Kept byte-identical to the source PR so the schema PR rebases cleanly once this lands. The Django model fields and SQL migrations stay in #74124 because they only make sense together with the schema.
