### PR TITLE
fix: stop a taxonomy timeout killing every AI subscription report

### DIFF
--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -225,11 +225,8 @@ def sanitize_prompt(raw: str | None) -> str:
 
 
 def _top_event_names(team: Team, limit: int) -> list[str]:
-    # Deliberately unlimited: the taxonomy is an unfiltered 30-day `GROUP BY event` over the whole
-    # events table, and the limit is applied to its *output* rows — so asking for fewer costs
-    # ClickHouse exactly the same. What the limit does change is the cache key (`limit` is hashed
-    # into it), which partitions us off the limit-less entry the other AI callers share and makes
-    # every run recompute a scan that may not fit its budget. Share their key; slice below.
+    # Unlimited on purpose: the limit bounds output rows, not the 30-day GROUP BY behind them, so it
+    # saves ClickHouse nothing and only forks our cache key away from the other AI callers'.
     response = TeamTaxonomyQueryRunner(TeamTaxonomyQuery(), team).run(
         ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
     )
@@ -238,11 +235,8 @@ def _top_event_names(team: Team, limit: int) -> list[str]:
     # Event names are user-controlled (project tokens are public — anyone can fire
     # events with arbitrary names). Sanitize so an attacker can't seed the LLM
     # context with prompt-injection payloads via crafted event names.
-    # `count > 0` drops the runner's WELL_KNOWN_EVENT_NAMES padding, which it appends at count=0 so
-    # Max can offer filters on events a project could send. Under a "Top events" heading that padding
-    # is a claim the event fired, so a project with fewer real events than `limit` would otherwise be
-    # told `$pageleave` is one of its top events. Events that exist but are dormant are a separate
-    # line, built from the Postgres taxonomy by `_no_data_event_names`.
+    # `count > 0` drops the runner's count=0 WELL_KNOWN_EVENT_NAMES padding: under a "Top events"
+    # heading it would claim events fired that never did. Dormant ones are `_no_data_event_names`.
     sanitized = (sanitize_user_text(item.event, EVENT_NAME_MAX_LENGTH) for item in response.results if item.count > 0)
     return [name for name in sanitized if name][:limit]
 
@@ -444,13 +438,9 @@ def _event_property_names(team: Team, events: list[str], per_event_limit: int) -
 
 
 def build_context_blob(team: Team, window: ReportWindow, relevant_events: Sequence[str] = ()) -> str:
-    # The volume-ranked top events are a context *hint* — every event the planner is asked to reason
-    # about arrives via `relevant_events`, whose names come from the Postgres taxonomy. On a
-    # high-volume project the 30-day scan behind this can exceed ClickHouse's execution limit, and
-    # letting that abort the run costs the whole report to save a hint, so it degrades instead —
-    # matching how `_llm_selected_events` already treats its own failures. None carries "we couldn't
-    # find out" through to the Top events line, which must not render it as "there are none"; typed
-    # Optional rather than a parallel bool so `ty` rejects any use that ignores the difference.
+    # Only a hint — the planner's actual event names arrive via `relevant_events` from the Postgres
+    # taxonomy — so a ClickHouse timeout on the 30-day scan behind it degrades rather than costing the
+    # whole report, as `_llm_selected_events` already does. None means "unknown", never "none".
     event_names: list[str] | None
     try:
         event_names = _top_event_names(team, EVENT_NAMES_SAMPLE_LIMIT)
@@ -479,13 +469,13 @@ def build_context_blob(team: Team, window: ReportWindow, relevant_events: Sequen
         f"- Previous-period start (for period-over-period comparisons only, project timezone): "
         f"{window.compare_start_literal}",
     ]
-    if event_names:
+    if event_names is None:
+        # State, not an instruction to the model: this blob is also quoted verbatim into the synthesis
+        # prompt, so an imperative here can end up paraphrased at the reader. Distinct from the empty
+        # case because the projects whose scan times out are the ones with the most data.
+        lines.append("- Top events: (unavailable this run)")
+    elif event_names:
         lines.append("- Top events: " + ", ".join(event_names))
-    elif event_names is None:
-        # Never claim "none recorded yet" after a failed lookup. The projects big enough to break that
-        # lookup are exactly the ones with the most data, so the reassuring version of this line is the
-        # one that would make the planner report that nothing happened.
-        lines.append("- Top events: (could not be retrieved this run — do NOT infer the project has no data)")
     else:
         lines.append("- Top events: (none recorded yet)")
 

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -225,8 +225,12 @@ def sanitize_prompt(raw: str | None) -> str:
 
 
 def _top_event_names(team: Team, limit: int) -> list[str]:
-    query = TeamTaxonomyQuery(limit=limit)
-    response = TeamTaxonomyQueryRunner(query, team).run(
+    # Deliberately unlimited: the taxonomy is an unfiltered 30-day `GROUP BY event` over the whole
+    # events table, and the limit is applied to its *output* rows — so asking for fewer costs
+    # ClickHouse exactly the same. What the limit does change is the cache key (`limit` is hashed
+    # into it), which partitions us off the limit-less entry the other AI callers share and makes
+    # every run recompute a scan that may not fit its budget. Share their key; slice below.
+    response = TeamTaxonomyQueryRunner(TeamTaxonomyQuery(), team).run(
         ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
     )
     if not isinstance(response, CachedTeamTaxonomyQueryResponse):
@@ -235,7 +239,7 @@ def _top_event_names(team: Team, limit: int) -> list[str]:
     # events with arbitrary names). Sanitize so an attacker can't seed the LLM
     # context with prompt-injection payloads via crafted event names.
     sanitized = (sanitize_user_text(item.event, EVENT_NAME_MAX_LENGTH) for item in response.results)
-    return [name for name in sanitized if name]
+    return [name for name in sanitized if name][:limit]
 
 
 def _no_data_event_names(team: Team, limit: int) -> list[str]:
@@ -435,7 +439,19 @@ def _event_property_names(team: Team, events: list[str], per_event_limit: int) -
 
 
 def build_context_blob(team: Team, window: ReportWindow, relevant_events: Sequence[str] = ()) -> str:
-    event_names = _top_event_names(team, EVENT_NAMES_SAMPLE_LIMIT)
+    # The volume-ranked top events are a context *hint* — every event the planner is asked to reason
+    # about arrives via `relevant_events`, whose names come from the Postgres taxonomy. On a
+    # high-volume project the 30-day scan behind this can exceed ClickHouse's execution limit, and
+    # letting that abort the run costs the whole report to save a hint, so it degrades instead —
+    # matching how `_llm_selected_events` already treats its own failures. None carries "we couldn't
+    # find out" through to the Top events line, which must not render it as "there are none"; typed
+    # Optional rather than a parallel bool so `ty` rejects any use that ignores the difference.
+    event_names: list[str] | None
+    try:
+        event_names = _top_event_names(team, EVENT_NAMES_SAMPLE_LIMIT)
+    except Exception:
+        logger.warning("ai_subscription.top_event_names_failed", team_id=team.pk, exc_info=True)
+        event_names = None
 
     # Team / org names are also user-controlled and end up in the LLM context, so
     # apply the same sanitization as event names.
@@ -460,12 +476,17 @@ def build_context_blob(team: Team, window: ReportWindow, relevant_events: Sequen
     ]
     if event_names:
         lines.append("- Top events: " + ", ".join(event_names))
+    elif event_names is None:
+        # Never claim "none recorded yet" after a failed lookup. The projects big enough to break that
+        # lookup are exactly the ones with the most data, so the reassuring version of this line is the
+        # one that would make the planner report that nothing happened.
+        lines.append("- Top events: (could not be retrieved this run — do NOT infer the project has no data)")
     else:
         lines.append("- Top events: (none recorded yet)")
 
     if relevant_events:
         props_by_event = _event_property_names(team, list(relevant_events), EVENT_PROPERTIES_PER_EVENT_LIMIT)
-        top_set = set(event_names)
+        top_set = set(event_names or ())
         seen: set[str] = set()
         matched: list[tuple[str, str]] = []  # (raw, clean), deduped on the sanitized name
         for raw in relevant_events:

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -238,7 +238,12 @@ def _top_event_names(team: Team, limit: int) -> list[str]:
     # Event names are user-controlled (project tokens are public — anyone can fire
     # events with arbitrary names). Sanitize so an attacker can't seed the LLM
     # context with prompt-injection payloads via crafted event names.
-    sanitized = (sanitize_user_text(item.event, EVENT_NAME_MAX_LENGTH) for item in response.results)
+    # `count > 0` drops the runner's WELL_KNOWN_EVENT_NAMES padding, which it appends at count=0 so
+    # Max can offer filters on events a project could send. Under a "Top events" heading that padding
+    # is a claim the event fired, so a project with fewer real events than `limit` would otherwise be
+    # told `$pageleave` is one of its top events. Events that exist but are dormant are a separate
+    # line, built from the Postgres taxonomy by `_no_data_event_names`.
+    sanitized = (sanitize_user_text(item.event, EVENT_NAME_MAX_LENGTH) for item in response.results if item.count > 0)
     return [name for name in sanitized if name][:limit]
 
 

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 
+from posthog.schema import CachedTeamTaxonomyQueryResponse, TeamTaxonomyItem, TeamTaxonomyQuery
+
+from posthog.exceptions import ClickHouseQueryTimeOut
 from posthog.models import EventDefinition, EventProperty, PropertyDefinition, Team
 
 from products.exports.backend.models.subscription import Subscription
@@ -31,6 +34,7 @@ from products.exports.backend.temporal.subscriptions.ai_subscription.spec_genera
     _pinned_event_names,
     _recent_event_names,
     _select_relevant_events,
+    _top_event_names,
     build_context_blob,
     build_frozen_prompt,
     compute_report_window,
@@ -710,6 +714,82 @@ class TestContextBlob(APIBaseTest):
         blob = build_context_blob(self.team, _window(7))
 
         assert "Events matching your request" not in blob
+
+    @parameterized.expand(
+        [
+            ("clickhouse_timeout", ClickHouseQueryTimeOut()),
+            ("unexpected_error", Exception("boom")),
+        ]
+    )
+    @patch(f"{_SG}.get_group_types_for_project", return_value=[])
+    def test_builds_blob_when_top_events_lookup_fails(self, _name: str, exc: Exception, _mock_groups: object) -> None:
+        # The top-events list is only a hint; on a high-volume project its 30-day scan can exceed
+        # ClickHouse's execution limit. Losing the hint must not cost the whole report, so the blob
+        # still has to carry the parts the planner cannot work without.
+        window = _window(7)
+
+        with patch(f"{_SG}._top_event_names", side_effect=exc):
+            blob = build_context_blob(self.team, window)
+
+        assert f"Analysis window start (inclusive, project timezone): {window.start_literal}" in blob
+        assert "{{date_range}}" in blob
+        # A failed lookup must not read as an empty project: the projects whose scan times out are the
+        # ones with the most data, so "none recorded yet" here would invite a "nothing happened" report.
+        assert "none recorded yet" not in blob
+        assert "do NOT infer the project has no data" in blob
+
+    @patch(f"{_SG}.get_group_types_for_project", return_value=[])
+    def test_still_injects_relevant_event_schema_when_top_events_lookup_fails(self, _mock_groups: object) -> None:
+        # The relevant-events section cross-references the top-events list to avoid repeating names, so
+        # the failure path has to stay compatible with it rather than blowing up downstream.
+        EventDefinition.objects.create(team=self.team, name="export created")
+        EventProperty.objects.create(team=self.team, event="export created", property="duration_ms")
+
+        with patch(f"{_SG}._top_event_names", side_effect=ClickHouseQueryTimeOut()):
+            blob = build_context_blob(self.team, _window(7), relevant_events=["export created"])
+
+        assert "export created" in blob
+        assert "duration_ms" in blob
+
+    @patch(f"{_SG}.get_group_types_for_project", return_value=[])
+    @patch(f"{_SG}._top_event_names", return_value=[])
+    def test_still_reports_a_genuinely_empty_project_as_empty(self, _mock_top: object, _mock_groups: object) -> None:
+        # The counterpart to the failure case: a project that really has no events must keep saying so,
+        # or the two states become indistinguishable to the planner.
+        blob = build_context_blob(self.team, _window(7))
+
+        assert "- Top events: (none recorded yet)" in blob
+
+
+class TestTopEventNames(APIBaseTest):
+    def _run_with_results(self, results: list[TeamTaxonomyItem], limit: int) -> tuple[list[str], TeamTaxonomyQuery]:
+        response = CachedTeamTaxonomyQueryResponse(
+            cache_key="test_key",
+            is_cached=True,
+            last_refresh=datetime(2026, 1, 1, tzinfo=UTC),
+            next_allowed_client_refresh=datetime(2026, 1, 1, 1, 0, tzinfo=UTC),
+            timezone="UTC",
+            results=results,
+        )
+        with patch(f"{_SG}.TeamTaxonomyQueryRunner") as mock_runner:
+            mock_runner.return_value.run.return_value = response
+            names = _top_event_names(self.team, limit)
+        return names, mock_runner.call_args.args[0]
+
+    def test_asks_for_no_limit_so_the_cache_key_is_shared(self) -> None:
+        # `limit` is hashed into the cache key but applied to the query's output rows, so passing one
+        # buys no ClickHouse saving and partitions us off the entry other AI callers keep warm —
+        # turning every run into a recompute of a scan that may not finish.
+        _, query = self._run_with_results([TeamTaxonomyItem(event="$pageview", count=1)], limit=20)
+
+        assert query.limit is None
+
+    def test_returns_at_most_limit_names_ranked_by_volume(self) -> None:
+        results = [TeamTaxonomyItem(event=f"event_{i}", count=100 - i) for i in range(5)]
+
+        names, _ = self._run_with_results(results, limit=3)
+
+        assert names == ["event_0", "event_1", "event_2"]
 
 
 class TestGenerateQueryPlanSubstitution(APIBaseTest):

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -736,7 +736,12 @@ class TestContextBlob(APIBaseTest):
         # A failed lookup must not read as an empty project: the projects whose scan times out are the
         # ones with the most data, so "none recorded yet" here would invite a "nothing happened" report.
         assert "none recorded yet" not in blob
-        assert "do NOT infer the project has no data" in blob
+        assert "- Top events: (unavailable this run)" in blob
+        # The blob is quoted verbatim into the synthesis prompt, so this line has to stay a statement of
+        # state — an imperative aimed at the planner can reach the reader as report prose. (The blob does
+        # carry imperatives elsewhere, e.g. the date-placeholder rule, hence asserting on this line only.)
+        (top_events_line,) = [line for line in blob.splitlines() if line.startswith("- Top events:")]
+        assert "do NOT" not in top_events_line
 
     @patch(f"{_SG}.get_group_types_for_project", return_value=[])
     def test_still_injects_relevant_event_schema_when_top_events_lookup_fails(self, _mock_groups: object) -> None:

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -791,6 +791,20 @@ class TestTopEventNames(APIBaseTest):
 
         assert names == ["event_0", "event_1", "event_2"]
 
+    def test_excludes_zero_count_padding_events(self) -> None:
+        # The runner appends WELL_KNOWN_EVENT_NAMES at count=0 when there are no more real rows. Under a
+        # "Top events" heading those read as events that fired, so a project with fewer real events than
+        # the limit would be handed fabricated ones — the same misinformation the None/empty split avoids.
+        results = [
+            TeamTaxonomyItem(event="export created", count=42),
+            TeamTaxonomyItem(event="$pageleave", count=0),
+            TeamTaxonomyItem(event="$identify", count=0),
+        ]
+
+        names, _ = self._run_with_results(results, limit=20)
+
+        assert names == ["export created"]
+
 
 class TestGenerateQueryPlanSubstitution(APIBaseTest):
     """Test the substitution *behaviour* — that the planner actually receives the prompt and context


### PR DESCRIPTION
## What

AI-prompt subscriptions couldn't deliver a report on high-volume projects.

Before writing any report query, the planner gathers context via `TeamTaxonomyQueryRunner` — an unfiltered 30-day `GROUP BY event` over the whole events table. On project 2 (~85M events/day, ~2.5B rows in the window) that exceeds ClickHouse's 60s limit, so `generate_ai_subscription_report` raised `ClickHouseQueryTimeOut` and the delivery failed with `ai_report` null.

Not a regression — this has never worked at that size (`limit=20` dates to #59630). The scan is marginal rather than hopeless: 7- and 14-day windows complete, 30-day doesn't. Hence 4 such timeouts across US cloud in 7 days, all on project 2, against 7,968 report runs.

## The fix

- **Degrade instead of aborting.** The top-events list is only a hint — the events the planner reasons about come from `relevant_events` (Postgres-backed, unaffected by a ClickHouse timeout). Losing the hint shouldn't cost the report. Matches how `_llm_selected_events` already handles its own failures.
- **Distinguish "unknown" from "none".** The existing fallback reads `(none recorded yet)`, and the projects whose scan times out are the ones with the most data — so the naive degradation invites a "nothing happened" report. Failure now renders `(unavailable this run)`, typed `Optional` so `ty` catches uses that ignore the difference.
- **Drop zero-count padding.** The runner appends `WELL_KNOWN_EVENT_NAMES` at `count=0`; under a "Top events" heading that claims events fired that never did.
- **Share the cache key.** `limit` is hashed into the key but applied to output rows, so it bought no ClickHouse saving while forking us off the entry other AI callers share.

## Reviewer notes

- The blob is quoted verbatim into the synthesis prompt without the `strip_llm_framing_markers` pass its siblings get, so the degraded line is deliberately a statement of state, not an instruction to the model — otherwise it can surface in the delivered report.
- **Gap not closed here:** if the taxonomy fails *and* `_select_relevant_events` returns nothing, the resulting plan can still be frozen onto `Subscription.ai_query_plan` (invented names return 0 rows rather than erroring, so `_plan_to_freeze` accepts it). Fixing it properly means separating `build_context_blob`'s lookups from its formatting so the freeze gate can see the degradation. Needs both conditions, and an `AI_QUERY_PLAN_VERSION` bump re-plans frozen subscriptions.
- Adjacent latent bug: `TeamTaxonomyQueryRunner` accepts a `settings: HogQLGlobalSettings` kwarg that `_calculate` never forwards, so a caller raising `max_execution_time` is silently ignored.

## Testing

`pytest products/exports/backend/temporal/subscriptions/ai_subscription/test/` -> 196 passed, rebased onto current master. Each new test was checked to fail against the code it guards.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
