### PR TITLE
chore(ci): skip non-gating PR bots on trunk-merge branches

### DIFF
--- a/.github/workflows/auto-assign-labels.yml
+++ b/.github/workflows/auto-assign-labels.yml
@@ -32,6 +32,9 @@ concurrency:
 
 jobs:
     assign-labels:
+        # Labels derived from the queue's own PR title are discarded with the
+        # branch; the PR being queued was already labeled from its real title.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         runs-on: 'ubuntu-22.04'
         timeout-minutes: 5
 

--- a/.github/workflows/docs-preview-trigger.yml
+++ b/.github/workflows/docs-preview-trigger.yml
@@ -15,6 +15,11 @@ permissions:
 
 jobs:
     trigger-preview:
+        # The queue's branch is deleted the moment it merges, so its Vercel
+        # preview is torn down before anyone could open it. No gate coverage is
+        # lost either: the frontmatter, internal-docs and link checks below are
+        # all continue-on-error, so they never blocked a merge anyway.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         name: Trigger posthog.com preview build
         runs-on: ubuntu-latest
         timeout-minutes: 5

--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -114,6 +114,11 @@ jobs:
     # unlabeled-cancel trap: a no-op event runs only this job, never touches the
     # `preview`/`teardown` concurrency group, so it can't cancel an active build.
     decide:
+        # A preview for the queue's branch would outlive it by minutes, so the
+        # answer is always "do nothing" — skip before spending the API calls.
+        # Downstream jobs key off `needs.decide.outputs.build`, which is empty
+        # when this skips, so they stay skipped too.
+        if: ${{ !startsWith(github.head_ref, 'trunk-merge/') }}
         name: '[Optional] decide eligibility'
         runs-on: ubuntu-24.04
         timeout-minutes: 5

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -63,7 +63,9 @@ jobs:
         # No synchronize: board status only transitions on reviewer/draft
         # changes, and pushes change neither. Re-asserting the same status on
         # every push wasted the run and fought manual card moves.
-        if: contains(fromJSON('["opened", "reopened", "ready_for_review", "review_requested", "converted_to_draft"]'), github.event.action) && github.event.pull_request.head.repo.full_name == github.repository
+        # No trunk-merge/**: the queue's copy of the PR would add a second,
+        # throwaway card for work the real PR already tracks.
+        if: contains(fromJSON('["opened", "reopened", "ready_for_review", "review_requested", "converted_to_draft"]'), github.event.action) && github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.head_ref, 'trunk-merge/')
         uses: PostHog/.github/.github/workflows/flags-project-board.yml@2db3d3b946aeb9e479ce9f0078139a67f8ef38ce
         permissions:
             contents: read
@@ -76,7 +78,9 @@ jobs:
             PROJECT_BOARD_BOT_PRIVATE_KEY: ${{ secrets.PROJECT_BOARD_BOT_PRIVATE_KEY }}
 
     pr-opened:
-        if: contains(fromJSON('["opened", "ready_for_review"]'), github.event.action)
+        # The queue's PR is authored by the Trunk bot, so assigning it and
+        # nudging about the git email has nobody to reach.
+        if: contains(fromJSON('["opened", "ready_for_review"]'), github.event.action) && !startsWith(github.head_ref, 'trunk-merge/')
         uses: ./.github/workflows/pr-opened.yml
         permissions:
             pull-requests: write

--- a/.github/workflows/pr-posthog-js-reviewer.yml
+++ b/.github/workflows/pr-posthog-js-reviewer.yml
@@ -27,7 +27,10 @@ jobs:
         # Skip forks for security - they could manipulate package.json to trigger unwanted reviews.
         # Only request reviewers for PRs targeting master. Stacked PR diffs can include package.json
         # changes from the stack base and leave stale reviewer requests after the PR is retargeted.
+        # Skip trunk-merge/**: requesting a review on the queue's throwaway PR
+        # pings the client-libraries team for a copy nobody will look at.
         if: >-
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             github.event.pull_request.head.repo.fork == false &&
             github.event.pull_request.base.ref == 'master' &&
             (github.event.action != 'edited' || github.event.changes.base.ref.from != '')


### PR DESCRIPTION
## Problem

Our shared `github_token` rate-limit bucket (30k req/hr, per-repo, not adjustable) has been running hot since the Trunk merge queue went in, peaking at 100% on Jul 30.

