### PR TITLE
fix(replay-vision): disable next when the scanner form has errors

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorScene.tsx
@@ -42,6 +42,7 @@ import {
     SCANNER_EDITOR_STEP_ORDER,
     ScannerEditorStep,
     scannerEditorSceneLogic,
+    scannerStepErrors,
     scannerStepUrl,
 } from './scannerEditorSceneLogic'
 import { ScannerEditorStepper, STEP_LABELS } from './ScannerEditorStepper'
@@ -80,6 +81,13 @@ const STEP_HEADERS: Record<
     },
 }
 
+const NO_STEP_ERRORS: Record<ScannerEditorStep, string[]> = {
+    template: [],
+    configure: [],
+    triggers: [],
+    self_driving: [],
+}
+
 export function ScannerEditorSceneComponent(): JSX.Element {
     const { scannerId, step, isNew, visibleSteps } = useValues(scannerEditorSceneLogic)
 
@@ -116,12 +124,16 @@ export function ScannerEditorSceneComponent(): JSX.Element {
 
     const title = isNew ? scanner?.name || 'New scanner' : scanner?.name || 'Scanner'
 
+    // Hold the stepper's error markers back until the user has tried to advance or save, so a form they
+    // haven't filled in yet doesn't start out covered in warnings.
+    const stepErrorMessages = showScannerErrors
+        ? scannerStepErrors(scannerValidationErrors, durationValidationError)
+        : NO_STEP_ERRORS
     const stepErrors: Record<ScannerEditorStep, boolean> = {
-        template: false,
-        self_driving: false,
-        configure: showScannerErrors && !!(scannerValidationErrors?.name || scannerValidationErrors?.scanner_config),
-        triggers:
-            showScannerErrors && (scannerValidationErrors?.sampling_rate != null || durationValidationError != null),
+        template: stepErrorMessages.template.length > 0,
+        configure: stepErrorMessages.configure.length > 0,
+        triggers: stepErrorMessages.triggers.length > 0,
+        self_driving: stepErrorMessages.self_driving.length > 0,
     }
 
     // Validate the current step and move on: submit routes to the next visible step on success.
@@ -356,15 +368,28 @@ function EditorFooter({
     onAdvance: () => void
     onSave: () => void
 }): JSX.Element {
-    const { scanner, durationValidationError } = useValues(replayScannerLogic({ id: scannerId }))
+    const { scanner, scannerValidationErrors, durationValidationError } = useValues(
+        replayScannerLogic({ id: scannerId })
+    )
     const stepIndex = visibleSteps.indexOf(step)
     const prevStep = stepIndex > 0 ? visibleSteps[stepIndex - 1] : null
     const nextStep = stepIndex < visibleSteps.length - 1 ? visibleSteps[stepIndex + 1] : null
-    // A broken duration filter (scans nothing) blocks the save — surface it as a disabled reason so the
-    // button explains itself instead of silently doing nothing. RBAC takes priority: it's the more
-    // fundamental blocker, and this must match the backend's create/update requirement exactly — a
-    // disabled-looking button that the backend would still accept (or vice versa) is a real bug here.
-    const saveDisabledReason = getReplayVisionEditDisabledReason(scanner?.user_access_level) ?? durationValidationError
+
+    // Every reason the submit would be refused has to reach this prop. kea-forms stops a submit with
+    // validation errors before it runs the submit handler, and that handler holds all the navigation, toasts
+    // and API calls, so an error the button doesn't know about leaves it enabled and makes clicking it a
+    // no-op with no feedback at all. Naming the blocking field keeps the button honest about why it's off.
+    // RBAC takes priority: it's the more fundamental blocker, and this must match the backend's
+    // create/update requirement exactly, since a disabled-looking button that the backend would still
+    // accept (or vice versa) is a real bug here.
+    const stepErrors = scannerStepErrors(scannerValidationErrors, durationValidationError)
+    const blockingStep = visibleSteps.find((s) => stepErrors[s].length > 0)
+    const blockingError = blockingStep
+        ? blockingStep === step
+            ? stepErrors[blockingStep][0]
+            : `${stepErrors[blockingStep][0]}. Fix it on the ${STEP_LABELS[blockingStep]} step.`
+        : null
+    const saveDisabledReason = getReplayVisionEditDisabledReason(scanner?.user_access_level) ?? blockingError
 
     return (
         <div className="flex items-center justify-between">

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorStepper.test.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorStepper.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react'
+
+import { SCANNER_EDITOR_STEPS, ScannerEditorStep } from './scannerEditorSceneLogic'
+import { ScannerEditorStepper } from './ScannerEditorStepper'
+
+describe('ScannerEditorStepper', () => {
+    // The scanner form validates every step at once, so the step blocking the wizard is frequently not the
+    // one on screen. A marker that only rendered for the current step would leave a user on scan conditions
+    // with no hint that configure is what's holding them up.
+    it.each([
+        { name: 'marks an errored step the user is not on', current: 'triggers', errored: 'configure' },
+        { name: 'marks an errored step the user is on', current: 'configure', errored: 'configure' },
+        { name: 'marks nothing when no step has errors', current: 'triggers', errored: null },
+    ] as { name: string; current: ScannerEditorStep; errored: ScannerEditorStep | null }[])(
+        '$name',
+        ({ current, errored }) => {
+            const { container } = render(
+                <ScannerEditorStepper
+                    currentStep={current}
+                    steps={SCANNER_EDITOR_STEPS}
+                    onStepClick={() => {}}
+                    stepErrors={errored ? { [errored]: true } : {}}
+                />
+            )
+
+            const marker = errored
+                ? container.querySelector(`[data-attr="vision-editor-step-${errored}"] .text-warning`)
+                : container.querySelector('.text-warning')
+            expect(marker).toEqual(errored ? expect.anything() : null)
+        }
+    )
+})

--- a/products/replay_vision/frontend/replay_scanners/ScannerEditorStepper.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ScannerEditorStepper.tsx
@@ -41,7 +41,7 @@ export function ScannerEditorStepper({
                             <div
                                 className={cn(
                                     'w-6 h-px transition-colors duration-150',
-                                    hasErrors && isCurrent
+                                    hasErrors
                                         ? 'bg-warning'
                                         : isCompleted || isCurrent
                                           ? 'bg-success'
@@ -60,7 +60,10 @@ export function ScannerEditorStepper({
                             )}
                             aria-current={isCurrent ? 'step' : undefined}
                         >
-                            {hasErrors && isCurrent ? (
+                            {/* Errors are shown on whichever step owns the offending field, current or not:
+                                the form validates every step at once, so the step blocking the wizard is
+                                often not the one being looked at. */}
+                            {hasErrors ? (
                                 <IconWarning className="size-5 text-warning" />
                             ) : isCompleted ? (
                                 <IconCheckCircle className="size-5 text-success" />

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -15,9 +15,17 @@ import {
     replayScannerLogic,
     shouldGuardScannerNavigation,
 } from './replayScannerLogic'
+import { SCANNER_EDITOR_STEPS, ScannerEditorStep, scannerStepErrors } from './scannerEditorSceneLogic'
 import { observationsDrilldownSearchParams } from './scannerOverviewLogic'
 import { defaultScannerTemplates } from './scannerTemplates'
 import { ClassifierScanner, ReplayScanner, ScorerScanner } from './types'
+
+const collectErrorMessages = (errors: unknown): string[] => {
+    if (typeof errors === 'string') {
+        return [errors]
+    }
+    return errors && typeof errors === 'object' ? Object.values(errors).flatMap(collectErrorMessages) : []
+}
 
 describe('replayScannerLogic', () => {
     let logic: ReturnType<typeof replayScannerLogic.build>
@@ -366,6 +374,60 @@ describe('replayScannerLogic', () => {
                 isScannerValid: true,
             })
         })
+
+        // kea-forms refuses a submit with validation errors before running the submit handler, and that
+        // handler holds the wizard's navigation. So an error no step claims blocks the wizard while leaving
+        // the footer button enabled and untooltipped: clicking it does nothing and explains nothing.
+        it.each([
+            { case: 'a missing name', setup: () => undefined, owner: 'configure' },
+            {
+                case: 'a missing prompt',
+                setup: () => logic.actions.setScannerValues({ name: 'My scanner' }),
+                owner: 'configure',
+            },
+            {
+                case: 'a scorer scale with min >= max',
+                setup: () => {
+                    logic.actions.setScannerType('scorer')
+                    logic.actions.setScannerValues({
+                        name: 'My scanner',
+                        scanner_config: {
+                            prompt: 'rate this',
+                            scale: { min: 10, max: 5 },
+                        } as ScorerScanner['scanner_config'],
+                    })
+                },
+                owner: 'configure',
+            },
+            {
+                case: 'a sampling rate of 0',
+                setup: () =>
+                    logic.actions.setScannerValues({
+                        name: 'My scanner',
+                        scanner_config: { prompt: 'Q?' },
+                        sampling_rate: 0,
+                    }),
+                owner: 'triggers',
+            },
+        ] as { case: string; setup: () => void; owner: ScannerEditorStep }[])(
+            'assigns $case to the $owner step, leaving no error unclaimed',
+            ({ setup, owner }) => {
+                setup()
+
+                const flatErrors = collectErrorMessages(logic.values.scannerValidationErrors)
+                expect(flatErrors).not.toHaveLength(0)
+
+                const stepErrors = scannerStepErrors(
+                    logic.values.scannerValidationErrors,
+                    logic.values.durationValidationError
+                )
+                expect(stepErrors[owner]).toEqual(expect.arrayContaining(flatErrors))
+                // A step that doesn't own the error must stay clean, so the button names the step to go to.
+                expect(
+                    SCANNER_EDITOR_STEPS.filter((step) => step !== owner).flatMap((step) => stepErrors[step])
+                ).toHaveLength(0)
+            }
+        )
     })
 
     describe('buildObservationListParams', () => {

--- a/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
@@ -1,9 +1,12 @@
 import { MakeLogicType, actions, kea, path, reducers, selectors } from 'kea'
+import type { DeepPartialMap, ValidationErrorType } from 'kea-forms'
 import { router, urlToAction } from 'kea-router'
 
 import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
+
+import { ReplayScanner } from './types'
 
 export type ScannerEditorStep = 'template' | 'configure' | 'triggers' | 'self_driving'
 export const SCANNER_EDITOR_STEPS: readonly ScannerEditorStep[] = ['template', 'configure', 'triggers', 'self_driving']
@@ -12,6 +15,31 @@ export const SCANNER_EDITOR_STEP_ORDER: Record<ScannerEditorStep, number> = {
     configure: 1,
     triggers: 2,
     self_driving: 3,
+}
+
+/**
+ * The scanner form validates every field on every step, so an error on one step blocks the others. Grouping
+ * each error under the step that renders its field lets both the stepper and the footer button point at the
+ * field to fix, which they can't do from the flat error map: a blank name belongs to `configure` but blocks
+ * `triggers`, where the name field isn't rendered at all.
+ *
+ * Every field `replayScannerLogic`'s `errors()` can reject has to be claimed by a step here. An unclaimed
+ * one blocks the submit while leaving the footer button enabled, which makes clicking it a silent no-op.
+ */
+export function scannerStepErrors(
+    validationErrors: DeepPartialMap<ReplayScanner, ValidationErrorType> | undefined,
+    durationValidationError: string | null
+): Record<ScannerEditorStep, string[]> {
+    const messages = (...candidates: unknown[]): string[] => candidates.filter((c): c is string => !!c)
+
+    return {
+        template: [],
+        self_driving: [],
+        configure: messages(validationErrors?.name, ...Object.values(validationErrors?.scanner_config ?? {})),
+        // durationValidationError isn't a form error (kea-forms can't attach a scalar error to the
+        // object-typed `query` field), but it blocks the same submit, so it belongs to the same step.
+        triggers: messages(validationErrors?.sampling_rate, durationValidationError),
+    }
 }
 
 export function scannerStepUrl(step: ScannerEditorStep, scannerId: string): string {

--- a/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerEditorSceneLogic.ts
@@ -6,7 +6,7 @@ import { urls } from 'scenes/urls'
 
 import { Breadcrumb } from '~/types'
 
-import { ReplayScanner } from './types'
+import type { ReplayScanner } from './types'
 
 export type ScannerEditorStep = 'template' | 'configure' | 'triggers' | 'self_driving'
 export const SCANNER_EDITOR_STEPS: readonly ScannerEditorStep[] = ['template', 'configure', 'triggers', 'self_driving']


### PR DESCRIPTION
## Problem

The Replay Vision new-scanner wizard had a Next button that looked enabled, did nothing when clicked, and gave no error. A user reported it through the in-product Replay Vision feedback survey, and the autocapture data backs it up: the click lands, three `$dead_click` events fire in a row on the scan conditions step, no exception is captured, and the user gives up. It's not specific to one project, and the scan conditions step is by far the worst offender in the flow.

The cause is that the footer only told the button about *some* of the reasons a submit would be refused:

```ts
const saveDisabledReason = getReplayVisionEditDisabledReason(scanner?.user_access_level) ?? durationValidationError
```

`replayScannerLogic`'s `errors()` validates the whole scanner on every step (`name`, `scanner_config`, `sampling_rate`), but only RBAC and the duration filter reach `disabledReason`. Any other error leaves the button fully enabled with no tooltip. Clicking it calls `submitScanner()`, kea-forms sees the errors and stops before invoking the submit handler, and that handler is where every `router.actions.push` and `lemonToast` lives. So nothing navigates and nothing complains.

It gets worse across steps. `name` and `scanner_config` are only rendered on the configure step, so when one of them is the blocker the scan conditions step shows no hint at all: no inline error (the field isn't there), and the only signal is a small icon on a different stepper item.

```mermaid
flowchart TD
    A{{Click Next}} --> B[submitScanner]
    B --> C{form has errors?}
    C -->|no| D[push next step URL]
    C -->|yes| E[kea-forms stops here]
    E --> F[no navigation, no toast, no exception]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phYellow;
    class B,D phBlue;
    class E,F phRed;
```

```mermaid
flowchart TD
    A[Form errors] --> B[grouped by owning step]
    B --> C[disabledReason names the field]
    C --> D{{Next is disabled, with a tooltip}}
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phGray;
    class B,C phBlue;
    class D phYellow;
```

## Changes

New `scannerStepErrors` helper in `scannerEditorSceneLogic` groups each validation error under the wizard step that renders its field. Both call sites use it:

- The footer button derives its `disabledReason` from the first blocking error, so it disables itself and says what's wrong. When the blocker lives on another step it appends where to go, e.g. "Prompt is required. Fix it on the Configure step."
- The stepper's error markers come from the same mapping instead of a second hand-rolled copy, so the two can't drift.

`durationValidationError` keeps priority over form errors in the message, and RBAC still comes first.

> [!NOTE]
> On the configure step of a fully custom scanner, Next now starts disabled with "Name is required" until a name is entered. That's the intended behavior. Template-based scanners prefill the name, so they're unaffected.

I didn't touch `errors()` itself. The validation rules were right, they just weren't reaching the button.

## How did you test this code?

Automated only. I (Claude, via the PostHog Slack app) did not run the app or click through the wizard, so the UI behavior is not manually verified and the change deserves a click-through in review.

What I actually ran:

- `jest products/replay_vision/frontend/replay_scanners/` — 284 tests pass, including 4 new cases.
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the touched files. The pre-existing `@posthog/quill` resolution errors across the repo are unrelated and unchanged.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt).
- `hogli ci:preflight` could not run here (no Python env in this sandbox), so the lint/format/typecheck steps above stand in for it.

The new test is one parameterized case in `replayScannerLogic.test.ts`. The regression it catches that nothing else did: if a field `errors()` can reject is not claimed by a step in `scannerStepErrors`, the submit is blocked while the button stays enabled — exactly this bug. Existing tests assert the contents of the flat error map, but never that a step claims them. I verified the guard by deleting `sampling_rate` from the mapping and confirming the case fails, then restoring it.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog employee brought me a Replay Vision survey response in Slack and asked whether there was a real bug behind it. I started from the survey event, walked the reporter's session to find the three `$dead_click` events on the Next button, confirmed no exception was captured, then checked whether the pattern held beyond that one session before going near the code.

Two candidate root causes fit the symptom: a genuinely enabled button whose submit silently early-returns, and a disabled button that isn't styled as disabled. `LemonButton` handles the second case correctly (it sets `disabled`, shows a tooltip, and skips `onClick`), and the reporter explicitly described the button as active, which pointed at the first. Reading the kea-forms submit path confirmed it.

I considered fixing this in `replayScannerLogic` by scoping `errors()` per step, but that would weaken validation on the final save. Surfacing the existing errors through `disabledReason` fixes the dead click without changing what counts as a valid scanner. I also moved the field-to-step mapping out of the component and into `scannerEditorSceneLogic` so it's unit-testable and so the stepper and the button share one source of truth rather than two copies that already disagreed slightly.

Skills invoked: the repo's `/writing-user-facing-copy` (for the new tooltip strings), `/writing-code-comments`, and `/writing-tests` (the value gate is why this is one parameterized test and not four).

I could not verify the reporter's GitHub identity from the Slack thread, so I've left this PR unassigned rather than guess a handle. Whoever picks it up should set the assignee.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1785866393664879)*
