### PR TITLE
feat(dashboards): add per-tile test account filtering override

### DIFF
--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -78,7 +78,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                 </p>
             </div>
 
-            <div className="space-y-4">
+            <div className="flex flex-col gap-4">
                 <div>
                     <LemonSwitch
                         checked={!!overrides.ignoreDashboardFilters}
@@ -93,7 +93,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                     </p>
                 </div>
 
-                <LemonDivider className="my-0" />
+                <LemonDivider className="mb-2" />
 
                 <div>
                     <label className="text-sm font-medium mb-2 block">Date range</label>
@@ -134,7 +134,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                     />
                 </div>
 
-                <LemonDivider className="my-0" />
+                <LemonDivider className="mb-2" />
 
                 <div>
                     <label className="text-sm font-medium mb-2 block">Properties</label>
@@ -161,7 +161,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                 </div>
 
                 <div>
-                    <div className="flex items-center justify-between gap-2 mb-2">
+                    <div className="flex items-center gap-1 mb-2">
                         <label className="text-sm font-medium">Test account filtering</label>
                         <LemonButton
                             icon={<IconGear />}
@@ -172,7 +172,6 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                         />
                     </div>
                     <LemonSegmentedButton<TestAccountFilterChoice>
-                        fullWidth
                         size="small"
                         value={testAccountChoice}
                         onChange={(next) => setFilterTestAccounts(CHOICE_TO_FILTER[next])}
@@ -203,7 +202,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                     <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
                 </div>
 
-                <LemonDivider className="my-0" />
+                <LemonDivider className="mb-2" />
 
                 <div>
                     <label className="text-sm font-medium mb-2 block">Breakdown</label>

--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -3,8 +3,8 @@ import './TileFiltersOverride.scss'
 
 import { BindLogic, useActions, useValues } from 'kea'
 
