### PR TITLE
fix(cohorts): keep type and created_by filters when searching

### DIFF
--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.test.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.test.ts
@@ -129,6 +129,26 @@ describe('cohortsSceneLogic', () => {
                         cohortFilters: expect.objectContaining({ created_by_id: 123 }),
                     })
             })
+
+            it('keeps the type and created_by_id filters when searching', async () => {
+                router.actions.push(urls.cohorts())
+                await expectLogic(logic).toDispatchActions(['loadCohortsSuccess'])
+
+                logic.actions.setCohortFilters({ type: 'static', created_by_id: 123, page: 1 })
+                await expectLogic(logic).toDispatchActions(['loadCohortsSuccess'])
+
+                await expectLogic(logic, () => {
+                    logic.actions.setCohortFilters({ search: 'New', page: 1 })
+                })
+                    .toDispatchActions(['loadCohortsSuccess'])
+                    .toMatchValues({
+                        cohortFilters: expect.objectContaining({
+                            search: 'New',
+                            type: 'static',
+                            created_by_id: 123,
+                        }),
+                    })
+            })
         })
 
         describe('cohort operations', () => {

--- a/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
+++ b/frontend/src/scenes/cohorts/cohortsSceneLogic.ts
@@ -335,6 +335,20 @@ export const cohortsSceneLogic = kea<cohortsSceneLogicType>([
                 delete searchParams['search']
             }
 
+            // urlToAction replaces the whole filter state, so every filter has to round-trip
+            // through the URL or changing one would reset the others
+            if (values.cohortFilters.type != null) {
+                searchParams['type'] = values.cohortFilters.type
+            } else {
+                delete searchParams['type']
+            }
+
+            if (values.cohortFilters.created_by_id != null) {
+                searchParams['created_by_id'] = values.cohortFilters.created_by_id
+            } else {
+                delete searchParams['created_by_id']
+            }
+
             return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         },
         setCohortSorting: () => {


### PR DESCRIPTION
## Problem

On the cohorts list, the `Type` and `Created by` dropdowns silently reset to their defaults as soon as you type in the search box. Set `Type = Static`, type `New`, and `Type` snaps back to `All`. Same for `Created by`.

The scene keeps its filter state in the URL. `urlToAction` replaces the *entire* filter object from searchParams on every URL change, but `trackedActionToUrl` only wrote `page` and `search`. So any search keystroke pushed a URL with no `type` or `created_by_id`, which came straight back as "those filters are unset". Changing the sort had the same effect.

## Changes

Write `type` and `created_by_id` into searchParams alongside `page` and `search`, so every filter round-trips through the URL instead of being dropped. Side benefit: a filtered cohorts list is now shareable and survives a refresh, which the `urlToAction` handler already expected (it was reading both params all along).

## How did you test this code?

Added one Jest case in `cohortsSceneLogic.test.ts`: with `type` and `created_by_id` set, searching keeps both. It catches exactly the reported regression, and I confirmed it fails on `master` and passes with the fix.

```
✕ keeps the type and created_by_id filters when searching   (without fix)
✓ keeps the type and created_by_id filters when searching   (with fix)
```

Full suite for the file passes (11/11). I did not manually click through the UI in a running app.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude via the PostHog Slack app, from a bug report about the cohorts filter dropdowns resetting. Invoked `/writing-tests` before adding the test case.

I traced the reset to the mismatch between the two URL hooks rather than to the components: `Cohorts.tsx` correctly passes partial filter updates, and the reducer merges them fine, so the state loss had to be happening on the URL round-trip. Fixing it in `trackedActionToUrl` (make the URL carry all filters) rather than in `urlToAction` (stop replacing) keeps the filters bookmarkable, which is what the existing `urlToAction` parsing for `type`/`created_by_id` was clearly written for.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1785878043138409)*
