### PR TITLE
chore(signals): print match quality in the grouping eval summary

### DIFF
--- a/products/signals/eval/AGENTS.md
+++ b/products/signals/eval/AGENTS.md
@@ -68,7 +68,28 @@ Two tqdm progress bars:
 - **Matching** — per-signal progress with `processing` (in-flight) and `dropped` (filtered/failed) counters
 - **Judging** — per-report progress
 
-Followed by an aggregate results summary table.
+Followed by an aggregate results summary:
+
+```text
+Results (48 groups → 43 reports):
+  Signals placed   87/111
+  ARI              0.79
+  Homogeneity      0.97
+  Completeness     0.94
+  Mean purity      0.97
+  Mean recall      0.77
+  Correct match    71/87 (81.6%), overgrouped 5, undergrouped 11
+  Pre-gate match   68/87 (78.2%), overgrouped 14, undergrouped 5
+  Malicious leaked 0/24
+```
+
+Everything needed to compare two runs is here, so no PostHog query is required for that.
+Two lines are easy to misread:
+
+- **Signals placed** is how many signals reached grouping. The rest were dropped by the actionability or safety filters.
+  Only compare runs that placed the same number, since a run that drops more is scored on a smaller set and the clustering metrics won't show it.
+- **Pre-gate match** is the matcher's decision before `verify_match_specificity` runs, and **Correct match** is the decision after.
+  The difference between the two is what the specificity gate contributed, in both directions.
 
 ### Eval metrics captured to PostHog
 

--- a/products/signals/eval/eval_grouping_e2e.py
+++ b/products/signals/eval/eval_grouping_e2e.py
@@ -90,6 +90,7 @@ class EvalGroupingPipeline:
         self.no_capture = no_capture
         self.online = online
         self._match_lock = asyncio.Lock()
+        self.match_outcomes: list[tuple[MatchFailureMode, MatchFailureMode]] = []
         self.start_time = time()
 
         # Suppress structlog noise from downstream modules during the eval
@@ -374,6 +375,7 @@ class EvalGroupingPipeline:
         specificity_failure_mode = evaluate_match_failure(specificity_match_result)
         correct = specificity_failure_mode == MatchFailureMode.NONE
         pre_specificity_correct = match_failure_mode == MatchFailureMode.NONE
