### PR TITLE
fix(warehouse_sources): recognize blank-reason-phrase 400s from Zoho's OAuth endpoint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/source.py
@@ -54,6 +54,10 @@ class ZohoCRMSource(ResumableSource[ZohoCRMSourceConfig, ZohoCRMResumeConfig]):
         return {
             "Zoho CRM token refresh failed": REFRESH_TOKEN_REJECTED_MESSAGE,
             "400 Client Error: Bad Request for url: https://accounts.zoho": "Zoho CRM rejected your OAuth credentials. Check that the client ID, client secret, and refresh token all belong to the same self client.",
+            # Some responses carry no reason phrase (e.g. over HTTP/2, which has none), so
+            # `requests.raise_for_status()` renders it blank instead of "Bad Request" — match that
+            # variant too, or the same credential rejection retries the whole activity budget.
+            "400 Client Error:  for url: https://accounts.zoho": "Zoho CRM rejected your OAuth credentials. Check that the client ID, client secret, and refresh token all belong to the same self client.",
             "401 Client Error: Unauthorized for url": "Your Zoho CRM access token is invalid or expired. Reconnect the source to issue a new one.",
             "403 Client Error: Forbidden for url": "Your Zoho CRM token is missing a scope for this module. Re-authorize with the ZohoCRM.modules.ALL and ZohoCRM.settings.fields.READ scopes.",
         }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm_source.py
@@ -95,6 +95,8 @@ class TestZohoCRMSource:
         [
             "Zoho CRM token refresh failed: invalid_client",
             "400 Client Error: Bad Request for url: https://accounts.zoho.eu/oauth/v2/token",
+            # Blank reason phrase variant (e.g. an HTTP/2 response, which has none).
+            "400 Client Error:  for url: https://accounts.zoho.eu/oauth/v2/token",
             "401 Client Error: Unauthorized for url: https://www.zohoapis.com/crm/v8/Leads",
             "403 Client Error: Forbidden for url: https://www.zohoapis.com/crm/v8/Deals",
         ],


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` from `zoho_crm.py`'s `mint_access_token`: `400 Client Error:  for url: https://accounts.zoho.eu/oauth/v2/token` (note the double space).

Zoho's OAuth token endpoint rejects bad credentials (client ID/secret/refresh token mismatch) with an HTTP 400. The source already has a `get_non_retryable_errors` entry for this ("400 Client Error: Bad Request for url: https://accounts.zoho"), but it depends on the response carrying the standard "Bad Request" reason phrase. Some responses to this endpoint carry no reason phrase at all (e.g. HTTP/2, which has no reason-phrase concept), so `requests.raise_for_status()` renders it blank instead. The existing pattern doesn't match that variant, so this credential rejection was retrying through the whole activity budget instead of stopping immediately with the actionable message already written for it.

## Changes

Added the blank-reason-phrase variant of the same pattern to `ZohoCRMSource.get_non_retryable_errors()`, mapped to the same friendly message as the existing "Bad Request" variant.

## How did you test this code?

Added a case to the existing parameterized `test_auth_failures_are_non_retryable` in `test_zoho_crm_source.py` asserting the blank-reason-phrase message is recognized as non-retryable — this is the exact message observed in production and the previous entry didn't catch it.

Ran the full `zoho_crm` test suite (45 passed), `ruff check`/`ruff format --check`, and repo-wide `mypy` (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog's error-tracking MCP tools: pulled the issue's compact details and stack trace, confirmed the failure originates in `mint_access_token` in this source's own code, and confirmed 122 occurrences all carrying the identical blank-reason-phrase message.
- Traced `requests`' `raise_for_status()` formatting (`f"{status} Client Error: {reason} for url: {url}"`) to confirm a blank `reason` reliably produces the double-space message observed in production, and that this only fires for genuine 4xx responses to the accounts host (never for the source's own bugs against the API host).
- Checked for overlapping work: found open PR #75937 (Zoho CRM credential-check scope fix), but it only touches `validate_credentials`'s probe endpoint, not this `mint_access_token`/`get_non_retryable_errors` matching path — no overlap.
- No skills were needed beyond `/writing-tests` (consulted before extending the parameterized test).