-import { IconCalendar } from '@posthog/icons'
-import { LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { IconCalendar, IconGear } from '@posthog/icons'
+import { LemonButton, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -12,6 +12,8 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
 import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { groupsModel } from '~/models/groupsModel'
 import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
@@ -20,10 +22,26 @@ import type { DashboardTile, InsightLogicProps, IntervalType, QueryBasedInsightM
 
 import { tileLogic } from './tileLogic'
 
+type TestAccountFilterChoice = 'inherit' | 'filter-out' | 'include'
+
+const CHOICE_TO_FILTER: Record<TestAccountFilterChoice, boolean | null> = {
+    inherit: null,
+    'filter-out': true,
+    include: false,
+}
+
+const CHOICE_HINTS: Record<TestAccountFilterChoice, string> = {
+    inherit: "Uses the dashboard's setting, or the insight's own if the dashboard doesn't set one.",
+    'filter-out': 'Internal and test users are filtered out of this insight.',
+    include: 'Internal and test users are included in this insight.',
+}
+
 export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedInsightModel> }): JSX.Element {
     const { overrides } = useValues(tileLogic)
-    const { setDates, setProperties, setBreakdown, setInterval, setIgnoreDashboardFilters } = useActions(tileLogic)
+    const { setDates, setProperties, setBreakdown, setInterval, setFilterTestAccounts, setIgnoreDashboardFilters } =
+        useActions(tileLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
+    const { currentTeam } = useValues(teamLogic)
 
     const { hasPageview, hasScreen } = getProjectEventExistence()
 
@@ -31,6 +49,11 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
     const querySource = isInsightVizNode(query) ? query.source : query
     const supportsInterval = isInsightQueryWithSeries(querySource ?? undefined)
     const supportsBreakdown = isInsightQueryWithBreakdown(querySource)
+
+    const filterTestAccounts = overrides.filterTestAccounts ?? null
+    const testAccountChoice: TestAccountFilterChoice =
+        filterTestAccounts === null ? 'inherit' : filterTestAccounts ? 'filter-out' : 'include'
+    const hasTestAccountFilters = (currentTeam?.test_account_filters || []).length > 0
 
     // The breakdown picker needs a mounted insightLogic. Bind a throwaway one, like DashboardEditBar,
     // keyed per tile so it can't collide with the edit bar's `dashboardItemId: 'new'` binding.
@@ -51,7 +74,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
             <div>
                 <p className="text-sm text-muted mb-4">
                     Set custom filters for this tile. Property filters apply on top of the dashboard's, while the tile's
-                    date range, interval, and breakdown replace the dashboard's.
+                    date range, interval, breakdown, and test account filtering replace the dashboard's.
                 </p>
             </div>
 
@@ -162,6 +185,49 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                             size="small"
                         />
                     </BindLogic>
+                </div>
+
+                <div>
+                    <div className="flex items-center justify-between gap-2 mb-2">
+                        <label className="text-sm font-medium">Test account filtering</label>
+                        <LemonButton
+                            icon={<IconGear />}
+                            size="xsmall"
+                            noPadding
+                            to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+                            tooltip="Configure internal and test account filters"
+                        />
+                    </div>
+                    <LemonSegmentedButton<TestAccountFilterChoice>
+                        fullWidth
+                        size="small"
+                        value={testAccountChoice}
+                        onChange={(next) => setFilterTestAccounts(CHOICE_TO_FILTER[next])}
+                        options={[
+                            {
+                                value: 'inherit',
+                                label: 'Inherit',
+                                tooltip: "Use the dashboard's setting, or the insight's own",
+                                'data-attr': 'tile-test-account-filter-inherit',
+                            },
+                            {
+                                value: 'filter-out',
+                                label: 'Filter out',
+                                tooltip: 'Force test account filtering on for this insight',
+                                disabledReason: !hasTestAccountFilters
+                                    ? "You haven't set any internal test filters. Click the gear icon to configure."
+                                    : undefined,
+                                'data-attr': 'tile-test-account-filter-out',
+                            },
+                            {
+                                value: 'include',
+                                label: 'Include',
+                                tooltip: 'Force test account filtering off for this insight',
+                                'data-attr': 'tile-test-account-filter-include',
+                            },
+                        ]}
+                    />
+                    <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -4,7 +4,7 @@ import './TileFiltersOverride.scss'
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconCalendar, IconGear } from '@posthog/icons'
-import { LemonButton, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -93,6 +93,8 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                     </p>
                 </div>
 
+                <LemonDivider className="my-0" />
+
                 <div>
                     <label className="text-sm font-medium mb-2 block">Date range</label>
                     <DateFilter
@@ -132,6 +134,8 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                     />
                 </div>
 
+                <LemonDivider className="my-0" />
+
                 <div>
                     <label className="text-sm font-medium mb-2 block">Properties</label>
                     <PropertyFilters
@@ -154,37 +158,6 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                             TaxonomicFilterGroupType.DataWarehousePersonProperties,
                         ]}
                     />
-                </div>
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Breakdown</label>
-                    <BindLogic logic={insightLogic} props={breakdownInsightProps}>
-                        <TaxonomicBreakdownFilter
-                            insightProps={breakdownInsightProps}
-                            breakdownFilter={overrides.breakdown_filter}
-                            isTrends={false}
-                            isFunnels={false}
-                            showLabel={false}
-                            disabledReason={
-                                supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
-                            }
-                            updateBreakdownFilter={(breakdown_filter) => {
-                                let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
-                                // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
-                                if (
-                                    breakdown_filter &&
-                                    !breakdown_filter.breakdown_type &&
-                                    !breakdown_filter.breakdowns
-                                ) {
-                                    newBreakdownFilter = null
-                                }
-                                setBreakdown(newBreakdownFilter)
-                            }}
-                            updateDisplay={() => {}}
-                            disablePropertyInfo
-                            size="small"
-                        />
-                    </BindLogic>
                 </div>
 
                 <div>
@@ -228,6 +201,39 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                         ]}
                     />
                     <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
