### PR TITLE
chore(ci): restore node tool cache in pnpm-install

### DIFF
--- a/.depot/actions/pnpm-install/action.yml
+++ b/.depot/actions/pnpm-install/action.yml
@@ -1,6 +1,8 @@
 # Depot mirror of .github/actions/pnpm-install (same pattern as .depot/actions/setup-sqlx-cli).
-# Kept byte-for-byte equivalent to canonical except the node-gyp chmod below, which is hardened
-# for Depot Cache restores. actions/cache routes to Depot Cache, so the shared key does not collide.
+# Kept byte-for-byte equivalent to canonical except: the node-gyp chmod below (hardened for
+# Depot Cache restores) and no `token` input (org secrets are unavailable on Depot, so
+# setup-node stays on github.token). actions/cache routes to Depot Cache, so shared keys do
+# not collide.
 name: Install pnpm dependencies
 description: |
     Sets up pnpm + Node, restores the shared pnpm store cache, installs, and
@@ -9,6 +11,9 @@ description: |
     Single source of truth for the pnpm cache key. Every node workflow shares
     one namespace (`pnpm-<os>-<lockfile-hash>`), so the store is cached once
     instead of fragmenting across runner-arch casings or per-workflow keys.
+
+    Also pre-seeds the Node tool cache (`node-toolcache-<os>-<arch>-<version>`,
+    master-gated save) so setup-node makes no GitHub API calls on a hit.
 
     Deliberately does NOT use setup-node's `cache: pnpm`: that auto-saves on
     every run (PRs included, and the post-save can't be gated) and keys on
@@ -41,11 +46,46 @@ runs:
           # Locate it across pnpm/action-setup layouts and never fail if it is absent.
           run: find ~/setup-pnpm -name gyp_main.py -path '*/node-gyp/*' -exec chmod +x {} + 2>/dev/null || true
 
+        - name: Resolve Node version
+          id: node-version
+          shell: bash
+          # An empty version (missing file or non-exact pin) skips the tool cache
+          # steps, so setup-node falls back to resolving the version itself. Only
+          # exact x.y.z pins are cacheable: the tool-cache directory is named after
+          # the resolved version, so a range spec would never match it.
+          env:
+              NODE_VERSION_FILE: ${{ inputs.node-version-file }}
+          run: |
+              version=""
+              [[ -f "$NODE_VERSION_FILE" ]] && version=$(tr -d 'v[:space:]' < "$NODE_VERSION_FILE")
+              [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || version=""
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+
+        # A tool-cache hit turns setup-node into a filesystem lookup. On a miss it
+        # fetches the version manifest from api.github.com (two rate-limited API
+        # calls per job) and downloads the tarball, on every Node job, because
+        # runner images don't ship the .nvmrc version.
+        - name: Restore Node tool cache
+          id: node-toolcache
+          if: steps.node-version.outputs.version != ''
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/node/${{ steps.node-version.outputs.version }}
+              key: node-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.version }}
+
         - name: Set up Node.js
           uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
           with:
               node-version-file: ${{ inputs.node-version-file }}
               token: ${{ github.token }}
+
+        # Save only on the default branch, for the same reasons as the pnpm store save below.
+        - name: Save Node tool cache
+          if: github.ref == 'refs/heads/master' && steps.node-version.outputs.version != '' && steps.node-toolcache.outputs.cache-hit != 'true'
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/node/${{ steps.node-version.outputs.version }}
+              key: node-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.version }}
 
         - name: Get pnpm store path
           id: pnpm-store

--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -7,6 +7,9 @@ description: |
     one namespace (`pnpm-<os>-<lockfile-hash>`), so the store is cached once
     instead of fragmenting across runner-arch casings or per-workflow keys.
 
