### PR TITLE
perf(propdefs): skip lowercasing already-lowercase property keys

### DIFF
--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -1,4 +1,4 @@
-use std::{fmt, hash::Hash, str::FromStr, sync::LazyLock};
+use std::{borrow::Cow, fmt, hash::Hash, str::FromStr, sync::LazyLock};
 
 use chrono::{DateTime, Duration, DurationRound, RoundingError, Utc};
 use regex::Regex;
@@ -392,7 +392,20 @@ impl Event {
 }
 
 pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueType> {
-    let key = key.to_lowercase();
+    // This runs for every property of every event, so the allocation matters. Borrow when the key
+    // is already lowercase ASCII, which is effectively all real traffic. The ASCII gate is what
+    // makes the borrow equivalent to an unconditional `to_lowercase()`: over ASCII with no
+    // uppercase bytes, Unicode lowercasing is the identity, so no case analysis of the patterns
+    // below is needed to see that the result is unchanged. Gating on `char::is_uppercase` instead
+    // would reach the same answers, but only because every pattern below is an ASCII literal;
+    // that argument has to be redone whenever a pattern changes, and it costs a char decode plus
+    // a Unicode property lookup per character rather than a byte scan.
+    let lowered: Cow<str> = if key.is_ascii() && !key.bytes().any(|b| b.is_ascii_uppercase()) {
+        Cow::Borrowed(key)
+    } else {
+        Cow::Owned(key.to_lowercase())
+    };
+    let key: &str = &lowered;
 
     // There are a whole set of special cases here, taken from the TS
     if key.starts_with("utm_") || key.starts_with("$initial_utm_") {
@@ -428,7 +441,7 @@ pub fn detect_property_type(key: &str, value: &Value) -> Option<PropertyValueTyp
         return Some(PropertyValueType::String);
     }
 
-    if detect_timestamp_property_by_key_and_value(&key, value) {
+    if detect_timestamp_property_by_key_and_value(key, value) {
         return Some(PropertyValueType::DateTime);
     }
 

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -427,6 +427,77 @@ fn test_bare_utm_properties_still_string() {
     }
 }
 
+// Case normalization is what makes each special-case branch in detect_property_type match. Only
+// the DATETIME-keyword branch had mixed-case coverage before (the "TIMESTAMP" assertion in
+// test_property_timestamp_detection); the utm, feature-flag and survey cases are all spelled
+// lowercase everywhere else. Each case here pairs a mixed-case key with a lowercase twin and a
+// value that would classify differently if the key were left as-is, so dropping the conversion
+// fails this instead of silently mistyping properties. The last case is non-ASCII, covering the
+// owning fallback rather than the borrow.
+#[rstest]
+#[case(
+    "UTM_Source",
+    "utm_source",
+    Value::Number(Number::from(12345)),
+    PropertyValueType::String
+)]
+#[case(
+    "$Initial_UTM_Campaign",
+    "$initial_utm_campaign",
+    Value::from("2023-12-13"),
+    PropertyValueType::String
+)]
+#[case(
+    "$FEATURE/My-Flag",
+    "$feature/my-flag",
+    Value::Bool(true),
+    PropertyValueType::String
+)]
+#[case(
+    "$Feature_Flag_Response",
+    "$feature_flag_response",
+    Value::Bool(true),
+    PropertyValueType::String
+)]
+#[case(
+    "$Survey_Response_2",
+    "$survey_response_2",
+    Value::Number(Number::from(7)),
+    PropertyValueType::String
+)]
+// A numeric value only reads as a timestamp when the key carries a DATETIME keyword, so this is
+// the case where normalizing "_At" to "_at" is the whole decision. The epoch is computed rather
+// than fixed because the value-side check only accepts the last six months.
+#[case(
+    "Created_At",
+    "created_at",
+    Value::Number(Number::from(Utc::now().timestamp())),
+    PropertyValueType::DateTime
+)]
+#[case(
+    "UTM_Sourceǅ",
+    "utm_sourceǅ",
+    Value::Number(Number::from(12345)),
+    PropertyValueType::String
+)]
+fn test_property_type_detection_normalizes_key_case(
+    #[case] mixed_case: &str,
+    #[case] lower_case: &str,
+    #[case] value: Value,
+    #[case] expected: PropertyValueType,
+) {
+    assert_eq!(
+        detect_property_type(mixed_case, &value),
+        Some(expected.clone()),
+        "expected {expected:?} for mixed-case key={mixed_case}, value={value}"
+    );
+    assert_eq!(
+        detect_property_type(lower_case, &value),
+        Some(expected.clone()),
+        "expected {expected:?} for lowercase key={lower_case}, value={value}"
+    );
+}
+
 #[test]
 fn test_property_keys_are_sanitized_of_null_bytes() {
     // Property keys with embedded null bytes must be sanitized before reaching Postgres,


### PR DESCRIPTION
## Problem

`detect_property_type` starts with an unconditional `key.to_lowercase()`. It runs once per property per event, and in prod-us propdefs expands about 49k events/s into roughly 9.1M update candidates/s, so this is the hottest allocation in the crate. Nearly every real key is already lowercase, so nearly every one of those allocations produces a copy identical to its input.

## Changes

Borrow when the key is already lowercase ASCII, fall back to the same `to_lowercase()` otherwise.

```rust
let lowered: Cow<str> = if key.is_ascii() && !key.bytes().any(|b| b.is_ascii_uppercase()) {
    Cow::Borrowed(key)
} else {
    Cow::Owned(key.to_lowercase())
};
let key: &str = &lowered;
```

Why the ASCII gate rather than the shorter `!key.chars().any(char::is_uppercase)`: over ASCII with no uppercase bytes, Unicode lowercasing is the identity, so the borrow is obviously equivalent without reasoning about what the key is compared against afterwards. The `char::is_uppercase` version reaches the same answers here, but only because every pattern in this function is an ASCII literal, and that argument has to be redone whenever a pattern changes. It also costs a char decode plus a Unicode property lookup per character instead of a byte scan.

> [!NOTE]
> No behavior change. This is the same classification for every input, including non-ASCII keys, which take the owning path.

## How did you test this code?

I'm an agent, directed by @eli-r-ph. Automated tests only, no manual or staging verification. I also did not benchmark this: the effect is fewer allocations, and CPU in prod-us currently sits at ~63% of request, so I would not expect a visible change in any dashboard. Treat the win as headroom, not throughput.

Added `test_property_type_detection_normalizes_key_case`, a 7-case `rstest`. Each case pairs a mixed-case key with its lowercase twin and a value chosen so the two would classify *differently* if the key were not normalized, covering `utm_`, `$initial_utm_`, `$feature/`, the exact-match `$feature_flag_response`, `$survey_response`, the DATETIME-keyword branch, and one non-ASCII key for the owning path.

On the regression it catches: I checked, and case normalization was not entirely uncovered. `test_property_timestamp_detection` has a single `"TIMESTAMP"` assertion that pins the DATETIME-keyword branch. The other four special-case branches had no mixed-case coverage at all, and nothing covered the non-ASCII path this PR introduces. I verified every case discriminates by stubbing the normalization out entirely and re-running: all 7 fail (alongside `test_property_timestamp_detection`, as expected).

One case needed care. `Created_At` with a numeric value only reads as DateTime because the key carries a keyword, but the value-side check only accepts timestamps from the last six months, so a hardcoded epoch would have started failing later. It computes the epoch instead.

Full suite against a local Postgres: 66 tests pass across all `property-defs-rs` targets. `cargo fmt --check` and `cargo clippy --all-targets` clean. `hogli ci:preflight --strict` reports nothing triggered.

Caveat: I compiled with rustup's 1.96.0, not flox's 1.91.1. Nothing here is toolchain-sensitive, but CI is the first run on the flox toolchain.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @eli-r-ph.

Extracted from the stale PR #65112, which bundles five separable propdefs changes. This is one of them, lifted onto current master and shipped alone.

I changed the predicate from the original. #65112 used `key.chars().any(char::is_uppercase)`, and my first pass at this PR asserted that was a correctness bug because titlecase characters (Unicode category Lt, such as `ǅ`) are not `Uppercase` yet still have a lowercase mapping. That claim was wrong and I dropped it: the divergence is unobservable here, since every pattern the key is compared against is an ASCII literal, and every character whose lowercase mapping *is* ASCII (the Kelvin sign, for instance) has category Lu and therefore takes the owning path under either predicate. I kept the ASCII gate on the narrower grounds above rather than on correctness.

Skills invoked: `/writing-code-comments` and `/writing-tests`.
