### PR TITLE
fix(support): don't auto-assign the sender on send and set status

### DIFF
--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -1,5 +1,3 @@
-import { MOCK_DEFAULT_USER } from 'lib/api.mock'
-
 import { expectLogic } from 'kea-test-utils'
 
 import { tagsModel } from '~/models/tagsModel'
@@ -299,21 +297,16 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
     })
 
     // "Send and set status" must persist through the same PATCH as the "Save changes" button,
-    // and auto-assign the current user unless a specific user is already assigned.
-    test.each<[string, TicketAssignee, TicketStatus, TicketAssignee]>([
-        ['auto-assigns the current user when unassigned', null, 'resolved', { type: 'user', id: MOCK_DEFAULT_USER.id }],
-        [
-            'replaces a role assignee with the current user',
-            { type: 'role', id: 'role-1' },
-            'on_hold',
-            { type: 'user', id: MOCK_DEFAULT_USER.id },
-        ],
-        ['keeps an existing user assignee', { type: 'user', id: 999 }, 'pending', { type: 'user', id: 999 }],
-    ])('%s', async (_name, presetAssignee, statusAfterSend, expectedAssignee) => {
+    // and must never change who the ticket is assigned to.
+    test.each<[string, TicketAssignee, TicketStatus]>([
+        ['leaves an unassigned ticket unassigned', null, 'resolved'],
+        ['keeps a role assignee', { type: 'role', id: 'role-1' }, 'on_hold'],
+        ['keeps a user assignee', { type: 'user', id: 999 }, 'pending'],
+    ])('%s', async (_name, presetAssignee, statusAfterSend) => {
         if (presetAssignee) {
             logic.actions.setAssignee(presetAssignee)
         }
-        ticketUpdateMock.mockResolvedValue({ ...loadedTicket(), status: statusAfterSend, assignee: expectedAssignee })
+        ticketUpdateMock.mockResolvedValue({ ...loadedTicket(), status: statusAfterSend, assignee: presetAssignee })
 
         await expectLogic(logic, () => {
             logic.actions.sendMessage('hello', null, false, undefined, statusAfterSend)
@@ -321,7 +314,7 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
 
         expect(ticketUpdateMock).toHaveBeenCalledWith(
             '42',
-            expect.objectContaining({ status: statusAfterSend, assignee: expectedAssignee })
+            expect.objectContaining({ status: statusAfterSend, assignee: presetAssignee })
         )
         expect(logic.values.status).toBe(statusAfterSend)
         expect(logic.values.hasUnsavedChanges).toBe(false)

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -24,7 +24,6 @@ import { isUUIDLike } from 'lib/utils/guards'
 import { fullName } from 'lib/utils/strings'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { impersonationNoticeLogic } from '~/layout/navigation/ImpersonationNotice/impersonationNoticeLogic'
@@ -45,7 +44,6 @@ import { signalsReportsList } from 'products/signals/frontend/generated/api'
 import type { SignalReportApi } from 'products/signals/frontend/generated/api.schemas'
 
 import type { TeamPublicType, TeamType } from '../../../../../frontend/src/types'
-import type { UserType } from '../../../../../frontend/src/types'
 import { assigneeSelectLogic } from '../../components/Assignee'
 import type { Assignee, TicketAssignee } from '../../components/Assignee'
 import { supportTicketCounterLogic } from '../../supportTicketCounterLogic'
@@ -177,7 +175,6 @@ export interface supportTicketSceneLogicValues {
     draftModeDefault: boolean // conversationsDraftModeLogic
     availableTags: string[] // tagsModel
     currentTeam: TeamPublicType | TeamType | null // teamLogic
-    user: UserType | null // userLogic
     assignee: TicketAssignee
     breadcrumbs: Breadcrumb[]
     chatMessages: ChatMessage[]
@@ -462,8 +459,6 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             ['currentTeam'],
             conversationsDraftModeLogic,
             ['draftModeDefault'],
-            userLogic,
-            ['user'],
             assigneeSelectLogic,
             ['resolveAssignee'],
             tagsModel,
@@ -1159,10 +1154,6 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 }
                 if (statusAfterSend) {
                     actions.setStatus(statusAfterSend)
-                    // Pick up the ticket for the sender unless a specific user is already assigned.
-                    if (values.assignee?.type !== 'user' && values.user) {
-                        actions.setAssignee({ type: 'user', id: values.user.id })
-                    }
                     actions.updateTicket()
                 }
                 setTimeout(() => {


### PR DESCRIPTION
## Problem

In the support ticket view, replying with "send + set status" also quietly reassigned the ticket to whoever sent the reply, if the ticket was unassigned or assigned to a role. Replying to a ticket is not the same as taking ownership of it, and the silent reassignment moved tickets out of team queues. Sending a reply should not touch assignment at all.

## Changes

`sendMessage` in `supportTicketSceneLogic` no longer sets an assignee when `statusAfterSend` is present. The status change still persists through the same PATCH as before, and the ticket keeps whatever assignee it already had (including none). The now-unused `userLogic` wiring came out with it.

## How did you test this code?

Automated only, no manual testing in the app.

- Reworked the existing `sendMessage with statusAfterSend` parameterized cases to assert the assignee is unchanged for the three states that used to behave differently: unassigned, role-assigned, user-assigned. The old rows asserted the auto-assign behavior, so they were the thing locking in the bug. These catch a regression that re-adds any assignment on send.
- `jest products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts` - 34 passed.
- `pnpm --filter=@posthog/frontend typescript:check` - no errors in `products/conversations`. The remaining errors in the output are pre-existing and unrelated (unbuilt quill workspace).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus) in PostHog Code, directed by the assignee. The fix itself is a deletion, so the work was mostly in confirming there was no other path that reassigns on send (there isn't - `statusAfterSend` only flows from the message input into this one listener) and in fixing the test that had the old behavior baked into its parameterized rows.

No repo skills applied beyond the test-writing gate, which is why the change extends the existing `test.each` block instead of adding new test functions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
