### PR TITLE
fix(desktop): preserve auto mode after tool approval

### DIFF
--- a/products/desktop/packages/core/src/sessions/permissionResponse.test.ts
+++ b/products/desktop/packages/core/src/sessions/permissionResponse.test.ts
@@ -1,3 +1,4 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
 import type { PermissionRequest } from "@posthog/shared";
 import { describe, expect, it } from "vitest";
 import {
@@ -8,6 +9,7 @@ import {
   isPermissionRejection,
   permissionOptionUsesCustomInput,
   planPermissionResponse,
+  resolveAllowAlwaysUpgradeMode,
   resolveInitialPlanApprovalOption,
   selectPlanPermissionOptions,
 } from "./permissionResponse";
@@ -99,6 +101,22 @@ describe("planPermissionResponse", () => {
     );
     const plan = planPermissionResponse(permission, "allow");
     expect(plan.applyAllowAlwaysUpgrade).toBe(false);
+  });
+
+  it("keeps auto mode when always allowing a tool", () => {
+    const modeOption: SessionConfigOption = {
+      id: "mode",
+      name: "Mode",
+      type: "select",
+      category: "mode",
+      currentValue: "auto",
+      options: [
+        { value: "acceptEdits", name: "Accept edits" },
+        { value: "auto", name: "Auto" },
+      ],
+    };
+
+    expect(resolveAllowAlwaysUpgradeMode(modeOption)).toBeUndefined();
   });
 
   it("responds with custom input for the other option", () => {

--- a/products/desktop/packages/core/src/sessions/permissionResponse.ts
+++ b/products/desktop/packages/core/src/sessions/permissionResponse.ts
@@ -1,4 +1,5 @@
-import type { PermissionRequest } from "@posthog/shared";
+import type { SessionConfigOption } from "@agentclientprotocol/sdk";
+import { flattenSelectOptions, type PermissionRequest } from "@posthog/shared";
 
 export type PermissionOption = PermissionRequest["options"][number];
 
@@ -78,6 +79,35 @@ export interface PermissionSelectionPlan {
   applyAllowAlwaysUpgrade: boolean;
   respondWithCustomInput: boolean;
   resendPromptText: string | null;
+}
+
+/**
+ * Resolves whether an "allow always" approval should change the session's
+ * permission mode. Sessions not already in Auto use the least broad available
+ * automatic mode.
+ */
+export function resolveAllowAlwaysUpgradeMode(
+  modeOption: SessionConfigOption | undefined,
+): string | undefined {
+  if (modeOption?.type !== "select") {
+    return undefined;
+  }
+
+  const availableIds = new Set(
+    flattenSelectOptions(modeOption.options).map((option) => option.value),
+  );
+  // Allow-always saves a tool-specific rule. Preserve Auto because switching to
+  // Accept edits would downgrade the session's broader permission mode.
+  if (modeOption.currentValue === "auto" && availableIds.has("auto")) {
+    return undefined;
+  }
+  if (availableIds.has("acceptEdits")) {
+    return "acceptEdits";
+  }
+  if (availableIds.has("auto")) {
+    return "auto";
+  }
+  return undefined;
 }
 
 export function planPermissionResponse(

--- a/products/desktop/packages/core/src/sessions/sessionService.ts
+++ b/products/desktop/packages/core/src/sessions/sessionService.ts
@@ -87,6 +87,7 @@ import {
   formatPermissionAnswerPrompt,
   type PermissionSelectionPlan,
   planPermissionResponse,
+  resolveAllowAlwaysUpgradeMode,
 } from "./permissionResponse";
 import {
   convertStoredEntriesToEvents,
@@ -7135,23 +7136,11 @@ export class SessionService {
     });
   }
 
-  public resolveAllowAlwaysUpgradeMode(
-    modeOption: SessionConfigOption | undefined,
-  ): string | undefined {
-    if (modeOption?.type !== "select") return undefined;
-    const availableIds = new Set(
-      flattenSelectOptions(modeOption.options).map((opt) => opt.value),
-    );
-    if (availableIds.has("acceptEdits")) return "acceptEdits";
-    if (availableIds.has("auto")) return "auto";
-    return undefined;
-  }
-
   public applyAllowAlwaysUpgrade(
     taskId: string,
     modeOption: SessionConfigOption | undefined,
   ): void {
-    const upgradeMode = this.resolveAllowAlwaysUpgradeMode(modeOption);
+    const upgradeMode = resolveAllowAlwaysUpgradeMode(modeOption);
     if (!upgradeMode) return;
     this.setSessionConfigOptionByCategory(taskId, "mode", upgradeMode);
   }


### PR DESCRIPTION
# Problem

Approving an MCP tool with Always allow could change a session already in Auto mode to Accept edits.

## Changes

- Preserve Auto mode when a tool approval saves an Always allow rule.
- Add coverage for the Auto-mode approval path.

## How did you test this code?

- `pnpm --filter @posthog/core test`
- `pnpm typecheck`
- `pnpm exec biome lint packages/core`
- `./bin/hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update needed. This corrects session permission-state behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with the Pi coding agent (session `019fccc0-7d16-7248-8a52-dab36e6bde0d`). Skills invoked: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, and `/running-ci-preflight`. The agent preserved Auto mode rather than selecting a narrower mode when a tool-specific approval is saved.
