### PR TITLE
fix(access-control): honor member-specific denial

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -142,6 +142,14 @@ class AccessControlSerializer(serializers.ModelSerializer):
         if data.get("role") and not team.organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS):
             raise exceptions.PermissionDenied("Role-based access controls require the Role-based access feature.")
 
+        # Neither relation is scoped by organization on the way in, so a rule could otherwise name
+        # a role or member from a different organization and cross the authorization boundary
+        if data.get("role") and data["role"].organization_id != team.organization_id:
+            raise serializers.ValidationError("The role must belong to the same organization as this project.")
+
+        if data.get("organization_member") and data["organization_member"].organization_id != team.organization_id:
+            raise serializers.ValidationError("The member must belong to the same organization as this project.")
+
         if resource_id:
             if str(the_object.pk) != str(resource_id):
                 raise exceptions.PermissionDenied(

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from rest_framework import status
 
 from posthog.constants import AvailableFeature
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
 from posthog.models.utils import generate_random_token_personal, hash_key_value
@@ -146,6 +146,28 @@ class TestAccessControlProjectLevelAPI(BaseAccessControlTest):
             {"organization_member": str(self.organization_membership.id), "access_level": "admin"}
         )
         assert res.status_code == status.HTTP_200_OK, res.json()
+
+    def test_project_change_rejected_if_role_belongs_to_another_organization(self):
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        other_organization = Organization.objects.create(name="Other organization")
+        foreign_role = Role.objects.create(name="Foreign role", organization=other_organization)
+
+        res = self._put_project_access_control({"role": str(foreign_role.id), "access_level": "admin"})
+        assert res.status_code == status.HTTP_400_BAD_REQUEST, res.json()
+        assert res.json()["detail"] == "The role must belong to the same organization as this project."
+
+    def test_project_change_rejected_if_member_belongs_to_another_organization(self):
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        other_organization = Organization.objects.create(name="Other organization")
+        foreign_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+
+        res = self._put_project_access_control(
+            {"organization_member": str(foreign_membership.id), "access_level": "admin"}
+        )
+        assert res.status_code == status.HTTP_400_BAD_REQUEST, res.json()
+        assert res.json()["detail"] == "The member must belong to the same organization as this project."
 
 
 class TestAccessControlMinimumLevelValidation(BaseAccessControlTest):

--- a/posthog/api/test/__snapshots__/test_element.ambr
+++ b/posthog/api/test/__snapshots__/test_element.ambr
@@ -577,7 +577,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -811,7 +811,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -2134,7 +2135,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -3284,7 +3286,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -3567,7 +3570,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -4232,7 +4236,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -5119,7 +5124,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -7418,7 +7424,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -8433,7 +8440,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -8457,7 +8465,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -9427,7 +9436,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -10308,7 +10318,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -12225,7 +12236,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -13389,7 +13401,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -14404,7 +14417,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -14428,7 +14442,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -882,8 +882,10 @@
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.26
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -2401,8 +2403,10 @@
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -4299,8 +4303,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.108
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -5184,8 +5190,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.129
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -7481,8 +7489,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.25
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -8518,8 +8528,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.43
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -9486,8 +9498,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.66
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -9575,8 +9589,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.7
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -10363,8 +10379,10 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.87
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -12278,8 +12296,10 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard.8
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -13440,8 +13460,10 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.25
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -14477,8 +14499,10 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.43
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---
@@ -14703,8 +14727,10 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.7
   '''
-  SELECT "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_role"."organization_id" AS "role__organization_id",
+         "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
+  INNER JOIN "ee_role" ON ("ee_rolemembership"."role_id" = "ee_role"."id")
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
 # ---

--- a/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
+++ b/posthog/api/test/dashboards/__snapshots__/test_dashboard.ambr
@@ -882,8 +882,7 @@
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.26
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -2402,8 +2401,7 @@
 # ---
 # name: TestDashboard.test_adding_insights_is_not_nplus1_for_gets.7
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -4301,8 +4299,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.108
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -5187,8 +5184,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.129
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -7485,8 +7481,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.25
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -8523,8 +8518,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.43
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -9492,8 +9486,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.66
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -9582,8 +9575,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.7
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -10371,8 +10363,7 @@
 # ---
 # name: TestDashboard.test_loading_individual_dashboard_does_not_prefetch_all_possible_tiles.87
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -12287,8 +12278,7 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard.8
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -13450,8 +13440,7 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.25
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -14488,8 +14477,7 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.43
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''
@@ -14715,8 +14703,7 @@
 # ---
 # name: TestDashboard.test_retrieve_dashboard_list.7
   '''
