### PR TITLE
chore(ci): offload hot setup-action calls and alert on mint failures

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1258,6 +1258,8 @@ jobs:
               run: |
                   # Same as above, except now for CH looking at files that were added in posthog/clickhouse/migrations/
                   git diff --name-status origin/master..HEAD | grep "A\sposthog/clickhouse/migrations/" | grep -v README | awk '{print $2}' | python manage.py test_ch_migrations_are_safe
+            # Shadow trial: canonical threads a setup-action app token into
+            # pnpm-install; mint stripped here (secret not available on Depot).
             - name: Install package.json dependencies with pnpm
               uses: ./.depot/actions/pnpm-install
               with:
@@ -1675,6 +1677,10 @@ jobs:
               shell: bash
               run: |
                   UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+            # Shadow trial: canonical precedes this with a setup-node step (.nvmrc,
+            # threading a setup-action app token). The shadow has never mirrored that
+            # step and runs npm on the runner's ambient Node, so the token threading
+            # has nothing to mirror here.
             - name: Install canvas builder dependencies
               if: ${{ needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' }}
               shell: bash

--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -10,6 +10,7 @@
 
 const POSTHOG_HOST = 'https://us.i.posthog.com'
 const EVENT_NAME = 'github_rate_limit_observed'
+const MINT_FAILURE_EVENT_NAME = 'github_app_token_mint_failed'
 const DEFAULT_SOURCE = 'github_token'
 
 async function captureEvent({ fetchImpl, posthogToken, event, distinctId, properties, timestamp }) {
@@ -77,6 +78,53 @@ function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, re
     }
 }
 
+// Every App-token mint in the workflows is `continue-on-error`, and every
+// consumer reads `steps.<mint>.outputs.token || github.token`. That combination
+// degrades silently: a broken App credential leaves the run green while the
+// bucket's entire call volume moves onto the shared per-repo GITHUB_TOKEN — a
+// whole matrix's worth of stampede that only shows up downstream as an
+// unexplained burn. Emitting the failure makes the fallback alertable.
+async function reportMintFailures({ context, core }, { mints, now: _now, fetch: _fetch } = {}) {
+    const posthogToken = process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN
+    if (!posthogToken) {
+        core.warning('POSTHOG_DEVEX_PROJECT_API_TOKEN not set; nothing to emit')
+        core.setOutput('mint_failures', '0')
+        return []
+    }
+
+    const fetchImpl = _fetch || fetch
+    const observedAt = (_now ? _now() : new Date()).toISOString()
+    const repo = `${context.repo.owner}/${context.repo.repo}`
+    // An App whose secrets aren't configured yet is a deliberate no-op, not a
+    // failure — only a configured App that handed back no token is broken.
+    const failed = (mints || []).filter((mint) => mint.configured && !mint.minted)
+
+    for (const { source } of failed) {
+        core.warning(`App token mint failed for ${source}; its callers fell back to the shared GITHUB_TOKEN bucket`)
+        try {
+            await captureEvent({
+                fetchImpl,
+                posthogToken,
+                event: MINT_FAILURE_EVENT_NAME,
+                distinctId: repo,
+                properties: {
+                    repo,
+                    source,
+                    observed_at: observedAt,
+                    workflow_run_id: process.env.GITHUB_RUN_ID || null,
+                },
+                timestamp: observedAt,
+            })
+        } catch (err) {
+            core.warning(`Failed to emit mint failure for ${source}: ${err.message}`)
+        }
+    }
+
+    core.info(`${failed.length} App token mint failure(s)`)
+    core.setOutput('mint_failures', String(failed.length))
+    return failed.map(({ source }) => source)
+}
+
 module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch, source: _source } = {}) => {
     const source = _source || DEFAULT_SOURCE
     const fetchImpl = _fetch || fetch
@@ -128,3 +176,4 @@ module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch, s
 module.exports.buildProperties = buildProperties
 module.exports.buildTrigger = buildTrigger
 module.exports.captureEvent = captureEvent
+module.exports.reportMintFailures = reportMintFailures

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -191,6 +191,69 @@ describe('monitor-github-rate-limit', () => {
         })
     }
 
