### PR TITLE
feat(logs): suppress empty log batches instead of producing them

### DIFF
--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -364,15 +364,18 @@ export const processLogMessageBuffer = instrumented({
 
         const { kept, stats } = await runPipelineStages(records, stages)
 
-        if (!mustReencode) {
-            // Only a visitor ran — the buffer is unchanged, so forward it without re-encoding.
-            return { value: buffer, pii, drops: stats }
-        }
-        if (kept.length === 0 && stats.droppedBy) {
-            // A filter stage emptied the batch — signal the caller to suppress it. A batch that was
-            // *already* empty (nothing dropped) still re-encodes to a schema-only buffer, matching the
-            // pre-pipeline behavior; suppressing those is a separate change.
+        if (kept.length === 0) {
+            // No surviving records — signal the caller to suppress the message rather than forward or
+            // re-encode an empty batch downstream. Checked before the visitor-only shortcut below so a
+            // zero-record batch decoded solely for metric-rule tallying is suppressed too.
+            // `stats.droppedBy` distinguishes a filter drop (sampling / transformations) from an
+            // already-empty batch so the caller can attribute it correctly.
             return { value: null, pii, drops: stats }
+        }
+        if (!mustReencode) {
+            // Only a visitor ran and records survive — the buffer is unchanged, so forward it without
+            // re-encoding.
+            return { value: buffer, pii, drops: stats }
         }
 
         const value = await encodeLogRecordsInstrumented(logRecordType, codec, kept)

--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -368,10 +368,10 @@ export const processLogMessageBuffer = instrumented({
             // Only a visitor ran — the buffer is unchanged, so forward it without re-encoding.
             return { value: buffer, pii, drops: stats }
         }
-        if (kept.length === 0 && stats.droppedBy) {
-            // A filter stage emptied the batch — signal the caller to suppress it. A batch that was
-            // *already* empty (nothing dropped) still re-encodes to a schema-only buffer, matching the
-            // pre-pipeline behavior; suppressing those is a separate change.
+        if (kept.length === 0) {
+            // No surviving records — signal the caller to suppress the message rather than produce a
+            // schema-only buffer downstream. `stats.droppedBy` distinguishes a filter drop (sampling /
+            // transformations) from an already-empty batch so the caller can attribute it correctly.
             return { value: null, pii, drops: stats }
         }
 

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -430,7 +430,7 @@ export class LogsIngestionConsumer {
           }
         | {
               outcome: 'all_dropped'
-              reason: 'sampling_all_dropped' | 'transformations_all_dropped'
+              reason: 'sampling_all_dropped' | 'transformations_all_dropped' | 'empty_batch'
               pii: PiiScrubStats
               recordsDropped: number
               recordsDroppedByRuleId: Map<string, number>
@@ -510,9 +510,17 @@ export class LogsIngestionConsumer {
         }
 
         if (value === null) {
+            // `droppedBy` tells us which filter emptied the batch; its absence means the batch decoded
+            // to zero records to begin with, so attribute it to an empty batch rather than sampling.
+            const reason =
+                drops.droppedBy === 'transformations'
+                    ? 'transformations_all_dropped'
+                    : drops.droppedBy === 'sampling'
+                      ? 'sampling_all_dropped'
+                      : 'empty_batch'
             return {
                 outcome: 'all_dropped',
-                reason: drops.droppedBy === 'transformations' ? 'transformations_all_dropped' : 'sampling_all_dropped',
+                reason,
                 pii,
                 recordsDropped: drops.recordsDropped,
                 recordsDroppedByRuleId: drops.recordsDroppedByRuleId,


### PR DESCRIPTION
## Problem

When a log message batch ends up with **zero records**, the ingestion consumer still re-encoded a schema-only Avro buffer and produced it downstream — wasteful, and pointless for a batch carrying no logs. This includes batches that decoded to zero records to begin with (a valid header-only Object Container File from capture-logs).

This behavior was called out on the pipeline PR ([#77328](https://github.com/PostHog/posthog/pull/77328)): the pipeline briefly suppressed *all* empty batches, but that was pulled back out so #77328 stays a pure no-op refactor. This PR reintroduces the suppression deliberately, on its own.

## Changes

- `processLogMessageBuffer` returns `null` (suppress) whenever no records survive, not only when a filter stage dropped them.
- The consumer attributes the suppression correctly via `drops.droppedBy`:
  - filter emptied the batch → `sampling_all_dropped` / `transformations_all_dropped` (unchanged)
  - batch was already empty → **`empty_batch`** (new reason), instead of being mislabeled a sampling drop.

The `all_dropped` path only increments the `logs_ingestion_message_dropped_count{reason}` counter and skips the produce — no DLQ, no error — so an empty batch is simply not forwarded.

## How did you test this code?

- Full `src/logs` jest suite (420 tests) green — no regression to the sampling / transform / retention drop paths, which still map to their existing reasons.
- `tsc`, `eslint`, `prettier --check`, ingestion-boundary guard pass locally.

No new unit test: the new trigger is a batch that decodes to **zero records**, and avsc's `BlockEncoder` emits no metadata for an empty input (`encodeLogRecords([])` produces an undecodable buffer), so the header-only-zero-records shape that capture-logs' Rust writer produces isn't reproducible with the test encoder. The change is a small, commented branch; the reason-attribution logic is covered by the existing consumer suite for the filter-drop cases.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Split out of the pipeline refactor at the maintainer's request: the "return null for empty batches" behavior was a real (if minor) behavior change riding along in what was supposed to be a no-op refactor (#77328, greptile P1 "empty batches misattributed as drops"). #77328 now preserves master (only suppress when a filter emptied the batch); this PR makes the improvement on its own and fixes the attribution so an empty batch reports `empty_batch` rather than `sampling_all_dropped`. Stacked on the retention PR (top of the logs pipeline stack).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
