### PR TITLE
feat(aio): remove beta tag from prompts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3037,9 +3037,9 @@ snapshots:
     layout-nav-bar-installation-status--local-session-active--light:
         hash: v1.k794b7964.3862c2f44a83857e0b8723b7239b046f57fdfd567c0077480f353c351c9b321a.dlSfwZqhbIYc_dvTH75ZoyYJMihnh_iAkr8hcOw1t14
     layout-project-tree--all-products--dark:
-        hash: v1.k794b7964.cd8b935f69a2cd2a2508f76af290cefb427c152da1e16da4a00a13323cdd9db3.1CCRxEt9aLJdov9fkKkA15aVxOCDGHTPub1O7bze484
+        hash: v1.k794b7964.d99d287a01a5a7a23724e27a1d5630b62d9fb1c3084f42368fa18b2710e0879a._jB1EVhcnBMQkz_qk1UYM-bzTNSI4Q5Woh5gPYUXbgA
     layout-project-tree--all-products--light:
-        hash: v1.k794b7964.c26cd26dbfc2bd1bd9d0f7d2b3ac7983793e350e6b542b24bd6e7473ad63b83b.uKplxPUSAHj6i9bnJBhUpIuA8Q4lRWdz4_xVGaktDMU
+        hash: v1.k794b7964.107596d843244de83b7ede428e7ffe9168972880ec3b209b83d62469b273bbe0._xf4qk9OtU55ir84B4WQV_Ard-3zwH_ip5u4nXbUWWI
     layout-project-tree--default--dark:
         hash: v1.k794b7964.f4f9711fbb4dc3ee399130d90800a85f3340ef956400a0d153ed381c2b745993.TTkQwJ8WWysKBJ6Yfigp_NEJr4p_Mc4QoohX0x2vcvU
     layout-project-tree--default--light:

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -2230,7 +2230,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'llm_prompts' as FileSystemIconType,
         iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
         href: urls.aiObservabilityPrompts(),
-        tags: ['beta'],
         sceneKey: 'AIObservabilityPrompts',
         sceneKeys: [
             'AIObservability',

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -669,7 +669,7 @@ export function PromptCode({ prompt }: { prompt: LLMPrompt }): JSX.Element {
             <PromptCodeSnippets prompt={prompt} />
 
             <LemonBanner type="info">
-                During the beta period, each prompt fetch is currently charged as a Product analytics event. See the{' '}
+                Each prompt fetch is charged as a Product analytics event. See the{' '}
                 <Link to="https://posthog.com/pricing" target="_blank">
                     pricing page
                 </Link>

--- a/products/ai_observability/manifest.tsx
+++ b/products/ai_observability/manifest.tsx
@@ -434,7 +434,6 @@ export const manifest: ProductManifest = {
             iconType: 'llm_prompts' as FileSystemIconType,
             iconColor: ['var(--color-product-llm-prompts-light)'] as FileSystemIconColor,
             href: urls.aiObservabilityPrompts(),
-            tags: ['beta'],
             sceneKey: 'AIObservabilityPrompts',
         },
     ],


### PR DESCRIPTION
## Problem

Prompts is leaving beta.

## Changes

- Removed the `beta` tag from the Prompts entry in the AI observability manifest and regenerated `products.tsx`.
- Reworded the prompt fetch billing banner to drop the beta framing.

## How did you test this code?

Regenerated `frontend/src/products.tsx` with `pnpm build:products`. No tests added, the change removes a tag and tweaks copy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Website counterpart: removes the beta callout from /docs/prompt-management (separate posthog.com PR).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /writing-user-facing-copy. Kept the pricing note in the banner, only dropped the beta wording.