### PR TITLE
fix(hogvm): compare a datetime string against a temporal by instant, not as text

### DIFF
--- a/common/hogvm/typescript/src/__tests__/utils.test.ts
+++ b/common/hogvm/typescript/src/__tests__/utils.test.ts
@@ -31,6 +31,45 @@ describe('hogvm utils', () => {
             const [a, b] = unifyComparisonTypes(laterDateTime, toHogDateTime(1782988689))
             expect(a === b).toBe(true)
         })
+
+        // The same defect one step out: `event.timestamp` in filter globals is an ISO *string*, so a filter
+        // like `timestamp > toDateTime('2026-07-01')` pairs a string with a HogDateTime. That pair fell
+        // through unchanged too, and the string was compared against "[object Object]" — always false
+        // whichever way the dates actually ordered.
+        describe('datetime-shaped string against a temporal', () => {
+            const cutoff = toHogDateTime(1782518400) // 2026-06-23 00:00:00 UTC
+
+            test.each([
+                ['offset-bearing ISO after the cutoff', '2026-06-28T12:00:00.000Z', true],
+                ['offset-bearing ISO before the cutoff', '2026-06-01T12:00:00.000Z', false],
+                // No offset: parsed as UTC, matching toDateTime() and ClickHouse's stored timestamps.
+                ['naive ISO after the cutoff', '2026-06-28T12:00:00', true],
+                ['naive ISO before the cutoff', '2026-06-01T12:00:00', false],
+                ['date-only after the cutoff', '2026-06-28', true],
+            ])('orders %s', (_label, timestamp, expected) => {
+                const [a, b] = unifyComparisonTypes(timestamp, cutoff)
+                expect(a > b).toBe(expected)
+            })
+
+            test('orders with the temporal on the left too', () => {
+                const [a, b] = unifyComparisonTypes(cutoff, '2026-06-01T12:00:00.000Z')
+                expect(a > b).toBe(true)
+            })
+
+            test('leaves a non-datetime string alone rather than coercing it to NaN', () => {
+                const [a, b] = unifyComparisonTypes('not a date', cutoff)
+                expect(a).toBe('not a date')
+                expect(b).toBe(cutoff)
+            })
+
+            test('leaves string-to-string comparisons untouched', () => {
+                // The coercion must only engage when the other side is temporal, or ordinary string filters
+                // would start being read as dates.
+                const [a, b] = unifyComparisonTypes('2026-06-28', '2026-06-01')
+                expect(a).toBe('2026-06-28')
+                expect(b).toBe('2026-06-01')
+            })
+        })
     })
 
     test('calculateCost', async () => {

--- a/common/hogvm/typescript/src/utils.ts
+++ b/common/hogvm/typescript/src/utils.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 import { isHogDate, isHogDateTime } from './objects'
 import { toHogDate, toHogDateTime } from './stl/date'
 
@@ -10,6 +12,20 @@ function temporalSeconds(value: any): number | null {
         return toHogDateTime(value).dt
     }
     return null
+}
+
+/**
+ * Epoch seconds for a datetime-shaped string, else null. Parsed exactly as `toDateTime()` does — ISO, and
+ * UTC when the string carries no offset — so comparing a string against a temporal gives what the user
+ * would get from wrapping it in toDateTime() themselves, and what ClickHouse gives for the same
+ * expression over a real DateTime column.
+ */
+function stringTemporalSeconds(value: any): number | null {
+    if (typeof value !== 'string') {
+        return null
+    }
+    const parsed = DateTime.fromISO(value, { zone: 'UTC' })
+    return parsed.isValid ? parsed.toSeconds() : null
 }
 
 export class HogVMException extends Error {
@@ -223,6 +239,22 @@ export function unifyComparisonTypes(left: any, right: any): [any, any] {
     const rightSeconds = temporalSeconds(right)
     if (leftSeconds !== null && rightSeconds !== null) {
         return [leftSeconds, rightSeconds]
+    }
+    // One temporal, one datetime-shaped string. `event.timestamp` in filter globals is an ISO string, so
+    // `timestamp > toDateTime(...)` lands here; without this the string is compared against "[object
+    // Object]" and the filter is always false, however the dates actually order. Only coerce when the other
+    // side is temporal, so ordinary string comparisons are untouched.
+    if (leftSeconds !== null) {
+        const rightAsTemporal = stringTemporalSeconds(right)
+        if (rightAsTemporal !== null) {
+            return [leftSeconds, rightAsTemporal]
+        }
+    }
+    if (rightSeconds !== null) {
+        const leftAsTemporal = stringTemporalSeconds(left)
+        if (leftAsTemporal !== null) {
+            return [leftAsTemporal, rightSeconds]
+        }
     }
     if (typeof left === 'number' && typeof right === 'string') {
         return [left, Number(right)]

--- a/nodejs/src/cdp/utils/hog-function-filtering.test.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.test.ts
@@ -358,4 +358,49 @@ describe('hog-function-filtering', () => {
             expect(result.match).toBe(true)
         })
     })
+
+    describe('a SQL filter comparing timestamp against toDateTime', () => {
+        // `event.timestamp` reaches the VM as an ISO string, while toDateTime() yields a temporal, so this
+        // filter pairs a string with an object. That pair used to fall through the comparison unchanged and
+        // be compared against "[object Object]", making the filter always false — a live trigger that never
+        // fired however the dates ordered, with no error to show for it.
+        // Compiled from `timestamp > toDateTime('2026-07-01')` by the HogQL compiler.
+        const BYTECODE = ['_H', 1, 32, '2026-07-01', 2, 'toDateTime', 1, 32, 'timestamp', 1, 1, 13]
+
+        const matchesAt = async (timestamp: string): Promise<boolean> => {
+            const filterGlobals = convertToHogFunctionFilterGlobal({
+                event: {
+                    uuid: 'event_uuid',
+                    event: 'Account Email Verified',
+                    distinct_id: 'user_123',
+                    properties: {},
+                    elements_chain: '',
+                    timestamp,
+                    url: 'http://example.com/event',
+                },
+                person: undefined,
+                groups: {},
+            } as unknown as HogFunctionInvocationGlobals)
+
+            const result = await filterFunctionInstrumented({
+                fn: { id: 'fn', team_id: 1, name: 'fn' } as unknown as HogFunctionType,
+                // The hogql property entry is carried alongside the bytecode, as the compiler emits it. A
+                // filters object holding only bytecode is short-circuited to a match before the VM runs.
+                filters: {
+                    properties: [{ key: "timestamp > toDateTime('2026-07-01')", type: 'hogql', value: null }],
+                    bytecode: BYTECODE,
+                } as unknown as HogFunctionType['filters'],
+                filterGlobals,
+            })
+            return result.match
+        }
+
+        it('matches an event after the cutoff', async () => {
+            await expect(matchesAt('2026-08-04T09:12:33.000Z')).resolves.toBe(true)
+        })
+
+        it('does not match an event before the cutoff', async () => {
+            await expect(matchesAt('2026-01-15T09:12:33.000Z')).resolves.toBe(false)
+        })
+    })
 })