+                </div>
+
+                <LemonDivider className="my-0" />
+
+                <div>
+                    <label className="text-sm font-medium mb-2 block">Breakdown</label>
+                    <BindLogic logic={insightLogic} props={breakdownInsightProps}>
+                        <TaxonomicBreakdownFilter
+                            insightProps={breakdownInsightProps}
+                            breakdownFilter={overrides.breakdown_filter}
+                            isTrends={false}
+                            isFunnels={false}
+                            showLabel={false}
+                            disabledReason={
+                                supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
+                            }
+                            updateBreakdownFilter={(breakdown_filter) => {
+                                let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
+                                // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
+                                if (
+                                    breakdown_filter &&
+                                    !breakdown_filter.breakdown_type &&
+                                    !breakdown_filter.breakdowns
+                                ) {
+                                    newBreakdownFilter = null
+                                }
+                                setBreakdown(newBreakdownFilter)
+                            }}
+                            updateDisplay={() => {}}
+                            disablePropertyInfo
+                            size="small"
+                        />
+                    </BindLogic>
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -78,161 +78,170 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                 </p>
             </div>
 
-            <div className="flex flex-col gap-4">
-                <div>
-                    <LemonSwitch
-                        checked={!!overrides.ignoreDashboardFilters}
-                        onChange={setIgnoreDashboardFilters}
-                        label="Ignore dashboard filters"
-                        bordered
-                        fullWidth
-                        data-attr="tile-ignore-dashboard-filters"
-                    />
-                    <p className="text-xs text-muted mt-1 mb-0">
-                        When on, none of the dashboard's filters apply to this insight. The overrides below still do.
-                    </p>
+            <div>
+                <LemonDivider label="Scope" />
+                <div className="flex flex-col gap-4 pb-4">
+                    <div>
+                        <LemonSwitch
+                            checked={!!overrides.ignoreDashboardFilters}
+                            onChange={setIgnoreDashboardFilters}
+                            label="Ignore dashboard filters"
+                            bordered
+                            fullWidth
+                            data-attr="tile-ignore-dashboard-filters"
+                        />
+                        <p className="text-xs text-muted mt-1 mb-0">
+                            When on, none of the dashboard's filters apply to this insight. The overrides below still
+                            do.
+                        </p>
+                    </div>
                 </div>
 
-                <LemonDivider className="mb-2" />
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Date range</label>
-                    <DateFilter
-                        showCustom
-                        showExplicitDateToggle
-                        dateFrom={overrides.date_from ?? null}
-                        dateTo={overrides.date_to ?? null}
-                        explicitDate={overrides.explicitDate}
-                        onChange={(from, to, explicitDate) => setDates(from, to, explicitDate)}
-                        makeLabel={(key) => (
-                            <>
-                                <IconCalendar />
-                                <span className="hide-when-small"> {key}</span>
-                            </>
-                        )}
-                    />
-                </div>
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Interval</label>
-                    <LemonSelect<IntervalType | null>
-                        size="small"
-                        value={overrides.interval ?? null}
-                        dropdownMatchSelectWidth={false}
-                        disabledReason={
-                            supportsInterval ? undefined : "This insight type doesn't support an interval override"
-                        }
-                        onChange={(interval) => setInterval(interval)}
-                        options={[
-                            { value: null, label: 'inherit' },
-                            { value: 'hour', label: 'hour' },
-                            { value: 'day', label: 'day' },
-                            { value: 'week', label: 'week' },
-                            { value: 'month', label: 'month' },
-                        ]}
-                        data-attr="tile-override-interval"
-                    />
-                </div>
-
-                <LemonDivider className="mb-2" />
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Properties</label>
-                    <PropertyFilters
-                        onChange={(properties) => setProperties(properties)}
-                        pageKey={`tile_${tile.id}_properties`}
-                        propertyFilters={overrides.properties ?? []}
-                        taxonomicGroupTypes={[
-                            TaxonomicFilterGroupType.EventProperties,
-                            TaxonomicFilterGroupType.PersonProperties,
-                            TaxonomicFilterGroupType.EventFeatureFlags,
-                            TaxonomicFilterGroupType.EventMetadata,
-                            ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
-                            ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
-                            TaxonomicFilterGroupType.EmailAddresses,
-                            ...groupsTaxonomicTypes,
-                            TaxonomicFilterGroupType.Cohorts,
-                            TaxonomicFilterGroupType.Elements,
-                            TaxonomicFilterGroupType.SessionProperties,
-                            TaxonomicFilterGroupType.HogQLExpression,
-                            TaxonomicFilterGroupType.DataWarehousePersonProperties,
-                        ]}
-                    />
-                </div>
-
-                <div>
-                    <div className="flex items-center gap-1 mb-2">
-                        <label className="text-sm font-medium">Test account filtering</label>
-                        <LemonButton
-                            icon={<IconGear />}
-                            size="xsmall"
-                            noPadding
-                            to={urls.settings('project-product-analytics', 'internal-user-filtering')}
-                            tooltip="Configure internal and test account filters"
+                <LemonDivider label="Time" />
+                <div className="flex flex-col gap-4 pb-4">
+                    <div>
+                        <label className="text-sm font-medium mb-2 block">Date range</label>
+                        <DateFilter
+                            showCustom
+                            showExplicitDateToggle
+                            dateFrom={overrides.date_from ?? null}
+                            dateTo={overrides.date_to ?? null}
+                            explicitDate={overrides.explicitDate}
+                            onChange={(from, to, explicitDate) => setDates(from, to, explicitDate)}
+                            makeLabel={(key) => (
+                                <>
+                                    <IconCalendar />
+                                    <span className="hide-when-small"> {key}</span>
+                                </>
+                            )}
                         />
                     </div>
