### PR TITLE
chore(devex): trim codex MCP startup

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -27,12 +27,3 @@ inherit = "core"
 # xdist opens a loopback socket even without parallel workers, which the
 # Codex sandbox blocks.
 set = { PATH = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin", PYTEST_ADDOPTS = "-p no:xdist" }
-
-[mcp_servers.phrocs]
-command = "bin/dev-sandbox"
-args = [".flox/cache/venv/bin/python tools/phrocs/mcp_server.py"]
-cwd = ".."
-startup_timeout_sec = 120
-
-[mcp_servers.posthog-local]
-url = "http://localhost:8787/mcp"


### PR DESCRIPTION
## Problem

Codex starts phrocs and posthog-local MCP servers for every repository session, even when local stack tools are not needed.

## Changes

- Remove both MCP server entries from the Codex startup config.
- Keep `.mcp.json` unchanged for clients that opt into those servers.

## How did you test this code?

- Ran `git diff --check`.
- Parsed `.codex/config.toml` with Python `tomllib`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Not needed. This only changes repo-scoped Codex startup behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used terminal tooling, GitHub CLI, and `/wt`; a session link is unavailable from this CLI context.
- Limited the edit to Codex configuration because `.mcp.json` serves separate MCP clients.