### PR TITLE
fix(warehouse): reject incremental sync without a primary key

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6373,6 +6373,10 @@ export type SchemaIncrementalFieldsResponse = {
     detected_primary_keys: string[] | null
     cdc_available?: boolean
     xmin_available?: boolean
+    /** True only for sources whose discovery reports primary keys authoritatively (e.g. Postgres),
+     *  where an empty selection means the incremental merge has nothing to key on. Other sources
+     *  resolve keys at sync time, so the picker must not require one. */
+    primary_key_required?: boolean
 }
 
 // numeric is snowflake specific and objectid is mongodb specific
@@ -6404,6 +6408,10 @@ export interface ExternalDataSourceSyncSchema {
     append_available: boolean
     cdc_available?: boolean
     xmin_available?: boolean
+    /** True only for sources whose discovery reports primary keys authoritatively (e.g. Postgres),
+     *  where an empty selection means the incremental merge has nothing to key on. Other sources
+     *  resolve keys at sync time, so the picker must not require one. */
+    primary_key_required?: boolean
     cdc_table_mode?: 'consolidated' | 'cdc_only' | 'both'
     supports_webhooks: boolean
     /** True when the resource has no API list endpoint and can only be populated via webhooks

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.test.tsx
@@ -1,7 +1,7 @@
 import { ExternalDataSourceSyncSchema } from '~/types'
 
 import { SyncTypeLabelMap } from '../../../utils'
-import { shouldOfferXmin } from './SyncMethodForm'
+import { getSaveDisabledReason, shouldOfferXmin } from './SyncMethodForm'
 
 const baseSchema: ExternalDataSourceSyncSchema = {
     table: 'orders',
@@ -32,5 +32,19 @@ describe('SyncMethodForm', () => {
 
     it('exposes a label for the xmin sync type', () => {
         expect(SyncTypeLabelMap.xmin).toBe('xmin')
+    })
+
+    const missingPrimaryKey = 'You must select a primary key, or use full table replication instead'
+
+    it.each([
+        ['incremental with no primary key', 'incremental', [], true, missingPrimaryKey],
+        ['incremental with a primary key', 'incremental', ['id'], true, undefined],
+        ['incremental when the source resolves keys at sync time', 'incremental', [], false, undefined],
+        ['full refresh with no primary key', 'full_refresh', [], true, undefined],
+        ['append with no primary key', 'append', [], true, undefined],
+    ] as const)('save disabled reason: %s', (_, syncType, primaryKeyColumns, primaryKeyRequired, expected) => {
+        expect(
+            getSaveDisabledReason(syncType, 'updated_at', 'updated_at', [...primaryKeyColumns], primaryKeyRequired)
+        ).toBe(expected)
     })
 })

--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
@@ -129,10 +129,14 @@ const getCdcSyncSupported = (
 export const shouldOfferXmin = (schema: ExternalDataSourceSyncSchema): boolean =>
     !schema.webhook_only && !!schema.xmin_available
 
-const getSaveDisabledReason = (
+export const getSaveDisabledReason = (
     syncType: 'full_refresh' | 'incremental' | 'append' | 'webhook' | 'cdc' | 'xmin' | undefined,
     incrementalField: string | null,
-    appendField: string | null
+    appendField: string | null,
+    primaryKeyColumns: string[],
+    // False when the source resolves keys at sync time, or when the selector isn't rendered or is
+    // read-only, in which case blocking the save would demand something the user can't supply here.
+    primaryKeyRequired: boolean
 ): string | undefined => {
     if (!syncType) {
         return 'You must select a sync method before saving'
@@ -140,6 +144,12 @@ const getSaveDisabledReason = (
 
     if (syncType === 'incremental' && !incrementalField) {
         return 'You must select an incremental field'
+    }
+
+    // Incremental merges on the primary key from the second sync onward, so a schema saved without
+    // one imports cleanly on the initial backfill and then fails every run after it.
+    if (syncType === 'incremental' && primaryKeyRequired && primaryKeyColumns.length === 0) {
+        return 'You must select a primary key, or use full table replication instead'
     }
 
     if (syncType === 'append' && !appendField) {
@@ -195,6 +205,10 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
 
     const columns = availableColumns ?? schema.available_columns ?? []
     const resolvedDetectedPks = detectedPrimaryKeys ?? schema.detected_primary_keys ?? null
+    // A primary key can only be demanded when the source reports keys authoritatively and the user
+    // can actually pick one here: the selector below renders only when the columns are known, and
+    // it's read-only once data has been synced.
+    const primaryKeyRequired = !!schema.primary_key_required && columns.length > 0 && !primaryKeyLocked
 
     const defaultField = schema.incremental_field ?? schema.incremental_fields[0]?.field ?? null
 
@@ -490,7 +504,10 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
                                         {primaryKeyColumns.length === 0 &&
                                             !resolvedDetectedPks &&
                                             !primaryKeyLocked && (
-                                                <LemonBanner type="info" className="mt-2">
+                                                <LemonBanner
+                                                    type={primaryKeyRequired ? 'warning' : 'info'}
+                                                    className="mt-2"
+                                                >
                                                     No primary key could be auto-detected from the source. Select one
                                                     manually to enable incremental sync, or use full table replication
                                                     instead.
@@ -627,7 +644,13 @@ export const SyncMethodForm = forwardRef<SyncMethodFormHandle, SyncMethodFormPro
         return false
     })()
 
-    const validationDisabledReason = getSaveDisabledReason(radioValue, incrementalFieldValue, appendFieldValue)
+    const validationDisabledReason = getSaveDisabledReason(
+        radioValue,
+        incrementalFieldValue,
+        appendFieldValue,
+        primaryKeyColumns,
+        primaryKeyRequired
+    )
     const saveDisabledReason = validationDisabledReason ?? (!isDirty ? 'No changes to save' : undefined)
 
     const handleSave = (): void => {

--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -94,6 +94,22 @@ def source_supports_row_filters(source_type: str) -> bool:
     return bool(source.supports_row_filters)
 
 
+def source_detects_primary_keys(source_type: str) -> bool:
+    """Whether this source's discovery reports primary keys authoritatively.
+
+    Only these sources can be validated for primary key presence at config time. Sources built on a
+    static endpoint catalog resolve keys at sync time instead, so an empty `primary_key_columns`
+    does not mean their incremental sync will fail. Unknown source types return False so validation
+    stays permissive rather than blocking a save it can't reason about.
+    """
+    try:
+        source = SourceRegistry.get_source(ExternalDataSourceType(source_type))
+    except Exception as e:
+        capture_exception(e)
+        return False
+    return bool(source.detects_primary_keys)
+
+
 _CDC_WRITE_TARGETS_BY_TABLE_MODE: dict[str, frozenset[str]] = {
     "consolidated": frozenset({"consolidated"}),
     "cdc_only": frozenset({"cdc_history"}),
@@ -806,6 +822,22 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
                     )
                 payload["primary_key_columns"] = new_pk
 
+            # Incremental merges on the primary key from the second sync onward, so a schema saved
+            # without one backfills successfully and then fails every run after it. Enforced only
+            # when the caller explicitly sets sync_type, so that schemas already stuck in this state
+            # stay editable: an unrelated PATCH (sync_frequency, enabled_columns) on one of them
+            # must not start failing with an error about a field the caller never touched.
+            if (
+                "sync_type" in data
+                and resulting_sync_type == ExternalDataSchema.SyncType.INCREMENTAL
+                and not payload.get("primary_key_columns")
+                and source_detects_primary_keys(instance.source.source_type)
+            ):
+                raise ValidationError(
+                    f"Incremental replication requires a primary key on table '{instance.name}'. "
+                    "Choose a primary key for the table, or use full table replication instead."
+                )
+
             # Detect incremental field changes before mutating payload
             incremental_field_changed = False
             incremental_field = data.get("incremental_field")
@@ -927,19 +959,22 @@ class ExternalDataSchemaSerializer(UserAccessControlSerializerMixin, serializers
         if source.supports_scheduled_sync and should_sync is True and sync_type is None and instance.sync_type is None:
             raise ValidationError("Sync type must be set up first before enabling schema")
 
-        # Catches a CDC schema being flipped on later when sync_type isn't changing — the
-        # sync_type branch above doesn't run, so PK presence isn't enforced there.
+        # Catches a CDC or incremental schema being flipped on later when sync_type isn't changing —
+        # the sync_type branch above doesn't run, so PK presence isn't enforced there.
         effective_sync_type = sync_type or instance.sync_type
-        if (
-            should_sync is True
-            and not instance.should_sync
-            and effective_sync_type == ExternalDataSchema.SyncType.CDC
-            and not instance.primary_key_columns
-        ):
-            raise ValidationError(
-                f"CDC requires a primary key on table '{instance.name}'. "
-                "Add a primary key on the source table and retry."
-            )
+        if should_sync is True and not instance.should_sync and not instance.primary_key_columns:
+            if effective_sync_type == ExternalDataSchema.SyncType.CDC:
+                raise ValidationError(
+                    f"CDC requires a primary key on table '{instance.name}'. "
+                    "Add a primary key on the source table and retry."
+                )
+            if effective_sync_type == ExternalDataSchema.SyncType.INCREMENTAL and source_detects_primary_keys(
+                instance.source.source_type
+            ):
+                raise ValidationError(
+                    f"Incremental replication requires a primary key on table '{instance.name}'. "
+                    "Choose a primary key for the table, or use full table replication instead."
+                )
 
         # Switching sync type across the xmin boundary changes the physical Delta schema: xmin
         # force-projects a non-nullable `_ph_xmin` control column that no other sync type writes.
@@ -1710,12 +1745,9 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         # strings, so bool(...) would treat "False" as truthy. str_to_bool decodes both.
         source_cdc_enabled = str_to_bool(source.job_inputs.get("cdc_enabled"))
         cdc_available = schema.supports_cdc if is_cdc_enabled_for_team(self.team) and source_cdc_enabled else None
+        source_impl = SourceRegistry.get_source(ExternalDataSourceType(source.source_type))
         # xmin is source-capability-gated, mirroring the database_schema endpoint.
-        xmin_available = (
-            schema.supports_xmin
-            if SourceRegistry.get_source(ExternalDataSourceType(source.source_type)).supports_xmin
-            else None
-        )
+        xmin_available = schema.supports_xmin if source_impl.supports_xmin else None
 
         data = {
             "incremental_fields": schema.incremental_fields,
@@ -1731,6 +1763,12 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 for col_name, col_type, nullable in schema.columns
             ],
             "detected_primary_keys": schema.detected_primary_keys,
+            # True only where discovery reports keys authoritatively, so an empty selection really
+            # does mean the incremental merge has nothing to key on. Other sources resolve keys at
+            # sync time, so the UI must not demand one from the user up front.
+            # `bool()` guards against test mocks whose attribute access returns a Mock — orjson
+            # can't serialize one.
+            "primary_key_required": bool(source_impl.detects_primary_keys),
         }
 
         return Response(status=status.HTTP_200_OK, data=data)

--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -2380,6 +2380,40 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         # source type. None for non-direct-capable sources.
         direct_engine_adapter = get_direct_query_engine(new_source_model.direct_engine)
 
+        # Incremental merges on the primary key from the second sync onward, so a schema created
+        # without one backfills successfully and then fails every subsequent run. Refuse up front
+        # instead of letting the caller discover it one full table load later. Resolution mirrors
+        # `effective_primary_key_columns` below so this sees exactly what would be persisted.
+        #
+        # Gated on `detects_primary_keys`: only sources that introspect real key constraints can be
+        # trusted when they report none. Endpoint-catalog sources leave `detected_primary_keys`
+        # unset and supply keys at sync time via `SourceResponse.primary_keys`, so blocking them
+        # here would reject configurations that sync fine.
+        if source.detects_primary_keys and new_source_model.supports_scheduled_sync:
+            detected_pks_by_name = {schema.name: schema.detected_primary_keys for schema in source_schemas}
+            incremental_tables_missing_pk = sorted(
+                {
+                    schema["name"]
+                    for schema in payload_schemas
+                    if schema.get("sync_type") == "incremental"
+                    and schema.get("should_sync", False)
+                    and isinstance(schema.get("name"), str)
+                    and not (schema.get("primary_key_columns") or detected_pks_by_name.get(schema["name"]))
+                }
+            )
+            if incremental_tables_missing_pk:
+                new_source_model.delete()
+                return Response(
+                    status=status.HTTP_400_BAD_REQUEST,
+                    data={
+                        "message": (
+                            "Incremental replication requires a primary key on each table. The following tables "
+                            f"have no primary key: {', '.join(incremental_tables_missing_pk)}. Choose a primary key "
+                            "for them, or use full table replication instead."
+                        )
+                    },
+                )
+
         # Create all ExternalDataSchema objects and enable syncing for active schemas
         for schema in payload_schemas:
             sync_type = schema.get("sync_type")
@@ -3145,6 +3179,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 "append_available": schema.supports_append,
                 "cdc_available": schema.supports_cdc if cdc_enabled else None,
                 "xmin_available": schema.supports_xmin if xmin_capable else None,
+                # True only where discovery reports keys authoritatively, so an empty selection
+                # really does mean the incremental merge has nothing to key on. Other sources
+                # resolve keys at sync time, so the UI must not demand one from the user up front.
+                # `bool()` guards against test mocks whose attribute access returns a Mock — orjson
+                # can't serialize one.
+                "primary_key_required": bool(source.detects_primary_keys),
                 "incremental_field": schema.incremental_fields[0]["field"]
                 if len(schema.incremental_fields) > 0 and len(schema.incremental_fields[0]["field"]) > 0
                 else None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
@@ -157,6 +157,14 @@ class _BaseSource(ABC, Generic[ConfigType]):
     # instead of naming the source type.
     supports_xmin: bool = False
 
+    # `True` only for sources whose `get_schemas` populates `SourceSchema.detected_primary_keys`
+    # by introspecting real key constraints, so an empty value means the table genuinely has no
+    # key. Sources built on a static endpoint catalog leave the field unset and supply keys at sync
+    # time through `SourceResponse.primary_keys` instead, so an empty value there says nothing about
+    # whether an incremental merge will resolve a key. Config-time primary key validation branches
+    # on this flag, because enforcing it for the other sources would reject configs that sync fine.
+    detects_primary_keys: bool = False
+
     # Vendor API versions this source implements, as opaque vendor labels (Stripe date
     # versions, semver, names) — never parsed or ordered by the framework. Sources whose
     # vendor has no meaningful API versioning keep the `UNVERSIONED_API_VERSION` default.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -209,6 +209,9 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
     # xmin replication is Postgres-only; per-table availability is still decided by
     # `SourceSchema.supports_xmin` at discovery.
     supports_xmin = True
+    # `get_schemas` resolves `detected_primary_keys` from pg_catalog key constraints, so an empty
+    # value here means the table really has no key available for an incremental merge.
+    detects_primary_keys = True
 
     def __init__(self, source_name: str = "Postgres"):
         super().__init__()

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -120,6 +120,7 @@ class TestExternalDataSchema(APIBaseTest):
             "webhook_only": False,
             "available_columns": [],
             "detected_primary_keys": None,
+            "primary_key_required": False,
         }
 
     @parameterized.expand(
@@ -335,6 +336,7 @@ class TestExternalDataSchema(APIBaseTest):
                 {"field": "id", "label": "id", "type": "integer", "nullable": True},
             ],
             "detected_primary_keys": ["id"],
+            "primary_key_required": True,
         }
 
     @parameterized.expand(
@@ -453,6 +455,9 @@ class TestExternalDataSchema(APIBaseTest):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["xmin_available"] is expected_xmin_available
+        # Same source-capability gating decides whether the UI may require a primary key before
+        # allowing an incremental sync. Only Postgres discovery reports keys authoritatively.
+        assert response.json()["primary_key_required"] is (source_type == ExternalDataSourceType.POSTGRES)
 
     def test_incremental_fields_matches_schema_by_name(self):
         source = ExternalDataSource.objects.create(
@@ -1471,6 +1476,109 @@ class TestExternalDataSchema(APIBaseTest):
         assert "primary key" in str(response.json()).lower()
         schema.refresh_from_db()
         assert schema.should_sync is False
+
+    def _incremental_schema_without_primary_key(self, source: ExternalDataSource) -> ExternalDataSchema:
+        return ExternalDataSchema.objects.create(
+            name="public.orders",
+            team=self.team,
+            source=source,
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+            sync_type_config={"incremental_field": "updated_at", "incremental_field_type": "timestamp"},
+        )
+
+    @parameterized.expand(
+        [
+            ("with_primary_key", {"primary_key_columns": ["id"]}, status.HTTP_200_OK),
+            ("without_primary_key", {}, status.HTTP_400_BAD_REQUEST),
+        ]
+    )
+    def test_update_schema_to_incremental_requires_primary_key(self, _name, extra_data, expected_status):
+        schema = ExternalDataSchema.objects.create(
+            name="public.orders",
+            team=self.team,
+            source=self._xmin_postgres_source(),
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+            sync_type_config={},
+        )
+
+        # Any PATCH carrying sync_type runs the webhook-only probe, which calls the source's
+        # get_schemas over the network.
+        with self._xmin_discovery_patch():
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={
+                    "sync_type": "incremental",
+                    "incremental_field": "updated_at",
+                    "incremental_field_type": "timestamp",
+                    **extra_data,
+                },
+            )
+
+        assert response.status_code == expected_status, response.json()
+        schema.refresh_from_db()
+        if expected_status == status.HTTP_200_OK:
+            assert schema.sync_type == ExternalDataSchema.SyncType.INCREMENTAL
+        else:
+            assert "primary key" in str(response.json()).lower()
+            assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+
+    def test_update_schema_to_incremental_without_primary_key_allowed_when_source_resolves_keys_at_sync_time(self):
+        # Endpoint-catalog sources leave detected_primary_keys unset and supply keys from their
+        # static endpoint config at sync time, so a missing PK here is not a broken config. Blocking
+        # them would break onboarding for the whole family of sources built that way.
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+            sync_type_config={},
+        )
+
+        with mock.patch.object(StripeSource, "get_schemas", return_value=[]):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={"sync_type": "incremental", "incremental_field": "created", "incremental_field_type": "integer"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        schema.refresh_from_db()
+        assert schema.sync_type == ExternalDataSchema.SyncType.INCREMENTAL
+
+    def test_update_schema_enable_should_sync_rejects_incremental_without_primary_key(self):
+        schema = self._incremental_schema_without_primary_key(self._xmin_postgres_source())
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={"should_sync": True},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "primary key" in str(response.json()).lower()
+        schema.refresh_from_db()
+        assert schema.should_sync is False
+
+    def test_update_schema_allows_unrelated_edit_on_incremental_without_primary_key(self):
+        # Schemas already stuck without a PK stay editable, so the owner can retune them or move
+        # them to full_refresh. Enforcing PK presence on every PATCH would reject edits that have
+        # nothing to do with the primary key.
+        schema = self._incremental_schema_without_primary_key(self._xmin_postgres_source())
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+            data={"sync_frequency": "1hour"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        schema.refresh_from_db()
+        assert schema.sync_frequency_interval == timedelta(hours=1)
 
     @parameterized.expand(
         [ExternalDataSchema.SyncType.APPEND, ExternalDataSchema.SyncType.INCREMENTAL],

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -119,8 +119,13 @@ def _configure_source_mock_versioning(mock_get_source) -> None:
 
     The update path also asks the source whether an edit introduces a new connection host or leaves
     row-backed credentials preserved; a bare MagicMock returns truthy for both, which would wrongly
-    trip the credential-reentry gate. Stub them to their real (falsy) defaults."""
+    trip the credential-reentry gate. Stub them to their real (falsy) defaults.
+
+    `detects_primary_keys` needs the same treatment: truthy would both activate the incremental
+    primary-key gate and put an unserializable MagicMock in the database_schema payload. Tests that
+    want the gate active set it to True themselves."""
     mock_get_source.return_value.default_version = "v1"
+    mock_get_source.return_value.detects_primary_keys = False
     mock_get_source.return_value.get_version_deprecation.return_value = None
     mock_get_source.return_value.max_instances_per_team = None
     mock_get_source.return_value.connection_host_fields = []
@@ -4384,8 +4389,11 @@ class TestExternalDataSource(APIBaseTest):
             ("fallback_to_detected", None, ["id"], ["id"]),
             # User explicitly overrides — caller value wins, detected is ignored.
             ("explicit_wins_over_detected", ["custom_pk"], ["id"], ["custom_pk"]),
-            # Nothing detected and nothing provided — key omitted from sync_type_config
-            # entirely (preserves pre-existing behaviour for tables without a PK).
+            # Nothing detected and nothing provided: key omitted from sync_type_config entirely,
+            # leaving the sync to resolve one. Only valid because this mocked source leaves
+            # `detects_primary_keys` False; see
+            # test_create_rejects_incremental_without_primary_key_when_source_detects_keys for a
+            # source whose discovery is authoritative.
             ("both_absent_omits_key", None, None, None),
         ]
     )
@@ -4464,6 +4472,75 @@ class TestExternalDataSource(APIBaseTest):
             assert "primary_key_columns" not in schema.sync_type_config
         else:
             assert schema.sync_type_config["primary_key_columns"] == expected_persisted
+
+    @patch("products.warehouse_sources.backend.presentation.views.external_data_source.SourceRegistry.get_source")
+    def test_create_rejects_incremental_without_primary_key_when_source_detects_keys(self, mock_get_source):
+        # An incremental schema with no key backfills fine and then fails every later run on the
+        # delta merge, so creation is refused up front. Only for sources whose discovery reports keys
+        # authoritatively: for the rest an empty key here is normal and the sync resolves one.
+        _configure_source_mock_versioning(mock_get_source)
+        source_mock = mock_get_source.return_value
+        source_mock.detects_primary_keys = True
+        source_mock.validate_config.return_value = (True, [])
+        parsed_config = Mock()
+        parsed_config.schema = "public"
+        parsed_config.to_dict.return_value = {
+            "host": "localhost",
+            "port": 5432,
+            "database": "app",
+            "user": "user",
+            "password": "pass",
+            "schema": "public",
+        }
+        source_mock.parse_config.return_value = parsed_config
+        source_mock.validate_credentials.return_value = (True, None)
+        source_mock.get_schemas.return_value = [
+            SourceSchema(
+                name="events",
+                supports_incremental=True,
+                supports_append=True,
+                incremental_fields=[
+                    {
+                        "label": "updated_at",
+                        "type": IncrementalFieldType.Timestamp,
+                        "field": "updated_at",
+                        "field_type": IncrementalFieldType.Timestamp,
+                    }
+                ],
+                detected_primary_keys=None,
+            ),
+        ]
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/",
+            data={
+                "source_type": "Postgres",
+                "payload": {
+                    "host": "localhost",
+                    "port": 5432,
+                    "database": "app",
+                    "user": "user",
+                    "password": "pass",
+                    "schema": "public",
+                    "schemas": [
+                        {
+                            "name": "events",
+                            "should_sync": True,
+                            "sync_type": "incremental",
+                            "incremental_field": "updated_at",
+                            "incremental_field_type": "timestamp",
+                            "primary_key_columns": None,
+                        },
+                    ],
+                },
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
+        assert "events" in response.json()["message"]
+        assert "primary key" in response.json()["message"].lower()
+        # The half-built source must not survive a rejected payload.
+        assert ExternalDataSource.objects.filter(team_id=self.team.pk).count() == 0
 
     @parameterized.expand(
         [
@@ -5108,6 +5185,7 @@ class TestExternalDataSource(APIBaseTest):
                     "append_available": True,
                     "cdc_available": None,
                     "xmin_available": False,
+                    "primary_key_required": True,
                     "incremental_field": "id",
                     "sync_type": None,
                     "supports_webhooks": False,
@@ -5186,6 +5264,7 @@ class TestExternalDataSource(APIBaseTest):
                     "append_available": True,
                     "cdc_available": None,
                     "xmin_available": False,
+                    "primary_key_required": True,
                     "incremental_field": "id",
                     "sync_type": None,
                     "supports_webhooks": False,


### PR DESCRIPTION
## Problem

An incremental sync merges on the primary key from the second sync onward, but nothing checked that a key was actually set.
The result is a config that looks like it worked and then never syncs again.

The initial backfill goes down the append-into-a-fresh-Delta-table branch, which never touches the key, so it succeeds.
Every run after that takes the merge branch, whose first statement is a hard `raise`:

https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py#L299-L301

So a successful first sync tells the user nothing, and they only find out one full table load later.
The runtime error message is already good and correctly non-retryable, it just arrives far too late to be actionable.

Primary keys were already required for CDC (radio option disabled in the UI, 400 on both create and update) and for xmin.
Incremental was never added to that set, even though it merges on the key the same way.

Refs #47664

## Changes

The interesting part of this change is what it does *not* reject.

"No primary key at config time" does not reliably predict "will fail on the second sync".
`build_endpoint_schemas`, the shared helper behind most REST sources, never populates `SourceSchema.detected_primary_keys` — it isn't even a parameter.
Those sources set `SourceResponse.primary_keys` from a static per-endpoint config at sync time instead, and `persist_primary_keys` writes the resolved key back after run one.
Lever's `opportunities` supports incremental, detects nothing at discovery, and resolves `["id"]` on every run.
A naive config-time check would have broken onboarding for that whole family of sources.

So this adds a `detects_primary_keys` source capability, defaulting to `False` and set only on `PostgresSource`, whose discovery reads real key constraints out of `pg_catalog`.
Postgres is the one source where an empty result is authoritative, and it is the case that actually breaks.
All three guards branch on the flag.

- **Create** and **update** reject an incremental schema with no resolvable key, reusing the wording already shipped in the runtime error map so the save-time and run-time messages agree.
- The schema payloads expose `primary_key_required`, following the `cdc_available` / `xmin_available` precedent, so the sync method form applies the same rule instead of guessing from the client side.
- The form blocks the save rather than disabling the Incremental option, because the primary key selector lives inside that panel — disabling the option would hide the only way to fix it. That is the opposite of the CDC treatment, where no key means no recovery.

> [!NOTE]
> Two deliberate behavior changes worth a look. Re-enabling `should_sync` on an already-affected Postgres schema is now rejected, since that is what produces the repeat failures. And a Postgres table with a unique `uuid` or `order_ref` but no declared constraint is now blocked at save time, because `resolve_detected_primary_keys` only falls back to a column literally named `id`. Both fail earlier and more clearly than before, and both are fixed by picking a key in the form, but neither is purely additive. Widening that fallback felt like a separate change.

Unrelated PATCHes (`sync_frequency`, `enabled_columns`) on a schema already in this state still succeed, so existing broken schemas stay editable and can be given a key or moved to full refresh.
This PR does not find or repair those schemas.

## How did you test this code?

I (Claude) ran these locally against the dev stack. No manual UI testing — the form change is covered by unit tests on the extracted validation function, not by clicking through the wizard.

- `products/warehouse_sources/backend/tests/api/` — **706 passed**
- `products/data_warehouse/frontend` — **332 passed** (21 suites)
- `tsc --noEmit`, `oxlint`, `oxfmt`, `ruff check`, `ruff format` clean on changed files

New tests and the regressions they catch:

| Test | Regression |
| --- | --- |
| `test_update_schema_to_incremental_requires_primary_key` | Switching a Postgres schema to incremental with no key is accepted again |
| `test_create_rejects_incremental_without_primary_key_when_source_detects_keys` | The create path stops rejecting it (I had only covered PATCH at first) |
| `test_update_schema_to_incremental_without_primary_key_allowed_when_source_resolves_keys_at_sync_time` | The guard widens to endpoint-catalog sources and breaks their onboarding — the main risk in this change |
| `test_update_schema_allows_unrelated_edit_on_incremental_without_primary_key` | The guard creeps onto every PATCH and strands already-affected schemas |
| `test_update_schema_enable_should_sync_rejects_incremental_without_primary_key` | A broken schema can be flipped back on without a key |
| `getSaveDisabledReason` cases | The form stops blocking, or starts blocking sources that resolve keys at sync time |

Two existing tests had to change, both meaningful rather than cosmetic:

- `test_create_postgres_incremental_primary_key_fallback[both_absent_omits_key]` documented the old contract in a comment ("preserves pre-existing behaviour for tables without a PK"). It now reads as coverage for a source that resolves keys at sync time, which is what its mock actually represents.
- `test_internal_postgres` and `test_database_schema_does_not_request_row_counts` compare the payload dict exactly. They caught a real bug: tests patching `SourceRegistry.get_source` with a bare `MagicMock` made the new field an unserializable `Mock` and returned a 500. Fixed with `bool()` at both emission sites and a `False` default in the shared mock helper, matching what `supports_row_filters` already does.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Claude Code, Opus 4.5) after I asked it to check whether we guard against incremental being set when no primary key is detected, prompted by a customer whose first full sync succeeded and whose first incremental sync then failed. It traced the asymmetry to the `is_first_sync` branch in `DeltaWriter.write` and confirmed the gap layer by layer.

The plan I approved was narrower than what shipped, and the change is better for it. It scoped a straight copy of the CDC guard. During verification Claude found that would reject valid configs for the entire `build_endpoint_schemas` source family, and flagged it instead of shipping the regression. The capability flag is the response to that. It also initially gated the form on "are the source columns known", which would have blocked MySQL and Snowflake too — hence plumbing `primary_key_required` through so the client and server share one rule rather than the client approximating it.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`.

Not done here, both worth follow-ups: finding existing incremental schemas with no `primary_key_columns` so affected customers can be reached proactively, and widening `resolve_detected_primary_keys` beyond the `id`-name fallback.
