### PR TITLE
feat(dashboards): support groups in templates and MCP

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -58,51 +58,72 @@ export function dashboardToSaveableTemplate(
         dashboard_description: dashboard.description,
         dashboard_filters: dashboard.filters,
         tags: dashboard.tags || [],
-        tiles: dashboard.tiles
-            .filter((tile) => !tile.error)
-            .map((tile) => {
-                if (tile.text) {
-                    return {
-                        type: 'TEXT' as const,
-                        body: tile.text.body,
-                        layouts: tile.layouts,
-                        color: tile.color,
+        tiles: [
+            ...(dashboard.groups ?? []).map((group) => ({
+                type: 'GROUP' as const,
+                group_key: group.id,
+                name: group.name,
+                layouts: group.layouts.sm
+                    ? {
+                          sm: {
+                              x: group.layouts.sm.x ?? 0,
+                              y: group.layouts.sm.y ?? 0,
+                              w: group.layouts.sm.w ?? BREAKPOINT_COLUMN_COUNTS.sm,
+                              h: group.layouts.sm.h ?? 1,
+                          },
+                      }
+                    : {},
+            })),
+            ...dashboard.tiles
+                .filter((tile) => !tile.error)
+                .map((tile) => {
+                    if (tile.text) {
+                        return {
+                            type: 'TEXT' as const,
+                            body: tile.text.body,
+                            layouts: tile.layouts,
+                            color: tile.color,
+                            group_key: tile.parent_group_id ?? undefined,
+                        }
                     }
-                }
-                if (tile.insight) {
-                    return {
-                        type: 'INSIGHT' as const,
-                        name: tile.insight.name,
-                        description: tile.insight.description || '',
-                        query: tile.insight.query,
-                        layouts: tile.layouts,
-                        color: tile.color,
+                    if (tile.insight) {
+                        return {
+                            type: 'INSIGHT' as const,
+                            name: tile.insight.name,
+                            description: tile.insight.description || '',
+                            query: tile.insight.query,
+                            layouts: tile.layouts,
+                            color: tile.color,
+                            group_key: tile.parent_group_id ?? undefined,
+                        }
                     }
-                }
-                if (tile.button_tile) {
-                    return {
-                        type: 'BUTTON' as const,
-                        button_tile: {
-                            url: tile.button_tile.url,
-                            text: tile.button_tile.text,
-                            placement: tile.button_tile.placement,
-                            style: tile.button_tile.style,
-                        },
-                        layouts: tile.layouts,
-                        color: tile.color,
+                    if (tile.button_tile) {
+                        return {
+                            type: 'BUTTON' as const,
+                            button_tile: {
+                                url: tile.button_tile.url,
+                                text: tile.button_tile.text,
+                                placement: tile.button_tile.placement,
+                                style: tile.button_tile.style,
+                            },
+                            layouts: tile.layouts,
+                            color: tile.color,
+                            group_key: tile.parent_group_id ?? undefined,
+                        }
                     }
-                }
-                if (tile.widget) {
-                    return {
-                        type: 'WIDGET' as const,
-                        widget_type: tile.widget.widget_type,
-                        config: tile.widget.config,
-                        layouts: tile.layouts,
-                        color: tile.color,
+                    if (tile.widget) {
+                        return {
+                            type: 'WIDGET' as const,
+                            widget_type: tile.widget.widget_type,
+                            config: tile.widget.config,
+                            layouts: tile.layouts,
+                            color: tile.color,
+                            group_key: tile.parent_group_id ?? undefined,
+                        }
                     }
-                }
-                throw new Error('Unknown tile type')
-            }),
+                    throw new Error('Unknown tile type')
+                }),
+        ],
         variables: [],
     }
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -81,6 +81,7 @@ import type {
 import { QueryContext } from '~/queries/types'
 
 import { AlertType } from 'products/alerts/frontend/types'
+import type { DashboardGroupApi } from 'products/dashboards/frontend/generated/api.schemas'
 import type { DataWarehouseSavedQueryApiSuspended } from 'products/data_warehouse/frontend/generated/api.schemas'
 import type { ExperimentFeatureFlagInputApi } from 'products/experiments/frontend/generated/api.schemas'
 import type { CommentSlackThreadRefApi } from 'products/platform_features/frontend/generated/api.schemas'
@@ -2487,6 +2488,7 @@ export interface DashboardTile<T = InsightModel> extends Tileable {
     text?: TextModel
     button_tile?: ButtonTileModel
     widget?: DashboardWidgetModel
+    parent_group_id?: string | null
     deleted?: boolean
     is_cached?: boolean
     order?: number
@@ -2682,6 +2684,7 @@ export type DashboardTemplateScope = 'team' | 'global' | 'feature_flag' | 'organ
 
 export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     tiles: DashboardTile<T>[]
+    groups?: DashboardGroupApi[]
     filters: DashboardFilter
     variables?: Record<string, HogQLVariable>
     persisted_filters?: DashboardFilter | null
@@ -2709,6 +2712,7 @@ export type DashboardTemplateStoredInsightTile = {
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
     filters?: Record<string, unknown>
+    group_key?: string
 }
 
 export type DashboardTemplateStoredTextTile = {
@@ -2716,6 +2720,7 @@ export type DashboardTemplateStoredTextTile = {
     body: string
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
+    group_key?: string
 }
 
 export type DashboardTemplateStoredButtonTile = {
@@ -2728,6 +2733,7 @@ export type DashboardTemplateStoredButtonTile = {
     }
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
+    group_key?: string
 }
 
 export type DashboardTemplateStoredWidgetTile = {
@@ -2736,6 +2742,14 @@ export type DashboardTemplateStoredWidgetTile = {
     config?: Record<string, unknown>
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
+    group_key?: string
+}
+
+export type DashboardTemplateStoredGroupTile = {
+    type: 'GROUP'
+    group_key: string
+    name: string
+    layouts?: Partial<Record<DashboardLayoutSize, TileLayout>>
 }
 
 export type DashboardTemplateStoredTile =
@@ -2743,6 +2757,7 @@ export type DashboardTemplateStoredTile =
     | DashboardTemplateStoredTextTile
     | DashboardTemplateStoredButtonTile
     | DashboardTemplateStoredWidgetTile
+    | DashboardTemplateStoredGroupTile
 
 /** Project-specific references embedded in a template's tiles that may not resolve in another project. */
 export interface NonPortableReferences {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -81,6 +81,7 @@ import type {
 import { QueryContext } from '~/queries/types'
 
 import { AlertType } from 'products/alerts/frontend/types'
+import type { DashboardGroupApi } from 'products/dashboards/frontend/generated/api.schemas'
 import type { DataWarehouseSavedQueryApiSuspended } from 'products/data_warehouse/frontend/generated/api.schemas'
 import type { ExperimentFeatureFlagInputApi } from 'products/experiments/frontend/generated/api.schemas'
 import type { InsightFilterOverrideContextApi } from 'products/product_analytics/frontend/generated/api.schemas'
@@ -2473,6 +2474,7 @@ export interface DashboardTile<T = InsightModel> extends Tileable {
     text?: TextModel
     button_tile?: ButtonTileModel
     widget?: DashboardWidgetModel
+    parent_group_id?: string | null
     deleted?: boolean
     is_cached?: boolean
     order?: number
@@ -2664,6 +2666,7 @@ export type DashboardTemplateScope = 'team' | 'global' | 'feature_flag' | 'organ
 
 export interface DashboardType<T = InsightModel> extends DashboardBasicType {
     tiles: DashboardTile<T>[]
+    groups?: DashboardGroupApi[]
     filters: DashboardFilter
     variables?: Record<string, HogQLVariable>
     persisted_filters?: DashboardFilter | null
@@ -2691,6 +2694,7 @@ export type DashboardTemplateStoredInsightTile = {
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
     filters?: Record<string, unknown>
+    group_key?: string
 }
 
 export type DashboardTemplateStoredTextTile = {
@@ -2698,6 +2702,7 @@ export type DashboardTemplateStoredTextTile = {
     body: string
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
+    group_key?: string
 }
 
 export type DashboardTemplateStoredButtonTile = {
@@ -2710,6 +2715,7 @@ export type DashboardTemplateStoredButtonTile = {
     }
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
+    group_key?: string
 }
 
 export type DashboardTemplateStoredWidgetTile = {
@@ -2718,6 +2724,14 @@ export type DashboardTemplateStoredWidgetTile = {
     config?: Record<string, unknown>
     layouts?: Record<DashboardLayoutSize, TileLayout> | Record<string, never>
     color?: InsightColor | null
+    group_key?: string
+}
+
+export type DashboardTemplateStoredGroupTile = {
+    type: 'GROUP'
+    group_key: string
+    name: string
+    layouts?: Partial<Record<DashboardLayoutSize, TileLayout>>
 }
 
 export type DashboardTemplateStoredTile =
@@ -2725,6 +2739,7 @@ export type DashboardTemplateStoredTile =
     | DashboardTemplateStoredTextTile
     | DashboardTemplateStoredButtonTile
     | DashboardTemplateStoredWidgetTile
+    | DashboardTemplateStoredGroupTile
 
 /** Project-specific references embedded in a template's tiles that may not resolve in another project. */
 export interface NonPortableReferences {

--- a/posthog/helpers/dashboard_templates.py
+++ b/posthog/helpers/dashboard_templates.py
@@ -12,6 +12,7 @@ from posthog.models.scoping import team_scope
 from posthog.models.tag import Tag
 
 from products.dashboards.backend.models.dashboard import Dashboard
+from products.dashboards.backend.models.dashboard_group import DashboardGroup
 from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
 from products.dashboards.backend.models.dashboard_tile import ButtonTile, DashboardTile, Text
 from products.dashboards.backend.models.dashboard_widget import DashboardWidget
@@ -512,8 +513,34 @@ def create_from_template(
         dashboard.tagged_items.create(tag_id=tag.id)
     dashboard.save()
 
+    groups_by_key: dict[str, DashboardGroup] = {}
+    for template_tile in template.tiles or []:
+        if template_tile.get("type") != "GROUP":
+            continue
+        group_key = template_tile.get("group_key")
+        if not group_key:
+            logger.error("dashboard_templates.creation.group_missing_key", template=template)
+            continue
+        group = DashboardGroup.all_teams.create(
+            dashboard=dashboard,
+            team=dashboard.team,
+            name=template_tile.get("name", "Group"),
+            created_by=user,
+            last_modified_by=user,
+        )
+        DashboardTile.objects.create(
+            dashboard=dashboard,
+            team=dashboard.team,
+            dashboard_group=group,
+            layouts=template_tile.get("layouts") or {},
+        )
+        groups_by_key[group_key] = group
+
     for template_tile in template.tiles or []:
         tile_type = template_tile.get("type")
+        if tile_type == "GROUP":
+            continue
+        parent_group = groups_by_key.get(template_tile.get("group_key"))
         if tile_type == "INSIGHT":
             query = template_tile.get("query", None)
             _create_tile_for_insight(
@@ -524,6 +551,7 @@ def create_from_template(
                 color=template_tile.get("color"),
                 layouts=template_tile.get("layouts"),
                 user=user,
+                parent_group=parent_group,
             )
         elif tile_type == "TEXT":
             _create_tile_for_text(
@@ -532,6 +560,7 @@ def create_from_template(
                 layouts=template_tile.get("layouts"),
                 body=template_tile.get("body"),
                 transparent_background=template_tile.get("transparent_background"),
+                parent_group=parent_group,
             )
         elif tile_type == "BUTTON":
             button = {**template_tile, **(template_tile.get("button_tile") or {})}
@@ -544,6 +573,7 @@ def create_from_template(
                 placement=button.get("placement", "left"),
                 style=button.get("style", "primary"),
                 transparent_background=template_tile.get("transparent_background"),
+                parent_group=parent_group,
             )
         elif tile_type == "WIDGET":
             _create_tile_for_widget(
@@ -555,6 +585,7 @@ def create_from_template(
                 transparent_background=template_tile.get("transparent_background"),
                 user=user,
                 user_access_control=user_access_control,
+                parent_group=parent_group,
             )
         else:
             logger.error("dashboard_templates.creation.unknown_type", template=template)
@@ -566,6 +597,7 @@ def _create_tile_for_text(
     layouts: dict,
     color: Optional[str],
     transparent_background: Optional[bool] = None,
+    parent_group: DashboardGroup | None = None,
 ) -> None:
     text = Text.objects.create(
         team=dashboard.team,
@@ -578,6 +610,7 @@ def _create_tile_for_text(
         layouts=layouts,
         color=color,
         transparent_background=transparent_background,
+        parent_group=parent_group,
     )
 
 
@@ -590,6 +623,7 @@ def _create_tile_for_button(
     placement: str = "left",
     style: str = "primary",
     transparent_background: Optional[bool] = None,
+    parent_group: DashboardGroup | None = None,
 ) -> None:
     button_tile = ButtonTile.objects.create(
         team=dashboard.team,
@@ -605,6 +639,7 @@ def _create_tile_for_button(
         layouts=layouts,
         color=color,
         transparent_background=transparent_background,
+        parent_group=parent_group,
     )
 
 
@@ -618,6 +653,7 @@ def _create_tile_for_widget(
     user=None,
     *,
     user_access_control: UserAccessControl | None = None,
+    parent_group: DashboardGroup | None = None,
 ) -> None:
     from products.dashboards.backend.widget_create import (
         prepare_widget_tile_create,  # noqa: PLC0415 — breaks posthog.models import cycle
@@ -645,6 +681,7 @@ def _create_tile_for_widget(
         layouts=layouts or {},
         color=color,
         transparent_background=transparent_background,
+        parent_group=parent_group,
     )
 
 
@@ -656,6 +693,7 @@ def _create_tile_for_insight(
     color: Optional[str],
     query: Optional[dict] = None,
     user=None,
+    parent_group: DashboardGroup | None = None,
 ) -> None:
     insight = Insight.objects.create(
         team=dashboard.team,
@@ -672,6 +710,7 @@ def _create_tile_for_insight(
         team_id=dashboard.team_id,
         layouts=layouts,
         color=color,
+        parent_group=parent_group,
     )
 
 

--- a/products/dashboards/backend/api/test/test_dashboard_groups.py
+++ b/products/dashboards/backend/api/test/test_dashboard_groups.py
@@ -3,8 +3,11 @@ from posthog.test.base import APIBaseTest
 from rest_framework import status
 
 from posthog.api.test.dashboards import DashboardAPI
+from posthog.helpers.dashboard_templates import create_from_template
 
+from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_group import DashboardGroup
+from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 
 
@@ -60,3 +63,32 @@ class TestDashboardGroups(APIBaseTest):
         )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_template_remaps_group_membership(self) -> None:
+        template = DashboardTemplate(
+            template_name="Grouped template",
+            dashboard_description="",
+            dashboard_filters={},
+            tags=[],
+            tiles=[
+                {
+                    "type": "GROUP",
+                    "group_key": "acquisition",
+                    "name": "Acquisition",
+                    "layouts": {"sm": {"x": 0, "y": 0, "w": 12, "h": 1}},
+                },
+                {
+                    "type": "TEXT",
+                    "group_key": "acquisition",
+                    "body": "Signups",
+                    "layouts": {"sm": {"x": 0, "y": 1, "w": 12, "h": 2}},
+                },
+            ],
+        )
+        dashboard = Dashboard.objects.create(team=self.team, name="From template")
+
+        create_from_template(dashboard, template, self.user)
+
+        group = dashboard.groups.get()
+        self.assertEqual(group.name, "Acquisition")
+        self.assertEqual(group.member_tiles.get().text.body, "Signups")

--- a/products/dashboards/mcp/tools.yaml
+++ b/products/dashboards/mcp/tools.yaml
@@ -96,6 +96,66 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+    dashboard-group-create:
+        operation: dashboards_groups_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        enrich_url: '{params.id}'
+        title: Create dashboard group
+        description: Create a named group at the bottom of a dashboard.
+        param_overrides:
+            id:
+                cast: string-int
+    dashboard-group-update:
+        operation: dashboards_groups_update_partial_update
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{params.id}'
+        title: Update dashboard group
+        description: Rename a dashboard group or update its full-width grid position.
+        param_overrides:
+            id:
+                cast: string-int
+    dashboard-group-move-tile:
+        operation: dashboards_groups_move_tile_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        enrich_url: '{params.id}'
+        title: Move tile to dashboard group
+        description: Move a content tile into a group or into the ungrouped section.
+        param_overrides:
+            id:
+                cast: string-int
+    dashboard-group-delete:
+        operation: dashboards_groups_delete_create
+        enabled: true
+        scopes:
+            - dashboard:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: false
+        enrich_url: '{params.id}'
+        title: Delete dashboard group
+        description: Delete a group and either delete its member tiles or move them to the ungrouped section.
+        param_overrides:
+            id:
+                cast: string-int
     dashboard-delete:
         operation: dashboards_destroy
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2081,6 +2081,62 @@
             "readOnlyHint": true
         }
     },
+    "dashboard-group-create": {
+        "description": "Create a named group at the bottom of a dashboard.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Create dashboard group",
+        "title": "Create dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-delete": {
+        "description": "Delete a group and either delete its member tiles or move them to the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Delete dashboard group",
+        "title": "Delete dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-move-tile": {
+        "description": "Move a content tile into a group or into the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Move tile to dashboard group",
+        "title": "Move tile to dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-update": {
+        "description": "Rename a dashboard group or update its full-width grid position.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard group",
+        "title": "Update dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-insights-run": {
         "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override and filters_override query params to run insights with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.",
         "category": "Dashboards",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1983,6 +1983,62 @@
             "readOnlyHint": true
         }
     },
+    "dashboard-group-create": {
+        "description": "Create a named group at the bottom of a dashboard.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Create dashboard group",
+        "title": "Create dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-delete": {
+        "description": "Delete a group and either delete its member tiles or move them to the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Delete dashboard group",
+        "title": "Delete dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-move-tile": {
+        "description": "Move a content tile into a group or into the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Move tile to dashboard group",
+        "title": "Move tile to dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-update": {
+        "description": "Rename a dashboard group or update its full-width grid position.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard group",
+        "title": "Update dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-insights-run": {
         "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override and filters_override query params to run insights with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.",
         "category": "Dashboards",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2096,6 +2096,62 @@
             "readOnlyHint": true
         }
     },
+    "dashboard-group-create": {
+        "description": "Create a named group at the bottom of a dashboard.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Create dashboard group",
+        "title": "Create dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-delete": {
+        "description": "Delete a group and either delete its member tiles or move them to the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Delete dashboard group",
+        "title": "Delete dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-move-tile": {
+        "description": "Move a content tile into a group or into the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Move tile to dashboard group",
+        "title": "Move tile to dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-update": {
+        "description": "Rename a dashboard group or update its full-width grid position.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard group",
+        "title": "Update dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-insights-run": {
         "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override and filters_override query params to run insights with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.",
         "category": "Dashboards",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1998,6 +1998,62 @@
             "readOnlyHint": true
         }
     },
+    "dashboard-group-create": {
+        "description": "Create a named group at the bottom of a dashboard.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Create dashboard group",
+        "title": "Create dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-delete": {
+        "description": "Delete a group and either delete its member tiles or move them to the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Delete dashboard group",
+        "title": "Delete dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-move-tile": {
+        "description": "Move a content tile into a group or into the ungrouped section.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Move tile to dashboard group",
+        "title": "Move tile to dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "dashboard-group-update": {
+        "description": "Rename a dashboard group or update its full-width grid position.",
+        "category": "Dashboards",
+        "feature": "dashboards",
+        "summary": "Update dashboard group",
+        "title": "Update dashboard group",
+        "required_scopes": ["dashboard:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "dashboard-insights-run": {
         "description": "Run all insights on a dashboard and return their results. Uses cached results by default (may be stale); set refresh to 'blocking' for fresh results. Set format to 'optimized' (default) for LLM-friendly text tables or 'json' for raw query results. Supports variables_override and filters_override query params to run insights with one-off overrides without persisting; see the parameter descriptions for the exact JSON shape required.",
         "category": "Dashboards",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -7939,6 +7939,8 @@ export namespace Schemas {
       text: Text;
       button_tile: ButtonTile;
       widget?: DashboardWidget | null;
+      /** @nullable */
+      readonly parent_group_id: string | null;
       layouts?: unknown;
       /**
          * @maxLength 400
@@ -15876,6 +15878,33 @@ export namespace Schemas {
       memory_gb?: number;
     }
 
+    export interface TileLayoutBox {
+      /** Column position in the dashboard grid (0-indexed). */
+      x?: number;
+      /** Row position in the dashboard grid (0-indexed). */
+      y?: number;
+      /** Width in grid columns. The desktop grid is 12 columns wide. */
+      w?: number;
+      /** Height in grid rows. */
+      h?: number;
+    }
+
+    export interface TileLayouts {
+      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
+      sm?: TileLayoutBox;
+    }
+
+    export interface CreateDashboardGroupRequest {
+      /**
+         * Name displayed in the dashboard group row.
+         * @minLength 1
+         * @maxLength 400
+         */
+      name: string;
+      /** Optional grid layout for the group row. Group rows always span the desktop grid. */
+      layouts?: TileLayouts;
+    }
+
     /**
      * Typed configuration for a FileDownload batch-export destination.
      */
@@ -16144,24 +16173,6 @@ export namespace Schemas {
       text: string;
       /** When true, this source's content is injected into every support reply prompt as general context (tone, policies, direction). */
       always_include?: boolean;
-    }
-
-    export interface TileLayoutBox {
-      /** Column position in the dashboard grid (0-indexed). */
-      x?: number;
-      /** Row position in the dashboard grid (0-indexed). */
-      y?: number;
-      /** Width in grid columns. The desktop grid is 12 columns wide. */
-      w?: number;
-      /** Height in grid rows. */
-      h?: number;
-    }
-
-    export interface TileLayouts {
-      /** Layout for the standard (desktop) breakpoint. The grid is 12 columns wide. */
-      sm?: TileLayoutBox;
-      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
-      xs?: TileLayoutBox;
     }
 
     export interface CreateTextTileRequest {
@@ -16846,6 +16857,23 @@ export namespace Schemas {
       Number37: 37,
     } as const;
 
+    export interface DashboardGroup {
+      readonly id: string;
+      readonly name: string;
+      /** Grid tile ID for this group row. */
+      readonly tile_id: number;
+      /** Grid layout for the group row. */
+      readonly layouts: TileLayouts;
+      /** Content tile IDs assigned to this group. */
+      readonly member_tile_ids: readonly number[];
+      readonly created_at: string;
+      /** @nullable */
+      readonly created_by: number | null;
+      readonly last_modified_at: string;
+      /** @nullable */
+      readonly last_modified_by: number | null;
+    }
+
     /**
      * Serializer mixin that handles tags for objects.
      */
@@ -16904,6 +16932,8 @@ export namespace Schemas {
          * @nullable
          */
       quick_filter_ids?: string[] | null;
+      /** Ordered groups configured on this dashboard. */
+      readonly groups: readonly DashboardGroup[];
       /** @nullable */
       readonly tiles: readonly DashboardTilesItem[] | null;
       /** Template key to create the dashboard from a predefined template. */
@@ -22311,6 +22341,30 @@ export namespace Schemas {
       Bayesian: 'bayesian',
       Frequentist: 'frequentist',
     } as const;
+
+    /**
+     * * `delete_tiles` - delete_tiles
+     * * `move_to_ungrouped` - move_to_ungrouped
+     */
+    export type MemberHandlingEnum = typeof MemberHandlingEnum[keyof typeof MemberHandlingEnum];
+
+
+    export const MemberHandlingEnum = {
+      DeleteTiles: 'delete_tiles',
+      MoveToUngrouped: 'move_to_ungrouped',
+    } as const;
+
+    export interface DeleteDashboardGroupRequest {
+      /** Dashboard group ID to delete. */
+      group_id: string;
+      /** How to handle content tiles currently assigned to the group.
+       *
+       * * `delete_tiles` - delete_tiles
+       * * `move_to_ungrouped` - move_to_ungrouped */
+      member_handling: MemberHandlingEnum;
+      /** Layout for the small (mobile) breakpoint. The grid is 1 column wide. */
+      xs?: TileLayoutBox;
+    }
 
     export interface DeleteTileRequest {
       /** ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs. */
@@ -42705,6 +42759,18 @@ export namespace Schemas {
       inconclusive_total: number;
     }
 
+    export interface MoveDashboardTileToGroupRequest {
+      /** Content tile ID to move. */
+      tile_id: number;
+      /**
+         * Destination group ID, or null to move the tile to the ungrouped section.
+         * @nullable
+         */
+      group_id?: string | null;
+      /** Optional new layout for the moved tile. */
+      layouts?: TileLayouts;
+    }
+
     export interface MoveTileTile {
       /** Dashboard tile ID to move. */
       id: number;
@@ -57443,6 +57509,19 @@ export namespace Schemas {
       cpu_cores?: number;
       /** New memory (GB) allocation for the sandbox. */
       memory_gb?: number;
+    }
+
+    export interface PatchedUpdateDashboardGroupRequest {
+      /** Dashboard group ID to update. */
+      group_id?: string;
+      /**
+         * New group name. Omit to keep the existing name.
+         * @minLength 1
+         * @maxLength 400
+         */
+      name?: string;
+      /** New grid layout for the group row. Omit to keep its current layout. */
+      layouts?: TileLayouts;
     }
 
     export type SessionReplayListWidgetUpdateRequestOpenApiWidgetType = typeof SessionReplayListWidgetUpdateRequestOpenApiWidgetType[keyof typeof SessionReplayListWidgetUpdateRequestOpenApiWidgetType];
@@ -78391,6 +78470,54 @@ export namespace Schemas {
 
 
     export const DashboardsDeleteTileFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsCreateParams = {
+    format?: DashboardsGroupsCreateFormat;
+    };
+
+    export type DashboardsGroupsCreateFormat = typeof DashboardsGroupsCreateFormat[keyof typeof DashboardsGroupsCreateFormat];
+
+
+    export const DashboardsGroupsCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsDeleteCreateParams = {
+    format?: DashboardsGroupsDeleteCreateFormat;
+    };
+
+    export type DashboardsGroupsDeleteCreateFormat = typeof DashboardsGroupsDeleteCreateFormat[keyof typeof DashboardsGroupsDeleteCreateFormat];
+
+
+    export const DashboardsGroupsDeleteCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsMoveTileCreateParams = {
+    format?: DashboardsGroupsMoveTileCreateFormat;
+    };
+
+    export type DashboardsGroupsMoveTileCreateFormat = typeof DashboardsGroupsMoveTileCreateFormat[keyof typeof DashboardsGroupsMoveTileCreateFormat];
+
+
+    export const DashboardsGroupsMoveTileCreateFormat = {
+      Json: 'json',
+      Txt: 'txt',
+    } as const;
+
+    export type DashboardsGroupsUpdatePartialUpdateParams = {
+    format?: DashboardsGroupsUpdatePartialUpdateFormat;
+    };
+
+    export type DashboardsGroupsUpdatePartialUpdateFormat = typeof DashboardsGroupsUpdatePartialUpdateFormat[keyof typeof DashboardsGroupsUpdatePartialUpdateFormat];
+
+
+    export const DashboardsGroupsUpdatePartialUpdateFormat = {
       Json: 'json',
       Txt: 'txt',
     } as const;

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 18 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1119,6 +1119,149 @@ export const DashboardsDeleteTileQueryParams = /* @__PURE__ */ zod.object({
 
 export const DashboardsDeleteTileBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.'),
+})
+
+export const DashboardsGroupsCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsGroupsCreateBodyNameMax = 400
+
+export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .min(1)
+        .max(dashboardsGroupsCreateBodyNameMax)
+        .describe('Name displayed in the dashboard group row.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+        })
+        .optional()
+        .describe('Optional grid layout for the group row. Group rows always span the desktop grid.'),
+})
+
+export const DashboardsGroupsDeleteCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsDeleteCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
+    group_id: zod.string().describe('Dashboard group ID to delete.'),
+    member_handling: zod
+        .enum(['delete_tiles', 'move_to_ungrouped'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .describe(
+            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+        ),
+    xs: zod
+        .object({
+            x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+            y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+            w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+            h: zod.number().optional().describe('Height in grid rows.'),
+        })
+        .optional()
+        .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+})
+
+export const DashboardsGroupsMoveTileCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsMoveTileCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('Content tile ID to move.'),
+    group_id: zod
+        .string()
+        .nullish()
+        .describe('Destination group ID, or null to move the tile to the ungrouped section.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+        })
+        .optional()
+        .describe('Optional new layout for the moved tile.'),
+})
+
+export const DashboardsGroupsUpdatePartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsUpdatePartialUpdateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsGroupsUpdatePartialUpdateBodyNameMax = 400
+
+export const DashboardsGroupsUpdatePartialUpdateBody = /* @__PURE__ */ zod.object({
+    group_id: zod.string().optional().describe('Dashboard group ID to update.'),
+    name: zod
+        .string()
+        .min(1)
+        .max(dashboardsGroupsUpdatePartialUpdateBodyNameMax)
+        .optional()
+        .describe('New group name. Omit to keep the existing name.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+        })
+        .optional()
+        .describe('New grid layout for the group row. Omit to keep its current layout.'),
 })
 
 export const DashboardsMoveTilePartialUpdateParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 18 enabled ops
+ * PostHog API - MCP 22 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1005,15 +1005,6 @@ export const DashboardsCreateTextTileCreateBody = /* @__PURE__ */ zod.object({
                 })
                 .optional()
                 .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-            xs: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
         })
         .optional()
         .describe(
@@ -1048,6 +1039,149 @@ export const DashboardsDeleteTileQueryParams = /* @__PURE__ */ zod.object({
 
 export const DashboardsDeleteTileBody = /* @__PURE__ */ zod.object({
     tile_id: zod.number().describe('ID of the dashboard tile to delete. Use dashboard-get to look up tile IDs.'),
+})
+
+export const DashboardsGroupsCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsGroupsCreateBodyNameMax = 400
+
+export const DashboardsGroupsCreateBody = /* @__PURE__ */ zod.object({
+    name: zod
+        .string()
+        .min(1)
+        .max(dashboardsGroupsCreateBodyNameMax)
+        .describe('Name displayed in the dashboard group row.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+        })
+        .optional()
+        .describe('Optional grid layout for the group row. Group rows always span the desktop grid.'),
+})
+
+export const DashboardsGroupsDeleteCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsDeleteCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const DashboardsGroupsDeleteCreateBody = /* @__PURE__ */ zod.object({
+    group_id: zod.string().describe('Dashboard group ID to delete.'),
+    member_handling: zod
+        .enum(['delete_tiles', 'move_to_ungrouped'])
+        .describe('\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped')
+        .describe(
+            'How to handle content tiles currently assigned to the group.\n\n\* `delete_tiles` - delete_tiles\n\* `move_to_ungrouped` - move_to_ungrouped'
+        ),
+    xs: zod
+        .object({
+            x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+            y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+            w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+            h: zod.number().optional().describe('Height in grid rows.'),
+        })
+        .optional()
+        .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
+})
+
+export const DashboardsGroupsMoveTileCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsMoveTileCreateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const DashboardsGroupsMoveTileCreateBody = /* @__PURE__ */ zod.object({
+    tile_id: zod.number().describe('Content tile ID to move.'),
+    group_id: zod
+        .string()
+        .nullish()
+        .describe('Destination group ID, or null to move the tile to the ungrouped section.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+        })
+        .optional()
+        .describe('Optional new layout for the moved tile.'),
+})
+
+export const DashboardsGroupsUpdatePartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.number().describe('A unique integer value identifying this dashboard.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DashboardsGroupsUpdatePartialUpdateQueryParams = /* @__PURE__ */ zod.object({
+    format: zod.enum(['json', 'txt']).optional(),
+})
+
+export const dashboardsGroupsUpdatePartialUpdateBodyNameMax = 400
+
+export const DashboardsGroupsUpdatePartialUpdateBody = /* @__PURE__ */ zod.object({
+    group_id: zod.string().optional().describe('Dashboard group ID to update.'),
+    name: zod
+        .string()
+        .min(1)
+        .max(dashboardsGroupsUpdatePartialUpdateBodyNameMax)
+        .optional()
+        .describe('New group name. Omit to keep the existing name.'),
+    layouts: zod
+        .object({
+            sm: zod
+                .object({
+                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
+                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
+                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
+                    h: zod.number().optional().describe('Height in grid rows.'),
+                })
+                .optional()
+                .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
+        })
+        .optional()
+        .describe('New grid layout for the group row. Omit to keep its current layout.'),
 })
 
 export const DashboardsMoveTilePartialUpdateParams = /* @__PURE__ */ zod.object({
@@ -1195,15 +1329,6 @@ export const DashboardsUpdateTextTileCreateBody = /* @__PURE__ */ zod.object({
                 })
                 .optional()
                 .describe('Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.'),
-            xs: zod
-                .object({
-                    x: zod.number().optional().describe('Column position in the dashboard grid (0-indexed).'),
-                    y: zod.number().optional().describe('Row position in the dashboard grid (0-indexed).'),
-                    w: zod.number().optional().describe('Width in grid columns. The desktop grid is 12 columns wide.'),
-                    h: zod.number().optional().describe('Height in grid rows.'),
-                })
-                .optional()
-                .describe('Layout for the small (mobile) breakpoint. The grid is 1 column wide.'),
         })
         .optional()
         .describe('New grid layout per breakpoint. Omit to leave the layout unchanged.'),

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -14,6 +14,14 @@ import {
     DashboardsDeleteTileBody,
     DashboardsDeleteTileParams,
     DashboardsDestroyParams,
+    DashboardsGroupsCreateBody,
+    DashboardsGroupsCreateParams,
+    DashboardsGroupsDeleteCreateBody,
+    DashboardsGroupsDeleteCreateParams,
+    DashboardsGroupsMoveTileCreateBody,
+    DashboardsGroupsMoveTileCreateParams,
+    DashboardsGroupsUpdatePartialUpdateBody,
+    DashboardsGroupsUpdatePartialUpdateParams,
     DashboardsListQueryParams,
     DashboardsMoveTilePartialUpdateBody,
     DashboardsMoveTilePartialUpdateParams,
@@ -162,6 +170,124 @@ const dashboardCreateTextTile = (): ToolBase<
         const result = await context.api.request<Schemas.DashboardTile>({
             method: 'POST',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/create_text_tile/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
+    },
+})
+
+const DashboardGroupCreateSchema = DashboardsGroupsCreateParams.omit({ project_id: true })
+    .extend(DashboardsGroupsCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsGroupsCreateParams.shape['id']) })
+
+const dashboardGroupCreate = (): ToolBase<
+    typeof DashboardGroupCreateSchema,
+    WithPostHogUrl<Schemas.DashboardGroup>
+> => ({
+    name: 'dashboard-group-create',
+    schema: DashboardGroupCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardGroupCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        const result = await context.api.request<Schemas.DashboardGroup>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/groups/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
+    },
+})
+
+const DashboardGroupUpdateSchema = DashboardsGroupsUpdatePartialUpdateParams.omit({ project_id: true })
+    .extend(DashboardsGroupsUpdatePartialUpdateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsGroupsUpdatePartialUpdateParams.shape['id']) })
+
+const dashboardGroupUpdate = (): ToolBase<
+    typeof DashboardGroupUpdateSchema,
+    WithPostHogUrl<Schemas.DashboardGroup>
+> => ({
+    name: 'dashboard-group-update',
+    schema: DashboardGroupUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardGroupUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.group_id !== undefined) {
+            body['group_id'] = params.group_id
+        }
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        const result = await context.api.request<Schemas.DashboardGroup>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/groups/update/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
+    },
+})
+
+const DashboardGroupMoveTileSchema = DashboardsGroupsMoveTileCreateParams.omit({ project_id: true })
+    .extend(DashboardsGroupsMoveTileCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsGroupsMoveTileCreateParams.shape['id']) })
+
+const dashboardGroupMoveTile = (): ToolBase<
+    typeof DashboardGroupMoveTileSchema,
+    WithPostHogUrl<Schemas.DashboardTile>
+> => ({
+    name: 'dashboard-group-move-tile',
+    schema: DashboardGroupMoveTileSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardGroupMoveTileSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.tile_id !== undefined) {
+            body['tile_id'] = params.tile_id
+        }
+        if (params.group_id !== undefined) {
+            body['group_id'] = params.group_id
+        }
+        if (params.layouts !== undefined) {
+            body['layouts'] = params.layouts
+        }
+        const result = await context.api.request<Schemas.DashboardTile>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/groups/move-tile/`,
+            body,
+        })
+        return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
+    },
+})
+
+const DashboardGroupDeleteSchema = DashboardsGroupsDeleteCreateParams.omit({ project_id: true })
+    .extend(DashboardsGroupsDeleteCreateBody.shape)
+    .extend({ id: z.preprocess(castStringToInt, DashboardsGroupsDeleteCreateParams.shape['id']) })
+
+const dashboardGroupDelete = (): ToolBase<typeof DashboardGroupDeleteSchema, unknown> => ({
+    name: 'dashboard-group-delete',
+    schema: DashboardGroupDeleteSchema,
+    handler: async (context: Context, params: z.infer<typeof DashboardGroupDeleteSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.group_id !== undefined) {
+            body['group_id'] = params.group_id
+        }
+        if (params.member_handling !== undefined) {
+            body['member_handling'] = params.member_handling
+        }
+        if (params.xs !== undefined) {
+            body['xs'] = params.xs
+        }
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/dashboards/${encodeURIComponent(String(params.id))}/groups/delete/`,
             body,
         })
         return await withPostHogUrl(context, result, `/dashboard/${params.id}`)
@@ -727,6 +853,10 @@ const dashboardsMoveTilePartialUpdate = (): ToolBase<
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'dashboard-create': dashboardCreate,
     'dashboard-create-text-tile': dashboardCreateTextTile,
+    'dashboard-group-create': dashboardGroupCreate,
+    'dashboard-group-update': dashboardGroupUpdate,
+    'dashboard-group-move-tile': dashboardGroupMoveTile,
+    'dashboard-group-delete': dashboardGroupDelete,
     'dashboard-delete': dashboardDelete,
     'dashboard-delete-tile': dashboardDeleteTile,
     'dashboard-get': dashboardGet,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create-text-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-create-text-tile.json
@@ -47,28 +47,6 @@
                         }
                     },
                     "type": "object"
-                },
-                "xs": {
-                    "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
-                    "properties": {
-                        "h": {
-                            "description": "Height in grid rows.",
-                            "type": "number"
-                        },
-                        "w": {
-                            "description": "Width in grid columns. The desktop grid is 12 columns wide.",
-                            "type": "number"
-                        },
-                        "x": {
-                            "description": "Column position in the dashboard grid (0-indexed).",
-                            "type": "number"
-                        },
-                        "y": {
-                            "description": "Row position in the dashboard grid (0-indexed).",
-                            "type": "number"
-                        }
-                    },
-                    "type": "object"
                 }
             },
             "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-create.json
@@ -1,30 +1,12 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "body": {
-            "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
-            "maxLength": 4000,
-            "minLength": 1,
-            "type": "string"
-        },
-        "color": {
-            "anyOf": [
-                {
-                    "maxLength": 400,
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "New accent color name, empty string or null to clear. Omit to leave unchanged."
-        },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
         "layouts": {
-            "description": "New grid layout per breakpoint. Omit to leave the layout unchanged.",
+            "description": "Optional grid layout for the group row. Group rows always span the desktop grid.",
             "properties": {
                 "sm": {
                     "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
@@ -51,11 +33,13 @@
             },
             "type": "object"
         },
-        "tile_id": {
-            "description": "ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
-            "type": "number"
+        "name": {
+            "description": "Name displayed in the dashboard group row.",
+            "maxLength": 400,
+            "minLength": 1,
+            "type": "string"
         }
     },
-    "required": ["id", "tile_id"],
+    "required": ["id", "name"],
     "type": "object"
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-delete.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-delete.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "group_id": {
+            "description": "Dashboard group ID to delete.",
+            "type": "string"
+        },
+        "id": {
+            "description": "A unique integer value identifying this dashboard.",
+            "type": "number"
+        },
+        "member_handling": {
+            "description": "How to handle content tiles currently assigned to the group.\n\n* `delete_tiles` - delete_tiles\n* `move_to_ungrouped` - move_to_ungrouped",
+            "enum": ["delete_tiles", "move_to_ungrouped"],
+            "type": "string"
+        },
+        "xs": {
+            "description": "Layout for the small (mobile) breakpoint. The grid is 1 column wide.",
+            "properties": {
+                "h": {
+                    "description": "Height in grid rows.",
+                    "type": "number"
+                },
+                "w": {
+                    "description": "Width in grid columns. The desktop grid is 12 columns wide.",
+                    "type": "number"
+                },
+                "x": {
+                    "description": "Column position in the dashboard grid (0-indexed).",
+                    "type": "number"
+                },
+                "y": {
+                    "description": "Row position in the dashboard grid (0-indexed).",
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "required": ["id", "group_id", "member_handling"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-move-tile.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-move-tile.json
@@ -1,30 +1,23 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "body": {
-            "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
-            "maxLength": 4000,
-            "minLength": 1,
-            "type": "string"
-        },
-        "color": {
+        "group_id": {
             "anyOf": [
                 {
-                    "maxLength": 400,
                     "type": "string"
                 },
                 {
                     "type": "null"
                 }
             ],
-            "description": "New accent color name, empty string or null to clear. Omit to leave unchanged."
+            "description": "Destination group ID, or null to move the tile to the ungrouped section."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
         "layouts": {
-            "description": "New grid layout per breakpoint. Omit to leave the layout unchanged.",
+            "description": "Optional new layout for the moved tile.",
             "properties": {
                 "sm": {
                     "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
@@ -52,7 +45,7 @@
             "type": "object"
         },
         "tile_id": {
-            "description": "ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
+            "description": "Content tile ID to move.",
             "type": "number"
         }
     },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-group-update.json
@@ -1,30 +1,16 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
-        "body": {
-            "description": "New markdown body for the text tile. Omit to leave the body unchanged. Max 4000 characters.",
-            "maxLength": 4000,
-            "minLength": 1,
+        "group_id": {
+            "description": "Dashboard group ID to update.",
             "type": "string"
-        },
-        "color": {
-            "anyOf": [
-                {
-                    "maxLength": 400,
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "New accent color name, empty string or null to clear. Omit to leave unchanged."
         },
         "id": {
             "description": "A unique integer value identifying this dashboard.",
             "type": "number"
         },
         "layouts": {
-            "description": "New grid layout per breakpoint. Omit to leave the layout unchanged.",
+            "description": "New grid layout for the group row. Omit to keep its current layout.",
             "properties": {
                 "sm": {
                     "description": "Layout for the standard (desktop) breakpoint. The grid is 12 columns wide.",
@@ -51,11 +37,13 @@
             },
             "type": "object"
         },
-        "tile_id": {
-            "description": "ID of the dashboard tile to update. Use dashboard-get to look up tile IDs.",
-            "type": "number"
+        "name": {
+            "description": "New group name. Omit to keep the existing name.",
+            "maxLength": 400,
+            "minLength": 1,
+            "type": "string"
         }
     },
-    "required": ["id", "tile_id"],
+    "required": ["id"],
     "type": "object"
 }


### PR DESCRIPTION
## Problem

Dashboard groups must survive templates and be manageable by agents, not exist only in the dashboard UI. Refs #58307.

## Changes

| Before | After |
| --- | --- |
| Templates flatten dashboard structure | Template group keys preserve membership |
| MCP cannot manage groups | Four group tools expose create, update, move, and delete |

- Regenerates the affected MCP and template types.

## How did you test this code?

- Template membership regression test.
- MCP tool-name lint.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- MCP tool documentation is generated from the tool schemas.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex implemented this with the implementing-mcp-tools, adopting-generated-api-types, and writing-tests skills.
- This PR depends on the dashboard group model and API layer below it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*