### PR TITLE
fix(data-warehouse): convert anchor time using project timezone

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -971,7 +971,6 @@ function AnchorTimeField({
     const localTime = isProjectTime
         ? dayjs
               .utc(`${dayjs().format('YYYY-MM-DD')}T${utcTime}`)
-              .local()
               .tz(currentTeam?.timezone || 'UTC')
               .format('HH:mm:00')
         : utcTime
@@ -1025,7 +1024,7 @@ function AnchorTimeField({
                         accessDisabledReason ?? (!schema.should_sync ? 'Enable syncing to set anchor time' : undefined)
                     }
                     onChange={(checked) => {
-                        setDraftSyncTimeOfDay(checked ? (isProjectTime ? localTime : utcTime) : null)
+                        setDraftSyncTimeOfDay(checked ? utcTime : null)
                     }}
                 />
                 <LemonInput
@@ -1035,9 +1034,11 @@ function AnchorTimeField({
                     value={isSyncTimeSet ? localTime.substring(0, 5) : undefined}
                     onChange={(value) => {
                         const newValue = `${value}:00`
+                        // dayjs.tz(str, zone) interprets the wall-clock time in the project
+                        // timezone; plain dayjs(str) would parse it in the browser's timezone.
                         const utcValue = isProjectTime
-                            ? dayjs(`${dayjs().format('YYYY-MM-DD')}T${newValue}`)
-                                  .tz(currentTeam?.timezone || 'UTC')
+                            ? dayjs
+                                  .tz(`${dayjs().format('YYYY-MM-DD')}T${newValue}`, currentTeam?.timezone || 'UTC')
                                   .utc()
                                   .format('HH:mm:00')
                             : newValue


### PR DESCRIPTION
## Problem

The anchor time field in a schema's Schedule section has a UTC/project-timezone toggle, but it never actually applied the project timezone. Entered times were parsed in the browser's timezone (`dayjs(str).tz(...)` only re-labels the instant, it doesn't reinterpret it), and enabling the anchor switch stored the project-local wall clock as if it were UTC, so the displayed time came back doubly shifted.

## Changes

- Parse entered times with `dayjs.tz(str, projectTz)` so they're interpreted as project-timezone wall clock before converting to UTC
- Always store the UTC value when enabling the anchor switch (`sync_time_of_day` is UTC everywhere else)
- Dropped a redundant `.local()` in the display conversion

## How did you test this code?

Frontend typecheck passes. No automated tests added since the conversion logic lives inline in the component. Manually verify: set project timezone to America/New_York, toggle the anchor time switch to project time, enter a time, and confirm the saved UTC value is offset correctly (and round-trips on reload).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code diagnosed and fixed this. Two bugs found in `AnchorTimeField`: browser-local parsing on input, and storing the local wall clock in the UTC draft when enabling the switch. Noted but left alone: `sourceSettingsLogic` carries an unused `isProjectTime` copy (dead code, separate cleanup).