+        self.match_outcomes.append((match_failure_mode, specificity_failure_mode))
 
         specificity_reasoning = (
             specificity_match_result.match_metadata.reason
@@ -573,13 +575,31 @@ class EvalGroupingPipeline:
 
         unsafe_leaked_rate = unsafe_leaked / total_unsafe if total_unsafe > 0 else 0.0
 
+        # Comparing two runs is only valid when they placed the same signals, and a run that drops
+        # more of them scores on an easier subset without any of the other metrics moving.
+        n_placed = len(true_labels)
+
+        def summarize_match(modes: list[MatchFailureMode]) -> str:
+            if not modes:
+                return "no signals placed"
+            correct = sum(1 for mode in modes if mode is MatchFailureMode.NONE)
+            over = sum(1 for mode in modes if mode is MatchFailureMode.OVERGROUP)
+            under = sum(1 for mode in modes if mode is MatchFailureMode.UNDERGROUP)
+            return f"{correct}/{len(modes)} ({correct / len(modes):.1%}), overgrouped {over}, undergrouped {under}"
+
+        post_specificity = summarize_match([post for _, post in self.match_outcomes])
+        pre_specificity = summarize_match([pre for pre, _ in self.match_outcomes])
+
         tqdm.write(
             f"\nResults ({n_groups_expected} groups → {n_reports_actual} reports):\n"
+            f"  Signals placed   {n_placed}/{len(stream)}\n"
             f"  ARI              {ari:.2f}\n"
             f"  Homogeneity      {homogeneity:.2f}\n"
             f"  Completeness     {completeness:.2f}\n"
             f"  Mean purity      {mean_purity:.2f}\n"
             f"  Mean recall      {mean_group_recall:.2f}\n"
+            f"  Correct match    {post_specificity}\n"
+            f"  Pre-gate match   {pre_specificity}\n"
             f"  Malicious leaked {unsafe_leaked}/{total_unsafe}",
             file=sys.stderr,
         )


### PR DESCRIPTION
## Problem

The grouping eval already measures the thing you care about when you change a grouping prompt: whether errors are over-grouping or under-grouping. It just doesn't show it to you.

The terminal summary prints ARI, homogeneity, completeness, purity, recall and the malicious leak count. To see `correct_match` and the over/under split you had to let the run capture `$ai_evaluation` events to PostHog and then run a HogQL query from `AGENTS.md`. That's a lot of friction for the single most decision-relevant number, and it doesn't work at all with `--no-capture`.

It also hid a trap. Signals dropped by the actionability or safety filters never reach the clustering metrics, so a run that drops more is scored on a smaller, easier set and none of the other numbers move to tell you. Comparing two runs with different placement counts quietly compares different datasets.

## Changes

Three more lines in the summary:

```text
Results (48 groups → 43 reports):
  Signals placed   87/111
  ARI              0.79
  Homogeneity      0.97
  Completeness     0.94
  Mean purity      0.97
  Mean recall      0.77
  Correct match    71/87 (81.6%), overgrouped 5, undergrouped 11
  Pre-gate match   68/87 (78.2%), overgrouped 14, undergrouped 5
  Malicious leaked 0/24
```

`Pre-gate match` is the matcher's decision before `verify_match_specificity`, and `Correct match` is after, so the gap between them is what the specificity gate contributed and in which direction. Both numbers already existed as the `correct_match` and `correct_match_pre_specificity` metrics; this only surfaces them.

No metric definitions change and nothing new is captured to PostHog. `AGENTS.md` gains the sample output and a note on how to read the two lines that are easy to misinterpret.

## How did you test this code?

Ran the eval twice against the real pipeline, `--limit 8 --no-capture --reuse-db`, and confirmed the summary renders with the alignment above and that the run still passes. The one error in the output is the pre-existing teardown flush failure (`cannot truncate a table referenced in a foreign key constraint`) that every run of this eval produces.

Separately checked the arithmetic by replaying a full 111-signal run's per-signal failure modes through the new `summarize_match` helper offline: it reproduces 71/87 (81.6%), matching the `correct_match_rate` that run computed independently.

`ruff check` and `ruff format --check` are clean. No automated test was added, since the change is a print statement in an eval that is itself the measurement surface, and a test asserting on its stderr format would only pin the string.

Note for reviewers: the run above used a local patch pointing the LLM calls at Anthropic directly, because `LLM_GATEWAY_URL` and `LLM_GATEWAY_PERSONAL_API_KEY` are documented as required in `AGENTS.md` but ship in neither `.env.example` nor a default dev `.env`, and `get_async_anthropic_gateway_client` raises without them. That patch is not in this PR. It's a real gap in the eval's reproducibility and worth fixing separately.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`AGENTS.md` (and `CLAUDE.md`, which symlinks to it) updated in this PR with the new sample output.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Came out of a review of how much the grouping eval can actually prove, prompted by a reviewer's concern that prompt changes could quietly reintroduce over-grouping. Two findings drove this change.

First, over-grouping is measurable here but invisible by default. Simulating regressions on a real run by wrongly merging report pairs moves ARI by about −0.02 per merged pair, while two runs of identical code differed by 0.035. So a single run resolves roughly three or more bad merges and is blind below that, and the explicit over/under counts are a much more direct read on the failure mode than a third-decimal ARI shift. Second, the placement count was a silent confound in any A/B.

Only the printing changed. The deeper improvements the review surfaced are deliberately not here: fixing the gateway env gap, stamping runs with a commit SHA and arm label so history is comparable, repeated trials for a variance estimate, and some ground-truth corrections in the fixture.

Skills invoked: `/writing-user-facing-copy`, which scopes itself out of log lines, so its rules were applied only as a plain-language sanity check on the new strings.
