### PR TITLE
fix(meta_ads): drop the business field from the ad_account sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/schemas.py
@@ -355,7 +355,10 @@ RESOURCE_SCHEMAS: dict[MetaAdsResource, dict[str, Any]] = {
             "created_time",
             "business_country_code",
             "business_name",
-            "business",
+            # No `business`: reading it needs the `business_management` scope, which the Meta
+            # OAuth consent doesn't request (`ads_read` only) — see `AD_ACCOUNT_FIELDS` in
+            # meta_ads.py, which excludes it from the account-listing request for the same reason.
+            # Meta 400s the whole request when it's asked for, failing this table's sync outright.
             "funding_source_details",
             "disable_reason",
             "is_prepay_account",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1758,3 +1758,12 @@ class TestSingleObjectEndpoint:
 
         with pytest.raises(Exception, match=META_AUTH_ERROR_MESSAGE):
             self._rows(monkeypatch, response)
+
+    def test_field_list_omits_business_field_requiring_ungranted_scope(self) -> None:
+        # `business` needs the `business_management` scope, which the Meta OAuth consent never
+        # requests (`ads_read` only), so Meta 400s the whole request whenever it's asked for —
+        # failing every sync of this table. `business_name` and `business_country_code` are plain
+        # fields with no such requirement and must stay.
+        field_names = get_meta_ads_schemas()[MetaAdsResource.AdAccount].field_names
+        assert "business" not in field_names
+        assert {"business_name", "business_country_code"} <= set(field_names)


### PR DESCRIPTION
## Problem

Every `ad_account` table sync for the Meta Ads source fails with a 400: `(#100) Requires business_management permission to access the field.`

The `ad_account` schema requests Meta's `business` field on the ad account object, which requires the `business_management` permission scope. The Meta Ads integration's OAuth consent only requests `ads_read`, so this scope is never granted for any connected account — the request fails 100% of the time, for every customer, on every sync of this table.

`meta_ads.py`'s `AD_ACCOUNT_FIELDS` (used for account listing in the account picker) already excludes this exact field for this exact reason. The `ad_account` table's own field list just hadn't been updated to match.

## Changes

- Remove `business` from the `AdAccount` resource's `field_names` in `schemas.py`, with a comment pointing at the existing precedent in `meta_ads.py`.
- `business_name` and `business_country_code` are kept — they're plain fields with no such permission requirement.

This is a code fix rather than a `NonRetryableErrors` addition: since the OAuth scope this field needs is never granted by design, adding it to `NonRetryableErrors` would just permanently fail the whole table's sync for every customer instead of letting it succeed without this one field.

## How did you test this code?

Added `test_field_list_omits_business_field_requiring_ungranted_scope` in `test_meta_ads.py`, asserting the `AdAccount` schema's field list excludes `business` but keeps the two unaffected fields — this would have caught the regression (and catches it coming back). Ran the full `meta_ads` test suite locally (139 passed) and `hogli ci:preflight --fix` (ruff lint/format clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was generated by an agent triaging a live error-tracking issue for the `meta_ads` data warehouse source (message: `Meta API request failed: 400 - {"error":{"message":"(#100) Requires business_management permission to access the field."...}}`). The stack trace was confirmed to originate in `meta_ads.py`'s `_fetch_single_object` → `get_rows` path, which only the `AdAccount` (single-object) resource takes. Cross-referencing the `AD_ACCOUNT_FIELDS` comment in the same file (which already excludes `business` from the account-listing request for the identical reason) confirmed this as a code bug rather than a per-customer permission gap, since the OAuth scope is never requested for any account.

No repo skills were invoked beyond `/writing-tests` before adding the regression test.