### PR TITLE
feat(logs): scaffold flag-gated anomalies tab

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -354,6 +354,7 @@ export const FEATURE_FLAGS = {
     LLM_PROMPT_LABELS: 'prompt-labels', // owner: @jurajmajerik #team-ai-observability
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
+    LOGS_ANOMALIES: 'logs-anomalies', // owner: @jonmcwest #team-logs
     LOGS_COLUMN_CONFIGURATION: 'logs-column-configuration', // owner: #team-logs
     LOGS_GROUP_BY: 'logs-group-by', // owner: #team-logs
     LOGS_IN_ERROR_TRACKING: 'logs-in-error-tracking', // owner: @jonmcwest #team-logs

--- a/products/logs/frontend/LogsAnomalies.tsx
+++ b/products/logs/frontend/LogsAnomalies.tsx
@@ -1,0 +1,11 @@
+import { EmptyMessage } from 'lib/components/EmptyMessage/EmptyMessage'
+
+// Intentionally bare: the learning-status surface lands here in a later change.
+export function LogsAnomalies(): JSX.Element {
+    return (
+        <EmptyMessage
+            title="Anomaly detection"
+            description="PostHog learns each service's normal log volume and surfaces spikes, drops, and silences here, so there's nothing to configure."
+        />
+    )
+}

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -25,6 +25,7 @@ import { logsIngestionLogic } from 'products/logs/frontend/components/SetupPromp
 import { LogsSetupPrompt } from 'products/logs/frontend/components/SetupPrompt/SetupPrompt'
 
 import { useOpenLogsSettingsPanel } from './hooks/useOpenLogsSettingsPanel'
+import { LogsAnomalies } from './LogsAnomalies'
 import { LOGS_SCENE_VIEWER_ID, LogsSceneActiveTab, logsSceneLogic } from './logsSceneLogic'
 
 export const LOGS_LOGIC_KEY = 'logs'
@@ -96,11 +97,13 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const showAlerting = useFeatureFlag('LOGS_ALERTING')
     const showSqlView = useFeatureFlag('LOGS_SQL_VIEW')
     const showTransformations = useFeatureFlag('LOGS_TRANSFORMATIONS')
+    const showAnomalies = useFeatureFlag('LOGS_ANOMALIES')
 
     const tabs: { key: LogsSceneActiveTab; label: string }[] = [
         { key: 'viewer', label: 'Viewer' },
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
         ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
+        ...(showAnomalies ? [{ key: 'anomalies' as const, label: 'Anomalies' }] : []),
         ...(showSqlView ? [{ key: 'sql' as const, label: 'SQL' }] : []),
         ...(showTransformations ? [{ key: 'transformations' as const, label: 'Transformations' }] : []),
         { key: 'configuration', label: 'Configuration' },
@@ -156,6 +159,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                 </>
             )}
             {activeTab === 'alerts' && showAlerting && <LogsAlertingSection />}
