### PR TITLE
fix(logs): let the pointer reach the volume preview tooltip so it can be scrolled

### DIFF
--- a/frontend/src/lib/components/Sparkline.tsx
+++ b/frontend/src/lib/components/Sparkline.tsx
@@ -13,6 +13,7 @@ import { useChart } from 'lib/hooks/useChart'
 import { useEventListener } from 'lib/hooks/useEventListener'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
+import { useLingeringTooltip } from 'lib/hooks/useLingeringTooltip'
 import { hexToRGBA } from 'lib/utils/colors'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
@@ -115,6 +116,12 @@ export interface SparklineProps {
      * `indices` array to clear.
      */
     incompleteBars?: { indices: number[]; tooltip?: string } | null
+    /**
+     * Let the pointer move onto the tooltip without dismissing it, so a tooltip taller than its
+     * max height can be scrolled. Off by default: an interactive tooltip sits over the canvas and
+     * would swallow clicks meant for the chart (e.g. clickable markers or drag-to-select).
+     */
+    interactiveTooltip?: boolean
 }
 
 /** Normalize the permissive `data` prop into one `SparklineTimeSeries` per series. */
@@ -310,6 +317,7 @@ function LegacySparkline({
     highlightedRange,
     incompleteBars,
     markers,
+    interactiveTooltip = false,
 }: SparklineProps): JSX.Element {
     const tooltipRef = useRef<HTMLDivElement | null>(null)
 
@@ -547,7 +555,13 @@ function LegacySparkline({
 
     const finalClassName = sparklineClassName(adjustedData[0]?.values?.length || 0, className)
 
-    const tooltipVisible = !!(tooltip && tooltip.opacity > 0)
+    // Chart.js keeps `dataPoints` populated after it zeroes `opacity`, so the content survives the
+    // linger — only visibility needs holding open.
+    const {
+        visible: tooltipVisible,
+        onMouseEnter: onTooltipMouseEnter,
+        onMouseLeave: onTooltipMouseLeave,
+    } = useLingeringTooltip(!!(tooltip && tooltip.opacity > 0), interactiveTooltip)
     const toolTipDataPoints = tooltip && tooltip.dataPoints ? tooltip.dataPoints : []
 
     const hoveredElementX = toolTipDataPoints[0]?.element?.x ?? 0
@@ -676,6 +690,8 @@ function LegacySparkline({
                     }
                     placement="bottom-start"
                     padded={false}
+                    onMouseEnterInside={interactiveTooltip ? onTooltipMouseEnter : undefined}
+                    onMouseLeaveInside={interactiveTooltip ? onTooltipMouseLeave : undefined}
                 >
                     <div ref={tooltipRef} />
                 </Popover>

--- a/frontend/src/lib/hooks/useLingeringTooltip.test.tsx
+++ b/frontend/src/lib/hooks/useLingeringTooltip.test.tsx
@@ -1,0 +1,107 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { LINGERING_TOOLTIP_MS, useLingeringTooltip } from './useLingeringTooltip'
+
+describe('useLingeringTooltip', () => {
+    beforeEach(() => {
+        jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+        jest.useRealTimers()
+    })
+
+    it('passes the chart visibility straight through when disabled', () => {
+        const { result, rerender } = renderHook(({ chartVisible }) => useLingeringTooltip(chartVisible, false), {
+            initialProps: { chartVisible: true },
+        })
+        expect(result.current.visible).toBe(true)
+
+        rerender({ chartVisible: false })
+        expect(result.current.visible).toBe(false)
+    })
+
+    it('lingers after the chart hides so the pointer can reach the tooltip, then hides', () => {
+        const { result, rerender } = renderHook(({ chartVisible }) => useLingeringTooltip(chartVisible, true), {
+            initialProps: { chartVisible: true },
+        })
+        expect(result.current.visible).toBe(true)
+
+        rerender({ chartVisible: false })
+        // Still up — this window is the whole point: without it the pointer never arrives.
+        expect(result.current.visible).toBe(true)
+
+        act(() => {
+            jest.advanceTimersByTime(LINGERING_TOOLTIP_MS)
+        })
+        expect(result.current.visible).toBe(false)
+    })
+
+    it('holds the tooltip open indefinitely while the pointer is over it', () => {
+        const { result, rerender } = renderHook(({ chartVisible }) => useLingeringTooltip(chartVisible, true), {
+            initialProps: { chartVisible: true },
+        })
+
+        rerender({ chartVisible: false })
+        act(() => {
+            result.current.onMouseEnter()
+        })
+
+        act(() => {
+            jest.advanceTimersByTime(LINGERING_TOOLTIP_MS * 20)
+        })
+        expect(result.current.visible).toBe(true)
+    })
+
+    it('hides once the pointer leaves the tooltip', () => {
+        const { result, rerender } = renderHook(({ chartVisible }) => useLingeringTooltip(chartVisible, true), {
+            initialProps: { chartVisible: true },
+        })
+
+        rerender({ chartVisible: false })
+        act(() => {
+            result.current.onMouseEnter()
+        })
+        act(() => {
+            jest.advanceTimersByTime(LINGERING_TOOLTIP_MS * 5)
+        })
+        expect(result.current.visible).toBe(true)
+
+        act(() => {
+            result.current.onMouseLeave()
+        })
+        act(() => {
+            jest.advanceTimersByTime(LINGERING_TOOLTIP_MS)
+        })
+        expect(result.current.visible).toBe(false)
+    })
+
+    it('re-shows immediately when the pointer returns to the chart mid-linger', () => {
+        const { result, rerender } = renderHook(({ chartVisible }) => useLingeringTooltip(chartVisible, true), {
+            initialProps: { chartVisible: true },
+        })
+
+        rerender({ chartVisible: false })
+        rerender({ chartVisible: true })
+        act(() => {
+            jest.advanceTimersByTime(LINGERING_TOOLTIP_MS * 3)
+        })
+        expect(result.current.visible).toBe(true)
+    })
+
+    it('does not stay wedged open when the behaviour is disabled mid-hover', () => {
+        const { result, rerender } = renderHook(
+            ({ chartVisible, enabled }) => useLingeringTooltip(chartVisible, enabled),
+            { initialProps: { chartVisible: true, enabled: true } }
+        )
+
+        rerender({ chartVisible: false, enabled: true })
+        act(() => {
+            result.current.onMouseEnter()
+        })
+        expect(result.current.visible).toBe(true)
+
+        rerender({ chartVisible: false, enabled: false })
+        expect(result.current.visible).toBe(false)
+    })
+})

--- a/frontend/src/lib/hooks/useLingeringTooltip.ts
+++ b/frontend/src/lib/hooks/useLingeringTooltip.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react'
+
+/** How long the tooltip stays up after the chart stops reporting a hover, to let the pointer reach it. */
+export const LINGERING_TOOLTIP_MS = 300
+
+export interface LingeringTooltip {
+    visible: boolean
+    onMouseEnter: () => void
+    onMouseLeave: () => void
+}
+
+/**
+ * Keeps a chart's hover tooltip open long enough for the pointer to travel from the canvas onto the
+ * tooltip itself, so one taller than its max height can be scrolled. Charting libraries hide the
+ * tooltip the instant the pointer leaves the canvas — which is before it can ever reach the
+ * tooltip — so without a grace period an interactive tooltip is unreachable.
+ *
+ * Pass the chart's own notion of tooltip visibility as `chartVisible`, and spread the returned
+ * mouse handlers onto the tooltip overlay. While the pointer is over the overlay the tooltip is
+ * held open indefinitely; once it leaves, the grace period runs again and then it hides.
+ *
+ * When `enabled` is false this is a pass-through, so callers can keep the default
+ * non-interactive behaviour (an interactive tooltip overlays the canvas and swallows its clicks).
+ */
+export function useLingeringTooltip(chartVisible: boolean, enabled: boolean): LingeringTooltip {
+    const [hovered, setHovered] = useState(false)
+    const [lingering, setLingering] = useState(false)
+
+    useEffect(() => {
+        if (!enabled) {
+            return
+        }
+        if (chartVisible) {
+            setLingering(true)
+            return
+        }
+        // Hold indefinitely while the pointer is on the tooltip; the timer restarts when it leaves.
+        if (!lingering || hovered) {
+            return
+        }
+        const timeout = setTimeout(() => setLingering(false), LINGERING_TOOLTIP_MS)
+        return () => clearTimeout(timeout)
+    }, [enabled, chartVisible, lingering, hovered])
+
+    useEffect(() => {
+        // Turning the behaviour off mid-hover would otherwise wedge the tooltip open forever.
+        if (!enabled) {
+            setHovered(false)
+            setLingering(false)
+        }
+    }, [enabled])
+
+    return {
+        visible: enabled ? chartVisible || lingering || hovered : chartVisible,
+        onMouseEnter: () => setHovered(true),
+        onMouseLeave: () => setHovered(false),
+    }
+}

--- a/products/logs/frontend/components/LogsFilterPreview/LogsFilterVolumeSparkline.tsx
+++ b/products/logs/frontend/components/LogsFilterPreview/LogsFilterVolumeSparkline.tsx
@@ -112,6 +112,9 @@ export function LogsFilterVolumeSparkline({
                         maximumIndicator={false}
                         referenceLines={referenceLines}
                         renderTooltipValue={metric === 'bytes' ? formatBytes : undefined}
+                        // Up to 11 rows (top services plus "Others") overflows the tooltip's max
+                        // height, so the pointer has to be able to reach it to scroll.
+                        interactiveTooltip
                     />
                 )}
             </div>


### PR DESCRIPTION
Follow-up to [#77166](https://github.com/PostHog/posthog/pull/77166). Split out of a combined PR; the sparkline row-limit fix is now [#78150](https://github.com/PostHog/posthog/pull/78150).

## The bug

The tooltip on the logs volume preview closed the instant you moved toward it, so its contents could never be scrolled.

The content is *already* scrollable — `InsightTooltip` renders into a `max-height: 16rem; overflow-y: auto` box, and with `rowCutoff` unset all 11 rows (top 10 services + the "Others" rollup) go in. The box was simply unreachable: `LegacySparkline` derived visibility from Chart.js's `tooltip.opacity` alone, and Chart.js zeroes that the moment the pointer leaves the canvas — which happens *before* the pointer can land on the tooltip.

## The fix

New `useLingeringTooltip` hook holds the tooltip open for a 300ms grace period so the pointer can cross the gap, then indefinitely while it's hovered, hiding once it leaves.

`Popover` already supported `onMouseEnterInside`/`onMouseLeaveInside` — this `Popover` was the only chart tooltip in the codebase not wiring them up.

**Opt-in** via `interactiveTooltip`, enabled only on the logs volume preview. An interactive tooltip overlays the canvas with `pointer-events: auto` and would swallow clicks meant for charts that have clickable markers or drag-to-select (e.g. error tracking's volume sparkline), so defaulting it on would regress those.

One detail worth recording: Chart.js assigns `dataPoints` only when building an *active* tooltip, and on hide it empties `_tooltipItems` rather than clearing `dataPoints`. So the content survives the linger with no extra retention state. Had it cleared `dataPoints`, the lingering tooltip would have rendered blank.

## Testing

7 new hook tests cover: pass-through when disabled, the linger window, indefinite hold while hovered, hide on leave, re-show when the pointer returns to the chart mid-linger, and not wedging open if the behaviour is disabled mid-hover.

544/544 frontend tests pass across 32 suites — including the 11 pre-existing `Sparkline` tests, so extracting the visibility logic didn't regress the default path. oxlint and `tsgo` clean (0 errors in touched files). No kea logic files touched, so typegen has nothing to regenerate.

**Not verified in a browser.** The hook tests cover the state machine, but I haven't actually hovered the tooltip and scrolled it in a running app — worth a click-through on the hogbox preview, since the 300ms grace period is a feel judgement that tests can't validate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*