### PR TITLE
fix(query-cache): drop per-team labels from cache metrics

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1604,12 +1604,12 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 )
 
             if not self._is_stale_for_request(last_refresh=last_refresh_from_cached_result(cached_response)):
-                count_query_cache_hit(self.team.pk, hit="hit", trigger=cached_response.calculation_trigger or "")
+                count_query_cache_hit(hit="hit", trigger=cached_response.calculation_trigger or "")
                 # We have a valid result that's fresh enough, let's return it
                 cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
                 return cached_response
 
-            count_query_cache_hit(self.team.pk, hit="stale", trigger=cached_response.calculation_trigger or "")
+            count_query_cache_hit(hit="stale", trigger=cached_response.calculation_trigger or "")
             # We have a stale result. If we aren't allowed to calculate, let's still return it
             # – otherwise let's proceed to calculation
             if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
@@ -1641,7 +1641,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
                 return cached_response
         else:
-            count_query_cache_hit(self.team.pk, hit="miss", trigger="")
+            count_query_cache_hit(hit="miss", trigger="")
             # We have no cached result. If we aren't allowed to calculate, let's return the cache miss
             # – otherwise let's proceed to calculation
             if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:

--- a/posthog/query_cache/cache.py
+++ b/posthog/query_cache/cache.py
@@ -89,4 +89,4 @@ class QueryCache:
         else:
             remove_last_refresh(team_id=self.team_id, insight_id=self.insight_id, dashboard_id=self.dashboard_id)
 
-        count_cache_write_data(self.team_id, data_size)
+        count_cache_write_data(data_size)

--- a/posthog/query_cache/metrics.py
+++ b/posthog/query_cache/metrics.py
@@ -6,7 +6,7 @@ from prometheus_client import CollectorRegistry, Counter, Histogram
 
 from posthog.clickhouse.query_tagging import get_query_tag_value
 from posthog.exceptions_capture import capture_exception
-from posthog.metrics import LABEL_TEAM_ID, pushed_metrics_registry
+from posthog.metrics import pushed_metrics_registry
 
 
 class CacheMetrics(NamedTuple):