-  SELECT "ee_rolemembership"."organization_member_id" AS "organization_member_id",
-         "ee_rolemembership"."role_id" AS "role_id"
+  SELECT "ee_rolemembership"."role_id" AS "role_id"
   FROM "ee_rolemembership"
   WHERE "ee_rolemembership"."user_id" = 99999
   '''

--- a/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
+++ b/posthog/api/test/notebooks/__snapshots__/test_notebook.ambr
@@ -405,7 +405,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1499,7 +1500,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1698,7 +1700,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -144,6 +144,30 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         assert self.user_access_control._user_role_ids == [self.role_a.id]
         assert self.user_access_control.get_user_access_level(self.team) == expected_level
 
+    @parameterized.expand(
+        [
+            ("denial", "none", "member", "member"),
+            ("grant", "admin", "none", "none"),
+        ]
+    )
+    def test_member_rule_from_another_organization_is_ignored(self, _name, member_level, default_level, expected_level):
+        # Same as above for the member arm: nothing scopes `organization_member` to the project's
+        # organization, so a rule can name a membership the user holds in an unrelated organization
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self._create_access_control(resource_id=str(self.team.id), access_level=default_level)
+
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+        self._create_access_control(
+            resource_id=str(self.team.id), access_level=member_level, organization_member=other_membership
+        )
+
+        self._clear_uac_caches()
+        assert self.user_access_control.get_user_access_level(self.team) == expected_level
+
     def test_without_available_product_features(self):
         self.organization.available_product_features = []
         self.organization.save()

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -119,6 +119,31 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         assert user_access_control._organization is None
         assert user_access_control._user_role_ids == []
 
+    @parameterized.expand(
+        [
+            ("denial", "none", "member", "member"),
+            ("grant", "admin", "none", "none"),
+        ]
+    )
+    def test_role_rule_from_another_organization_is_ignored(self, _name, role_level, default_level, expected_level):
+        # Nothing scopes the role on an AccessControl row to the project's organization, so a rule
+        # can name a role the user holds in an unrelated organization
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self._create_access_control(resource_id=str(self.team.id), access_level=default_level)
+
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+        foreign_role = Role.objects.create(name="Foreign role", organization=other_organization)
+        RoleMembership.objects.create(role=foreign_role, user=self.user, organization_member=other_membership)
+        self._create_access_control(resource_id=str(self.team.id), access_level=role_level, role=foreign_role)
+
+        self._clear_uac_caches()
+        assert self.user_access_control._user_role_ids == [self.role_a.id]
+        assert self.user_access_control.get_user_access_level(self.team) == expected_level
+
     def test_without_available_product_features(self):
         self.organization.available_product_features = []
         self.organization.save()

--- a/posthog/rbac/test/test_user_access_control_pbt.py
+++ b/posthog/rbac/test/test_user_access_control_pbt.py
@@ -40,6 +40,7 @@ from posthog.rbac.user_access_control import (
     ordered_access_levels,
 )
 from posthog.scopes import APIScopeObject
+from posthog.user_permissions import UserPermissions
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -395,6 +396,38 @@ def oracle_explicit_level(specs: list[RowSpec], order: list[AccessControlLevel])
     return None
 
 
+def oracle_project_membership_level(
+    specs: list[RowSpec],
+    membership_level: OrganizationMembership.Level,
+    role_based_access: bool,
+) -> Optional[OrganizationMembership.Level]:
+    # Mirrors UserTeamPermissions.effective_membership_level_for_parent_membership. Same
+    # shadowing as oracle_explicit_level, applied to project rows: rules naming the user (their
+    # member row, or a role they hold) decide, highest of them winning, so an all-"none" set of
+    # them denies instead of falling through to the team default. Role rows are invisible without
+    # ROLE_BASED_ACCESS, so a stale role rule neither grants nor denies.
+    if membership_level >= OrganizationMembership.Level.ADMIN:
+        return membership_level
+
+    visible = {"team_default", "self_member"} | ({"role_a"} if role_based_access else set())
+    matching = [s for s in specs if s.target in visible]
+    explicit = [s.level for s in matching if s.target != "team_default"]
+    team_default = [s.level for s in matching if s.target == "team_default"]
+
+    if explicit:
+        resolved = _max_level(explicit, PROJECT_LEVELS)
+    elif team_default:
+        resolved = _max_level(team_default, PROJECT_LEVELS)
+    else:
+        resolved = default_access_level("project")
+
+    return {
+        "none": None,
+        "member": OrganizationMembership.Level.MEMBER,
+        "admin": OrganizationMembership.Level.ADMIN,
+    }[cast(str, resolved)]
+
+
 def oracle_object_access_level(
     resource: APIScopeObject, specs: list[RowSpec], is_creator: bool, is_org_admin: bool
 ) -> AccessControlLevel:
@@ -544,6 +577,16 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
     def _fresh_uac(self) -> UserAccessControl:
         return UserAccessControl(self.user, self.team)
 
+    def _set_role_based_access(self, enabled: bool) -> None:
+        # Written on every example (not just when disabling) so the class-level in-memory
+        # organization, which hypothesis's per-example rollback does not restore, can't drift
+        # from the row the resolvers read
+        features = [{"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}]
+        if enabled:
+            features.append({"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS})
+        self.organization.available_product_features = features
+        self.organization.save()
+
 
 class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
     def test_every_access_controlled_model_is_buildable(self):
@@ -690,6 +733,50 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
         assert uac.access_level_for_resource(resource) == highest_access_level(effective)
         assert uac.get_user_access_level(obj) == highest_access_level(resource)
         assert uac.check_can_modify_access_levels_for_object(obj) is True
+
+    @given(
+        team_rows=project_rows(),
+        membership_level=membership_levels_st,
+        role_based_access=st.booleans(),
+    )
+    @settings(max_examples=100, deadline=None, suppress_health_check=SUPPRESSED_HEALTH_CHECKS)
+    def test_effective_membership_level_matches_oracle(self, team_rows, membership_level, role_based_access):
+        self._set_membership_level(membership_level)
+        self._set_role_based_access(role_based_access)
+        self._materialize_project_rows(team_rows)
+
+        expected = oracle_project_membership_level(team_rows, membership_level, role_based_access)
+        assert UserPermissions(self.user, self.team).current_team.effective_membership_level == expected
+
+    @given(
+        team_rows=project_rows(),
+        membership_level=membership_levels_st,
+        role_based_access=st.booleans(),
+    )
+    @settings(max_examples=100, deadline=None, suppress_health_check=SUPPRESSED_HEALTH_CHECKS)
+    def test_effective_membership_level_agrees_with_enforced_project_access(
+        self, team_rows, membership_level, role_based_access
+    ):
+        # The two project resolvers must not contradict each other: effective_membership_level
+        # gates ~25 call sites, while get_user_access_level is what PermissionClass 403s on, so a
+        # disagreement means one of them grants access the other denies.
+        self._set_membership_level(membership_level)
+        self._set_role_based_access(role_based_access)
+        self._materialize_project_rows(team_rows)
+
+        level = UserPermissions(self.user, self.team).current_team.effective_membership_level
+        enforced = self._fresh_uac().get_user_access_level(self.team)
+
+        assert (level is None) == (enforced == NO_ACCESS_LEVEL)
+        if membership_level == OrganizationMembership.Level.MEMBER:
+            assert (
+                level
+                == {
+                    "none": None,
+                    "member": OrganizationMembership.Level.MEMBER,
+                    "admin": OrganizationMembership.Level.ADMIN,
+                }[cast(str, enforced)]
+            )
 
     @given(data=object_resource_and_rows(), admin_target=st.sampled_from(sorted(MATCHING)))
     @settings(max_examples=50, deadline=None, suppress_health_check=SUPPRESSED_HEALTH_CHECKS)

--- a/posthog/rbac/test/test_user_access_control_pbt.py
+++ b/posthog/rbac/test/test_user_access_control_pbt.py
@@ -21,7 +21,7 @@ from hypothesis import (
 from hypothesis.extra.django import TestCase as HypothesisDjangoTestCase
 
 from posthog.constants import AvailableFeature
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.rbac.user_access_control import (
@@ -302,9 +302,11 @@ def model_has_created_by(model_cls: type[models.Model]) -> bool:
 
 
 # Row targets: who an AccessControl row applies to, relative to self.user
-# (who is in role_a; other_user is in role_b).
-TARGETS = ("team_default", "self_member", "other_member", "role_a", "role_b")
-# Rows _filter_options can ever see for self.user - other_member/role_b rows are invisible
+# (who is in role_a and in role_other_org; other_user is in role_b).
+# role_other_org is a role self.user holds in a different organization, which nothing on the write
+# path scopes out of a rule on this team - resolving it here would cross the authorization boundary.
+TARGETS = ("team_default", "self_member", "other_member", "role_a", "role_b", "role_other_org")
+# Rows _filter_options can ever see for self.user - other_member/role_b/role_other_org are invisible
 MATCHING = {"team_default", "self_member", "role_a"}
 
 PROJECT_LEVELS = ordered_access_levels("project")
@@ -509,6 +511,9 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
     other_user: User
     role_a: "Role"
     role_b: "Role"
+    role_other_org: "Role"
+    other_organization: Organization
+    other_organization_membership: OrganizationMembership
 
     # Fixtures live in setUpTestData (class-level atomics): hypothesis runs each
     # example inside Django's per-test transaction via _pre_setup/_post_teardown,
@@ -528,6 +533,16 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
         RoleMembership.objects.create(user=cls.user, role=cls.role_a)
         RoleMembership.objects.create(user=cls.other_user, role=cls.role_b)
 
+        # A second organization self.user also belongs to, holding a role there
+        cls.other_organization = Organization.objects.create(name="PBT other organization")
+        cls.other_organization_membership = OrganizationMembership.objects.create(
+            organization=cls.other_organization, user=cls.user, level=OrganizationMembership.Level.MEMBER
+        )
+        cls.role_other_org = Role.objects.create(name="PBT foreign role", organization=cls.other_organization)
+        RoleMembership.objects.create(
+            user=cls.user, role=cls.role_other_org, organization_member=cls.other_organization_membership
+        )
+
     def _membership(self, user: User) -> OrganizationMembership:
         return OrganizationMembership.objects.get(user=user, organization=self.organization)
 
@@ -545,6 +560,8 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
             return {"organization_member": self._membership(self.other_user)}
         if target == "role_a":
             return {"role": self.role_a}
+        if target == "role_other_org":
+            return {"role": self.role_other_org}
         return {"role": self.role_b}
 
     def _materialize(self, specs: list[RowSpec], resource: APIScopeObject, obj: Optional[models.Model]) -> None:

--- a/posthog/rbac/test/test_user_access_control_pbt.py
+++ b/posthog/rbac/test/test_user_access_control_pbt.py
@@ -303,10 +303,20 @@ def model_has_created_by(model_cls: type[models.Model]) -> bool:
 
 # Row targets: who an AccessControl row applies to, relative to self.user
 # (who is in role_a and in role_other_org; other_user is in role_b).
-# role_other_org is a role self.user holds in a different organization, which nothing on the write
-# path scopes out of a rule on this team - resolving it here would cross the authorization boundary.
-TARGETS = ("team_default", "self_member", "other_member", "role_a", "role_b", "role_other_org")
-# Rows _filter_options can ever see for self.user - other_member/role_b/role_other_org are invisible
+# role_other_org/member_other_org are a role and a membership self.user holds in a different
+# organization, neither of which the write path scopes out of a rule on this team - resolving either
+# here would cross the authorization boundary.
+TARGETS = (
+    "team_default",
+    "self_member",
+    "other_member",
+    "role_a",
+    "role_b",
+    "role_other_org",
+    "member_other_org",
+)
+# Rows _filter_options can ever see for self.user - other_member/role_b and both *_other_org targets
+# are invisible
 MATCHING = {"team_default", "self_member", "role_a"}
 
 PROJECT_LEVELS = ordered_access_levels("project")
@@ -409,7 +419,8 @@ def oracle_project_membership_level(
     # them denies instead of falling through to the team default. Role rows are invisible without
     # ROLE_BASED_ACCESS, so a stale role rule neither grants nor denies.
     if membership_level >= OrganizationMembership.Level.ADMIN:
-        return membership_level
+        # Project access caps at admin, so an org owner resolves to admin and never OWNER
+        return OrganizationMembership.Level.ADMIN
 
     visible = {"team_default", "self_member"} | ({"role_a"} if role_based_access else set())
     matching = [s for s in specs if s.target in visible]
@@ -562,6 +573,8 @@ class BaseAccessControlPropertyTest(HypothesisDjangoTestCase, BaseTest):
             return {"role": self.role_a}
         if target == "role_other_org":
             return {"role": self.role_other_org}
+        if target == "member_other_org":
+            return {"organization_member": self.other_organization_membership}
         return {"role": self.role_b}
 
     def _materialize(self, specs: list[RowSpec], resource: APIScopeObject, obj: Optional[models.Model]) -> None:
@@ -777,6 +790,14 @@ class TestUserAccessControlProperties(BaseAccessControlPropertyTest):
         # The two project resolvers must not contradict each other: effective_membership_level
         # gates ~25 call sites, while get_user_access_level is what PermissionClass 403s on, so a
         # disagreement means one of them grants access the other denies.
+        #
+        # Scope: object-scope rows only (`project_rows()` draws `("object",)`, so every row carries
+        # `resource_id = str(team.pk)`). Agreement is *not* asserted for resource-level project rows
+        # (`resource="project", resource_id IS NULL`): those make `get_user_access_level` return
+        # `default_access_level("project")` == "admin" via `access_level_for_resource`, while
+        # `effective_membership_level` filters them out on `resource_id`. Only a project admin can
+        # create such a row and the UI never sends `resource: "project"` to `resource_access_controls`,
+        # so that path is left as-is rather than modelled here.
         self._set_membership_level(membership_level)
         self._set_role_based_access(role_based_access)
         self._materialize_project_rows(team_rows)

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -557,8 +557,13 @@ class UserAccessControl:
             # Early return to prevent an unnecessary lookup
             return []
 
-        role_memberships = cast(Any, self._user).role_memberships.select_related("role").all()
-        return [membership.role.id for membership in role_memberships]
+        # Scoped to this organization: an AccessControl row can name a role belonging to a
+        # different organization, and such a row must not grant or deny anything here.
+        return list(
+            cast(Any, self._user)
+            .role_memberships.filter(role__organization_id=self._organization_id)
+            .values_list("role_id", flat=True)
+        )
 
     @cached_property
     def _cached_access_controls(self) -> list[_AccessControl]:

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -625,7 +625,13 @@ class UserAccessControl:
                 **filters, organization_member=None, role=None
             )
             | Q(  # Access controls applying to this user
-                **filters, organization_member__user=self._user, role=None
+                # Scoped to this organization for the same reason as `_user_role_ids`: a row can name
+                # a membership the user holds in a *different* organization, and such a row must not
+                # grant or deny anything here.
+                **filters,
+                organization_member__user=self._user,
+                organization_member__organization_id=self._organization_id,
+                role=None,
             )
             | Q(  # Access controls applying to this user's roles
                 **filters, organization_member=None, role__in=self._user_role_ids

--- a/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recording_playlist.ambr
@@ -599,7 +599,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1704,7 +1705,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -2337,7 +2339,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
+++ b/posthog/session_recordings/test/__snapshots__/test_session_recordings.ambr
@@ -472,7 +472,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1236,7 +1237,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1996,7 +1998,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -2756,7 +2759,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -3520,7 +3524,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -4284,7 +4289,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -5048,7 +5054,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -5781,7 +5788,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -6642,7 +6650,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -7557,7 +7566,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -8389,7 +8399,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -8413,7 +8424,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -9829,7 +9841,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -10283,7 +10296,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -10604,7 +10618,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -11512,7 +11527,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -12365,7 +12381,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -13239,7 +13256,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -499,12 +499,35 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             access_level=access_level,
         )
 
-    def _grant_project_access_via_new_role(self, access_level: str) -> None:
+    def _grant_project_access_via_new_role(self, access_level: str, *, legacy_membership: bool = False) -> None:
         from ee.models.rbac.role import Role, RoleMembership
 
         role = Role.objects.create(name=f"Role {access_level}", organization=self.organization)
-        RoleMembership.objects.create(role=role, user=self.user, organization_member=self.organization_membership)
+        RoleMembership.objects.create(
+            role=role,
+            user=self.user,
+            organization_member=None if legacy_membership else self.organization_membership,
+        )
         self._grant_project_access(access_level, role=role)
+
+    @parameterized.expand(
+        [
+            ("denial", "none", None),
+            ("grant", "admin", OrganizationMembership.Level.ADMIN),
+        ]
+    )
+    def test_role_rule_applies_through_a_role_membership_without_organization_member(
+        self, _name, role_level, expected_level
+    ):
+        # RoleMembership.organization_member is nullable and legacy rows have it NULL, so resolving
+        # roles through that FK drops those rows' rules
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        self._grant_project_access("member")
+        self._grant_project_access_via_new_role(role_level, legacy_membership=True)
+
+        assert self.permissions().current_team.effective_membership_level == expected_level
 
     @parameterized.expand(
         [

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -3,7 +3,7 @@ from posthog.test.base import BaseTest
 from parameterized import parameterized
 
 from posthog.constants import AvailableFeature
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
 from posthog.user_permissions import UserPermissions
@@ -509,6 +509,38 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
             organization_member=None if legacy_membership else self.organization_membership,
         )
         self._grant_project_access(access_level, role=role)
+
+    @parameterized.expand(
+        [
+            ("denial", "none", "member", OrganizationMembership.Level.MEMBER),
+            ("grant", "admin", "none", None),
+        ]
+    )
+    def test_role_rule_from_another_organization_is_ignored(self, _name, role_level, default_level, expected_level):
+        # Nothing scopes the role on an AccessControl row to the project's organization, so a rule
+        # can name a role the user holds in an unrelated organization
+        from ee.models.rbac.access_control import AccessControl
+        from ee.models.rbac.role import Role, RoleMembership
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self._grant_project_access(default_level)
+
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+        foreign_role = Role.objects.create(name="Foreign role", organization=other_organization)
+        RoleMembership.objects.create(role=foreign_role, user=self.user, organization_member=other_membership)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            role=foreign_role,
+            access_level=role_level,
+        )
+
+        assert self.permissions().current_team.effective_membership_level == expected_level
 
     @parameterized.expand(
         [

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -544,6 +544,55 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
 
     @parameterized.expand(
         [
+            ("denial", "none", "member", OrganizationMembership.Level.MEMBER),
+            ("grant", "admin", "none", None),
+        ]
+    )
+    def test_member_rule_from_another_organization_is_ignored(self, _name, member_level, default_level, expected_level):
+        # Same as above for the member arm: nothing scopes `organization_member` on an AccessControl
+        # row to the project's organization, so a rule can name a membership the user holds elsewhere
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self._grant_project_access(default_level)
+
+        other_organization = Organization.objects.create(name="Other organization")
+        other_membership = OrganizationMembership.objects.create(
+            organization=other_organization, user=self.user, level=OrganizationMembership.Level.MEMBER
+        )
+        self._grant_project_access(member_level, member=other_membership)
+
+        assert self.permissions().current_team.effective_membership_level == expected_level
+
+    def test_effective_membership_level_rejects_a_membership_from_another_user(self):
+        # Roles are resolved through the UserPermissions principal, so a mismatched membership would
+        # mix one user's roles into another user's resolution
+        other_user = User.objects.create_and_join(self.organization, "other@posthog.com", None)
+        other_membership = OrganizationMembership.objects.get(user=other_user, organization=self.organization)
+
+        permissions = self.permissions()
+        with self.assertRaises(ValueError):
+            permissions.current_team.effective_membership_level_for_parent_membership(
+                self.organization, other_membership
+            )
+
+    @parameterized.expand(
+        [
+            ("with_access_control", True),
+            ("without_access_control", False),
+        ]
+    )
+    def test_effective_membership_level_caps_organization_owner_at_admin(self, _name, access_control_available):
+        # Project access tops out at admin, so OWNER must not leak out of a project-level resolver
+        if not access_control_available:
+            self.organization.available_product_features = []
+            self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.OWNER
+        self.organization_membership.save()
+
+        assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    @parameterized.expand(
+        [
             ("denial", "none", None),
             ("grant", "admin", OrganizationMembership.Level.ADMIN),
         ]

--- a/posthog/test/test_user_permissions.py
+++ b/posthog/test/test_user_permissions.py
@@ -1,5 +1,7 @@
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.constants import AvailableFeature
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
@@ -484,6 +486,96 @@ class TestUserTeamPermissions(BaseTest, WithPermissionsBase):
         # Expected: Should return ADMIN level (role access trumps direct access)
         # Currently fails: Returns MEMBER level (direct access returned early)
         assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    def _grant_project_access(self, access_level: str, *, member=None, role=None) -> None:
+        from ee.models.rbac.access_control import AccessControl
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=member,
+            role=role,
+            access_level=access_level,
+        )
+
+    def _grant_project_access_via_new_role(self, access_level: str) -> None:
+        from ee.models.rbac.role import Role, RoleMembership
+
+        role = Role.objects.create(name=f"Role {access_level}", organization=self.organization)
+        RoleMembership.objects.create(role=role, user=self.user, organization_member=self.organization_membership)
+        self._grant_project_access(access_level, role=role)
+
+    @parameterized.expand(
+        [
+            ("member_none_without_default", "none", None, None, None),
+            ("member_none_with_admin_default", "none", None, "admin", None),
+            ("role_none_without_default", None, "none", None, None),
+            ("role_none_with_member_default", None, "none", "member", None),
+            ("member_none_role_admin", "none", "admin", None, OrganizationMembership.Level.ADMIN),
+            ("member_admin_role_none", "admin", "none", None, OrganizationMembership.Level.ADMIN),
+            ("member_none_role_member", "none", "member", "none", OrganizationMembership.Level.MEMBER),
+        ]
+    )
+    def test_team_effective_membership_level_explicit_denial(
+        self, _name, member_level, role_level, default_level, expected_level
+    ):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        if default_level is not None:
+            self._grant_project_access(default_level)
+        if member_level is not None:
+            self._grant_project_access(member_level, member=self.organization_membership)
+        if role_level is not None:
+            self._grant_project_access_via_new_role(role_level)
+
+        assert self.permissions().current_team.effective_membership_level == expected_level
+
+    def test_team_effective_membership_level_stale_role_denial_inert_without_role_based_access(self):
+        self.organization.available_product_features = [
+            {"name": AvailableFeature.ACCESS_CONTROL, "key": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        self._grant_project_access_via_new_role("none")
+
+        assert self.permissions().current_team.effective_membership_level == OrganizationMembership.Level.ADMIN
+
+    @parameterized.expand([("member_specific", True), ("role_based", False)])
+    def test_team_denied_by_explicit_rule_is_not_visible(self, _name, via_member):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        if via_member:
+            self._grant_project_access("none", member=self.organization_membership)
+        else:
+            self._grant_project_access_via_new_role("none")
+
+        assert self.team.id not in self.permissions().team_ids_visible_for_user
+        assert self.team.project_id not in self.permissions().project_ids_visible_for_user
+
+    @parameterized.expand([("member_specific", True), ("role_based", False)])
+    def test_team_effective_membership_level_agrees_with_user_access_control(self, _name, via_member):
+        from posthog.rbac.user_access_control import UserAccessControl
+
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        # An open project default, so only the explicit denial can deny
+        self._grant_project_access("admin")
+        if via_member:
+            self._grant_project_access("none", member=self.organization_membership)
+        else:
+            self._grant_project_access_via_new_role("none")
+
+        # `get_user_access_level` is what `check_access_level_for_object` gates project API access
+        # on, so an effective membership level here must not contradict it
+        user_access_control = UserAccessControl(user=self.user, team=self.team)
+        assert user_access_control.get_user_access_level(self.team) == "none"
+        assert self.permissions().current_team.effective_membership_level is None
 
 
 class TestUserDashboardPermissions(BaseTest, WithPermissionsBase):

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -198,33 +198,16 @@ class UserTeamPermissions:
         if not organization.is_feature_available(AvailableFeature.ACCESS_CONTROL):
             return cast("OrganizationMembership.Level", organization_membership.level)
 
-        # Use prefetched data to check team privacy and access
-        access_controls = self.p._prefetched_access_controls.get(self.team.id, [])
-
-        # For private teams, check if the user has specific access
+        # Project rules for this team, from prefetched data
+        access_controls = [
+            ac
+            for ac in self.p._prefetched_access_controls.get(self.team.id, [])
+            if ac["resource_id"] == str(self.team.id)
+        ]
 
         # Organization admins and owners always have access
         if organization_membership.level >= OrganizationMembership.Level.ADMIN:
             return cast("OrganizationMembership.Level", organization_membership.level)
-
-        # Check for direct admin access first - highest priority
-        user_has_admin_access = any(
-            ac["resource_id"] == str(self.team.id)
-            and ac["organization_member_id"] == organization_membership.id
-            and ac["access_level"] == "admin"
-            for ac in access_controls
-        )
-
-        if user_has_admin_access:
-            return OrganizationMembership.Level.ADMIN
-
-        # Check for direct member access
-        user_has_member_access = any(
-            ac["resource_id"] == str(self.team.id)
-            and ac["organization_member_id"] == organization_membership.id
-            and ac["access_level"] == "member"
-            for ac in access_controls
-        )
 
         # Role-backed project AccessControl rows only take effect if the organization has
         # the ROLE_BASED_ACCESS feature — same gate as the UI's "Roles" block on the
@@ -232,53 +215,45 @@ class UserTeamPermissions:
         role_based_access_supported = organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
         user_roles = self.p._prefetched_role_memberships.get(organization_membership.id, [])
 
-        if user_roles and role_based_access_supported:
-            role_has_admin_access = any(
-                ac["resource_id"] == str(self.team.id) and ac["role_id"] in user_roles and ac["access_level"] == "admin"
-                for ac in access_controls
-            )
+        # Rules naming this user — directly, or through a role they hold. These decide on their
+        # own: the highest of them wins, and an explicit "none" is a denial rather than a miss
+        # that falls through to the team default. Same explicit-wins precedence as
+        # `_object_access_level_from_rows` in `posthog/rbac/user_access_control.py`.
+        explicit_access_levels = [
+            ac["access_level"]
+            for ac in access_controls
+            if ac["organization_member_id"] == organization_membership.id
+            or (role_based_access_supported and ac["role_id"] is not None and ac["role_id"] in user_roles)
+        ]
 
-            if role_has_admin_access:
-                return OrganizationMembership.Level.ADMIN
+        if explicit_access_levels:
+            return self._highest_membership_level(explicit_access_levels)
 
-            role_has_member_access = any(
-                ac["resource_id"] == str(self.team.id)
-                and ac["role_id"] in user_roles
-                and ac["access_level"] == "member"
-                for ac in access_controls
-            )
-
-            if role_has_member_access:
-                return OrganizationMembership.Level.MEMBER
-
-        # Return direct member access only if no higher role permissions found
-        if user_has_member_access:
-            return OrganizationMembership.Level.MEMBER
-
-        # Check for a default access level for this team (applies to all org members)
+        # Fall back to the default access level for this team (applies to all org members)
         default_access_level = next(
             (
                 ac["access_level"]
                 for ac in access_controls
-                if ac["resource_id"] == str(self.team.id)
-                and ac["organization_member_id"] is None
-                and ac["role_id"] is None
+                if ac["organization_member_id"] is None and ac["role_id"] is None
             ),
             None,
         )
 
-        if default_access_level == "none":
-            # Team is private and user has no specific access
-            return None
-
-        if default_access_level == "admin":
-            return OrganizationMembership.Level.ADMIN
-
-        if default_access_level == "member":
-            return OrganizationMembership.Level.MEMBER
+        if default_access_level is not None:
+            return self._highest_membership_level([default_access_level])
 
         # No access control row in the database, admin by default. See: `default_access_level()` in `posthog/rbac/user_access_control.py`
         return OrganizationMembership.Level.ADMIN
+
+    @staticmethod
+    def _highest_membership_level(access_levels: list[str]) -> Optional["OrganizationMembership.Level"]:
+        """Highest of the given project access levels as a membership level. None for "none", which
+        is a denial — callers gate on `effective_membership_level is not None`."""
+        if "admin" in access_levels:
+            return OrganizationMembership.Level.ADMIN
+        if "member" in access_levels:
+            return OrganizationMembership.Level.MEMBER
+        return None
 
 
 class UserDashboardPermissions:

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -132,22 +132,18 @@ class UserPermissions:
         return result
 
     @cached_property
-    def _prefetched_role_memberships(self) -> dict[UUID, list[UUID]]:
-        """
-        Prefetch all role memberships for the user.
-        Returns a dict mapping organization_member_id to list of role_ids.
+    def _prefetched_role_ids(self) -> set[UUID]:
+        """Prefetch the ids of every role the user holds.
+
+        Keyed off the user rather than grouped by the `organization_member` FK because legacy
+        RoleMembership rows predating that FK have it NULL (see `RoleMembershipViewSet.
+        safely_get_queryset`), and grouping would silently drop their role rules — including
+        denials. Mirrors `UserAccessControl._user_role_ids`. Role ids are unique, so a role from
+        another organization can never match a row on this team.
         """
         from ee.models.rbac.role import RoleMembership
 
-        memberships = RoleMembership.objects.filter(user=self.user).values("organization_member_id", "role_id")
-
-        result: dict[UUID, list[UUID]] = {}
-        for membership in memberships:
-            org_member_id = membership["organization_member_id"]
-            if org_member_id not in result:
-                result[org_member_id] = []
-            result[org_member_id].append(membership["role_id"])
-        return result
+        return set(RoleMembership.objects.filter(user=self.user).values_list("role_id", flat=True))
 
     def set_preloaded_dashboard_tiles(self, tiles: list[DashboardTile]):
         """
@@ -213,7 +209,7 @@ class UserTeamPermissions:
         # the ROLE_BASED_ACCESS feature — same gate as the UI's "Roles" block on the
         # project access settings page (and as resource-level role overrides).
         role_based_access_supported = organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
-        user_roles = self.p._prefetched_role_memberships.get(organization_membership.id, [])
+        user_roles = self.p._prefetched_role_ids
 
         # Rules naming this user — directly, or through a role they hold. These decide on their
         # own: the highest of them wins, and an explicit "none" is a denial rather than a miss

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -197,8 +197,14 @@ class UserTeamPermissions:
         if organization is None or organization_membership is None:
             return None
 
+        # The member arm below resolves rules against the passed membership, while roles are looked
+        # up under `self.p.user`. A mismatched pair would mix one user's roles into another user's
+        # resolution, so require the caller to pair them.
+        if organization_membership.user_id != self.p.user.pk:
+            raise ValueError("organization_membership must belong to the UserPermissions principal")
+
         if not organization.is_feature_available(AvailableFeature.ACCESS_CONTROL):
-            return cast("OrganizationMembership.Level", organization_membership.level)
+            return self._capped_at_admin(organization_membership.level)
 
         # Project rules for this team, from prefetched data
         access_controls = [
@@ -209,7 +215,7 @@ class UserTeamPermissions:
 
         # Organization admins and owners always have access
         if organization_membership.level >= OrganizationMembership.Level.ADMIN:
-            return cast("OrganizationMembership.Level", organization_membership.level)
+            return self._capped_at_admin(organization_membership.level)
 
         # Role-backed project AccessControl rows only take effect if the organization has
         # the ROLE_BASED_ACCESS feature — same gate as the UI's "Roles" block on the
@@ -246,6 +252,13 @@ class UserTeamPermissions:
 
         # No access control row in the database, admin by default. See: `default_access_level()` in `posthog/rbac/user_access_control.py`
         return OrganizationMembership.Level.ADMIN
+
+    @staticmethod
+    def _capped_at_admin(organization_level: int) -> "OrganizationMembership.Level":
+        """Project access tops out at admin, so an organization owner resolves to admin here rather
+        than leaking `OWNER` out of a project-level resolver. No call site distinguishes the two —
+        they all gate on `is not None`, `>= MEMBER` or `>= ADMIN`."""
+        return min(cast("OrganizationMembership.Level", organization_level), OrganizationMembership.Level.ADMIN)
 
     @staticmethod
     def _highest_membership_level(access_levels: list[str]) -> Optional["OrganizationMembership.Level"]:

--- a/posthog/user_permissions.py
+++ b/posthog/user_permissions.py
@@ -132,18 +132,24 @@ class UserPermissions:
         return result
 
     @cached_property
-    def _prefetched_role_ids(self) -> set[UUID]:
-        """Prefetch the ids of every role the user holds.
+    def _prefetched_role_ids_by_organization(self) -> dict[UUID, set[UUID]]:
+        """Prefetch the ids of every role the user holds, grouped by the role's organization.
 
-        Keyed off the user rather than grouped by the `organization_member` FK because legacy
-        RoleMembership rows predating that FK have it NULL (see `RoleMembershipViewSet.
-        safely_get_queryset`), and grouping would silently drop their role rules — including
-        denials. Mirrors `UserAccessControl._user_role_ids`. Role ids are unique, so a role from
-        another organization can never match a row on this team.
+        Grouped by the role's organization rather than by the `organization_member` FK for two
+        reasons. That FK is nullable and legacy rows have it NULL (see `RoleMembershipViewSet.
+        safely_get_queryset`), so grouping by it silently drops those rows' role rules, including
+        denials. And the organization is the authorization boundary a role must not cross: an
+        AccessControl row can name a role belonging to a different organization, so callers have to
+        look roles up under the organization of the team being resolved.
         """
         from ee.models.rbac.role import RoleMembership
 
-        return set(RoleMembership.objects.filter(user=self.user).values_list("role_id", flat=True))
+        result: dict[UUID, set[UUID]] = {}
+        for organization_id, role_id in RoleMembership.objects.filter(user=self.user).values_list(
+            "role__organization_id", "role_id"
+        ):
+            result.setdefault(organization_id, set()).add(role_id)
+        return result
 
     def set_preloaded_dashboard_tiles(self, tiles: list[DashboardTile]):
         """
@@ -209,7 +215,7 @@ class UserTeamPermissions:
         # the ROLE_BASED_ACCESS feature — same gate as the UI's "Roles" block on the
         # project access settings page (and as resource-level role overrides).
         role_based_access_supported = organization.is_feature_available(AvailableFeature.ROLE_BASED_ACCESS)
-        user_roles = self.p._prefetched_role_ids
+        user_roles = self.p._prefetched_role_ids_by_organization.get(self.team.organization_id, set())
 
         # Rules naming this user — directly, or through a role they hold. These decide on their
         # own: the highest of them wins, and an explicit "none" is a denial rather than a miss

--- a/products/actions/backend/api/test/__snapshots__/test_action.ambr
+++ b/products/actions/backend/api/test/__snapshots__/test_action.ambr
@@ -315,7 +315,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -936,7 +937,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1187,7 +1189,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
+++ b/products/annotations/backend/api/test/__snapshots__/test_annotation.ambr
@@ -315,7 +315,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -946,7 +947,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1207,7 +1209,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
+++ b/products/feature_flags/backend/api/test/__snapshots__/test_feature_flag.ambr
@@ -1525,7 +1525,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''

--- a/products/product_analytics/backend/api/test/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/api/test/__snapshots__/test_insight.ambr
@@ -1094,7 +1094,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''
@@ -1486,7 +1487,8 @@
   WHERE (("ee_accesscontrol"."organization_member_id" IS NULL
           AND "ee_accesscontrol"."role_id" IS NULL
           AND "ee_accesscontrol"."team_id" = 99999)
-         OR ("posthog_organizationmembership"."user_id" = 99999
+         OR ("posthog_organizationmembership"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid
+             AND "posthog_organizationmembership"."user_id" = 99999
              AND "ee_accesscontrol"."role_id" IS NULL
              AND "ee_accesscontrol"."team_id" = 99999))
   '''