### PR DESCRIPTION
## Problem

A workflow trigger with a SQL condition comparing `timestamp` against a date never fires on live events, silently. Reported by a customer using:

```sql
timestamp > toDateTime('2026-07-01')
```

The condition matches when checked in Activity, and the workflow's test trigger passes, but no live event ever invokes it.

`event.timestamp` reaches the VM as an **ISO string** (`HogFunctionFilterGlobals.timestamp` is typed `string`, populated from `globals.event.timestamp`). `toDateTime()` returns a **HogDateTime**. In `unifyComparisonTypes`, `temporalSeconds()` returns null for anything that is not a `HogDateTime`/`HogDate`, so the temporal branch is skipped, and no later branch handles the `(string, object)` pair. Both values pass through unchanged and JS coerces the object:

```
"2026-08-04T09:12:33.000Z" > "[object Object]"   →   "2" < "["   →   false
```

Always false, whichever way the dates order, with no error raised. ClickHouse evaluating the same expression over a real `DateTime` column gives the right answer, which is why the Activity view disagrees with the live trigger.

This is the same defect one step out from a fix already in this file. The comment above `unifyComparisonTypes` describes it for the temporal-vs-temporal case:

> Without this they stay as objects and `object > object` coerces to "[object Object]", which is always false — silently breaking realtime `is date after`/`is date before` filters.

