### PR TITLE
chore(warehouse-sources): give run-finalization ownership one named home

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -593,6 +593,10 @@ class ExternalDataJobWorkflow(PostHogWorkflow):
                 **timeout_params,
             )  # type: ignore
 
+            # Run-finalization ownership (terminal status write, v3 lock release, post-import
+            # start) — the full contract lives on the PipelineResult docstring. False on every
+            # failure path by construction: a raising activity returns no result, so this line
+            # is never reached and the workflow finalizes in `finally`.
             consumer_manages_job_status = pipeline_result.get("consumer_manages_job_status", False)
             skip_post_import_activities = pipeline_result.get("skip_post_import_activities", False)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/typings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/typings.py
@@ -2,6 +2,27 @@ from typing import NotRequired, TypedDict
 
 
 class PipelineResult(TypedDict):
+    """The import activity's report back to `ExternalDataJobWorkflow`.
+
+    `consumer_manages_job_status` is the run-finalization ownership contract. Exactly one party
+    writes the terminal job status, releases the v3 sync lock, and starts the post-import
+    workflow:
+
+    - False / absent (v2, and every failure path — an activity that raises returns no result):
+      the workflow finalizes in its `finally` block.
+    - True: the v3 load consumer finalizes after loading the final batch, and the workflow must
+      keep its hands off all three.
+
+    It is a runtime value, not a pure property of `ExternalDataJob.pipeline_version`, for one
+    reason: a v3 extraction that produced zero batches never notifies the load consumer, so the
+    consumer cannot finalize a run it will never hear about — the workflow must. PipelineV3
+    therefore reports True iff at least one batch reached the queue. The two other producers of
+    True (`import_data_sync`'s terminal-retry skip, and the CDC-handled-externally path) are
+    runs some other party already finalized, where True likewise means "workflow: hands off".
+    Making this a pure version property requires an empty-final-batch queue message so the
+    consumer hears about every v3 run — deferred until the v2 pipeline is deleted.
+    """
+
     should_trigger_cdp_producer: bool
     consumer_manages_job_status: NotRequired[bool]
     skip_post_import_activities: NotRequired[bool]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -364,9 +364,14 @@ class PipelineV3(Generic[ResumableData]):
 
             await self._finalize(row_count=row_count)
 
+            # With zero batches, `_finalize` sent no final-batch notification, so the load
+            # consumer will never hear about this run and cannot finalize it — the workflow must.
+            # See the PipelineResult docstring for the full ownership contract.
+            consumer_will_hear_about_this_run = len(self._batch_results) > 0
+
             return {
                 "should_trigger_cdp_producer": await self._sinks.cdp_producer.should_run(),
-                "consumer_manages_job_status": len(self._batch_results) > 0,
+                "consumer_manages_job_status": consumer_will_hear_about_this_run,
             }
         except Exception:
             status = "error"

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -123,6 +123,8 @@ async def import_data_activity_sync(inputs: ImportDataActivityInputs) -> Pipelin
                     status=model.status,
                     attempt=attempt,
                 )
+                # The consumer already finalized this run (that's how it became terminal), so the
+                # workflow must not overwrite the status or release the lock — see PipelineResult.
                 return PipelineResult(
                     should_trigger_cdp_producer=False,
                     consumer_manages_job_status=True,
@@ -279,6 +281,8 @@ async def import_data_activity_sync(inputs: ImportDataActivityInputs) -> Pipelin
                 except Exception:
                     await logger.awarning("Failed to pause per-schema schedule for CDC streaming schema")
 
+                # This activity finalized the job itself just above, so the workflow must not
+                # write a second terminal status — see PipelineResult for the ownership contract.
                 return PipelineResult(
                     should_trigger_cdp_producer=False,
                     consumer_manages_job_status=True,
@@ -455,7 +459,7 @@ async def _run(
         if use_v3:
             from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3 import PipelineV3
 
-            logger.info("Running V3 pipeline (feature flag enabled)")
+            logger.info("Running V3 pipeline (persisted job.pipeline_version is V3)")
             pipeline: PipelineV3 | PipelineNonDLT = PipelineV3(
                 source_response,
                 logger,


### PR DESCRIPTION
## Problem

Phase 5 (scoped to its minimal version) of the warehouse-sources pipeline untangling. The v3 rollout decision itself already has a single source of truth — the flag is evaluated once per workflow (`check_pipeline_version_activity`) and everything downstream reads the persisted `job.pipeline_version`. But who finalizes a run (writes the terminal job status, releases the v3 sync lock, starts post-import) is a runtime boolean threaded through `PipelineResult` with three producers and three workflow decision sites, and the rule behind it was written down nowhere — reconstructing it means reading all six.

## Changes

Writes the rule down without changing it:

- `PipelineResult`'s docstring now carries the full ownership contract, including why it is a runtime value rather than a pure property of the pipeline version: a zero-batch v3 extraction never notifies the load consumer, so the consumer cannot finalize a run it will never hear about. Promoting ownership to a pure version property needs an empty-final-batch queue message — deliberately deferred until the v2 pipeline is deleted, when that question must be answered anyway.
- `PipelineV3` names the expression (`consumer_will_hear_about_this_run`) instead of returning a bare `len()` comparison; the two hardcoded `True` producers (terminal-retry skip, CDC-handled-externally) explain themselves; the workflow's derivation site points at the contract.
- The `Running V3 pipeline (feature flag enabled)` log line stops claiming the flag decides — the persisted `pipeline_version` does.

> [!NOTE]
> The `external_data_job.py` workflow edit is comments only — no command changes, replay-safe. No behavior changes anywhere.

## How did you test this code?

Comments, docstrings, and one local-variable naming — no behavior to test, so no new tests. Ran the v3 pipeline and post-import-fork suites (14 tests, green), `ruff`, and repo-wide `uv run mypy --cache-fine-grained .` (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing or documented-workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The full phase 5 (empty-final-batch protocol change so the consumer finalizes every v3 run and ownership becomes a pure version property) was proposed, discussed, and deliberately scoped down to this documentation-only version — the protocol change carries deploy-ordering and rollout risk in the queue/lock area for no present bug, and will be better motivated when v2 deletion forces the zero-batch question regardless. The deferred design is recorded in the `PipelineResult` docstring so it isn't lost.
Commit landed via GraphQL `createCommitOnBranch` (server-side signing), remote tree verified equal to the locally tested commit.