### PR TITLE
fix(data-warehouse): record sync frequency changes on tiered teams

### DIFF
--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -690,11 +690,15 @@ class DataWarehouseSavedQuerySerializer(
                     UnsatisfiableFrequencyError,
                     UnsupportedFrequencyTargetError,
                     apply_saved_query_frequency_target,
+                    declared_targets_by_saved_query,
                 )
 
                 target = (
                     None if sync_frequency == "never" else sync_frequency_to_sync_frequency_interval(sync_frequency)
                 )
+                # Read before the write: on a tiered team the node target is where the cadence
+                # lives, so it is the only place the activity log below can learn what changed.
+                previous_target = declared_targets_by_saved_query(view.team_id, [view.pk]).get(str(view.pk))
                 try:
                     # Validates inside the transaction (a rejected frequency rolls the whole
                     # update back) and queues the schedule reconcile for after commit.
@@ -758,6 +762,20 @@ class DataWarehouseSavedQuerySerializer(
                 )
                 for change in changes
             ]
+            if dag_managed_frequency and previous_target != target:
+                # `sync_frequency_interval` stays NULL on a tiered team, so changes_between() sees
+                # no field change and log_activity would drop the whole entry as a no-op update.
+                # Same field and `str(timedelta)` shape the v1 path logs, so the describer and the
+                # sync_frequency_reset reader both keep working.
+                changes.append(
+                    Change(
+                        type="DataWarehouseSavedQuery",
+                        action="changed",
+                        field="sync_frequency_interval",
+                        before=str(previous_target) if previous_target is not None else None,
+                        after=str(target) if target is not None else None,
+                    )
+                )
             activity_log = log_activity(
                 organization_id=team.organization_id,
                 team_id=team.id,

--- a/products/data_warehouse/backend/presentation/views/saved_query.py
+++ b/products/data_warehouse/backend/presentation/views/saved_query.py
@@ -696,8 +696,6 @@ class DataWarehouseSavedQuerySerializer(
                 target = (
                     None if sync_frequency == "never" else sync_frequency_to_sync_frequency_interval(sync_frequency)
                 )
-                # Read before the write: on a tiered team the node target is where the cadence
-                # lives, so it is the only place the activity log below can learn what changed.
                 previous_target = declared_targets_by_saved_query(view.team_id, [view.pk]).get(str(view.pk))
                 try:
                     # Validates inside the transaction (a rejected frequency rolls the whole
@@ -763,10 +761,8 @@ class DataWarehouseSavedQuerySerializer(
                 for change in changes
             ]
             if dag_managed_frequency and previous_target != target:
-                # `sync_frequency_interval` stays NULL on a tiered team, so changes_between() sees
-                # no field change and log_activity would drop the whole entry as a no-op update.
-                # Same field and `str(timedelta)` shape the v1 path logs, so the describer and the
-                # sync_frequency_reset reader both keep working.
+                # The cadence lives on the DAG node, so changes_between() sees nothing and
+                # log_activity would discard the whole updated entry as a no-op.
                 changes.append(
                     Change(
                         type="DataWarehouseSavedQuery",

--- a/products/data_warehouse/backend/tests/api/test_saved_query.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query.py
@@ -746,6 +746,47 @@ class TestSavedQuery(APIBaseTest):
         # a stale v1 schedule from a half-finished migration must not be revived by the PATCH
         v1_exists.assert_not_called()
 
+    @parameterized.expand(
+        [
+            ("24hour", "12:00:00", "1 day, 0:00:00"),
+            ("never", "12:00:00", None),
+        ]
+    )
+    def test_sync_frequency_change_on_tiered_v2_is_recorded_in_the_activity_log(
+        self, sync_frequency: str, expected_before: str, expected_after: str | None
+    ):
+        # a tiered team stores the cadence on the DAG node and keeps the interval column NULL, so a
+        # frequency edit changes no model field — changes_between() returns nothing and log_activity
+        # drops an "updated" entry with no changes, leaving the edit with no audit trail at all
+        from products.data_modeling.backend.logic.node_frequency import set_declared_target
+        from products.data_modeling.backend.models import Node
+
+        saved_query = self._create_saved_query_for_frequency_tests()
+        node = Node.objects.get(saved_query_id=saved_query["id"])
+        set_declared_target(node, timedelta(hours=12))
+        reconcile_module = "products.data_modeling.backend.logic.schedule_reconcile"
+
+        with (
+            patch(
+                "products.data_warehouse.backend.presentation.views.saved_query.posthoganalytics.feature_enabled",
+                side_effect=self._v2_flag_only,
+            ),
+            patch(f"{reconcile_module}.tiered_schedules_enabled", return_value=True),
+            patch(f"{reconcile_module}.maybe_reconcile_dag"),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/warehouse_saved_queries/{saved_query['id']}",
+                {"sync_frequency": sync_frequency},
+            )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        log = ActivityLog.objects.get(scope="DataWarehouseSavedQuery", item_id=saved_query["id"], activity="updated")
+        detail = cast(dict[str, Any], log.detail)
+        frequency_changes = [change for change in detail["changes"] if change["field"] == "sync_frequency_interval"]
+        self.assertEqual(len(frequency_changes), 1, detail["changes"])
+        self.assertEqual(frequency_changes[0]["before"], expected_before)
+        self.assertEqual(frequency_changes[0]["after"], expected_after)
+
     def test_update_sync_frequency_on_tiered_v2_without_node_is_rejected(self):
         from products.data_modeling.backend.models import Node
 


### PR DESCRIPTION
## Problem

Changing a view's materialization frequency on a team using per-node DAG schedules leaves no trace in the activity log.
The edit happens, the schedule changes, and the history shows nothing.

The cause is that a tiered team stores its cadence on the DAG node and deliberately keeps `sync_frequency_interval` NULL, so a v1 schedule can never be revived from a stale column value.
A frequency edit therefore changes no model field.
`changes_between()` returns an empty change set, and `log_activity` drops any `updated` entry that has no changes, so the whole entry disappears - not just the frequency part.

This gets worse as more teams move onto per-node schedules, and it is the one field where the audit trail matters most, since the cadence is what drives compute spend.

## Changes

Read the node's declared target before writing the new one, and emit the difference as a `sync_frequency_interval` change on the existing `updated` entry.

Same field name and `str(timedelta)` value shape the v1 path already logs, so the frontend describer renders it with no change - it already maps those values to "changed sync frequency from 12 hours to 1 day".
The `sync_frequency_reset` reader, which looks up the same field, keeps working too.

Nothing else changes: no new fields, no request or response shape change, and `hogli build:openapi` regenerates to an empty diff.

## How did you test this code?

Automated tests only.

Two parameterized cases in `test_sync_frequency_change_on_tiered_v2_is_recorded_in_the_activity_log`, covering a cadence change (12h to 24h) and a pause ("never").
Both were verified red before the fix, and they fail on the real assertion - the run logs `activity_log.ignore_update_activity_no_changes` and the `ActivityLog` lookup raises `DoesNotExist`, which is the mechanism itself rather than an incidental failure.

The regression they catch that nothing else did: a frequency edit on a tiered team producing no activity-log entry at all.
Every existing tiered-frequency test asserts on the node target or the API response, so all of them still pass when the audit trail is missing.

Suite runs: `products/data_warehouse/backend/tests/api/test_saved_query.py` 91 passed, `products/data_modeling/backend/` 574 passed 1 skipped.
`ruff` clean, and repo-wide `mypy` reports no errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - this restores a missing audit-log entry, with no user-facing workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) found this while verifying in production that new teams are now born on tiered schedules.
A test project's node carried a 15 minute target while the activity log recorded only the original 24 hour materialize request, and the missing entry in between turned out to be this bug rather than the discrepancy I first suspected.

On field naming: I reused `sync_frequency_interval` rather than adding a `sync_frequency` field, because the frontend describer and the `sync_frequency_reset` reader both key off that exact field and the `str(timedelta)` format.
A new field name would have rendered as the fallback "changed sync_frequency" and needed a frontend change for no benefit.

The read has to happen before `apply_saved_query_frequency_target` writes the new target, which is why it sits a few lines above the call rather than next to the logging.

Skills invoked: `/writing-tests` (which is what pushed me to name the specific regression and fold the pause case into a parameterized pair rather than a second test) and `/improving-drf-endpoints` (which confirmed there is no schema surface here to annotate or regenerate).
