### PR TITLE
fix(ci): skip separation checks on merge queue batches

### DIFF
--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -64,7 +64,13 @@ jobs:
         # trunk-merge/** is the same story for Trunk's merge queue: it opens a real
         # PR batching several already-checked PRs, so a desktop PR riding along with
         # an unrelated backend PR would fail a coupling that no author introduced.
-        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'trunk-merge/')
+        # The skip is scoped to same-repo heads so a fork can't opt out of the gate
+        # by naming its branch trunk-merge/**; only write access can create one here.
+        if: |
+            github.event_name == 'pull_request' && !(
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.head_ref, 'trunk-merge/')
+            )
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -60,8 +60,11 @@ jobs:
     # existing Desktop Tests Pass required check covers it.
     backend-coupling:
         name: Desktop backend coupling
-        # merge_group has no pull_request payload; the check already ran on the PR
-        if: github.event_name == 'pull_request'
+        # merge_group has no pull_request payload; the check already ran on the PR.
+        # trunk-merge/** is the same story for Trunk's merge queue: it opens a real
+        # PR batching several already-checked PRs, so a desktop PR riding along with
+        # an unrelated backend PR would fail a coupling that no author introduced.
+        if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'trunk-merge/')
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -95,7 +95,12 @@ jobs:
         # Same reason the desktop coupling check skips trunk-merge/**: the queue's
         # batch PR is the union of several PRs that each passed separately, so a
         # migration PR batched with a nodejs or rust PR trips a coupling nobody wrote.
-        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action) && !startsWith(github.head_ref, 'trunk-merge/')
+        # Same-repo scoping too, so a fork can't skip the check by branch name.
+        if: |
+            contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action) && !(
+                github.event.pull_request.head.repo.full_name == github.repository &&
+                startsWith(github.head_ref, 'trunk-merge/')
+            )
         uses: ./.github/workflows/ci-migrations-service-separation-check.yml
         secrets:
             GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -92,7 +92,10 @@ jobs:
             GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY: ${{ secrets.GH_APP_POSTHOG_REVIEW_COMMENT_RESOLVER_PRIVATE_KEY }}
 
     migrations-separation:
-        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+        # Same reason the desktop coupling check skips trunk-merge/**: the queue's
+        # batch PR is the union of several PRs that each passed separately, so a
+        # migration PR batched with a nodejs or rust PR trips a coupling nobody wrote.
+        if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action) && !startsWith(github.head_ref, 'trunk-merge/')
         uses: ./.github/workflows/ci-migrations-service-separation-check.yml
         secrets:
             GH_APP_POSTHOG_PATHS_FILTER_APP_ID: ${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID }}


### PR DESCRIPTION
## Problem

Trunk's merge queue opens a real PR per batch, from a `trunk-merge/**` head branch, whose diff is the union of every PR in the batch.
Two of our CI gates ask "do these two path groups both appear in this diff?", and a union answers yes for reasons no author is responsible for.

Batch a desktop PR with an unrelated backend PR and `Desktop backend coupling` fails, telling you to split a PR that was never coupled.
Same story for the migration check: a migration PR batched with any nodejs or rust service PR trips `Check migrations and service changes are not in same PR`.

The desktop check already guarded against GitHub's native `merge_group` event, but Trunk's queue is PR-shaped, not `merge_group`-shaped, so the guard never fired.

## Changes

One line each, using the `!startsWith(github.head_ref, 'trunk-merge/')` guard that `ci-backend.yml`, `ci-frontend.yml`, `ci-storybook.yml`, `ci-mcp.yml` and `pr-housekeeping.yml`'s own `lint-pr` job already use.

```diff
 # .github/workflows/desktop-ci.yml — backend-coupling
-if: github.event_name == 'pull_request'
+if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'trunk-merge/')
```

```diff
 # .github/workflows/pr-housekeeping.yml — migrations-separation
-if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action)
+if: contains(fromJSON('["opened", "synchronize", "reopened"]'), github.event.action) && !startsWith(github.head_ref, 'trunk-merge/')
```

> [!NOTE]
> No coverage is lost. Both checks are about one author coupling two halves inside one PR, and every PR in a batch already ran them on its own head.
> Neither check could ever enforce cross-PR deploy ordering anyway, since two separate PRs have always been free to merge back to back.

`Desktop Tests Pass` counts a skipped `backend-coupling` as success, so the umbrella gate keeps reporting on batches.

## How did you test this code?

I (Claude) ran `bin/hogli lint:workflows`, which passes all 7 checks across 124 workflows, and `hogli ci:preflight --strict` on push, which passes.
No tests added: the change is a workflow `if:` condition, and the shell script behind the desktop check is untouched, so its existing `check-pr-backend-coupling.test.sh` still covers everything it covered before.
I did not exercise a live merge queue batch, so the real confirmation is the next batch that mixes a desktop or migration PR with a backend one.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, driven by me after I hit the desktop failure on a batch that mixed backend and desktop PRs.

The starting point was just the desktop check. I then asked Claude to sweep the rest of CI for the same failure mode, which turned out to have a crisp signature: only a gate whose predicate is "these two path groups must not co-occur" can flip from green on each PR to red on their union. Everything else in CI (lint, typecheck, generated-file drift, repo invariants) evaluates the merged tree and is legitimately correct on a batch. That narrowed 45 PR-scoped workflows down to exactly one more hit, `migrations-separation`, which is the check the desktop one was modeled on in the first place.

Rejected: guarding inside the scripts instead of the workflows. Workflow-level matches how every other trunk-merge skip in this repo is written, and keeps the script's own tests meaningful.

Out of scope, worth a follow-up: a handful of non-gating workflows still fire on every batch PR and post comments or assign reviewers on a branch that gets deleted minutes later (`ci-survey-sdk-check`, `desktop-react-doctor`, `pr-posthog-js-reviewer`, `auto-assign-labels`). That is wasted budget against the 500-runs/10s dispatch cap rather than a broken check, and two of them use `pull_request_target`, so I left them alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
