### PR TITLE
fix(desktop): show the plan in plan mode for models like Kimi K3

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.test.ts
@@ -480,6 +480,105 @@ describe("canUseTool auto mode hands-off approval", () => {
   );
 });
 
+describe("ExitPlanMode plan recovery", () => {
+  function exitPlanTextNotification(text: string) {
+    return {
+      sessionId: "test-session",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      },
+    };
+  }
+
+  function exitPlanToolCallNotification() {
+    return {
+      sessionId: "test-session",
+      update: {
+        sessionUpdate: "tool_call",
+        _meta: { claudeCode: { toolName: "ExitPlanMode" } },
+      },
+    };
+  }
+
+  const PLAIN_TEXT_PLAN = [
+    "Here is what I will do:",
+    "First step is to read the file and understand the layout.",
+    "Second step is to write the migration in the right directory.",
+    "Finally I will run the test suite to make sure nothing regressed.",
+  ].join("\n");
+
+  it("recovers a plan from earlier assistant text when ExitPlanMode is the last action", async () => {
+    const context = createContext("ExitPlanMode", {
+      session: {
+        permissionMode: "plan" as const,
+        notificationHistory: [
+          exitPlanTextNotification(PLAIN_TEXT_PLAN),
+          exitPlanToolCallNotification(),
+        ],
+      },
+      client: createClient({
+        outcome: { outcome: "selected", optionId: "default" },
+      }),
+      applySessionMode: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("allow");
+    expect(context.client.requestPermission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCall: expect.objectContaining({
+          rawInput: expect.objectContaining({ plan: PLAIN_TEXT_PLAN }),
+        }),
+      }),
+    );
+  });
+
+  it("accepts a heading-less multi-line plan and asks for approval", async () => {
+    const context = createContext("ExitPlanMode", {
+      session: {
+        permissionMode: "plan" as const,
+        notificationHistory: [exitPlanTextNotification(PLAIN_TEXT_PLAN)],
+      },
+      client: createClient({
+        outcome: { outcome: "selected", optionId: "default" },
+      }),
+      applySessionMode: vi.fn().mockResolvedValue(undefined),
+      emittedToolCalls: new Set<string>(),
+    });
+
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("allow");
+    expect(context.client.requestPermission).toHaveBeenCalledOnce();
+    const emittedCall = (
+      context.client.sessionUpdate as ReturnType<typeof vi.fn>
+    ).mock.calls.find(
+      (call) => call[0]?.update?.sessionUpdate === "tool_call",
+    )?.[0];
+    expect(emittedCall).toBeDefined();
+    // Plan content should be visible in the emitted tool call even though it
+    // has no markdown heading.
+    expect(
+      JSON.stringify(emittedCall.update.content ?? emittedCall.update),
+    ).toContain("First step is to read the file");
+  });
+
+  it("still denies an empty ExitPlanMode", async () => {
+    const context = createContext("ExitPlanMode", {
+      session: {
+        permissionMode: "plan" as const,
+        notificationHistory: [],
+      },
+    });
+
+    const result = await canUseTool(context);
+
+    expect(result.behavior).toBe("deny");
+  });
+});
+
 describe("AskUserQuestion cancelled outcomes", () => {
   const QUESTION_INPUT = {
     question: "Which license should I use?",

--- a/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/permissions/permission-handlers.ts
@@ -24,6 +24,7 @@ import {
 import {
   getClaudePlansDir,
   getLatestAssistantText,
+  getLatestAssistantTextExtended,
   isClaudePlanFilePath,
   isPlanReady,
 } from "../plan/utils";
@@ -315,10 +316,18 @@ async function handleExitPlanModeTool(
   const { session, toolInput, fileContentCache } = context;
 
   const planFromFile = getPlanFromFile(session, fileContentCache);
-  const latestText = getLatestAssistantText(session.notificationHistory);
+  const latestText =
+    getLatestAssistantText(session.notificationHistory) ??
+    getLatestAssistantTextExtended(session.notificationHistory);
   const fallbackPlan = planFromFile || (latestText ?? undefined);
   const updatedInput = ensurePlanInInput(toolInput, fallbackPlan);
   const planText = extractPlanText(updatedInput);
+
+  // Surface the plan in the UI before any validation path runs. Failing
+  // validations previously left nothing on screen, which read as "plan mode
+  // silently broke" for models that end their turn with the tool call.
+  context.toolInput = updatedInput;
+  await ensureToolCallEmitted(context);
 
   const validationResult = await validatePlanContent(planText, context);
   if (!validationResult.valid) {

--- a/products/desktop/packages/agent/src/adapters/claude/plan/utils.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/plan/utils.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import {
+  getLatestAssistantText,
+  getLatestAssistantTextExtended,
+  isPlanReady,
+} from "./utils";
+
+function textNotification(text: string): SessionNotification {
+  return {
+    sessionId: "s",
+    update: {
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text },
+    },
+  } as unknown as SessionNotification;
+}
+
+function toolCallNotification(toolName: string): SessionNotification {
+  return {
+    sessionId: "s",
+    update: {
+      sessionUpdate: "tool_call",
+      _meta: { claudeCode: { toolName } },
+    },
+  } as unknown as SessionNotification;
+}
+
+describe("isPlanReady", () => {
+  it("accepts a markdown-headed plan", () => {
+    expect(isPlanReady("# Plan\n\n1. do a thing\n2. do another thing\n3. profit")).toBe(
+      true,
+    );
+  });
+
+  it("rejects short plans", () => {
+    expect(isPlanReady("tiny")).toBe(false);
+    expect(isPlanReady("short heading-only-ish text")).toBe(false);
+  });
+
+  it("rejects heading-less single-line text", () => {
+    expect(
+      isPlanReady(
+        "a single long line of prose that goes on and on without any headings or breaks",
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts multi-line plain-text plans (no heading)", () => {
+    const plan = [
+      "Here is what I will do:",
+      "First step is to read the file and understand the layout.",
+      "Second step is to write the migration in the right directory.",
+      "Finally I will run the test suite to make sure nothing regressed.",
+    ].join("\n");
+    expect(isPlanReady(plan)).toBe(true);
+  });
+});
+
+describe("getLatestAssistantText", () => {
+  it("returns the latest contiguous assistant text", () => {
+    const notifications = [
+      textNotification("first"),
+      textNotification(" second"),
+      toolCallNotification("Read"),
+      textNotification("third"),
+    ];
+    expect(getLatestAssistantText(notifications)).toBe("third");
+  });
+
+  it("returns null when the last notification is not text", () => {
+    const notifications = [
+      textNotification("here is the plan"),
+      toolCallNotification("ExitPlanMode"),
+    ];
+    expect(getLatestAssistantText(notifications)).toBeNull();
+  });
+
+  it("returns null on empty history", () => {
+    expect(getLatestAssistantText([])).toBeNull();
+  });
+});
+
+describe("getLatestAssistantTextExtended", () => {
+  it("skips a trailing ExitPlanMode call to find earlier text", () => {
+    const notifications = [
+      textNotification("# Plan\n\nstep one\nstep two\nstep three"),
+      toolCallNotification("ExitPlanMode"),
+    ];
+    expect(getLatestAssistantTextExtended(notifications)).toBe(
+      "# Plan\n\nstep one\nstep two\nstep three",
+    );
+  });
+
+  it("scans past other tool calls when collecting fallback text", () => {
+    const notifications = [
+      textNotification("some text"),
+      toolCallNotification("Bash"),
+    ];
+    expect(getLatestAssistantTextExtended(notifications)).toBe("some text");
+  });
+
+  it("returns null when there is no earlier text to recover", () => {
+    const notifications = [toolCallNotification("ExitPlanMode")];
+    expect(getLatestAssistantTextExtended(notifications)).toBeNull();
+  });
+
+  it("still returns trailing text when present", () => {
+    const notifications = [
+      textNotification("earlier"),
+      toolCallNotification("ExitPlanMode"),
+      textNotification("final draft"),
+    ];
+    expect(getLatestAssistantTextExtended(notifications)).toBe("final draft");
+  });
+});

--- a/products/desktop/packages/agent/src/adapters/claude/plan/utils.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/plan/utils.ts
@@ -21,21 +21,48 @@ export function isPlanReady(plan: string | undefined): boolean {
   if (!plan) return false;
   const trimmed = plan.trim();
   if (trimmed.length < 40) return false;
-  return /(^|\n)#{1,6}\s+\S/.test(trimmed);
+  if (/(^|\n)#{1,6}\s+\S/.test(trimmed)) return true;
+  // Models that emit plain-text plans (no markdown heading) still carry
+  // real content. Accept longer multi-line text as a stand-in.
+  const lineCount = trimmed.split(/\r?\n/).filter((line) => line.trim()).length;
+  return lineCount >= 4;
 }
 
+// Original strict variant: only considers the last contiguous text run and
+// returns null when anything else follows it (e.g. the ExitPlanMode call).
 export function getLatestAssistantText(
   notifications: SessionNotification[],
 ): string | null {
-  const chunks: string[] = [];
-  let started = false;
+  return collectTrailingText(notifications, false);
+}
 
-  for (let i = notifications.length - 1; i >= 0; i -= 1) {
+// Extended variant: skips past a trailing ExitPlanMode tool call (or thought
+// chunks) so models that end their turn on the tool call still surface the
+// last assistant text they wrote.
+export function getLatestAssistantTextExtended(
+  notifications: SessionNotification[],
+): string | null {
+  return collectTrailingText(notifications, true);
+}
+
+function collectTrailingText(
+  notifications: SessionNotification[],
+  extendPastToolCall: boolean,
+): string | null {
+  const chunks: string[] = [];
+  const maxNotifications = 200;
+  let scanned = 0;
+
+  for (
+    let i = notifications.length - 1;
+    i >= 0 && scanned < maxNotifications;
+    i -= 1
+  ) {
     const update = notifications[i]?.update;
     if (!update) continue;
+    scanned += 1;
 
     if (update.sessionUpdate === "agent_message_chunk") {
-      started = true;
       const content = update.content as {
         type?: string;
         text?: string;
@@ -46,11 +73,43 @@ export function getLatestAssistantText(
       continue;
     }
 
-    if (started) {
+    if (
+      extendPastToolCall &&
+      chunks.length === 0 &&
+      update.sessionUpdate === "tool_call" &&
+      isExitPlanModeCall(update)
+    ) {
+      continue;
+    }
+
+    if (
+      extendPastToolCall &&
+      chunks.length === 0 &&
+      update.sessionUpdate === "agent_thought_chunk"
+    ) {
+      continue;
+    }
+
+    if (chunks.length > 0) {
+      break;
+    }
+    if (!extendPastToolCall) {
       break;
     }
   }
 
-  if (chunks.length === 0) return null;
-  return chunks.reverse().join("");
+  return chunks.length === 0 ? null : chunks.reverse().join("");
+}
+
+function isExitPlanModeCall(update: unknown): boolean {
+  const candidate = update as {
+    _meta?: { claudeCode?: { toolName?: string } };
+    toolName?: string;
+    name?: string;
+  };
+  return (
+    (candidate._meta?.claudeCode?.toolName ??
+      candidate.toolName ??
+      candidate.name) === "ExitPlanMode"
+  );
 }


### PR DESCRIPTION
## Problem

Models that call ExitPlanMode as their final action (e.g. Kimi K3) never show a plan UI in the desktop app. The session looks stuck: the harness denies the tool call with "Plan not ready" and nothing renders.

Three gaps in the Claude adapter's plan handling caused this:

| Gap | Effect |
|---|---|
| `getLatestAssistantText` returned null when the model ended on the tool call (no trailing text) | Plan silently dropped |
| `isPlanReady` required a markdown heading | Plain-text plans rejected |
| The tool call was only emitted after validation passed | Failed plans never appeared on screen |

Refs #76290

## Changes

- **Before:** plan only reached the UI when the model wrote trailing text with a markdown heading
- **After:** plan recovered from earlier assistant text, heading-less multi-line plans accepted, and the plan renders even if validation denies the call

```mermaid
flowchart TD
    A[ExitPlanMode called] --> B{Plan in input?}
    B -->|no| C{Plan file in ~/.claude/plans?}
    C -->|no| D[Scan assistant text backwards]
    B -->|yes| E[Emit tool call with plan content]
    C -->|yes| E
    D --> E
    E --> F{isPlanReady}
    F -->|yes| G[Approval dialog]
    F -->|no| H[Deny, plan still visible in thread]
```

## How did you test this code?

Automated only (agent-run, no manual testing):

- `pnpm exec vitest run src/adapters/claude/plan src/adapters/claude/permissions` — 57 passed
- Full adapter suite shows the same 14 pre-existing failures before and after this change (unrelated, dependency resolution in this checkout)
- New tests in `plan/utils.test.ts` cover heading-less plans and the extended text scan; new handler tests cover plan recovery from earlier text and visibility on the failure path

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) from a user report that Kimi K3 plan mode never shows a plan in the desktop app. The agent found the failure chain in the Claude adapter (plan utils + permission handlers) and chose recovery-over-rejection: accept heading-less plans, scan past the trailing tool call for earlier text, and emit the tool call before validation so failures stay visible. Rejected the alternative of loosening the heading regex alone, since that would not fix the silent-failure path.
