### PR TITLE
fix(propdefs): correct the channel gauges and write-latency buckets

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9256,7 +9256,6 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "serve-metrics",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/rust/property-defs-rs/Cargo.toml
+++ b/rust/property-defs-rs/Cargo.toml
@@ -15,7 +15,6 @@ sqlx = { workspace = true }
 futures = { workspace = true }
 lifecycle = { path = "../common/lifecycle" }
 axum = { workspace = true }
-serve-metrics = { path = "../common/serve_metrics" }
 metrics = { workspace = true }
 chrono = { workspace = true }
 quick_cache = { workspace = true }

--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -28,6 +28,7 @@ pub mod batch_ingestion;
 pub mod config;
 pub mod group_type_resolver;
 pub mod measuring_channel;
+pub mod metrics_buckets;
 pub mod metrics_consts;
 pub mod types;
 pub mod update_cache;

--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -8,13 +8,14 @@ use property_defs_rs::{
     app_context::AppContext,
     config::Config,
     measuring_channel::measuring_channel,
-    metrics_consts::CHANNEL_CAPACITY,
+    metrics_buckets::bucket_overrides,
+    metrics_consts::{CHANNEL_CAPACITY, CHANNEL_CAPACITY_TOTAL},
     types::MAX_EVENTDEF_LAST_SEEN_FLOOR_SECS,
     update_cache::Cache,
     update_consumer_loop, update_producer_loop,
 };
 
-use serve_metrics::setup_metrics_routes;
+use common_metrics::setup_metrics_routes_with_overrides;
 use sqlx::postgres::PgPoolOptions;
 use tokio::net::TcpListener;
 use tracing::level_filters::LevelFilter;
@@ -133,13 +134,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     drop(producer_handle);
 
-    // Publish the tx capacity metric every 10 seconds
+    // Publish the tx capacity metrics every 10 seconds. Both are needed to read occupancy:
+    // `capacity()` is remaining slots, `max_capacity()` is the channel size.
     tokio::spawn({
         let tx = tx.clone();
         async move {
             loop {
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 metrics::gauge!(CHANNEL_CAPACITY).set(tx.capacity() as f64);
+                metrics::gauge!(CHANNEL_CAPACITY_TOTAL).set(tx.max_capacity() as f64);
             }
         }
     });
@@ -178,7 +181,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }),
         );
     let app = apply_routes(app, context);
-    let app = setup_metrics_routes(app);
+    let app = setup_metrics_routes_with_overrides(app, &bucket_overrides());
 
     let bind = format!("{}:{}", config.host, config.port);
     info!(address = %bind, "HTTP server starting");

