### PR TITLE
fix(web-analytics): Stop oversized replay snapshots crashing the browser

### DIFF
--- a/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/heatmapsBrowserLogic.ts
@@ -29,7 +29,11 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonBannerProps } from 'lib/lemon-ui/LemonBanner'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { objectsEqual } from 'lib/utils/objects'
-import { removeReplayIframeDataFromLocalStorage } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
+import {
+    ReplayIframeData,
+    getStoredRecordingBackground,
+    removeReplayIframeDataFromLocalStorage,
+} from 'scenes/heatmaps/replayIframeData'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { hogql } from '~/queries/utils'
@@ -88,14 +92,6 @@ export function preflightBannerMessage(preflight: PagePreflight | null): string 
     }
 
     return null
-}
-
-export interface ReplayIframeData {
-    html: string
-    width: number // NB this should be meta width
-    height: number // NB this should be meta height
-    startDateTime: string | undefined
-    url: string | undefined
 }
 
 // Helper function to detect if a URL contains regex pattern characters
@@ -827,10 +823,7 @@ export const heatmapsBrowserLogic = kea<heatmapsBrowserLogicType>([
         },
         '/heatmaps/recording': (_, searchParams) => {
             if (searchParams.iframeStorage) {
-                const replayFrameData = JSON.parse(
-                    localStorage.getItem(searchParams.iframeStorage) || '{}'
-                ) as ReplayIframeData
-                actions.setReplayIframeData(replayFrameData)
+                actions.setReplayIframeData(getStoredRecordingBackground(searchParams.iframeStorage))
             }
         },
     })),

--- a/frontend/src/scenes/heatmaps/components/recordingClickmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/components/recordingClickmapLogic.ts
@@ -26,8 +26,8 @@ import type {
 import type { CommonFilters } from '../../../lib/components/heatmaps/types'
 import type { FeatureFlagsSet } from '../../../lib/logic/featureFlagLogic'
 import type { TeamPublicType, TeamType } from '../../../types'
+import type { ReplayIframeData } from '../replayIframeData'
 import { heatmapsBrowserLogic, isUrlPattern } from './heatmapsBrowserLogic'
-import type { ReplayIframeData } from './heatmapsBrowserLogic'
 
 export interface ClickmapBox {
     top: number

--- a/frontend/src/scenes/heatmaps/replayIframeData.test.ts
+++ b/frontend/src/scenes/heatmaps/replayIframeData.test.ts
@@ -1,0 +1,61 @@
+import {
+    ReplayIframeData,
+    ReplayIframeDatakeyPrefix as PREFIX,
+    getStoredRecordingBackground,
+    persistReplayIframeData,
+} from './replayIframeData'
+
+describe('replayIframeData', () => {
+    const data: ReplayIframeData = {
+        html: '<body>snapshot</body>',
+        width: 100,
+        height: 200,
+        startDateTime: undefined,
+        url: 'https://e',
+    }
+
+    const prefixedKeys = (): string[] => Object.keys(localStorage).filter((k) => k.startsWith(PREFIX))
+
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('prunes older snapshots once the new one is written', () => {
+        localStorage.setItem(`${PREFIX}stale`, '{}')
+
+        const key = persistReplayIframeData(data)
+
+        expect(key).not.toBeNull()
+        expect(prefixedKeys()).toEqual([key])
+        expect(getStoredRecordingBackground(key)).toEqual(data)
+    })
+
+    it('keeps the previous snapshot when the write is rejected', () => {
+        localStorage.setItem(`${PREFIX}previous`, '{"html":"<body>old</body>"}')
+        jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new DOMException('quota', 'QuotaExceededError')
+        })
+
+        expect(persistReplayIframeData(data)).toBeNull()
+        expect(prefixedKeys()).toEqual([`${PREFIX}previous`])
+    })
+
+    it.each([
+        ['malformed json', '{not json'],
+        ['a snapshot missing its dimensions', '{"html":"<body>x</body>"}'],
+        ['a blank snapshot', '{"html":"  ","width":1,"height":2}'],
+    ])('reads %s as null', (_name, stored) => {
+        localStorage.setItem('stored', stored)
+
+        expect(getStoredRecordingBackground('stored')).toBeNull()
+    })
+
+    it('reads an absent snapshot as null', () => {
+        expect(getStoredRecordingBackground(null)).toBeNull()
+        expect(getStoredRecordingBackground('never-written')).toBeNull()
+    })
+})

