### PR TITLE
feat(web-analytics): expose path-cleaning suggestions as an MCP tool

### DIFF
--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -140,4 +140,5 @@ export const AGENT_USE_CASE_SCOPES = [
     'warehouse_view:read',
     'warehouse_view:write',
     'web_analytics:read',
+    'web_analytics:write',
 ] as const

--- a/products/posthog_ai/frontend/policy/toolPolicy.ts
+++ b/products/posthog_ai/frontend/policy/toolPolicy.ts
@@ -55,6 +55,7 @@ const POSTHOG_DESTRUCTIVE_SUB_TOOLS = new Set([
     'skill-archive',
     'user-interview-topics-remove-interviewee',
     'visual-review-runs-finalize-create',
+    'web-analytics-path-cleaning-suggestions-apply',
     'workflows-discard-draft',
     'workflows-publish',
     'workflows-restore-revision',

--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -160,6 +160,7 @@ POSTHOG_EXEC_DESTRUCTIVE_SUB_TOOLS: tuple[str, ...] = (
     "skill-archive",
     "user-interview-topics-remove-interviewee",
     "visual-review-runs-finalize-create",
+    "web-analytics-path-cleaning-suggestions-apply",
     "workflows-discard-draft",
     "workflows-publish",
     "workflows-restore-revision",

--- a/products/web_analytics/mcp/tools.yaml
+++ b/products/web_analytics/mcp/tools.yaml
@@ -204,6 +204,9 @@ tools:
     web-analytics-path-cleaning-suggestions-generate:
         operation: web_analytics_path_cleaning_suggestions_generate
         enabled: true
+        # Generation samples real URL paths and sends them to the LLM — hide the tool from
+        # orgs that haven't approved AI data processing.
+        requires_ai_consent: true
         scopes:
             - web_analytics:write
         annotations:

--- a/products/web_analytics/mcp/tools.yaml
+++ b/products/web_analytics/mcp/tools.yaml
@@ -204,9 +204,6 @@ tools:
     web-analytics-path-cleaning-suggestions-generate:
         operation: web_analytics_path_cleaning_suggestions_generate
         enabled: true
-        # Generation samples real URL paths and sends them to the LLM — hide the tool from
-        # orgs that haven't approved AI data processing.
-        requires_ai_consent: true
         scopes:
             - web_analytics:write
         annotations:
@@ -224,6 +221,7 @@ tools:
             flag. Use when the user asks to clean up or normalize their paths and no suggestion exists yet. This only
             proposes rules — apply them with `web-analytics-path-cleaning-suggestions-apply`; nothing changes until
             then.
+        requires_ai_consent: true
         feature_flag: web-analytics-path-cleaning-suggestions
     web-analytics-path-cleaning-suggestions-preview:
         operation: web_analytics_path_cleaning_suggestions_preview

--- a/products/web_analytics/mcp/tools.yaml
+++ b/products/web_analytics/mcp/tools.yaml
@@ -185,10 +185,43 @@ tools:
         enabled: false
     web-analytics-path-cleaning-suggestions-apply:
         operation: web_analytics_path_cleaning_suggestions_apply
-        enabled: false
+        enabled: true
+        scopes:
+            - web_analytics:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: false
+        title: Apply a path-cleaning suggestion
+        description: >
+            Apply a suggested set of path-cleaning rules by its health-issue `id`, merging them into the project's path
+            cleaning configuration. Existing rules are never overwritten — only new rules are appended — and the
+            underlying `path_cleaning_suggestions` health issue is resolved. Returns how many rules were added. Requires
+            project admin (the same gate as editing path cleaning rules in team settings). Applying changes historical
+            numbers in every Web analytics and Paths chart that has cleaning enabled, so confirm with the user before
+            calling this.
+        feature_flag: web-analytics-path-cleaning-suggestions
     web-analytics-path-cleaning-suggestions-generate:
         operation: web_analytics_path_cleaning_suggestions_generate
-        enabled: false
+        enabled: true
+        scopes:
+            - web_analytics:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Generate path-cleaning suggestions
+        description: >
+            Analyze the project's recent URL paths and generate suggested path-cleaning rules on demand. Samples the
+            most-viewed paths, asks the model for `{regex, alias}` rules, and validates each against the real paths
+            (dropping any that don't match), then stores the result as a `path_cleaning_suggestions` health issue.
+            Returns `status` ('generated' with a `suggestion`, or a skip reason like 'skipped_no_paths' /
+            'skipped_low_cardinality' when there isn't enough to suggest from). Pending suggestions surface through the
+            health-issues API (filter `kind=path_cleaning_suggestions`); dismiss one by PATCHing the issue's `dismissed`
+            flag. Use when the user asks to clean up or normalize their paths and no suggestion exists yet. This only
+            proposes rules — apply them with `web-analytics-path-cleaning-suggestions-apply`; nothing changes until
+            then.
+        feature_flag: web-analytics-path-cleaning-suggestions
     web-analytics-path-cleaning-suggestions-preview:
         operation: web_analytics_path_cleaning_suggestions_preview
         enabled: false

--- a/products/web_analytics/skills/suggesting-path-cleaning-rules/SKILL.md
+++ b/products/web_analytics/skills/suggesting-path-cleaning-rules/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: suggesting-path-cleaning-rules
+description: 'Runs and reasons about the automated AI health check that suggests path-cleaning rules for web-analytics teams. Use when asked to generate path-cleaning suggestions for a team or cohort, to run the suggestion check, to review/apply AI-suggested rules, to inspect path_cleaning_suggestions health issues, or to extend the suggestion pipeline. Covers the suggest_path_cleaning_rules management command, the path_cleaning_suggestions health check, the cohort gating (precompute teams), and how suggestions are validated against real paths before storage. For hand-authoring or applying rules directly, use managing-path-cleaning-rules instead.'
+---
+
+# Suggesting path-cleaning rules
+
+Many teams never configure path cleaning, so their Web analytics breakdowns fragment across
+thousands of near-identical URLs. This feature **proactively suggests** cleaning rules for the
+web-analytics precompute cohort: weekly, for each team, it samples real paths, asks the LLM for
+`{regex, alias}` rules, validates them against the team's own paths, and stores them for review.
+
+It **only suggests** — it never auto-applies. Applying rewrites historical numbers in every cleaned
+chart, so that stays a human decision (the existing settings UI, or the `--apply` flag below after
+review). To hand-author or directly apply rules, use the `managing-path-cleaning-rules` skill.
+
+## Architecture
+
+- **Core**: `products/web_analytics/backend/path_cleaning_suggestions/service.py`
+  - `sample_pathnames` / `count_distinct_pathnames` — top `$pathname` by views via HogQL.
+  - `call_llm_for_rules` — one-shot call through the LLM gateway
+    (`get_llm_client(product="web_analytics", team_id=...)`, model
+    `WEB_ANALYTICS_PATH_CLEANING_SUGGESTIONS_MODEL`, default `claude-haiku-4-5`).
+  - `validate_and_annotate_rules` — compiles each regex with **re2** (the engine ClickHouse
+    `replaceRegexpAll` uses) and test-applies it to the sampled paths. Rules that don't compile or
+    match nothing are dropped; survivors get a dense `order`, a `match_count`, and in-memory
+    before/after `examples` (printed by the management command, never stored — health-issue
+    payloads are readable with just `health_issue:read` and must not leak real paths). This is
+    the skill's "test before saving" step, automated.
+  - `generate_suggestions_for_team` — orchestrates the above with gating (see below); pure
+    generation, no storage.
+  - `apply_suggestions_to_team` — **merges** rules into `path_cleaning_filters`, never overwrites
+    (dedupes by regex, continues `order`).
+- **Storage**: a `path_cleaning_suggestions` **health issue** (`HealthIssue`, severity `info`) — no
+  dedicated model. One active issue per team (`hash_keys=[]`); `payload` carries `rules`, `model`,
+  `sampled_path_count`, `distinct_path_count`. Applying (or hand-configuring rules) resolves the
+  issue on the next check run; dismissal is the health-issue `dismissed` flag.
+- **Schedule**: `PathCleaningSuggestionsCheck`
+  (`products/web_analytics/backend/temporal/health_checks/path_cleaning_suggestions.py`), a health
+  check on the shared health-check framework, weekly (Mon 06:23 UTC), small sequential batches
+  because each eligible team costs an LLM call. Teams with an existing active suggestion are
+  re-emitted without a fresh LLM round trip.
+- **Cohort**: `WEB_ANALYTICS_PATH_CLEANING_SUGGESTIONS_TEAM_IDS`, defaulting to the precompute
+  enrollment list `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS`.
+
+## Gating (why a team is skipped)
+
+`generate_suggestions_for_team` returns a status:
+
+- `skipped_inactive` — team sent no `$pageview` within `visited_within_days` (default 30); we only
+  suggest for teams actively using web analytics. Bypass with `--ignore-visit-gate`.
+- `skipped_configured` — team already has path cleaning rules (override with `include_configured`).
+- `skipped_low_cardinality` — fewer distinct paths than `min_distinct_paths` (default 50); cleaning
+  adds no value, so we don't spend tokens.
+- `skipped_no_paths` — no pageviews in the window.
+- `generated` — rules produced (may be an empty list if paths are already clean; empty generations
+  are never stored, so they can't shadow an actionable suggestion).
+- `error` — sampling/LLM failed; captured per-team, never aborts the cohort sweep.
+
+## How users see and apply suggestions
+
+- **Settings banner**: `PathCleaningSuggestionsBanner` on `/settings/project#path_cleaning` shows the
+  latest `suggested` row as regex → alias previews with match counts; "Apply all" (project admins
+  only) merges the rules, the close button dismisses. Driven by `pathCleaningSuggestionsLogic`.
+- **Onboarding step**: `OnboardingWebAnalyticsPathCleaningStep` (stepKey `path_cleaning`) surfaces the
+  same banner during Web analytics onboarding.
+- **API** (`products/web_analytics/backend/api/web_analytics_path_cleaning_suggestions.py`):
+  `POST /api/projects/:id/web_analytics_path_cleaning_suggestions/generate/` produces and stores a
+  fresh suggestion on demand; `GET .../{issue_id}/preview/` applies the rules to a fresh sample of
+  the team's top paths and returns before/after pairs (read scope, computed on demand, never
+  stored — this backs the banner's "Preview on your paths" modal); `POST .../{issue_id}/apply/`
+  merges the rules and resolves the issue (project admin only — the same gate the team API puts on
+  `path_cleaning_filters`).
+  Listing and dismissing go through the generic health-issues API
+  (`GET /api/projects/:id/health_issues/?kind=path_cleaning_suggestions&status=active&dismissed=false`,
+  `PATCH .../health_issues/{id}/` with `{"dismissed": true}`).
+- **Health page**: the check renders on `/web/health` alongside the other web-analytics checks, with
+  remediation guidance for humans and agents.
+- **PostHog AI (Max)**: generate/apply are exposed as MCP tools in
+  `products/web_analytics/mcp/tools.yaml` (`web-analytics-path-cleaning-suggestions-{generate,apply}`),
+  so a user can ask Max to suggest path-cleaning rules and apply them conversationally. Apply is
+  `destructive` (it changes historical chart numbers), so the MCP confirmation gate applies.
+
+## Running it
+
+```sh
+# Default cohort, print suggestions, store health issues:
+python manage.py suggest_path_cleaning_rules
+
+# Specific teams, dry run (nothing stored):
+python manage.py suggest_path_cleaning_rules --teams 2,19279 --no-store
+
+# Generate AND apply for one reviewed team (merges, never overwrites):
+python manage.py suggest_path_cleaning_rules --teams 2 --apply
+```
+
+Useful flags: `--days` (lookback), `--limit` (top-N paths sampled), `--min-distinct-paths`,
+`--include-configured`, `--no-store`, `--apply`.
+
+The health check can also be triggered per team from the health-issues `refresh` endpoint or the
+admin UI, like any other health check.
+
+## Reviewing suggestions
+
+Read a team's active suggestion:
+
+```python
+HealthIssue.objects.filter(team_id=team_id, kind="path_cleaning_suggestions", status="active").first()
+```
+
+Each rule in `payload["rules"]` carries `regex`, `alias`, `order`, `reason`, and `match_count` —
+that's what to show a human deciding whether to apply. Before/after examples on real paths are only
+printed by the management command at generation time; they are deliberately kept out of the stored
+payload.
+
+## Extending
+
+- Adding a surfacing channel (in-app notification, settings banner, onboarding wizard step): read the
+  team's active `path_cleaning_suggestions` health issue and render its `payload["rules"]`. Keep
+  apply manual.
+- Changing the model: it must be allowlisted for the `web_analytics` product in
+  `services/llm-gateway/src/llm_gateway/products/config.py`.
+- The agentic alternative — a `signals-scout-web-analytics-path-cleaning` scout — is sketched in the
+  design notes; prefer the dedicated job for the precompute cohort because it targets that exact
+  cohort and surfaces structured, validated rows rather than Signals-inbox findings.

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -10575,6 +10575,36 @@
             "readOnlyHint": false
         }
     },
+    "web-analytics-path-cleaning-suggestions-apply": {
+        "description": "Apply a suggested set of path-cleaning rules by its health-issue `id`, merging them into the project's path cleaning configuration. Existing rules are never overwritten — only new rules are appended — and the underlying `path_cleaning_suggestions` health issue is resolved. Returns how many rules were added. Requires project admin (the same gate as editing path cleaning rules in team settings). Applying changes historical numbers in every Web analytics and Paths chart that has cleaning enabled, so confirm with the user before calling this.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Apply a path-cleaning suggestion",
+        "title": "Apply a path-cleaning suggestion",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "web-analytics-path-cleaning-suggestions"
+    },
+    "web-analytics-path-cleaning-suggestions-generate": {
+        "description": "Analyze the project's recent URL paths and generate suggested path-cleaning rules on demand. Samples the most-viewed paths, asks the model for `{regex, alias}` rules, and validates each against the real paths (dropping any that don't match), then stores the result as a `path_cleaning_suggestions` health issue. Returns `status` ('generated' with a `suggestion`, or a skip reason like 'skipped_no_paths' / 'skipped_low_cardinality' when there isn't enough to suggest from). Pending suggestions surface through the health-issues API (filter `kind=path_cleaning_suggestions`); dismiss one by PATCHing the issue's `dismissed` flag. Use when the user asks to clean up or normalize their paths and no suggestion exists yet. This only proposes rules — apply them with `web-analytics-path-cleaning-suggestions-apply`; nothing changes until then.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Generate path-cleaning suggestions",
+        "title": "Generate path-cleaning suggestions",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "web-analytics-path-cleaning-suggestions"
+    },
     "web-analytics-weekly-digest": {
         "description": "Summarizes a project's web analytics over a lookback window (default 7 days): unique visitors, pageviews, sessions, bounce rate, and average session duration with period-over-period comparisons, plus the top 5 pages, top 5 traffic sources, and goal conversions. Accepts optional `days` (1–90, default 7) and `compare` (bool, default true) query params — pass `days=30` to summarize the last month, or `compare=false` to skip the period-over-period comparison for a faster response. Use this to answer questions like \"how are my web analytics?\", \"how did the site do last week?\", or \"what's my traffic looking like this month?\".",
         "category": "Web analytics",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -10603,6 +10603,7 @@
             "openWorldHint": true,
             "readOnlyHint": false
         },
+        "requires_ai_consent": true,
         "feature_flag": "web-analytics-path-cleaning-suggestions"
     },
     "web-analytics-weekly-digest": {

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -11215,6 +11215,36 @@
             "readOnlyHint": false
         }
     },
+    "web-analytics-path-cleaning-suggestions-apply": {
+        "description": "Apply a suggested set of path-cleaning rules by its health-issue `id`, merging them into the project's path cleaning configuration. Existing rules are never overwritten — only new rules are appended — and the underlying `path_cleaning_suggestions` health issue is resolved. Returns how many rules were added. Requires project admin (the same gate as editing path cleaning rules in team settings). Applying changes historical numbers in every Web analytics and Paths chart that has cleaning enabled, so confirm with the user before calling this.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Apply a path-cleaning suggestion",
+        "title": "Apply a path-cleaning suggestion",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "web-analytics-path-cleaning-suggestions"
+    },
+    "web-analytics-path-cleaning-suggestions-generate": {
+        "description": "Analyze the project's recent URL paths and generate suggested path-cleaning rules on demand. Samples the most-viewed paths, asks the model for `{regex, alias}` rules, and validates each against the real paths (dropping any that don't match), then stores the result as a `path_cleaning_suggestions` health issue. Returns `status` ('generated' with a `suggestion`, or a skip reason like 'skipped_no_paths' / 'skipped_low_cardinality' when there isn't enough to suggest from). Pending suggestions surface through the health-issues API (filter `kind=path_cleaning_suggestions`); dismiss one by PATCHing the issue's `dismissed` flag. Use when the user asks to clean up or normalize their paths and no suggestion exists yet. This only proposes rules — apply them with `web-analytics-path-cleaning-suggestions-apply`; nothing changes until then.",
+        "category": "Web analytics",
+        "feature": "web_analytics",
+        "summary": "Generate path-cleaning suggestions",
+        "title": "Generate path-cleaning suggestions",
+        "required_scopes": ["web_analytics:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "web-analytics-path-cleaning-suggestions"
+    },
     "web-analytics-weekly-digest": {
         "description": "Summarizes a project's web analytics over a lookback window (default 7 days): unique visitors, pageviews, sessions, bounce rate, and average session duration with period-over-period comparisons, plus the top 5 pages, top 5 traffic sources, and goal conversions. Accepts optional `days` (1–90, default 7) and `compare` (bool, default true) query params — pass `days=30` to summarize the last month, or `compare=false` to skip the period-over-period comparison for a faster response. Use this to answer questions like \"how are my web analytics?\", \"how did the site do last week?\", or \"what's my traffic looking like this month?\".",
         "category": "Web analytics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -11243,6 +11243,7 @@
             "openWorldHint": true,
             "readOnlyHint": false
         },
+        "requires_ai_consent": true,
         "feature_flag": "web-analytics-path-cleaning-suggestions"
     },
     "web-analytics-weekly-digest": {

--- a/services/mcp/src/generated/web_analytics/api.ts
+++ b/services/mcp/src/generated/web_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 8 enabled ops
+ * PostHog API - MCP 10 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -414,4 +414,29 @@ export const WebAnalyticsWeeklyDigestQueryParams = /* @__PURE__ */ zod.object({
         .number()
         .default(webAnalyticsWeeklyDigestQueryDaysDefault)
         .describe('Lookback window in days (1–90). Defaults to 7.'),
+})
+
+/**
+ * Merges the suggestion's rules into the team's path_cleaning_filters (never overwrites existing rules) and resolves the underlying health issue. Requires project admin, matching the team API's gate on path_cleaning_filters.
+ * @summary Apply a path-cleaning suggestion
+ */
+export const WebAnalyticsPathCleaningSuggestionsApplyParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Samples the team's recent paths, asks the LLM for cleaning rules, validates them against the real paths, and stores the result as a `path_cleaning_suggestions` health issue (replacing any previous active one). Runs even if the team already has rules. Returns the suggestion (or a skip status when there aren't enough paths to suggest from).
+ * @summary Generate path-cleaning suggestions on demand
+ */
+export const WebAnalyticsPathCleaningSuggestionsGenerateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
 })

