### PR TITLE
feat(mcp): close telemetry gaps in tool validation failures

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -21,6 +21,7 @@ import { estimateTokens } from '@/lib/estimate-tokens'
 import { getPostHogClient } from '@/lib/posthog'
 import {
     createExecTool,
+    describeApiValidationError,
     describeExecCommand,
     describeValidationError,
     formatInputValidationError,
@@ -616,8 +617,13 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
     if (apiError instanceof PostHogValidationError) {
         const errorCode = apiError.code ? sanitizeErrorToken(apiError.code) : undefined
         const errorField = apiError.attr ? normalizeErrorField(apiError.attr) : undefined
+        // Same descriptor property and format as a local schema rejection, so one
+        // query covers both layers. There is no `validationInputKeys` counterpart:
+        // the request body reached the API, so the keys it carried aren't ours to
+        // reconstruct here.
         return {
             errorType: 'validation',
+            validationFields: describeApiValidationError(apiError.attr, apiError.code),
             ...(errorCode ? { errorCode } : {}),
             ...(errorField ? { errorField } : {}),
         }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -19,7 +19,13 @@ import {
 } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { getPostHogClient } from '@/lib/posthog'
-import { createExecTool, formatInputValidationError, type ExecInnerCallTracker } from '@/tools/exec'
+import {
+    createExecTool,
+    describeExecCommand,
+    describeValidationError,
+    formatInputValidationError,
+    type ExecInnerCallTracker,
+} from '@/tools/exec'
 import { EXECUTE_SQL_TOOL_NAME } from '@/tools/posthogAiTools/executeSql'
 import { createRenderUiTool } from '@/tools/render-ui'
 import type { Context, ZodObjectAny } from '@/tools/types'
@@ -189,8 +195,25 @@ export class ToolExecutor {
         const validation = tool.schema.safeParse(toolArgs, { reportInput: true })
         if (!validation.success) {
             toolCallsTotal.inc({ tool: tool.name, status: 'validation_error' })
+            const message = formatInputValidationError(tool.name, validation.error)
+            // Emit the same errored `$mcp_tool_call` the exec path emits for an
+            // identical rejection. Without it, direct-mode ('tools') schema
+            // rejections are absent from analytics entirely — so every
+            // exec-vs-direct comparison silently flatters direct mode, and
+            // clients registered individually look error-free when they aren't.
+            // Duration is 0: no handler ran (see `trackInnerCall`, same rule).
+            const rejection = new ToolInputValidationError(message, describeValidationError(validation.error, toolArgs))
+            void trackToolCall(
+                tool.name,
+                0,
+                true,
+                state,
+                errorAnalyticsProperties(classifyToolError(rejection, tool.name), rejection),
+                intentMeta,
+                this.servedToolDescription(tool.name, state)
+            )
             return {
-                content: [{ type: 'text', text: formatInputValidationError(tool.name, validation.error) }],
+                content: [{ type: 'text', text: message }],
                 isError: true,
             }
         }
@@ -335,6 +358,12 @@ export class ToolExecutor {
         // attributed to `exec`.
         const execToolName = (): string => execMetrics.innerToolName ?? 'exec'
 
+        // Which verb ran and which tool it targeted. Stamped on every exec event —
+        // success and failure alike — so the discovery verbs stop collapsing into
+        // one opaque `exec` bucket and an `info <tool>` can be linked to the
+        // `call <tool>` that follows it.
+        const execShape = execCommandAnalyticsProperties(validation.data)
+
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
             const duration = Date.now() - startMs
@@ -356,6 +385,7 @@ export class ToolExecutor {
                 false,
                 state,
                 {
+                    ...execShape,
                     input_tokens: estimateTokens(validation.data),
                     output_tokens: estimateResponseTokens(response),
                 },
@@ -378,7 +408,7 @@ export class ToolExecutor {
                 Date.now() - startMs,
                 true,
                 state,
-                errorAnalyticsProperties(classification, error),
+                { ...execShape, ...errorAnalyticsProperties(classification, error) },
                 intentMeta,
                 this.servedToolDescription(metricTool, state)
             )
@@ -719,5 +749,28 @@ function errorAnalyticsProperties(classification: ToolErrorClassification, error
         ...(classification.errorCode ? { $mcp_error_code: classification.errorCode } : {}),
         ...(classification.errorField ? { $mcp_error_field: classification.errorField } : {}),
         ...(message !== undefined ? { $mcp_error_message: message } : {}),
+    }
+}
+
+/**
+ * Properties describing the exec command itself: `$mcp_exec_verb` (which
+ * dispatcher verb ran) and `$mcp_exec_target_tool` (the tool `info`/`schema`/
+ * `call` named).
+ *
+ * `$mcp_tool_name` already carries the inner tool for a successful `call`, but
+ * it reads `exec` for every other verb and for a `call` that never resolved — so
+ * schema discovery, tool search, and a mistyped verb are indistinguishable, and
+ * an `unknown_tool` rejection records nothing about what was attempted. Both
+ * values are value-free by construction (see `describeExecCommand`).
+ */
+function execCommandAnalyticsProperties(execArgs: unknown): Record<string, unknown> {
+    const command = (execArgs as { command?: unknown } | undefined)?.command
+    if (typeof command !== 'string') {
+        return {}
+    }
+    const { verb, targetTool } = describeExecCommand(command)
+    return {
+        ...(verb !== undefined ? { $mcp_exec_verb: verb } : {}),
+        ...(targetTool !== undefined ? { $mcp_exec_target_tool: targetTool } : {}),
     }
 }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -203,7 +203,10 @@ export class ToolExecutor {
             // exec-vs-direct comparison silently flatters direct mode, and
             // clients registered individually look error-free when they aren't.
             // Duration is 0: no handler ran (see `trackInnerCall`, same rule).
-            const rejection = new ToolInputValidationError(message, describeValidationError(validation.error, toolArgs))
+            const rejection = new ToolInputValidationError(
+                message,
+                describeValidationError(validation.error, toolArgs, tool.schema)
+            )
             void trackToolCall(
                 tool.name,
                 0,
@@ -363,7 +366,7 @@ export class ToolExecutor {
         // success and failure alike — so the discovery verbs stop collapsing into
         // one opaque `exec` bucket and an `info <tool>` can be linked to the
         // `call <tool>` that follows it.
-        const execShape = execCommandAnalyticsProperties(validation.data)
+        const execShape = execCommandAnalyticsProperties(validation.data, state)
 
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
@@ -767,14 +770,19 @@ function errorAnalyticsProperties(classification: ToolErrorClassification, error
  * it reads `exec` for every other verb and for a `call` that never resolved — so
  * schema discovery, tool search, and a mistyped verb are indistinguishable, and
  * an `unknown_tool` rejection records nothing about what was attempted. Both
- * values are value-free by construction (see `describeExecCommand`).
+ * values are value-free by construction (see `describeExecCommand`): the verb comes
+ * from the closed grammar and the target from this connection's own catalog, so a
+ * token outside either is recorded as unrecognized rather than echoed.
  */
-function execCommandAnalyticsProperties(execArgs: unknown): Record<string, unknown> {
+function execCommandAnalyticsProperties(execArgs: unknown, state: ResolvedState): Record<string, unknown> {
     const command = (execArgs as { command?: unknown } | undefined)?.command
     if (typeof command !== 'string') {
         return {}
     }
-    const { verb, targetTool } = describeExecCommand(command)
+    const { verb, targetTool } = describeExecCommand(
+        command,
+        (name) => state.allTools.some((t) => t.name === name) || state.scopeGatedTools.some((t) => t.name === name)
+    )
     return {
         ...(verb !== undefined ? { $mcp_exec_verb: verb } : {}),
         ...(targetTool !== undefined ? { $mcp_exec_target_tool: targetTool } : {}),

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -21,6 +21,7 @@ import { estimateTokens } from '@/lib/estimate-tokens'
 import { getPostHogClient } from '@/lib/posthog'
 import {
     createExecTool,
+    describeApiValidationError,
     describeExecCommand,
     describeValidationError,
     formatInputValidationError,
@@ -580,7 +581,11 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
 
     const apiError = findRecoverableApiError(error)
     if (apiError instanceof PostHogValidationError) {
-        return { errorType: 'validation' }
+        // Same descriptor property and format as a local schema rejection, so one
+        // query covers both layers. There is no `validationInputKeys` counterpart:
+        // the request body reached the API, so the keys it carried aren't ours to
+        // reconstruct here.
+        return { errorType: 'validation', validationFields: describeApiValidationError(apiError.attr, apiError.code) }
     }
     if (apiError instanceof PostHogApiError && apiError.status === 429) {
         return { errorType: 'rate_limited', status: apiError.status }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -19,7 +19,13 @@ import {
 } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { getPostHogClient } from '@/lib/posthog'
-import { createExecTool, formatInputValidationError, type ExecInnerCallTracker } from '@/tools/exec'
+import {
+    createExecTool,
+    describeExecCommand,
+    describeValidationError,
+    formatInputValidationError,
+    type ExecInnerCallTracker,
+} from '@/tools/exec'
 import { EXECUTE_SQL_TOOL_NAME } from '@/tools/posthogAiTools/executeSql'
 import { createRenderUiTool } from '@/tools/render-ui'
 import type { Context, ZodObjectAny } from '@/tools/types'
@@ -183,8 +189,25 @@ export class ToolExecutor {
         const validation = tool.schema.safeParse(toolArgs, { reportInput: true })
         if (!validation.success) {
             toolCallsTotal.inc({ tool: tool.name, status: 'validation_error' })
+            const message = formatInputValidationError(tool.name, validation.error)
+            // Emit the same errored `$mcp_tool_call` the exec path emits for an
+            // identical rejection. Without it, direct-mode ('tools') schema
+            // rejections are absent from analytics entirely — so every
+            // exec-vs-direct comparison silently flatters direct mode, and
+            // clients registered individually look error-free when they aren't.
+            // Duration is 0: no handler ran (see `trackInnerCall`, same rule).
+            const rejection = new ToolInputValidationError(message, describeValidationError(validation.error, toolArgs))
+            void trackToolCall(
+                tool.name,
+                0,
+                true,
+                state,
+                errorAnalyticsProperties(classifyToolError(rejection, tool.name), rejection),
+                intentMeta,
+                this.servedToolDescription(tool.name, state)
+            )
             return {
-                content: [{ type: 'text', text: formatInputValidationError(tool.name, validation.error) }],
+                content: [{ type: 'text', text: message }],
                 isError: true,
             }
         }
@@ -315,6 +338,12 @@ export class ToolExecutor {
         // attributed to `exec`.
         const execToolName = (): string => execMetrics.innerToolName ?? 'exec'
 
+        // Which verb ran and which tool it targeted. Stamped on every exec event —
+        // success and failure alike — so the discovery verbs stop collapsing into
+        // one opaque `exec` bucket and an `info <tool>` can be linked to the
+        // `call <tool>` that follows it.
+        const execShape = execCommandAnalyticsProperties(validation.data)
+
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
             const duration = Date.now() - startMs
@@ -336,6 +365,7 @@ export class ToolExecutor {
                 false,
                 state,
                 {
+                    ...execShape,
                     input_tokens: estimateTokens(validation.data),
                     output_tokens: estimateResponseTokens(response),
                 },
@@ -358,7 +388,7 @@ export class ToolExecutor {
                 Date.now() - startMs,
                 true,
                 state,
-                errorAnalyticsProperties(classification, error),
+                { ...execShape, ...errorAnalyticsProperties(classification, error) },
                 intentMeta,
                 this.servedToolDescription(metricTool, state)
             )
@@ -649,5 +679,28 @@ function errorAnalyticsProperties(classification: ToolErrorClassification, error
             ? { $mcp_validation_input_keys: classification.validationInputKeys }
             : {}),
         ...(message !== undefined ? { $mcp_error_message: message } : {}),
+    }
+}
+
+/**
+ * Properties describing the exec command itself: `$mcp_exec_verb` (which
+ * dispatcher verb ran) and `$mcp_exec_target_tool` (the tool `info`/`schema`/
+ * `call` named).
+ *
+ * `$mcp_tool_name` already carries the inner tool for a successful `call`, but
+ * it reads `exec` for every other verb and for a `call` that never resolved — so
+ * schema discovery, tool search, and a mistyped verb are indistinguishable, and
+ * an `unknown_tool` rejection records nothing about what was attempted. Both
+ * values are value-free by construction (see `describeExecCommand`).
+ */
+function execCommandAnalyticsProperties(execArgs: unknown): Record<string, unknown> {
+    const command = (execArgs as { command?: unknown } | undefined)?.command
+    if (typeof command !== 'string') {
+        return {}
+    }
+    const { verb, targetTool } = describeExecCommand(command)
+    return {
+        ...(verb !== undefined ? { $mcp_exec_verb: verb } : {}),
+        ...(targetTool !== undefined ? { $mcp_exec_target_tool: targetTool } : {}),
     }
 }

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -127,55 +127,68 @@ export function parseExecCallInnerToolName(command: string): string | undefined 
 }
 
 /** Verbs the dispatcher grammar accepts. A verb outside this set is what the
- *  `unknown_command` rejection fires on, and is recorded normalized. */
+ *  `unknown_command` rejection fires on, and is recorded as unrecognized. */
 const KNOWN_EXEC_VERBS = new Set(['learn', 'tools', 'search', 'info', 'schema', 'call'])
 
 /** Verbs whose first positional argument names a tool. */
 const TOOL_TARGETING_VERBS = new Set(['info', 'schema', 'call'])
 
-const MAX_EXEC_TOKEN_LENGTH = 64
-
 /**
- * Reduces a model-supplied token to a bounded, punctuation-free identifier so an
- * unrecognized verb or tool name can be recorded without carrying arbitrary text
- * into analytics. Tool names are lowercase kebab-case, so a legitimate value
- * survives this untouched; anything else collapses to a harmless fragment.
+ * Recorded in place of a verb or tool name the server doesn't recognize. A token
+ * the grammar rejected is caller text, and bounding its charset does not make it
+ * value-free — an identifier-shaped secret survives sanitization intact. This file
+ * already withholds `ExecCommandError`'s message from analytics for exactly this
+ * reason (it echoes the caller's tool name); the rejection reason on the event says
+ * which of the two failed, so the sentinel loses only the misspelling itself.
  */
-function normalizeExecToken(raw: string): string | undefined {
-    const normalized = raw
-        .toLowerCase()
-        .replace(/[^a-z0-9._-]/g, '')
-        .slice(0, MAX_EXEC_TOKEN_LENGTH)
-    return normalized || undefined
-}
+const UNRECOGNIZED_EXEC_TOKEN = 'unrecognized'
 
 export interface ExecCommandShape {
-    /** The dispatcher verb, normalized when it isn't one we accept. */
+    /** The dispatcher verb, or `unrecognized` when it isn't one we accept. */
     verb?: string
-    /** The tool `info`/`schema`/`call` targeted — present even when it resolves to nothing. */
+    /** The tool `info`/`schema`/`call` targeted, or `unrecognized` when the name
+     *  resolves to nothing in our catalog. */
     targetTool?: string
 }
 
 /**
  * Describes an exec command for analytics: which verb ran, and which tool it
- * targeted. Both are value-free — a bounded grammar token and a tool name — so
- * neither can carry caller input (see `describeValidationError` for the same
- * constraint applied to schema rejections).
+ * targeted. Both are value-free by construction — a verb from the closed grammar
+ * and a tool name from our own catalog, never the caller's token (see
+ * `describeValidationError` for the same constraint applied to schema rejections).
  *
  * Without this, every non-`call` verb lands in one undifferentiated `exec`
  * bucket: schema discovery is indistinguishable from tool search, and an
  * `unknown_command` rejection records no verb to diagnose. `targetTool` is what
  * links an `info <tool>` to the `call <tool>` that follows it.
+ *
+ * `isKnownToolName` decides whether a target resolves against the catalog this
+ * connection can see; anything it rejects is recorded as
+ * `UNRECOGNIZED_EXEC_TOKEN`.
  */
-export function describeExecCommand(command: string): ExecCommandShape {
+export function describeExecCommand(command: string, isKnownToolName: (name: string) => boolean): ExecCommandShape {
     const { verb: rawVerb, rest } = parseCommand(command)
-    const verb = KNOWN_EXEC_VERBS.has(rawVerb) ? rawVerb : normalizeExecToken(rawVerb)
+    if (!rawVerb) {
+        return {}
+    }
+    const verb = KNOWN_EXEC_VERBS.has(rawVerb) ? rawVerb : UNRECOGNIZED_EXEC_TOKEN
     if (!TOOL_TARGETING_VERBS.has(rawVerb) || !rest) {
         return { verb }
     }
     // `call` and `info` carry flags before the tool name; `schema` takes none.
     const args = rawVerb === 'call' ? parseCallFlags(rest).rest : rest.replace(/^--json(\s+|$)/, '')
-    return { verb, targetTool: args ? normalizeExecToken(parseCommand(args).verb) : undefined }
+    const target = args ? parseCommand(args).verb : ''
+    if (!target) {
+        return { verb }
+    }
+    return { verb, targetTool: isRecordableToolName(target, isKnownToolName) ? target : UNRECOGNIZED_EXEC_TOKEN }
+}
+
+/** Tool names we own, and can therefore record: the ones this connection can see,
+ *  plus the removed ones kept only to redirect a call. A name outside both is the
+ *  caller's own text. */
+function isRecordableToolName(name: string, isKnownToolName: (name: string) => boolean): boolean {
+    return isKnownToolName(name) || Object.prototype.hasOwnProperty.call(DEPRECATED_TOOL_REDIRECTS, name)
 }
 
 // Resolves the inner tool an `exec` call targets: given a request, return the
@@ -284,22 +297,98 @@ const MAX_KEY_LENGTH = 64
 const TYPE_REVEALING_CODES = new Set(['invalid_type', 'invalid_union'])
 
 /**
- * Joins an issue path into a descriptor, collapsing array indices to `N`.
+ * Recorded in place of a path segment the schema never declared. An open record
+ * (`generate-app-url`'s `params: z.record(z.string(), z.string())`) puts the
+ * caller's own key in the issue path, so recording the path verbatim would carry
+ * caller text into analytics. Which field held the bad value is preserved; only
+ * the key inside it is masked.
+ */
+const UNDECLARED_PATH_SEGMENT = '*'
+
+/** Defensive bound on the JSON Schema walk behind `declaredPropertyNames`. */
+const MAX_SCHEMA_WALK_DEPTH = 20
+
+/**
+ * Joins an issue path into a descriptor, collapsing array indices to `N` and
+ * masking any segment `declaredNames` doesn't cover.
  *
  * `series.0.event` and `series.1.event` describe one defect. Without the collapse
  * a malformed 50-element array yields 50 distinct descriptors that fill
  * `MAX_VALIDATION_DESCRIPTORS` with restatements of itself — and because the cap
  * truncates in schema-traversal order, it evicts genuinely different fields that
  * failed later. The dedupe is what keeps the cap meaningful.
+ *
+ * `declaredNames` is omitted only where every segment is ours by construction
+ * (`describeApiValidationError`, whose `attr` is a serializer field name).
  */
-function normalizeDescriptorPath(segments: readonly PropertyKey[]): string {
+function normalizeDescriptorPath(segments: readonly PropertyKey[], declaredNames?: ReadonlySet<string>): string {
     if (!segments.length) {
         return '(root)'
     }
     return segments
-        .map((segment) => (typeof segment === 'number' || /^\d+$/.test(String(segment)) ? 'N' : String(segment)))
+        .map((segment) => {
+            if (typeof segment === 'number' || /^\d+$/.test(String(segment))) {
+                return 'N'
+            }
+            const name = String(segment)
+            if (declaredNames && !declaredNames.has(name)) {
+                return UNDECLARED_PATH_SEGMENT
+            }
+            return name
+        })
         .join('.')
         .slice(0, MAX_KEY_LENGTH)
+}
+
+const declaredPropertyNamesCache = new WeakMap<object, ReadonlySet<string>>()
+
+/**
+ * Every property name a tool's schema declares, at any depth. A path segment
+ * outside this set came from an open record or a catchall, which means the caller
+ * chose it.
+ *
+ * Read off the JSON Schema exec already generates for `info`, so this depends on
+ * no Zod internals. A schema that can't be converted yields an empty set: more
+ * masking than strictly needed, never less.
+ */
+function declaredPropertyNames(schema: z.ZodType): ReadonlySet<string> {
+    const cached = declaredPropertyNamesCache.get(schema)
+    if (cached) {
+        return cached
+    }
+    const names = new Set<string>()
+    try {
+        collectDeclaredPropertyNames(z.toJSONSchema(schema, { io: 'input' }), names)
+    } catch {
+        // Telemetry must never break a tool call; an empty set only costs detail.
+    }
+    declaredPropertyNamesCache.set(schema, names)
+    return names
+}
+
+function collectDeclaredPropertyNames(node: unknown, into: Set<string>, depth = 0): void {
+    if (depth > MAX_SCHEMA_WALK_DEPTH || typeof node !== 'object' || node === null) {
+        return
+    }
+    if (Array.isArray(node)) {
+        for (const child of node) {
+            collectDeclaredPropertyNames(child, into, depth + 1)
+        }
+        return
+    }
+    for (const [key, value] of Object.entries(node)) {
+        // Only a `properties` map is keyed by field names. `patternProperties`,
+        // `additionalProperties` and `$defs` are keyed by pattern or definition name,
+        // so descend into their values without recording the keys.
+        if (key === 'properties' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+            for (const [name, child] of Object.entries(value)) {
+                into.add(name)
+                collectDeclaredPropertyNames(child, into, depth + 1)
+            }
+            continue
+        }
+        collectDeclaredPropertyNames(value, into, depth + 1)
+    }
 }
 
 /** The JSON-shaped type of a rejected value — never the value, never its length. */
@@ -342,16 +431,20 @@ export function describeApiValidationError(attr: string | undefined, code: strin
  * Records only structural information: field names, issue codes, and the TYPE of a
  * rejected value. It never records input VALUES — the ZodError embeds those in
  * `issue.input` and in `.message` (see `formatInputValidationError`), so this reads
- * `typeof issue.input` and never the value behind it.
+ * `typeof issue.input` and never the value behind it. `schema` is what keeps that
+ * true of the field paths as well: a key the schema never declared belongs to the
+ * caller, so it is masked rather than recorded (see `normalizeDescriptorPath`).
  */
 export function describeValidationError(
     error: z.ZodError,
-    input: Record<string, unknown>
+    input: Record<string, unknown>,
+    schema: z.ZodType
 ): { fields: string[]; inputKeys: string[] } {
+    const declaredNames = declaredPropertyNames(schema)
     const fields = [
         ...new Set(
             error.issues.map((issue) => {
-                const descriptor = `${normalizeDescriptorPath(issue.path)}:${issue.code}`
+                const descriptor = `${normalizeDescriptorPath(issue.path, declaredNames)}:${issue.code}`
                 // `input` is only present under `safeParse(..., { reportInput: true })`;
                 // without it there is no type to report, and an absent value and an
                 // unreported one must not both read as `undefined`.
@@ -717,7 +810,10 @@ export function createExecTool(
                         // classifies it as `validation`, not `internal`. The value-free
                         // descriptor rides along so the errored `$mcp_tool_call` records
                         // which field/alias was rejected — without the payload.
-                        throw new ToolInputValidationError(message, describeValidationError(validation.error, input))
+                        throw new ToolInputValidationError(
+                            message,
+                            describeValidationError(validation.error, input, tool.schema)
+                        )
                     }
                     input = validation.data as Record<string, unknown>
 

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -276,20 +276,73 @@ const MAX_VALIDATION_DESCRIPTORS = 20
 const MAX_KEY_LENGTH = 64
 
 /**
+ * Issue codes where the type of the rejected value is the diagnostic signal: a
+ * parameter that is absent and one that is present under the right name but the
+ * wrong shape are different bugs with different fixes, and both otherwise read as
+ * a bare `invalid_type`.
+ */
+const TYPE_REVEALING_CODES = new Set(['invalid_type', 'invalid_union'])
+
+/**
+ * Joins an issue path into a descriptor, collapsing array indices to `N`.
+ *
+ * `series.0.event` and `series.1.event` describe one defect. Without the collapse
+ * a malformed 50-element array yields 50 distinct descriptors that fill
+ * `MAX_VALIDATION_DESCRIPTORS` with restatements of itself — and because the cap
+ * truncates in schema-traversal order, it evicts genuinely different fields that
+ * failed later. The dedupe is what keeps the cap meaningful.
+ */
+function normalizeDescriptorPath(segments: readonly PropertyKey[]): string {
+    if (!segments.length) {
+        return '(root)'
+    }
+    return segments
+        .map((segment) => (typeof segment === 'number' || /^\d+$/.test(String(segment)) ? 'N' : String(segment)))
+        .join('.')
+        .slice(0, MAX_KEY_LENGTH)
+}
+
+/** The JSON-shaped type of a rejected value — never the value, never its length. */
+function describeReceivedType(value: unknown): string {
+    if (value === null) {
+        return 'null'
+    }
+    if (Array.isArray(value)) {
+        return 'array'
+    }
+    return typeof value
+}
+
+/**
+ * Builds a descriptor in the same `path:code[:received]` shape
+ * `describeValidationError` emits, for a rejection that came from the PostHog API
+ * rather than the local schema — so both kinds of validation failure answer one
+ * query instead of requiring `$mcp_error_message` to be string-parsed.
+ *
+ * `attr` is one of our own serializer field names and `code` a DRF code; neither
+ * carries caller input, unlike the API's free-text `detail`.
+ */
+export function describeApiValidationError(attr: string | undefined, code: string | undefined): string[] {
+    const path = normalizeDescriptorPath((attr ?? '').split('.').filter(Boolean))
+    return [`${path}:${code ?? 'unknown'}`]
+}
+
+/**
  * Derives a value-free descriptor of a validation failure for telemetry, so a
  * contract regression (agents sending a field name the schema doesn't accept) is
  * diagnosable from the `$mcp_tool_call` event alone — without ever recording the
  * request payload.
  *
- * `fields` are the offending top-level field + issue code (e.g. `orgId:invalid_type`);
- * for a union rejection the path is empty and it reads `(root):invalid_union`, which
- * is why `inputKeys` — the top-level keys the caller actually sent — carries the real
- * signal there (it surfaces the unaccepted alias, e.g. `organizationId`).
+ * `fields` are the offending field path + issue code, plus the received type where
+ * that distinguishes the bug (e.g. `id:invalid_type:undefined` for an omitted
+ * parameter vs `query:invalid_union:string` for an envelope the agent flattened).
+ * `inputKeys` — the top-level keys the caller actually sent — is what surfaces an
+ * unaccepted alias (e.g. `organizationId` where the schema wants `orgId`).
  *
- * Records only structural information (field names, issue codes). It never touches
- * input VALUES: the ZodError embeds raw values in `issue.input` and `.message` (see
- * `formatInputValidationError`), so we read `issue.path[0]`/`issue.code` and the
- * input's own key names only.
+ * Records only structural information: field names, issue codes, and the TYPE of a
+ * rejected value. It never records input VALUES — the ZodError embeds those in
+ * `issue.input` and in `.message` (see `formatInputValidationError`), so this reads
+ * `typeof issue.input` and never the value behind it.
  */
 export function describeValidationError(
     error: z.ZodError,
@@ -298,8 +351,14 @@ export function describeValidationError(
     const fields = [
         ...new Set(
             error.issues.map((issue) => {
-                const top = issue.path.length ? String(issue.path[0]) : '(root)'
-                return `${top.slice(0, MAX_KEY_LENGTH)}:${issue.code}`
+                const descriptor = `${normalizeDescriptorPath(issue.path)}:${issue.code}`
+                // `input` is only present under `safeParse(..., { reportInput: true })`;
+                // without it there is no type to report, and an absent value and an
+                // unreported one must not both read as `undefined`.
+                if (!TYPE_REVEALING_CODES.has(issue.code) || !('input' in issue)) {
+                    return descriptor
+                }
+                return `${descriptor}:${describeReceivedType(issue.input)}`
             })
         ),
     ].slice(0, MAX_VALIDATION_DESCRIPTORS)

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -175,9 +175,21 @@ export function describeExecCommand(command: string, isKnownToolName: (name: str
     if (!TOOL_TARGETING_VERBS.has(rawVerb) || !rest) {
         return { verb }
     }
-    // `call` and `info` carry flags before the tool name; `schema` takes none.
-    const args = rawVerb === 'call' ? parseCallFlags(rest).rest : rest.replace(/^--json(\s+|$)/, '')
-    const target = args ? parseCommand(args).verb : ''
+    // The target must be parsed exactly as the dispatcher looks it up, or a
+    // rejected command gets attributed to a valid tool. `call` strips its flags
+    // then takes the first token; `schema` takes the first token. `info` is the
+    // exception: it hands the entire remaining argument to `findTool` as an exact
+    // name (after an optional `--json`), so `info execute-sql extra` looks up
+    // "execute-sql extra", resolves to nothing, and records `unrecognized` — not
+    // the `execute-sql` its first token would suggest.
+    let target: string
+    if (rawVerb === 'call') {
+        target = parseCommand(parseCallFlags(rest).rest).verb
+    } else if (rawVerb === 'info') {
+        target = rest.replace(/^--json(\s+|$)/, '').trim()
+    } else {
+        target = parseCommand(rest).verb
+    }
     if (!target) {
         return { verb }
     }

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -126,6 +126,58 @@ export function parseExecCallInnerToolName(command: string): string | undefined 
     return innerName || undefined
 }
 
+/** Verbs the dispatcher grammar accepts. A verb outside this set is what the
+ *  `unknown_command` rejection fires on, and is recorded normalized. */
+const KNOWN_EXEC_VERBS = new Set(['learn', 'tools', 'search', 'info', 'schema', 'call'])
+
+/** Verbs whose first positional argument names a tool. */
+const TOOL_TARGETING_VERBS = new Set(['info', 'schema', 'call'])
+
+const MAX_EXEC_TOKEN_LENGTH = 64
+
+/**
+ * Reduces a model-supplied token to a bounded, punctuation-free identifier so an
+ * unrecognized verb or tool name can be recorded without carrying arbitrary text
+ * into analytics. Tool names are lowercase kebab-case, so a legitimate value
+ * survives this untouched; anything else collapses to a harmless fragment.
+ */
+function normalizeExecToken(raw: string): string | undefined {
+    const normalized = raw
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]/g, '')
+        .slice(0, MAX_EXEC_TOKEN_LENGTH)
+    return normalized || undefined
+}
+
+export interface ExecCommandShape {
+    /** The dispatcher verb, normalized when it isn't one we accept. */
+    verb?: string
+    /** The tool `info`/`schema`/`call` targeted — present even when it resolves to nothing. */
+    targetTool?: string
+}
+
+/**
+ * Describes an exec command for analytics: which verb ran, and which tool it
+ * targeted. Both are value-free — a bounded grammar token and a tool name — so
+ * neither can carry caller input (see `describeValidationError` for the same
+ * constraint applied to schema rejections).
+ *
+ * Without this, every non-`call` verb lands in one undifferentiated `exec`
+ * bucket: schema discovery is indistinguishable from tool search, and an
+ * `unknown_command` rejection records no verb to diagnose. `targetTool` is what
+ * links an `info <tool>` to the `call <tool>` that follows it.
+ */
+export function describeExecCommand(command: string): ExecCommandShape {
+    const { verb: rawVerb, rest } = parseCommand(command)
+    const verb = KNOWN_EXEC_VERBS.has(rawVerb) ? rawVerb : normalizeExecToken(rawVerb)
+    if (!TOOL_TARGETING_VERBS.has(rawVerb) || !rest) {
+        return { verb }
+    }
+    // `call` and `info` carry flags before the tool name; `schema` takes none.
+    const args = rawVerb === 'call' ? parseCallFlags(rest).rest : rest.replace(/^--json(\s+|$)/, '')
+    return { verb, targetTool: args ? normalizeExecToken(parseCommand(args).verb) : undefined }
+}
+
 // Resolves the inner tool an `exec` call targets: given a request, return the
 // inner tool's { name, description } when the agent invoked it via
 // `call <tool> ...`, or undefined otherwise. Lives here (alongside

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -270,20 +270,73 @@ const MAX_VALIDATION_DESCRIPTORS = 20
 const MAX_KEY_LENGTH = 64
 
 /**
+ * Issue codes where the type of the rejected value is the diagnostic signal: a
+ * parameter that is absent and one that is present under the right name but the
+ * wrong shape are different bugs with different fixes, and both otherwise read as
+ * a bare `invalid_type`.
+ */
+const TYPE_REVEALING_CODES = new Set(['invalid_type', 'invalid_union'])
+
+/**
+ * Joins an issue path into a descriptor, collapsing array indices to `N`.
+ *
+ * `series.0.event` and `series.1.event` describe one defect. Without the collapse
+ * a malformed 50-element array yields 50 distinct descriptors that fill
+ * `MAX_VALIDATION_DESCRIPTORS` with restatements of itself — and because the cap
+ * truncates in schema-traversal order, it evicts genuinely different fields that
+ * failed later. The dedupe is what keeps the cap meaningful.
+ */
+function normalizeDescriptorPath(segments: readonly PropertyKey[]): string {
+    if (!segments.length) {
+        return '(root)'
+    }
+    return segments
+        .map((segment) => (typeof segment === 'number' || /^\d+$/.test(String(segment)) ? 'N' : String(segment)))
+        .join('.')
+        .slice(0, MAX_KEY_LENGTH)
+}
+
+/** The JSON-shaped type of a rejected value — never the value, never its length. */
+function describeReceivedType(value: unknown): string {
+    if (value === null) {
+        return 'null'
+    }
+    if (Array.isArray(value)) {
+        return 'array'
+    }
+    return typeof value
+}
+
+/**
+ * Builds a descriptor in the same `path:code[:received]` shape
+ * `describeValidationError` emits, for a rejection that came from the PostHog API
+ * rather than the local schema — so both kinds of validation failure answer one
+ * query instead of requiring `$mcp_error_message` to be string-parsed.
+ *
+ * `attr` is one of our own serializer field names and `code` a DRF code; neither
+ * carries caller input, unlike the API's free-text `detail`.
+ */
+export function describeApiValidationError(attr: string | undefined, code: string | undefined): string[] {
+    const path = normalizeDescriptorPath((attr ?? '').split('.').filter(Boolean))
+    return [`${path}:${code ?? 'unknown'}`]
+}
+
+/**
  * Derives a value-free descriptor of a validation failure for telemetry, so a
  * contract regression (agents sending a field name the schema doesn't accept) is
  * diagnosable from the `$mcp_tool_call` event alone — without ever recording the
  * request payload.
  *
- * `fields` are the offending top-level field + issue code (e.g. `orgId:invalid_type`);
- * for a union rejection the path is empty and it reads `(root):invalid_union`, which
- * is why `inputKeys` — the top-level keys the caller actually sent — carries the real
- * signal there (it surfaces the unaccepted alias, e.g. `organizationId`).
+ * `fields` are the offending field path + issue code, plus the received type where
+ * that distinguishes the bug (e.g. `id:invalid_type:undefined` for an omitted
+ * parameter vs `query:invalid_union:string` for an envelope the agent flattened).
+ * `inputKeys` — the top-level keys the caller actually sent — is what surfaces an
+ * unaccepted alias (e.g. `organizationId` where the schema wants `orgId`).
  *
- * Records only structural information (field names, issue codes). It never touches
- * input VALUES: the ZodError embeds raw values in `issue.input` and `.message` (see
- * `formatInputValidationError`), so we read `issue.path[0]`/`issue.code` and the
- * input's own key names only.
+ * Records only structural information: field names, issue codes, and the TYPE of a
+ * rejected value. It never records input VALUES — the ZodError embeds those in
+ * `issue.input` and in `.message` (see `formatInputValidationError`), so this reads
+ * `typeof issue.input` and never the value behind it.
  */
 export function describeValidationError(
     error: z.ZodError,
@@ -292,8 +345,14 @@ export function describeValidationError(
     const fields = [
         ...new Set(
             error.issues.map((issue) => {
-                const top = issue.path.length ? String(issue.path[0]) : '(root)'
-                return `${top.slice(0, MAX_KEY_LENGTH)}:${issue.code}`
+                const descriptor = `${normalizeDescriptorPath(issue.path)}:${issue.code}`
+                // `input` is only present under `safeParse(..., { reportInput: true })`;
+                // without it there is no type to report, and an absent value and an
+                // unreported one must not both read as `undefined`.
+                if (!TYPE_REVEALING_CODES.has(issue.code) || !('input' in issue)) {
+                    return descriptor
+                }
+                return `${descriptor}:${describeReceivedType(issue.input)}`
             })
         ),
     ].slice(0, MAX_VALIDATION_DESCRIPTORS)

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -120,6 +120,58 @@ export function parseExecCallInnerToolName(command: string): string | undefined 
     return innerName || undefined
 }
 
+/** Verbs the dispatcher grammar accepts. A verb outside this set is what the
+ *  `unknown_command` rejection fires on, and is recorded normalized. */
+const KNOWN_EXEC_VERBS = new Set(['learn', 'tools', 'search', 'info', 'schema', 'call'])
+
+/** Verbs whose first positional argument names a tool. */
+const TOOL_TARGETING_VERBS = new Set(['info', 'schema', 'call'])
+
+const MAX_EXEC_TOKEN_LENGTH = 64
+
+/**
+ * Reduces a model-supplied token to a bounded, punctuation-free identifier so an
+ * unrecognized verb or tool name can be recorded without carrying arbitrary text
+ * into analytics. Tool names are lowercase kebab-case, so a legitimate value
+ * survives this untouched; anything else collapses to a harmless fragment.
+ */
+function normalizeExecToken(raw: string): string | undefined {
+    const normalized = raw
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]/g, '')
+        .slice(0, MAX_EXEC_TOKEN_LENGTH)
+    return normalized || undefined
+}
+
+export interface ExecCommandShape {
+    /** The dispatcher verb, normalized when it isn't one we accept. */
+    verb?: string
+    /** The tool `info`/`schema`/`call` targeted — present even when it resolves to nothing. */
+    targetTool?: string
+}
+
+/**
+ * Describes an exec command for analytics: which verb ran, and which tool it
+ * targeted. Both are value-free — a bounded grammar token and a tool name — so
+ * neither can carry caller input (see `describeValidationError` for the same
+ * constraint applied to schema rejections).
+ *
+ * Without this, every non-`call` verb lands in one undifferentiated `exec`
+ * bucket: schema discovery is indistinguishable from tool search, and an
+ * `unknown_command` rejection records no verb to diagnose. `targetTool` is what
+ * links an `info <tool>` to the `call <tool>` that follows it.
+ */
+export function describeExecCommand(command: string): ExecCommandShape {
+    const { verb: rawVerb, rest } = parseCommand(command)
+    const verb = KNOWN_EXEC_VERBS.has(rawVerb) ? rawVerb : normalizeExecToken(rawVerb)
+    if (!TOOL_TARGETING_VERBS.has(rawVerb) || !rest) {
+        return { verb }
+    }
+    // `call` and `info` carry flags before the tool name; `schema` takes none.
+    const args = rawVerb === 'call' ? parseCallFlags(rest).rest : rest.replace(/^--json(\s+|$)/, '')
+    return { verb, targetTool: args ? normalizeExecToken(parseCommand(args).verb) : undefined }
+}
+
 // Resolves the inner tool an `exec` call targets: given a request, return the
 // inner tool's { name, description } when the agent invoked it via
 // `call <tool> ...`, or undefined otherwise. Lives here (alongside

--- a/services/mcp/tests/hono/tool-executor-intent.test.ts
+++ b/services/mcp/tests/hono/tool-executor-intent.test.ts
@@ -136,11 +136,12 @@ describe('ToolExecutor intent capture', () => {
     })
 
     // A native (non-exec) tool call with context: proves the native callTool path
-    // strips context and forwards intent. captureToolCall only fires *after*
-    // validation passes (the validation-error path returns before tracking), so its
-    // being called with the intent proves context was stripped before validation.
-    // (projects-get hits the API, which the harness can't fulfill, so we assert on
-    // the captured analytics, not the tool's own result.)
+    // strips context and forwards intent. The native path now also tracks schema
+    // rejections, so "captureToolCall fired" alone no longer implies validation
+    // passed — assert the absence of a validation error explicitly, otherwise an
+    // unstripped `context` (rejected as an unrecognized key) would satisfy this
+    // test. (projects-get hits the API, which the harness can't fulfill, so we
+    // assert on the captured analytics, not the tool's own result.)
     it('strips context before a native tool validates and still forwards intent', async () => {
         const captureSpy = vi.spyOn(getPostHogClient(), 'captureToolCall').mockImplementation(() => {})
 
@@ -150,8 +151,10 @@ describe('ToolExecutor intent capture', () => {
         )
 
         expect(captureSpy).toHaveBeenCalledTimes(1)
-        expect(captureSpy.mock.calls[0]![0].toolName).toBe('projects-get')
-        expect(captureSpy.mock.calls[0]![0].intent).toBe('looking up the current user')
+        const arg = captureSpy.mock.calls[0]![0]
+        expect(arg.toolName).toBe('projects-get')
+        expect(arg.intent).toBe('looking up the current user')
+        expect(arg.properties?.$mcp_error_type).not.toBe('validation')
 
         captureSpy.mockRestore()
     })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -484,9 +484,10 @@ describe('ToolExecutor metrics', () => {
             ['tools', { $mcp_exec_verb: 'tools' }],
             ['info docs-search', { $mcp_exec_verb: 'info', $mcp_exec_target_tool: 'docs-search' }],
             ['schema docs-search query', { $mcp_exec_verb: 'schema', $mcp_exec_target_tool: 'docs-search' }],
-            // Rejected verbs and unresolvable tools still carry their (normalized) token.
-            ['frobnicate whatever', { $mcp_exec_verb: 'frobnicate' }],
-            ['call not-a-real-tool {}', { $mcp_exec_verb: 'call', $mcp_exec_target_tool: 'not-a-real-tool' }],
+            // A verb or tool name we don't recognize is caller text, so the event
+            // records that it was unrecognized rather than the token itself.
+            ['frobnicate whatever', { $mcp_exec_verb: 'unrecognized' }],
+            ['call not-a-real-tool {}', { $mcp_exec_verb: 'call', $mcp_exec_target_tool: 'unrecognized' }],
         ])('stamps the exec verb and target for "%s"', async (command, expected) => {
             await executor.handleToolCall({ name: 'exec', arguments: { command } }, execState())
 

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -274,6 +274,35 @@ describe('ToolExecutor metrics', () => {
             expect(trackToolCallExtras('fail-tool')).toMatchObject({ $mcp_error_message: expected })
         })
 
+        // An API-layer rejection used to carry no structured field, so it was only
+        // reachable by string-parsing $mcp_error_message. It now populates the same
+        // property a local schema rejection does — the API's free-text `detail` still
+        // never reaches analytics.
+        it('stamps $mcp_validation_fields for an API validation error, without the detail body', async () => {
+            vi.spyOn(catalog, 'getToolByName').mockReturnValue(
+                makeFakeTool('fail-tool', async () => {
+                    throw new PostHogValidationError({
+                        detail: 'Unable to resolve field: SECRET=sk_live_abc123',
+                        attr: 'series.0.event',
+                        code: 'invalid_input',
+                        extra: undefined,
+                        url: 'https://us.posthog.com/api/environments/2/query/',
+                        method: 'POST',
+                    })
+                }) as any
+            )
+
+            await executor.handleToolCall({ name: 'fail-tool', arguments: {} }, makeState([{ name: 'fail-tool' }]))
+
+            const extras = trackToolCallExtras('fail-tool')
+            expect(extras).toMatchObject({
+                $mcp_error_type: 'validation',
+                // Array indices collapse here too, matching the schema path.
+                $mcp_validation_fields: ['series.N.event:invalid_input'],
+            })
+            expect(JSON.stringify(extras)).not.toContain('sk_live_abc123')
+        })
+
         it('rebuilds PostHogApiError messages from status + path, never the response body or query string', async () => {
             vi.spyOn(catalog, 'getToolByName').mockReturnValue(
                 makeFakeTool('fail-tool', async () => {
@@ -403,7 +432,9 @@ describe('ToolExecutor metrics', () => {
             expect(call![1]).toBe(0)
             expect(trackToolCallExtras('strict-tool')).toMatchObject({
                 $mcp_error_type: 'validation',
-                $mcp_validation_fields: ['required_field:invalid_type'],
+                // `:undefined` is the received type — the param was absent, not
+                // mistyped, which is what separates an alias slip from a coercion bug.
+                $mcp_validation_fields: ['required_field:invalid_type:undefined'],
                 $mcp_validation_input_keys: ['requiredField'],
             })
         })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -381,6 +381,33 @@ describe('ToolExecutor metrics', () => {
             expect(mockToolDurationStartTimer).not.toHaveBeenCalled()
         })
 
+        // The direct path used to return before tracking, so a schema rejection in
+        // 'tools' mode produced no `$mcp_tool_call` at all — leaving every
+        // exec-vs-direct error comparison silently flattering direct mode. Pin both
+        // the event and the value-free diagnostics that make it actionable.
+        it('emits an errored analytics event with the rejected fields on a schema rejection', async () => {
+            vi.spyOn(catalog, 'getToolByName').mockReturnValue({
+                name: 'strict-tool',
+                base: { schema: z.object({ required_field: z.string() }), handler: vi.fn(), _meta: undefined },
+            } as any)
+
+            await executor.handleToolCall(
+                { name: 'strict-tool', arguments: { requiredField: 'sent under the wrong name' } },
+                makeState([{ name: 'strict-tool' }])
+            )
+
+            const call = mockTrackToolCall.mock.calls.find((c) => c[0] === 'strict-tool')
+            expect(call).not.toBeUndefined()
+            expect(call![2]).toBe(true)
+            // No handler ran, so the call carries no duration (mirrors the exec path).
+            expect(call![1]).toBe(0)
+            expect(trackToolCallExtras('strict-tool')).toMatchObject({
+                $mcp_error_type: 'validation',
+                $mcp_validation_fields: ['required_field:invalid_type'],
+                $mcp_validation_input_keys: ['requiredField'],
+            })
+        })
+
         it('records error for unknown tool', async () => {
             await executor.handleToolCall({ name: 'nonexistent', arguments: {} }, makeState([]))
 
@@ -411,6 +438,25 @@ describe('ToolExecutor metrics', () => {
 
             expect(callsFor(mockToolCallsInc, 'exec')).toHaveLength(0)
             expect(callsFor(mockToolDurationStartTimer, 'exec')).toHaveLength(0)
+        })
+
+        // Without the verb, every non-`call` command lands in one undifferentiated
+        // `exec` bucket — schema discovery, tool search and a mistyped verb become
+        // indistinguishable, and `unknown_command` records nothing to diagnose.
+        // `$mcp_exec_target_tool` is what links an `info <tool>` to the `call <tool>`
+        // that follows it, and is the only trace of an attempted unknown tool.
+        it.each([
+            ['tools', { $mcp_exec_verb: 'tools' }],
+            ['info docs-search', { $mcp_exec_verb: 'info', $mcp_exec_target_tool: 'docs-search' }],
+            ['schema docs-search query', { $mcp_exec_verb: 'schema', $mcp_exec_target_tool: 'docs-search' }],
+            // Rejected verbs and unresolvable tools still carry their (normalized) token.
+            ['frobnicate whatever', { $mcp_exec_verb: 'frobnicate' }],
+            ['call not-a-real-tool {}', { $mcp_exec_verb: 'call', $mcp_exec_target_tool: 'not-a-real-tool' }],
+        ])('stamps the exec verb and target for "%s"', async (command, expected) => {
+            await executor.handleToolCall({ name: 'exec', arguments: { command } }, execState())
+
+            const call = mockTrackToolCall.mock.calls.at(-1)
+            expect(call?.[4]).toMatchObject(expected)
         })
 
         it('emits inner tool name for counter and duration on inner tool call', async () => {

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -425,11 +425,15 @@ describe('ToolExecutor metrics', () => {
                 makeState([{ name: 'strict-tool' }])
             )
 
-            const call = mockTrackToolCall.mock.calls.find((c) => c[0] === 'strict-tool')
-            expect(call).not.toBeUndefined()
-            expect(call![2]).toBe(true)
+            // Exactly one event: the rejection returns before the handler runs, so
+            // neither the success nor the catch tracker can also fire. A second emit
+            // here would double-count the call in every error-rate metric.
+            const calls = mockTrackToolCall.mock.calls.filter((c) => c[0] === 'strict-tool')
+            expect(calls).toHaveLength(1)
+            const call = calls[0]!
+            expect(call[2]).toBe(true)
             // No handler ran, so the call carries no duration (mirrors the exec path).
-            expect(call![1]).toBe(0)
+            expect(call[1]).toBe(0)
             expect(trackToolCallExtras('strict-tool')).toMatchObject({
                 $mcp_error_type: 'validation',
                 // `:undefined` is the received type — the param was absent, not

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -242,6 +242,35 @@ describe('ToolExecutor metrics', () => {
             expect(trackToolCallExtras('fail-tool')).toMatchObject({ $mcp_error_message: expected })
         })
 
+        // An API-layer rejection used to carry no structured field, so it was only
+        // reachable by string-parsing $mcp_error_message. It now populates the same
+        // property a local schema rejection does — the API's free-text `detail` still
+        // never reaches analytics.
+        it('stamps $mcp_validation_fields for an API validation error, without the detail body', async () => {
+            vi.spyOn(catalog, 'getToolByName').mockReturnValue(
+                makeFakeTool('fail-tool', async () => {
+                    throw new PostHogValidationError({
+                        detail: 'Unable to resolve field: SECRET=sk_live_abc123',
+                        attr: 'series.0.event',
+                        code: 'invalid_input',
+                        extra: undefined,
+                        url: 'https://us.posthog.com/api/environments/2/query/',
+                        method: 'POST',
+                    })
+                }) as any
+            )
+
+            await executor.handleToolCall({ name: 'fail-tool', arguments: {} }, makeState([{ name: 'fail-tool' }]))
+
+            const extras = trackToolCallExtras('fail-tool')
+            expect(extras).toMatchObject({
+                $mcp_error_type: 'validation',
+                // Array indices collapse here too, matching the schema path.
+                $mcp_validation_fields: ['series.N.event:invalid_input'],
+            })
+            expect(JSON.stringify(extras)).not.toContain('sk_live_abc123')
+        })
+
         it('rebuilds PostHogApiError messages from status + path, never the response body or query string', async () => {
             vi.spyOn(catalog, 'getToolByName').mockReturnValue(
                 makeFakeTool('fail-tool', async () => {
@@ -371,7 +400,9 @@ describe('ToolExecutor metrics', () => {
             expect(call![1]).toBe(0)
             expect(trackToolCallExtras('strict-tool')).toMatchObject({
                 $mcp_error_type: 'validation',
-                $mcp_validation_fields: ['required_field:invalid_type'],
+                // `:undefined` is the received type — the param was absent, not
+                // mistyped, which is what separates an alias slip from a coercion bug.
+                $mcp_validation_fields: ['required_field:invalid_type:undefined'],
                 $mcp_validation_input_keys: ['requiredField'],
             })
         })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -349,6 +349,33 @@ describe('ToolExecutor metrics', () => {
             expect(mockToolDurationStartTimer).not.toHaveBeenCalled()
         })
 
+        // The direct path used to return before tracking, so a schema rejection in
+        // 'tools' mode produced no `$mcp_tool_call` at all — leaving every
+        // exec-vs-direct error comparison silently flattering direct mode. Pin both
+        // the event and the value-free diagnostics that make it actionable.
+        it('emits an errored analytics event with the rejected fields on a schema rejection', async () => {
+            vi.spyOn(catalog, 'getToolByName').mockReturnValue({
+                name: 'strict-tool',
+                base: { schema: z.object({ required_field: z.string() }), handler: vi.fn(), _meta: undefined },
+            } as any)
+
+            await executor.handleToolCall(
+                { name: 'strict-tool', arguments: { requiredField: 'sent under the wrong name' } },
+                makeState([{ name: 'strict-tool' }])
+            )
+
+            const call = mockTrackToolCall.mock.calls.find((c) => c[0] === 'strict-tool')
+            expect(call).not.toBeUndefined()
+            expect(call![2]).toBe(true)
+            // No handler ran, so the call carries no duration (mirrors the exec path).
+            expect(call![1]).toBe(0)
+            expect(trackToolCallExtras('strict-tool')).toMatchObject({
+                $mcp_error_type: 'validation',
+                $mcp_validation_fields: ['required_field:invalid_type'],
+                $mcp_validation_input_keys: ['requiredField'],
+            })
+        })
+
         it('records error for unknown tool', async () => {
             await executor.handleToolCall({ name: 'nonexistent', arguments: {} }, makeState([]))
 
@@ -379,6 +406,25 @@ describe('ToolExecutor metrics', () => {
 
             expect(callsFor(mockToolCallsInc, 'exec')).toHaveLength(0)
             expect(callsFor(mockToolDurationStartTimer, 'exec')).toHaveLength(0)
+        })
+
+        // Without the verb, every non-`call` command lands in one undifferentiated
+        // `exec` bucket — schema discovery, tool search and a mistyped verb become
+        // indistinguishable, and `unknown_command` records nothing to diagnose.
+        // `$mcp_exec_target_tool` is what links an `info <tool>` to the `call <tool>`
+        // that follows it, and is the only trace of an attempted unknown tool.
+        it.each([
+            ['tools', { $mcp_exec_verb: 'tools' }],
+            ['info docs-search', { $mcp_exec_verb: 'info', $mcp_exec_target_tool: 'docs-search' }],
+            ['schema docs-search query', { $mcp_exec_verb: 'schema', $mcp_exec_target_tool: 'docs-search' }],
+            // Rejected verbs and unresolvable tools still carry their (normalized) token.
+            ['frobnicate whatever', { $mcp_exec_verb: 'frobnicate' }],
+            ['call not-a-real-tool {}', { $mcp_exec_verb: 'call', $mcp_exec_target_tool: 'not-a-real-tool' }],
+        ])('stamps the exec verb and target for "%s"', async (command, expected) => {
+            await executor.handleToolCall({ name: 'exec', arguments: { command } }, execState())
+
+            const call = mockTrackToolCall.mock.calls.at(-1)
+            expect(call?.[4]).toMatchObject(expected)
         })
 
         it('emits inner tool name for counter and duration on inner tool call', async () => {

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -1270,6 +1270,10 @@ describe('exec tool', () => {
             ['info execute-sql', 'info', 'execute-sql'],
             ['info --json execute-sql', 'info', 'execute-sql'],
             ['schema query-trends series', 'schema', 'query-trends'],
+            // `info` matches the whole remainder as an exact tool name, so a
+            // trailing token makes the lookup fail — telemetry must mirror the
+            // dispatcher's rejection, not credit the valid first token.
+            ['info execute-sql extra', 'info', 'unrecognized'],
             ['call my-tool {"a":1}', 'call', 'my-tool'],
             ['call --json --confirm my-tool {}', 'call', 'my-tool'],
             ['  info   execute-sql  ', 'info', 'execute-sql'],

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -12,6 +12,7 @@ import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
 import {
     createExecTool,
+    describeApiValidationError,
     describeExecCommand,
     describeValidationError,
     type ExecInnerCallProperties,
@@ -1425,8 +1426,74 @@ describe('exec tool', () => {
 
             const detail = describeValidationError(result.error!, input)
 
-            expect(detail.fields).toContain('projectId:invalid_type')
+            expect(detail.fields).toContain('projectId:invalid_type:string')
             expect(JSON.stringify(detail)).not.toContain('not-a-number')
+        })
+
+        // `invalid_type` alone conflates an omitted parameter with one sent under the
+        // right name but the wrong shape — the two dominant rejection classes, and
+        // they need different fixes (aliasing vs coercion/envelope). The received
+        // type is what separates them.
+        it.each([
+            ['omitted entirely', {}, 'id:invalid_type:undefined'],
+            ['sent as the wrong primitive', { id: 42 }, 'id:invalid_type:number'],
+            ['sent as an envelope object', { id: { value: 'x' } }, 'id:invalid_type:object'],
+            ['sent as an array', { id: ['x'] }, 'id:invalid_type:array'],
+            ['sent as null', { id: null }, 'id:invalid_type:null'],
+        ])('distinguishes a required param %s', (_label, input, expected) => {
+            const result = z.object({ id: z.string() }).safeParse(input, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            expect(describeValidationError(result.error!, input as Record<string, unknown>).fields).toEqual([expected])
+        })
+
+        // The received type is only meaningful for the type-shaped codes; appending it
+        // to every code would bloat the descriptor and say nothing (`too_big:string`).
+        it('omits the received type for a code the type does not explain', () => {
+            const input = { description: 'far too long' }
+            const result = z.object({ description: z.string().max(3) }).safeParse(input, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            expect(describeValidationError(result.error!, input).fields).toEqual(['description:too_big'])
+        })
+
+        // A malformed array produces one issue per element. Collapsing indices keeps
+        // them a single descriptor — otherwise they fill the 20-descriptor cap with
+        // restatements of one defect and evict the genuinely different field that
+        // failed after them, which is the information the event exists to carry.
+        it('collapses array indices so one bad array cannot evict other failed fields', () => {
+            const schema = z.object({
+                series: z.array(z.object({ event: z.string() })),
+                dateRange: z.string(),
+            })
+            const input = {
+                series: Array.from({ length: 50 }, () => ({ event: 123 })),
+                dateRange: 456,
+            }
+            const result = schema.safeParse(input, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            const { fields } = describeValidationError(result.error!, input as Record<string, unknown>)
+
+            expect(fields).toEqual(['series.N.event:invalid_type:number', 'dateRange:invalid_type:number'])
+        })
+    })
+
+    describe('describeApiValidationError', () => {
+        // API-layer rejections carried no structured field at all, so they could only
+        // be reached by string-parsing $mcp_error_message. Same format as the schema
+        // path so a single query spans both.
+        it.each([
+            ['name', 'required', 'name:required'],
+            ['series.0.event', 'invalid', 'series.N.event:invalid'],
+            [undefined, 'invalid', '(root):invalid'],
+            ['name', undefined, 'name:unknown'],
+        ])('describes attr=%s code=%s as %s', (attr, code, expected) => {
+            expect(describeApiValidationError(attr, code)).toEqual([expected])
+        })
+
+        it('bounds an over-long attr to the shared key-length cap', () => {
+            expect(describeApiValidationError('a'.repeat(200), 'invalid')[0]).toBe(`${'a'.repeat(64)}:invalid`)
         })
     })
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -1259,6 +1259,8 @@ describe('exec tool', () => {
     })
 
     describe('describeExecCommand', () => {
+        const isKnownToolName = (name: string): boolean => ['execute-sql', 'query-trends', 'my-tool'].includes(name)
+
         // The verb/target pair is what separates schema discovery from tool search
         // from a mistyped verb in analytics. Flag handling differs per verb, so a
         // parser regression silently collapses the funnel back into one bucket.
@@ -1271,37 +1273,34 @@ describe('exec tool', () => {
             ['call my-tool {"a":1}', 'call', 'my-tool'],
             ['call --json --confirm my-tool {}', 'call', 'my-tool'],
             ['  info   execute-sql  ', 'info', 'execute-sql'],
-            // A `call` that never resolves still records what was attempted — the
-            // only signal there is behind an `unknown_tool` rejection.
-            ['call not-a-real-tool {}', 'call', 'not-a-real-tool'],
+            // A removed tool is still one of our own names, so the redirect it
+            // triggers stays diagnosable.
+            ['call query-run {}', 'call', 'query-run'],
             // Verb present, target absent: nothing to record for the tool, but the
             // verb still is.
             ['info', 'info', undefined],
             ['call', 'call', undefined],
             ['', undefined, undefined],
         ])('describes "%s" as verb=%s target=%s', (command, expectedVerb, expectedTarget) => {
-            expect(describeExecCommand(command)).toEqual({
+            expect(describeExecCommand(command, isKnownToolName)).toEqual({
                 verb: expectedVerb,
                 ...(expectedTarget !== undefined ? { targetTool: expectedTarget } : {}),
             })
         })
 
-        // Both fields reach analytics, so an unrecognized token must never carry
-        // caller text through. Anything outside [a-z0-9._-] is dropped and the
-        // result is capped — the same value-free constraint `describeValidationError`
-        // holds for schema rejections.
+        // Both fields reach analytics, and a token the grammar rejected is caller
+        // text — sanitizing its charset would leave an identifier-shaped secret
+        // intact, so it is replaced outright. Same value-free constraint
+        // `describeValidationError` holds for schema rejections.
         it.each([
-            ['LIST {"secret":"value"}', 'list'],
-            ['<script>alert(1)</script>', 'scriptalert1script'],
-            ['a'.repeat(200), 'a'.repeat(64)],
-        ])('normalizes unrecognized verb in "%s"', (command, expectedVerb) => {
-            const { verb } = describeExecCommand(command)
-            expect(verb).toBe(expectedVerb)
-            expect(verb!.length).toBeLessThanOrEqual(64)
-        })
+            ['an unknown verb', 'sk-live-abc123 {"a":1}', { verb: 'unrecognized' }],
+            ['an unresolvable call target', 'call sk-live-abc123 {}', { verb: 'call', targetTool: 'unrecognized' }],
+            ['an unresolvable info target', 'info sk-live-abc123', { verb: 'info', targetTool: 'unrecognized' }],
+        ])('records a sentinel instead of %s', (_label, command, expected) => {
+            const shape = describeExecCommand(command, isKnownToolName)
 
-        it('normalizes and bounds an unrecognized target tool', () => {
-            expect(describeExecCommand(`call ${'x'.repeat(200)} {}`).targetTool).toBe('x'.repeat(64))
+            expect(shape).toEqual(expected)
+            expect(JSON.stringify(shape)).not.toContain('sk-live-abc123')
         })
     })
 
@@ -1411,7 +1410,7 @@ describe('exec tool', () => {
             const result = schema.safeParse(input, { reportInput: true })
             expect(result.success).toBe(false)
 
-            const detail = describeValidationError(result.error!, input)
+            const detail = describeValidationError(result.error!, input, schema)
 
             expect(detail.inputKeys).toEqual(['organizationId'])
             // Never record input values — the raw uuid must not appear anywhere.
@@ -1424,7 +1423,7 @@ describe('exec tool', () => {
             const result = schema.safeParse(input, { reportInput: true })
             expect(result.success).toBe(false)
 
-            const detail = describeValidationError(result.error!, input)
+            const detail = describeValidationError(result.error!, input, schema)
 
             expect(detail.fields).toContain('projectId:invalid_type:string')
             expect(JSON.stringify(detail)).not.toContain('not-a-number')
@@ -1441,20 +1440,24 @@ describe('exec tool', () => {
             ['sent as an array', { id: ['x'] }, 'id:invalid_type:array'],
             ['sent as null', { id: null }, 'id:invalid_type:null'],
         ])('distinguishes a required param %s', (_label, input, expected) => {
-            const result = z.object({ id: z.string() }).safeParse(input, { reportInput: true })
+            const schema = z.object({ id: z.string() })
+            const result = schema.safeParse(input, { reportInput: true })
             expect(result.success).toBe(false)
 
-            expect(describeValidationError(result.error!, input as Record<string, unknown>).fields).toEqual([expected])
+            expect(describeValidationError(result.error!, input as Record<string, unknown>, schema).fields).toEqual([
+                expected,
+            ])
         })
 
         // The received type is only meaningful for the type-shaped codes; appending it
         // to every code would bloat the descriptor and say nothing (`too_big:string`).
         it('omits the received type for a code the type does not explain', () => {
+            const schema = z.object({ description: z.string().max(3) })
             const input = { description: 'far too long' }
-            const result = z.object({ description: z.string().max(3) }).safeParse(input, { reportInput: true })
+            const result = schema.safeParse(input, { reportInput: true })
             expect(result.success).toBe(false)
 
-            expect(describeValidationError(result.error!, input).fields).toEqual(['description:too_big'])
+            expect(describeValidationError(result.error!, input, schema).fields).toEqual(['description:too_big'])
         })
 
         // A malformed array produces one issue per element. Collapsing indices keeps
@@ -1473,9 +1476,40 @@ describe('exec tool', () => {
             const result = schema.safeParse(input, { reportInput: true })
             expect(result.success).toBe(false)
 
-            const { fields } = describeValidationError(result.error!, input as Record<string, unknown>)
+            const { fields } = describeValidationError(result.error!, input as Record<string, unknown>, schema)
 
             expect(fields).toEqual(['series.N.event:invalid_type:number', 'dateRange:invalid_type:number'])
+        })
+
+        // The full issue path is what distinguishes a flattened envelope from a bad
+        // discriminator, but under an open record (`generate-app-url`'s `params`) the
+        // path's own segments are the caller's keys. Masking them keeps the field that
+        // held the bad value visible without recording anything the caller chose.
+        it('masks a path segment the schema never declared', () => {
+            const schema = z.object({
+                url: z.string(),
+                params: z.record(z.string(), z.string()),
+            })
+            const input = { url: '/project/2', params: { 'sk-live-abc123': 42 } }
+            const result = schema.safeParse(input, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            const detail = describeValidationError(result.error!, input as Record<string, unknown>, schema)
+
+            expect(detail.fields).toEqual(['params.*:invalid_type:number'])
+            expect(JSON.stringify(detail)).not.toContain('sk-live-abc123')
+        })
+
+        // Nested schema fields are ours, so they must survive the mask — otherwise
+        // every descriptor collapses to `*` and the reason the PR widened the path
+        // (telling `query:invalid_union` apart from `query.kind:invalid_type`) is lost.
+        it('keeps a declared nested path intact', () => {
+            const schema = z.object({ query: z.object({ kind: z.literal('TrendsQuery') }) })
+            const input = { query: { kind: 'trends' } }
+            const result = schema.safeParse(input, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            expect(describeValidationError(result.error!, input, schema).fields).toEqual(['query.kind:invalid_value'])
         })
     })
 

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -12,6 +12,7 @@ import { SessionManager } from '@/lib/SessionManager'
 import { getToolsFromContext } from '@/tools'
 import {
     createExecTool,
+    describeExecCommand,
     describeValidationError,
     type ExecInnerCallProperties,
     type ExecToolOptions,
@@ -1253,6 +1254,53 @@ describe('exec tool', () => {
             ['   '],
         ])('returns undefined for "%s"', (command) => {
             expect(parseExecCallInnerToolName(command)).toBeUndefined()
+        })
+    })
+
+    describe('describeExecCommand', () => {
+        // The verb/target pair is what separates schema discovery from tool search
+        // from a mistyped verb in analytics. Flag handling differs per verb, so a
+        // parser regression silently collapses the funnel back into one bucket.
+        it.each([
+            ['tools', 'tools', undefined],
+            ['search query-', 'search', undefined],
+            ['info execute-sql', 'info', 'execute-sql'],
+            ['info --json execute-sql', 'info', 'execute-sql'],
+            ['schema query-trends series', 'schema', 'query-trends'],
+            ['call my-tool {"a":1}', 'call', 'my-tool'],
+            ['call --json --confirm my-tool {}', 'call', 'my-tool'],
+            ['  info   execute-sql  ', 'info', 'execute-sql'],
+            // A `call` that never resolves still records what was attempted — the
+            // only signal there is behind an `unknown_tool` rejection.
+            ['call not-a-real-tool {}', 'call', 'not-a-real-tool'],
+            // Verb present, target absent: nothing to record for the tool, but the
+            // verb still is.
+            ['info', 'info', undefined],
+            ['call', 'call', undefined],
+            ['', undefined, undefined],
+        ])('describes "%s" as verb=%s target=%s', (command, expectedVerb, expectedTarget) => {
+            expect(describeExecCommand(command)).toEqual({
+                verb: expectedVerb,
+                ...(expectedTarget !== undefined ? { targetTool: expectedTarget } : {}),
+            })
+        })
+
+        // Both fields reach analytics, so an unrecognized token must never carry
+        // caller text through. Anything outside [a-z0-9._-] is dropped and the
+        // result is capped — the same value-free constraint `describeValidationError`
+        // holds for schema rejections.
+        it.each([
+            ['LIST {"secret":"value"}', 'list'],
+            ['<script>alert(1)</script>', 'scriptalert1script'],
+            ['a'.repeat(200), 'a'.repeat(64)],
+        ])('normalizes unrecognized verb in "%s"', (command, expectedVerb) => {
+            const { verb } = describeExecCommand(command)
+            expect(verb).toBe(expectedVerb)
+            expect(verb!.length).toBeLessThanOrEqual(64)
+        })
+
+        it('normalizes and bounds an unrecognized target tool', () => {
+            expect(describeExecCommand(`call ${'x'.repeat(200)} {}`).targetTool).toBe('x'.repeat(64))
         })
     })
 


### PR DESCRIPTION
## Problem

Validation errors are a large share of MCP tool call failures, and today we cannot tell what is actually going wrong. Three gaps, in the order they hurt:

1. **Direct-mode schema rejections emit nothing.** In `tools` mode, a rejection returns before `trackToolCall` runs, so no `$mcp_tool_call` event is produced at all. Any comparison of single-exec against direct registration silently flatters direct mode, and clients that register tools individually look error-free when they are not.
2. **Non-`call` exec verbs all collapse into one bucket.** `$mcp_tool_name` reads `exec` for `tools`, `search`, `info`, `schema` and `learn`, which is roughly 27% of single-exec traffic. Schema discovery, tool search and a mistyped verb are indistinguishable, and an `unknown_command` rejection records no verb to diagnose.
3. **`<field>:<code>` conflates the two dominant rejection classes.** A parameter that was omitted and one sent under the right name but the wrong shape both read as a bare `invalid_type`. They need opposite fixes (aliasing versus coercion or an envelope correction). API-layer rejections carried no structured field at all and were reachable only by string-parsing `$mcp_error_message`.

Origin: [#mcp-analytics thread](https://posthog.slack.com/archives/C0AV33BDCJ3/p1785438394638489) on AI observability tool error rates.

## Changes

**Direct-mode rejections now emit the same errored event the exec path does**, carrying the existing value-free `$mcp_validation_fields` and `$mcp_validation_input_keys`. Duration is 0, since no handler ran.

**Two new properties on exec events**, stamped on success and failure alike:

| Property | Carries |
| --- | --- |
| `$mcp_exec_verb` | Which dispatcher verb ran, including a rejected one |
| `$mcp_exec_target_tool` | The tool `info` / `schema` / `call` named, including one that failed to resolve |

Together they make the discovery funnel queryable (searched, read the schema, called, succeeded) and link an `info <tool>` to the `call <tool>` that follows it.

**Richer validation descriptors**, no new property and no cap changes:

| Before | After |
| --- | --- |
| `id:invalid_type` | `id:invalid_type:undefined` (omitted) |
| `id:invalid_type` | `id:invalid_type:object` (envelope sent) |
| `query:invalid_union` | `query:invalid_union:string` (flattened envelope) |
| `query:invalid_union` | `query.kind:invalid_type:string` (bad discriminator) |

The full field path replaces the first-segment-only truncation, which is what makes the last two rows distinguishable. Segments the schema never declared are masked (`params.*:invalid_type:number`), so widening the path cannot carry an open record's caller-chosen key into analytics. `PostHogValidationError` populates the same property in the same format, so one query spans both the local schema and the API.

Array indices collapse to `N`. This is load-bearing rather than cosmetic: a malformed 50 element array would otherwise emit 50 distinct descriptors, filling the 20 descriptor cap with restatements of one defect and evicting the genuinely different fields that failed after it, since the cap truncates in schema traversal order.

> [!NOTE]
> Every new value stays value-free by construction. `$mcp_exec_verb` comes from the closed verb grammar and `$mcp_exec_target_tool` from the catalog this connection can see (plus the removed names kept for redirects); a token outside either records as `unrecognized` rather than being sanitized and echoed, since an identifier-shaped secret survives sanitization intact. Descriptor path segments are checked against the property names the tool's schema declares, so an open record's caller-chosen key (`generate-app-url`'s `params`) records as `*` instead of verbatim — the field that held the bad value stays visible. The descriptor reads `typeof issue.input` and never the value or its length. The API's free-text `detail` still never reaches analytics.

> [!WARNING]
> `$mcp_validation_fields` changes format. `<field>:<code>` stays a prefix of `<field>:<code>:<received>`, so anything using `splitByChar` or `startsWith` keeps working and only exact-equality matches need updating. I grepped for consumers and found none outside the emitter and its tests, so the blast radius is ad-hoc queries.

Two side effects worth a look during review:

- The direct path now runs `classifyToolError`, so its rejections also increment `toolErrorsTotal{error_type="validation"}`, matching the exec path which already did. Ops alerting is on the `internal` bucket, so this does not change what alerts. Happy to keep the metric untouched instead, it is a one line swap.
- Measured over 14 days, `$mcp_validation_fields` peaks at 162 characters and 6 elements against a cap of 20 x 64, so the added segment costs roughly ten characters per element.

## How did you test this code?

Automated only. I (Claude) ran these; I did not exercise a live MCP client.

- Full suites green: 2510 unit tests and 350 hono tests. Typecheck and lint clean on all touched files.
- I stashed the production change and confirmed all six new executor tests fail without it, so they are not vacuous.

New and changed tests, and the regression each catches:

- `describeExecCommand` parsing and normalization: catches flag-parsing drift that would silently break the discovery funnel, and a loosened normalizer letting unbounded model text into analytics.
- Direct-mode rejection emits an errored event: catches exactly the bug being fixed, an early return before tracking. That was the status quo, so it demonstrably regresses.
- Exec verb and target stamped on success and failure: catches losing the discovery dimension, including the `unknown_command` and `unknown_tool` cases where it is the only signal.
- Received type per issue code: catches losing the omitted versus wrong-shape distinction.
- Index collapsing: asserts a 50 element malformed array plus a separate bad field yields two descriptors, not twenty restatements with the other field evicted.
- API validation error wiring: catches `resolveToolErrorClassification` dropping the structured field, and asserts a secret embedded in `detail` does not leak.

I also repaired an existing test rather than only adding ones. `tool-executor-intent.test.ts` relied on "capture only fires after validation passes" to prove `context` was stripped. Tracking rejections breaks that inference, so an unstripped `context` would have satisfied it while guarding nothing. It now asserts the absence of a validation error explicitly. Two other assertions moved to the new descriptor format.

One hono test failed once mid-session and I could not identify it. It passed on the next seven consecutive full runs and I do not believe it is related, but I did not capture the name, so I cannot prove that.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing behavior changes, so no docs update. These are internal analytics properties.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, directed by me. Skills invoked: `/writing-tests` before adding any test, and `posthog:exploring-mcp-tool-quality` plus `posthog:querying-posthog-data` for the analysis that motivated the work.

The work started as a root-cause investigation, not a code change. The starting hypothesis was that `exec` accepts any string and defers validation to the underlying tool. That turned out to be wrong: `exec` validates against the identical Zod schema before dispatch. The real finding was that parameter names are mechanically projected from the HTTP layer, so the same concept is called `id`, `evaluation_id` or `prompt_name` depending on whether the generator read a path param, a body serializer or a URL segment. Agents guess the self-describing name and get rejected. Roughly three quarters of schema rejections carry the right value under a lexically related name or the right name in the wrong shape.

Gap 1 surfaced while trying to measure exec against direct mode and finding the comparison structurally impossible. That is why it is first here: without it the original question cannot be answered.

Considered and rejected for gaps 3 and the API-layer field: routing them through error tracking. `handleToolError` deliberately excludes both classes from `captureException` because fingerprinting is by tool name, which would collapse every field-level variant into one issue and drown the 5xx signal that is actually actionable. Also rejected: a parallel `received_types` array (three arrays that must stay index-aligned, awkward to join in HogQL) and an array of objects (painful to query). Extending the existing token won because there are no consumers to break.

Not included, deliberately: capturing input values, capturing `expected` (derivable from the schema, roughly doubles token size), and raising any cap. `$mcp_validation_input_keys` does hit its 20 element cap in production, but the 21st key answers nothing the first 20 do not.

These properties only accumulate forward, so the dashboards will not show them until data builds up after deploy.


## Review follow-up

Both Greptile findings were valid and are fixed in `edc51fc`, with a test each that fails without the production change:

- Unrecognized verbs and unresolved tool targets are no longer echoed after charset normalization — they are gated on names the server owns and otherwise record as `unrecognized`. Cost: an `unknown_command`/`unknown_tool` event says a token was unrecognized but not which one. Worth it — the file already withholds `ExecCommandError`'s message from analytics for exactly this reason.
- Descriptor path segments are checked against the property names the tool's schema declares, so `generate-app-url`'s open `params` record can no longer put a caller-chosen key into `$mcp_validation_fields`. Declared nested paths (`query.kind`) are unaffected, so the distinction the widening exists for survives.
