### PR TITLE
chore(aio): let creating-online-evaluations propose multiple evals

### DIFF
--- a/products/ai_observability/skills/creating-online-evaluations/SKILL.md
+++ b/products/ai_observability/skills/creating-online-evaluations/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: creating-online-evaluations
 description: >
-  Author continuously-running online evaluations in PostHog AI observability, grounded in a real failure
-  mode you've identified. Use when the user wants an evaluation that automatically scores new generations
+  Author continuously-running online evaluations in PostHog AI observability, grounded in real failure
+  modes you've identified. Use when the user wants evaluations that automatically score new generations
   or whole traces going forward — "create an eval to catch X", "continuously check that responses do Y",
-  "turn this failure into an eval". Covers choosing the target and eval type (hog / llm_judge / sentiment),
-  configuring a provider, model, and usable provider key for an llm_judge eval, scoping which generations
-  trigger it via conditions (property filters + rollout sampling), creating it disabled, verifying scope,
-  and enabling.
+  "turn these failures into evals". Covers letting the explored data decide how many evals to create,
+  proposing that set in plain language and asking the user which ones they want, choosing the target and
+  eval type (hog / llm_judge / sentiment), configuring a provider, model, and usable provider key for an
+  llm_judge eval, scoping which generations trigger it via conditions, creating disabled, verifying scope,
+  and enabling. Falls back to proposing a sentiment eval when there is no AI data or no failure mode found.
   Finding and ranking the failure modes worth evaluating is its own job — use exploring-ai-failures first.
   To debug or manage evaluations that already exist, use exploring-llm-evaluations.
 ---
@@ -16,8 +17,15 @@ description: >
 
 An **online evaluation** automatically scores either each matching `$ai_generation` or the whole trace
 containing it, until disabled. A good eval comes from a real failure mode you've found in production traffic,
-not from a guess or a generic metric like "hallucination" or "helpfulness". This skill starts once that
-failure mode is identified and turns it into a scoped, continuously-running eval.
+not from a guess or a generic metric like "hallucination" or "helpfulness". This skill starts once those
+failure modes are identified and turns them into scoped, continuously-running evals.
+
+**One eval per failure mode, and as many evals as the data justifies.** How many to create is a judgment
+call you make from what the traces actually showed — sometimes one, often three or four. Never assume the
+answer is one, and never bundle several modes into one evaluator.
+
+**Propose before you create.** Bring the user a short list of candidate evals and let them pick which ones
+they want (Phase 1.1). Creating evals they didn't ask for costs them money and noise.
 
 **First, know what you're evaluating.** Finding and ranking the failure modes worth catching is a
 separate job. If the user doesn't specify what they want to evaluate, ask them. If they are still vague
@@ -44,21 +52,73 @@ debugging a live eval), defer to `exploring-llm-evaluations`.
 The full create payload (every field, the config schemas, the exact `conditions` shape) is in
 [references/evaluation-payload.md](references/evaluation-payload.md).
 
-## Phase 1 — Pick the failure mode to evaluate
+## Phase 1 — Decide what to propose, then let the user choose
 
-Start from a real, observed failure, not a metric you picked in advance. If you don't already have one,
+Start from real, observed failures, not metrics you picked in advance. If you don't already have them,
 run `exploring-ai-failures` to scope a use case, find failing traces, and produce a ranked list of failure
-modes — then come back. With that list in hand, talk with the user to choose what to turn into an eval:
+modes — then come back.
 
-- **Most frequent, most painful first.** A handful of modes usually cover the majority of failures.
-- **Pair obvious fixes with the eval, don't skip it.** If a prompt tweak would likely fix the failure, set
-  up the eval anyway and suggest the fix alongside it — a rising pass rate is how you confirm the fix landed.
-- **One mode per eval.** Three failure modes is three evals, not one prompt trying to catch everything.
+### 1.1 — Turn the failure modes into a candidate set
 
-You should end with a single, crisp, checkable criterion — "the reply must stay on the user's topic", "the
-tool call must include an `order_id`". Then move to Phase 2.
+**Let the data decide how many.** One failure mode is one eval, so a ranked list of four distinct modes is
+a candidate set of four evals. Don't collapse them into one evaluator that tries to catch everything, and
+don't stop at the top mode when the traces clearly showed more worth watching. Keep a candidate when:
 
