### PR TITLE
fix(conversations): stop reporting an unconfirmed send as a failure

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6054,7 +6054,13 @@ export type CommentType = {
     completed_by: UserBasicType | null
 }
 
-export type CommentCreationParams = { mentions?: number[]; slug?: string }
+export type CommentCreationParams = {
+    mentions?: number[]
+    slug?: string
+    /** Client-generated UUID that makes creating the comment retry-safe: a repeat carrying the same
+     * key returns the comment the first attempt created instead of a duplicate. */
+    idempotency_key?: string
+}
 
 export interface DataWarehouseCredential {
     access_key: string

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -517,7 +517,9 @@ describe('supportTicketSceneLogic message sending', () => {
         initKeaTests()
         createMock.mockReset()
         listMock.mockReset().mockResolvedValue({ results: [] })
-        logic = supportTicketSceneLogic({ id: 42 })
+        // A distinct key from the other suites: they mount id 42 and leave its 5s message poll
+        // running, and those stray polls would otherwise reset this logic's message list.
+        logic = supportTicketSceneLogic({ id: 4242 })
         logic.mount()
         logic.actions.setTicket(makeTicket())
     })
@@ -575,6 +577,22 @@ describe('supportTicketSceneLogic message sending', () => {
 
         expect(createMock).toHaveBeenCalledTimes(1)
         expect(logic.values.messageSending).toBe(false)
+    })
+
+    // Flipping a failed public reply to a private note (or back) must not be swallowed as a
+    // replay of the message the operator no longer intends to send.
+    it('mints a fresh key when the draft switches between a reply and a private note', async () => {
+        createMock.mockRejectedValue(new ApiError('Failed to fetch', undefined))
+        await expectLogic(logic, () => send()).toFinishAllListeners()
+        const abandonedKey = logic.values.sendIdempotencyKey
+
+        logic.actions.setDraftIsPrivate(true)
+        expect(logic.values.sendIdempotencyKey).toBeNull()
+
+        createMock.mockReset().mockResolvedValue(makeSupportComment('msg-1'))
+        await expectLogic(logic, () => send()).toDispatchActions(['appendMessage'])
+
+        expect(sentKey()).not.toEqual(abandonedKey)
     })
 
     it('mints a fresh key once the draft changes', async () => {

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -570,6 +570,25 @@ describe('supportTicketSceneLogic message sending', () => {
         expect(sentKey()).toEqual(abandonedKey)
     })
 
+    // If the composer's cleanup callback throws after the create resolved (e.g. the editor was
+    // torn down mid-send), the send still succeeded and must not be reported as a failure.
+    it('does not report a failure when post-send cleanup throws', async () => {
+        const { lemonToast } = jest.requireMock('@posthog/lemon-ui')
+        const errorSpy = jest.spyOn(lemonToast, 'error')
+        createMock.mockResolvedValue(makeSupportComment('msg-1'))
+
+        await expectLogic(logic, () => {
+            logic.actions.sendMessage('reply body', null, false, () => {
+                throw new Error('editor already destroyed')
+            })
+        }).toDispatchActions(['appendMessage', 'incrementUnreadCustomerCount'])
+
+        expect(logic.values.messages.map((m) => m.id)).toEqual(['msg-1'])
+        expect(logic.values.sendIdempotencyKey).toBeNull()
+        expect(errorSpy).not.toHaveBeenCalled()
+        errorSpy.mockRestore()
+    })
+
     it('does not repeat a send the server definitively rejected', async () => {
         createMock.mockRejectedValue(new ApiError('Bad request', 400))
 

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -2,6 +2,8 @@ import { MOCK_DEFAULT_USER } from 'lib/api.mock'
 
 import { expectLogic } from 'kea-test-utils'
 
+import { ApiError } from 'lib/api-error'
+
 import { tagsModel } from '~/models/tagsModel'
 import { initKeaTests } from '~/test/init'
 import type { CommentType } from '~/types'
@@ -483,5 +485,125 @@ describe('supportTicketSceneLogic loadPreviousTickets email gating', () => {
         }).toDispatchActions(['loadPreviousTicketsSuccess'])
 
         expect(ticketsListMock).toHaveBeenLastCalledWith(expectedParams)
+    })
+})
+
+describe('supportTicketSceneLogic message sending', () => {
+    let logic: ReturnType<typeof supportTicketSceneLogic.build>
+    const createMock = api.comments.create as jest.Mock
+    const listMock = api.comments.list as jest.Mock
+
+    function makeSupportComment(id: string): CommentType {
+        return {
+            id,
+            content: 'reply body',
+            scope: 'conversations_ticket',
+            item_id: 'ticket-1',
+            item_context: { author_type: 'support', is_private: false },
+            created_at: '2026-01-01T00:00:00Z',
+            created_by: null,
+        } as unknown as CommentType
+    }
+
+    function send(): void {
+        logic.actions.sendMessage('reply body', null, false, () => logic.actions.setDraftContent(null))
+    }
+
+    function sentKey(callIndex = 0): string {
+        return createMock.mock.calls[callIndex][0].idempotency_key
+    }
+
+    beforeEach(() => {
+        initKeaTests()
+        createMock.mockReset()
+        listMock.mockReset().mockResolvedValue({ results: [] })
+        logic = supportTicketSceneLogic({ id: 42 })
+        logic.mount()
+        logic.actions.setTicket(makeTicket())
+    })
+
+    it('shows the sent reply without waiting for a refetch', async () => {
+        createMock.mockResolvedValue(makeSupportComment('msg-1'))
+
+        await expectLogic(logic, () => send()).toDispatchActions(['appendMessage'])
+
+        expect(logic.values.messages.map((m) => m.id)).toEqual(['msg-1'])
+        expect(createMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not show the reply twice when the poll has already delivered it', async () => {
+        createMock.mockResolvedValue(makeSupportComment('msg-1'))
+        logic.actions.setMessages([makeSupportComment('msg-1')])
+
+        await expectLogic(logic, () => send()).toDispatchActions(['appendMessage'])
+
+        expect(logic.values.messages).toHaveLength(1)
+    })
+
+    // A dropped connection leaves the outcome unknown: the write may well have landed, so the
+    // repeat has to carry the same key or it becomes the duplicate we're trying to prevent.
+    it('repeats a send whose outcome is unknown using the same key', async () => {
+        createMock
+            .mockRejectedValueOnce(new ApiError('Failed to fetch', undefined))
+            .mockResolvedValueOnce(makeSupportComment('msg-1'))
+
+        await expectLogic(logic, () => send()).toDispatchActions(['appendMessage'])
+
+        expect(createMock).toHaveBeenCalledTimes(2)
+        expect(sentKey(0)).toEqual(sentKey(1))
+        expect(logic.values.messages).toHaveLength(1)
+    })
+
+    it('keeps the key after giving up so a manual resend cannot duplicate the message', async () => {
+        createMock.mockRejectedValue(new ApiError('Failed to fetch', undefined))
+
+        await expectLogic(logic, () => send()).toFinishAllListeners()
+
+        const abandonedKey = logic.values.sendIdempotencyKey
+        expect(abandonedKey).not.toBeNull()
+
+        createMock.mockReset().mockResolvedValue(makeSupportComment('msg-1'))
+        await expectLogic(logic, () => send()).toDispatchActions(['appendMessage'])
+
+        expect(sentKey()).toEqual(abandonedKey)
+    })
+
+    it('does not repeat a send the server definitively rejected', async () => {
+        createMock.mockRejectedValue(new ApiError('Bad request', 400))
+
+        await expectLogic(logic, () => send()).toFinishAllListeners()
+
+        expect(createMock).toHaveBeenCalledTimes(1)
+        expect(logic.values.messageSending).toBe(false)
+    })
+
+    it('mints a fresh key once the draft changes', async () => {
+        createMock.mockRejectedValue(new ApiError('Failed to fetch', undefined))
+        await expectLogic(logic, () => send()).toFinishAllListeners()
+        const abandonedKey = logic.values.sendIdempotencyKey
+
+        logic.actions.setDraftContent({ type: 'doc', content: [] })
+        expect(logic.values.sendIdempotencyKey).toBeNull()
+
+        createMock.mockReset().mockResolvedValue(makeSupportComment('msg-1'))
+        await expectLogic(logic, () => send()).toDispatchActions(['appendMessage'])
+
+        expect(sentKey()).not.toEqual(abandonedKey)
+    })
+
+    // The 5s poll overlaps under load, and setMessages replaces the list wholesale, so a slow
+    // reply to an earlier poll used to wipe a message that had just been sent.
+    it('ignores a poll response that a newer poll has already superseded', async () => {
+        let resolveSlow: (value: any) => void = () => {}
+        listMock
+            .mockReturnValueOnce(new Promise((resolve) => (resolveSlow = resolve)))
+            .mockResolvedValueOnce({ results: [makeSupportComment('msg-1')] })
+
+        logic.actions.loadMessages()
+        await expectLogic(logic, () => logic.actions.loadMessages()).toDispatchActions(['setMessages'])
+        resolveSlow({ results: [] })
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.messages.map((m) => m.id)).toEqual(['msg-1'])
     })
 })

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -513,7 +513,7 @@ describe('supportTicketSceneLogic message sending', () => {
         return createMock.mock.calls[callIndex][0].idempotency_key
     }
 
-    beforeEach(() => {
+    beforeEach(async () => {
         initKeaTests()
         createMock.mockReset()
         listMock.mockReset().mockResolvedValue({ results: [] })
@@ -521,6 +521,9 @@ describe('supportTicketSceneLogic message sending', () => {
         // running, and those stray polls would otherwise reset this logic's message list.
         logic = supportTicketSceneLogic({ id: 4242 })
         logic.mount()
+        // Drain mount-time listeners: loadTicket dispatches its own loadMessages, which would
+        // otherwise race the polls these tests stage and consume their queued mock responses.
+        await expectLogic(logic).toFinishAllListeners()
         logic.actions.setTicket(makeTicket())
     })
 

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -224,7 +224,6 @@ export interface supportTicketSceneLogicValues {
     messageSending: boolean
     messages: CommentType[]
     messagesLoading: boolean
-    sendIdempotencyKey: string | null
     olderMessagesLoading: boolean
     person: PersonType | null
     personLoading: boolean
@@ -232,6 +231,7 @@ export interface supportTicketSceneLogicValues {
     previousTicketsLoading: boolean
     priority: TicketPriority | null
     replyRecipientDescription: string
+    sendIdempotencyKey: string | null
     sidePanelContext: SidePanelSceneContext | null
     snoozedUntil: string | null
     status: TicketStatus | null
@@ -248,6 +248,9 @@ export interface supportTicketSceneLogicActions {
         value: true
     } // supportTicketsSceneLogic
     loadTags: () => any // tagsModel
+    appendMessage: (message: CommentType) => {
+        message: CommentType
+    }
     dismissKnowledgeGap: (suggestionId: string) => {
         suggestionId: string
     }
@@ -382,12 +385,6 @@ export interface supportTicketSceneLogicActions {
     setHasMoreMessages: (hasMore: boolean) => {
         hasMore: boolean
     }
-    appendMessage: (message: CommentType) => {
-        message: CommentType
-    }
-    setSendIdempotencyKey: (key: string | null) => {
-        key: string | null
-    }
     setMessageSending: (sending: boolean) => {
         sending: boolean
     }
@@ -405,6 +402,9 @@ export interface supportTicketSceneLogicActions {
     }
     setPriority: (priority: TicketPriority) => {
         priority: TicketPriority
+    }
+    setSendIdempotencyKey: (key: string | null) => {
+        key: string | null
     }
     setSnoozedUntil: (snoozedUntil: string | null) => {
         snoozedUntil: string | null

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1195,11 +1195,15 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 actions.setSendIdempotencyKey(idempotencyKey)
             }
 
+            // Only the network call sits inside the try: a throw from the success handling below
+            // must not be reported as a failed send after the message actually sent.
+            let created: CommentType | undefined
+            let sent = false
             let lastError: any
             let attempt = 0
             for (;;) {
                 try {
-                    const created = await api.comments.create(
+                    created = await api.comments.create(
                         {
                             content,
                             rich_content: richContent,
@@ -1213,28 +1217,8 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                         },
                         {}
                     )
-                    // "Added", not "sent": email delivery is async (outbox + Celery) and can still fail
-                    // after this API call succeeds; the per-message delivery status is the send signal.
-                    lemonToast.success(isPrivate ? 'Private note added' : 'Reply added')
-                    actions.setMessageSending(false)
-                    if (created?.id) {
-                        actions.appendMessage(created)
-                    }
-                    onSuccess?.()
-                    actions.setSendIdempotencyKey(null)
-                    if (!isPrivate) {
-                        actions.incrementUnreadCustomerCount()
-                    }
-                    if (statusAfterSend) {
-                        actions.setStatus(statusAfterSend)
-                        // Pick up the ticket for the sender unless a specific user is already assigned.
-                        if (values.assignee?.type !== 'user' && values.user) {
-                            actions.setAssignee({ type: 'user', id: values.user.id })
-                        }
-                        actions.updateTicket()
-                    }
-                    actions.loadTickets()
-                    return
+                    sent = true
+                    break
                 } catch (error: any) {
                     lastError = error
                     if (attempt >= sendRetryBudget(error)) {
@@ -1243,6 +1227,36 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                     attempt++
                     await delay(SEND_RETRY_DELAY_MS)
                 }
+            }
+
+            if (sent) {
+                // "Added", not "sent": email delivery is async (outbox + Celery) and can still fail
+                // after this API call succeeds; the per-message delivery status is the send signal.
+                lemonToast.success(isPrivate ? 'Private note added' : 'Reply added')
+                actions.setMessageSending(false)
+                if (created?.id) {
+                    actions.appendMessage(created)
+                }
+                actions.setSendIdempotencyKey(null)
+                try {
+                    onSuccess?.()
+                } catch (cleanupError) {
+                    // The send succeeded; a composer-cleanup failure must not derail the rest.
+                    posthog.captureException(cleanupError)
+                }
+                if (!isPrivate) {
+                    actions.incrementUnreadCustomerCount()
+                }
+                if (statusAfterSend) {
+                    actions.setStatus(statusAfterSend)
+                    // Pick up the ticket for the sender unless a specific user is already assigned.
+                    if (values.assignee?.type !== 'user' && values.user) {
+                        actions.setAssignee({ type: 'user', id: values.user.id })
+                    }
+                    actions.updateTicket()
+                }
+                actions.loadTickets()
+                return
             }
 
             actions.setMessageSending(false)

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -15,10 +15,14 @@ import {
 } from 'kea'
 import { loaders } from 'kea-loaders'
 import { beforeUnload, router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
+import { ApiError } from 'lib/api-error'
 import { dayjs } from 'lib/dayjs'
+import { delay } from 'lib/utils/async'
+import { uuid } from 'lib/utils/dom'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { isUUIDLike } from 'lib/utils/guards'
 import { fullName } from 'lib/utils/strings'
@@ -62,6 +66,26 @@ import { conversationsDraftModeLogic } from '../settings/conversationsDraftModeL
 import { supportTicketsSceneLogic } from '../tickets/supportTicketsSceneLogic'
 
 const MESSAGE_POLL_INTERVAL = 5000 // 5 seconds
+const SEND_RETRY_DELAY_MS = 500
+
+/** True when the send's outcome is unknown: either no response arrived at all, or the server may
+ * have committed the message before failing. A 4xx is a definite rejection, so it isn't unknown. */
+function isSendOutcomeUnknown(error: any): boolean {
+    if (!(error instanceof ApiError)) {
+        return false
+    }
+    return error.status === undefined || error.status >= 500
+}
+
+/** How many times to repeat a send whose outcome we couldn't determine. Safe only because the
+ * write is idempotent. A failure with no response is cheap to repeat, while a 5xx has already
+ * cost a round trip on an endpoint that can be slow, so it gets one attempt rather than two. */
+function sendRetryBudget(error: any): number {
+    if (!isSendOutcomeUnknown(error)) {
+        return 0
+    }
+    return error.status === undefined ? 2 : 1
+}
 
 function regionFromUrl(url?: string): Region | undefined {
     if (url) {
@@ -200,6 +224,7 @@ export interface supportTicketSceneLogicValues {
     messageSending: boolean
     messages: CommentType[]
     messagesLoading: boolean
+    sendIdempotencyKey: string | null
     olderMessagesLoading: boolean
     person: PersonType | null
     personLoading: boolean
@@ -357,6 +382,12 @@ export interface supportTicketSceneLogicActions {
     setHasMoreMessages: (hasMore: boolean) => {
         hasMore: boolean
     }
+    appendMessage: (message: CommentType) => {
+        message: CommentType
+    }
+    setSendIdempotencyKey: (key: string | null) => {
+        key: string | null
+    }
     setMessageSending: (sending: boolean) => {
         sending: boolean
     }
@@ -480,6 +511,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
 
         loadMessages: true,
         setMessages: (messages: CommentType[]) => ({ messages }),
+        appendMessage: (message: CommentType) => ({ message }),
         setMessagesLoading: (loading: boolean) => ({ loading }),
 
         loadOlderMessages: true,
@@ -501,6 +533,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             statusAfterSend,
         }),
         setMessageSending: (sending: boolean) => ({ sending }),
+        setSendIdempotencyKey: (key: string | null) => ({ key }),
 
         setStatus: (status: TicketStatus) => ({ status }),
         setPriority: (priority: TicketPriority) => ({ priority }),
@@ -712,6 +745,8 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             {
                 setMessages: (_, { messages }) => messages,
                 setOlderMessages: (state, { olderMessages }) => [...olderMessages, ...state],
+                appendMessage: (state, { message }) =>
+                    state.some((existing) => existing.id === message.id) ? state : [...state, message],
             },
         ],
         messagesLoading: [
@@ -742,6 +777,15 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             {
                 sendMessage: () => true,
                 setMessageSending: (_, { sending }) => sending,
+            },
+        ],
+        sendIdempotencyKey: [
+            null as string | null,
+            {
+                setSendIdempotencyKey: (_, { key }) => key,
+                // Editing the draft makes it a different message, so it must not reuse a key
+                // the server may already have stored against the previous text.
+                setDraftContent: () => null,
             },
         ],
         draftContent: [
@@ -1086,7 +1130,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 }
             }
         },
-        loadMessages: async () => {
+        loadMessages: async (_, breakpoint) => {
             if (props.id === 'new' || !values.ticket?.id) {
                 actions.setMessages([])
                 return
@@ -1096,9 +1140,15 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                     scope: 'conversations_ticket',
                     item_id: values.ticket.id,
                 })
+                // Drop responses superseded while in flight: the 5s poll overlaps under load, and
+                // a slow reply to an older poll would otherwise wipe a message that just sent.
+                breakpoint()
                 // Reverse to show oldest first (bottom = newest)
                 actions.setMessages((response.results || []).reverse())
-            } catch {
+            } catch (error: any) {
+                if (error?.isBreakpoint) {
+                    throw error
+                }
                 lemonToast.error('Failed to load messages')
                 actions.setMessagesLoading(false)
             }
@@ -1135,44 +1185,85 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 actions.setMessageSending(false)
                 return
             }
-            try {
-                await api.comments.create(
-                    {
-                        content,
-                        rich_content: richContent,
-                        scope: 'conversations_ticket',
-                        item_id: values.ticket.id,
-                        item_context: {
-                            author_type: 'support',
-                            is_private: isPrivate,
-                        },
-                    },
-                    {}
-                )
-                // "Added", not "sent": email delivery is async (outbox + Celery) and can still fail
-                // after this API call succeeds; the per-message delivery status is the send signal.
-                lemonToast.success(isPrivate ? 'Private note added' : 'Reply added')
-                actions.setMessageSending(false)
-                onSuccess?.()
-                if (!isPrivate) {
-                    actions.incrementUnreadCustomerCount()
-                }
-                if (statusAfterSend) {
-                    actions.setStatus(statusAfterSend)
-                    // Pick up the ticket for the sender unless a specific user is already assigned.
-                    if (values.assignee?.type !== 'user' && values.user) {
-                        actions.setAssignee({ type: 'user', id: values.user.id })
-                    }
-                    actions.updateTicket()
-                }
-                setTimeout(() => {
-                    actions.loadMessages()
-                }, 300)
-                actions.loadTickets()
-            } catch {
-                lemonToast.error('Failed to send message')
-                actions.setMessageSending(false)
+            const ticketId = values.ticket.id
+            // One key per composed message, held across retries and across a manual resend after a
+            // failure, so the server can recognise a repeat instead of storing it twice.
+            const idempotencyKey = values.sendIdempotencyKey ?? uuid()
+            if (!values.sendIdempotencyKey) {
+                actions.setSendIdempotencyKey(idempotencyKey)
             }
+
+            let lastError: any
+            let attempt = 0
+            for (;;) {
+                try {
+                    const created = await api.comments.create(
+                        {
+                            content,
+                            rich_content: richContent,
+                            scope: 'conversations_ticket',
+                            item_id: ticketId,
+                            item_context: {
+                                author_type: 'support',
+                                is_private: isPrivate,
+                            },
+                            idempotency_key: idempotencyKey,
+                        },
+                        {}
+                    )
+                    // "Added", not "sent": email delivery is async (outbox + Celery) and can still fail
+                    // after this API call succeeds; the per-message delivery status is the send signal.
+                    lemonToast.success(isPrivate ? 'Private note added' : 'Reply added')
+                    actions.setMessageSending(false)
+                    if (created?.id) {
+                        actions.appendMessage(created)
+                    }
+                    onSuccess?.()
+                    actions.setSendIdempotencyKey(null)
+                    if (!isPrivate) {
+                        actions.incrementUnreadCustomerCount()
+                    }
+                    if (statusAfterSend) {
+                        actions.setStatus(statusAfterSend)
+                        // Pick up the ticket for the sender unless a specific user is already assigned.
+                        if (values.assignee?.type !== 'user' && values.user) {
+                            actions.setAssignee({ type: 'user', id: values.user.id })
+                        }
+                        actions.updateTicket()
+                    }
+                    actions.loadTickets()
+                    return
+                } catch (error: any) {
+                    lastError = error
+                    if (attempt >= sendRetryBudget(error)) {
+                        break
+                    }
+                    attempt++
+                    await delay(SEND_RETRY_DELAY_MS)
+                }
+            }
+
+            actions.setMessageSending(false)
+
+            if (!isSendOutcomeUnknown(lastError)) {
+                lemonToast.error('Failed to send message')
+                return
+            }
+
+            // The write may well have landed, so the draft and its key are kept: sending again
+            // reuses the key and the server returns the original instead of a second copy.
+            posthog.capture('conversations reply send outcome unknown', {
+                ticket_id: ticketId,
+                is_private: isPrivate,
+                status: lastError?.status ?? null,
+            })
+            lemonToast.error("We couldn't confirm your message was sent. Check the thread before sending again.", {
+                autoClose: false,
+                button: {
+                    label: 'Check thread',
+                    action: () => actions.loadMessages(),
+                },
+            })
         },
         dismissKnowledgeGap: async ({ suggestionId }) => {
             try {

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -783,9 +783,11 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             null as string | null,
             {
                 setSendIdempotencyKey: (_, { key }) => key,
-                // Editing the draft makes it a different message, so it must not reuse a key
-                // the server may already have stored against the previous text.
+                // Editing the draft or flipping it between reply and private note makes it a
+                // different message, so it must not reuse a key the server may already have
+                // stored against the previous send.
                 setDraftContent: () => null,
+                setDraftIsPrivate: () => null,
             },
         ],
         draftContent: [


### PR DESCRIPTION
## Problem

Three things could make a reply that actually sent look like it hadn't, and each nudges the operator into sending it again.

**Every failure was called definite.** A dropped connection or a 5xx says nothing about whether the write landed, but the composer said "Failed to send message" and kept the draft. The obvious next move is to send a message the customer already has.

**The thread only showed a reply once a list response contained it.** The 5s poll has no ordering guard and `setMessages` replaces the list wholesale, so a slow reply to an earlier poll arriving after a newer one wiped a message that had just sent.

**Network-level failures produced no telemetry.** `client_request_failure` only fires when there's a response to inspect, so this exact failure mode was invisible.

## Changes

Each composed message carries an idempotency key, so a repeat is deduplicated server-side instead of delivered twice, and the UI stops claiming to know more than it does.

| Outcome | Before | After |
| --- | --- | --- |
| Success | toast, refetch after 300ms | toast, reply appended from the response |
| No response / 5xx | "Failed to send message" | retried with the same key; if still unconfirmed, told so, with a "Check thread" action |
| 4xx | "Failed to send message" | unchanged |
| Slow poll lands late | can wipe a just-sent reply | dropped as superseded |

Worth a reviewer's eye:

- **Key lifetime is tied to the draft.** Cleared by `setDraftContent` and `setDraftIsPrivate`, so editing the text or flipping between reply and private note mints a fresh key, because that's a different message. An unedited resend after a failure reuses the key, which is the case that actually bit us.
- **Only the network call sits inside the try.** A throw from post-send cleanup (the composer clearing an editor torn down mid-send) is captured and the rest of the success path still runs, instead of being misreported as a failed send.
- **Retry budget differs by failure kind**: two attempts when no response arrived at all (cheap, fails instantly), one for a 5xx (already cost a round trip on an endpoint that can be slow). Keeps the worst-case spinner bounded.
- **`appendMessage` dedupes by id**, so it's a no-op if the poll got there first, and it handles the `200` replay response like a fresh `201`.
- **The unconfirmed path keeps the draft and the key** and captures `conversations reply send outcome unknown`, so this failure mode is finally measurable.

> [!WARNING]
> Depends on #77601, which adds `idempotency_key` to comment creation. Merge and deploy that first, to both regions. On its own, this turns the auto-retry into a duplicate-message generator.

Copy for the unconfirmed case, run past `/writing-user-facing-copy`:

> We couldn't confirm your message was sent. Check the thread before sending again.

## How did you test this code?

Automated only, written and run by Claude, in `supportTicketSceneLogic.test.ts` (9 new tests, 43 in the file, 151 across the 14 conversations frontend suites, all passing):

- the sent reply appears without a refetch, and isn't shown twice when the poll already delivered it
- an unknown-outcome send repeats with the same key, and only one message results
- after giving up, the key is retained so a manual resend reuses it (the real-world sequence: apparent failure, operator presses send again)
- editing the draft mints a fresh key, and so does flipping between reply and private note
- a throw from post-send cleanup doesn't produce a failure toast, and the success path completes past it
- a 4xx isn't retried
- a superseded poll response no longer overwrites newer state (the suite drains mount-time listeners first, since `loadTicket` dispatches its own poll that raced the staged ones on a CI shard)

Each maps to a failure this PR fixes; the old listener had a single bare `catch`, so none had coverage before. Also `typescript:check` with no errors in the changed files (the remainder is a pre-existing unbuilt `@posthog/hogvm`), `kea-typegen check` clean, lint/format via `pnpm --filter=@posthog/frontend fix`, and `hogli ci:preflight` clean.

Not exercised in a browser. Manual routine worth running before merge: kill the network in devtools, send a reply, watch the retry then the unconfirmed toast, restore the network, press send again, confirm exactly one message lands in the thread and one copy reaches the customer's channel.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed. The only user-visible surface is the two toast states, and no documented workflow describes the old behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Last of three from an investigation I asked Claude (Claude Code, Opus 5) to run into support replies that looked unsent and then appeared more than once. #77601 made the write idempotent, #77605 got the slow work off the request, this is the client half. Skills: `/writing-user-facing-copy`, `/writing-tests`, plus the review-hog skills-store perspectives for a self-review, which caught that the original retry loop's try wrapped the whole success path, so a cleanup throw after a successful create was misreported as a failed send; fixed in `e862459ea7e`.

The main decision was where to mint the key. The composer at submit time was dropped: the key has to survive the failure and the operator's next click, and the composer's draft state is what changes underneath it. A logic-level reducer keyed to the draft gets both halves right, since the draft-changed signal that should invalidate a key is already an action. An optimistic pending bubble was also considered and left out: appending the real comment from the create response covers "did it appear" without placeholder rows to reconcile against the poll.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