@@ -67,28 +67,25 @@ def _create_cache_metrics(registry: Optional[CollectorRegistry] = None) -> Cache
     hit_counter = Counter(
         name="posthog_query_cache_hit_total",
         documentation="Whether we could fetch the query from the cache or not.",
-        labelnames=[LABEL_TEAM_ID, "cache_hit", "trigger"],
+        labelnames=["cache_hit", "trigger"],
         registry=registry,
     )
 
     write_counter = Counter(
         name="posthog_query_cache_write_total",
         documentation="When a query result was persisted in the cache.",
-        labelnames=[LABEL_TEAM_ID],
         registry=registry,
     )
 
     bytes_counter = Counter(
         name="posthog_query_cache_write_bytes_total",
         documentation="Total bytes written to cache (uncompressed JSON)",
-        labelnames=[LABEL_TEAM_ID],
         registry=registry,
     )
 
     size_histogram = Histogram(
         name="posthog_query_cache_write_size_bytes",
         documentation="Distribution of cache write data sizes in bytes (uncompressed JSON)",
-        labelnames=[LABEL_TEAM_ID],
         buckets=[
             100,  # Small responses < 100B
             1000,  # 100B - 1KB
@@ -129,18 +126,18 @@ def is_cache_warming() -> bool:
     return (get_query_tag_value("trigger") or "").startswith("warming")
 
 
-def count_query_cache_hit(team_id: int, hit: str, trigger: str = "") -> None:
+def count_query_cache_hit(hit: str, trigger: str = "") -> None:
     """Count cache hit/miss, excluding cache warming requests."""
     if is_cache_warming():
         return
 
     with get_cache_metrics_context("query_cache_hits") as metrics:
-        metrics.hit_counter.labels(team_id=team_id, cache_hit=hit, trigger=trigger).inc()
+        metrics.hit_counter.labels(cache_hit=hit, trigger=trigger).inc()
 
 
-def count_cache_write_data(team_id: int, data_size: int) -> None:
+def count_cache_write_data(data_size: int) -> None:
     """Count cache write operations and data size metrics."""
     with get_cache_metrics_context("query_cache_writes") as metrics:
-        metrics.write_counter.labels(team_id=team_id).inc()
-        metrics.bytes_counter.labels(team_id=team_id).inc(data_size)
-        metrics.size_histogram.labels(team_id=team_id).observe(data_size)
+        metrics.write_counter.inc()
+        metrics.bytes_counter.inc(data_size)
+        metrics.size_histogram.observe(data_size)

--- a/posthog/query_cache/size_tracker.py
+++ b/posthog/query_cache/size_tracker.py
@@ -19,19 +19,16 @@ logger = structlog.get_logger(__name__)
 CACHE_EVICTION_COUNTER = Counter(
     "query_cache_size_limit_evictions_total",
     "Cache entries evicted due to per-team size limits",
-    labelnames=["team_id"],
 )
 
 CACHE_EVICTION_BYTES_COUNTER = Counter(
     "query_cache_size_limit_evicted_bytes_total",
     "Bytes evicted due to per-team size limits",
-    labelnames=["team_id"],
 )
 
 CACHE_EVICTION_AGE_HISTOGRAM = Histogram(
     "query_cache_eviction_age_seconds",
     "Age of cache entries at eviction time (seconds since write)",
-    labelnames=["team_id"],
     buckets=[
         1800,  # 30 min
         3600,  # 1 hour
@@ -48,7 +45,6 @@ CACHE_EVICTION_AGE_HISTOGRAM = Histogram(
 CACHE_SIZE_HISTOGRAM = Histogram(
     "query_cache_team_size_bytes",
     "Distribution of per-team cache sizes in bytes",
-    labelnames=["team_id"],
     buckets=[
         1_000_000,  # 1MB
         10_000_000,  # 10MB
@@ -189,7 +185,7 @@ class TeamCacheSizeTracker:
 
         total_size = self.get_total_size()
         entry_count = self.redis_client.zcard(self.entries_key)
-        CACHE_SIZE_HISTOGRAM.labels(team_id=self.team_id).observe(total_size)
+        CACHE_SIZE_HISTOGRAM.observe(total_size)
 
         logger.info(
             "query_cache_write",
@@ -247,10 +243,10 @@ class TeamCacheSizeTracker:
             current_size -= removed_size
             evicted_keys.append(cache_key)
 
-            CACHE_EVICTION_COUNTER.labels(team_id=self.team_id).inc()
-            CACHE_EVICTION_BYTES_COUNTER.labels(team_id=self.team_id).inc(removed_size)
+            CACHE_EVICTION_COUNTER.inc()
+            CACHE_EVICTION_BYTES_COUNTER.inc(removed_size)
             eviction_age = time.time() - float(write_timestamp)
-            CACHE_EVICTION_AGE_HISTOGRAM.labels(team_id=self.team_id).observe(eviction_age)
+            CACHE_EVICTION_AGE_HISTOGRAM.observe(eviction_age)
 
         return evicted_keys
 


### PR DESCRIPTION
## Problem

The query cache metrics (`posthog_query_cache_hit_total`, `posthog_query_cache_write_*`, and the size tracker metrics) are all labeled by `team_id` which makes them painfully slow and timeout. 

## Changes

Removed the `team_id` label from all eight query cache metrics and dropped the now-unused `team_id` parameters from `count_query_cache_hit` and `count_cache_write_data`.


## How did you test this code?

Ran `posthog/query_cache/test/` (40 passed) and `posthog/hogql_queries/test/test_query_runner.py` plus the cluster connection factory tests (117 passed) locally. No tests asserted on the removed label. Metric behavior change itself is only observable in Grafana after deploy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session investigating query cache storage economics. Andy noticed size distribution queries against these metrics were timing out and asked to remove the team_id breakdown. Considered keeping team_id only on the low-volume eviction counters, but the per-team dashboard panels that would justify it depend on the high-volume counters anyway, so uniform removal was simpler. No repo skills applied to this change.