-## Phase 2 — Build the online eval
+- **It hurts.** Frequent or painful. A handful of modes usually covers the majority of failures.
+- **It's checkable.** It reduces to one crisp criterion — "the reply must stay on the user's topic", "the
+  tool call must include an `order_id`". If you can't state it in a line, it isn't ready to propose.
+- **It's distinct.** Two candidates that would fail on the same generations are one eval.
+
+Rank by how much they hurt and propose roughly the top five; mention in a line that you set weaker ones
+aside rather than silently dropping them.
+
+### 1.2 — Propose the set in plain language
+
+**Never create evals the user hasn't picked.** Lay out the candidates and ask which ones they want.
+
+Assume they haven't read the traces with you and don't know the eval vocabulary. Keep each one to a line or
+two — a wall of text per eval means they can't compare them — but make it obvious what it watches and what
+they'll see when it fails. No Hog snippets, property filters, or `hog`/`llm_judge` internals here. Number
+them so they can reply "1 and 3":
+
+> Found 3 failure patterns worth watching. Which should I set up?
+>
+> **1. Replies drift off topic** — checks the answer addresses what the user actually asked.
+> Catches support replies that confidently answer a different question. Seen ~40×/day.
+>
+> **2. Order lookups missing an order ID** — checks every `lookup_order` call includes an `order_id`.
+> Catches the silent tool failures that make the agent invent an order status. Seen ~15×/day.
+>
+> **3. Refuses questions it can answer** — checks the reply isn't a needless "I can't help with that".
+> Catches users being turned away from things the docs cover. Costs an LLM call per check.
+
+Per eval: what it checks, what bad thing it surfaces, and rough volume when you know it (Phase 2.5 verifies
+it properly). Flag the ones needing an LLM judge, since those cost per run — that's the only mechanic worth
+exposing up front. Keep the ranking implicit in the order; skip scoring tables.
+
+Recommend a starting point if they seem unsure (usually the top one or two), and treat "all of them" or "go
+ahead" as accepting the whole set. If a prompt tweak would likely fix a mode, suggest the fix alongside the
+eval rather than in place of it — a rising pass rate is how they confirm the fix landed.
+
+### 1.3 — When nothing surfaced, propose sentiment
+
+If the project has no `$ai_generation` events, or the traces were read and no failure mode is worth an eval,
+don't invent a failure and don't come back empty-handed. Say what you looked at, then propose a `sentiment`
+eval as the floor:
+
+> No clear failure pattern in the last 7 days. Worth starting with:
+>
+> **1. User frustration** — labels each user message positive, neutral, or negative.
+> Shows which conversations are going badly, which is usually where the real failures hide. No judge cost.
+
+It needs no provider key, it's cheap, and it gives them a signal to come back to once there's enough traffic
+to spot patterns. If AI observability has no events at all, sentiment has nothing to score — point them at
+`instrument-llm-analytics` first.
+
+## Phase 2 — Build each accepted eval
+
+Run this phase once per eval the user picked. Create them all disabled first, verify each one's scope, then
+enable — never enable one before the rest are checked.
 
 ### 2.1 — Choose the eval type
 
@@ -193,6 +253,10 @@ It now runs on every new matching generation, or once per matching trace for a t
 one-and-done: the user should be aware that they need to keep an eye on results and iterate if the outcome
 is not the expected one. To wire results into a Slack feed, see `feature-usage-feed`.
 
+When several evals were accepted, close the loop across the whole set at once — one short list of what's now
+live with a link each, not a play-by-play per eval. Mention any candidate you couldn't build (no usable
+provider key, volume too high to enable yet) and what would unblock it.
+
 ## Scoping with conditions
 
 `conditions` is a **list** of condition sets — **OR between sets, AND within a set's `properties`**. Each
@@ -225,8 +289,13 @@ creating so the user can review and toggle it in the UI.
 - **Evals come from real failures, not generic metrics.** Start from a failure found in this product's
   traffic (via `exploring-ai-failures`), not from "let's measure hallucination". A metric nobody traced
   back to a real bad output is noise.