+    Also pre-seeds the Node tool cache (`node-toolcache-<os>-<arch>-<version>`,
+    master-gated save) so setup-node makes no GitHub API calls on a hit.
+
     Deliberately does NOT use setup-node's `cache: pnpm`: that auto-saves on
     every run (PRs included, and the post-save can't be gated) and keys on
     `os.arch()` (lowercase `x64`), which never matches a hand-written
@@ -46,19 +49,22 @@ runs:
         - name: Resolve Node version
           id: node-version
           shell: bash
-          # Empty version on a missing/odd file just skips the tool cache steps —
-          # setup-node then resolves the version itself, as it does today.
+          # An empty version (missing file or non-exact pin) skips the tool cache
+          # steps, so setup-node falls back to resolving the version itself. Only
+          # exact x.y.z pins are cacheable: the tool-cache directory is named after
+          # the resolved version, so a range spec would never match it.
           env:
               NODE_VERSION_FILE: ${{ inputs.node-version-file }}
           run: |
               version=""
               [[ -f "$NODE_VERSION_FILE" ]] && version=$(tr -d 'v[:space:]' < "$NODE_VERSION_FILE")
+              [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || version=""
               echo "version=$version" >> "$GITHUB_OUTPUT"
 
         # A tool-cache hit turns setup-node into a filesystem lookup. On a miss it
-        # fetches the version manifest from api.github.com (two calls on the shared
-        # GITHUB_TOKEN core bucket) and downloads the tarball — on every Node job,
-        # because runner images don't ship the .nvmrc version.
+        # fetches the version manifest from api.github.com (two rate-limited API
+        # calls per job) and downloads the tarball, on every Node job, because
+        # runner images don't ship the .nvmrc version.
         - name: Restore Node tool cache
           id: node-toolcache
           if: steps.node-version.outputs.version != ''
@@ -73,7 +79,7 @@ runs:
               node-version-file: ${{ inputs.node-version-file }}
               token: ${{ inputs.token }}
 
-        # Save only on the default branch — same reasoning as the pnpm store save.
+        # Save only on the default branch, for the same reasons as the pnpm store save below.
         - name: Save Node tool cache
           if: github.ref == 'refs/heads/master' && steps.node-version.outputs.version != '' && steps.node-toolcache.outputs.cache-hit != 'true'
           uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -43,11 +43,43 @@ runs:
           shell: bash
           run: find ~/setup-pnpm -name gyp_main.py -exec chmod +x {} +
 
+        - name: Resolve Node version
+          id: node-version
+          shell: bash
+          # Empty version on a missing/odd file just skips the tool cache steps —
+          # setup-node then resolves the version itself, as it does today.
+          env:
+              NODE_VERSION_FILE: ${{ inputs.node-version-file }}
+          run: |
+              version=""
+              [[ -f "$NODE_VERSION_FILE" ]] && version=$(tr -d 'v[:space:]' < "$NODE_VERSION_FILE")
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+
+        # A tool-cache hit turns setup-node into a filesystem lookup. On a miss it
+        # fetches the version manifest from api.github.com (two calls on the shared
+        # GITHUB_TOKEN core bucket) and downloads the tarball — on every Node job,
+        # because runner images don't ship the .nvmrc version.
+        - name: Restore Node tool cache
+          id: node-toolcache
+          if: steps.node-version.outputs.version != ''
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/node/${{ steps.node-version.outputs.version }}
+              key: node-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.version }}
+
         - name: Set up Node.js
           uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
           with:
               node-version-file: ${{ inputs.node-version-file }}
               token: ${{ inputs.token }}
+
+        # Save only on the default branch — same reasoning as the pnpm store save.
+        - name: Save Node tool cache
+          if: github.ref == 'refs/heads/master' && steps.node-version.outputs.version != '' && steps.node-toolcache.outputs.cache-hit != 'true'
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/node/${{ steps.node-version.outputs.version }}
+              key: node-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.node-version.outputs.version }}
 
         - name: Get pnpm store path
           id: pnpm-store


### PR DESCRIPTION
## Problem

- Runner images don't ship the `.nvmrc` Node, so setup-node misses the tool cache on every Node job: a version-manifest call to `api.github.com` plus a tarball download, every time ([live job log](https://github.com/PostHog/posthog/actions/runs/30926971900/job/92052627847)).
- That quota lands on shared rate-limit buckets, which ran hot twice in the last week.
- #77607 reroutes the calls to an App bucket; this removes them. They compose.

## Changes

- `pnpm-install` composite: restore `$RUNNER_TOOL_CACHE/node/<version>` before setup-node (key: os/arch/version), save gated to master, same pattern as the pnpm store cache below it.
- A cache hit makes setup-node a filesystem lookup: zero API calls, no download. Covers all 26 call sites; the Depot mirror action gets the same steps (its header's exception list now names its two real divergences).
- Only exact `x.y.z` pins engage the cache; a missing file or range spec degrades to today's behavior (guards both the comma-key restore failure and the silent never-hit path).
- Review note: on Depot runners this lands in Depot Cache (repository-scoped, no branch isolation), so the entry carries the same trust level as the existing pnpm store and turbo caches there.

### Per-job effect

| | today (miss, every job) | on a hit (after first master save) |
|---|---|---|
| setup-node step | ~4s (live master job) | ~1s est. (0.5s lookup measured; entry unpopulated until merge) |
| api.github.com calls | 2 | 0 |
| downloads | ~30 MB node tarball | none |
| cache entry | n/a | 54 MB, one per os/arch/version |
| Depot Cache storage | n/a | ~0.05 GB, ~$0.01/month at $0.20/GB-month (GitHub store free) |

### Evidence

| claim | verification |
|---|---|
| a hit makes zero API calls and zero downloads | setup-node v6.2.0 source: `tc.find` runs before any manifest fetch and returns early; container repro of the pinned dist with networking disabled logs `Found in cache @ .../node/24.13.0/x64` and the restored node v24.13.0 runs |
| a miss makes exactly 2 api.github.com calls | CONNECT-logging proxy around the same dist in a clean container: 2x `api.github.com`, tarball from release assets only |
| the cached path is complete | the install writes `x64/` and the `x64.complete` marker inside `node/24.13.0/`, the exact path this PR caches |
| the steps run clean on real runners | [Frontend formatting job on this PR](https://github.com/PostHog/posthog/actions/runs/30934616337/job/92077965832): key `node-toolcache-Linux-X64-24.13.0`, miss non-fatal in 0.5s, setup-node falls back, save skipped on the PR ref |
| PR runs will hit master-saved entries | the same job restored the master-gated pnpm store cache from a PR run |

## How did you test this code?

- `bin/hogli lint:workflows` 7/7 across 124 workflows; YAML parses clean. actionlint lints workflows only, not composite actions.
- Not runnable locally: the first master run after merge populates the cache; until then restore misses and behavior is unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills: `/authoring-ci-workflows`, `/writing-code-comments`.
- Chose the shared composite over per-workflow cache steps (one edit, 26 sites) and an exact-version key with no `restore-keys` (another version's cache is useless).
- setup-python (django matrix) left for a follow-up: different bucket, different call sites.

