### PR TITLE
fix(surveys): keep SQL helper column aliases unique

### DIFF
--- a/frontend/src/scenes/surveys/SurveySQLHelper.tsx
+++ b/frontend/src/scenes/surveys/SurveySQLHelper.tsx
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 
 import { Survey, SurveyEventName, SurveyEventProperties, SurveyQuestion } from '~/types'
 
-import { buildPartialResponsesFilter, createAnswerFilterHogQLExpression } from './utils'
+import { buildPartialResponsesFilter, buildUniqueQuestionAliases, createAnswerFilterHogQLExpression } from './utils'
 
 function escapeSqlIdentifier(value: string): string {
     return value.replace(/"/g, '""')
@@ -48,11 +48,14 @@ LIMIT
     }
 
     const generateFullSurveyQuery = (): string => {
+        const aliases = buildUniqueQuestionAliases(
+            survey.questions.map((question: SurveyQuestion) => escapeSqlIdentifier(question.question))
+        )
         const questionSelects = survey.questions
             .map((question: SurveyQuestion, index: number) => {
                 return `    getSurveyResponse(${index}, '${question.id}'${
                     question.type === SurveyQuestionType.MultipleChoice ? ', true' : ''
-                }) AS "${escapeSqlIdentifier(question.question)}"`
+                }) AS "${aliases[index]}"`
             })
             .join(',\n')
 

--- a/frontend/src/scenes/surveys/utils.test.ts
+++ b/frontend/src/scenes/surveys/utils.test.ts
@@ -23,6 +23,7 @@ import {
     buildPartialResponsesFilter,
     buildSurveyOptionalBooleanPropertyFilter,
     buildSurveyTimestampFilter,
+    buildUniqueQuestionAliases,
     calculateNpsBreakdown,
     createAnswerFilterHogQLExpression,
     doesSurveyRepeatOnEveryEvent,
@@ -998,6 +999,27 @@ describe('survey utils', () => {
             expect(
                 buildSurveyOptionalBooleanPropertyFilter(SurveyEventProperties.SURVEY_PARTIALLY_COMPLETED, 'true')
             ).toBe(`coalesce(JSONExtractString(properties, '$survey_partially_completed'), '') != 'true'`)
+        })
+    })
+
+    describe('buildUniqueQuestionAliases', () => {
+        const cases: [string, string[], string[]][] = [
+            ['leaves distinct labels untouched', ['How was it?', 'Why?'], ['How was it?', 'Why?']],
+            [
+                'numbers repeated labels after the first',
+                ['Anything else?', 'Anything else?', 'Anything else?'],
+                ['Anything else?', 'Anything else? (2)', 'Anything else? (3)'],
+            ],
+            ['falls back to the question number for blank labels', ['', '   '], ['Question 1', 'Question 2']],
+            [
+                'stays unique when a label already looks like a numbered one',
+                ['Rate us', 'Rate us (2)', 'Rate us'],
+                ['Rate us', 'Rate us (2)', 'Rate us (3)'],
+            ],
+        ]
+
+        it.each(cases)('%s', (_, labels, expected) => {
+            expect(buildUniqueQuestionAliases(labels)).toEqual(expected)
         })
     })
 })

--- a/frontend/src/scenes/surveys/utils.ts
+++ b/frontend/src/scenes/surveys/utils.ts
@@ -998,6 +998,23 @@ export function getExpressionCommentForQuestion(
     return `Question ${questionIndex + 1}`
 }
 
+// Survey question text is neither unique within a survey nor guaranteed to be non-empty, but the SQL
+// helper uses it as a SELECT alias, and HogQL rejects a query that has the same column alias twice.
+// The first use of a label keeps it; blanks and later repeats fall back to their question number.
+export function buildUniqueQuestionAliases(labels: string[]): string[] {
+    const used = new Set<string>()
+    return labels.map((label, index) => {
+        const base = label.trim() || `Question ${index + 1}`
+        let alias = base
+        let attempt = index + 1
+        while (used.has(alias)) {
+            alias = `${base} (${attempt++})`
+        }
+        used.add(alias)
+        return alias
+    })
+}
+
 export function getSurveyForFeatureFlagVariant(variantKey: string, surveys?: Survey[]): Survey | undefined {
     return surveys?.find((survey) => survey.conditions?.linkedFlagVariant === variantKey)
 }


### PR DESCRIPTION
## Problem

The survey SQL helper's "Full Survey Query" snippet builds one SELECT alias per question directly from the question text:

https://github.com/PostHog/posthog/blob/5ae13566/frontend/src/scenes/surveys/SurveySQLHelper.tsx#L50-L57

Question text is neither unique within a survey nor guaranteed to be non-empty, and nothing stops you from asking "Anything else?" twice. When it repeats, the generated query has the same column alias twice and HogQL rejects it outright with `Duplicate column alias`. Empty question text has the same shape of problem, producing `AS ""`.

So the snippet the helper hands you is one you have to hand-edit before it runs. Low severity, since this is copy-paste output rather than a page that crashes, but it is a broken query in a place whose whole job is to give you a working one.

Refs #76099. That PR fixes a different failure in the same area (multi-line question text breaking the Results tab), and its normalization slightly widens the set of question pairs that collide here. This bug predates it though: exact duplicate text already collided, no newline needed. Keeping them separate so #76099 stays a tight, reviewed fix for the crash it targets.

## Changes

New `buildUniqueQuestionAliases` in `surveys/utils.ts`, applied in `generateFullSurveyQuery`. It keeps the first use of each label and falls back to the question number for blanks and later repeats, so `["Anything else?", "Anything else?"]` becomes `["Anything else?", "Anything else? (2)"]`. It loops rather than suffixing once, so a survey that already contains a literal `Rate us (2)` still ends up with distinct aliases.

The escaping in `escapeSqlIdentifier` is untouched, and the per-question snippets are unchanged (a single alias cannot collide with itself).

> [!NOTE]
> This will conflict with #76099 on the `utils.test.ts` import list. Trivial to resolve (both additions are kept), and I will rebase once that one lands.

## How did you test this code?

`pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/surveys/utils.test.ts` passes, 107 tests.

Four new `it.each` cases on `buildUniqueQuestionAliases` cover the regression no existing test did: nothing in the suite exercised alias generation at all, so dropping the dedup would have shipped silently. The cases are distinct paths rather than data variations, one each for distinct labels, repeats, blanks, and a label that already looks numbered.

I did not test this in a browser. The change is a pure function plus its call site, and the assertion that matters (aliases are unique and non-empty) is fully expressible at the unit level. Rendering `SurveySQLHelper` means mounting `surveyLogic` with a loaded survey, which is a much more expensive test for no extra signal.

Frontend typecheck (`typescript:check`) reports no errors in the files I touched. It does not pass cleanly in my sandbox, but every failure traces to unbuilt workspace packages (`@posthog/quill`, `@posthog/hogvm`) and is present on `master` here too.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs change. The SQL helper's behavior is unchanged apart from no longer emitting an invalid query.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude via the PostHog Slack app, from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1785873052454729) that started as CI triage on #76099. The visual regression failure there turned out to be an unrelated flaky story timeout, and while looking at the PR we picked up a Greptile finding about alias collisions. Invoked `/writing-tests` and `/writing-code-comments`.

The main decision was scope and placement. Greptile framed the collision as introduced by #76099's newline normalization, but the bug is older and broader, so this stands alone rather than being folded into a PR already in the merge queue. I considered moving `escapeSqlIdentifier` into `utils.ts` alongside the new helper, which reads better, but rejected it: #76099 edits that function in place, and a merge that silently dropped its newline collapse is a worse outcome than slightly split-up helpers. Passing pre-escaped labels into the helper keeps it pure and keeps the conflict surface to an import list.

Also considered fixing the empty-alias case in the per-question snippets for symmetry, and left it out. The dedup pass already covers blanks in the full-survey query, and the single-question path has no collision to fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1785873052454729)*
