### PR TITLE
perf(error-tracking): capture merge analytics without per-call client flush

### DIFF
--- a/posthog/ph_client.py
+++ b/posthog/ph_client.py
@@ -1,3 +1,4 @@
+import atexit
 import threading
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -127,14 +128,20 @@ def ph_background_capture() -> ScopedCapture:
 
     For long-lived processes (e.g. Temporal workers) where `ph_scoped_capture`'s
     per-call dedicated client and synchronous flush would sit on the hot path.
-    Events enqueued right before process exit can be lost, so don't use this where
-    delivery must be confirmed before checkpointing durable state.
+    Delivery is best-effort: a bounded flush runs at interpreter exit, so don't use
+    this where delivery must be confirmed before checkpointing durable state.
     """
     global _background_client
     if _background_client is None:
         with _background_client_lock:
             if _background_client is None:
                 _background_client = get_client()
+                # The SDK's own atexit hook only joins the consumer mid-batch without
+                # draining the queue. atexit is LIFO, so this flush (registered after
+                # the client's hook) runs first and drains what a graceful shutdown
+                # enqueued last. Bounded (SDK default 10s) so a dead network can't
+                # stall process exit.
+                atexit.register(_background_client.flush)
     return ScopedCapture(_background_client)
 
 

--- a/posthog/ph_client.py
+++ b/posthog/ph_client.py
@@ -1,3 +1,4 @@
+import threading
 from collections.abc import Mapping
 from contextlib import contextmanager
 from numbers import Number
@@ -98,6 +99,9 @@ def ph_scoped_capture():
     client's background flush may never run before the worker exits, silently losing events.
     This creates a dedicated client and flushes on context-manager exit.
 
+    In a long-lived worker (e.g. Temporal activities), prefer `ph_background_capture` —
+    the client setup and synchronous flush here add seconds of blocking per call.
+
     Usage::
 
         with ph_scoped_capture() as capture:
@@ -111,6 +115,27 @@ def ph_scoped_capture():
         yield ScopedCapture(ph_client)
     finally:
         ph_client.shutdown()
+
+
+_background_client: Any = None
+_background_client_lock = threading.Lock()
+
+
+def ph_background_capture() -> ScopedCapture:
+    """Capture through a process-lifetime client whose batches the SDK's consumer
+    thread delivers in the background — no per-call client setup or blocking flush.
+
+    For long-lived processes (e.g. Temporal workers) where `ph_scoped_capture`'s
+    per-call dedicated client and synchronous flush would sit on the hot path.
+    Events enqueued right before process exit can be lost, so don't use this where
+    delivery must be confirmed before checkpointing durable state.
+    """
+    global _background_client
+    if _background_client is None:
+        with _background_client_lock:
+            if _background_client is None:
+                _background_client = get_client()
+    return ScopedCapture(_background_client)
 
 
 def get_client(region: str = "US", **kwargs: Any):

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -12,7 +12,7 @@ from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
-from posthog.ph_client import ph_scoped_capture
+from posthog.ph_client import ph_background_capture
 
 from products.error_tracking.backend.indexed_embedding import EMBEDDING_TABLES
 from products.error_tracking.backend.models import (
@@ -180,13 +180,13 @@ def _report_closest_fingerprint_metrics(
         properties[f"rank_{index}_fingerprint"] = closest_fingerprint.fingerprint
         properties[f"rank_{index}_distance"] = closest_fingerprint.distance
 
-    with ph_scoped_capture() as capture:
-        capture(
-            distinct_id=str(team.uuid),
-            event="error_tracking_fingerprint_embedding_result_metrics",
-            groups=groups(team=team),
-            properties=properties,
-        )
+    capture = ph_background_capture()
+    capture(
+        distinct_id=str(team.uuid),
+        event="error_tracking_fingerprint_embedding_result_metrics",
+        groups=groups(team=team),
+        properties=properties,
+    )
 
 
 def _merge_fingerprint_into_closest_issue(
@@ -247,20 +247,20 @@ def _merge_fingerprint_into_closest_issue(
         if merge_result != ErrorTrackingIssueMergeResult.MERGED:
             raise StaleAutoMergeStateError(f"Fingerprint issue ownership changed before auto-merge for team {team_id}")
 
-        with ph_scoped_capture() as capture:
-            capture(
-                distinct_id=str(team.uuid),
-                event="error_tracking_issue_merged",
-                groups=groups(team=team),
-                properties={
-                    "merge_source": "auto",
-                    "source_issue_id": str(source_issue_id),
-                    "target_issue_id": str(target_issue_id),
-                    "source_fingerprint": fingerprint,
-                    "target_fingerprint": candidate.fingerprint,
-                    "distance": candidate.distance,
-                },
-            )
+        capture = ph_background_capture()
+        capture(
+            distinct_id=str(team.uuid),
+            event="error_tracking_issue_merged",
+            groups=groups(team=team),
+            properties={
+                "merge_source": "auto",
+                "source_issue_id": str(source_issue_id),
+                "target_issue_id": str(target_issue_id),
+                "source_fingerprint": fingerprint,
+                "target_fingerprint": candidate.fingerprint,
+                "distance": candidate.distance,
+            },
+        )
         return 1
 
     return 0

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
@@ -116,13 +116,11 @@ class TestFingerprintEmbeddingResultActivity:
             SimilarFingerprintDistance(fingerprint="fingerprint-3", distance=0.03),
         ]
         capture = MagicMock()
-        capture_context = MagicMock()
-        capture_context.__enter__.return_value = capture
 
         with (
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_scoped_capture",
-                return_value=capture_context,
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_background_capture",
+                return_value=capture,
             ),
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.groups",
@@ -238,8 +236,6 @@ class TestFingerprintEmbeddingResultActivity:
             source_fingerprint,
         ]
         capture = MagicMock()
-        capture_context = MagicMock()
-        capture_context.__enter__.return_value = capture
 
         with (
             override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
@@ -248,8 +244,8 @@ class TestFingerprintEmbeddingResultActivity:
                 return_value=fingerprint_query,
             ) as filter_fingerprints,
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_scoped_capture",
-                return_value=capture_context,
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_background_capture",
+                return_value=capture,
             ),
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.groups",
@@ -293,9 +289,6 @@ class TestFingerprintEmbeddingResultActivity:
             same_issue_fingerprint,
             target_fingerprint,
         ]
-        capture_context = MagicMock()
-        capture_context.__enter__.return_value = MagicMock()
-
         with (
             override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
@@ -303,8 +296,8 @@ class TestFingerprintEmbeddingResultActivity:
                 return_value=fingerprint_query,
             ),
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_scoped_capture",
-                return_value=capture_context,
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_background_capture",
+                return_value=MagicMock(),
             ),
         ):
             result = _merge_fingerprint_into_closest_issue(
@@ -434,14 +427,11 @@ class TestMergeFingerprintCrossTeamIsolation(BaseTest):
         other_source_issue = self._create_issue(other_team, "fp-source")
         other_target_issue = self._create_issue(other_team, "fp-target")
 
-        capture_context = MagicMock()
-        capture_context.__enter__.return_value = MagicMock()
-
         with (
             override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_scoped_capture",
-                return_value=capture_context,
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_background_capture",
+                return_value=MagicMock(),
             ),
         ):
             merged_count = _merge_fingerprint_into_closest_issue(


### PR DESCRIPTION
## Problem

The error tracking lifecycle Temporal worker reports analytics from `merge_issue_created_fingerprint_activity` through `ph_scoped_capture`, which builds a dedicated `posthoganalytics` client and synchronously flushes it (client `shutdown()`, unbounded timeout) on every call - up to twice per activity run. That helper exists for short-lived Celery tasks, where the global client's background flush may never get a chance to run. In a long-lived Temporal worker it puts blocking client setup + HTTP flush on the hot path of every run.

Off-CPU profiling of the lifecycle worker showed this flush dominating the blocking time of the merge activity - several seconds per run, far more than the ClickHouse similarity query itself (which the activity's own `query_duration_ms` metric puts at ~1s). Since all lifecycle activities share one task queue and slot pool, slow merges back up the whole queue when new-issue volume is high.

## Changes

- Add `ph_background_capture` to `posthog/ph_client.py`: returns a `ScopedCapture` backed by a lazily-created, process-lifetime client whose batches the SDK's consumer thread delivers in the background. No per-call client setup, no blocking flush. Its docstring spells out the trade-off: events enqueued right before process exit can be lost, so it's not for flows that checkpoint durable state on delivery.
- Point `ph_scoped_capture`'s docstring at the new helper for the long-lived worker case.
- Switch the two capture sites in `products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py` (candidate metrics + auto-merge event) to `ph_background_capture`.

Event content, gating (`is_cloud()`), and destinations are unchanged - only the client lifecycle differs.

## How did you test this code?

- `pytest products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py` - 16 passed (existing tests, mocks updated for the new helper; no new tests since the change is client lifecycle, not behavior).
- `pytest posthog/test/test_ph_client.py` - 3 passed.
- No manual testing. After deploy, the effect should show up as a drop in `temporal_activity_execution_latency` for `merge_issue_created_fingerprint_activity` relative to its self-reported `query_duration_ms`, and `ph_scoped_capture` disappearing from the worker's off-CPU profile.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Internal analytics plumbing, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during an investigation of a lifecycle task-queue backlog alert. Diagnosis path: Temporal Cloud backlog metrics -> worker slot saturation -> per-activity latency breakdown -> the activity's self-reported `query_duration_ms` vs total execution latency -> pyroscope off-CPU profile pinning the gap on `ph_scoped_capture.__exit__`. Skills invoked: `/pr-closeout`, `/autoreview`, repo skills `writing-code-comments` and `writing-tests` (read as gates; no new tests added under the value bar). Considered reusing the global `posthoganalytics` client instead of a module-level cached one, but the worker doesn't configure it and `get_client()` carries the region/key selection this path already relied on.
