### PR TITLE
fix(data-warehouse): keep the person-property modal usable while searching tables

### DIFF
--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertyModal.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertyModal.tsx
@@ -67,6 +67,7 @@ function PersonSourceEditor(): JSX.Element {
         columnMappingWarnings,
         selectedTableColumns,
         selectedTableColumnsLoading,
+        hasSyncedWarehouseTables,
     } = useValues(customPropertyDefinitionsLogic)
     const { setCustomPropertyFormValue, loadSelectedTableColumns, loadWarehouseTables } =
         useActions(customPropertyDefinitionsLogic)
@@ -75,7 +76,10 @@ function PersonSourceEditor(): JSX.Element {
     const isGroup = customPropertyForm.targetType === 'group'
     const entityLabel = isGroup ? 'group' : 'person'
     const hasExistingSource = !!editingDefinition?.source
-    const noTables = !warehouseTablesLoading && warehouseTables.length === 0
+    // Deliberately not derived from `warehouseTables` — the picker's search narrows that list, and a
+    // search with no matches would otherwise collapse the whole editor into the empty-state banner,
+    // taking the search box with it. The picker shows its own "no options matching" instead.
+    const noTables = hasSyncedWarehouseTables === false
     const mappings = customPropertyForm.columnMappings
     const setMappings = (next: typeof mappings): void => setCustomPropertyFormValue('columnMappings', next)
     const columnByName = new Map(selectedTableColumns.map((column) => [column.name, column]))
@@ -188,7 +192,7 @@ function PersonSourceEditor(): JSX.Element {
                         Map each warehouse column to the {entityLabel} property name it should set.
                     </span>
                     {mappings.map((mapping, index) => (
-                        <div key={index} className="flex flex-col gap-1 border rounded p-2">
+                        <div key={index} className="flex flex-col gap-1">
                             <div className="flex items-center gap-2">
                                 <div className="flex-1">
                                     <LemonInputSelect
@@ -206,7 +210,9 @@ function PersonSourceEditor(): JSX.Element {
                                                               column,
                                                               // Seed the property name and description from the
                                                               // column when they're still empty, so a mapping is
-                                                              // one click when the warehouse names are good.
+                                                              // one click when the warehouse names are good. The
+                                                              // description has no input here — it rides along
+                                                              // from the warehouse column's own description.
                                                               property: m.property.trim() ? m.property : column,
                                                               description: m.description.trim()
                                                                   ? m.description
@@ -242,15 +248,6 @@ function PersonSourceEditor(): JSX.Element {
                                     onClick={() => setMappings(mappings.filter((_, i) => i !== index))}
                                 />
                             </div>
-                            <LemonInput
-                                value={mapping.description}
-                                onChange={(description) =>
-                                    setMappings(mappings.map((m, i) => (i === index ? { ...m, description } : m)))
-                                }
-                                placeholder="Description (optional)"
-                                size="small"
-                                fullWidth
-                            />
                             {columnMappingWarnings[index] && (
                                 <span className="text-warning text-xs">{columnMappingWarnings[index]}</span>
                             )}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/WarehousePersonPropertiesSetting.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/WarehousePersonPropertiesSetting.tsx
@@ -16,7 +16,7 @@ import type {
 
 import { CustomPropertyTargetType, customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
 import { CustomPropertyModal } from './CustomPropertyModal'
-import { type SourceSyncStatusLevel, sourceSyncStatus } from './customPropertyTypes'
+import { type SourceSyncStatusLevel, runOutcomeNote, sourceSyncStatus } from './customPropertyTypes'
 
 const TAG_TYPE_BY_SYNC_LEVEL: Record<SourceSyncStatusLevel, LemonTagType> = {
     synced: 'success',
@@ -46,15 +46,43 @@ function ProfilePropertyRuns({ sourceId, labels }: { sourceId: string; labels: P
     const columns: LemonTableColumns<CustomPropertySyncRunApi> = [
         {
             title: 'Status',
-            render: (_, run) => (
-                <Tooltip title={run.error ?? undefined}>
-                    <LemonTag type={TAG_TYPE_BY_RUN_STATUS[run.status] ?? 'default'}>{run.status}</LemonTag>
-                </Tooltip>
-            ),
+            render: (_, run) => {
+                const note = runOutcomeNote(run, labels.entityPlural)
+                return (
+                    <div className="flex items-center gap-2">
+                        <Tooltip title={run.error ?? undefined}>
+                            <LemonTag type={TAG_TYPE_BY_RUN_STATUS[run.status] ?? 'default'}>{run.status}</LemonTag>
+                        </Tooltip>
+                        {note && (
+                            <Tooltip title={note.tooltip}>
+                                <span className="text-secondary text-xs whitespace-nowrap">{note.label}</span>
+                            </Tooltip>
+                        )}
+                    </div>
+                )
+            },
         },
         { title: 'Trigger', dataIndex: 'trigger' },
-        { title: 'Rows produced', render: (_, run) => run.produced },
-        { title: `Affected ${labels.entityPlural}`, render: (_, run) => run.existing },
+        {
+            title: (
+                <Tooltip title="Warehouse rows this sync staged. A sync only stages rows the import itself added or changed, so a quiet table reads zero.">
+                    <span>Rows read</span>
+                </Tooltip>
+            ),
+            render: (_, run) => run.rows_read,
+        },
+        {
+            title: (
+                <Tooltip title="Rows whose mapped values differ from what was last sent. Rows that already match are skipped, even on a full refresh.">
+                    <span>Changed</span>
+                </Tooltip>
+            ),
+            render: (_, run) => run.changed,
+        },
+        {
+            title: `Affected ${labels.entityPlural}`,
+            render: (_, run) => run.existing,
+        },
         {
             title: `Skipped (no ${labels.entity})`,
             render: (_, run) => <span className="text-secondary">{run.skipped_missing_person}</span>,

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
@@ -415,6 +415,37 @@ describe('customPropertyDefinitionsLogic', () => {
         expect(searchedFor).toBe('user')
     })
 
+    it.each([
+        ['a search that matches nothing', 'nope', true],
+        ['a cleared search', '', false],
+    ])('keeps the empty-catalog flag intact across %s', async (_name, search, expectedAfterEmpty) => {
+        let emptyResponse = false
+        useMocks({
+            ...defaultMocks(),
+            get: {
+                ...defaultMocks().get,
+                [WAREHOUSE_TABLES_URL]: () =>
+                    emptyResponse
+                        ? [200, { count: 0, next: null, results: [] }]
+                        : [200, { count: 1, results: [buildTable()] }],
+            },
+        })
+        mountLogic()
+        await expectLogic(logic, () => logic.actions.openCreateModal()).toDispatchActions([
+            'loadWarehouseTablesSuccess',
+        ])
+        expect(logic.values.hasSyncedWarehouseTables).toBe(true)
+
+        // A searched load that comes back empty must not read as "this project has no synced tables"
+        // — that would collapse the whole person editor into the empty-state banner, search box and all.
+        emptyResponse = true
+        await expectLogic(logic, () => logic.actions.loadWarehouseTables({ search })).toDispatchActions([
+            'loadWarehouseTablesSuccess',
+        ])
+        expect(logic.values.warehouseTables).toEqual([])
+        expect(logic.values.hasSyncedWarehouseTables).toBe(expectedAfterEmpty)
+    })
+
     it('locks the target type when the modal is opened from a profile settings page', async () => {
         useMocks(defaultMocks())
         mountLogic()
@@ -424,6 +455,62 @@ describe('customPropertyDefinitionsLogic', () => {
         // Opening the generic "New custom property" flow leaves the switch available again.
         logic.actions.openCreateModal()
         expect(logic.values.targetTypeLocked).toBe(false)
+    })
+
+    it('keeps polling a triggered backfill until its run finishes', async () => {
+        // The workflow creates the run row after the trigger call returns, so the first refreshes see
+        // no run at all. The poll has to survive that instead of reading it as already settled and
+        // leaving the row stuck on "Awaiting first sync" until a manual page refresh.
+        const runPerCall: (Record<string, string> | null)[] = [
+            null,
+            null,
+            { id: 'run-1', status: 'running' },
+            { id: 'run-1', status: 'completed' },
+        ]
+        let call = 0
+        useMocks({
+            ...defaultMocks(),
+            get: {
+                ...defaultMocks().get,
+                [DEFINITIONS_URL]: () => {
+                    const latestRun = runPerCall[Math.min(call++, runPerCall.length - 1)]
+                    return [
+                        200,
+                        {
+                            count: 1,
+                            results: [
+                                buildDefinition({
+                                    target_type: 'person',
+                                    source: buildSource({
+                                        latest_run: latestRun,
+                                        last_synced_at:
+                                            latestRun?.status === 'completed' ? '2026-01-03T00:00:00Z' : null,
+                                    } as Partial<CustomPropertySourceApi>),
+                                }),
+                            ],
+                        },
+                    ]
+                },
+            },
+            post: { ...defaultMocks().post, [`${SOURCE_URL}backfill/`]: { status: 'started', already_running: false } },
+        })
+        mountLogic()
+        await expectLogic(logic).toDispatchActions(['loadDefinitionsSuccess'])
+
+        jest.useFakeTimers()
+        try {
+            await expectLogic(logic, () => logic.actions.triggerBackfill({ sourceId: 'src-1' })).toDispatchActions([
+                'pollRunsStatus',
+            ])
+            // Three rounds: no run yet, no run yet, running — none of which may stop the poll.
+            for (let round = 0; round < 3; round++) {
+                await jest.advanceTimersByTimeAsync(3000)
+            }
+            expect(logic.values.definitions[0].source?.latest_run?.status).toBe('completed')
+            expect(logic.values.definitions[0].source?.last_synced_at).toBe('2026-01-03T00:00:00Z')
+        } finally {
+            jest.useRealTimers()
+        }
     })
 
     it('hydrates per-mapping descriptions when editing a person source', async () => {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -39,10 +39,17 @@ import { NEW_OPTION_ID_PREFIX, isNumericDisplayType, optionLabelError } from './
 export type CustomPropertySourceMode = 'manual' | 'data_warehouse' | 'workflow'
 export type CustomPropertyTargetType = 'account' | 'person' | 'group'
 
-// After triggering a sync/backfill, poll until the source's run settles so the UI reflects
-// completion without a manual refresh. Bounded so a stuck run can't poll forever.
+// Poll until a source's run settles so the UI reflects completion without a manual refresh: fast at
+// first (a small table finishes in seconds), then slower, and bounded so a stuck run can't poll
+// forever. 10 × 3s + 30 × 10s ≈ 5.5 minutes.
 const RUNS_POLL_INTERVAL_MS = 3000
-const RUNS_POLL_MAX_ATTEMPTS = 20
+const RUNS_POLL_SLOW_INTERVAL_MS = 10000
+const RUNS_POLL_FAST_ATTEMPTS = 10
+const RUNS_POLL_MAX_ATTEMPTS = 40
+
+// A run that has reached one of these is finished — anything else (including no run row yet, which
+// is the state right after a trigger while the workflow starts up) means keep polling.
+const TERMINAL_RUN_STATUSES = new Set(['completed', 'failed'])
 
 // One warehouse-column → person-property pair in the person-target editor. Serialized to the
 // backend's `column_property_map` object ({column: property}) on save; the optional per-mapping
@@ -190,6 +197,7 @@ export interface customPropertyDefinitionsLogicValues {
     editingDefinition: CustomPropertyDefinitionApi | null
     editingReferences: readonly CustomPropertyReferenceApi[]
     filteredDefinitions: CustomPropertyDefinitionApi[]
+    hasSyncedWarehouseTables: boolean | null
     isCustomPropertyFormSubmitting: boolean
     isCustomPropertyFormValid: boolean
     materializedViews: DataWarehouseSavedQuery[]
@@ -535,6 +543,16 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 openCreateModal: (_, { lockTargetType }) => lockTargetType,
                 openEditModal: () => false,
                 closeModal: () => false,
+            },
+        ],
+        // Whether the project has any synced warehouse tables at all — null until the first unsearched
+        // load lands. Tracked apart from `warehouseTables`, which the picker's server-side search
+        // narrows: a search that matches nothing must not read as an empty catalog.
+        hasSyncedWarehouseTables: [
+            null as boolean | null,
+            {
+                loadWarehouseTablesSuccess: (state, { warehouseTables, payload }) =>
+                    payload?.search ? state : warehouseTables.length > 0,
             },
         ],
         // The sources whose sync/backfill trigger is in flight, for the per-row loading/disabled guard.
@@ -1087,6 +1105,14 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         pollRunsStatus: ({ sourceId }) => {
             cache.pollSourceIds = cache.pollSourceIds ?? new Set<string>()
             cache.pollAttempts = cache.pollAttempts ?? {}
+            cache.pollBaselines = cache.pollBaselines ?? {}
+            // Remember which run we already knew about. A trigger returns before its workflow creates
+            // the run row, so "no run yet" and "the same finished run as before" both have to keep
+            // polling — otherwise the first response settles the poll and the status stays stale.
+            const latestRun = values.definitions.find((d) => d.source?.id === sourceId)?.source?.latest_run
+            cache.pollBaselines[sourceId] = latestRun
+                ? { id: latestRun.id, finished: TERMINAL_RUN_STATUSES.has(latestRun.status) }
+                : null
             cache.pollSourceIds.add(sourceId)
             cache.pollAttempts[sourceId] = 0
             cache.disposables.add(() => {
@@ -1095,22 +1121,44 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
             }, 'runsPoll')
         },
         loadDefinitionsSuccess: () => {
-            // Reschedule the trigger poll until each polled source's run settles (or attempts run out),
-            // so the buttons/status reflect completion without a manual refresh (see pollRunsStatus).
-            const pollSourceIds: Set<string> | undefined = cache.pollSourceIds
-            if (!pollSourceIds || pollSourceIds.size === 0) {
+            cache.pollSourceIds = cache.pollSourceIds ?? new Set<string>()
+            cache.pollAttempts = cache.pollAttempts ?? {}
+            cache.pollBaselines = cache.pollBaselines ?? {}
+            // Also follow runs that were already in flight when the list loaded — a scheduled sync, or
+            // one started from another tab — so those settle live rather than only on a refresh.
+            values.definitions.forEach(({ source }) => {
+                const run = source?.latest_run
+                if (!source || !run || TERMINAL_RUN_STATUSES.has(run.status) || cache.pollSourceIds.has(source.id)) {
+                    return
+                }
+                cache.pollSourceIds.add(source.id)
+                cache.pollAttempts[source.id] = 0
+                cache.pollBaselines[source.id] = { id: run.id, finished: false }
+            })
+            if (cache.pollSourceIds.size === 0) {
                 return
             }
             // Build the next round rather than mutating the set while iterating it.
             const stillPolling = new Set<string>()
-            pollSourceIds.forEach((sourceId) => {
-                const definition = values.definitions.find((d) => d.source?.id === sourceId)
-                const stillRunning = definition?.source?.latest_run?.status === 'running'
+            let soonestAttempts = RUNS_POLL_MAX_ATTEMPTS
+            cache.pollSourceIds.forEach((sourceId: string) => {
+                const latestRun = values.definitions.find((d) => d.source?.id === sourceId)?.source?.latest_run
+                const baseline = cache.pollBaselines[sourceId]
+                const settled =
+                    !!latestRun &&
+                    TERMINAL_RUN_STATUSES.has(latestRun.status) &&
+                    // The run we started from, already finished back then, tells us nothing new.
+                    !(baseline?.finished && baseline.id === latestRun.id)
                 const attempts = (cache.pollAttempts[sourceId] ?? 0) + 1
                 cache.pollAttempts[sourceId] = attempts
-                actions.loadRuns({ sourceId })
-                if (stillRunning && attempts < RUNS_POLL_MAX_ATTEMPTS) {
+                // Only refresh history for rows that have it open — an unexpanded row would just be
+                // a request nobody reads.
+                if (sourceId in values.runsBySourceId) {
+                    actions.loadRuns({ sourceId })
+                }
+                if (!settled && attempts < RUNS_POLL_MAX_ATTEMPTS) {
                     stillPolling.add(sourceId)
+                    soonestAttempts = Math.min(soonestAttempts, attempts)
                 }
             })
             cache.pollSourceIds = stillPolling
@@ -1119,7 +1167,10 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 return
             }
             cache.disposables.add(() => {
-                const timeoutId = setTimeout(() => actions.loadDefinitions(), RUNS_POLL_INTERVAL_MS)
+                const timeoutId = setTimeout(
+                    () => actions.loadDefinitions(),
+                    soonestAttempts < RUNS_POLL_FAST_ATTEMPTS ? RUNS_POLL_INTERVAL_MS : RUNS_POLL_SLOW_INTERVAL_MS
+                )
                 return () => clearTimeout(timeoutId)
             }, 'runsPoll')
         },

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
@@ -2,6 +2,7 @@ import type {
     CustomPropertyDisplayTypeEnumApi,
     CustomPropertyOptionApi,
     CustomPropertySourceApi,
+    CustomPropertySyncRunApi,
 } from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import {
@@ -10,6 +11,7 @@ import {
     isNumericDisplayType,
     labelForDisplayType,
     optionLabelError,
+    runOutcomeNote,
     sourceSyncStatus,
 } from './customPropertyTypes'
 
@@ -106,5 +108,40 @@ describe('customPropertyTypes', () => {
         const status = sourceSyncStatus(buildSource({ is_enabled: false, last_sync_error: null }))
         expect(status.level).toBe('disabled')
         expect(status.tooltip).toBe('Syncing is turned off for this source.')
+    })
+
+    describe('runOutcomeNote', () => {
+        const buildRun = (overrides: Partial<CustomPropertySyncRunApi>): CustomPropertySyncRunApi =>
+            ({
+                status: 'completed',
+                rows_read: 0,
+                changed: 0,
+                existing: 0,
+                produced: 0,
+                skipped_missing_person: 0,
+                ...overrides,
+            }) as CustomPropertySyncRunApi
+
+        // An all-zero run is the normal quiet case, and the counts alone can't say which quiet case
+        // it was — the note is the only thing distinguishing "nothing imported" from "nothing changed".
+        it.each([
+            ['nothing staged by the sync', {}, 'no new rows'],
+            ['rows staged but all matching the last send', { rows_read: 12 }, 'no changes'],
+            [
+                'changed rows matching no person',
+                { rows_read: 12, changed: 3, skipped_missing_person: 3 },
+                'no matching people',
+            ],
+        ])('names the reason when %s', (_name, overrides, expected) => {
+            expect(runOutcomeNote(buildRun(overrides), 'people')?.label).toBe(expected)
+        })
+
+        it.each([
+            ['the run produced intents', { rows_read: 5, changed: 5, existing: 5, produced: 5 }],
+            ['the run is still going', { status: 'running' }],
+            ['the run failed', { status: 'failed' }],
+        ])('stays quiet when %s', (_name, overrides) => {
+            expect(runOutcomeNote(buildRun(overrides), 'people')).toBeNull()
+        })
     })
 })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
@@ -6,6 +6,7 @@ import type {
     CustomPropertyDisplayTypeEnumApi,
     CustomPropertyOptionApi,
     CustomPropertySourceApi,
+    CustomPropertySyncRunApi,
 } from 'products/customer_analytics/frontend/generated/api.schemas'
 
 // The backend stores the granular display type directly, so the form value maps 1:1 to the API.
@@ -113,4 +114,38 @@ export function sourceSyncStatus(source: CustomPropertySourceApi): SourceSyncSta
         return { level: 'pending', label: 'Awaiting first sync' }
     }
     return { level: 'synced', label: 'Synced' }
+}
+
+export interface RunOutcomeNote {
+    label: string
+    tooltip: string
+}
+
+// A completed run that updated nobody is normal, not a failure: a sync only stages rows the
+// warehouse import actually changed, and the snapshot diff then drops rows whose mapped values
+// already match what was last sent. Both look identical in the counts (all zeros), so name which
+// one happened rather than leaving a row of zeros to be read as a broken sync.
+export function runOutcomeNote(run: CustomPropertySyncRunApi, entityPlural: string): RunOutcomeNote | null {
+    if (run.status !== 'completed' || run.produced > 0) {
+        return null
+    }
+    if (run.rows_read === 0) {
+        return {
+            label: 'no new rows',
+            tooltip: `This sync imported no rows for the table, so there was nothing to map onto ${entityPlural}.`,
+        }
+    }
+    if (run.changed === 0) {
+        return {
+            label: 'no changes',
+            tooltip: `All ${run.rows_read} rows this sync read already hold the values last sent, so nothing needed updating.`,
+        }
+    }
+    if (run.existing === 0) {
+        return {
+            label: `no matching ${entityPlural}`,
+            tooltip: `${run.changed} rows changed, but none of their key column values matched an existing ${entityPlural === 'people' ? 'person' : 'group'}.`,
+        }
+    }
+    return null
 }


### PR DESCRIPTION
## Problem

Four things broke while using the warehouse -> person property config behind `WAREHOUSE_PERSON_PROPERTIES`.

**Typing a table name that doesn't exist wipes the modal.** The table picker searches server-side, so a search matching nothing empties `warehouseTables`. The editor's empty-state guard read that list directly, so it early-returned the "No synced data warehouse tables found" banner over the whole editor. That banner replaces the search box too, so there's no way back short of closing the modal.

**Backfill status never updates.** After triggering a backfill the row sits on "Awaiting first sync" until you hard-refresh, even once the run has finished. The poll already existed, it just exited on the first response.

**A quiet sync run looks broken.** A scheduled run that updated nobody shows a row of zeros with no explanation. Two very different situations produce identical output: the sync staged no rows at all, or it staged rows whose mapped values already match what was last sent. The run row records both (`rows_read`, `changed`) and the API returns them, the table just dropped them.

**The per-mapping description input isn't ready yet** and clutters the mapping rows.

## Changes

Empty-catalog state moved into its own `hasSyncedWarehouseTables` reducer, which only records emptiness from unsearched loads. A fruitless search now falls through to `LemonInputSelect`'s own "No options matching ..." inside the picker, and the editor stays put.

The description input is gone from the mapping rows, along with the row border that only existed to group it. Descriptions still persist: the auto-seed from the warehouse column's own description stays, so `column_descriptions` keeps filling and a proper editing UI can land later without a data gap.

The poll's exit condition was `latest_run?.status === 'running'`. A trigger returns before its workflow creates the run row, so the first refresh saw `latest_run: null`, read it as settled, and disposed the timer. Now:

- Settle only on a terminal run (`completed`/`failed`) that isn't the one we started from. The baseline is captured at trigger time, so a coalesced backfill joining an already-running run also waits for the right thing.
- Auto-follow runs that were already in flight when the list loaded, so a scheduled sync or one started in another tab settles live too.
- Window widened from 60s to ~5.5 min, backing off 3s -> 10s after 10 attempts. Backfills routinely outran the old budget.
- Run history only re-fetches for rows that are actually expanded, instead of every polled source.

Run history gained the two columns that were missing from the funnel, `Rows read` and `Changed`, both with header tooltips explaining what gets filtered where. Alongside them a new `runOutcomeNote` helper names why a completed run produced nothing, shown next to the status tag: `no new rows`, `no changes`, or `no matching people`, each with a tooltip carrying the actual counts.

> [!NOTE]
> Separate from this PR: the `warehouse-person-property-consumer` pods can't reach capture. No value file in their chart chain sets `CAPTURE_INTERNAL_URL`, so it falls back to the Django default `http://localhost:8010` and every send is refused. Since offsets only commit after a successful send, the consumer group never registers. Fixed in PostHog/charts#13893.

## How did you test this code?

Regression tests, all verified to fail against the old logic and pass against the new (I reverted each fix in turn and re-ran):

- `keeps the empty-catalog flag intact across ...` (parameterized over a no-match search and a cleared search) covers the search path emptying the list without flipping the empty-catalog state. No existing test asserted anything about `hasSyncedWarehouseTables`, only that the search term reaches the backend.
- `keeps polling a triggered backfill until its run finishes` drives the definitions endpoint through no-run -> no-run -> running -> completed and asserts the poll survives the two no-run responses. This is the exact sequence that broke, and nothing covered the poll's exit condition before.
- `runOutcomeNote` gets two parameterized groups: the three quiet outcomes it has to tell apart (which the counts alone cannot), and the cases where it must stay silent (produced something, still running, failed).

Full suite for the scene passes (52 tests). `oxfmt` clean. Scoped tsgo reports nothing on the changed files, though the repo-wide run has pre-existing unbuilt-quill errors unrelated to this.

I did not verify the fixes by hand in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit all of these while testing the person-property config and had Claude (Claude Code, Opus 5) diagnose and fix them.

The search bug and the polling bug turned out to be the same shape of mistake: deriving a "nothing here" conclusion from a value that something else narrows underneath you. The table list is narrowed by search, and `latest_run` is empty during the window before a workflow creates its row. Both fixes separate the signal from the narrowed value rather than special-casing.

The quiet-run confusion was mine first, not the code's. I assumed we only push to Kafka every n hours. We don't, every sync of the bound schema runs the person-property step, but only rows the import actually staged and whose values differ from the last snapshot produce anything. The counts that distinguish those cases were already on the API, so this is a display fix rather than a behavior one.

On descriptions, we kept the auto-seed rather than ripping out the plumbing, since the field is already persisted via migration 0021 and removing the write path would strand existing data. Worth a second opinion if you'd rather it go fully.

Invoked `/using-kea-disposables` before touching the poll timers, which confirmed the existing `cache.disposables.add(..., 'runsPoll')` keyed-replacement pattern was right to keep.
