### PR TITLE
fix(data-warehouse): recognize Neon's pooler rejection of libpq options

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -134,7 +134,10 @@ class PgCDCStreamReader:
                 # sits idle between yields as the caller flushes to S3 and advances the slot —
                 # statement_timeout doesn't apply there because no statement is running. Both are
                 # dropped if the source sits behind a pooler that rejects the libpq `options`
-                # parameter (CDC sources never do).
+                # parameter — CDC sources do sit behind one (a Neon pooled endpoint serves the peek
+                # functions fine), and without the fallback the connection can never be opened at
+                # all. The activity's start-to-close and heartbeat timeouts still bound a stalled
+                # peek when the server-side ceiling is gone.
                 options="-c statement_timeout=1800000 -c idle_in_transaction_session_timeout=0",
             ),
             logger,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -664,12 +664,15 @@ def _get_sslmode(require_ssl: bool) -> str:
 # Transaction-mode connection poolers reject the libpq `options` startup parameter outright:
 # Supabase's Supavisor (port 6543) and PgBouncer in transaction mode report "unsupported startup
 # parameter: options", and AWS RDS Proxy reports "RDS Proxy currently doesn't support command-line
-# options". We only send `options` to pin client_encoding=UTF8 for Redshift's legacy UNICODE alias
-# (see FORCE_UTF8_CLIENT_ENCODING), and Redshift never sits behind these poolers — so when a server
-# rejects `options`, dropping it and retrying is safe (UTF8 is the default client encoding for real
-# Postgres). The RDS Proxy text uses a typographic apostrophe, so match the apostrophe-free tail.
+# options". Neon's pooler names the offending setting instead — "unsupported startup parameter in
+# options: statement_timeout" — so match on the prefix rather than any one parameter name.
+# Beyond client_encoding=UTF8 for Redshift's legacy UNICODE alias (see FORCE_UTF8_CLIENT_ENCODING),
+# `options` only ever carries server-side timeouts that the caller's own deadlines already bound —
+# so when a server rejects it, dropping it and retrying is safe. The RDS Proxy text uses a
+# typographic apostrophe, so match the apostrophe-free tail.
 _OPTIONS_STARTUP_PARAM_UNSUPPORTED_SUBSTRINGS = (
     "unsupported startup parameter: options",
+    "unsupported startup parameter in options",
     "support command-line options",
 )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -2068,9 +2068,10 @@ class TestConnectToPostgresMultiAddressFailover:
         assert connect_mock.call_args.kwargs["hostaddr"] == "203.0.113.5"
 
 
-# Transaction-mode poolers (Supabase Supavisor on :6543, PgBouncer transaction mode, AWS RDS Proxy)
-# reject the libpq `options` startup parameter we send to pin client_encoding=UTF8. When they do, we
-# drop `options` and retry rather than failing the connection.
+# Transaction-mode poolers (Supabase Supavisor on :6543, PgBouncer transaction mode, AWS RDS Proxy,
+# Neon's pooled endpoint) reject the libpq `options` startup parameter we send to pin
+# client_encoding=UTF8 and, on the CDC path, server-side timeouts. When they do, we drop `options`
+# and retry rather than failing the connection.
 class TestConnectOptionsStartupParamFallback:
     @pytest.mark.parametrize(
         "message,expected",
@@ -2082,6 +2083,19 @@ class TestConnectOptionsStartupParamFallback:
             (
                 "connection failed: FATAL:  Feature not supported: RDS Proxy currently "
                 "doesn’t support command-line options.",
+                True,
+            ),
+            # Neon names the rejected setting after the colon, so a match on the exact
+            # "parameter: options" wording above misses it and the connection never opens.
+            (
+                'connection to server at "1.2.3.4", port 5432 failed: ERROR:  unsupported startup '
+                "parameter in options: statement_timeout. Please use unpooled connection or remove "
+                "this parameter from the startup package.",
+                True,
+            ),
+            (
+                'connection to server at "1.2.3.4", port 5432 failed: ERROR:  unsupported startup '
+                "parameter in options: idle_in_transaction_session_timeout.",
                 True,
             ),
             ("password authentication failed for user", False),


### PR DESCRIPTION
## Problem

Transaction-mode connection poolers reject the libpq `options` startup parameter, so `_connect_with_options_fallback` drops `options` and reconnects. The match is on the exact wording those poolers use:

```
FATAL:  unsupported startup parameter: options
```

Neon's pooled endpoint names the offending setting instead of the parameter:

```
ERROR:  unsupported startup parameter in options: statement_timeout.
Please use unpooled connection or remove this parameter from the startup package.
```

`"unsupported startup parameter: options"` is not a substring of that, so the fallback never fires and the connect just fails.

On the CDC path that connect is the first thing `cdc_extract_activity` does, and the stream reader always sends `options` (`statement_timeout=1800000 -c idle_in_transaction_session_timeout=0`). So every extraction run against a Neon pooled endpoint fails at `stream_reader.connect()`, forever. It classifies as a generic retryable `connection_failed`, so the user sees "Could not connect to the source database. PostHog will keep retrying — if this persists, check that the database is reachable and accepting connections" for a database that is reachable and perfectly healthy. There is nothing they can do to make that message go away, because it isn't describing their problem.

One source has been in this state since the day it was created. It never had a single successful extraction run.

## Changes

Match on the prefix `unsupported startup parameter in options` so any setting Neon names is covered, alongside the existing exact-wording and RDS Proxy matches.

The stale comment on the CDC stream reader claimed CDC sources never sit behind a pooler that rejects `options`. They do. Neon's pooler serves the `pg_logical_slot_peek_binary_changes` calls the reader uses just fine, so dropping the two server-side timeouts is the difference between working change capture and none at all. Updated it to say so, and to note that the activity's start-to-close and heartbeat timeouts still bound a stalled peek once the server-side ceiling is gone.

> [!NOTE]
> Nothing about retry or classification behavior changes here. This makes the connection succeed where it currently cannot be opened at all.

## How did you test this code?

Added two cases to the existing `test_detects_options_unsupported_message` parameterization, one per Neon-named setting (`statement_timeout`, `idle_in_transaction_session_timeout`). That class had cases for Supavisor/PgBouncer and RDS Proxy but nothing that would catch a pooler phrasing the rejection differently, which is exactly the gap that shipped. Confirmed the new strings do not match the pre-change substring tuple and do match the new one.

Ran locally (Claude, worktree venv on Python 3.13):

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py .../postgres/cdc/tests/` — 755 passed
- `ruff check` / `ruff format` — clean

I could not test against a real Neon pooled endpoint. The error string is taken verbatim from a production log line for the affected source.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #77884, which stopped an unreachable CDC source from writing thousands of identical failed job rows. That PR treated the symptom. I asked Claude (Opus 5, Claude Code) whether the error should have been non-retryable instead, which sent it to the raw exception in the worker logs rather than the friendly copy stored on the job row. The friendly copy said "could not connect"; the actual exception was this pooler rejection, which is deterministic and self-inflicted.

Worth considering separately, not included here: `connection_failed` is the catch-all bucket for any `psycopg.OperationalError` that isn't SSL or host-unreachable, and it is retryable-forever by design. A deterministic connect rejection that lands in it loops indefinitely behind a message that tells the user to check something that isn't wrong. Tightening that bucket, or validating a pooled endpoint at CDC setup time, would both be reasonable next steps.

Skills invoked: `/writing-tests`.