+    // The `configured` flag is the whole reason this isn't just `!minted`: the
+    // Apps are rolled out one org secret at a time, so an App with no secrets
+    // yet reports exactly like one whose credential broke. Collapsing the two
+    // would alert on every run until the last secret landed.
+    for (const [configured, minted, expectedEmissions] of [
+        [true, false, 1],
+        [true, true, 0],
+        [false, false, 0],
+    ]) {
+        it(`emits ${expectedEmissions} mint failure(s) when configured=${configured} minted=${minted}`, async () => {
+            process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+            const captured = []
+            const fetchMock = recordingFn((_url, opts) => {
+                captured.push(JSON.parse(opts.body))
+                return fetchOk()
+            })
+            const core = createCore()
+
+            const failed = await monitor.reportMintFailures(
+                { context, core },
+                {
+                    mints: [{ source: 'posthog-setup-actions', configured, minted }],
+                    now: () => T_BASE,
+                    fetch: fetchMock,
+                }
+            )
+
+            assert.equal(captured.length, expectedEmissions)
+            assert.equal(failed.length, expectedEmissions)
+            assert.ok(calledWith(core.setOutput, 'mint_failures', String(expectedEmissions)))
+        })
+    }
+
+    it('names the broken bucket in the mint failure payload', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        const captured = []
+        const fetchMock = recordingFn((_url, opts) => {
+            captured.push(JSON.parse(opts.body))
+            return fetchOk()
+        })
+        const core = createCore()
+
+        await monitor.reportMintFailures(
+            { context, core },
+            {
+                mints: [
+                    { source: 'posthog-tests', configured: true, minted: true },
+                    { source: 'posthog-paths-filter', configured: true, minted: false },
+                ],
+                now: () => T_BASE,
+                fetch: fetchMock,
+            }
+        )
+
+        assert.equal(captured.length, 1)
+        assertMatch(captured[0], {
+            api_key: 'devex-key',
+            event: 'github_app_token_mint_failed',
+            distinct_id: 'PostHog/posthog',
+            properties: { repo: 'PostHog/posthog', source: 'posthog-paths-filter' },
+        })
+    })
+
     it('skips emission when devex token is not configured', async () => {
         const fetchMock = recordingFn(fetchOk)
         const github = createGithubMock({ core: snapshot({ remaining: 1, limit: 15000 }) })

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -428,6 +428,11 @@ jobs:
                       echo "migrations_key=posthog-schema-mig-${SCHEMA_CACHE_EPOCH}-${MIG_HASH}" >> $GITHUB_OUTPUT
                   fi
 
+            # Dedicated app: every "Mint setup-action GitHub token" step in this file
+            # draws on posthog-devex-general rather than the posthog-setup-actions app
+            # the other workflows share. Backend CI is the largest single consumer of
+            # setup-action calls in the repo, enough to threaten a shared 15k/hr bucket
+            # at merge peaks, so it gets one to itself.
             - name: Mint setup-action GitHub token
               id: setup-gh-token
               if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2035,6 +2035,7 @@ jobs:
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/root --filter=@posthog/frontend... --filter=@posthog/mcp... install --frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Wait for Docker services
               env:
@@ -2630,6 +2631,7 @@ jobs:
               uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
               with:
                   node-version-file: .nvmrc
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install canvas builder dependencies
               if: ${{ needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' }}

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -329,10 +329,21 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/playwright... install --frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Prepare frontend
               run: bin/turbo --filter=@posthog/frontend prepare
@@ -626,10 +637,21 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/playwright... install --no-frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Prepare frontend
               run: bin/turbo --filter=@posthog/frontend prepare
@@ -818,11 +840,23 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             # Full workspace install: the suite's jsdom test environment resolves
             # through the workspace root, not the package's own dependencies, so a
             # filtered install can't run it.
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
+              with:
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Test with Jest
               id: run-jest

--- a/.github/workflows/ci-mcp-ui-apps.yml
+++ b/.github/workflows/ci-mcp-ui-apps.yml
@@ -66,11 +66,22 @@ jobs:
                   cache-dependency-glob: uv.lock
                   save-cache: ${{ github.ref == 'refs/heads/master' }}
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               # Match services/mcp/Dockerfile exactly
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/mcp... install --frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Check generated UI apps are up to date
               run: |

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -222,10 +222,21 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/mcp... --filter='./products/*' install --frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             # The workers-pool project in vitest.config.mts parses wrangler.jsonc
             # up front and needs `assets.directory` (./public/) populated and

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -143,10 +143,21 @@ jobs:
               with:
                   clean: false
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/nodejs... install --frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install rust
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
@@ -197,10 +208,21 @@ jobs:
               with:
                   clean: false
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/nodejs... install --frozen-lockfile
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install rust
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9

--- a/.github/workflows/ci-turbo.yml
+++ b/.github/workflows/ci-turbo.yml
@@ -49,10 +49,21 @@ jobs:
                     echo "TURBO_SCM_BASE=master" >> $GITHUB_ENV
                   fi
 
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Install pnpm dependencies
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm install --frozen-lockfile --filter=@posthog/root
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Turbo Affected
               run: |

--- a/.github/workflows/monitor-github-rate-limit.yml
+++ b/.github/workflows/monitor-github-rate-limit.yml
@@ -215,3 +215,26 @@ jobs:
                   script: |
                       const script = require('./.github/scripts/monitor-github-rate-limit.js')
                       await script({ github, context, core }, { source: 'posthog-product-tests' })
+
+            # A mint that fails is invisible from the buckets alone: the poll for
+            # that source is simply absent, which looks the same as an App whose
+            # secrets were never configured. Report the two apart so a broken
+            # credential — which silently redirects that App's whole call volume
+            # onto the shared GITHUB_TOKEN bucket — can be alerted on downstream.
+            # Only booleans are interpolated here, never the tokens themselves.
+            - name: Report App token mint failures
+              if: always()
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              env:
+                  POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
+                  MINTS: >-
+                      [{"source":"posthog-devex-general","configured":${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_APP_ID != '' }},"minted":${{ steps.devex-token.outputs.token != '' }}},
+                      {"source":"posthog-tests","configured":${{ secrets.GH_APP_POSTHOG_TESTS_APP_ID != '' }},"minted":${{ steps.tests-token.outputs.token != '' }}},
+                      {"source":"posthog-paths-filter","configured":${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID != '' }},"minted":${{ steps.paths-filter-token.outputs.token != '' }}},
+                      {"source":"posthog-telemetry","configured":${{ secrets.GH_APP_TELEMETRY_APP_ID != '' }},"minted":${{ steps.telemetry-token.outputs.token != '' }}},
+                      {"source":"posthog-setup-actions","configured":${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID != '' }},"minted":${{ steps.setup-actions-token.outputs.token != '' }}},
+                      {"source":"posthog-product-tests","configured":${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID != '' }},"minted":${{ steps.product-tests-token.outputs.token != '' }}}]
+              with:
+                  script: |
+                      const script = require('./.github/scripts/monitor-github-rate-limit.js')
+                      await script.reportMintFailures({ github, context, core }, { mints: JSON.parse(process.env.MINTS) })

