### PR TITLE
fix(ci): emit junit results for MCP integration tests

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -636,7 +636,9 @@ jobs:
               # every failure is an already-quarantined flake, fails otherwise.
               continue-on-error: true
               # The junit reporter (alongside the default console one) feeds the Trunk upload below.
-              run: cd services/mcp && pnpm run test:integration -- --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
+              # No `--` before the flags: pnpm forwards it literally, and vitest then treats
+              # everything after it as positional args, silently dropping the junit reporter.
+              run: cd services/mcp && pnpm run test:integration --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
               env:
                   TEST_POSTHOG_API_BASE_URL: http://localhost:8000
                   TEST_POSTHOG_PERSONAL_API_KEY: phx_e2e_demo_api_key


### PR DESCRIPTION
## Problem

MCP integration test failures never get quarantined by Trunk, so every failure reds the job even when it is a known flake. Example: [this run](https://github.com/PostHog/posthog/actions/runs/30906686823/job/91983447537), which took down a merge-queue bisection.

The upload step reports the tell:

```
📚 Test Report
   Total: 0   Pass: 0   Fail: 0   Quarantined: 0   Pass Ratio: N/A
⚠️  No tests were found in the provided test results
##[error]The test results you are uploading contain non quarantined test failures
```

Zero results, because `services/mcp/junit-integration.xml` is never written.

The cause is the `--` in the test step. pnpm forwards it verbatim rather than stripping it, and vitest (cac) treats everything after `--` as positional args. The job log shows the expansion:

```
> vitest run --config vitest.integration.config.mts -- --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
```

So the junit reporter is never registered. The run looks normal otherwise, which is why this went unnoticed since the Trunk upload landed in c05437fb91e on 7 Jul. MCP integration tests have never uploaded a single result.

From there the rest follows: `allow-missing-junit-files: true` means the uploader does not fail on the missing file, but with `previous-step-outcome: failure` and no known results it errors anyway, so `quarantine_gate.outcome != 'success'` and the `Fail on test failure` step exits 1.

## Changes

Dropped the `--`, with a comment so it does not come back.

```diff
-run: cd services/mcp && pnpm run test:integration -- --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
+run: cd services/mcp && pnpm run test:integration --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
```

This is the only `-- --` step of its kind in `.github/workflows/`. Every other suite feeds Trunk through env vars (`JEST_JUNIT_OUTPUT_*`) or a config file, which is why they were unaffected.

> [!NOTE]
> Quarantining also needs `TRUNK_QUARANTINE_ENABLED` set to `true` as a repo variable. It defaults off, in which case the verdict step reds the job on any failure regardless of a clean upload. This PR only fixes the missing data.

## How did you test this code?

I could not run the MCP integration job locally (it needs the full dev stack), so I verified the mechanism directly with the repo's vitest 4.1.8 on a throwaway test file:

<details>
<summary>Reproduction</summary>

With the `--`, matching what CI ran, no file is produced and no `JUNIT report written to …` line appears:

```
$ vitest run --root . -- --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
 Test Files  1 failed (1)
$ ls junit-integration.xml
ls: junit-integration.xml: No such file or directory
```

Without it, the file is written:

```
$ vitest run --root . --reporter=default --reporter=junit --outputFile.junit=junit-integration.xml
JUNIT report written to .../junit-integration.xml
```

The CI log has no `JUNIT report written to` line, consistent with the first case.

</details>

I also confirmed pnpm forwards the flags through without a separator:

```
$ cd services/mcp && pnpm run test:integration --version
> vitest run --config vitest.integration.config.mts --version
```

And checked that the failure shape in the linked run is actually trackable once results flow. It is a `beforeAll` hook failure, which vitest's junit reporter emits as a testcase named after the enclosing suite, so Trunk gets a stable id to quarantine on.

No automated tests added. This is a one-line workflow fix whose only real verification is the next MCP CI run reporting a non-zero total.

> [!WARNING]
> The failure in the linked run looks like a real regression, not a flake: `POST /api/projects/1/property_definitions/` returns `This action does not support personal API key access`. Worth someone looking at separately, since quarantining would hide it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I pointed Claude Code (Opus 5) at the failing job and asked why MCP tests were not being quarantined. It worked backwards from the uploader's zero-total output to the `--` in the pnpm invocation, then reproduced both the broken and working invocations locally against the repo's own vitest rather than reasoning about cac's arg handling from memory. No repo skills were invoked.

The alternative considered was moving `reporters` and `outputFile` into `vitest.integration.config.mts`, which would be immune to this class of bug. Rejected because that config is also used for local runs where a junit file is noise, and gating it on `process.env.CI` trades a one-line fix for config branching.
