### PR TITLE
fix(managed-warehouse): batch DuckLake file registration

### DIFF
--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -528,18 +528,17 @@ def _register_prepared_parquet_files(
                         psql.SQL(", ").join(psql.Identifier(column) for column in partition_columns),
                     )
                 )
-            for landing_path in landing_paths:
-                conn.execute(
-                    psql.SQL(
-                        "CALL ducklake_add_data_files({}, {}, {}, schema => {}, "
-                        "allow_missing => true, hive_partitioning => true)"
-                    ).format(
-                        psql.Literal("ducklake"),
-                        psql.Literal(shadow_name),
-                        psql.Literal(landing_path),
-                        psql.Literal(schema_name),
-                    )
+            conn.execute(
+                psql.SQL(
+                    "CALL ducklake_add_data_files({}, {}, {}, schema => {}, "
+                    "allow_missing => true, hive_partitioning => true)"
+                ).format(
+                    psql.Literal("ducklake"),
+                    psql.Literal(shadow_name),
+                    parquet_paths,
+                    psql.Literal(schema_name),
                 )
+            )
 
         with _stage_timer(stage="verify", team_id=inputs.team_id, schema_id=inputs.metadata.source_schema_id):
             source_row = conn.execute(

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
@@ -222,7 +222,10 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
         index for index, query in enumerate(executed) if "DROP TABLE IF EXISTS" in query and "customers" in query
     )
     rename_index = next(index for index, query in enumerate(executed) if "RENAME TO" in query)
-    assert len(registration_indexes) == 2
+    assert len(registration_indexes) == 1
+    registration_query = executed[registration_indexes[0]]
+    assert "_ph_partition_key=2026-07/a.parquet" in registration_query
+    assert "_ph_partition_key=2026-08/b.parquet" in registration_query
     assert len(verification_indexes) == 2
     assert max(registration_indexes) < min(verification_indexes)
     assert max(verification_indexes) < drop_live_index < rename_index


### PR DESCRIPTION
## Problem

Large prepared generations make one DuckLake catalog call per Parquet file. The repeated round trips can consume most of the registration activity timeout before row-count verification starts.

## Changes

- Pass the existing list of exact Parquet paths to one `ducklake_add_data_files` call.
- Extend the registration test to verify that both paths are included in a single catalog call.

## How did you test this code?

- `ruff check` and `ruff format --check` passed for both changed files.
- `hogli ci:preflight --fix` completed with no failures.
- The targeted test file completed 17 tests successfully. The command then exited with an unrelated local ClickHouse teardown error because the `exchange_rate` replica was read-only.
- The changed regression assertion catches a return to one registration call per Parquet file or omission of a prepared file from the batched call.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update is needed. This changes internal registration execution without changing configuration or user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated the change. It used the repo's `/writing-tests` and `/writing-user-facing-copy` skills, plus the public `github:yeet` publishing skill.

I kept the existing exact-path list used for schema discovery and verification, and reused it for a single DuckLake registration call. This avoids adding a glob or changing transaction and verification behavior.