--- a/.github/workflows/monitor-github-rate-limit.yml
+++ b/.github/workflows/monitor-github-rate-limit.yml
@@ -228,12 +228,12 @@ jobs:
               env:
                   POSTHOG_DEVEX_PROJECT_API_TOKEN: ${{ secrets.POSTHOG_DEVEX_PROJECT_API_TOKEN }}
                   MINTS: >-
-                      [{"source":"posthog-devex-general","configured":${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_APP_ID != '' }},"minted":${{ steps.devex-token.outputs.token != '' }}},
-                      {"source":"posthog-tests","configured":${{ secrets.GH_APP_POSTHOG_TESTS_APP_ID != '' }},"minted":${{ steps.tests-token.outputs.token != '' }}},
-                      {"source":"posthog-paths-filter","configured":${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID != '' }},"minted":${{ steps.paths-filter-token.outputs.token != '' }}},
-                      {"source":"posthog-telemetry","configured":${{ secrets.GH_APP_TELEMETRY_APP_ID != '' }},"minted":${{ steps.telemetry-token.outputs.token != '' }}},
-                      {"source":"posthog-setup-actions","configured":${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID != '' }},"minted":${{ steps.setup-actions-token.outputs.token != '' }}},
-                      {"source":"posthog-product-tests","configured":${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID != '' }},"minted":${{ steps.product-tests-token.outputs.token != '' }}}]
+                      [{"source":"posthog-devex-general","configured":${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_APP_ID != '' && secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY != '' }},"minted":${{ steps.devex-token.outputs.token != '' }}},
+                      {"source":"posthog-tests","configured":${{ secrets.GH_APP_POSTHOG_TESTS_APP_ID != '' && secrets.GH_APP_POSTHOG_TESTS_PRIVATE_KEY != '' }},"minted":${{ steps.tests-token.outputs.token != '' }}},
+                      {"source":"posthog-paths-filter","configured":${{ secrets.GH_APP_POSTHOG_PATHS_FILTER_APP_ID != '' && secrets.GH_APP_POSTHOG_PATHS_FILTER_PRIVATE_KEY != '' }},"minted":${{ steps.paths-filter-token.outputs.token != '' }}},
+                      {"source":"posthog-telemetry","configured":${{ secrets.GH_APP_TELEMETRY_APP_ID != '' && secrets.GH_APP_TELEMETRY_PRIVATE_KEY != '' }},"minted":${{ steps.telemetry-token.outputs.token != '' }}},
+                      {"source":"posthog-setup-actions","configured":${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID != '' && secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY != '' }},"minted":${{ steps.setup-actions-token.outputs.token != '' }}},
+                      {"source":"posthog-product-tests","configured":${{ secrets.GH_APP_POSTHOG_PRODUCT_TESTS_APP_ID != '' && secrets.GH_APP_POSTHOG_PRODUCT_TESTS_PRIVATE_KEY != '' }},"minted":${{ steps.product-tests-token.outputs.token != '' }}}]
               with:
                   script: |
                       const script = require('./.github/scripts/monitor-github-rate-limit.js')


