### PR TITLE
chore(warehouse): report repartition rewrite progress instead of per-batch noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/partitioning.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/partitioning.py
@@ -249,6 +249,5 @@ def append_partition_key_to_table(
                 raise ValueError(f"Partition mode '{mode}' not supported")
 
     new_column = pa.array(partition_array, type=pa.string())
-    logger.debug(f"append_partition_key_to_table: Partition key added with mode={mode}")
 
     return table.append_column(PARTITION_KEY, new_column), mode, partition_format, normalized_partition_keys

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py
@@ -404,6 +404,16 @@ def _read_next_batch(reader: pa.RecordBatchReader) -> pa.RecordBatch | None:
         return None
 
 
+def _format_scheme(target: RepartitionTarget) -> str:
+    """`datetime/month`, `md5/64`, `numerical/1000000` — the scheme in one readable token."""
+    knob = target.partition_format or target.partition_count or target.partition_size
+    return f"{target.partition_mode or 'auto'}/{knob}" if knob else (target.partition_mode or "auto")
+
+
+def _format_fields(fields: dict[str, Any]) -> str:
+    return " ".join(f"{key}={value}" for key, value in fields.items() if value is not None)
+
+
 async def _rewrite_into_temp(
     *,
     old_delta: deltalake.DeltaTable,
@@ -415,6 +425,7 @@ async def _rewrite_into_temp(
     ensure_claim: Callable[[], Awaitable[None]] | None = None,
     claim_recheck_interval_seconds: float = CLAIM_RECHECK_INTERVAL_SECONDS,
     deadline: float | None = None,
+    total_rows: int | None = None,
 ) -> tuple[int, RepartitionTarget]:
     """Stream the live table into a fresh temp table under the new partition scheme.
 
@@ -426,7 +437,18 @@ async def _rewrite_into_temp(
 
     `deadline` is a `time.monotonic()` value past which the rewrite gives up with
     `RepartitionBudgetExceededError` rather than run until Temporal kills it. None runs unbounded.
+
+    `total_rows` is the source row count, used only to report progress as a percentage and an ETA.
     """
+    await logger.ainfo(
+        f"repartition: rewrite starting target_scheme={_format_scheme(target)} total_rows={total_rows} "
+        f"batch_size={batch_size} temp_uri={temp_uri}",
+        target_scheme=_format_scheme(target),
+        total_rows=total_rows,
+        batch_size=batch_size,
+        temp_uri=temp_uri,
+    )
+
     dataset = await asyncio.to_thread(old_delta.to_pyarrow_dataset)
     reader = await asyncio.to_thread(lambda: dataset.scanner(batch_size=batch_size).to_reader())
     live_schema = await asyncio.to_thread(old_delta.schema)
@@ -438,11 +460,31 @@ async def _rewrite_into_temp(
     buffered_rows = 0
     buffered_bytes = 0
 
-    async def flush() -> int:
-        """Write the buffered batches as one Delta commit and return the rows written."""
-        nonlocal buffered, buffered_rows, buffered_bytes
+    started_at = time.monotonic()
+    commits = 0
+
+    def progress() -> dict[str, Any]:
+        """Structured rewrite progress. One of these per commit is the whole story of a rewrite."""
+        elapsed = max(time.monotonic() - started_at, 1e-6)
+        rate = rows_written / elapsed
+        fields: dict[str, Any] = {
+            "rows_written": rows_written,
+            "commits": commits,
+            "elapsed_seconds": round(elapsed),
+            "rows_per_second": round(rate),
+        }
+        if total_rows:
+            fields["total_rows"] = total_rows
+            fields["percent_complete"] = round(100 * rows_written / total_rows, 1)
+            # Only meaningful once a commit has landed; before that there is no rate to project from.
+            fields["eta_seconds"] = round(max(total_rows - rows_written, 0) / rate) if rate else None
+        return fields
+
+    async def flush() -> None:
+        """Write the buffered batches as one Delta commit, then report progress."""
+        nonlocal buffered, buffered_rows, buffered_bytes, rows_written, commits
         if not buffered:
-            return 0
+            return
         # Every buffered table was already aligned to `live_schema`, so they concat without promotion.
         combined = buffered[0] if len(buffered) == 1 else pa.concat_tables(buffered)
         buffered = []
@@ -457,7 +499,10 @@ async def _rewrite_into_temp(
             schema_mode="merge",
             storage_options=storage_options,
         )
-        return combined.num_rows
+        rows_written += combined.num_rows
+        commits += 1
+        fields = progress()
+        await logger.ainfo(f"repartition: rewrite progress {_format_fields(fields)}", **fields)
 
     last_claim_check: float | None = None
 
@@ -531,16 +576,22 @@ async def _rewrite_into_temp(
             buffered_rows + partitioned_table.num_rows > batch_size
             or buffered_bytes + table_bytes > REWRITE_BUFFER_MAX_BYTES
         ):
-            rows_written += await flush()
+            await flush()
         buffered.append(partitioned_table)
         buffered_rows += partitioned_table.num_rows
         buffered_bytes += table_bytes
 
-    rows_written += await flush()
+    await flush()
 
     if resolved is None:
         # Empty source table — nothing to rewrite.
         resolved = target
+    fields = progress()
+    await logger.ainfo(
+        f"repartition: rewrite complete scheme={_format_scheme(resolved)} {_format_fields(fields)}",
+        scheme=_format_scheme(resolved),
+        **fields,
+    )
     return rows_written, resolved
 
 
@@ -667,6 +718,7 @@ async def repartition_table_in_place(
                 logger=logger,
                 ensure_claim=ensure_claim,
                 deadline=deadline,
+                total_rows=old_row_count,
             )
         except (RepartitionSupersededError, RepartitionUnpartitionableError, RepartitionBudgetExceededError):
             raise

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import datetime
+import itertools
 from types import SimpleNamespace
 
 import pytest
@@ -330,10 +331,11 @@ class TestRewriteIntoTemp:
         old_delta = _write_month_partitioned(str(tmp_path / "src"), rows)
         temp_uri = str(tmp_path / "tmp")
 
-        # One reading per batch read. Batches coalesce into a commit rather than writing one each,
-        # so the deadline has to fall after the buffer has flushed at least once for any row to be
-        # observable in temp at all.
-        clock = Mock(side_effect=[0.0, 0.0, 100.0])
+        # Batches coalesce into a commit rather than writing one each, so the deadline has to fall
+        # after the buffer has flushed at least once for any row to be observable in temp at all.
+        # The rewrite also samples this clock for its own progress timing, so the prefix stays under
+        # the deadline for the early reads and every later read is over it.
+        clock = Mock(side_effect=itertools.chain([0.0] * 4, itertools.repeat(100.0)))
 
         with patch.object(repartition_module, "time", Mock(monotonic=clock)):
             with pytest.raises(RepartitionBudgetExceededError):
@@ -369,7 +371,9 @@ class TestRewriteIntoTemp:
         old_delta = _write_month_partitioned(str(tmp_path / "src"), rows)
         temp_uri = str(tmp_path / "tmp")
 
-        clock = Mock(side_effect=[0.0, 100.0])
+        # Every deadline check must land under the deadline for the rewrite to reach the swap; the
+        # later readings only feed progress timing, so they are free to be past it.
+        clock = Mock(side_effect=itertools.chain([0.0] * 2, itertools.repeat(100.0)))
 
         with patch.object(repartition_module, "time", Mock(monotonic=clock)):
             rows_written, _ = asyncio.run(


### PR DESCRIPTION
## Problem

Debugging a slow repartition meant reading thousands of copies of this:

```
{"msg": "append_partition_key_to_table: Partition key added with mode=datetime", "activity_type": "maybe_repartition_table_activity", ...}
```

Four things are wrong with it.

It fires **once per batch**, and the reader yields at least one batch per source file, so the tables worth debugging (the over-fragmented ones) are exactly the tables that bury you. The **payload never varies** - same message every time, and `mode` is constant once the first batch resolves. There is **no progress**: nothing about rows done, rows total, elapsed, commits, or rate, so the questions you actually have during an incident are all unanswerable.

And it is emitted from a helper the **load path also calls**, so it inherits whatever structlog context is bound. That tagged load-path lines with `activity_type=maybe_repartition_table_activity`, which during a recent investigation led to a rewrite being reported as progressing when it had already stood down. That one produced a wrong diagnosis, not just noise.

## Changes

Remove the per-batch line, and report from the rewrite itself instead:

```
repartition: rewrite starting target_scheme=datetime/month total_rows=3268884 batch_size=50000 temp_uri=...
repartition: rewrite progress rows_written=524288 commits=11 elapsed_seconds=63 rows_per_second=8322 total_rows=3268884 percent_complete=16.0 eta_seconds=330
repartition: rewrite complete scheme=datetime/month rows_written=3268884 commits=66 elapsed_seconds=395
```

One line on start, one per Delta commit, one on completion. After the batch coalescing that shipped in #76957 that is a handful of lines per rewrite rather than thousands, and it answers what the old output could not: is it progressing, how far along, and will it finish before the next worker restart.

All the inputs already existed - `old_row_count` is computed just above the rewrite call, and the loop already tracked rows and commits. Everything is emitted as structlog kwargs as well as in the message, so it is queryable rather than only greppable.

> [!NOTE]
> Removing the line also affects the v3 load path, which calls the same helper. That is intended - the message was equally uninformative there. The remaining `logger.debug` calls in `append_partition_key_to_table` only run during auto-detection, which is skipped once a mode is persisted, so they are already once-per-run rather than per-batch.

## How did you test this code?

Automated only. I have not watched this output against a live production rewrite.

- `pipelines/core/` + `workflow_activities/tests/` - 686 passed
- `pipelines/pipeline_v3/` (the other caller of the changed helper) - 512 passed
- `uv run mypy --cache-fine-grained .` - clean across 17,652 files
- `ruff check` / `ruff format` - clean

No new tests. The behavior worth pinning is the row accounting, which moved from the call site into `flush()`, and existing tests already assert `rows_written` for the coalescing, byte-bound and empty-source cases. Asserting on log text would be a change-detector test, so I left it out.

I did have to change two existing tests. `test_stops_mid_stream_once_the_deadline_passes` and `test_a_finished_rewrite_beats_the_deadline` patch the whole `time` module with an exact-length `side_effect` list, so they were counting internal `time.monotonic()` calls and broke the moment the rewrite sampled the clock for its own timing. They now use `itertools.chain(prefix, repeat(...))`, which expresses the same intent (early reads under the deadline, later reads past it) without being coupled to how many times the implementation reads the clock.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code, Opus 5) wrote it. It came directly out of debugging a customer's repartitions, where the logs above cost real time on three separate diagnoses and produced one outright wrong conclusion.

Skills invoked: `/writing-tests`, which is why this adds no logging-assertion tests and instead relies on the existing row-count coverage.

Scope note for review: the alternative was to add the progress lines and leave the noisy one alone, which has zero blast radius but keeps the flood. I went wider deliberately, after checking every caller of `append_partition_key_to_table` and confirming nothing in the repo greps for that message.