-                    <LemonSegmentedButton<TestAccountFilterChoice>
-                        size="small"
-                        value={testAccountChoice}
-                        onChange={(next) => setFilterTestAccounts(CHOICE_TO_FILTER[next])}
-                        options={[
-                            {
-                                value: 'inherit',
-                                label: 'Inherit',
-                                tooltip: "Use the dashboard's setting, or the insight's own",
-                                'data-attr': 'tile-test-account-filter-inherit',
-                            },
-                            {
-                                value: 'filter-out',
-                                label: 'Filter out',
-                                tooltip: 'Force test account filtering on for this insight',
-                                disabledReason: !hasTestAccountFilters
-                                    ? "You haven't set any internal test filters. Click the gear icon to configure."
-                                    : undefined,
-                                'data-attr': 'tile-test-account-filter-out',
-                            },
-                            {
-                                value: 'include',
-                                label: 'Include',
-                                tooltip: 'Force test account filtering off for this insight',
-                                'data-attr': 'tile-test-account-filter-include',
-                            },
-                        ]}
-                    />
-                    <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
+
+                    <div>
+                        <label className="text-sm font-medium mb-2 block">Interval</label>
+                        <LemonSelect<IntervalType | null>
+                            size="small"
+                            value={overrides.interval ?? null}
+                            dropdownMatchSelectWidth={false}
+                            disabledReason={
+                                supportsInterval ? undefined : "This insight type doesn't support an interval override"
+                            }
+                            onChange={(interval) => setInterval(interval)}
+                            options={[
+                                { value: null, label: 'inherit' },
+                                { value: 'hour', label: 'hour' },
+                                { value: 'day', label: 'day' },
+                                { value: 'week', label: 'week' },
+                                { value: 'month', label: 'month' },
+                            ]}
+                            data-attr="tile-override-interval"
+                        />
+                    </div>
                 </div>
 
