### PR TITLE
feat(experiments): emit experiment metric retry event from recalc orchestrator

### DIFF
--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -756,6 +756,22 @@ def _calculate_experiment_metric_for_recalculation_sync(
                     _safe_retry_message(e, error_type),
                     CONCURRENCY_LIMIT_RETRY_DELAY_SECONDS,
                 )
+                _capture_experiment_metric_event(
+                    experiment,
+                    metric_uuid,
+                    metric_type,
+                    metric_dict,
+                    "experiment metric retry",
+                    {
+                        "duration_ms": round((time.perf_counter() - calc_started_at) * 1000),
+                        "error_type": error_type,
+                        "error_message": message,
+                        "attempt": attempt,
+                        "max_attempts": MAX_METRIC_ATTEMPTS,
+                        "next_retry_delay_seconds": CONCURRENCY_LIMIT_RETRY_DELAY_SECONDS,
+                    },
+                    trigger=state.trigger,
+                )
             raise ApplicationError(
                 message,
                 type=type(e).__name__,
@@ -810,13 +826,30 @@ def _calculate_experiment_metric_for_recalculation_sync(
             if is_final_attempt or is_permanent:
                 _clear_retry(recalculation_id, metric_uuid)
             else:
+                retry_delay_seconds = _estimated_retry_delay_seconds(attempt)
                 _record_retry(
                     recalculation_id,
                     metric_uuid,
                     attempt,
                     error_type,
                     _safe_retry_message(e, error_type),
-                    _estimated_retry_delay_seconds(attempt),
+                    retry_delay_seconds,
+                )
+                _capture_experiment_metric_event(
+                    experiment,
+                    metric_uuid,
+                    metric_type,
+                    metric_dict,
+                    "experiment metric retry",
+                    {
+                        "duration_ms": round((time.perf_counter() - calc_started_at) * 1000),
+                        "error_type": error_type,
+                        "error_message": message,
+                        "attempt": attempt,
+                        "max_attempts": MAX_METRIC_ATTEMPTS,
+                        "next_retry_delay_seconds": retry_delay_seconds,
+                    },
+                    trigger=state.trigger,
                 )
             if is_permanent:
                 raise ApplicationError(message, type=error_type, non_retryable=True) from e

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -748,12 +748,13 @@ def _calculate_experiment_metric_for_recalculation_sync(
             else:
                 # Exact, not estimated: this branch sets the delay explicitly via next_retry_delay.
                 error_type = classify_experiment_query_error(e)
+                safe_message = _safe_retry_message(e, error_type)
                 _record_retry(
                     recalculation_id,
                     metric_uuid,
                     attempt,
                     error_type,
-                    _safe_retry_message(e, error_type),
+                    safe_message,
                     CONCURRENCY_LIMIT_RETRY_DELAY_SECONDS,
                 )
                 _capture_experiment_metric_event(
@@ -765,7 +766,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                     {
                         "duration_ms": round((time.perf_counter() - calc_started_at) * 1000),
                         "error_type": error_type,
-                        "error_message": message,
+                        "error_message": safe_message,
                         "attempt": attempt,
                         "max_attempts": MAX_METRIC_ATTEMPTS,
                         "next_retry_delay_seconds": CONCURRENCY_LIMIT_RETRY_DELAY_SECONDS,
@@ -827,12 +828,13 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 _clear_retry(recalculation_id, metric_uuid)
             else:
                 retry_delay_seconds = _estimated_retry_delay_seconds(attempt)
+                safe_message = _safe_retry_message(e, error_type)
                 _record_retry(
                     recalculation_id,
                     metric_uuid,
                     attempt,
                     error_type,
-                    _safe_retry_message(e, error_type),
+                    safe_message,
                     retry_delay_seconds,
                 )
                 _capture_experiment_metric_event(
@@ -844,7 +846,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                     {
                         "duration_ms": round((time.perf_counter() - calc_started_at) * 1000),
                         "error_type": error_type,
-                        "error_message": message,
+                        "error_message": safe_message,
                         "attempt": attempt,
                         "max_attempts": MAX_METRIC_ATTEMPTS,
                         "next_retry_delay_seconds": retry_delay_seconds,

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -1097,19 +1097,38 @@ class TestRecalculationAnalytics(BaseTest):
 
     @parameterized.expand(
         [
-            # (name, exc, expected_error_type, expected_delay_seconds) — backpressure uses the explicit
-            # concurrency delay; a generic transient on attempt 2 follows the policy backoff (5 * 2^1).
-            ("backpressure", ConcurrencyLimitExceeded("quota"), "rate_limited", 60),
-            ("generic_transient", RuntimeError("kaboom"), "server_error", 10),
+            # (name, exc, expected_error_type, expected_delay_seconds, expected_message) — backpressure uses
+            # the explicit concurrency delay; a generic transient on attempt 2 follows the policy backoff
+            # (5 * 2^1). The generic exception carries a fake credential to lock in that raw exception text
+            # (which can embed the executed query, warehouse secrets included) never reaches analytics.
+            (
+                "backpressure",
+                ConcurrencyLimitExceeded("quota"),
+                "rate_limited",
+                60,
+                "The query was deferred because the cluster is at capacity.",
+            ),
+            (
+                "generic_transient",
+                RuntimeError("blip aws_access_key_id=AKIAFAKESECRET"),
+                "server_error",
+                10,
+                "The query failed with a server error.",
+            ),
         ]
     )
     def test_non_final_failure_emits_retry_event(
-        self, name: str, exc: Exception, expected_error_type: str, expected_delay_seconds: int
+        self,
+        name: str,
+        exc: Exception,
+        expected_error_type: str,
+        expected_delay_seconds: int,
+        expected_message: str,
     ):
         # A non-final attempt re-raises for Temporal to retry. It emits 'experiment metric retry' (not
         # 'experiment metric error', which is reserved for the terminal attempt) so retries that later
-        # succeed are still countable. Guards against dropping the retry emit or double-counting a
-        # non-terminal failure as an error.
+        # succeed are still countable. Guards against dropping the retry emit, double-counting a
+        # non-terminal failure as an error, and leaking the raw exception (secrets included) into analytics.
         exp = self._experiment(flag_key=f"an-retry-{name}", metrics=[_mean_metric("m1")])
         recalc = self._recalc(exp, metric_uuids=["m1"])
 
@@ -1125,6 +1144,8 @@ class TestRecalculationAnalytics(BaseTest):
         assert captured[0]["event"] == "experiment metric retry"
         props = captured[0]["properties"]
         assert props["error_type"] == expected_error_type
+        assert props["error_message"] == expected_message
+        assert "AKIAFAKESECRET" not in props["error_message"]
         assert props["attempt"] == 2
         assert props["max_attempts"] == MAX_METRIC_ATTEMPTS
         assert props["next_retry_delay_seconds"] == expected_delay_seconds

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -1095,21 +1095,41 @@ class TestRecalculationAnalytics(BaseTest):
 
         assert captured[0]["properties"]["is_primary"] is False
 
-    def test_non_final_failure_emits_no_per_metric_event(self):
-        # A non-final attempt re-raises for Temporal to retry; emitting there would double-count a
-        # failure that may still succeed on a later attempt. Only the terminal attempt emits.
-        exp = self._experiment(flag_key="an-transient", metrics=[_mean_metric("m1")])
+    @parameterized.expand(
+        [
+            # (name, exc, expected_error_type, expected_delay_seconds) — backpressure uses the explicit
+            # concurrency delay; a generic transient on attempt 2 follows the policy backoff (5 * 2^1).
+            ("backpressure", ConcurrencyLimitExceeded("quota"), "rate_limited", 60),
+            ("generic_transient", RuntimeError("kaboom"), "server_error", 10),
+        ]
+    )
+    def test_non_final_failure_emits_retry_event(
+        self, name: str, exc: Exception, expected_error_type: str, expected_delay_seconds: int
+    ):
+        # A non-final attempt re-raises for Temporal to retry. It emits 'experiment metric retry' (not
+        # 'experiment metric error', which is reserved for the terminal attempt) so retries that later
+        # succeed are still countable. Guards against dropping the retry emit or double-counting a
+        # non-terminal failure as an error.
+        exp = self._experiment(flag_key=f"an-retry-{name}", metrics=[_mean_metric("m1")])
         recalc = self._recalc(exp, metric_uuids=["m1"])
 
         with _record_captures() as captured:
             with patch(
                 "products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner"
             ) as mock_runner:
-                mock_runner.return_value.run.side_effect = RuntimeError("kaboom")
-                with pytest.raises(RuntimeError, match="kaboom"):
-                    _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO, is_final_attempt=False)
+                mock_runner.return_value.run.side_effect = exc
+                with pytest.raises((type(exc), ApplicationError)):
+                    _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO, is_final_attempt=False, attempt=2)
 
-        assert captured == []
+        assert len(captured) == 1
+        assert captured[0]["event"] == "experiment metric retry"
+        props = captured[0]["properties"]
+        assert props["error_type"] == expected_error_type
+        assert props["attempt"] == 2
+        assert props["max_attempts"] == MAX_METRIC_ATTEMPTS
+        assert props["next_retry_delay_seconds"] == expected_delay_seconds
+        assert props["execution_mode"] == "recalculation"
+        assert props["mechanism"] == "orchestrated"
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The recalculation workflow retries a metric when a query fails transiently (ClickHouse backpressure, a generic transient error), and those retries are the whole point of the workflow's reliability design. We had no way to count them. The transient `metric_retries` column is wiped on the metric's terminal write, and `experiment metric error` only fires on the final attempt, so a metric that retried and then succeeded left no trace anywhere in product analytics. We could not answer "does the new workflow retry more or less over time?".

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

This PR adds a new `experiment metric retry` product analytics event, emitted from the recalculation orchestrator on every non-terminal retry.

### Retry event

The event fires from both non-terminal retry branches in `_calculate_experiment_metric_for_recalculation_sync`: the `ConcurrencyLimitExceeded` / `ClickHouseAtCapacity` backpressure branch (explicit retry delay) and the generic transient branch (policy backoff). It reuses `_capture_experiment_metric_event`, so it inherits `execution_mode=recalculation`, `context=ui`, `mechanism=orchestrated`, `trigger`, and the org/team groups, and carries retry-specific properties: `attempt`, `max_attempts`, `error_type`, `error_message`, `next_retry_delay_seconds`, `duration_ms`.

The orchestrator owns retries, so the orchestrator owns the event. This keeps the taxonomy clean: `experiment metric retry` is a non-terminal attempt (the metric may still succeed), `experiment metric error` stays reserved for the terminal, user-facing load failure. Emitting from the query runner instead would count every attempt as a failure, since the runner has no `is_final_attempt` context.

- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/temporal/test_recalculation_activities.py`

> [!NOTE]
> This is a new event, so there is no historical data. The retry trend starts accumulating from deploy.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/9fa96413-af4e-4ff9-a50b-cdee48e6e67f)

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **no**

Skills used:

- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Added a new `experiment metric retry` event rather than reusing `experiment metric error`. Reusing it would double-count failures on the terminal-failure dashboards, since a retried-then-succeeded metric is not a failure.
- Emitted from the orchestrator, not the query runner. The runner runs once per attempt with `user_facing=False` under recalc and cannot tell it is about to be retried; only the orchestrator knows `is_final_attempt`.
- Repurposed the existing `test_non_final_failure_emits_no_per_metric_event` (which asserted the old "retries emit nothing" contract) into a parameterized test asserting the retry event fires across both retry branches, rather than adding a separate test.