### PR DESCRIPTION
## Problem

Follow-up to #77600 on the same `github_token` rate-limit work. Two gaps in the App-token offload.

**1. The hottest per-PR jobs were still on the shared bucket.** `setup-node` resolves `.nvmrc` through `api.github.com`, and I confirmed from a live run log that it is a real call every time. `.nvmrc` pins `v24.13.0`, which the runner images do not ship, so setup-node never finds it in the tool cache:

```
Attempting to download 24.13.0...
Acquiring 24.13.0 - x64 from https://github.com/actions/node-versions/releases/download/...
```

Manifest lookup, then a fresh download, on every Node job. The `posthog-setup-actions` App bucket exists exactly for this and is sitting around 20% utilization, but a set of per-PR jobs never routed through it.

**2. A failed App-token mint is invisible.** Every mint is `continue-on-error` and every consumer reads `steps.<mint>.outputs.token || github.token`. So a broken credential keeps the run green while that App's entire call volume silently relocates onto the shared 30k bucket. The buckets alone cannot show this: a failed mint and an App whose secrets were never configured both look identical downstream, because both just stop emitting samples for that source.

## Changes

**Routing.** Per-PR jobs in `ci-frontend` (3), `ci-nodejs` (2), `ci-turbo`, `ci-mcp` and `ci-mcp-ui-apps` now pass the setup-actions App token. The two `ci-backend` jobs already minted a token and simply were not passing it, so those are one line each.

Correcting an earlier claim here: those two `ci-backend` sites do **not** land on setup-actions. Backend CI mints from `posthog-devex-general`, and has since before the setup-actions App existed. Either way the calls come off the shared 30k `github_token` bucket, which is the goal, and the split should stay: measured over the last seven days, devex-general is the hottest App bucket in the repo and setup-actions the one with headroom, so folding Backend CI's volume in would exhaust the shared bucket at merge peaks. Every mint step in that file is named "Mint setup-action GitHub token", so the name alone reads as a mismatch — there is now a comment at the first one recording why it is deliberate.