That covered `toDateTime(x) > toDateTime(y)`. It did not cover a bare string on one side, which is what any filter on `timestamp` produces.

## Changes

When exactly one side of a comparison is temporal and the other is a datetime-shaped string, order both by epoch seconds.

The string is parsed the same way `toDateTime()` parses it — ISO, UTC when it carries no offset — so `timestamp > toDateTime(x)` now behaves as if the author had written `toDateTime(timestamp) > toDateTime(x)`, and matches what ClickHouse gives for the same expression.

Two deliberate limits:

- **Only when the other side is temporal.** String-to-string comparisons are untouched, or ordinary string filters would start being read as dates.
- **Unparseable strings are left alone** rather than coerced to `NaN`, so a non-date string keeps its existing comparison behaviour instead of acquiring a new silently-false one.

## How did you test this code?

**Reproduced the customer's bug first**, then confirmed the fix, both by executing their exact expression compiled by the real HogQL compiler (`['_H', 1, 32, '2026-07-01', 2, 'toDateTime', 1, 32, 'timestamp', 1, 1, 13]`) through the real filter path — `convertToHogFunctionFilterGlobal` to build globals, then `filterFunctionInstrumented` to evaluate:

| `timestamp` on the event | Before | After |
|---|---|---|
| after the cutoff | **false** (the bug) | **true** |
| before the cutoff | false | false |

The globals' `timestamp` was confirmed to be a string (`typeof === 'string'`, `"2026-08-04T09:12:33.000Z"`) at the point the VM sees it, so the reproduction is the real shape rather than a constructed one.

**Tests:**

- `common/hogvm/typescript/src/__tests__/utils.test.ts` — the string-vs-temporal cases beside the existing temporal-vs-temporal ones: offset-bearing ISO, naive ISO (asserting UTC parsing), date-only, the temporal on either side, plus the two guards that the coercion does *not* engage (a non-date string, and string-to-string).
- `nodejs/src/cdp/utils/hog-function-filtering.test.ts` — the chain-level case through `filterFunctionInstrumented`, which is what actually decides whether a live trigger fires.

Verified against master's VM to confirm the tests fail without the fix: the three "after the cutoff" cases fail, and the filter-path case fails. The "before the cutoff" cases pass either way, which is expected — the bug makes everything false, so only the cases that should be true can catch it.

Full hogvm TypeScript suite: **104 tests pass**, so the new coercion does not disturb existing comparison behaviour.

One fixture note: the filter-path test carries the `hogql` property entry alongside the bytecode, because a filters object holding only `bytecode` is short-circuited to a match before the VM runs. My first attempt omitted it and passed for that reason rather than on the merits.

## Scope: the Python VM behaves differently, and is left alone

`common/hogvm/python` has no temporal handling in `unify_comparison_types` at all, but its `_compare_values` catches `TypeError` and raises `HogVMException`, so a string-vs-datetime comparison there **errors loudly** rather than silently returning false. That is a different failure mode from the one reported, and CDP evaluates live filters on the TypeScript VM, so this change is TS-only. Worth a separate look if any Python-side path evaluates user filters.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No documented behaviour changes; this makes an existing expression evaluate correctly.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) at my direction, from a customer report that a SQL filter stopped live events from triggering a workflow.

Skills invoked: `/writing-tests` (why the string-vs-temporal cases were added to the existing temporal describe rather than a new file, and why the two "does not engage" guards earn their place) and `/writing-code-comments`.

Found by tracing the compiled bytecode rather than reading the filter code: compiling the customer's expression and executing it against a live-shaped globals object returned `false` with no error, which located the problem in comparison coercion rather than in filter plumbing or trigger matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