--- a/services/mcp/src/tools/generated/web_analytics.ts
+++ b/services/mcp/src/tools/generated/web_analytics.ts
@@ -11,6 +11,7 @@ import {
     SavedPartialUpdateParams,
     SavedRegenerateCreateParams,
     SavedRetrieveParams,
+    WebAnalyticsPathCleaningSuggestionsApplyParams,
     WebAnalyticsWeeklyDigestQueryParams,
 } from '@/generated/web_analytics/api'
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
@@ -208,6 +209,45 @@ const heatmapsSavedUpdate = (): ToolBase<typeof HeatmapsSavedUpdateSchema, Schem
             method: 'PATCH',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/saved/${encodeURIComponent(String(params.short_id))}/`,
             body,
+        })
+        return result
+    },
+})
+
+const WebAnalyticsPathCleaningSuggestionsApplySchema = WebAnalyticsPathCleaningSuggestionsApplyParams.omit({
+    project_id: true,
+})
+
+const webAnalyticsPathCleaningSuggestionsApply = (): ToolBase<
+    typeof WebAnalyticsPathCleaningSuggestionsApplySchema,
+    Schemas.ApplyPathCleaningSuggestionResponse
+> => ({
+    name: 'web-analytics-path-cleaning-suggestions-apply',
+    schema: WebAnalyticsPathCleaningSuggestionsApplySchema,
+    handler: async (context: Context, params: z.infer<typeof WebAnalyticsPathCleaningSuggestionsApplySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ApplyPathCleaningSuggestionResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/web_analytics_path_cleaning_suggestions/${encodeURIComponent(String(params.id))}/apply/`,
+        })
+        return result
+    },
+})
+
+const WebAnalyticsPathCleaningSuggestionsGenerateSchema = z.object({})
+
+const webAnalyticsPathCleaningSuggestionsGenerate = (): ToolBase<
+    typeof WebAnalyticsPathCleaningSuggestionsGenerateSchema,
+    Schemas.GeneratePathCleaningSuggestionResponse
+> => ({
+    name: 'web-analytics-path-cleaning-suggestions-generate',
+    schema: WebAnalyticsPathCleaningSuggestionsGenerateSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof WebAnalyticsPathCleaningSuggestionsGenerateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.GeneratePathCleaningSuggestionResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/web_analytics_path_cleaning_suggestions/generate/`,
         })
         return result
     },
@@ -542,6 +582,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'heatmaps-saved-list': heatmapsSavedList,
     'heatmaps-saved-regenerate': heatmapsSavedRegenerate,
     'heatmaps-saved-update': heatmapsSavedUpdate,
+    'web-analytics-path-cleaning-suggestions-apply': webAnalyticsPathCleaningSuggestionsApply,
+    'web-analytics-path-cleaning-suggestions-generate': webAnalyticsPathCleaningSuggestionsGenerate,
     'web-analytics-weekly-digest': webAnalyticsWeeklyDigest,
     'query-web-overview': createQueryWrapper({
         name: 'query-web-overview',

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -852,6 +852,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'metrics',
                 'endpoints-ai-materialization-fix',
                 'engineering-analytics',
+                'web-analytics-path-cleaning-suggestions',
                 'stamphog',
                 'product-data-catalog',
                 'loops',
@@ -860,7 +861,7 @@ describe('Tool Filtering - Feature Flags', () => {
                 'streamlit-apps',
             ])
         )
-        expect(flags).toHaveLength(28)
+        expect(flags).toHaveLength(29)
     })
 
     it('every loops tool is gated on the loops flag', () => {


### PR DESCRIPTION
## Problem

#65832 adds AI-suggested path-cleaning rules with a review/apply flow in the web UI. Agents (Claude Code, the PostHog CLI, etc.) can't act on those suggestions yet because nothing exposes the generate/apply API as an MCP tool.

This PR is stacked on #65832 and only adds the agent-facing surface. It replaces #73316, which had accumulated ~8,000 lines of reformatted generated files from stale regeneration commits — this is the same change rebuilt cleanly (10 files, ~290 lines).

## Changes

- Adds `web-analytics-path-cleaning-suggestions-generate` and `-apply` MCP tools wrapping the API from #65832.
- `-apply` is annotated `destructive: true` (it rewrites path-cleaning rules used across Web analytics and Paths), so it's gated behind the exec-permission confirmation prompt in both `products/tasks/backend/constants.py` (server-side regex) and `products/posthog_ai/frontend/policy/toolPolicy.ts` (client-side mirror) — a backend test (`test_exec_permission_regex_covers_destructive_annotated_tools`) keeps these two in sync automatically.
- Adds a skill (`suggesting-path-cleaning-rules`) documenting when an agent should generate vs. apply suggestions.
- Regenerated MCP tool/schema artifacts via `hogli build:openapi` — the generated diff is purely additive (43 added lines in `web_analytics.ts`, zero removals).

## How did you test this code?

- `vitest run tests/unit` (services/mcp) — 2438 passed, including the flag/tool-count assertions updated for the new tools.
- `pnpm --filter=@posthog/mcp` typecheck — passes.
- `hogli test products/tasks/backend/tests/test_constants.py` — passes (confirms the new destructive tool is covered by the exec-permission regex).
- Did not manually exercise the tools against a running MCP server.

## Docs update

N/A — the skill file documents agent usage; no user-facing docs changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code) rebuilt this from #73316 at Lucas's request after that PR's diff ballooned: earlier regeneration commits on the old branch had committed local-formatter churn across ~70 generated MCP files, swamping the real change. The rebuild took the old branch's 5 hand-written files (verified by diffing against the base branch), reapplied them on a fresh branch off #65832's head, and regenerated artifacts with `hogli build:openapi` — this time keeping only the additive web-analytics deltas. The destructive-tool gate fix (the `-apply` tool missing from both exec-permission mirrors) carries over from the original PR.

Skills invoked: `/implementing-mcp-tools` (original authoring).
