### PR TITLE
fix(endpoints): only count a fallback when inline recovers

### DIFF
--- a/products/endpoints/backend/logic/execution.py
+++ b/products/endpoints/backend/logic/execution.py
@@ -528,6 +528,7 @@ class EndpointExecutionService(PydanticModelMixin):
         _ch_query_start = time.monotonic()
         try:
             result: Response | None = None
+            materialized_failed = False
             if use_materialized:
                 try:
                     result = self._execute_materialized_endpoint(
@@ -542,10 +543,13 @@ class EndpointExecutionService(PydanticModelMixin):
                 except ConcurrencyLimitExceeded:
                     raise
                 except Exception:
-                    # Already logged/captured/signaled inside the materialized path. Serve the
-                    # request from the original query instead of failing — stale tables and
-                    # series drift self-heal on the next materialization run.
-                    execution_type = "materialized_fallback"
+                    # Already logged/captured/signaled inside the materialized path. Re-run
+                    # inline: only stamp materialized_fallback once inline succeeds, because
+                    # only an inline success proves the materialized table was the sole thing
+                    # broken. If inline also fails the request was never recoverable (a bad
+                    # query fails on both paths) — that's an inline failure, not a fallback.
+                    materialized_failed = True
+                    execution_type = "inline"
                     result = None
 
             if result is None:
@@ -558,6 +562,8 @@ class EndpointExecutionService(PydanticModelMixin):
                     limit=limit,
                     offset=offset,
                 )
+                if materialized_failed:
+                    execution_type = "materialized_fallback"
             # Query-only wall-clock, to compare fairly with the DuckLake shadow.
             _ch_query_ms = (time.monotonic() - _ch_query_start) * 1000
             execution_status = "success"

--- a/products/endpoints/backend/tests/test_endpoint_execution.py
+++ b/products/endpoints/backend/tests/test_endpoint_execution.py
@@ -2457,6 +2457,36 @@ class TestEndpointExecution(ClickhouseTestMixin, APIBaseTest):
         mock_trigger.assert_called_once()
         self.assertEqual(mock_exec.call_count, 2, "expected materialized attempt then inline fallback")
 
+    def test_unrecoverable_failure_not_labeled_materialized_fallback(self):
+        from prometheus_client import REGISTRY
+
+        endpoint = self._make_fresh_materialized_endpoint(
+            "mat-both-fail", {"kind": "HogQLQuery", "query": "SELECT count() FROM events"}
+        )
+        fallback_labels = {"execution_type": "materialized_fallback", "query_kind": "hogql", "status": "user_error"}
+        inline_labels = {"execution_type": "inline", "query_kind": "hogql", "status": "user_error"}
+        fallback_before = REGISTRY.get_sample_value("posthog_endpoint_execution_total", fallback_labels) or 0.0
+        inline_before = REGISTRY.get_sample_value("posthog_endpoint_execution_total", inline_labels) or 0.0
+
+        with mock.patch.object(
+            EndpointExecutionService,
+            "_execute_query_and_respond",
+            side_effect=[RuntimeError("materialized table exploded"), ExposedHogQLError("Unknown field: bad")],
+        ) as mock_exec:
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/run/", {}, format="json"
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(mock_exec.call_count, 2, "expected materialized attempt then inline retry")
+
+        fallback_after = REGISTRY.get_sample_value("posthog_endpoint_execution_total", fallback_labels) or 0.0
+        inline_after = REGISTRY.get_sample_value("posthog_endpoint_execution_total", inline_labels) or 0.0
+        self.assertEqual(
+            fallback_after - fallback_before, 0.0, "an unrecoverable request must not count as materialized_fallback"
+        )
+        self.assertEqual(inline_after - inline_before, 1.0)
+
     def test_emit_failure_signal_reaches_workflow_boundary(self):
         """The failure-signal plumbing must make it to the Temporal boundary when the
         org/source gates allow it — anything raising before that is a plumbing bug."""


### PR DESCRIPTION
## Problem

Endpoint runs that use a materialized table fall back to inline execution when the materialized read throws.
The `execution_type="materialized_fallback"` label was set before the inline retry ran, so a request that failed on both paths (an invalid query fails against the materialized table and inline alike) still got counted and logged as a materialization fallback.
Those are user errors, not materialization breakage, and they made up the bulk of the counter.
A vmalert rule that watches this counter was paging on them.

## Changes

Defer the label until the inline retry's outcome is known.
Only stamp `materialized_fallback` once inline succeeds, which is the one signal that proves the query was valid and only the materialized table or read was broken.
When inline also fails, the request was never recoverable, so it counts as an ordinary inline failure (and logs `path=inline`).

Net effect on the metric:

- materialized fails, inline succeeds → `materialized_fallback` (unchanged, the genuine self-heal)
- materialized fails, inline fails → `inline` + `user_error` (no longer polluting the fallback counter and logs)
- materialized succeeds → `materialized` (unchanged)

The materialized path's own exception handling is untouched, so the series-mismatch re-materialization trigger still fires.
A companion change in the charts repo scopes the alert that watches this counter to `status="success"` as belt-and-suspenders.

## How did you test this code?

- New test `test_unrecoverable_failure_not_labeled_materialized_fallback`: the materialized read fails and the inline retry also fails, so the request is a 400 user_error and the metric is recorded under `execution_type="inline"`, not `materialized_fallback`. Nothing covered the both-fail path before; the two existing fallback tests both have inline succeed, so this catches a revert of the deferral logic.
- Ran the fallback-related tests in `test_endpoint_execution.py` (the existing two plus the new one): all pass.
- I (Claude) type-checked the changed module with mypy; no new errors.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thiago directed this; I (Claude) investigated and implemented.
The trail started from the paging vmalert rule: I pulled the metric's status breakdown from VictoriaMetrics and found the fallback counter was almost entirely user errors, not system faults or materialization breakage.
I considered re-raising user-error exception types from the materialized path to skip the fallback entirely, but rejected it: the same exception types (`ResolutionError`, `ExposedHogQLError`) also arise from recoverable schema drift where inline succeeds, so the inline outcome is the only reliable discriminator. The fix keys on that.
Skills invoked: /writing-tests, /writing-code-comments.
