### PR TITLE
feat(ingestion): emit broker-side offset lag from the rust consumer

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -95,6 +95,14 @@ pub struct Config {
     #[envconfig(default = "102400")]
     pub kafka_consumer_queued_max_messages_kbytes: u32,
 
+    /// Interval at which librdkafka delivers statistics to the consumer
+    /// context, driving the `ingestion_consumer_offset_lag` gauge
+    /// (`SentinelContext::stats`). 0 disables statistics entirely (and with
+    /// them the gauge). Computed by librdkafka from fetch responses it already
+    /// receives — no extra broker requests.
+    #[envconfig(default = "15000")]
+    pub kafka_consumer_statistics_interval_ms: u32,
+
     /// Pod hostname from K8s, used as client.id and group.instance.id
     /// for sticky partition assignment (same as Node.js hostname())
     #[envconfig(from = "HOSTNAME")]
@@ -396,6 +404,7 @@ impl Config {
         .with_fetch_wait_max_ms(self.kafka_consumer_fetch_wait_max_ms)
         .with_queued_min_messages(self.kafka_consumer_queued_min_messages)
         .with_queued_max_messages_kbytes(self.kafka_consumer_queued_max_messages_kbytes)
+        .with_statistics_interval_ms(self.kafka_consumer_statistics_interval_ms)
         .with_sticky_partition_assignment(
             self.pod_hostname.as_deref(),
             self.kafka_consumer_static_membership,

--- a/rust/ingestion-consumer/src/kafka_config.rs
+++ b/rust/ingestion-consumer/src/kafka_config.rs
@@ -154,6 +154,13 @@ impl ConsumerConfigBuilder {
         self
     }
 
+    /// Set the interval at which librdkafka delivers statistics to the client
+    /// context's `stats` callback. 0 (the rdkafka default) disables statistics.
+    pub fn with_statistics_interval_ms(mut self, ms: u32) -> Self {
+        self.config.set("statistics.interval.ms", ms.to_string());
+        self
+    }
+
     // ---- Group-consumer-only settings (batch consumer) ----
 
     /// Override offset reset policy (group consumers only)

--- a/rust/ingestion-consumer/src/order_sentinel.rs
+++ b/rust/ingestion-consumer/src/order_sentinel.rs
@@ -45,6 +45,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use metrics::{counter, gauge};
 use rdkafka::consumer::{BaseConsumer, ConsumerContext, Rebalance};
+use rdkafka::statistics::Statistics;
 use rdkafka::ClientContext;
 use tracing::{info, warn};
 
@@ -551,7 +552,58 @@ impl SentinelContext {
     }
 }
 
-impl ClientContext for SentinelContext {}
+impl ClientContext for SentinelContext {
+    /// Broker-side backlog for this pod's assigned partitions, refreshed every
+    /// `statistics.interval.ms`. Emitted as one pod-level gauge rather than
+    /// per partition: each tick recomputes from the current assignment, so a
+    /// partition moving to another pod can't leave a stale series behind, and
+    /// the fleet-wide backlog is a plain `sum()` over pods. `consumer_lag` is
+    /// measured against the committed offset, so uncommitted in-flight batches
+    /// still count as backlog — matching what replays if the pod dies.
+    fn stats(&self, statistics: Statistics) {
+        let AssignedLag {
+            messages,
+            partitions,
+        } = assigned_offset_lag(&statistics);
+        gauge!("ingestion_consumer_offset_lag").set(messages as f64);
+        gauge!("ingestion_consumer_assigned_partitions").set(partitions as f64);
+    }
+}
+
+/// This pod's share of the consumer group's backlog, from an rdkafka
+/// statistics snapshot.
+struct AssignedLag {
+    /// Sum of `consumer_lag` over assigned partitions whose lag is known.
+    messages: i64,
+    /// Assigned partition count — lets dashboards verify fleet coverage
+    /// (sum over pods == topic partition count) before trusting the lag sum.
+    partitions: usize,
+}
+
+/// Sum backlog over the partitions this consumer is assigned (`desired`),
+/// skipping librdkafka's internal unassigned partition (-1) and partitions
+/// whose lag is not yet known (`consumer_lag` is -1 until both a committed
+/// offset and a broker watermark have been observed, e.g. right after
+/// assignment).
+fn assigned_offset_lag(statistics: &Statistics) -> AssignedLag {
+    let mut messages = 0i64;
+    let mut partitions = 0usize;
+    for topic in statistics.topics.values() {
+        for partition in topic.partitions.values() {
+            if partition.partition < 0 || !partition.desired {
+                continue;
+            }
+            partitions += 1;
+            if partition.consumer_lag >= 0 {
+                messages += partition.consumer_lag;
+            }
+        }
+    }
+    AssignedLag {
+        messages,
+        partitions,
+    }
+}
 
 impl ConsumerContext for SentinelContext {
     fn pre_rebalance(&self, _consumer: &BaseConsumer<Self>, rebalance: &Rebalance) {
@@ -883,5 +935,45 @@ mod tests {
             .is_empty());
         sentinel.note_acked("t:a", 100);
         assert!(sentinel.note_sent("t:a", &[msg_at(0, 101)]).is_empty());
+    }
+
+    fn stats_partition(
+        id: i32,
+        desired: bool,
+        consumer_lag: i64,
+    ) -> rdkafka::statistics::Partition {
+        rdkafka::statistics::Partition {
+            partition: id,
+            desired,
+            consumer_lag,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn assigned_offset_lag_sums_desired_partitions_with_known_lag() {
+        let partitions = HashMap::from([
+            // librdkafka's internal unassigned-partition bucket.
+            (-1, stats_partition(-1, false, 42)),
+            (0, stats_partition(0, true, 5)),
+            // Assigned but lag not yet known (no committed offset observed).
+            (1, stats_partition(1, true, -1)),
+            // Known lag on a partition owned by another consumer.
+            (2, stats_partition(2, false, 7)),
+        ]);
+        let statistics = Statistics {
+            topics: HashMap::from([(
+                "t".to_string(),
+                rdkafka::statistics::Topic {
+                    partitions,
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let lag = assigned_offset_lag(&statistics);
+        assert_eq!(lag.messages, 5);
+        assert_eq!(lag.partitions, 2);
     }
 }


### PR DESCRIPTION
## Problem

The ingestion consumer's autoscaling triggers are built on `ingestion_lag_ms`, a time-based lag gauge emitted at processing time. That signal has two structural problems for scaling decisions:

1. It only tells you how far behind you are, not whether current capacity is winning or losing against the backlog. During recovery it stays high long after the drain rate exceeds the arrival rate, so scaling keeps reacting to a problem that is already solved.
2. It freezes when consumption stops. A stalled partition keeps exporting its last value and gets filtered out as inactive by the trigger queries, so the exact failure the triggers exist for is the one they can't see.

A backlog signal in messages, measured against broker offsets and emitted by the consumer itself, supports capacity math (backlog, and its derivative, relative to throughput) and keeps reporting when consumption stalls.

## Changes

- `SentinelContext` now implements the rdkafka `stats` callback and emits two pod-level gauges from each statistics snapshot:
  - `ingestion_consumer_offset_lag` - sum of librdkafka's `consumer_lag` (high watermark minus committed offset) over the partitions this pod is assigned. Committed-offset basis means uncommitted in-flight batches still count as backlog, matching what would replay if the pod died.
  - `ingestion_consumer_assigned_partitions` - assigned partition count, so dashboards can verify fleet coverage (sum over pods equals the topic's partition count) before trusting the lag sum.
- New `KAFKA_CONSUMER_STATISTICS_INTERVAL_MS` config (default 15000) wired through a `with_statistics_interval_ms` builder method. librdkafka computes `consumer_lag` from fetch responses it already receives, so enabling statistics adds no broker requests. 0 disables statistics and the gauges.

Pod-level (not per-partition) is deliberate. Each tick recomputes from the pod's current assignment, so a partition moving to another consumer can't leave a stale series behind, and fleet-wide backlog is a plain `sum()` over pods. It also keeps cardinality at one series per pod instead of one per partition. The gauges inherit the existing `ingestion_pipeline`/`ingestion_lane` global labels.

## How did you test this code?

- New unit test `assigned_offset_lag_sums_desired_partitions_with_known_lag` covers the summation edge cases no existing test touches: librdkafka's internal partition (-1), assigned partitions whose lag is not yet known (`consumer_lag: -1` right after assignment), and partitions owned by other consumers (`desired: false`).
- `cargo test -p ingestion-consumer --lib` (all 153 lib tests pass) and `cargo clippy -p ingestion-consumer --lib -- -D warnings` (clean).
- Not yet verified against a live broker; the plan is to confirm the gauge against the Kafka exporter's numbers for the same consumer group once deployed to a low-volume lane.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Internal metric, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, driven by Pawel during an autoscaling revision session for the split consumer/processor ingestion architecture. Decisions along the way:

- Chose the librdkafka statistics callback over a periodic `fetch_watermarks` task (the pattern used elsewhere in the rust tree): statistics piggyback on fetch responses the client already receives, so there are no extra broker round trips and no new background task to manage.
- Chose pod-level gauges over per-partition after considering rebalance semantics: `metrics-exporter-prometheus` never forgets a registered label set, so per-partition gauges would need explicit cleanup on revoke to avoid double counting after partition moves.
- Chose `consumer_lag` (committed-offset basis) over `consumer_lag_stored`, so in-flight-but-uncommitted work counts as backlog, consistent with at-least-once replay semantics.