-- **One eval, one failure mode.** Different failure modes need different evals; don't make one eval try to
-  catch everything.
+- **One eval, one failure mode — and as many evals as the data justifies.** Different failure modes need
+  different evals; don't make one eval try to catch everything, and don't default to creating exactly one
+  when the traces showed several modes worth watching.
+- **Propose, then create what they picked.** Show the candidate set in plain language, a line or two each,
+  and wait for the user to choose. Long per-eval write-ups get skimmed, not read.
+- **Nothing found still has an answer.** Empty AI data or no failure mode worth an eval means proposing a
+  `sentiment` eval, not returning empty-handed.
 - **Suggest changes along with the eval if possible.** If it's clear a prompt change would fix the issue, for
   instance, set up the eval but also suggest to the user they change the prompt: they should soon see the eval
   go from low pass rate to a higher pass rate.

--- a/products/ai_observability/skills/creating-online-evaluations/SKILL.md
+++ b/products/ai_observability/skills/creating-online-evaluations/SKILL.md
@@ -8,7 +8,7 @@ description: >
   proposing that set in plain language and asking the user which ones they want, choosing the target and
   eval type (hog / llm_judge / sentiment), configuring a provider, model, and usable provider key for an
   llm_judge eval, scoping which generations trigger it via conditions, creating disabled, verifying scope,
-  and enabling. Falls back to proposing a sentiment eval when there is no AI data or no failure mode found.
+  and enabling. Falls back to proposing a sentiment eval when no failure mode is worth catching.
   Finding and ranking the failure modes worth evaluating is its own job — use exploring-ai-failures first.
   To debug or manage evaluations that already exist, use exploring-llm-evaluations.
 ---
@@ -102,9 +102,8 @@ eval rather than in place of it — a rising pass rate is how they confirm the f
 
 ### 1.3 — When nothing surfaced, propose sentiment
 
-If the project has no `$ai_generation` events, or the traces were read and no failure mode is worth an eval,
-don't invent a failure and don't come back empty-handed. Say what you looked at, then propose a `sentiment`
-eval as the floor:
+If the traces were read and no failure mode is worth an eval, don't invent a failure and don't come back
+empty-handed. Say what you looked at, then propose a `sentiment` eval as the floor:
 
 > No clear failure pattern in the last 7 days. Worth starting with:
 >
@@ -112,13 +111,19 @@ eval as the floor:
 > Shows which conversations are going badly, which is usually where the real failures hide. No judge cost.
 
 It needs no provider key, it's cheap, and it gives them a signal to come back to once there's enough traffic
-to spot patterns. If AI observability has no events at all, sentiment has nothing to score — point them at
-`instrument-llm-analytics` first.
+to spot patterns.
+
+**No generations means no eval of any kind.** Sentiment only scores matching `$ai_generation` events, so if
+the project has none, every eval you could create — sentiment included — would sit there never firing. Don't
+propose one. Point them at `instrument-llm-analytics` to get AI observability capturing generations first,
+and come back to this skill once there's traffic to read.
 
 ## Phase 2 — Build each accepted eval
 
-Run this phase once per eval the user picked. Create them all disabled first, verify each one's scope, then
-enable — never enable one before the rest are checked.
+Run 2.1 through 2.5 once per eval the user picked, so each one lands as a verified draft. **Leave every one
+of them disabled until the whole set is verified** — 2.6 is a single pass over the finished set at the end,
+not the last step of each loop. Enabling eval 1 while eval 3 is still being written puts a partially live
+set into production, which is noise and (for a judge) cost the user didn't agree to yet.
 
 ### 2.1 — Choose the eval type
 
@@ -242,20 +247,22 @@ but they do not reproduce the complete settled trace. Review the first live trac
 > **Watch out:** some orgs reuse a single `$ai_trace_id` across 100k+ events. Scoping by trace-ID prefix
 > can match far more than expected — verify volume with the SQL above before enabling.
 
-### 2.6 — Enable, then close the loop
+### 2.6 — Enable the verified set, then close the loop
+
+Only once every accepted eval is a scope-verified draft, enable them — one call each:
 
 ```json
 posthog:llma-evaluation-update
 { "evaluationId": "<uuid>", "enabled": true }
 ```
 
