### PR TITLE
chore(web-analytics): report warming progress rate per minute

### DIFF
--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1080,7 +1080,10 @@ def _warm_queries(context: dagster.OpExecutionContext, mode: str, queries: list[
                 breakdown = ", ".join(f"{k}={v}" for k, v in sorted(outcomes.items()))
                 context.log.info(
                     f"Warming progress: {processed}/{total} ({100 * processed // total}%) "
-                    f"at {rate:.0f}/s, ETA ~{eta_min:.0f}m — {breakdown}"
+                    # Per-minute: cold passes run well under 1 shape/s, and the
+                    # integer /s rate rendered a healthy 14/min and a wedged
+                    # 1/min identically as "0/s".
+                    f"at {rate * 60:.0f}/min, ETA ~{eta_min:.0f}m — {breakdown}"
                 )
                 last_log_at = now
         pool.shutdown(wait=False)

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1080,9 +1080,9 @@ def _warm_queries(context: dagster.OpExecutionContext, mode: str, queries: list[
                 breakdown = ", ".join(f"{k}={v}" for k, v in sorted(outcomes.items()))
                 context.log.info(
                     f"Warming progress: {processed}/{total} ({100 * processed // total}%) "
-                    # Per-minute: cold passes run well under 1 shape/s, and the
-                    # integer /s rate rendered a healthy 14/min and a wedged
-                    # 1/min identically as "0/s".
+                    # Cold passes run well under 1 shape/s, so only per-minute
+                    # precision distinguishes slow-but-healthy progress from the
+                    # crawl the pass deadline guards against.
                     f"at {rate * 60:.0f}/min, ETA ~{eta_min:.0f}m — {breakdown}"
                 )
                 last_log_at = now


### PR DESCRIPTION
## Problem

The warming progress log prints the processing rate as integer shapes per second. Cold passes run well under 1 shape/s, so a healthy shard doing 14 shapes/min and a genuinely wedged shard doing 1 shape/min both render as "0/s" — the display can't distinguish normal cold-pass pace from the slow-crawl failure mode #77743 guards against, and it caused a false stall alarm while watching the post-incident recovery pass.

## Changes

Print the rate per minute (`14/min`) instead of per second.

## How did you test this code?

`hogli test products/web_analytics/dags/tests/test_cache_warming.py` - 70/70 pass. No new test: a log format string change with no branching behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude-authored one-liner spotted while Lucas and I were investigating an apparent shard stall during the post-outage recovery pass - the shard was healthy; only the display was misleading.