### PR TITLE
feat(desktop): add 3x1 layout option to command center

### DIFF
--- a/products/desktop/packages/core/src/command-center/grid.test.ts
+++ b/products/desktop/packages/core/src/command-center/grid.test.ts
@@ -18,6 +18,7 @@ describe("getGridDimensions / getCellCount", () => {
   it.each([
     { preset: "1x1", cols: 1, rows: 1, count: 1 },
     { preset: "2x1", cols: 2, rows: 1, count: 2 },
+    { preset: "3x1", cols: 3, rows: 1, count: 3 },
     { preset: "1x2", cols: 1, rows: 2, count: 2 },
     { preset: "2x2", cols: 2, rows: 2, count: 4 },
     { preset: "3x2", cols: 3, rows: 2, count: 6 },

--- a/products/desktop/packages/core/src/command-center/grid.ts
+++ b/products/desktop/packages/core/src/command-center/grid.ts
@@ -1,4 +1,11 @@
-export type LayoutPreset = "1x1" | "2x1" | "1x2" | "2x2" | "3x2" | "3x3";
+export type LayoutPreset =
+  | "1x1"
+  | "2x1"
+  | "3x1"
+  | "1x2"
+  | "2x2"
+  | "3x2"
+  | "3x3";
 
 export interface GridDimensions {
   cols: number;

--- a/products/desktop/packages/core/src/sessions/sessionEviction.test.ts
+++ b/products/desktop/packages/core/src/sessions/sessionEviction.test.ts
@@ -128,6 +128,7 @@ describe("MAX_CONNECTED_SESSIONS", () => {
     const allPresets: Record<LayoutPreset, true> = {
       "1x1": true,
       "2x1": true,
+      "3x1": true,
       "1x2": true,
       "2x2": true,
       "3x2": true,

--- a/products/desktop/packages/ui/src/features/command-center/components/CommandCenterToolbar.tsx
+++ b/products/desktop/packages/ui/src/features/command-center/components/CommandCenterToolbar.tsx
@@ -58,6 +58,7 @@ const LAYOUT_OPTIONS: {
 }[] = [
   { value: "1x1", label: "1x1", cols: 1, rows: 1 },
   { value: "2x1", label: "2x1", cols: 2, rows: 1 },
+  { value: "3x1", label: "3x1", cols: 3, rows: 1 },
   { value: "1x2", label: "1x2", cols: 1, rows: 2 },
   { value: "2x2", label: "2x2", cols: 2, rows: 2 },
   { value: "3x2", label: "3x2", cols: 3, rows: 2 },


### PR DESCRIPTION
## Problem

The desktop command center's layout dropdown offers 1x1, 2x1, 1x2, 2x2, 3x2, and 3x3 grids, but no way to view three panes side by side. On wide screens a single row of three tall panes is a natural way to watch three agent tasks at once.

## Changes

Adds a `3x1` preset (3 columns × 1 row) to the command center:

- `LayoutPreset` union in `packages/core/src/command-center/grid.ts`
- `LAYOUT_OPTIONS` in `CommandCenterToolbar.tsx` (the dropdown icon renders generically from cols/rows)

No grid or store logic changes — `getGridDimensions` parses dimensions from the preset string and `setLayout` already resizes cells to the new count.

## How did you test this code?

Automated only (no manual run of the Electron app):

- `vitest run src/command-center/grid.test.ts src/sessions/sessionEviction.test.ts` in `@posthog/core` — added a `3x1` case to the parameterized grid dimensions test, and added `3x1` to the `Record<LayoutPreset, true>` compile-time guard in the `MAX_CONNECTED_SESSIONS` test (3 cells stays under the session cap).
- `pnpm --filter @posthog/core --filter @posthog/ui typecheck` and Biome check on the touched directories.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Followed the existing preset-addition seam: the `LayoutPreset` union drives grid math, cell resizing, and session-eviction guards, so the change is the union member, the dropdown option, and the two tests the type system forces to grow with the union.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
