### PR TITLE
feat(signals): debounce research so bursts of signals share one run

### DIFF
--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -55,6 +55,7 @@ from products.signals.backend.temporal.signal_queries import (
 from products.signals.backend.temporal.summary import SignalReportSummaryWorkflow
 from products.signals.backend.temporal.types import (
     RERESEARCH_MAX_SIGNALS,
+    RESEARCH_DEBOUNCE_SECONDS,
     EmitSignalInputs,
     ExistingReportMatch,
     MatchedMetadata,
@@ -678,6 +679,11 @@ class AssignAndEmitSignalOutput:
     promoted: bool
     timestamp: datetime
     run_count: int
+    # Debounce for the research run this promotion spawns, read here rather than in the workflow:
+    # reading the setting inside a workflow body would be non-deterministic on replay, and grouping
+    # workflows are long-lived, so they replay across a rollout. Defaults to 0 so histories written
+    # before this field decode to "no wait".
+    research_debounce_seconds: int = 0
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -968,6 +974,7 @@ async def assign_and_emit_signal_activity(input: AssignAndEmitSignalInput) -> As
             promoted=db_result.promoted,
             timestamp=db_result.timestamp,
             run_count=db_result.run_count,
+            research_debounce_seconds=RESEARCH_DEBOUNCE_SECONDS,
         )
     except Exception as e:
         logger.exception(
@@ -1330,7 +1337,11 @@ async def _process_signal_batch(
 
             if assign_result.promoted:
                 promoted_reports[assign_result.report_id] = (
-                    SignalReportSummaryWorkflowInputs(team_id=signal.team_id, report_id=assign_result.report_id),
+                    SignalReportSummaryWorkflowInputs(
+                        team_id=signal.team_id,
+                        report_id=assign_result.report_id,
+                        debounce_seconds=assign_result.research_debounce_seconds,
+                    ),
                     assign_result.run_count,
                 )
 
@@ -1374,11 +1385,12 @@ async def _process_signal_batch(
                 task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
                 parent_close_policy=ParentClosePolicy.ABANDON,
                 id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
-                execution_timeout=timedelta(hours=1),
+                execution_timeout=timedelta(hours=1, seconds=report_input.debounce_seconds),
             )
         except temporalio.exceptions.WorkflowAlreadyStartedError:
-            # Expected when CANDIDATE re-promotion fires against an in-flight workflow; no-op.
-            pass
+            # Expected when CANDIDATE re-promotion fires against an in-flight workflow; no-op. With
+            # the debounce on this is the common path, and the count is what the debounce saves.
+            metrics.increment_research_run_collapsed()
         except Exception:
             # Log and continue: raising here would reprocess the whole batch and double-count
             # signals. The report stays CANDIDATE and re-promotes on the next matching signal.

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -679,10 +679,6 @@ class AssignAndEmitSignalOutput:
     promoted: bool
     timestamp: datetime
     run_count: int
-    # Debounce for the research run this promotion spawns, read here rather than in the workflow:
-    # reading the setting inside a workflow body would be non-deterministic on replay, and grouping
-    # workflows are long-lived, so they replay across a rollout. Defaults to 0 so histories written
-    # before this field decode to "no wait".
     research_debounce_seconds: int = 0
 
 
@@ -1388,8 +1384,6 @@ async def _process_signal_batch(
                 execution_timeout=timedelta(hours=1, seconds=report_input.debounce_seconds),
             )
         except temporalio.exceptions.WorkflowAlreadyStartedError:
-            # Expected when CANDIDATE re-promotion fires against an in-flight workflow; no-op. With
-            # the debounce on this is the common path, and the count is what the debounce saves.
             metrics.increment_research_run_collapsed()
         except Exception:
             # Log and continue: raising here would reprocess the whole batch and double-count

--- a/products/signals/backend/temporal/metrics.py
+++ b/products/signals/backend/temporal/metrics.py
@@ -76,6 +76,20 @@ def increment_ch_wait_timeout() -> None:
     ).add(1)
 
 
+def increment_research_run_collapsed() -> None:
+    """Count a promotion that folded into an already-running research workflow instead of its own run.
+
+    This is the research-debounce savings metric: with the debounce off it counts the rare race where
+    a signal lands mid-run, and with it on it counts every signal that a waiting run absorbed.
+    """
+    if not _in_temporal_context():
+        return
+    get_metric_meter().create_counter(
+        "signals_research_runs_collapsed_total",
+        "Report promotions absorbed by an already-running research workflow",
+    ).add(1)
+
+
 def increment_scout_run(status: str) -> None:
     """Count a scout run by terminal status."""
     if not _in_temporal_context():

--- a/products/signals/backend/temporal/parallel_grouping.py
+++ b/products/signals/backend/temporal/parallel_grouping.py
@@ -391,7 +391,11 @@ async def _process_parallel_batch(
 
         if result.assign_result.promoted:
             promoted_reports[result.assign_result.report_id] = (
-                SignalReportSummaryWorkflowInputs(team_id=signal.team_id, report_id=result.assign_result.report_id),
+                SignalReportSummaryWorkflowInputs(
+                    team_id=signal.team_id,
+                    report_id=result.assign_result.report_id,
+                    debounce_seconds=result.assign_result.research_debounce_seconds,
+                ),
                 result.assign_result.run_count,
             )
 

--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -147,6 +147,13 @@ class SignalReportSummaryWorkflow:
         # Bind team_id + report_id so all logs flow to the log_entries sink (the Temporal
         # structlog renderer skips producing when team_id isn't in the event dict).
         log = logger.bind(team_id=inputs.team_id, report_id=inputs.report_id)
+        # Wait before researching so a burst of signals lands in one run. This workflow already holds
+        # the report's workflow ID, so every signal arriving while it waits is swallowed by the
+        # WorkflowAlreadyStartedError handler in grouping rather than spawning its own run, and the
+        # fetch below then picks up the whole burst. patched(): in-flight histories predate the timer.
+        if inputs.debounce_seconds and workflow.patched("signals-research-debounce"):
+            log.info("Debouncing research", debounce_seconds=inputs.debounce_seconds)
+            await workflow.sleep(timedelta(seconds=inputs.debounce_seconds))
         # If new signals arrived after the report was generated - loop back to process them also
         max_iterations = 10  # Basic safety guard
         for _ in range(max_iterations):

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -7,6 +7,15 @@ from typing import Any, Optional
 # re-researching on new signals; signals are still assigned. See assign_and_emit_signal_activity.
 RERESEARCH_MAX_SIGNALS = int(os.getenv("SIGNAL_RERESEARCH_MAX_SIGNALS", "10"))
 
+# How long a research run waits before starting, so signals arriving in a burst are researched
+# together instead of once each. A report re-promotes on *every* new signal, and ~46% of signals join
+# a report within 5 minutes of the previous one, so most research today re-reads the same report for
+# one extra signal. The waiting workflow already owns the report's workflow ID, so signals landing
+# during the wait collapse into it (see the WorkflowAlreadyStartedError handler in grouping) and the
+# run then covers the whole burst. Applies to a report's first research too, so sibling signals join
+# that run rather than forcing an immediate re-research. 0 disables the wait.
+RESEARCH_DEBOUNCE_SECONDS = int(os.getenv("SIGNAL_RESEARCH_DEBOUNCE_SECONDS", "0"))
+
 
 @dataclass
 class EmitSignalInputs:
@@ -138,6 +147,9 @@ class SignalReportSummaryWorkflowInputs:
 
     team_id: int
     report_id: str
+    # Seconds to wait before the first cycle, so a burst of signals is researched in one run rather
+    # than one run each. Defaults to 0 so histories written before this field replay unchanged.
+    debounce_seconds: int = 0
 
 
 @dataclass


### PR DESCRIPTION
A report promotes on every new signal, so each signal spawns its own research run. In production ~46% of signals join a report within 5 minutes of the previous one, and re-research is ~40% of research spend, most of it re-reading a report for one extra signal.

This has some undesired affects:
- The auto-start task is kicked off based on the first signal, when often more come in immediately after the first, which makes the PR worse quality
- We spend $ researching the report, then immediately after research it again

This debounces research and waits for up to 5 minutes for signals to collect on a report before kicking off research. It should reduce research costs by around ~15-20% in total.