--- a/frontend/src/scenes/heatmaps/replayIframeData.ts
+++ b/frontend/src/scenes/heatmaps/replayIframeData.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+import { uuid } from 'lib/utils/dom'
+import { localStorageSlot } from 'lib/utils/localStorageSlot'
+
+export interface ReplayIframeData {
+    html: string
+    width: number // NB this should be meta width
+    height: number // NB this should be meta height
+    startDateTime: string | undefined
+    url: string | undefined
+}
+
+export const ReplayIframeDatakeyPrefix = 'ph_replay_fixed_heatmap_'
+
+// Serializing the replayed DOM allocates several full copies of this on the main thread, in a tab
+// that is already holding a decoded recording. Past roughly this size that spike is what kills the
+// renderer.
+export const MAX_REPLAY_IFRAME_HTML_CHARS = 2_000_000
+
+const replayIframeDataSchema = z.object({
+    html: z.string().refine((html) => !!html.trim()),
+    width: z.number(),
+    height: z.number(),
+    startDateTime: z.union([z.string(), z.undefined()]),
+    url: z.union([z.string(), z.undefined()]),
+})
+
+export function removeReplayIframeDataFromLocalStorage(exceptKey?: string): void {
+    for (let i = localStorage.length - 1; i >= 0; i--) {
+        const key = localStorage.key(i)
+        if (key?.startsWith(ReplayIframeDatakeyPrefix) && key !== exceptKey) {
+            localStorage.removeItem(key)
+        }
+    }
+}
+
+export function persistReplayIframeData(data: ReplayIframeData): string | null {
+    const key = ReplayIframeDatakeyPrefix + uuid()
+    try {
+        localStorage.setItem(key, JSON.stringify(data))
+    } catch {
+        return null
+    }
+    // prune only after a successful write, so a failed write leaves the previous key usable
+    removeReplayIframeDataFromLocalStorage(key)
+    return key
+}
+
+// a missing or malformed snapshot must resolve to null rather than throwing, so callers land on the
+// recording fallback instead of unwinding out of a router listener with the scene half-mounted
+export function getStoredRecordingBackground(storageKey: string | null): ReplayIframeData | null {
+    return storageKey ? localStorageSlot(storageKey, replayIframeDataSchema).get() : null
+}

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.ts
@@ -24,7 +24,8 @@ import { FEATURE_FLAGS } from 'lib/constants'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
-import { ReplayIframeData, heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { ReplayIframeData, getStoredRecordingBackground } from 'scenes/heatmaps/replayIframeData'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -127,27 +128,6 @@ export function getBackgroundStepBlockReason({
         return 'Authorize this URL or choose Screenshot to continue'
     }
     return null
-}
-
-export function getStoredRecordingBackground(storageKey: string | null): ReplayIframeData | null {
-    if (!storageKey) {
-        return null
-    }
-    try {
-        const data = JSON.parse(localStorage.getItem(storageKey) ?? 'null') as Partial<ReplayIframeData> | null
-        if (
-            !data ||
-            typeof data.html !== 'string' ||
-            !data.html.trim() ||
-            typeof data.width !== 'number' ||
-            typeof data.height !== 'number'
-        ) {
-            return null
-        }
-        return data as ReplayIframeData
-    } catch {
-        return null
-    }
 }
 
 export function getAuthorizationOrigin(url: string | null): string | null {

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -3100,14 +3100,15 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 return
             }
 
-            const htmlChars = rawIframeHtml.length
+            const html = stripRrwebScriptShims(rawIframeHtml)
+            const htmlChars = html.length
             if (htmlChars > MAX_REPLAY_IFRAME_HTML_CHARS) {
                 rejectHeatmapSnapshot('too_large', htmlChars)
                 return
             }
 
             const data: ReplayIframeData = {
-                html: stripRrwebScriptShims(rawIframeHtml),
+                html,
                 width: resolution.width,
                 height: resolution.height,
                 startDateTime: values.sessionPlayerMetaData?.start_time,

--- a/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/sessionRecordingPlayerLogic.ts
@@ -37,11 +37,15 @@ import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { dayjs, now } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { findLastIndex } from 'lib/utils/arrays'
-import { downloadFile, uuid } from 'lib/utils/dom'
+import { downloadFile } from 'lib/utils/dom'
 import { clamp } from 'lib/utils/numbers'
 import { objectsEqual } from 'lib/utils/objects'
 import { openBillingPopupModal } from 'scenes/billing/BillingPopup'
-import { ReplayIframeData } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import {
+    MAX_REPLAY_IFRAME_HTML_CHARS,
+    ReplayIframeData,
+    persistReplayIframeData,
+} from 'scenes/heatmaps/replayIframeData'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { playerCommentModel } from 'scenes/session-recordings/player/commenting/playerCommentModel'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
@@ -153,8 +157,6 @@ export interface SessionRecordingPlayerLogicProps extends SessionRecordingDataCo
     skipToFirstMatchingEvent?: boolean
 }
 
-const ReplayIframeDatakeyPrefix = 'ph_replay_fixed_heatmap_'
-
 // Positions less than this far before the next FullSnapshot are treated as
 // renderable: recordings routinely start a few ms before their first
 // FullSnapshot (the recording start is min(event start, snapshot start)) and
@@ -218,19 +220,6 @@ const trackingStateMap: Record<SessionPlayerState, PlayerTimeTracking['state']> 
 const isMediaElementPlaying = (element: HTMLMediaElement): boolean =>
     !!(element.currentTime > 0 && !element.paused && !element.ended && element.readyState > 2)
 
-function removeFromLocalStorageWithPrefix(prefix: string): void {
-    for (let i = localStorage.length - 1; i >= 0; i--) {
-        const key = localStorage.key(i)
-        if (key?.startsWith(prefix)) {
-            localStorage.removeItem(key)
-        }
-    }
-}
-
-export function removeReplayIframeDataFromLocalStorage(): void {
-    removeFromLocalStorageWithPrefix(ReplayIframeDatakeyPrefix)
-}
-
 const NOSCRIPT_BLOCK_RE = /<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi
 
 /**
@@ -242,6 +231,18 @@ export function stripRrwebScriptShims(html: string): string {
         return html
     }
     return html.replace(NOSCRIPT_BLOCK_RE, '')
+}
+
+const SNAPSHOT_REJECTION_PROBLEM = {
+    too_large: 'This part of the recording is too large to use as a heatmap background.',
+    storage_failed: "Couldn't save this moment as a heatmap background.",
+} as const
+
+function rejectHeatmapSnapshot(reason: keyof typeof SNAPSHOT_REJECTION_PROBLEM, htmlChars: number): void {
+    posthog.capture('in-app heatmap background snapshot rejected', { reason, html_chars: htmlChars })
+    lemonToast.error(
+        `${SNAPSHOT_REJECTION_PROBLEM[reason]} Try a different moment, or create a heatmap from the page URL instead.`
+    )
 }
 
 /**
@@ -3099,8 +3100,12 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 return
             }
 
-            removeFromLocalStorageWithPrefix(ReplayIframeDatakeyPrefix)
-            const key = ReplayIframeDatakeyPrefix + uuid()
+            const htmlChars = rawIframeHtml.length
+            if (htmlChars > MAX_REPLAY_IFRAME_HTML_CHARS) {
+                rejectHeatmapSnapshot('too_large', htmlChars)
+                return
+            }
+
             const data: ReplayIframeData = {
                 html: stripRrwebScriptShims(rawIframeHtml),
                 width: resolution.width,
@@ -3108,7 +3113,11 @@ export const sessionRecordingPlayerLogic = kea<sessionRecordingPlayerLogicType>(
                 startDateTime: values.sessionPlayerMetaData?.start_time,
                 url: values.currentURL,
             }
-            localStorage.setItem(key, JSON.stringify(data))
+            const key = persistReplayIframeData(data)
+            if (!key) {
+                rejectHeatmapSnapshot('storage_failed', htmlChars)
+                return
+            }
             const modalLogic = sessionPlayerModalLogic.findMounted()
             if (modalLogic?.values.modalContext?.type === 'heatmap-background-selection') {
                 modalLogic.actions.completeHeatmapBackgroundSelection(key)


### PR DESCRIPTION
## Problem
Creating a heatmap from a session recording serialized the entire replayed DOM into localStorage unguarded, hard-crashing the browser tab on large pages.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
Cap the snapshot size and show a recoverable error instead of crashing, and move the replay-background storage contract into one module shared by the player and heatmaps.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