-                <LemonDivider className="mb-2" />
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Breakdown</label>
-                    <BindLogic logic={insightLogic} props={breakdownInsightProps}>
-                        <TaxonomicBreakdownFilter
-                            insightProps={breakdownInsightProps}
-                            breakdownFilter={overrides.breakdown_filter}
-                            isTrends={false}
-                            isFunnels={false}
-                            showLabel={false}
-                            disabledReason={
-                                supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
-                            }
-                            updateBreakdownFilter={(breakdown_filter) => {
-                                let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
-                                // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
-                                if (
-                                    breakdown_filter &&
-                                    !breakdown_filter.breakdown_type &&
-                                    !breakdown_filter.breakdowns
-                                ) {
-                                    newBreakdownFilter = null
-                                }
-                                setBreakdown(newBreakdownFilter)
-                            }}
-                            updateDisplay={() => {}}
-                            disablePropertyInfo
-                            size="small"
+                <LemonDivider label="Filters" />
+                <div className="flex flex-col gap-4 pb-4">
+                    <div>
+                        <label className="text-sm font-medium mb-2 block">Properties</label>
+                        <PropertyFilters
+                            onChange={(properties) => setProperties(properties)}
+                            pageKey={`tile_${tile.id}_properties`}
+                            propertyFilters={overrides.properties ?? []}
+                            taxonomicGroupTypes={[
+                                TaxonomicFilterGroupType.EventProperties,
+                                TaxonomicFilterGroupType.PersonProperties,
+                                TaxonomicFilterGroupType.EventFeatureFlags,
+                                TaxonomicFilterGroupType.EventMetadata,
+                                ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
+                                ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
+                                TaxonomicFilterGroupType.EmailAddresses,
+                                ...groupsTaxonomicTypes,
+                                TaxonomicFilterGroupType.Cohorts,
+                                TaxonomicFilterGroupType.Elements,
+                                TaxonomicFilterGroupType.SessionProperties,
+                                TaxonomicFilterGroupType.HogQLExpression,
+                                TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                            ]}
                         />