### PR DESCRIPTION
## Problem
In some cases, a member with an explicit denial for an access control resource has an effective access level of `ADMIN`. 
This is because we only tested rules for `ADMIN` and `MEMBER` levels, instead of all levels. 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

1. Simplify the project access level resolution logic to resolve max access level of member and role overrides in one spot
2. Consider `NONE` access level rules when evaluating role and member overrides (NOTE: this is still "max-wins". This PR does not implement "most-specific". It only fixes a specific edge case for overrides with `NONE` access)
3. Add new tests
4. Update property based tests

---
    default   member     role |  BEFORE   AFTER  max-wins |  enforced obj-level      ui
          -        -        - |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -        -     none |   ADMIN  DENIED    DENIED |      none      none   admin <== CHANGED
          -        -   member |  MEMBER  MEMBER    MEMBER |    member    member   admin
          -        -    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -     none        - |   ADMIN  DENIED    DENIED |      none      none   admin <== CHANGED
          -     none     none |   ADMIN  DENIED    DENIED |      none      none   admin <== CHANGED
          -     none   member |  MEMBER  MEMBER    MEMBER |    member    member   admin
          -     none    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -   member        - |  MEMBER  MEMBER    MEMBER |    member    member   admin
          -   member     none |  MEMBER  MEMBER    MEMBER |    member    member   admin
          -   member   member |  MEMBER  MEMBER    MEMBER |    member    member   admin
          -   member    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -    admin        - |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -    admin     none |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -    admin   member |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
          -    admin    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none        -        - |  DENIED  DENIED    DENIED |      none      none    none
       none        -     none |  DENIED  DENIED    DENIED |      none      none    none
       none        -   member |  MEMBER  MEMBER    MEMBER |    member    member  member
       none        -    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none     none        - |  DENIED  DENIED    DENIED |      none      none    none
       none     none     none |  DENIED  DENIED    DENIED |      none      none    none
       none     none   member |  MEMBER  MEMBER    MEMBER |    member    member  member
       none     none    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none   member        - |  MEMBER  MEMBER    MEMBER |    member    member  member
       none   member     none |  MEMBER  MEMBER    MEMBER |    member    member  member
       none   member   member |  MEMBER  MEMBER    MEMBER |    member    member  member
       none   member    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none    admin        - |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none    admin     none |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none    admin   member |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
       none    admin    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member        -        - |  MEMBER  MEMBER    MEMBER |    member    member  member
     member        -     none |  MEMBER  DENIED    MEMBER |      none    member  member <== CHANGED
     member        -   member |  MEMBER  MEMBER    MEMBER |    member    member  member
     member        -    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member     none        - |  MEMBER  DENIED    MEMBER |      none    member  member <== CHANGED
     member     none     none |  MEMBER  DENIED    MEMBER |      none    member  member <== CHANGED
     member     none   member |  MEMBER  MEMBER    MEMBER |    member    member  member
     member     none    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member   member        - |  MEMBER  MEMBER    MEMBER |    member    member  member
     member   member     none |  MEMBER  MEMBER    MEMBER |    member    member  member
     member   member   member |  MEMBER  MEMBER    MEMBER |    member    member  member
     member   member    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member    admin        - |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member    admin     none |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member    admin   member |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
     member    admin    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin        -        - |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin        -     none |   ADMIN  DENIED     ADMIN |      none     admin   admin <== CHANGED
      admin        -   member |  MEMBER  MEMBER     ADMIN |    member     admin   admin
      admin        -    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin     none        - |   ADMIN  DENIED     ADMIN |      none     admin   admin <== CHANGED
      admin     none     none |   ADMIN  DENIED     ADMIN |      none     admin   admin <== CHANGED
      admin     none   member |  MEMBER  MEMBER     ADMIN |    member     admin   admin
      admin     none    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin   member        - |  MEMBER  MEMBER     ADMIN |    member     admin   admin
      admin   member     none |  MEMBER  MEMBER     ADMIN |    member     admin   admin
      admin   member   member |  MEMBER  MEMBER     ADMIN |    member     admin   admin
      admin   member    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin    admin        - |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin    admin     none |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin    admin   member |   ADMIN   ADMIN     ADMIN |     admin     admin   admin
      admin    admin    admin |   ADMIN   ADMIN     ADMIN |     admin     admin   admin

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Tests + manually

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
