### PR TITLE
chore(devex): reflow dataclasses handbook paragraph onto one line

### DIFF
--- a/docs/published/handbook/engineering/conventions/backend-coding.md
+++ b/docs/published/handbook/engineering/conventions/backend-coding.md
@@ -135,9 +135,7 @@ A good test should:
 
 ### Dataclasses
 
-Prefer a small dataclass over a tuple when returning or passing multiple values:
-always when two or more elements share a type (callers can silently swap them, e.g. `(start, end)` timestamps or `(username, password)` credentials),
-and when there are roughly 3+ elements, where positional access hurts readability.
+Prefer a small dataclass over a tuple when returning or passing multiple values: always when two or more elements share a type (callers can silently swap them, e.g. `(start, end)` timestamps or `(username, password)` credentials), and when there are roughly 3+ elements, where positional access hurts readability.
 
 Use the house-default decorator:
 


### PR DESCRIPTION
## Problem

The Dataclasses section added to the backend coding handbook in #76156 split its opening sentence across three lines at clause boundaries, which reads as broken markdown in the source (flagged by a reviewer post-merge).

## Changes

Reflows that one paragraph onto a single line, matching the one-sentence-per-line style of the rest of the file. Rendered output on posthog.com is unchanged (single newlines collapse to spaces).

## How did you test this code?

Docs-only whitespace change; verified the paragraph is the only clause-level split in the section and the diff touches nothing else.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

This PR is the docs update; `skip-inkeep-docs` applied.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code, addressing a post-merge review comment on #76156.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