**Depot shadow.** The two `ci-backend` lines above tripped the shadow drift check. Both are depot-exempt, documented at the matching sites in `.depot/workflows/ci-backend.yml`: the shadow has no setup-actions secret to mint from, and it never mirrored canonical's canvas `setup-node` step in the first place, so there is no token to thread in either case. Worth a look separately — that missing `setup-node` means the shadow's Core shards run `npm ci` on the runner's ambient Node and skip the `.nvmrc` download that canonical pays for, which is a timing skew in a timing trial.

**Mint telemetry.** `reportMintFailures` emits `github_app_token_mint_failed` from the monitor workflow, naming the bucket whose callers fell back. The `configured` flag is what keeps it quiet during rollout:

```diff
- failed = mints.filter(m => !m.minted)                    // pages on every unconfigured App
+ failed = mints.filter(m => m.configured && !m.minted)    // only a real credential failure
```

Only booleans are interpolated into the step env, never the tokens.

> [!NOTE]
> This needs a downstream PostHog alert on `github_app_token_mint_failed` to be useful. The event is the prerequisite; I have not created the alert or the insight yet. Wiring it the same way as the existing burn-rate alert is the obvious next step.

## How did you test this code?

`node --test .github/scripts/monitor-github-rate-limit.test.js` - 12 pass, 0 fail.

Four new cases, all pure-function, no I/O:

- Three parameterized rows over `(configured, minted)`. These guard the `configured` flag specifically. If someone simplifies the filter to `!minted`, the `configured=false` row fails - which is the regression that would otherwise page the team on every run until the last org secret landed.
- One payload case asserting the event name and that the failing bucket is named, with a healthy bucket alongside it. If the emitter breaks, nothing else catches it, since the whole point of the event is to surface a failure that is invisible everywhere else.

I did not add tests for the workflow routing, since there is nothing to assert beyond the YAML itself. Instead I verified mechanically:

- `bin/hogli lint:workflows` - 7/7 checks pass across 124 workflows
- `actionlint` on all seven edited workflows - clean, apart from a pre-existing `SC2086` in `ci-backend.yml` at line 3285, far from anything this PR touches
- Parsed the workflow with PyYAML and confirmed the folded `MINTS` env renders to valid JSON for all six buckets
- Re-ran the inventory script that found the gaps: all six hot workflows now report zero `pnpm-install` or `setup-node` sites falling back to `github.token`

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus 5, Claude Code) did the investigation and the edits. Skills invoked: `/authoring-ci-workflows`, `/writing-tests`.

Worth flagging for review: the original plan was to convert all 70 call sites that fall back to `github.token`. Mapping each site to its enclosing job and matrix size showed that was wrong. The heavy matrices already pass App tokens, and essentially every remaining site is a `matrix=1` job in a release, publish or weekly-cron workflow. Converting those would mean adding 70 mint steps to save roughly one API call each, which is the over-isolation `/authoring-ci-workflows` explicitly warns against ("a long tail of light workflows can share `GITHUB_TOKEN`"). So this PR converts the per-PR hot paths only and leaves the tail alone.

Two other things we checked and dropped. The two unguarded `paths-filter` sites in `container-images-cd.yml` looked like a gap, but that workflow is push-only, so `paths-filter` uses git rather than the paginated PR files API and costs nothing. And #4 on our list was "add a seventh App bucket" - not needed. `posthog-setup-actions` has roughly 80% headroom, so the right move is routing load onto it rather than minting another App. A new App is worth it when an existing bucket crosses ~60% sustained.

The larger remaining lever is unchanged from #77600: the 1.80x queue-attempt-per-merge ratio. Separately, `.nvmrc` pinning a Node the runner images do not ship costs a manifest call plus a download and extract on all ~51 Node jobs. Aligning it with the image, or baking the version into the Depot image, would remove that everywhere and save wall-clock too. That is a repo-wide change with its own tradeoffs, so I left it out.

