### PR TITLE
fix(dashboards): keep refreshed tiles when persisting last_refresh

### DIFF
--- a/frontend/src/models/dashboardsModel.tsx
+++ b/frontend/src/models/dashboardsModel.tsx
@@ -484,7 +484,7 @@ export const dashboardsModel = kea<dashboardsModelType>([
                 }
 
                 if (discardResult) {
-                    return values.dashboard
+                    return null
                 }
 
                 const mappedDashboard = getQueryBasedDashboard(response)

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1437,6 +1437,31 @@ describe('dashboardLogic', () => {
                 expect(logic.values.oldestRefreshed?.toISOString()).toEqual(dayjs(staleIso).toISOString())
                 expect(logic.values.effectiveLastRefresh?.toISOString()).toEqual(dayjs(staleIso).toISOString())
             })
+
+            it('persisting the last refresh keeps refreshed results instead of an earlier snapshot', async () => {
+                await expectLogic(logic).toFinishAllListeners()
+
+                const snapshot = logic.values.dashboard!
+                dashboardsModel.actions.updateDashboardSuccess(snapshot)
+
+                const insight = snapshot.tiles.find((tile) => !!tile.insight)!.insight!
+                const freshResult = [{ count: 42 }]
+
+                await expectLogic(logic, () => {
+                    dashboardsModel.actions.updateDashboardInsight(
+                        { ...insight, result: freshResult, query: insight.query ?? null },
+                        undefined,
+                        5
+                    )
+                }).toFinishAllListeners()
+
+                await expectLogic(dashboardsModel, () => {
+                    logic.actions.updateDashboardLastRefresh(now())
+                }).toDispatchActions(['updateDashboard', 'updateDashboardSuccess'])
+
+                const refreshedTile = logic.values.tiles.find((tile) => tile.insight?.short_id === insight.short_id)
+                expect(refreshedTile?.insight?.result).toEqual(freshResult)
+            })
         })
 
         describe('insight refresh', () => {


### PR DESCRIPTION
## Problem

Refreshing a dashboard shows the correct numbers for a few seconds, then every tile silently reverts to data from an earlier time period. It doesn't error, so the tiles just sit there showing plausible but stale numbers, which is the worst version of this bug. Reported by a customer who hit it on several of their dashboards.

The cause is at the very end of a forced refresh. Once all tiles have been refreshed, `refreshDashboardItems` persists the refresh time through `dashboardsModel.updateDashboard` with `discardResult` set. `discardResult` returned the loader's previous value, and kea still dispatches `updateDashboardSuccess` with it, so whatever dashboard snapshot the model happened to be holding got re-broadcast as if it were a fresh update. `dashboardLogic`'s `dashboard` reducer applies that payload as a wholesale replacement whenever the id matches, so every tile's `result` was thrown away and replaced by the snapshot's.

The snapshot gets seeded by the paths that legitimately broadcast a whole dashboard, most commonly a layout or filter save via `saveEditModeChangesSuccess`. `dashboardsModel` is never unmounted, so once seeded it kept overwriting the results of every later forced refresh of that same dashboard for the rest of the session. That's why it looked intermittent: refresh on a freshly loaded page is fine, refresh any time after you've saved a layout is not.

This finishes the job started in #36568, which stopped the patch response from clobbering results but left the previous value being re-broadcast in its place.

## Changes

`discardResult` now returns `null`, so the success action carries no dashboard and the update can't touch dashboard state.

```diff
  if (discardResult) {
-     return values.dashboard
+     return null
  }
```

Nothing reads that loader value (the comment above the loader says as much, and it has no other reader anywhere), and all four consumers of `updateDashboardSuccess` already guard on a truthy dashboard or an id match, so a null payload is inert for them. `rawDashboards` also stops having a stale snapshot written into it on every refresh.

## How did you test this code?

Claude wrote this without a running local stack, so no manual browser verification. What it did run, in the worktree:

- Added one case to `dashboardLogic.test.ts`: seed the model with a dashboard snapshot the way a layout save does, land a fresh tile result, then persist the last refresh and assert the fresh result survives. It catches exactly the reported regression and fails on master (the tile's result comes back as the snapshot's older payload). No existing test covered it, because the nearby `updateDashboardLastRefresh` cases run with an unseeded model, so the reducer's truthiness guard hides the bug.
- `dashboardLogic.test.ts` in full: 93 passed, 1 pre-existing skip.
- The other suites that touch `dashboardsModel` (`dashboardsModel`, `dashboardsLogic`, `addToDashboardModalLogic`, `dashboardsFileSystemLogic`): 57 passed.
- `hogli ci:preflight --fix`: clean.

`typescript:check` reports 293 errors in this worktree both with and without this change, all from the unbuilt nested quill workspace and none in the touched files.

Manual check for a reviewer with a stack: open a dashboard, enter layout edit mode and save, then hit Refresh. On master the tiles fill with fresh data and then snap back to the pre-save results. With this change they stay.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I had Claude (Claude Code, Opus 5) investigate a customer report of dashboards reverting after a refresh. Skills invoked: `/writing-tests`.

Worth flagging on the diagnosis, because the first answer was wrong. An automated report had already blamed uncancelled SSE tile streams in `loadDashboardStreaming` and opened a PR against it. That path is behind the `sse-dashboards` flag, and the reporter evaluates it as `false` on every exposure across the period covered, so that fix couldn't have changed anything for them. Their own telemetry pointed at the non-streaming path instead: a `dashboard updated` patch landing 50 to 90ms after each forced refresh, always preceded earlier in the same page life by a layout save. That's what led to `discardResult`.

We also considered hardening `dashboardLogic`'s `updateDashboardSuccess` reducer to merge tile results rather than replace them wholesale, following the precedent in the `renameInsightSuccess` handler just below it. Left out here: it changes behavior for the paths that legitimately replace the whole dashboard, and deciding which side's `last_refresh` wins is a real design call rather than part of this fix.