The queue opens its own PR per attempt, and I measured what that costs. Over the last 24h:

| Metric | Value |
| --- | --- |
| trunk-merge PRs opened | 463 |
| PRs actually merged | 257 |
| Queue attempts per merge | 1.80x |
| Workflow runs per trunk-merge PR | 42 |

So every merged PR pays for roughly two full CI matrices, and a chunk of that fan-out is not CI at all. A handful of PR housekeeping jobs treat the queue's ephemeral PR like a real one.

## Changes

Six jobs now skip when `github.head_ref` starts with `trunk-merge/`:

| Workflow | Job | What it was doing on the queue's PR |
| --- | --- | --- |
| `pr-housekeeping.yml` | `flags-project-board` | Adding a second, throwaway card for work the real PR already tracks |
| `pr-housekeeping.yml` | `pr-opened` | Assigning the Trunk bot and nudging it about its git email |
| `auto-assign-labels.yml` | `assign-labels` | Deriving labels from a title like `trunk-merge/pr-70624/<uuid>` |
| `pr-posthog-js-reviewer.yml` | `check-posthog-js` | Requesting a client-libraries review on a copy nobody opens |
| `docs-preview-trigger.yml` | `trigger-preview` | Building a Vercel docs preview for a branch deleted minutes later |
| `hogbox-preview-env.yml` | `decide` | Deciding eligibility for a preview that would outlive its branch by minutes |

That is about 6 jobs per queue attempt, so roughly 2,800 jobs a day at the current rate, plus the Vercel builds and the reviewer and project-board noise.

> [!NOTE]
> No test workflow is touched. Re-running those against latest master is the entire point of the queue, so stripping them would trade rate limit for merge safety. This PR only removes work that produces no verification signal and whose output is discarded with the branch.

`hogbox-preview-env.yml` is the only one with dependents, and they are safe: `announce`, `build-frontend`, `deploy` and `teardown` all key off `needs.decide.outputs.build == 'true'`, which is empty when `decide` skips, so they stay skipped. There is no required-check gate in that workflow.

## How did you test this code?

No new tests. This is a set of `if:` guards on existing jobs, and the behavior it changes only reproduces inside the merge queue, which cannot be exercised from a branch.

What I actually ran:

- `bin/hogli lint:workflows` - all 7 checks pass across 124 workflows, including `WF007-required-check-gates`
- `actionlint` on all five edited files - clean (one pre-existing `SC2001` style hit in `pr-posthog-js-reviewer.yml` at an unrelated line, unchanged by this PR)
- `hogli ci:preflight --strict` via the pre-push hook - pass

I verified the guard conditions against live data rather than assuming them. Across 8 recent closed trunk-merge PRs, all had `merged: false`, zero labels, and draft status. That is what makes the guarded set correct, and it is also why I did not guard more.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed, no user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (Opus 5, Claude Code) to work out why the queue was pushing our token bucket toward the cap and to fix the cheapest layer of it. Skills invoked: `/authoring-ci-workflows`.

The first pass at this list was wrong and worth flagging for review. Claude built it from run-level `conclusion: success` on a sample trunk-merge PR, which also shows up when every job in a run skipped. Pulling job-level results cut the list roughly in half: `Inkeep Agent`, `Closed PR`, `Priority Review Slack Notifications`, `Desktop Tag Release`, `Auto Assign Reviewers` and `Desktop PR Build Installer` all already run zero jobs, because their existing merged, label and draft gates catch the queue's PR for free. Only the six above genuinely execute.

Two things we looked at and deliberately left alone:

- The container image CD workflows (`Tasks Sandbox`, `node`, `recording-rasterizer`, `ml-mirror-image-scrub`) do execute real jobs on trunk-merge branches, but they are build verification, so skipping them would cost gate coverage. Separately, `ci-ml-mirror-image-scrub-container.yml` has a bare unfiltered `pull_request:` trigger and fires on every PR in the repo, which looks like its own cleanup.
- `Desktop React Doctor` and `Desktop Agent Release Verify` each run one real job on the queue's PR. Both are verification, so they stay.

This is the smallest of four levers we identified. The larger ones are the 1.80x requeue ratio (a Trunk batching and flake-pressure question) and finishing the App-token offload, where about 20 `pnpm-install` call sites still fall back to `github.token` and there is no alert when an app-token mint fails and silently dumps a whole matrix onto the shared bucket. Those are follow-ups, not in this PR.