-It now runs on every new matching generation, or once per matching trace for a trace target. This isn't
+Each now runs on every new matching generation, or once per matching trace for a trace target. This isn't
 one-and-done: the user should be aware that they need to keep an eye on results and iterate if the outcome
 is not the expected one. To wire results into a Slack feed, see `feature-usage-feed`.
 
-When several evals were accepted, close the loop across the whole set at once — one short list of what's now
-live with a link each, not a play-by-play per eval. Mention any candidate you couldn't build (no usable
-provider key, volume too high to enable yet) and what would unblock it.
+Close the loop across the whole set at once — one short list of what's now live with a link each, not a
+play-by-play per eval. Mention any candidate you left disabled (no usable provider key, volume too high to
+enable yet) and what would unblock it.
 
 ## Scoping with conditions
 
@@ -294,8 +301,9 @@ creating so the user can review and toggle it in the UI.
   when the traces showed several modes worth watching.
 - **Propose, then create what they picked.** Show the candidate set in plain language, a line or two each,
   and wait for the user to choose. Long per-eval write-ups get skimmed, not read.
-- **Nothing found still has an answer.** Empty AI data or no failure mode worth an eval means proposing a
-  `sentiment` eval, not returning empty-handed.
+- **Nothing found still has an answer.** Traces read but no failure mode worth an eval means proposing a
+  `sentiment` eval, not returning empty-handed. No `$ai_generation` events at all is the exception — no eval
+  can fire, so send them to `instrument-llm-analytics` instead.
 - **Suggest changes along with the eval if possible.** If it's clear a prompt change would fix the issue, for
   instance, set up the eval but also suggest to the user they change the prompt: they should soon see the eval
   go from low pass rate to a higher pass rate.


### PR DESCRIPTION
## Problem

The `creating-online-evaluations` skill only ever creates one eval, and that is prompted, not accidental. Phase 1 says to pick a failure mode and end with "a single, crisp, checkable criterion", then Phase 2 runs a single create → verify → enable pass with no loop. So even when the trace reading surfaces four distinct failure modes, an agent following the skill faithfully ships one eval and stops.

It also created evals without proposing them first, and had no answer for a project where the AI observability data is empty or surfaces nothing worth evaluating.

## Changes

Phase 1 is now "decide what to propose, then let the user choose":

- The number of evals comes from the data. One failure mode is still one eval, but a ranked list of four modes is a candidate set of four, and the skill now says explicitly not to default to one.
- New proposal step. Candidates go to the user as a numbered list, one or two lines each: what it checks, what bad thing it surfaces, rough volume, and a flag when it needs an LLM judge. No Hog snippets or property filters at that stage, since the reader has not been reading traces alongside the agent. Short on purpose, so a set of five stays comparable.
- Sentiment fallback. No `$ai_generation` events, or no failure mode worth an eval, now means proposing a sentiment eval on user messages rather than inventing a failure or coming back empty-handed. If there are no AI events at all, it points at `instrument-llm-analytics` instead.
- Phase 2 is scoped per accepted eval, all created disabled before any get enabled, and the close-out is one list for the whole set.

Only prose changed, no new tool calls or payload fields.

## How did you test this code?

No automated tests here, this is a prose-only skill change. I could not run `hogli lint:skills` or `hogli build:skills` in this environment (no hogli, no repo setup), so I checked the lint-relevant constraints by hand instead: frontmatter still has `name` and `description`, the description is 1009 chars (under the 1024 limit), `SKILL.md` is 310 lines (under 500), and the reference link and `references/evaluation-payload.md.j2` template are untouched. Worth a `hogli lint:skills` run before this goes ready.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app (Claude Opus) from a Slack thread. The question that started it was whether the single-eval behavior was prompted in the skill or emergent, and it turned out to be prompted in about four separate places, which is why the fix is a Phase 1 rewrite rather than a line tweak.

Two decisions worth flagging. First, I kept "one eval per failure mode" and added "as many evals as the data justifies" next to it rather than replacing it, because the original line was guarding against a real failure (one evaluator prompt trying to catch three things) and only read as "create one eval" in context. Second, I put the proposal format inline as a worked example rather than in `references/`, since an agent needs it at the moment it drafts the message and the example is short enough to carry in `SKILL.md`. I did not invoke `/writing-skills`, but I read `.agents/skills/writing-skills/SKILL.md` and the ai_observability skills README for the conventions.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1785868940985269)*