+            {activeTab === 'anomalies' && showAnomalies && <LogsAnomalies />}
             {activeTab === 'sql' && showSqlView && <LogsSqlEditor id={LOGS_SCENE_VIEWER_ID} />}
             {activeTab === 'transformations' && showTransformations && <LogsTransformations />}
             {activeTab === 'configuration' && (

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -145,6 +145,7 @@ describe('logsSceneLogic', () => {
 
         it.each([
             ['viewer', 'viewer'],
+            ['anomalies', 'anomalies'],
             ['configuration', 'configuration'],
         ])('parses valid activeTab "%s" from URL', async (urlValue, expected) => {
             await expectLogic(logic, () => {

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -45,11 +45,19 @@ export const LOGS_SCENE_VIEWER_ID = `logs-scene-${window.POSTHOG_APP_CONTEXT?.cu
 
 const VALID_VIEW_MODES: LogsViewerViewMode[] = ['logs', 'patterns', 'group']
 
-export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'transformations' | 'configuration'
+export type LogsSceneActiveTab =
+    | 'viewer'
+    | 'services'
+    | 'alerts'
+    | 'anomalies'
+    | 'sql'
+    | 'transformations'
+    | 'configuration'
 const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = [
     'viewer',
     'services',
     'alerts',
+    'anomalies',
     'sql',
     'transformations',
     'configuration',


### PR DESCRIPTION
## Problem

Log anomaly detection is being built out, and the detector work needs somewhere to land. Right now there is no surface in the Logs product for it. Rather than let the detector and its UI land as one large change, this carves out the shell first so the two can proceed in parallel.

This is scaffolding only. No data, no queries, no backend.

## Changes

A new `logs-anomalies` feature flag, and an Anomalies tab in the Logs scene gated behind it. The tab body is a placeholder empty state.

This copies the pattern the scene already uses for its four other flag-gated tabs (Services, Alerts, SQL, Transformations), so it is four small edits plus one component:

| File | Change |
| --- | --- |
| `frontend/src/lib/constants.tsx` | `LOGS_ANOMALIES` flag |
| `products/logs/frontend/logsSceneLogic.tsx` | `'anomalies'` added to the `LogsSceneActiveTab` union and `VALID_ACTIVE_TABS` |
| `products/logs/frontend/LogsScene.tsx` | flag hook, tab entry between Alerts and SQL, body render guard |
| `products/logs/frontend/LogsAnomalies.tsx` | new placeholder, an `EmptyMessage` |

> [!NOTE]
> `VALID_ACTIVE_TABS` is deliberately flag-unaware, matching the existing tabs, so `?activeTab=anomalies` resolves even with the flag off. The `showAnomalies &&` guard on the body means nothing renders in that case. With the flag off the scene is unchanged.

No screenshots: the tab is a placeholder `EmptyMessage` behind a disabled flag, and I did not run the app (see below).

## How did you test this code?

I (actually Claude) ran these and they passed:

- `pnpm --filter=@posthog/frontend lint` - clean.
- `products/logs/frontend/logsSceneLogic.test.ts` - 30 passed.
- `oxfmt --check` scoped to the five touched files - clean.

One test line was added: an `anomalies` row on the existing parameterised `activeTab` URL table. The regression it catches, which no existing row does, is `'anomalies'` being dropped from `VALID_ACTIVE_TABS`, which would silently break `?activeTab=anomalies`. The `viewer` and `configuration` rows would both still pass. No snapshot test was added.

What I did not do: I did not run the app or Storybook, so the rendered tab is unverified visually, and I have not confirmed by eye that the tab sits between Alerts and SQL. That ordering is asserted only by reading the `tabs` array. `typescript:check` was also not run, so instead I checked every `LogsSceneActiveTab` consumer by hand to confirm none is an exhaustive `switch` or `Record` that widening the union would break. They are all pass-through parameter and array types.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus 4.5) in PostHog Code, working from a spec I handed it. Skills invoked: `/implement`, `/code-review`.

Two decisions worth surfacing. First, the placeholder was initially hand-rolled as a centred `div` with Tailwind, copying `ExploreWithAI/EmptyState.tsx`. Code review flagged that against Rule 1 of `frontend/src/AGENTS.md`, correctly. The suggested replacement, `ProductIntroduction`, was wrong though: it means "product not adopted yet" and wants a `ProductKey` and a CTA. The repo has three empty-state tiers and the right one here is `EmptyMessage`, already used elsewhere in this product. That swap cut the component from 17 lines to 11, removed all the Tailwind, and dropped an icon the spec never asked for.

Second, review argued the added test row earns nothing under the "tests must earn their place" rule. I kept it, because the regression is nameable and it is the acceptance criterion for the ticket. Reasoning is under testing above.

The shotgun-surgery smell here is real: adding one tab touches five places, and the flag gets checked twice, once for the tab entry and once for the body. It is pre-existing across all four sibling tabs, so I matched the pattern rather than refactor it in a scaffold PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