-                    </BindLogic>
+                    </div>
+
+                    <div>
+                        <div className="flex items-center gap-1 mb-2">
+                            <label className="text-sm font-medium">Test account filtering</label>
+                            <LemonButton
+                                icon={<IconGear />}
+                                size="xsmall"
+                                noPadding
+                                to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+                                tooltip="Configure internal and test account filters"
+                            />
+                        </div>
+                        <LemonSegmentedButton<TestAccountFilterChoice>
+                            size="small"
+                            value={testAccountChoice}
+                            onChange={(next) => setFilterTestAccounts(CHOICE_TO_FILTER[next])}
+                            options={[
+                                {
+                                    value: 'inherit',
+                                    label: 'Inherit',
+                                    tooltip: "Use the dashboard's setting, or the insight's own",
+                                    'data-attr': 'tile-test-account-filter-inherit',
+                                },
+                                {
+                                    value: 'filter-out',
+                                    label: 'Filter out',
+                                    tooltip: 'Force test account filtering on for this insight',
+                                    disabledReason: !hasTestAccountFilters
+                                        ? "You haven't set any internal test filters. Click the gear icon to configure."
+                                        : undefined,
+                                    'data-attr': 'tile-test-account-filter-out',
+                                },
+                                {
+                                    value: 'include',
+                                    label: 'Include',
+                                    tooltip: 'Force test account filtering off for this insight',
+                                    'data-attr': 'tile-test-account-filter-include',
+                                },
+                            ]}
+                        />
+                        <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
+                    </div>
+                </div>
+
+                <LemonDivider label="Display" />
+                <div className="flex flex-col gap-4 pb-4">
+                    <div>
+                        <label className="text-sm font-medium mb-2 block">Breakdown</label>
+                        <BindLogic logic={insightLogic} props={breakdownInsightProps}>
+                            <TaxonomicBreakdownFilter
+                                insightProps={breakdownInsightProps}
+                                breakdownFilter={overrides.breakdown_filter}
+                                isTrends={false}
+                                isFunnels={false}
+                                showLabel={false}
+                                disabledReason={
+                                    supportsBreakdown
+                                        ? undefined
+                                        : "This insight type doesn't support a breakdown override"
+                                }
+                                updateBreakdownFilter={(breakdown_filter) => {
+                                    let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
+                                    // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
+                                    if (
+                                        breakdown_filter &&
+                                        !breakdown_filter.breakdown_type &&
+                                        !breakdown_filter.breakdowns
+                                    ) {
+                                        newBreakdownFilter = null
+                                    }
+                                    setBreakdown(newBreakdownFilter)
+                                }}
+                                updateDisplay={() => {}}
+                                disablePropertyInfo
+                                size="small"
+                            />
+                        </BindLogic>
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -4269,6 +4269,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
             LemonDialog.openForm({
                 title: 'Override Tile Filters',
+                maxWidth: '40rem',
                 initialValues: {},
                 content: (
                     <BindLogic logic={tileLogic} props={tileLogicProps}>

--- a/frontend/src/scenes/dashboard/tileLogic.test.ts
+++ b/frontend/src/scenes/dashboard/tileLogic.test.ts
@@ -32,6 +32,17 @@ describe('tileLogic', () => {
         expect(logic.values.overrides).toEqual({ date_from: '-7d' })
     })
 
+    it('keeps an explicit false filterTestAccounts override, clearing only on null', () => {
+        logic.actions.setFilterTestAccounts(true)
+        expect(logic.values.overrides).toEqual({ date_from: '-7d', filterTestAccounts: true })
+
+        logic.actions.setFilterTestAccounts(false)
+        expect(logic.values.overrides).toEqual({ date_from: '-7d', filterTestAccounts: false })
+
+        logic.actions.setFilterTestAccounts(null)
+        expect(logic.values.overrides).toEqual({ date_from: '-7d' })
+    })
+
     it('resetOverrides wipes every override', () => {
         logic.actions.setInterval('day')
         logic.actions.setBreakdown({ breakdown: '$browser', breakdown_type: 'event' })

--- a/frontend/src/scenes/dashboard/tileLogic.tsx
+++ b/frontend/src/scenes/dashboard/tileLogic.tsx
@@ -31,6 +31,9 @@ export interface tileLogicActions {
         date_to: string | null | undefined
         explicitDate: boolean | undefined
     }
+    setFilterTestAccounts: (filterTestAccounts: boolean | null) => {
+        filterTestAccounts: boolean | null
+    }
     setIgnoreDashboardFilters: (ignoreDashboardFilters: boolean) => {
         ignoreDashboardFilters: boolean
     }
@@ -67,6 +70,7 @@ export const tileLogic = kea<tileLogicType>([
         setProperties: (properties: AnyPropertyFilter[] | null | undefined) => ({ properties }),
         setBreakdown: (breakdown_filter: BreakdownFilter | null | undefined) => ({ breakdown_filter }),
         setInterval: (interval: IntervalType | null | undefined) => ({ interval }),
+        setFilterTestAccounts: (filterTestAccounts: boolean | null) => ({ filterTestAccounts }),
         setIgnoreDashboardFilters: (ignoreDashboardFilters: boolean) => ({ ignoreDashboardFilters }),
         resetOverrides: true,
     })),
@@ -118,6 +122,17 @@ export const tileLogic = kea<tileLogicType>([
                         newState.interval = interval
                     } else {
                         delete newState.interval
+                    }
+                    return newState
+                },
+                setFilterTestAccounts: (state, { filterTestAccounts }) => {
+                    const newState = { ...state }
+                    // Tri-state: false means "force test account filtering off", so unlike the other
+                    // overrides only null (inherit) clears the key.
+                    if (filterTestAccounts === null) {
+                        delete newState.filterTestAccounts
+                    } else {
+                        newState.filterTestAccounts = filterTestAccounts
                     }
                     return newState
                 },

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -26,12 +26,19 @@ class TestMergeFiltersByPriority(SimpleTestCase):
     def test_returns_single_layer_when_other_absent(self, _name, dashboard, tile, expected):
         assert merge_filters_by_priority(dashboard, tile) == expected
 
-    def test_tile_scalar_fields_win_over_dashboard(self):
+    @parameterized.expand(
+        [
+            ("tile forces test accounts on", False, True),
+            # False is a meaningful override (force off), so it must beat a dashboard True too.
+            ("tile forces test accounts off", True, False),
+        ]
+    )
+    def test_tile_scalar_fields_win_over_dashboard(self, _name, dashboard_fta, tile_fta):
         merged = merge_filters_by_priority(
-            {"interval": "day", "filterTestAccounts": False},
-            {"interval": "week", "filterTestAccounts": True},
+            {"interval": "day", "filterTestAccounts": dashboard_fta},
+            {"interval": "week", "filterTestAccounts": tile_fta},
         )
-        assert merged == {"interval": "week", "filterTestAccounts": True}
+        assert merged == {"interval": "week", "filterTestAccounts": tile_fta}
 
     def test_dashboard_scalar_kept_when_tile_leaves_it_unset(self):
         merged = merge_filters_by_priority(


### PR DESCRIPTION
## TL;DR

Dashboard tiles can now override test account filtering on their own, the same way a whole dashboard already can. Pick "Filter out" or "Include" on one tile without touching the others, or leave it on "Inherit".

## Problem

Dashboard tile filter overrides (`DashboardTile.filters_overrides`) cover date range, properties, breakdown, and interval, but not test account filtering. The backend merge layer already treats `filterTestAccounts` as a scalar override field; only the control was missing. Users wanting a per-tile test-accounts override ended up flipping "Ignore dashboard filters" instead, which drops the whole dashboard filter layer for that tile.

## Changes

- Tri-state control (inherit / filter out / include) in the tile filter override modal, mirroring the dashboard-level one in `DashboardEditBarAdvancedFilters`. "Filter out" is disabled when the team has no test account filters configured.
- `setFilterTestAccounts` action/reducer in `tileLogic`. Unlike the other overrides, `false` is meaningful (force off), so only `null` clears the key.
- No schema changes needed: `TileFilters.filterTestAccounts` already exists in `schema-general.ts` and `posthog/schema.py`, and query runners already apply it from the merged `DashboardFilter`.
- The tile override indicator picks the new key up automatically (`hasTileOverrides` counts any key except `ignoreDashboardFilters`).
- The modal is grouped into sections with dividers: ignore toggle | date range + interval | properties + test account filtering | breakdown.

Default (inherit):

![tile-override-modal](https://raw.githubusercontent.com/PostHog/pr-assets/d92bbea75491b76ae4ad9424715f6abbe3300b5b/2026/08/f617baaf-ac83-41c1-99dd-60c5af6b39cc.png)

"Filter out" selected:

![tile-override-modal-filter-out](https://raw.githubusercontent.com/PostHog/pr-assets/11613da0acf545ed7bd5f39db0813fef5eeeeb3f/2026/08/daf53c15-002c-4b88-83be-493cea344198.png)

## How did you test this code?

- Rendered the change in the local dev app (screenshots above): opened a dashboard tile's "Set override" modal, switched the control between states, and confirmed the hint copy follows the selection.
- End-to-end on a local QA dashboard with seeded events (150 total, 100 after test-account filtering) across 4 tiles: "Filter out" drops an unfiltered insight to the filtered count, "Include" holds a filtered insight at the unfiltered count even with the dashboard-level filter on (tile `false` beats dashboard `true`), overrides persist across reload, "Clear All Overrides" resets to Inherit, and "Filter out" disables with a hint when the team has no test account filters. UI numbers cross-checked against `?refresh=force_blocking` API results at every step.
- `posthog/hogql_queries/test/test_merge_filters_by_priority.py`: parameterized `test_tile_scalar_fields_win_over_dashboard` to also cover tile `filterTestAccounts: false` beating dashboard `true`. Catches a regression of the `is not None` check in the scalar-override loop to a truthiness check, which the existing true-over-false case can't; the UI now writes `false` for the first time. 41 tests pass.
- `tileLogic.test.ts`: new case asserting `false` survives as an explicit override and only `null` clears the key. Catches someone "aligning" the reducer with its neighbors' delete-on-falsy pattern, which would silently break the "Include" choice. 4 tests pass.
- Frontend lint, format, kea typegen, and TypeScript check are clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code). Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`.
- The task turned out smaller than scoped: schema fields and backend merge support (including a merge test) already existed, so the change is UI + logic + two targeted test additions.
- Copy was adapted from the dashboard-level control to single-insight scope ("this insight" instead of "every insight on this dashboard").

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
