### PR TITLE
fix: anchor copy icon to top-right of error container to prevent scroll-away (Fixes #76240)

### DIFF
--- a/products/desktop/packages/ui/src/features/git-interaction/components/GitInteractionDialogs.tsx
+++ b/products/desktop/packages/ui/src/features/git-interaction/components/GitInteractionDialogs.tsx
@@ -46,16 +46,10 @@ export function ErrorContainer({
   };
 
   return (
-    <Box className="max-h-[200px] overflow-auto rounded-(--radius-2) border border-(--red-6) bg-(--red-2)">
-      <Flex direction="column" gap="2" p="2">
-        <Flex justify="between" align="start" gap="2">
-          <Text
-            color="red"
-            className="flex-1 whitespace-pre-wrap break-words font-[var(--code-font-family)] text-[13px]"
-          >
-            {error}
-          </Text>
-          <Flex gap="1" className="shrink-0">
+    <Box className="rounded-(--radius-2) border border-(--red-6) bg-(--red-2)">
+      <Flex direction="column">
+        <Flex justify="end" px="2" pt="2">
+          <Flex gap="1">
             {onFixWithAgent && (
               <Tooltip content="Fix with Agent">
                 <IconButton
@@ -80,6 +74,14 @@ export function ErrorContainer({
             </Tooltip>
           </Flex>
         </Flex>
+        <Box className="max-h-[200px] overflow-auto px-2 pb-2">
+          <Text
+            color="red"
+            className="whitespace-pre-wrap break-words font-[var(--code-font-family)] text-[13px]"
+          >
+            {error}
+          </Text>
+        </Box>
       </Flex>
     </Box>
   );


### PR DESCRIPTION
## Problem

In the commit modal, when an error message is displayed and the content overflows horizontally, the copy icon is rendered inside the scrollable area. As the user scrolls to read the error, the copy icon scrolls out of view.

## Fix

Restructured the `ErrorContainer` component so that the copy icon (and "Fix with Agent" button) is rendered **outside** the scrollable area, anchored to the top-right of the error container. Only the error text itself is scrollable.

### Before
- Copy icon placed inside the `overflow-auto` container — scrolls with content
- `ErrorContainer` had a single scrollable box containing both the text and icon

### After
- Copy icon rendered in a separate header bar above the scrollable text area
- Only the error text is inside the `max-h-[200px] overflow-auto` container
- Copy icon stays visible at the top-right regardless of scroll position

Fixes #76240