--- a/rust/property-defs-rs/src/measuring_channel.rs
+++ b/rust/property-defs-rs/src/measuring_channel.rs
@@ -37,18 +37,24 @@ pub fn measuring_channel<T>(capacity: usize) -> (MeasuringSender<T>, MeasuringRe
 }
 
 impl<T> MeasuringSender<T> {
+    // Both senders count the message *before* handing it to the channel. Counting afterwards
+    // leaves a window where the receiver has already dequeued the item and decremented, so the
+    // subtraction runs first and wraps the unsigned counter to usize::MAX, where the gauge then
+    // sits forever. On failure the item never entered the channel, so take the count back.
     pub fn try_send(&self, item: T) -> Result<(), TrySendError<T>> {
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
         let res = self.sender.try_send(item);
-        if res.is_ok() {
-            self.in_flight.fetch_add(1, Ordering::Relaxed);
+        if res.is_err() {
+            self.in_flight.fetch_sub(1, Ordering::Relaxed);
         }
         res
     }
 
     pub async fn send(&self, item: T) -> Result<(), SendError<T>> {
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
         let res = self.sender.send(item).await;
-        if res.is_ok() {
-            self.in_flight.fetch_add(1, Ordering::Relaxed);
+        if res.is_err() {
+            self.in_flight.fetch_sub(1, Ordering::Relaxed);
         }
         res
     }
@@ -57,8 +63,15 @@ impl<T> MeasuringSender<T> {
         self.in_flight.load(Ordering::Relaxed)
     }
 
+    /// Slots still free. Note this is *remaining* capacity, not the channel's size; pair it with
+    /// `max_capacity` to express occupancy.
     pub fn capacity(&self) -> usize {
         self.sender.capacity()
+    }
+
+    /// The channel's total size, which is fixed at construction.
+    pub fn max_capacity(&self) -> usize {
+        self.sender.max_capacity()
     }
 
     pub fn inner(&self) -> &Sender<T> {

--- a/rust/property-defs-rs/src/metrics_buckets.rs
+++ b/rust/property-defs-rs/src/metrics_buckets.rs
@@ -7,6 +7,12 @@
 //! distribution lands in the overflow bucket and no quantile over it is meaningful.
 //!
 //! Wired in at startup via `common_metrics::setup_metrics_routes_with_overrides`.
+//!
+//! One unit trap to know about: `http_requests_duration_seconds`, recorded by the
+//! `common_metrics` axum middleware, observes seconds while the default ladder is
+//! millisecond-shaped, so every sub-second request collapses into the first bucket. That is
+//! harmless while this service's HTTP surface is only `/metrics` and the probes, but if a real
+//! API endpoint ever ships here it needs a seconds-shaped override in this list.
 
 use common_metrics::Matcher;
 

--- a/rust/property-defs-rs/src/metrics_buckets.rs
+++ b/rust/property-defs-rs/src/metrics_buckets.rs
@@ -1,0 +1,53 @@
+//! Histogram bucket overrides for `property-defs-rs`.
+//!
+//! `common-metrics`' default ladder is millisecond-shaped and tops out at 10s, which suits the
+//! per-chunk write timings. It does not suit `prop_defs_batch_acquire_time_ms`, which measures how
+//! long the consumer waits for a batch to fill and is therefore bounded by `max_issue_period`
+//! (500s in production), not by any database operation. Left on the default ladder its whole
+//! distribution lands in the overflow bucket and no quantile over it is meaningful.
+//!
+//! Wired in at startup via `common_metrics::setup_metrics_routes_with_overrides`.
+
+use common_metrics::Matcher;
+
+use crate::metrics_consts::{
+    BATCH_ACQUIRE_TIME, V2_EVENT_DEFS_BATCH_WRITE_TIME, V2_EVENT_PROPS_BATCH_WRITE_TIME,
+    V2_PROP_DEFS_BATCH_WRITE_TIME,
+};
+
+// Batch-acquire spans "the channel already had a full batch waiting" to "we sat here until
+// max_issue_period expired", so the ladder has to cover sub-millisecond through the 500s
+// production timeout. Coarse at the top: past a minute the only question is which order of
+// magnitude.
+const BATCH_ACQUIRE_BUCKETS_MS: &[f64] = &[
+    1.0, 10.0, 100.0, 500.0, 1_000.0, 5_000.0, 10_000.0, 30_000.0, 60_000.0, 120_000.0, 300_000.0,
+    600_000.0,
+];
+
+// Per-chunk write times run in the hundreds of milliseconds normally. The 30s ceiling leaves room
+// for a stalled Postgres plus this path's three retries and their backoff, which the default 10s
+// ceiling would swallow.
+const BATCH_WRITE_BUCKETS_MS: &[f64] = &[
+    1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 30_000.0,
+];
+
+pub fn bucket_overrides() -> Vec<(Matcher, &'static [f64])> {
+    vec![
+        (
+            Matcher::Full(BATCH_ACQUIRE_TIME.to_string()),
+            BATCH_ACQUIRE_BUCKETS_MS,
+        ),
+        (
+            Matcher::Full(V2_EVENT_DEFS_BATCH_WRITE_TIME.to_string()),
+            BATCH_WRITE_BUCKETS_MS,
+        ),
+        (
+            Matcher::Full(V2_EVENT_PROPS_BATCH_WRITE_TIME.to_string()),
+            BATCH_WRITE_BUCKETS_MS,
+        ),
+        (
+            Matcher::Full(V2_PROP_DEFS_BATCH_WRITE_TIME.to_string()),
+            BATCH_WRITE_BUCKETS_MS,
+        ),
+    ]
+}

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -30,7 +30,10 @@ pub const CHUNK_SIZE: &str = "prop_defs_chunk_size";
 pub const DUPLICATES_IN_BATCH: &str = "prop_defs_duplicates_in_batch";
 pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_ms";
 pub const CHANNEL_MESSAGES_IN_FLIGHT: &str = "prop_defs_channel_messages_in_flight";
+// Remaining free slots, not the channel size. CHANNEL_CAPACITY_TOTAL carries the size, so
+// occupancy is 1 - (capacity / capacity_total).
 pub const CHANNEL_CAPACITY: &str = "prop_defs_channel_capacity";
+pub const CHANNEL_CAPACITY_TOTAL: &str = "prop_defs_channel_capacity_total";
 
 pub const ISOLATED_PROPDEFS_DB_SELECTED: &str = "isolated_propdefs_db_selected";
 

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -20,15 +20,12 @@ pub const UPDATE_PRODUCER_OFFSET: &str = "prop_defs_update_producer_offset";
 pub const GROUP_TYPE_CACHE: &str = "prop_defs_group_type_cache";
 pub const RECV_DEQUEUED: &str = "prop_defs_recv_dequeued";
 pub const COMPACTED_UPDATES: &str = "prop_defs_compaction_dropped_updates";
-pub const UPDATE_TRANSACTION_TIME: &str = "prop_defs_update_transaction_time_ms";
-pub const GROUP_TYPE_RESOLVE_TIME: &str = "prop_defs_group_type_resolve_time_ms";
 pub const UPDATES_SKIPPED: &str = "prop_defs_skipped_updates";
 pub const UPDATES_DROPPED: &str = "prop_defs_dropped_updates";
 pub const SKIPPED_DUE_TO_TEAM_FILTER: &str = "prop_defs_skipped_due_to_team_filter";
 pub const ISSUE_FAILED: &str = "prop_defs_issue_failed";
 pub const CHUNK_SIZE: &str = "prop_defs_chunk_size";
 pub const DUPLICATES_IN_BATCH: &str = "prop_defs_duplicates_in_batch";
-pub const SINGLE_UPDATE_ISSUE_TIME: &str = "prop_defs_single_update_issue_time_ms";
 pub const CHANNEL_MESSAGES_IN_FLIGHT: &str = "prop_defs_channel_messages_in_flight";
 // Remaining free slots, not the channel size. CHANNEL_CAPACITY_TOTAL carries the size, so
 // occupancy is 1 - (capacity / capacity_total).

--- a/rust/property-defs-rs/tests/measuring_channel.rs
+++ b/rust/property-defs-rs/tests/measuring_channel.rs
@@ -1,0 +1,64 @@
+use property_defs_rs::measuring_channel::measuring_channel;
+
+// The in-flight counter is unsigned, so a decrement landing before its matching increment wraps it
+// to usize::MAX, where the gauge then stays for the life of the process. That is what the
+// production gauge was doing.
+//
+// This is a stress test, not a deterministic one: the window only exists across threads, so it
+// takes a real multi-threaded interleaving to hit. Measured over 12 runs each way it catches the
+// old ordering 11 times and never fails against the current one. It is a few milliseconds, so the
+// occasional miss is worth having it in the suite. It cannot false-fail: the bound below is a hard
+// ceiling on a correct implementation, not a timing guess.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_in_flight_count_never_underflows_under_interleaved_send_and_recv() {
+    const CAPACITY: usize = 8;
+    const ROUNDS: usize = 2_000;
+
+    let (tx, mut rx) = measuring_channel::<u64>(CAPACITY);
+
+    let sender = tokio::spawn({
+        let tx = tx.clone();
+        async move {
+            for i in 0..ROUNDS as u64 {
+                tx.send(i).await.expect("receiver alive");
+            }
+        }
+    });
+
+    for _ in 0..ROUNDS {
+        rx.recv().await.expect("sender alive");
+        // A message is counted from submission, so the queued messages plus the one sender
+        // currently blocked inside send() is the true ceiling. What this is really watching for is
+        // a wrapped counter, which lands near usize::MAX and is nowhere near this bound.
+        let in_flight = rx.get_inflight_messages_count();
+        assert!(
+            in_flight <= CAPACITY + 1,
+            "in-flight count {in_flight} is above the ceiling, so the counter wrapped"
+        );
+    }
+
+    sender.await.expect("sender panicked");
+    assert_eq!(
+        rx.get_inflight_messages_count(),
+        0,
+        "every sent message was received, so the counter must be back to zero"
+    );
+}
+
+// A send that fails never reaches the channel, so it must not leave a phantom message counted.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_failed_send_does_not_leak_an_in_flight_count() {
+    let (tx, rx) = measuring_channel::<u64>(1);
+
+    tx.try_send(1).expect("first send fits");
+    assert!(tx.try_send(2).is_err(), "channel should be full");
+    assert_eq!(tx.get_inflight_messages_count(), 1);
+
+    drop(rx);
+    assert!(tx.send(3).await.is_err(), "receiver is gone");
+    assert_eq!(
+        tx.get_inflight_messages_count(),
+        1,
+        "a send to a closed channel must not be counted"
+    );
+}


### PR DESCRIPTION
## Problem

Three defects that together make propdefs' own telemetry useless for judging how the pipeline is behaving. I ran into all three while trying to measure whether the write path or the read path is the bottleneck, and ended up deriving the answer from loop cadence instead because none of these could be trusted.

**1. The in-flight counter wraps.** `MeasuringSender` incremented *after* handing the message to the channel, so a receiver could dequeue it and decrement first. The counter is a `usize`, so that subtraction wraps to `usize::MAX` and the gauge sits there for the life of the process. In production `prop_defs_channel_messages_in_flight` reads 18446744073709550000 in both regions.

**2. `CHANNEL_CAPACITY` is remaining slots, not the channel size.** `Sender::capacity()` returns free slots, so there is no way to turn that gauge into occupancy: a full channel and an empty one are indistinguishable without knowing the denominator.

**3. Every write-latency histogram is right-censored.** The recorder came from `serve_metrics::setup_metrics_recorder`, whose ladder is *seconds*-shaped and stops at 250 (`0.005 … 250`). This service records **milliseconds**, so everything from 250ms up lands in `+Inf`. In prod-us the eventprops write mean alone is ~480ms with 69% of observations above 250ms, so no p95 or p99 over any of these is meaningful.

## Changes

**Count before publishing.** The only ordering that cannot underflow, with the count taken back if the send fails.

```rust
self.in_flight.fetch_add(1, Ordering::Relaxed);
let res = self.sender.try_send(item);
if res.is_err() {
    self.in_flight.fetch_sub(1, Ordering::Relaxed);
}
```

One semantic consequence worth knowing: the gauge now counts messages from submission, so it includes a sender parked inside `send()` and can read up to capacity + number of producers (4 in prod) rather than capping at capacity. On a 10M-slot channel that's noise, and it can no longer wrap.

**Publish the denominator.** New `prop_defs_channel_capacity_total`, so occupancy is `1 - (capacity / capacity_total)`. `prop_defs_channel_capacity` keeps its current meaning and name, since the propdefs Grafana dashboard's "Channel Free Capacity" panel references it. (Correction: an earlier revision of this description said vmalert rules reference it too. That was wrong — the only propdefs metric in any vmalert rule is `prop_defs_issue_failed`.)

**Fix the buckets propdefs-locally, not in the shared crate.** `common_metrics`' own default ladder is already ms-shaped and reaches 10000, so nothing shared needs widening. Switching to `common_metrics::setup_metrics_routes_with_overrides` is a drop-in for `serve_metrics::setup_metrics_routes` (same `/metrics` route, same `track_metrics` middleware) and fixes the unit mismatch by itself.

On top of that, a small `metrics_buckets.rs` with `Matcher::Full` overrides, following the existing precedent in `feature-flags/src/metrics/buckets.rs`:

- `prop_defs_batch_acquire_time_ms` up to 600s. This one measures how long the consumer waits for a batch to fill, so it's bounded by `max_issue_period` (500s in production), not by any database operation. Its mean is 3.4s in prod-us and 12.2s in prod-eu, so even a 10s ceiling would swallow most of it.
- the three `propdefs_v2_*_batch_ms` up to 30s, leaving room for a stalled Postgres plus this path's three retries and backoff.

> [!NOTE]
> I deliberately did **not** touch `serve_metrics::setup_metrics_recorder`'s defaults. 20 crates share it, and changing their bucket boundaries fleet-wide is not something to do as a side effect of a propdefs fix.

Dropping the `serve-metrics` dependency falls out of the switch, since nothing else in the crate used it.

One trap documented rather than fixed: `http_requests_duration_seconds` (the shared axum middleware) records *seconds*, and the default `common_metrics` ladder is ms-shaped, so sub-second requests all land in the first bucket. Harmless while this service's HTTP surface is `/metrics` plus probes; `metrics_buckets.rs` now carries a note that a real API endpoint here would need a seconds-shaped override. Three histogram consts (`prop_defs_update_transaction_time_ms`, `prop_defs_group_type_resolve_time_ms`, `prop_defs_single_update_issue_time_ms`) turned out to be dead — declared but never recorded — so instead of carrying overrides for metrics that never exist, this PR removes the constants outright.

## How did you test this code?

I'm an agent, directed by @eli-r-ph. Automated tests plus a local smoke run. No staging verification.

**Smoke test**, because swapping the recorder is the risky part of this and both `install_recorder()` and `set_buckets_for_metric()` panic on bad input: built and ran the binary against the local stack. It starts cleanly, `/_liveness` returns 200, and `/metrics` renders the new gauges correctly.

```
prop_defs_channel_capacity_total 1000000
prop_defs_channel_capacity 1000000
prop_defs_channel_messages_in_flight 0
```

The histograms don't appear until they record an observation, and with no events flowing the consumer never completes a batch, so I could not confirm the new bucket boundaries render. That check has to happen on deploy.

**Tests.** `tests/measuring_channel.rs`, two cases:

`test_failed_send_does_not_leak_an_in_flight_count` is deterministic. It doesn't catch the original bug, but it catches the most likely *mis-fix* of it: moving the increment before the send and forgetting to take it back when the send fails, which leaks one count per failure permanently.

`test_in_flight_count_never_underflows_under_interleaved_send_and_recv` is a **stress test, and I want to be upfront about it**. The race only exists across threads, so it can't be forced deterministically from outside `send()`. I measured it 12 runs each way: it catches the old ordering 11/12 times and passes 12/12 against the fixed code. It cannot false-fail, because the bound it asserts is a hard ceiling on a correct implementation rather than a timing guess. At a few milliseconds, an occasional miss seemed worth having it in the suite.

Getting there took two corrections. My first version ran on the default single-threaded runtime and passed against the buggy code, because the increment and the receive can't actually interleave there. My second had a wrong invariant (`in_flight <= CAPACITY`) and false-failed 2/10 times against the *fixed* code, which is when I noticed the semantic change above. I also tried capacity 1 to maximise blocking, which made detection worse (1/8), not better.

Full suite against a local Postgres: 62 tests pass across all `property-defs-rs` targets. `cargo fmt --check` and `cargo clippy --all-targets` clean. `hogli ci:preflight --strict` reports nothing triggered.

Caveat: I compiled with rustup's 1.96.0, not flox's 1.91.1.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @eli-r-ph.

Not from #65112. This came out of gathering production telemetry to judge that PR's claims: I wanted channel occupancy to decide whether its decoupled-pipeline change was worth extracting, found the gauge pinned at `u64::MAX`, then found the capacity gauge was the wrong quantity, then found the latency histograms censored. The pipeline question got answered from consumer-loop cadence instead (78% of the loop is spent waiting for a batch to fill in prod-us), but these are worth fixing so the next person doesn't have to work around them.

Skills invoked: `/writing-code-comments` and `/writing-tests`.


