### PR TITLE
feat(propdefs): configurable dedup period + producer lull drain

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9250,6 +9250,7 @@ dependencies = [
  "personhog-proto",
  "quick_cache",
  "rand 0.8.5",
+ "rdkafka",
  "regex",
  "rstest",
  "serde",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9251,6 +9251,7 @@ dependencies = [
  "personhog-proto",
  "quick_cache",
  "rand 0.8.5",
+ "rdkafka",
  "regex",
  "rstest",
  "serde",

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -36,6 +36,9 @@ regex.workspace = true
 tokio-stream = { version = "0.1", features = ["net"] }
 metrics-util = { workspace = true }
 rstest = "0.26"
+# Drives common_kafka's MockCluster in tests/producer_loop.rs, so the producer loop can be
+# exercised end to end without a broker.
+rdkafka = { workspace = true }
 
 [lints]
 workspace = true

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -76,7 +76,8 @@ pub struct Config {
     // value is generated fresh at write time, so a coarser period only means a staler
     // last_seen_at in the DB. Its only consumers are staleness filters, so read them before
     // raising this: `?exclude_stale=true` compares against 30 days, but the event-screenshots
-    // Temporal workflow shortlists event types on a 3 hour window.
+    // Temporal workflow shortlists event types on a 3 hour window. Must be positive: flooring
+    // is what bounds this table's write volume, so startup fails rather than run without it.
     #[envconfig(from = "EVENTDEF_LAST_SEEN_FLOOR_SECS", default = "3600")]
     pub eventdef_last_seen_floor_secs: i64,
 

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -76,8 +76,9 @@ pub struct Config {
     // value is generated fresh at write time, so a coarser period only means a staler
     // last_seen_at in the DB. Its only consumers are staleness filters, so read them before
     // raising this: `?exclude_stale=true` compares against 30 days, but the event-screenshots
-    // Temporal workflow shortlists event types on a 3 hour window. Must be positive: flooring
-    // is what bounds this table's write volume, so startup fails rather than run without it.
+    // Temporal workflow shortlists event types on a 3 hour window. Must be in
+    // 1..=MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS: flooring is what bounds this table's write volume,
+    // so startup fails rather than run without it.
     #[envconfig(from = "EVENTDEF_LAST_SEEN_FLOOR_SECS", default = "3600")]
     pub eventdef_last_seen_floor_secs: i64,
 

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -55,6 +55,11 @@ pub struct Config {
     #[envconfig(default = "10000")]
     pub compaction_batch_size: usize,
 
+    // How long a producer's compaction batch may sit before it is flushed regardless of size.
+    // Bounds how stale the tail of a partition's updates can get once its traffic stops.
+    #[envconfig(default = "10")]
+    pub producer_drain_interval_secs: u64,
+
     // Workers send updates back to the main thread over a channel,
     // which has a depth of this many slots. If the main thread slows,
     // which usually means if postgres is slow, the workers will block

--- a/rust/property-defs-rs/src/config.rs
+++ b/rust/property-defs-rs/src/config.rs
@@ -71,6 +71,15 @@ pub struct Config {
     #[envconfig(default = "10000")]
     pub update_count_skip_threshold: usize,
 
+    // Period an event definition's last_seen_at is floored to for dedup purposes, which bounds
+    // how often we re-issue its write: once per (team, name) per period, per pod. The stored
+    // value is generated fresh at write time, so a coarser period only means a staler
+    // last_seen_at in the DB. Its only consumers are staleness filters, so read them before
+    // raising this: `?exclude_stale=true` compares against 30 days, but the event-screenshots
+    // Temporal workflow shortlists event types on a 3 hour window.
+    #[envconfig(from = "EVENTDEF_LAST_SEEN_FLOOR_SECS", default = "3600")]
+    pub eventdef_last_seen_floor_secs: i64,
+
     // Do everything except actually write to the DB
     #[envconfig(default = "true")]
     pub skip_writes: bool,

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -152,70 +152,79 @@ pub async fn update_producer_loop(
     let _guard = handle.process_scope();
     let mut batch = AHashSet::with_capacity(config.compaction_batch_size);
     let mut last_send = tokio::time::Instant::now();
+    let drain_interval = Duration::from_secs(config.producer_drain_interval_secs);
     loop {
+        // The timer arm is what lets the flush check at the bottom of the loop run while no
+        // events are arriving. Without it the loop parks in json_recv(), so a partial compaction
+        // batch left behind when a partition goes quiet stays unwritten until traffic resumes.
+        // The tick period is deliberately independent of drain_interval; it only bounds how
+        // often the elapsed check is re-evaluated, not how long a batch may sit.
         let recv_result = tokio::select! {
             _ = handle.shutdown_recv() => {
                 info!("Producer loop shutting down");
                 return;
             }
-            r = consumer.json_recv() => r,
+            r = consumer.json_recv() => Some(r),
+            _ = tokio::time::sleep(Duration::from_secs(1)) => None,
         };
 
-        let (event, offset): (Event, _) = match recv_result {
-            Ok(r) => r,
-            Err(RecvErr::Empty) => {
-                warn!("Received empty event");
-                metrics::counter!(EMPTY_EVENTS).increment(1);
+        if let Some(recv_result) = recv_result {
+            let (event, offset): (Event, _) = match recv_result {
+                Ok(r) => r,
+                Err(RecvErr::Empty) => {
+                    warn!("Received empty event");
+                    metrics::counter!(EMPTY_EVENTS).increment(1);
+                    continue;
+                }
+                Err(RecvErr::Serde(e)) => {
+                    metrics::counter!(EVENT_PARSE_ERROR).increment(1);
+                    warn!("Failed to parse event: {:?}", e);
+                    continue;
+                }
+                Err(RecvErr::Kafka(e)) => {
+                    handle.signal_failure(format!("Kafka error: {e:?}"));
+                    return;
+                }
+            };
+
+            // NOTE: we extended the autocommit interval in production envs to 20 seconds
+            // as a temporary remediation for events already buffered in a pod's internal
+            // queue being skipped when the consumer group rebalances or the service is
+            // redeployed. Long-term fix: start tracking max partition offsets in the
+            // Update batches and commit them only when each batch succeeds. This will
+            // not be perfect, as batch writes are async and can complete out of order,
+            // but is better than what we're doing right now
+            let curr_offset = offset.get_value();
+            match offset.store() {
+                Ok(_) => (),
+                Err(e) => {
+                    metrics::counter!(UPDATE_PRODUCER_OFFSET, &[("op", "store_fail")]).increment(1);
+                    // TODO: consumer json_recv() should expose the source partition ID too
+                    error!("update_producer_loop: failed to store offset {curr_offset}, got: {e}");
+                }
+            }
+
+            if !config
+                .filter_mode
+                .should_process(&config.filtered_teams.teams, event.team_id)
+            {
+                metrics::counter!(SKIPPED_DUE_TO_TEAM_FILTER).increment(1);
                 continue;
             }
-            Err(RecvErr::Serde(e)) => {
-                metrics::counter!(EVENT_PARSE_ERROR).increment(1);
-                warn!("Failed to parse event: {:?}", e);
-                continue;
+
+            let updates = event.into_updates(config.update_count_skip_threshold);
+
+            metrics::counter!(EVENTS_RECEIVED).increment(1);
+            metrics::counter!(UPDATES_SEEN).increment(updates.len() as u64);
+            metrics::histogram!(UPDATES_PER_EVENT).record(updates.len() as f64);
+
+            for update in updates {
+                if batch.contains(&update) {
+                    metrics::counter!(COMPACTED_UPDATES).increment(1);
+                    continue;
+                }
+                batch.insert(update);
             }
-            Err(RecvErr::Kafka(e)) => {
-                handle.signal_failure(format!("Kafka error: {e:?}"));
-                return;
-            }
-        };
-
-        // NOTE: we extended the autocommit interval in production envs to 20 seconds
-        // as a temporary remediation for events already buffered in a pod's internal
-        // queue being skipped when the consumer group rebalances or the service is
-        // redeployed. Long-term fix: start tracking max partition offsets in the
-        // Update batches and commit them only when each batch succeeds. This will
-        // not be perfect, as batch writes are async and can complete out of order,
-        // but is better than what we're doing right now
-        let curr_offset = offset.get_value();
-        match offset.store() {
-            Ok(_) => (),
-            Err(e) => {
-                metrics::counter!(UPDATE_PRODUCER_OFFSET, &[("op", "store_fail")]).increment(1);
-                // TODO: consumer json_recv() should expose the source partition ID too
-                error!("update_producer_loop: failed to store offset {curr_offset}, got: {e}");
-            }
-        }
-
-        if !config
-            .filter_mode
-            .should_process(&config.filtered_teams.teams, event.team_id)
-        {
-            metrics::counter!(SKIPPED_DUE_TO_TEAM_FILTER).increment(1);
-            continue;
-        }
-
-        let updates = event.into_updates(config.update_count_skip_threshold);
-
-        metrics::counter!(EVENTS_RECEIVED).increment(1);
-        metrics::counter!(UPDATES_SEEN).increment(updates.len() as u64);
-        metrics::histogram!(UPDATES_PER_EVENT).record(updates.len() as f64);
-
-        for update in updates {
-            if batch.contains(&update) {
-                metrics::counter!(COMPACTED_UPDATES).increment(1);
-                continue;
-            }
-            batch.insert(update);
         }
 
         // We do the full batch insert before checking the time/batch size, because if we did this
@@ -224,9 +233,7 @@ pub async fn update_producer_loop(
         // wait on the next event, which might come an arbitrary amount of time later. This bit me
         // in testing, and while it's not a correctness problem and under normal load we'd never
         // see it, we may as well just do the full batch insert first.
-        if batch.len() >= config.compaction_batch_size
-            || last_send.elapsed() > Duration::from_secs(10)
-        {
+        if batch.len() >= config.compaction_batch_size || last_send.elapsed() > drain_interval {
             last_send = tokio::time::Instant::now();
             for update in batch.drain() {
                 if shared_cache.contains_key(&update) {

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -212,7 +212,10 @@ pub async fn update_producer_loop(
                 continue;
             }
 
-            let updates = event.into_updates(config.update_count_skip_threshold);
+            let updates = event.into_updates_with(
+                config.update_count_skip_threshold,
+                config.eventdef_last_seen_floor_secs,
+            );
 
             metrics::counter!(EVENTS_RECEIVED).increment(1);
             metrics::counter!(UPDATES_SEEN).increment(updates.len() as u64);

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -9,6 +9,7 @@ use property_defs_rs::{
     config::Config,
     measuring_channel::measuring_channel,
     metrics_consts::CHANNEL_CAPACITY,
+    types::MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS,
     update_cache::Cache,
     update_consumer_loop, update_producer_loop,
 };
@@ -45,10 +46,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Refuse the "0 disables it" convention: with flooring off, every event's last_seen_at is
     // unique, dedup filters nothing, and the full event stream lands on posthog_eventdefinition
-    // as row updates. Failing the deploy is cheaper than that.
-    if config.eventdef_last_seen_floor_secs <= 0 {
+    // as row updates. Failing the deploy is cheaper than that. The upper bound guards the same
+    // outcome from the other direction, where the jitter offset outruns the timestamp range.
+    if config.eventdef_last_seen_floor_secs <= 0
+        || config.eventdef_last_seen_floor_secs > MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS
+    {
         return Err(format!(
-            "EVENTDEF_LAST_SEEN_FLOOR_SECS must be positive, got {}: flooring bounds how often event-definition writes are re-issued and must not be disabled",
+            "EVENTDEF_LAST_SEEN_FLOOR_SECS must be in 1..={MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS}, got {}: flooring bounds how often event-definition writes are re-issued and must not be disabled",
             config.eventdef_last_seen_floor_secs
         )
         .into());

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -43,6 +43,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let config = Config::init_with_defaults()?;
 
+    // Refuse the "0 disables it" convention: with flooring off, every event's last_seen_at is
+    // unique, dedup filters nothing, and the full event stream lands on posthog_eventdefinition
+    // as row updates. Failing the deploy is cheaper than that.
+    if config.eventdef_last_seen_floor_secs <= 0 {
+        return Err(format!(
+            "EVENTDEF_LAST_SEEN_FLOOR_SECS must be positive, got {}: flooring bounds how often event-definition writes are re-issued and must not be disabled",
+            config.eventdef_last_seen_floor_secs
+        )
+        .into());
+    }
+
     // Start continuous profiling if enabled (keep _agent alive for the duration of the program)
     let _profiling_agent = match config.continuous_profiling.start_agent() {
         Ok(agent) => agent,

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -564,6 +564,11 @@ impl Hash for GroupType {
 // so a coarser period trades a staler stored last_seen_at for proportionally fewer writes.
 pub const DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS: i64 = 3600;
 
+// Upper bound on the period, 30 days. Nothing operational wants a window this coarse — the cap
+// exists so the jitter offset stays small enough that the bucket arithmetic below cannot overflow
+// or leave chrono's representable range, which is what makes its fallback unreachable.
+pub const MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS: i64 = 30 * 24 * 3600;
+
 /// Start of the current `period_secs` window containing `now`, offset per identity by
 /// `jitter_seed` so that different identities roll over at different points in the period.
 ///
@@ -575,15 +580,20 @@ pub const DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS: i64 = 3600;
 /// The result always falls in `(now - period, now]`, matching un-jittered flooring, so it can
 /// never produce a future timestamp.
 ///
-/// A non-positive period is treated as `DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS` rather than
-/// disabling flooring. With flooring off, every event's `last_seen_at` is unique, the dedup
-/// cache filters nothing, and the full event stream reaches `posthog_eventdefinition` as row
-/// updates, so "disabled" must not be expressible here at all. Config validation at startup
-/// rejects non-positive values loudly; this clamp is the backstop for any caller that does
-/// not go through `Config`.
+/// The period is clamped into `1..=MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS`, with a non-positive value
+/// treated as `DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS`. Both ends of that clamp guard the same
+/// failure: an unfloored `last_seen_at` is unique per event, so the dedup cache filters nothing
+/// and the full event stream reaches `posthog_eventdefinition` as row updates. A non-positive
+/// period would produce that directly; an unbounded one would produce it via the fallback below,
+/// since a large enough offset pushes `bucket_start` outside chrono's range. Config validation at
+/// startup rejects out-of-range values loudly; this clamp backstops callers that bypass `Config`.
+///
+/// With the period capped, `offset` stays under a month of seconds, so `shifted` cannot overflow
+/// and `bucket_start` stays within a month of `now` — `from_timestamp` therefore cannot fail and
+/// the `unwrap_or` never fires.
 pub fn floor_last_seen(now: DateTime<Utc>, period_secs: i64, jitter_seed: u64) -> DateTime<Utc> {
     let period_secs = if period_secs > 0 {
-        period_secs
+        period_secs.min(MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS)
     } else {
         DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS
     };

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt, hash::Hash, str::FromStr, sync::LazyLock};
 
-use chrono::{DateTime, Duration, DurationRound, RoundingError, Utc};
+use chrono::{DateTime, Utc};
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
@@ -227,17 +227,35 @@ pub struct Event {
 
 impl From<&Event> for EventDefinition {
     fn from(event: &Event) -> Self {
-        EventDefinition {
-            name: sanitize_string(&event.event),
-            team_id: event.team_id,
-            project_id: event.project_id,
-            last_seen_at: get_floored_last_seen(),
-        }
+        event.to_event_definition(DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS)
     }
 }
 
 impl Event {
+    fn to_event_definition(&self, last_seen_floor_secs: i64) -> EventDefinition {
+        let name = sanitize_string(&self.event);
+        // Seed on the sanitized name because that is what ends up in the dedup key.
+        let jitter_seed = last_seen_jitter_seed(self.team_id, &name);
+
+        EventDefinition {
+            last_seen_at: floor_last_seen(Utc::now(), last_seen_floor_secs, jitter_seed),
+            name,
+            team_id: self.team_id,
+            project_id: self.project_id,
+        }
+    }
+
     pub fn into_updates(self, skip_threshold: usize) -> Vec<Update> {
+        self.into_updates_with(skip_threshold, DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS)
+    }
+
+    /// As `into_updates`, but with an explicit flooring period for the event-definition dedup
+    /// key. See `floor_last_seen` for what the period controls.
+    pub fn into_updates_with(
+        self,
+        skip_threshold: usize,
+        last_seen_floor_secs: i64,
+    ) -> Vec<Update> {
         if EVENTS_WITHOUT_PROPERTIES.contains(&self.event.as_str()) {
             metrics::counter!(EVENTS_SKIPPED, &[("reason", "no_properties_event")]).increment(1);
             return vec![];
@@ -252,7 +270,7 @@ impl Event {
         let team_id = self.team_id;
         let event = self.event.clone();
 
-        let updates = self.into_updates_inner();
+        let updates = self.into_updates_inner(last_seen_floor_secs);
         if updates.len() > skip_threshold {
             warn!(
                 "Event {} for team {} has more than {} properties, skipping",
@@ -265,8 +283,10 @@ impl Event {
         updates
     }
 
-    fn into_updates_inner(self) -> Vec<Update> {
-        let mut updates = vec![Update::Event(EventDefinition::from(&self))];
+    fn into_updates_inner(self, last_seen_floor_secs: i64) -> Vec<Update> {
+        let mut updates = vec![Update::Event(
+            self.to_event_definition(last_seen_floor_secs),
+        )];
         let Some(props) = &self.properties else {
             return updates;
         };
@@ -538,21 +558,50 @@ impl Hash for GroupType {
     }
 }
 
-// We round last seen to the nearest hour. Unwrap is safe here because
-// the duration is positive, non-zero, and smaller than time since epoch
-pub fn get_floored_last_seen() -> DateTime<Utc> {
-    floor_datetime(Utc::now(), Duration::hours(1)).unwrap()
+// An event definition's `last_seen_at` participates in its Hash and Eq, so flooring it is what
+// bounds how often we re-issue the definition's write: one per (team, name) per period, per pod.
+// The value itself never reaches Postgres — the write path binds a fresh Utc::now() per attempt —
+// so a coarser period trades a staler stored last_seen_at for proportionally fewer writes.
+pub const DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS: i64 = 3600;
+
+/// Start of the current `period_secs` window containing `now`, offset per identity by
+/// `jitter_seed` so that different identities roll over at different points in the period.
+///
+/// Without the offset every pod rotates every key at the same wall-clock instant, so each rollover
+/// makes the entire active keyspace writable at once. That is tolerable hourly and decidedly not
+/// at coarser periods, where a day's worth of definition writes would land in the minutes after
+/// the boundary, on a table that already struggles to keep autovacuum ahead of its dead tuples.
+///
+/// The result always falls in `(now - period, now]`, matching un-jittered flooring, so it can
+/// never produce a future timestamp. A non-positive period disables flooring entirely.
+pub fn floor_last_seen(now: DateTime<Utc>, period_secs: i64, jitter_seed: u64) -> DateTime<Utc> {
+    if period_secs <= 0 {
+        return now;
+    }
+
+    let offset = (jitter_seed % period_secs as u64) as i64;
+    let shifted = now.timestamp() + offset;
+    let bucket_start = shifted.div_euclid(period_secs) * period_secs - offset;
+
+    DateTime::from_timestamp(bucket_start, 0).unwrap_or(now)
 }
 
-fn floor_datetime(dt: DateTime<Utc>, duration: Duration) -> Result<DateTime<Utc>, RoundingError> {
-    let rounded = dt.duration_round(duration)?;
+/// Stable per-identity hash used to spread definition rollovers across the flooring period.
+///
+/// Hand-rolled FNV-1a rather than a standard library or `ahash` hasher because the offset has to
+/// be identical on every pod, across restarts, and across dependency upgrades. `DefaultHasher` and
+/// `ahash`'s default state are randomized per process, and any change to the hash shifts every
+/// key's boundary at once, which is the synchronized rewrite the offset exists to prevent.
+pub fn last_seen_jitter_seed(team_id: i32, name: &str) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
-    // If we rounded up
-    if rounded > dt {
-        Ok(rounded - duration)
-    } else {
-        Ok(rounded)
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in team_id.to_le_bytes().iter().chain(name.as_bytes()) {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
     }
+    hash
 }
 
 // We impose some limits on some fields for legacy reasons, and drop updates that don't conform to them
@@ -586,7 +635,9 @@ impl EventDefinition {
             self.name,
             self.team_id,
             self.project_id,
-            Utc::now() // We floor the update datetime to the nearest day for cache purposes, but can insert the exact time we see the event
+            // last_seen_at is floored only to bound how often we re-issue this write; the stored
+            // value is the real time we saw the event.
+            Utc::now()
         ).execute(executor).await.map(|_| ());
 
         metrics::counter!(UPDATES_ISSUED, &[("type", "event_definition")]).increment(1);

--- a/rust/property-defs-rs/src/types.rs
+++ b/rust/property-defs-rs/src/types.rs
@@ -573,11 +573,20 @@ pub const DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS: i64 = 3600;
 /// the boundary, on a table that already struggles to keep autovacuum ahead of its dead tuples.
 ///
 /// The result always falls in `(now - period, now]`, matching un-jittered flooring, so it can
-/// never produce a future timestamp. A non-positive period disables flooring entirely.
+/// never produce a future timestamp.
+///
+/// A non-positive period is treated as `DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS` rather than
+/// disabling flooring. With flooring off, every event's `last_seen_at` is unique, the dedup
+/// cache filters nothing, and the full event stream reaches `posthog_eventdefinition` as row
+/// updates, so "disabled" must not be expressible here at all. Config validation at startup
+/// rejects non-positive values loudly; this clamp is the backstop for any caller that does
+/// not go through `Config`.
 pub fn floor_last_seen(now: DateTime<Utc>, period_secs: i64, jitter_seed: u64) -> DateTime<Utc> {
-    if period_secs <= 0 {
-        return now;
-    }
+    let period_secs = if period_secs > 0 {
+        period_secs
+    } else {
+        DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS
+    };
 
     let offset = (jitter_seed % period_secs as u64) as i64;
     let shifted = now.timestamp() + offset;

--- a/rust/property-defs-rs/tests/producer_loop.rs
+++ b/rust/property-defs-rs/tests/producer_loop.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use rdkafka::producer::FutureRecord;
+use serde_json::json;
+
+use common_kafka::kafka_consumer::SingleTopicConsumer;
+use property_defs_rs::{
+    config::Config, measuring_channel::measuring_channel, types::Update, update_cache::Cache,
+    update_producer_loop,
+};
+
+const TOPIC: &str = "propdefs-lull-drain-topic";
+const DRAIN_SECS: u64 = 1;
+
+fn test_lifecycle_handle() -> lifecycle::Handle {
+    let mut manager = lifecycle::Manager::builder("test").build();
+    manager.register("producer", lifecycle::ComponentOptions::new())
+}
+
+// A partial compaction batch has to reach the channel once its partition goes quiet. The loop only
+// re-evaluates its flush condition when it wakes, so without the timer arm it parks in
+// json_recv() after consuming an event and the batch sits there until traffic resumes.
+//
+// Two details make this test actually exercise that path rather than passing by accident.
+// compaction_batch_size is far above one event's worth of updates, so size can never trigger the
+// flush. And the assertion is on a *second* event, produced after the first batch has drained:
+// the first event arrives while the consumer is still joining the group, several seconds after
+// `last_send` was initialised, so its flush check passes on elapsed time alone and proves nothing.
+// By the second event the consumer is warm and `last_send` was just reset, so elapsed is well
+// under the drain interval and only the timer can get that batch out.
+#[tokio::test]
+async fn test_producer_flushes_a_partial_batch_when_events_stop_arriving() {
+    let (cluster, producer) = common_kafka::test::create_mock_kafka().await;
+    cluster.create_topic(TOPIC, 1, 1).expect("create topic");
+
+    let mut config = Config::init_with_defaults().unwrap();
+    config.kafka.kafka_hosts = cluster.bootstrap_servers();
+    config.consumer.kafka_consumer_topic = TOPIC.to_string();
+    config.consumer.kafka_consumer_group = "propdefs-lull-drain-group".to_string();
+    config.consumer.kafka_consumer_offset_reset = "earliest".to_string();
+    config.compaction_batch_size = 10_000;
+    config.producer_drain_interval_secs = DRAIN_SECS;
+
+    let send = |event: &'static str| {
+        let payload = json!({
+            "team_id": 111,
+            "project_id": 111,
+            "event": event,
+            "properties": r#"{"$browser":"Chrome"}"#,
+        })
+        .to_string();
+        let producer = producer.clone();
+        async move {
+            producer
+                .send_result(FutureRecord::to(TOPIC).key("k").payload(&payload))
+                .expect("enqueue")
+                .await
+                .expect("delivery")
+                .expect("delivered");
+        }
+    };
+
+    let consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone()).unwrap();
+    let cache = Arc::new(Cache::new(1000, 1000, 1000));
+    let (tx, mut rx) = measuring_channel::<Update>(1000);
+
+    let handle = test_lifecycle_handle();
+    let loop_task = tokio::spawn(update_producer_loop(
+        config.clone(),
+        consumer,
+        cache,
+        tx,
+        handle.clone(),
+    ));
+
+    // First event: gets the consumer joined and the batch drained once, which resets `last_send`.
+    send("$pageview").await;
+    await_event_definition(&mut rx, "$pageview").await;
+
+    // Second event, on a warm consumer. Nothing else will arrive, so the timer is the only thing
+    // that can flush this one.
+    send("$identify").await;
+    await_event_definition(&mut rx, "$identify").await;
+
+    // Drop the consumer inside the task. Left running, its drop lands on runtime teardown, where
+    // librdkafka's synchronous close adds ~45s. Cancel the token directly rather than calling
+    // request_shutdown(): that routes through the lifecycle Manager, which this test doesn't run.
+    handle.shutdown_token().cancel();
+    tokio::time::timeout(Duration::from_secs(30), loop_task)
+        .await
+        .expect("producer loop did not observe the shutdown signal")
+        .expect("producer loop panicked");
+}
+
+// Reads until the named event's definition shows up. The compaction batch is an AHashSet, so a
+// flush delivers its updates in arbitrary order, and one event yields property rows alongside the
+// definition. The timeout is generous against mock-broker startup while staying far below the
+// point where a missing timer arm could be mistaken for slowness.
+async fn await_event_definition(
+    rx: &mut property_defs_rs::measuring_channel::MeasuringReceiver<Update>,
+    event: &str,
+) {
+    let deadline = Duration::from_secs(30);
+    let found = tokio::time::timeout(deadline, async {
+        loop {
+            let update = rx.recv().await.expect("producer channel closed");
+            if matches!(&update, Update::Event(ed) if ed.name == event && ed.team_id == 111) {
+                return;
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        found.is_ok(),
+        "no event definition for {event} was flushed within {deadline:?}"
+    );
+}

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use property_defs_rs::types::{
     detect_property_type, floor_last_seen, last_seen_jitter_seed, Event, PropertyValueType, Update,
+    DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS,
 };
 use rstest::rstest;
 use serde_json::{json, Map, Number, Value};
@@ -27,11 +28,17 @@ fn test_floor_last_seen_lands_in_the_current_window(#[case] period_secs: i64) {
     }
 }
 
-// The whole point of the period is that it reaches the dedup key. EventDefinition's Hash and Eq
-// both cover last_seen_at, so two periods must produce keys that don't compare equal, and the
-// default entry point has to agree with the documented default period.
+// The whole point of the period is that it reaches the dedup key: EventDefinition's Hash and Eq
+// both cover last_seen_at. Asserting hourly != daily keys here would be wrong, because the daily
+// window start is always also an hourly window start (3600 divides 86400 and both offsets are the
+// seed mod 3600), so the two keys legitimately coincide for one hour of every day. Instead,
+// compute the expected window independently and bracket Utc::now(): this can never false-fail,
+// and if the period stops reaching floor_last_seen it fails whenever the default and requested
+// windows differ, which is 23 of every 24 hours.
 #[test]
-fn test_flooring_period_changes_the_event_definition_dedup_key() {
+fn test_flooring_period_reaches_the_event_definition_dedup_key() {
+    const DAILY: i64 = 86400;
+
     let event = || Event {
         team_id: 111,
         project_id: 111,
@@ -44,17 +51,25 @@ fn test_flooring_period_changes_the_event_definition_dedup_key() {
         other => panic!("expected an event definition first, got {other:?}"),
     };
 
-    let hourly = def_of(event().into_updates_with(10_000, 3600));
-    let daily = def_of(event().into_updates_with(10_000, 86400));
+    let before = Utc::now();
+    let daily = def_of(event().into_updates_with(10_000, DAILY));
     let defaulted = def_of(event().into_updates(10_000));
+    let after = Utc::now();
 
-    assert_ne!(
-        hourly, daily,
-        "a coarser period must produce a different dedup key, or it cannot reduce writes"
+    let seed = last_seen_jitter_seed(111, "$pageview");
+    assert!(
+        daily.last_seen_at == floor_last_seen(before, DAILY, seed)
+            || daily.last_seen_at == floor_last_seen(after, DAILY, seed),
+        "the explicit period must reach floor_last_seen, got {}",
+        daily.last_seen_at
     );
-    assert_eq!(
-        hourly, defaulted,
-        "into_updates must agree with the documented default period"
+    assert!(
+        defaulted.last_seen_at
+            == floor_last_seen(before, DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS, seed)
+            || defaulted.last_seen_at
+                == floor_last_seen(after, DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS, seed),
+        "into_updates must floor at the documented default period, got {}",
+        defaulted.last_seen_at
     );
 }
 
@@ -119,14 +134,20 @@ fn test_window_advances_by_exactly_one_period() {
     }
 }
 
-// The period is env-driven, so a misconfigured deploy has to degrade to "no flooring" rather than
-// producing a nonsense window or dividing by zero on every event.
+// "No flooring" must not be expressible: an unfloored last_seen_at makes every event a unique
+// dedup key, so the cache filters nothing and the full event stream reaches
+// posthog_eventdefinition as row updates. Startup validation rejects a non-positive config
+// value loudly; this pins the function-level backstop that clamps to the default instead of
+// dividing by zero or passing the value through.
 #[rstest]
 #[case(0)]
 #[case(-1)]
-fn test_non_positive_period_disables_flooring(#[case] period_secs: i64) {
+fn test_non_positive_period_floors_at_the_default(#[case] period_secs: i64) {
     let now = Utc::now();
-    assert_eq!(floor_last_seen(now, period_secs, 12345), now);
+    assert_eq!(
+        floor_last_seen(now, period_secs, 12345),
+        floor_last_seen(now, DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS, 12345)
+    );
 }
 
 #[test]

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use property_defs_rs::types::{
     detect_property_type, floor_last_seen, last_seen_jitter_seed, Event, PropertyValueType, Update,
-    DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS,
+    DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS, MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS,
 };
 use rstest::rstest;
 use serde_json::{json, Map, Number, Value};
@@ -148,6 +148,29 @@ fn test_non_positive_period_floors_at_the_default(#[case] period_secs: i64) {
         floor_last_seen(now, period_secs, 12345),
         floor_last_seen(now, DEFAULT_EVENTDEF_LAST_SEEN_FLOOR_SECS, 12345)
     );
+}
+
+// The same hazard from the other end. An uncapped period lets the jitter offset push bucket_start
+// outside chrono's representable range, and the resulting fallback hands back an unfloored `now` —
+// a unique dedup key per event, which is exactly the write amplification flooring exists to stop.
+#[rstest]
+#[case(MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS + 1)]
+#[case(i64::MAX)]
+fn test_oversized_period_floors_at_the_maximum(#[case] period_secs: i64) {
+    let now = Utc::now();
+
+    for seed in [0, 12345, u64::MAX] {
+        let floored = floor_last_seen(now, period_secs, seed);
+        assert_eq!(
+            floored,
+            floor_last_seen(now, MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS, seed),
+            "seed {seed} did not clamp to the maximum period"
+        );
+        assert!(
+            floored <= now && (now - floored).num_seconds() < MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS,
+            "seed {seed} floored outside the current window"
+        );
+    }
 }
 
 #[test]

--- a/rust/property-defs-rs/tests/types.rs
+++ b/rust/property-defs-rs/tests/types.rs
@@ -1,25 +1,132 @@
 use chrono::Utc;
 use property_defs_rs::types::{
-    detect_property_type, get_floored_last_seen, Event, PropertyValueType, Update,
+    detect_property_type, floor_last_seen, last_seen_jitter_seed, Event, PropertyValueType, Update,
 };
 use rstest::rstest;
 use serde_json::{json, Map, Number, Value};
 
+// The floored value is a dedup key, so what matters is which window it identifies, not that it
+// lands on a round clock boundary (per-identity jitter means it usually won't). It must stay in
+// (now - period, now]: a future value would defeat the write path's
+// `last_seen_at < EXCLUDED.last_seen_at` guard, and one a full period old would re-issue the
+// definition's write early.
+#[rstest]
+#[case(3600)]
+#[case(86400)]
+fn test_floor_last_seen_lands_in_the_current_window(#[case] period_secs: i64) {
+    let now = Utc::now();
+
+    for seed in [0, 1, 12345, u64::MAX] {
+        let floored = floor_last_seen(now, period_secs, seed);
+        assert!(floored <= now, "seed {seed} produced a future timestamp");
+        assert!(
+            now - floored < chrono::Duration::seconds(period_secs),
+            "seed {seed} produced a timestamp a full period old"
+        );
+        assert_eq!(floored.timestamp_subsec_nanos(), 0);
+    }
+}
+
+// The whole point of the period is that it reaches the dedup key. EventDefinition's Hash and Eq
+// both cover last_seen_at, so two periods must produce keys that don't compare equal, and the
+// default entry point has to agree with the documented default period.
 #[test]
-fn test_date_flooring() {
-    use chrono::Timelike;
+fn test_flooring_period_changes_the_event_definition_dedup_key() {
+    let event = || Event {
+        team_id: 111,
+        project_id: 111,
+        event: "$pageview".to_string(),
+        properties: None,
+    };
+
+    let def_of = |updates: Vec<Update>| match updates.into_iter().next().unwrap() {
+        Update::Event(ed) => ed,
+        other => panic!("expected an event definition first, got {other:?}"),
+    };
+
+    let hourly = def_of(event().into_updates_with(10_000, 3600));
+    let daily = def_of(event().into_updates_with(10_000, 86400));
+    let defaulted = def_of(event().into_updates(10_000));
+
+    assert_ne!(
+        hourly, daily,
+        "a coarser period must produce a different dedup key, or it cannot reduce writes"
+    );
+    assert_eq!(
+        hourly, defaulted,
+        "into_updates must agree with the documented default period"
+    );
+}
+
+// Jitter has to be a pure function of the identity: every pod computes it independently, and if
+// they disagree the same definition gets written once per pod per period instead of once.
+#[test]
+fn test_jitter_seed_is_stable_and_identity_scoped() {
+    assert_eq!(
+        last_seen_jitter_seed(111, "$pageview"),
+        last_seen_jitter_seed(111, "$pageview")
+    );
+    assert_ne!(
+        last_seen_jitter_seed(111, "$pageview"),
+        last_seen_jitter_seed(112, "$pageview")
+    );
+    assert_ne!(
+        last_seen_jitter_seed(111, "$pageview"),
+        last_seen_jitter_seed(111, "$identify")
+    );
+}
+
+// This is the test that guards the reason jitter exists. Un-jittered, every key in the fleet rolls
+// over at the same instant, so a coarse period dumps a period's worth of definition writes into
+// the moments after the boundary. Spreading window starts across the period turns that burst into
+// a steady trickle.
+#[test]
+fn test_jitter_spreads_window_starts_across_the_period() {
+    const PERIOD: i64 = 86400;
+    const BUCKETS: i64 = 24;
 
     let now = Utc::now();
-    let rounded = get_floored_last_seen();
+    let mut occupied = std::collections::HashSet::new();
+    for team_id in 0..2000 {
+        let seed = last_seen_jitter_seed(team_id, "$pageview");
+        let age = now.timestamp() - floor_last_seen(now, PERIOD, seed).timestamp();
+        occupied.insert(age / (PERIOD / BUCKETS));
+    }
 
-    // Time should be rounded to the nearest hour
-    assert_eq!(rounded.minute(), 0);
-    assert_eq!(rounded.second(), 0);
-    assert_eq!(rounded.nanosecond(), 0);
-    assert!(rounded <= now);
+    assert_eq!(
+        occupied.len() as i64,
+        BUCKETS,
+        "expected window starts in all {BUCKETS} sub-ranges of the period, got {occupied:?}"
+    );
+}
 
-    // The difference between now and rounded should be less than 1 hour
-    assert!(now - rounded < chrono::Duration::hours(1));
+// Advancing by exactly one period must advance the window by exactly one period, for every
+// identity. An off-by-one here re-issues writes twice per period, or skips one entirely.
+#[test]
+fn test_window_advances_by_exactly_one_period() {
+    const PERIOD: i64 = 86400;
+    let now = Utc::now();
+
+    for team_id in 0..50 {
+        let seed = last_seen_jitter_seed(team_id, "$pageview");
+        let first = floor_last_seen(now, PERIOD, seed);
+        let next = floor_last_seen(now + chrono::Duration::seconds(PERIOD), PERIOD, seed);
+        assert_eq!(
+            (next - first).num_seconds(),
+            PERIOD,
+            "team {team_id} did not advance by exactly one period"
+        );
+    }
+}
+
+// The period is env-driven, so a misconfigured deploy has to degrade to "no flooring" rather than
+// producing a nonsense window or dividing by zero on every event.
+#[rstest]
+#[case(0)]
+#[case(-1)]
+fn test_non_positive_period_disables_flooring(#[case] period_secs: i64) {
+    let now = Utc::now();
+    assert_eq!(floor_last_seen(now, period_secs, 12345), now);
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Two separable propdefs changes, both extracted from the stale #65112 and rebuilt on current master. They were originally split across #77926 (this PR) and #77929; #77929 has been folded in here because both rewrite the same region of `update_producer_loop`, so keeping them together resolves the overlap once instead of through a risky post-merge rebase.

### 1. The producer drain timer

Each propdefs producer keeps a local compaction batch and flushes it when it fills or when 10s have passed. The size check works. The time check effectively does not, because the loop only ever reaches it after receiving an event:

```rust
let recv_result = tokio::select! {
    _ = handle.shutdown_recv() => { ... return; }
    r = consumer.json_recv() => r,
};
// ... decompose the event ...
if batch.len() >= config.compaction_batch_size || last_send.elapsed() > Duration::from_secs(10) { ... }
```

With only those two arms, the loop parks inside `json_recv()` when nothing is arriving. So a partial batch left behind when a partition goes quiet is not written until traffic resumes on that partition, however long that takes.

> [!NOTE]
> This is close to a no-op in production and I don't want to oversell it. All 128 partitions of `team_event_partitioned_events_json` carry traffic, and `prop_defs_forced_small_batch` never appears in either region, so batches fill. It matters for dev, for traffic dips, and it removes a latent tail-latency cliff.

### 2. The event-def dedup period

`EventDefinition`'s `last_seen_at` participates in its `Hash` and `Eq`, so the period it's floored to is what bounds how often we re-issue the definition's write: once per (team, name) per period, per pod. That period was hardcoded to an hour.

The floored value never reaches Postgres. The write path binds a fresh `Utc::now()` per attempt (`batch_ingestion.rs`), so a coarser period buys proportionally fewer writes in exchange for a staler stored `last_seen_at`, and nothing else.

That trade is worth taking. In prod-us `posthog_eventdefinition` absorbs about **763 row-updates/s (66M/day)** against roughly 2 genuinely new definitions/s, and sits at ~10% dead tuples with autovacuum never quite catching up.

## Changes

### Producer drain

- Add a timer arm to the producer `select!` so the flush check runs on a tick as well as on an event. `recv_result` becomes an `Option`, and the receive-and-decompose body moves inside an `if let Some(...)`. The tick period (1s) is deliberately independent of the drain interval: it bounds how often the elapsed check is re-evaluated, not how long a batch may sit.
- Replace the hardcoded 10s with `PRODUCER_DRAIN_INTERVAL_SECS`, default 10, so drain latency is tunable per environment without a code change.

Two things I deliberately did **not** take from #65112, where this originated:

- It also guarded the flush with `!batch.is_empty()`. That looks harmless but is a regression once the timer exists. With the guard, an idle period leaves `last_send` un-reset, so the first update after the lull is immediately over the interval and flushes on its own, and so does the next, until a batch fills. Compaction stops working for exactly the low-traffic partitions this is meant to help. Leaving the condition alone means an idle tick enters the block, resets `last_send`, drains nothing, and keeps the window anchored to now.
- It rewrote the compaction insert from `contains`-then-`insert` into `if !batch.insert(update)`. Behavior-identical and unrelated, so it stays out.

### Event-def dedup period

**1. The period becomes `EVENTDEF_LAST_SEEN_FLOOR_SECS`, default 3600.** The default is unchanged, so merging this changes nothing about write volume. Raising it is a charts change, per environment, revertable without a deploy.

**2. Each identity's window is offset by a stable hash of (team_id, name).** This is not in the original PR and it is the reason the knob is safe to turn.

Without it, every pod floors on the same wall-clock instant, so each rollover makes the whole active keyspace writable at once. Hourly that's absorbed. At 86400 it would collapse a day's definition writes into the minutes after UTC midnight: roughly 2.75M row-updates arriving as a burst instead of a steady 763/s, onto a table already fighting its dead tuples, whose multixact age is growing ~7x/day. Shipping the knob without the offset would be handing someone a footgun in a values file.

```rust
let offset = (jitter_seed % period_secs as u64) as i64;
let shifted = now.timestamp() + offset;
let bucket_start = shifted.div_euclid(period_secs) * period_secs - offset;
```

The result still lands in `(now - period, now]`, same as plain flooring, so it can never be a future timestamp.

The hash is hand-rolled FNV-1a rather than `DefaultHasher` or `ahash`. Both of those are randomized per process, and the offset has to agree across every pod and every restart. It also needs to survive dependency upgrades, since any change to the hash shifts every key's boundary at once, which is precisely the synchronized rewrite the offset exists to prevent.

Incidentally this removes `floor_datetime`, whose "round then subtract if we rounded up" dance and `.unwrap()` on a `RoundingError` are both unnecessary with plain timestamp arithmetic.

**A non-positive period is rejected, not honored.** An earlier revision had `0` disable flooring, which review flagged as the worst possible failure mode reachable from an env var typo: unfloored, every event's `last_seen_at` is a unique dedup key, the cache filters nothing, and the full event stream (~49k events/s per region vs the current ~763 writes/s) lands on `posthog_eventdefinition` as row updates. Now startup fails with an explicit error on a non-positive `EVENTDEF_LAST_SEEN_FLOOR_SECS` (halting the rollout, matching envconfig's existing behavior for unparseable values), and `floor_last_seen` clamps to the default as a backstop for callers that bypass `Config`.

**The period is capped at 30 days for the same reason.** Automated review pointed out the hazard was still reachable from the other end: with an uncapped period the jitter offset can push `bucket_start` outside chrono's representable range, `DateTime::from_timestamp` returns `None`, and the fallback hands back an unfloored `now` — the identical write-amplification path, arrived at silently. The bound now applies in both the startup validation and the function-level clamp, which keeps the offset under a month of seconds so the arithmetic can neither overflow nor leave the range, making that fallback unreachable rather than merely unlikely.

> [!NOTE]
> Behavior at the default is unchanged except for jitter, which changes *when* an hourly window rolls over per key but not how many writes it produces. That is a real behavior change, which is why it's a `feat` and not folded silently into a "just add a knob".

### Charts

Both env vars (`PRODUCER_DRAIN_INTERVAL_SECS` and `EVENTDEF_LAST_SEEN_FLOOR_SECS`) are wired into the bespoke and golden charts by PostHog/charts#13910, which also stages 7200 (2h, ~2x fewer definition writes, safely inside the 3h window below) for prod. That value is inert until this PR deploys, so the jitter is validated against production traffic at the unchanged hourly default before 7200 takes effect.

## How did you test this code?

I'm an agent, directed by @eli-r-ph. Automated tests only, no manual or staging verification.

**Producer drain** — `tests/producer_loop.rs` drives the real `update_producer_loop` against `common_kafka`'s in-process `MockCluster`, so it needs no broker. Getting it to actually cover the bug took two corrections, because the obvious version passes for the wrong reason:

1. Asserting on a single event **passed with the timer arm stubbed out**. The consumer spends ~4s joining the group, so by the time the first event is processed `last_send.elapsed()` already exceeds the drain interval and the flush fires on elapsed time alone. That tests startup, not a lull.
2. The fix is to assert on a *second* event, produced once the first batch has drained and `last_send` has been reset. The consumer is warm by then, so elapsed is well under the interval and the timer is the only thing that can flush it.

<details>
<summary>Failure with the timer arm stubbed out</summary>

```
---- test_producer_flushes_a_partial_batch_when_events_stop_arriving stdout ----
panicked at property-defs-rs/tests/producer_loop.rs:115:5:
no event definition for $identify was flushed within 30s
```

</details>

The test cancels the lifecycle shutdown token and awaits the loop at the end. Without that, the Kafka consumer is dropped during runtime teardown, where librdkafka's synchronous close adds ~45s; it runs in 5.8s now.

**Event-def dedup period** — six tests, each aimed at a specific failure:

| Test | Catches |
|---|---|
| `test_floor_last_seen_lands_in_the_current_window` | a sign error putting `last_seen_at` in the future, which would defeat the write path's `last_seen_at < EXCLUDED.last_seen_at` guard |
| `test_flooring_period_reaches_the_event_definition_dedup_key` | the period not actually reaching the dedup key, i.e. the knob doing nothing |
| `test_jitter_seed_is_stable_and_identity_scoped` | a per-process or non-identity-scoped hash |
| `test_jitter_spreads_window_starts_across_the_period` | the burst this PR exists to prevent: 2000 identities must occupy all 24 sub-ranges of a day |
| `test_window_advances_by_exactly_one_period` | an off-by-one that re-issues twice per period or skips one |
| `test_non_positive_period_floors_at_the_default` | someone reintroducing "0 disables flooring", i.e. the write-amplification path above |
| `test_oversized_period_floors_at_the_maximum` | the same path via an uncapped period, where an out-of-range bucket falls back to an unfloored `now` (verified failing without the cap) |

I verified the spread test is load-bearing by forcing the offset to zero: it fails, and nothing else does. One flake, found by an actual failing run and fixed: the dedup-key test originally asserted hourly != daily keys, but a daily window start is always also an hourly window start (3600 divides 86400 and both jitter offsets are the seed mod 3600), so the two keys legitimately coincide for one hour of every day and the assert fired during that hour — a ~4% CI flake. The test now computes the expected window independently via `floor_last_seen` with `Utc::now()` bracketed on both sides, which can never false-fail; a period-plumbing regression still fails it 23 of every 24 hours.

**Full suite under flox's 1.91.1 (the CI toolchain):** `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean, 77 tests pass across all `property-defs-rs` targets. This retires the earlier "compiled with rustup 1.96.0" caveat.

I did **not** port `tests/write_amplification.rs` from the original branch, which the plan called for. It's a 118-line DB-backed harness asserting the row-write reduction, but it duplicates what the unit tests above already prove about the mechanism, leans on a process-global metrics recorder shared across parallel tests, and interacts awkwardly with jittered windows. It didn't clear the bar in `/writing-tests`.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @eli-r-ph.

Extracted from the stale #65112, which bundles five separable propdefs changes; these are two of them, rebuilt onto current master and folded together here (they touch the same region of `update_producer_loop`).

Two deliberate departures from #65112 on the dedup-period change:

- It defaulted the period to **86400**. I kept 3600. Two reasons: the midnight burst above, which it had no mechanism for; and a consumer it missed — the `generate-event-screenshots` Temporal workflow shortlists event types with `ed.last_seen_at > now() - INTERVAL '3' HOUR`, so any period past ~3h makes that predicate match almost nothing and the custom-event image previews quietly stop being produced. That workflow appears in none of `posthog/temporal/schedule.py`, any charts CronJob, or any cron in either repo, so it may well be dormant, but "probably dormant" isn't a reason to default a knob to a value that breaks it.
- The jitter formulation comes from the propdefs redesign design doc rather than from #65112.

Skills invoked: `/writing-code-comments`, `/writing-tests`, and `/stacking-prs`.
