### PR TITLE
fix(notebooks): drop run_id line and lift the dataframe name row

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1209,17 +1209,17 @@ snapshots:
     components-markdown-editor-rich--with-markdown--light:
         hash: v1.k794b7964.98bef7667e05e7a86864149a5db5c24b3d4733bcef7d413ab6faf3053c79fba8.evR63xGwLPTzXw6Hi35ROggl2AHmH_y5lT5p05kFGTg
     components-markdown-notebook--component-catalog--dark:
-        hash: v1.k794b7964.c1195f4ea82d9c4e1c781e507bed8cb4f09526b6574099646b271245e65e2022.1mSVdYQnM-zC2d-82S3X4zhsChvArz9rNmSBDdfZNZE
+        hash: v1.k794b7964.0fa73ee3ef24c32506e4767041af6b2c8d71bb61327088326040088afb64b3ec.pSGbbgX0VBZKI5wdJbxX-GYJ5jGGATz0UYhmUsvCAH4
     components-markdown-notebook--component-catalog--light:
-        hash: v1.k794b7964.5739bda1024b64e13d93d1a8367101f6a1467ab053554b520ba37eba0b27068e.b_39_EGipiHnNS16kzBL4tPy4qoB-ktDllOZy0B2HvM
+        hash: v1.k794b7964.174044b73167c73e86e3b6f13e14389074ca5b3b3cf038267a0159e14a74b063.SJJmmxm1BTT1sLHHSmYn1aZuQe87BfdMhdcyJ5bfAWE
     components-markdown-notebook--edit-mode--dark:
-        hash: v1.k794b7964.75e68a67c0e1055d31d9ec97d48a01e991a971dc1d4169e810d49f09d7dd8dd9.s6xiwDf7dhx9bIE3p4FdovsjEQnrGtDXzRD8lJmHy90
+        hash: v1.k794b7964.240c75af9089383f91012b7e0c371e770dcac7601c4bf1c9c5794ab6bd374584.X04OJyCQZ-h_IeOeSpVjpFJMKkp9vNeGQ4cK0sOXbNQ
     components-markdown-notebook--edit-mode--light:
-        hash: v1.k794b7964.70359adcd7402800180983f982617fa3fc0f19edb5e52b14271c94527d51eed6.hr5Der5LQuhmqCgMsD3fHCbeQvzgvoZ7cvbhduHjgcs
+        hash: v1.k794b7964.f2be83a47d66731da41365b291e7f17ff81b2c644bca2ea786c29030d5b7568c.IMqLWGmz0nizYTUCqAsypxcRtbglkDMReNWZRNgNfqs
     components-markdown-notebook--embeds--dark:
-        hash: v1.k794b7964.666a1ab6a3279f149b4cf0f83265b64d484a8fd9ce21534b2997ed385d9fd8dc.pjdMc0yeqb9tATSP6Lrf5IP1ekkvKDv_U57c4URmmWM
+        hash: v1.k794b7964.c48e6775e4ac5d3ba394c99dca897de73aaba8c55dd62d39bb0402c0d0155e08.PpTFdlVHUcn0j1eXE0jFJYIHt1H_5AjD7voKgDqzkiM
     components-markdown-notebook--embeds--light:
-        hash: v1.k794b7964.231ca120286f24dbff92195655a747efe5c409da15a11bd848a8c25098321708.nD6Sf2SUy4runSGLLjl2hbmS5cUJwwsfde2nIkUfPXU
+        hash: v1.k794b7964.d8d839ccf276007ffdfd6264a78a939ed3320190e64b426b2a97ffbd21d0b264.3HtNJGUG1_3RF6p8wKumNv6YqZF5M32VNR8I4WPkeak
     components-markdown-notebook--empty-notebook--dark:
         hash: v1.k794b7964.8eead993034f2c49605117d1209d49eba6232f18509f28c36a11583c83a06c95.uNfIEuJu7VxEaywegw-eDdV7uZMCQrkGaRFqcexDrA0
     components-markdown-notebook--empty-notebook--light:
@@ -1229,9 +1229,9 @@ snapshots:
     components-markdown-notebook--headings-and-inline-formatting--light:
         hash: v1.k794b7964.38e87809a617b9d678891017ee6e78752effcf948b97ec7568efb71ac24bcf6a.xT83tL3e33wxruaCJlSjvTaBSjbK1zSX0Pif21pHkcM
     components-markdown-notebook--invalid-component-props--dark:
-        hash: v1.k794b7964.8ba512a554ed7dd8dc46e094992c1aa5311bcbe270db6487080c2ab3470d2cea.OByuS6edqSKSnB9tlHTlFOOqesQ6fi0-JvsmMWX66yM
+        hash: v1.k794b7964.939491923605bcfaecaa269696c06b32ae3ff932d925b4e9ff90d9bcd65f0f79.fFXMOWxD5VHbqMPwrity30gIXBu8ie7o_LExshpJGWE
     components-markdown-notebook--invalid-component-props--light:
-        hash: v1.k794b7964.4cab15d219d1f1989ec25b36bb0037097efa2dd651e0380ae9c8daeb799486dd.E6fa6X5W9THi_EqqDbMrpaYwAUjsLKKrztCRL3NwMsw
+        hash: v1.k794b7964.a607aaa7b45070590491b217522327f695e05e451bb123b0b2c4b77c52448c85.t3UYxEnFonR-kL6zwvrcPqS5poB_sI5ILk7F5rOvdng
     components-markdown-notebook--lists-and-links--dark:
         hash: v1.k794b7964.bbd83d85a0585d1a3428678151002e6b4da9084256f41ac239250ddb831321f6.W43uC9ABBUVWperGNIuAeXNp9AR4iCQH04kfwJktkbg
     components-markdown-notebook--lists-and-links--light:
@@ -1257,9 +1257,9 @@ snapshots:
     components-markdown-notebook--mocked-collaboration--light:
         hash: v1.k794b7964.5b0d52dc1eb8dd9f9906108308093d1e3f477b9f671027f613581e65f11738a4.izBrg-kCKLfpYBm77YuQe5SqULcKK8EmsVgz-P6M_kY
     components-markdown-notebook--query-block--dark:
-        hash: v1.k794b7964.9462b3e1e5303a27a5ba68940abb6a6b53c3ca6a6e7b7f6f3ebf80ba4c18eaeb.aqQJOmyCIGUyTzQ1NQS9dmQXWEu_G7YOxSCCvR-YS6M
+        hash: v1.k794b7964.021f20d3d72178f123b1b38d5d0f744fa02721d380313bf726d86747143c7f40.4PhxRYKpzn8RsnbYij9fd6OmFqB0AZxKDfylp6eAhHY
     components-markdown-notebook--query-block--light:
-        hash: v1.k794b7964.c7d938594b2adf78b1cb2b6b06502edd842701026e8e3b0014e6bd2571701ae5._HYTts0_d2ety-dJS140Adz40WvojQghhEJg-T4JwBI
+        hash: v1.k794b7964.6d682dcb63fb12d33f1b8c6a248df4bbf77a898024ccce8fa8347660df3f1356.77yctGGn_CGkcFIk7y1mzK0yZGyKGCdUtSQD4fJKLT4
     components-markdown-notebook--selection-toolbar-state--dark:
         hash: v1.k794b7964.3ae4e75244d0227c7e592b7937380ee3ff8e94a5cafa2b05cb49c5ef9cad727a.j7qvSpyDubygwc7VsU2sbliJbjCKR9EwWvoay5j5e2c
     components-markdown-notebook--selection-toolbar-state--light:
@@ -1273,9 +1273,9 @@ snapshots:
     components-markdown-notebook--text-only-notebook--light:
         hash: v1.k794b7964.fef48fc6ed9f1349a5d8fb7e988c301515d4623dfd68c2b55502f33d1e511dd8.uIPJinERIkOO-F9dYe_C102CBZ1nb51hWeQpx7z8zGU
     components-markdown-notebook--view-mode--dark:
-        hash: v1.k794b7964.7af7b745d77758ee42b42bf785db8a100f23ff01003dad9772c6a1c99c43faf4.Iv3JhJK0ubvLu9eFH6ft2ai5-VYWLzAiQD2HIKo_RJE
+        hash: v1.k794b7964.e75d339a8996015ebdf6254624e69c98d017b96755ce6e5193f0a5f71b4ddc15.atfSzS-ojPnzULnXxOzo6vkWzmDO595BmHR82sHiTf4
     components-markdown-notebook--view-mode--light:
-        hash: v1.k794b7964.11c2bd01a8840cb7147eb94693398331ab96b2dffc7fc049a5bf021fdef421e1.3HlB3wcmf1v_k83nyNus_piIMHd3_PwM9kun-EqTRgY
+        hash: v1.k794b7964.18756d0817269ce9812ce00338a4dcfa6bc806ec53a95aaa892de15763f4028f.8WxnPpCUWB54_iak9C1G46fGX9A_km53tBGVQHbSxZw
     components-mcp-hint-toast--annotations-create--dark:
         hash: v1.k794b7964.eec2ed99e26c3e17bb863aee733524cf25a5ae76808f594bdc41c0eddf501b8f.x88L0pkIlEBj6PedsMSeWEWk04MeGS8PbIdYCJmYYjs
     components-mcp-hint-toast--annotations-create--light:
@@ -6555,9 +6555,9 @@ snapshots:
     scenes-app-notebooks--numbered-list--light:
         hash: v1.k794b7964.a7c359b0c62468903ee153f7d554332ffb23ddeb5823f8772cbbc9bdda85ef39.vqBNXyRaDc-oPTu-JlCeXZXDW3hlVysSsDe1vCbkFbk
     scenes-app-notebooks--recordings-playlist--dark:
-        hash: v1.k794b7964.99878e1bbb2038170b53e000ee0268c2fc5dea97c6a9c803b3646eac13b1b570.n5KKoXyCYJ5EEweg66zzEI0cUM4cO5PgKN9X4haYLo0
+        hash: v1.k794b7964.48583df8f094f18d5d4e05e4346d1e79fe991abd493d45c546c517c32d89eee5.JWX1BYBL9a_g4ooIjDGPZBiQsyAmz3O6vk0n74rvKOA
     scenes-app-notebooks--recordings-playlist--light:
-        hash: v1.k794b7964.b844f9a09e6ebbad8d8ae458b33bde2936742262d1b1c1ffbbdcc90e1ab06221.cAy7C44N5Nb60X6CC3IGiVCwjY9vNUq49gZ2ui51Ew0
+        hash: v1.k794b7964.e07264c1ce288191160c2bd47144119ad49741c130c79d4ef62f349f9022076f.RhXKit-dltpqXG5VlUpH6vn-fuEDfTshPv1ZswjXa8c
     scenes-app-notebooks--text-formats--dark:
         hash: v1.k794b7964.6ba17ee8c1d8e0b4095b903100109314b701baa0a4956ca272f2b26f4d37879b.J-tNiP80EM3tE0ZaOdrZZ3vzZnEK1UdW5afDzziYijQ
     scenes-app-notebooks--text-formats--light:
@@ -6591,29 +6591,29 @@ snapshots:
     scenes-app-notebooks-components-notebook-select-button--with-slow-network-response--light:
         hash: v1.k794b7964.678b0f73befa0690622fd5eb7a920f5c25919af7a9b516a08756e866b37de352.QhzKGfEQA_MQykTL8uuyOryngt75iNv9BydvL5ckPjQ
     scenes-app-notebooks-nodes-customer-journey--all-steps-completed--dark:
-        hash: v1.k794b7964.b94ebe6c801275424991cdf5ce4eb8a96b3dd7396c73a52fbb5a7f3d12a15068.hFu00LQH66ItE_Drb7ulV97qHnEQhtkTj6xFPNDXCGQ
+        hash: v1.k794b7964.17cd072c0b5404cc9c96e6067ca5704a4c97096d8c30dfef42eedd0788f16343.r1T1xXdzK04DHRW8T5kzNrudpna8AuO_DMEKDwuI4_g
     scenes-app-notebooks-nodes-customer-journey--all-steps-completed--light:
-        hash: v1.k794b7964.4113e899994b3e11be7f11c644246f1188f9fbc79888523d73918e462d2ad69e.eOv4jXkHqWJ40c1R3Y16_8PP9wkxjaDn0LGDUM0TscE
+        hash: v1.k794b7964.63578a162564c8b1248bf43ee0b098efabf4b73a4e3dba029eac27f4c7ae7d19._PQlC6N2Xdb5cMhqsuAqzthaGNWedoROgtQWVDnn-No
     scenes-app-notebooks-nodes-customer-journey--no-steps-completed--dark:
-        hash: v1.k794b7964.8bd21b17105b8b063414ee164d0024348a7102c523b6d5976807f5fb7c55a701.FGb22hh3ogJZAfe9nnR8ZxY0DR8J9TTaIPVuR-RKzLo
+        hash: v1.k794b7964.a62d9fe306cfed726196750dded4ae18a372efe02ccc4eb0a68036e7c71226e1.myY4rwzVi_O9UpQvJillyjIv-Md9_4A1BlTTBxWdjuM
     scenes-app-notebooks-nodes-customer-journey--no-steps-completed--light:
-        hash: v1.k794b7964.c62ca9df283588709e93c98bdf17ecfce82e95ef87f3fab468888ae2876bb764.bdPnzvwGqQkTGsdyjrdkf5VpQDo_O3U1C9qfZWmZ2pU
+        hash: v1.k794b7964.df5ef387a6baeec8910fb1092eb7e66c8584af6e5b3f724ce64ab5a134ea9efa.mH8P8s4iDPH-UItw211ZR9aCTTErrHjdWnYAcTzBupo
     scenes-app-notebooks-nodes-customer-journey--some-steps-completed--dark:
-        hash: v1.k794b7964.6a14a5f61907fcb5e498673523439d6f4a4656abb24d4a10aff610651df30507.RonkMxoGopUpdybCoEmlUXGhCe__AXh7g_tWh5t-b1c
+        hash: v1.k794b7964.3e89975e4fd30ad3a2a4aef1a258dce5618e6b9ee9d2f58cfeb197a18a73a6bd.CMbleFR2gyJk6zWVbMvogKNK16fUs1ecUlfUX94COkM
     scenes-app-notebooks-nodes-customer-journey--some-steps-completed--light:
-        hash: v1.k794b7964.a23e4e2d8e2b57fde1fe00a712aea080e63154b0afccb6978ca5a51bb617ecc2.2TtuMM7o_e-493ewoo1amOjHD2J4tNblJ4hGdC6MSTA
+        hash: v1.k794b7964.cb898f63427c30e103c3eced3e45623d1ce84cc4ad0a7fadf0056789da8a4bdf.-6fJz2-iztg4Bk9LUIhqxGV78bJBnQcDwzDJ2HXVgNs
     scenes-app-notebooks-nodes-customer-journey--with-optional-steps--dark:
-        hash: v1.k794b7964.87da3e015b14a2155c496573da2eaa4507d465a22d0ee250e299ce8f26d57a1f.EerzBOCZUX1jlGPBzK9uWEFxWYR06nk7KKP5tllyV9o
+        hash: v1.k794b7964.2f24adc8c037b0c2bb7c2a24693b5e5b95034d9f218f5cc9ebbb38fcdffe2818.Au6Z_S_zDcs9m4kbqTgJFUpLr3V1rm9E-Wcwa4XDlNA
     scenes-app-notebooks-nodes-customer-journey--with-optional-steps--light:
-        hash: v1.k794b7964.121bfeb17a2130a74bda0cb2ba561f6c56e11c13834033a3ef39dd40432271cc.pSCqPjfCB9aUr8yyJ1xkpyRu8z5jlnGD8kHMWg-Ynpg
+        hash: v1.k794b7964.cad2f36b81e2195abf3093bd276ffa1fc852ca26e359121ba47ebc7b4b34b33f.cyicZj5qwhOfK3pcoNHUhbzJ0_p4WN1qahuPDadkjTs
     scenes-app-notebooks-nodes-support-tickets--empty--dark:
-        hash: v1.k794b7964.c10ab277396f4beab2f74bd77e785c75ede9f45b685c4255f9f89741035acf49.xcNVKC2tTI9utsycdzLuJmWfAsvCvh_Zib3ioZFfiTA
+        hash: v1.k794b7964.eb04a7b8a78b7ace0999c3621900011bb280ebfe924965ca991aadbca242495f.Say3nN9_bj27-yT2cWdaUNGiVDMdxmBBKrCj6ZJfOrM
     scenes-app-notebooks-nodes-support-tickets--empty--light:
-        hash: v1.k794b7964.8f8b52acc8bb55637bd7f08900e425729d2260849d4f736596afaa809a4db2d7.XS5NtFMSF3rgnNJsHwnpuDCZv4JAImonICFoLfT5zHI
+        hash: v1.k794b7964.5ca0588fdb06c373d435e9bc2be61abd58f14d4b9eba599890c31e5669bd87df.p0LLP6B_2RRqxyhe8iJlt2Xw3HqLwMaK3YCRCXICHD4
     scenes-app-notebooks-nodes-support-tickets--with-tickets--dark:
-        hash: v1.k794b7964.3cf38fb9c9a40942eece565d903573597c3d904666c6384a5bab2cbcf9644a5d.E9uJYL0s1GLzlbYJOal_S-NOkj6ht4j_DzLSWuq4WW4
+        hash: v1.k794b7964.6396ebcc80633c84fe59792b7f4e10a4afc863c89637e1f6797e68d14cc9c97d.1QaIki2Jd-vbKPWENqtlDqwkT8vWC1D8Ptiule4uLo8
     scenes-app-notebooks-nodes-support-tickets--with-tickets--light:
-        hash: v1.k794b7964.5006f99a89dd836d27796f18c961195c3d1481a2f098ed4366350f9d9ed3ad17.DmBrFHnDUAo9rYBJKBNmfJY5MZnmjixLZo06TMwyYS8
+        hash: v1.k794b7964.f2c26c12d9631046c9166c8256a037c729e04a348c6019fa99244c615e658a75.-WWBvaWqDZU1AzdZiLF7oa_es0R-oeM3zRF-e3X0su4
     scenes-app-oauth-authorize--all-scopes-optional--dark:
         hash: v1.k794b7964.03746d2e3646b97e4af61e54557db2ccb6268512cda02721b819fa30980af155.ZPcclnqMQQh8Qi_v2Z3cnVA1_LaYFx8XXncRQ8NQAdc
     scenes-app-oauth-authorize--all-scopes-optional--light:

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
@@ -1617,7 +1617,10 @@ h3.MarkdownNotebook__text-block--heading {
     overflow: hidden;
     background: var(--markdown-notebook-component-background);
     border: 1px solid var(--markdown-notebook-component-border);
-    border-left: 3px solid var(--markdown-notebook-component-gutter);
+
+    // Thicker than the neutral text-block gutters: this rail carries run status, so it should
+    // register as a result rather than as another block edge.
+    border-left: 5px solid var(--markdown-notebook-component-gutter);
     border-radius: 0.25rem;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -189,14 +189,11 @@ const Component = ({
                 ) : hasStreamOutput ? null : (
                     <div className="text-xs text-muted font-mono p-2">Run the cell to see execution results.</div>
                 )}
-                {attributes.runId ? (
-                    <div className="shrink-0 px-2 pb-2 text-[10px] uppercase tracking-wide text-muted select-text">
-                        run_id: {attributes.runId}
-                    </div>
-                ) : null}
             </div>
             <div
-                className="flex shrink-0 items-center gap-2 text-xs text-muted border-t p-2"
+                // Translucent overlay, not a surface token: the shell is surface-primary in light
+                // mode but surface-tertiary in dark, so a fixed surface vanishes against one of them.
+                className="flex shrink-0 items-center gap-2 text-xs text-muted border-t border-primary bg-fill-highlight-50 p-2"
                 onClick={(event) => event.stopPropagation()}
                 onMouseDown={(event) => event.stopPropagation()}
             >
@@ -207,7 +204,7 @@ const Component = ({
                     type="text"
                     // The dataframe name this cell's result is exposed as to later cells.
                     // Optional: left empty, the cell binds nothing and later cells can't read it.
-                    className="rounded border border-border px-1.5 py-0.5 text-xs font-mono bg-bg-light text-default focus:outline-none focus:ring-1 focus:ring-primary"
+                    className="rounded border border-primary px-1.5 py-0.5 text-xs font-mono bg-surface-primary text-default focus:outline-none focus:ring-1 focus:ring-primary"
                     value={attributes.returnVariable ?? ''}
                     onChange={(event) => updateAttributes({ returnVariable: event.target.value })}
                     placeholder="Dataframe name (optional)"

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -204,10 +204,13 @@ const Component = ({
                     type="text"
                     // The dataframe name this cell's result is exposed as to later cells.
                     // Optional: left empty, the cell binds nothing and later cells can't read it.
-                    className="rounded border border-primary px-1.5 py-0.5 text-xs font-mono bg-surface-primary text-default focus:outline-none focus:ring-1 focus:ring-primary"
+                    // Wide enough for the placeholder to sit on one line without clipping. The name
+                    // carries weight through size and a faintly warm near-black rather than a hue —
+                    // a saturated color here competes with the accent the app spends on links.
+                    className="w-56 rounded border border-primary px-1.5 py-0.5 text-sm font-medium font-mono bg-surface-primary text-[oklch(0.27_0.022_345deg)] dark:text-[oklch(0.93_0.014_345deg)] focus:outline-none focus:ring-1 focus:ring-primary"
                     value={attributes.returnVariable ?? ''}
                     onChange={(event) => updateAttributes({ returnVariable: event.target.value })}
-                    placeholder="Dataframe name (optional)"
+                    placeholder="Output dataframe name"
                     spellCheck={false}
                 />
             </div>

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
@@ -290,14 +290,11 @@ const Component = ({
                 ) : (
                     <div className="text-xs text-muted font-mono p-2">Run the query to see execution results.</div>
                 )}
-                {attributes.runId ? (
-                    <div className="shrink-0 px-2 pb-2 text-[10px] uppercase tracking-wide text-muted select-text">
-                        run_id: {attributes.runId}
-                    </div>
-                ) : null}
             </div>
             <div
-                className="flex shrink-0 items-center gap-2 text-xs text-muted border-t p-2"
+                // Translucent overlay, not a surface token: the shell is surface-primary in light
+                // mode but surface-tertiary in dark, so a fixed surface vanishes against one of them.
+                className="flex shrink-0 items-center gap-2 text-xs text-muted border-t border-primary bg-fill-highlight-50 p-2"
                 onClick={(event) => event.stopPropagation()}
                 onMouseDown={(event) => event.stopPropagation()}
             >
@@ -308,7 +305,7 @@ const Component = ({
                     type="text"
                     // A dataframe name other SQL nodes reference by table name (`from sql_df`).
                     // Optional: left empty, the cell is display-only and exports nothing.
-                    className="rounded border border-border px-1.5 py-0.5 text-xs font-mono bg-bg-light text-default focus:outline-none focus:ring-1 focus:ring-primary"
+                    className="rounded border border-primary px-1.5 py-0.5 text-xs font-mono bg-surface-primary text-default focus:outline-none focus:ring-1 focus:ring-primary"
                     value={attributes.returnVariable ?? ''}
                     onChange={(event) => updateAttributes({ returnVariable: event.target.value })}
                     placeholder="Dataframe name (optional)"

--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodeSQLV2.tsx
@@ -305,10 +305,13 @@ const Component = ({
                     type="text"
                     // A dataframe name other SQL nodes reference by table name (`from sql_df`).
                     // Optional: left empty, the cell is display-only and exports nothing.
-                    className="rounded border border-primary px-1.5 py-0.5 text-xs font-mono bg-surface-primary text-default focus:outline-none focus:ring-1 focus:ring-primary"
+                    // Wide enough for the placeholder to sit on one line without clipping. The name
+                    // carries weight through size and a faintly warm near-black rather than a hue —
+                    // a saturated color here competes with the accent the app spends on links.
+                    className="w-56 rounded border border-primary px-1.5 py-0.5 text-sm font-medium font-mono bg-surface-primary text-[oklch(0.27_0.022_345deg)] dark:text-[oklch(0.93_0.014_345deg)] focus:outline-none focus:ring-1 focus:ring-primary"
                     value={attributes.returnVariable ?? ''}
                     onChange={(event) => updateAttributes({ returnVariable: event.target.value })}
-                    placeholder="Dataframe name (optional)"
+                    placeholder="Output dataframe name"
                     spellCheck={false}
                 />
                 {returnVariableError ? <span className="text-danger">{returnVariableError}</span> : null}

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -345,6 +345,7 @@ export function getMarkdownNotebookNodeTitle(
     if (
         nodeType === NotebookNodeType.Python ||
         nodeType === NotebookNodeType.PythonV2 ||
+        nodeType === NotebookNodeType.SQLV2 ||
         nodeType === NotebookNodeType.DuckSQL ||
         nodeType === NotebookNodeType.HogQLSQL
     ) {


### PR DESCRIPTION
## Problem

A handful of rough edges in the V2 SQL and Python notebook cells, all behind `revamped-py-notebooks`.

The `run_id: 0193f2ac-...` line printed under every cell's output. It was debug chrome from bringing the nodes up, and it never earned its space: an uppercase UUID sitting between the results table and the footer, in the reader's way on every run.

The dataframe name row underneath was hard to pick out. It carries real meaning, since that name is what later cells reference as a table, but it rendered on the same background as the results table with only a hairline between them. The field was also narrower than its own placeholder, so the watermark clipped mid-word.

Separately, SQL cells titled themselves with their own query. A cell would show `SELECT person_id, count() AS total_events, uniq(toDate(timestamp))...` as its title, which is noise, not a name.

## Changes

**Dropped the `run_id` readout** from both nodes. The attribute stays, since run recovery, auto-height, and viz keying all still use it. Only the display goes.

**Gave the dataframe name row its own surface** so it separates from the results above it, and moved its border and input off deprecated tokens. On the fill: `bg-surface-secondary` is the usual footer-bar convention, and I tried it first. It does not work here. The markdown V2 shell sits on `surface-primary` in light mode but `surface-tertiary` in dark, so a fixed surface token lands about 2% lightness from the shell in dark mode and effectively disappears. `bg-fill-highlight-50` is a 5% black overlay in light and 5% white in dark, so it composites to the same subtle step against either.

**Widened the name field** from 163px to 224px. The placeholder needs 191px including padding, so it now fits with room to spare. The name itself gets a little more presence through size and weight rather than a hue: 14px, medium, and a faintly warm near-black. A saturated color competes with the accent this app already spends on links and actions.

**SQL cells no longer title themselves with their query.** The guard that keeps a code body out of a cell title listed Python, PythonV2, DuckSQL and HogQLSQL but not SQLV2, so SQL cells fell through to summarizing their own SQL. They now start untitled and wait for the user, like Python cells.

**Thickened the component status rail** from 3px to 5px, so a finished run reads as a result rather than as another block edge. It stays thicker than the neutral text-block gutters on purpose.

![notebooks-v2-light](https://raw.githubusercontent.com/PostHog/pr-assets/8f65f677ee4ec8990694620349bea274185af864/2026/08/7462d1bf-8e8e-4ff2-84a0-f4a0a5088ef3.png)

> [!NOTE]
> Purely visual. No behavior, API, or persisted attribute changes.

## How did you test this code?

Ran the dev stack and checked both nodes in a real notebook, in both themes.

- SQL cells: verified against real query results that `run_id` is gone, the strip separates, the name fits, and titles now read "Add a title". Read the computed styles rather than trusting screenshots: the dark shell resolves to `rgb(19,19,22)`, so `bg-surface-secondary` would have landed ~`rgb(23,23,26)` against it and been invisible, while the overlay reads correctly in both themes.
- A/B'd against master's version of the same files on the same node to confirm the before/after.
- Python cells: verified the footer and title placeholder on an inserted cell. I could not run one. The local Docker kernel never spawns a container, which is a pre-existing local-env limitation unrelated to this diff, so the Python node's post-run output area is the one path I did not exercise directly. The removed block was byte-identical to the SQL one and gated only on `runId`, and the footer sits outside the output container.

No new tests. This is a JSX deletion plus className and token changes, with no branch or state to cover, and nothing asserted on the removed text. `markdownNotebookRegistry.test.tsx` (18 tests) covers the title change and passes; no existing test asserted the old query-as-title behavior, which is part of why it looks like an oversight rather than intent.

Also ran: `pnpm --filter=@posthog/frontend typescript:check`, `oxlint`, `oxfmt --check`, and `hogli ci:preflight --strict` via the pre-push hook. All clean.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, driven by Sinan, iterating against the running app. Two Explore subagents mapped the V2 nodes and the token system up front.

Most of the work was color judgment made against real pixels rather than in the abstract. The footer fill started as `bg-surface-secondary`, matching a footer bar in `NotebookArtifactAnswer.tsx`; rendering it in dark mode exposed the markdown-V2 shell background flip and it was swapped for the overlay token. The name text went through green, then blue, then landed on a faintly warm near-black once it was clear that any saturated hue competed with the app's orange interactive language. Worth knowing for future work in this area: the design system has no cool-toned semantic text token (`info` exists for backgrounds and borders but not text), which is why the near-black is an arbitrary value rather than a token.

No skills were invoked. Nothing here touched migrations, DRF, or persisted data.
