### PR TITLE
feat(tasks): polish orchestration controls and messages

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -614,6 +614,7 @@ SPECTACULAR_SETTINGS = {
         # TaskRunUpdate.status and ExperimentFlagCleanupTask.run_status.
         "RunStatusEnum": ["not_started", "queued", "in_progress", "completed", "failed", "cancelled"],
         "TaskRunEnvironmentEnum": "products.tasks.backend.models.TaskRun.Environment",
+        "TierEnum": ["low", "medium", "high"],
         "ReasoningEffortEnum": ["low", "medium", "high", "xhigh", "max", "ultracode", None],
         "TaskRunReasoningEffortEnum": [
             "off",

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -1157,6 +1157,7 @@ export class AgentServer {
           ];
           const promptMeta: Record<string, unknown> = {
             ...(builtPrompt.meta ?? {}),
+            ...(params.origin ? { messageOrigin: params.origin } : {}),
             ...(hostContext.length > 0
               ? { prContext: hostContext.join("\n\n") }
               : {}),

--- a/products/desktop/packages/agent/src/server/schemas.ts
+++ b/products/desktop/packages/agent/src/server/schemas.ts
@@ -69,6 +69,12 @@ export const userMessageParamsSchema = z
     artifacts: z.array(z.record(z.string(), z.unknown())).optional(),
     messageId: z.string().min(1).optional(),
     steer: z.boolean().optional(),
+    origin: z
+      .object({
+        kind: z.literal("automation"),
+        source: z.enum(["child", "ci"]),
+      })
+      .optional(),
   })
   .refine(
     (params) => {

--- a/products/desktop/packages/ui/src/features/mcp-apps/components/McpToolBlock.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-apps/components/McpToolBlock.test.tsx
@@ -1,0 +1,29 @@
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { McpToolBlock } from "./McpToolBlock";
+
+describe("McpToolBlock", () => {
+  it("selects the tasks-spawn renderer for the PostHog tool", () => {
+    const toolCall: ToolCall = {
+      toolCallId: "spawn-1",
+      title: "tasks-spawn",
+      kind: "other",
+      status: "in_progress",
+      rawInput: { title: "Implement focused fix", delegation_profile: "low" },
+    };
+
+    render(
+      <Theme>
+        <McpToolBlock
+          toolCall={toolCall}
+          mcpToolName="mcp__posthog__tasks-spawn"
+        />
+      </Theme>,
+    );
+
+    expect(screen.getByText("Spawn child task")).toBeInTheDocument();
+    expect(screen.getByText("Implement focused fix")).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/mcp-apps/components/McpToolBlock.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-apps/components/McpToolBlock.tsx
@@ -5,6 +5,7 @@ import {
 import { useServiceOptional } from "@posthog/di/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import { McpToolView } from "@posthog/ui/features/mcp-apps/components/McpToolView";
+import { TasksSpawnToolView } from "@posthog/ui/features/mcp-apps/components/TasksSpawnToolView";
 import { parseMcpToolKey } from "@posthog/ui/features/mcp-apps/utils/mcp-app-host-utils";
 import type { ToolViewProps } from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
@@ -20,6 +21,18 @@ interface McpToolBlockProps extends ToolViewProps {
 }
 
 export function McpToolBlock(props: McpToolBlockProps) {
+  const { mcpToolName } = props;
+  const { serverName, toolName } = parseMcpToolKey(mcpToolName);
+  const isTasksSpawn = serverName === "posthog" && toolName === "tasks-spawn";
+
+  if (isTasksSpawn) {
+    return <TasksSpawnToolView {...props} />;
+  }
+
+  return <GenericMcpToolBlock {...props} />;
+}
+
+function GenericMcpToolBlock(props: McpToolBlockProps) {
   const { mcpToolName, toolCall } = props;
   const { serverName, toolName } = parseMcpToolKey(mcpToolName);
 

--- a/products/desktop/packages/ui/src/features/mcp-apps/components/TasksSpawnToolView.test.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-apps/components/TasksSpawnToolView.test.tsx
@@ -1,0 +1,37 @@
+import type { ToolCall } from "@posthog/ui/features/sessions/types";
+import { Theme } from "@radix-ui/themes";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TasksSpawnToolView } from "./TasksSpawnToolView";
+
+describe("TasksSpawnToolView", () => {
+  it("renders child details instead of raw JSON", () => {
+    const toolCall: ToolCall = {
+      toolCallId: "spawn-1",
+      title: "tasks-spawn",
+      kind: "other",
+      status: "in_progress",
+      rawInput: {
+        title: "Implement focused fix",
+        description: "Change the serializer and add tests.",
+        repository: "PostHog/posthog",
+        delegation_profile: "low",
+        wake_on: ["pr_merged"],
+      },
+    };
+
+    render(
+      <Theme>
+        <TasksSpawnToolView toolCall={toolCall} />
+      </Theme>,
+    );
+
+    expect(screen.getByText("Spawn child task")).toBeInTheDocument();
+    expect(screen.getByText("Implement focused fix")).toBeInTheDocument();
+    expect(
+      screen.getByText("Change the serializer and add tests."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("low profile")).toBeInTheDocument();
+    expect(screen.getByText("pr_merged")).toBeInTheDocument();
+  });
+});

--- a/products/desktop/packages/ui/src/features/mcp-apps/components/TasksSpawnToolView.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-apps/components/TasksSpawnToolView.tsx
@@ -1,0 +1,97 @@
+import { Robot } from "@phosphor-icons/react";
+import { ToolRow } from "@posthog/ui/features/sessions/components/session-update/ToolRow";
+import {
+  ContentPre,
+  getContentText,
+  ToolTitle,
+  type ToolViewProps,
+  useToolCallStatus,
+} from "@posthog/ui/features/sessions/components/session-update/toolCallUtils";
+
+type SpawnInput = {
+  title?: string;
+  description?: string;
+  repository?: string;
+  delegation_profile?: string;
+  runtime_adapter?: string;
+  model?: string;
+  reasoning_effort?: string;
+  wake_on?: string[];
+};
+
+function parseSpawnInput(rawInput: unknown): SpawnInput {
+  if (rawInput && typeof rawInput === "object") return rawInput as SpawnInput;
+  if (typeof rawInput !== "string") return {};
+  try {
+    const parsed = JSON.parse(rawInput);
+    return parsed && typeof parsed === "object" ? (parsed as SpawnInput) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function TasksSpawnToolView({
+  toolCall,
+  turnCancelled,
+  turnComplete,
+  expanded = false,
+}: ToolViewProps) {
+  const { isLoading, isFailed, wasCancelled, isComplete } = useToolCallStatus(
+    toolCall.status,
+    turnCancelled,
+    turnComplete,
+  );
+  const input = parseSpawnInput(toolCall.rawInput);
+  const route = input.delegation_profile
+    ? `${input.delegation_profile} profile`
+    : [input.runtime_adapter, input.model, input.reasoning_effort]
+        .filter(Boolean)
+        .join(" · ");
+  const wakeOn = input.wake_on?.length
+    ? input.wake_on.join(", ")
+    : "completion";
+  const output = getContentText(toolCall.content)?.trim();
+
+  return (
+    <ToolRow
+      icon={Robot}
+      isLoading={isLoading}
+      isFailed={isFailed}
+      wasCancelled={wasCancelled}
+      defaultOpen={expanded || !isComplete}
+      content={
+        <div className="space-y-3 p-3 text-sm">
+          {input.description && (
+            <div className="whitespace-pre-wrap text-foreground">
+              {input.description}
+            </div>
+          )}
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-muted-foreground">
+            {input.repository && (
+              <>
+                <dt>Repository</dt>
+                <dd className="text-foreground">{input.repository}</dd>
+              </>
+            )}
+            {route && (
+              <>
+                <dt>Capability</dt>
+                <dd className="text-foreground">{route}</dd>
+              </>
+            )}
+            <dt>Wake parent</dt>
+            <dd className="text-foreground">{wakeOn}</dd>
+          </dl>
+          {output && <ContentPre>{output}</ContentPre>}
+        </div>
+      }
+    >
+      <ToolTitle>Spawn child task</ToolTitle>
+      {input.title && (
+        <ToolTitle>
+          <span className="text-muted-foreground">{input.title}</span>
+        </ToolTitle>
+      )}
+    </ToolRow>
+  );
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/ConversationView.tsx
@@ -372,6 +372,7 @@ export function ConversationView({
               animate={!initialItemIds.has(item.id)}
               taskId={taskId}
               keyboardFocused={item.id === keyboardFocusedMessageId}
+              origin={item.origin}
               sourceUrl={
                 slackThreadUrl && item.id === firstUserMessageId
                   ? slackThreadUrl

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -169,6 +169,21 @@ function refusalStatusMsg(
 }
 
 describe("buildConversationItems", () => {
+  it("preserves trusted automation origin metadata on user messages", () => {
+    const event = userPromptMsg(1, 1, "Child finished the implementation");
+    if ("params" in event.message) {
+      event.message.params = {
+        ...(event.message.params as object),
+        _meta: { messageOrigin: { kind: "automation", source: "child" } },
+      };
+    }
+
+    expect(buildConversationItems([event], null).items[0]).toMatchObject({
+      type: "user_message",
+      origin: { kind: "automation", source: "child" },
+    });
+  });
+
   it("extracts cloud prompt attachments into user messages", () => {
     const uri = makeAttachmentUri("/tmp/hello world.txt");
 

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -41,6 +41,11 @@ export interface TurnContext {
   turnComplete: boolean;
 }
 
+export type MessageOrigin = {
+  kind: "automation";
+  source: "child" | "ci";
+};
+
 export type ConversationItem =
   | {
       type: "user_message";
@@ -49,6 +54,7 @@ export type ConversationItem =
       timestamp: number;
       attachments?: UserMessageAttachment[];
       pinToTop?: boolean;
+      origin?: MessageOrigin;
     }
   | { type: "git_action"; id: string; actionType: GitActionType }
   | { type: "skill_button_action"; id: string; buttonId: SkillButtonId }
@@ -466,6 +472,7 @@ function handlePromptRequest(
 
   const userPrompt = extractUserPrompt(msg.params);
   const userContent = userPrompt.content;
+  const origin = extractMessageOrigin(msg.params);
 
   if (userContent.trim().length === 0 && userPrompt.attachments.length === 0) {
     return;
@@ -544,8 +551,25 @@ function handlePromptRequest(
       content: userContent,
       timestamp: ts,
       attachments: userPrompt.attachments,
+      ...(origin ? { origin } : {}),
     });
   }
+}
+
+function extractMessageOrigin(params: unknown): MessageOrigin | undefined {
+  if (!params || typeof params !== "object") return undefined;
+  const meta = (params as { _meta?: unknown })._meta;
+  if (!meta || typeof meta !== "object") return undefined;
+  const origin = (meta as { messageOrigin?: unknown }).messageOrigin;
+  if (!origin || typeof origin !== "object") return undefined;
+  const value = origin as { kind?: unknown; source?: unknown };
+  if (
+    value.kind === "automation" &&
+    (value.source === "child" || value.source === "ci")
+  ) {
+    return { kind: value.kind, source: value.source };
+  }
+  return undefined;
 }
 
 function handlePromptResponse(

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -3,6 +3,7 @@ import {
   Check,
   Copy,
   FileText,
+  Robot,
   Scroll,
 } from "@phosphor-icons/react";
 import { WorkerPoolContextProvider } from "@pierre/diffs/react";
@@ -384,11 +385,13 @@ function UserBubble({
   timestamp,
   attachments = [],
   keyboardFocused = false,
+  origin,
 }: {
   content: string;
   timestamp?: number;
   attachments?: UserMessageAttachment[];
   keyboardFocused?: boolean;
+  origin?: Extract<ConversationItem, { type: "user_message" }>["origin"];
 }) {
   const bluebirdEnabled = useFeatureFlag(
     PROJECT_BLUEBIRD_FLAG,
@@ -436,6 +439,9 @@ function UserBubble({
   );
 
   const containsFileMentions = hasFileMentions(displayContent);
+  const isAutomation = origin?.kind === "automation";
+  const automationLabel =
+    origin?.source === "child" ? "Child task" : "CI automation";
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -458,8 +464,14 @@ function UserBubble({
 
   return (
     <MessageContextMenu value={displayContent}>
-      <ChatMessage align="end" className="group">
+      <ChatMessage align={isAutomation ? "start" : "end"} className="group">
         <ChatMessageContent className="gap-1">
+          {isAutomation && (
+            <ChatMessageHeader className="flex items-center gap-1 text-muted-foreground text-xs">
+              <Robot className="size-3.5" />
+              {automationLabel}
+            </ChatMessageHeader>
+          )}
           {showHeaderChips && (
             <ChatMessageHeader className="flex-wrap gap-1">
               {showChannelContextTag && channelContext && (
@@ -498,10 +510,11 @@ function UserBubble({
             </ChatMessageHeader>
           )}
           <ChatBubble
-            align="end"
+            align={isAutomation ? "start" : "end"}
             variant="default"
             className={cn(
               "rounded-lg ring-(--gray-11) ring-0 ring-inset transition-shadow",
+              isAutomation && "border border-border bg-muted/40",
               keyboardFocused && "ring-[3px]",
             )}
           >
@@ -672,6 +685,7 @@ function ThreadItemBody({
         timestamp={item.timestamp}
         attachments={item.attachments}
         keyboardFocused={keyboardFocused}
+        origin={item.origin}
       />
     );
   }

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.tsx
@@ -2,6 +2,7 @@ import {
   Check,
   Copy,
   FileText,
+  Robot,
   Scroll,
   SlackLogo,
 } from "@phosphor-icons/react";
@@ -14,6 +15,7 @@ import { MarkdownRenderer } from "../../../editor/components/MarkdownRenderer";
 import { useFeatureFlag } from "../../../feature-flags/useFeatureFlag";
 import { usePanelLayoutStore } from "../../../panels/panelLayoutStore";
 import type { UserMessageAttachment } from "../../userMessageTypes";
+import type { MessageOrigin } from "../buildConversationItems";
 import { UserMessageAttachments } from "../UserMessageAttachments";
 import { CollapsibleMessageContent } from "./CollapsibleMessageContent";
 import { extractCanvasInstructions } from "./canvasInstructions";
@@ -36,6 +38,7 @@ interface UserMessageProps {
   /** Task the message belongs to — needed to open the context file tab. */
   taskId?: string;
   keyboardFocused?: boolean;
+  origin?: MessageOrigin;
 }
 
 function formatTimestamp(ts: number): string {
@@ -62,6 +65,7 @@ export const UserMessage = memo(function UserMessage({
   animate = true,
   taskId,
   keyboardFocused = false,
+  origin,
 }: UserMessageProps) {
   // A channel's CONTEXT.md and the canvas generation instructions, if injected
   // into this prompt, are each collapsed into a clickable tag instead of
@@ -117,6 +121,8 @@ export const UserMessage = memo(function UserMessage({
 
   const containsFileMentions = hasFileMentions(displayContent);
   const showAttachmentChips = attachments.length > 0 && !containsFileMentions;
+  const automationLabel =
+    origin?.source === "child" ? "Child task" : "CI automation";
   const [copied, setCopied] = useState(false);
 
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -140,8 +146,14 @@ export const UserMessage = memo(function UserMessage({
     >
       <Box
         className={`group/msg relative border-l-2 bg-gray-2 py-2 pl-3 transition-shadow ${keyboardFocused ? "ring-(--accent-9) ring-2 ring-offset-(--gray-2) ring-offset-2" : ""}`}
-        style={{ borderColor: "var(--accent-9)" }}
+        style={{ borderColor: origin ? "var(--gray-8)" : "var(--accent-9)" }}
       >
+        {origin && (
+          <Flex align="center" gap="1" className="mb-1 text-gray-10 text-xs">
+            <Robot size={14} />
+            {automationLabel}
+          </Flex>
+        )}
         <CollapsibleMessageContent contentClassName="font-medium text-[13px] [&_p]:leading-[1.9]">
           {containsFileMentions ? (
             parseFileMentions(displayContent)

--- a/products/tasks/backend/facade/run_config.py
+++ b/products/tasks/backend/facade/run_config.py
@@ -22,6 +22,7 @@ from products.tasks.backend.constants import (
 from products.tasks.backend.models import TaskArtifact as _TaskArtifact
 from products.tasks.backend.temporal.process_task.utils import (
     CONTEXT_WINDOW_CHOICES,
+    DELEGATION_PROFILES,
     PUBLIC_REASONING_EFFORTS,
     GitHubCredentialSource,
     LLMProvider,
@@ -46,6 +47,7 @@ __all__ = [
     "ALL_INITIAL_PERMISSION_MODE_CHOICES",
     "CODEX_INITIAL_PERMISSION_MODE_CHOICES",
     "CONTEXT_WINDOW_CHOICES",
+    "DELEGATION_PROFILES",
     "INITIAL_PERMISSION_MODE_CHOICES",
     "InitialPermissionMode",
     "PUBLIC_REASONING_EFFORTS",

--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -285,6 +285,7 @@ def send_user_message(
     timeout: int = COMMAND_TIMEOUT_SECONDS,
     message_id: str | None = None,
     steer: bool = False,
+    origin: dict[str, str] | None = None,
 ) -> CommandResult:
     """Send a user_message command to the sandbox agent.
 
@@ -301,6 +302,8 @@ def send_user_message(
         params["messageId"] = message_id
     if steer:
         params["steer"] = True
+    if origin:
+        params["origin"] = origin
     return send_agent_command(
         task_run,
         method="user_message",

--- a/products/tasks/backend/logic/services/tests/test_agent_command.py
+++ b/products/tasks/backend/logic/services/tests/test_agent_command.py
@@ -406,6 +406,21 @@ class TestSendUserMessage:
             timeout=15,
         )
 
+    @patch("products.tasks.backend.logic.services.agent_command.send_agent_command")
+    def test_sends_trusted_message_origin(self, mock_send):
+        mock_send.return_value = CommandResult(success=True, status_code=200)
+        task_run = MagicMock()
+
+        send_user_message(task_run, "Child finished", origin={"kind": "automation", "source": "child"})
+
+        mock_send.assert_called_once_with(
+            task_run,
+            method="user_message",
+            params={"content": "Child finished", "origin": {"kind": "automation", "source": "child"}},
+            auth_token=None,
+            timeout=15,
+        )
+
 
 class TestSendCancel:
     @patch("products.tasks.backend.logic.services.agent_command.send_agent_command")

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -45,6 +45,7 @@ from products.tasks.backend.facade.run_config import (
     ALL_INITIAL_PERMISSION_MODE_CHOICES,
     CODEX_INITIAL_PERMISSION_MODE_CHOICES,
     CONTEXT_WINDOW_CHOICES,
+    DELEGATION_PROFILES,
     INITIAL_PERMISSION_MODE_CHOICES,
     PUBLIC_REASONING_EFFORTS,
     LLMProvider,
@@ -768,6 +769,16 @@ class TaskSpawnRequestSerializer(serializers.Serializer):
         allow_null=True,
         help_text="Optional target repository in organization/repository format.",
     )
+    delegation_profile = serializers.ChoiceField(
+        choices=list(DELEGATION_PROFILES),
+        required=False,
+        default=None,
+        help_text=(
+            "Server-managed child capability and cost profile. Choose 'low' for focused implementation, "
+            "'medium' for balanced work, or 'high' for difficult planning and implementation. Cannot be combined "
+            "with explicit runtime_adapter, model, or reasoning_effort fields."
+        ),
+    )
     runtime_adapter = serializers.ChoiceField(
         choices=[adapter.value for adapter in RuntimeAdapter], required=False, default=None
     )
@@ -794,6 +805,12 @@ class TaskSpawnRequestSerializer(serializers.Serializer):
         return value
 
     def validate(self, attrs: dict) -> dict:
+        if attrs.get("delegation_profile") is not None and any(
+            attrs.get(field) is not None for field in ("runtime_adapter", "model", "reasoning_effort")
+        ):
+            raise serializers.ValidationError(
+                {"delegation_profile": "Cannot be combined with explicit runtime_adapter, model, or reasoning_effort."}
+            )
         runtime_fields = ("runtime_adapter", "model")
         if any(attrs.get(field) is not None for field in (*runtime_fields, "reasoning_effort")):
             errors = {

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -66,7 +66,7 @@ from products.tasks.backend.facade.metrics import (
     observe_stream_length_on_connect,
     observe_stream_resume_gap,
 )
-from products.tasks.backend.facade.run_config import TaskArtifactAdapter, TaskArtifactType
+from products.tasks.backend.facade.run_config import DELEGATION_PROFILES, TaskArtifactAdapter, TaskArtifactType
 from products.tasks.backend.facade.streams import (
     TASK_RUN_STREAM_WAIT_DELAY_INCREMENT_SECONDS,
     TASK_RUN_STREAM_WAIT_INITIAL_DELAY_SECONDS,
@@ -411,6 +411,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             return Response({"detail": "Team task run rate limit exceeded"}, status=status.HTTP_429_TOO_MANY_REQUESTS)
 
         wake_on = data.pop("wake_on")
+        delegation_profile = data.pop("delegation_profile")
+        if delegation_profile is not None:
+            data.update(DELEGATION_PROFILES[delegation_profile])
         parent_state = parent_run.state or {}
         sandbox_environment_id = data.pop("sandbox_environment_id", parent_state.get("sandbox_environment_id"))
         custom_image_id = data.pop("custom_image_id", parent_state.get("custom_image_id"))
@@ -444,6 +447,7 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                     "parent_task_id": str(parent_run.task_id),
                     "parent_run_id": str(parent_run.id),
                     "wake_on": wake_on,
+                    **({"delegation_profile": delegation_profile} if delegation_profile else {}),
                 },
             )
             if result is None or result.error is not None or result.run is None:

--- a/products/tasks/backend/temporal/execute_sandbox/workflow.py
+++ b/products/tasks/backend/temporal/execute_sandbox/workflow.py
@@ -889,6 +889,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                     message_id=followup.message_id,
                     message_context=followup.context,
                     steer=followup.steer,
+                    source=followup.source,
                 )
                 if followup.steer and outcome == STEER_DECLINED_OUTCOME:
                     self._insert_followup_in_arrival_order(
@@ -1454,6 +1455,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
         message_context: dict[str, Any] | None = None,
         *,
         steer: bool = False,
+        source: str = FOLLOWUP_SOURCE_USER,
     ) -> str | None:
         workflow.logger.info(
             "execute_sandbox_send_followup_begin",
@@ -1472,6 +1474,7 @@ class ExecuteSandboxWorkflow(PostHogWorkflow):
                 actor_user_id=actor_user_id,
                 context=message_context if isinstance(message_context, dict) else {},
                 steer=steer,
+                source=source,
             ),
             start_to_close_timeout=timedelta(minutes=35),
             # See process_task: heartbeat detects worker restarts, message_id

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -81,6 +81,7 @@ class SendFollowupToSandboxInput:
     # Signal context, passed through from PendingFollowup.
     context: dict[str, Any] | None = None
     steer: bool = False
+    source: str = "user"
     max_attempts: int = SEND_FOLLOWUP_MAX_ATTEMPTS
 
 
@@ -247,6 +248,7 @@ def _deliver_followup(input: SendFollowupToSandboxInput) -> str | None:
         timeout=FOLLOWUP_TIMEOUT_SECONDS,
         message_id=input.message_id,
         steer=input.steer,
+        origin={"kind": "automation", "source": input.source} if input.source in {"child", "ci"} else None,
     )
     logger.info(
         "send_followup_to_sandbox_attempted",

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -221,6 +221,12 @@ DEFAULT_MODEL_BY_RUNTIME_ADAPTER: dict[str, str] = {
     RuntimeAdapter.CODEX.value: "gpt-5",
 }
 
+DELEGATION_PROFILES: dict[str, dict[str, str]] = {
+    "low": {"runtime_adapter": "codex", "model": "gpt-5.6-terra", "reasoning_effort": "low"},
+    "medium": {"runtime_adapter": "codex", "model": "gpt-5.6-sol", "reasoning_effort": "medium"},
+    "high": {"runtime_adapter": "claude", "model": "claude-fable-5", "reasoning_effort": "max"},
+}
+
 
 def get_default_model_for_runtime_adapter(runtime_adapter: RuntimeAdapter | str | None) -> str | None:
     if runtime_adapter is None:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1051,13 +1051,19 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
         channel = Channel.objects.unscoped().create(team=self.team, name="orchestration")
         parent_run = self._parent_run(channel=channel)
 
-        response = self.client.post(self.url, self._payload(parent_run, wake_on=["pr_merged"]), format="json")
+        response = self.client.post(
+            self.url, self._payload(parent_run, wake_on=["pr_merged"], delegation_profile="low"), format="json"
+        )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
         child = Task.objects.get(id=response.json()["id"])
         run = child.runs.get()
         self.assertEqual(child.channel_id, channel.id)
         self.assertEqual(run.environment, TaskRun.Environment.CLOUD)
+        self.assertEqual(run.state["delegation_profile"], "low")
+        self.assertEqual(run.state["runtime_adapter"], "codex")
+        self.assertEqual(run.state["model"], "gpt-5.6-terra")
+        self.assertEqual(run.state["reasoning_effort"], "low")
         self.assertIn("You were spawned by an orchestrator task", run.state["pending_user_message"])
         self.assertTrue(run.state["pending_user_message"].endswith("Make the focused change"))
         self.assertEqual(
@@ -1085,6 +1091,21 @@ class TestTaskSpawnAPI(BaseTaskAPITest):
                 for call in capture_event.call_args_list
             )
         )
+
+    def test_spawn_rejects_profile_with_explicit_runtime(self):
+        response = self.client.post(
+            self.url,
+            self._payload(
+                self._parent_run(),
+                delegation_profile="low",
+                runtime_adapter="codex",
+                model="gpt-5.6-sol",
+            ),
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("delegation_profile", response.json())
 
     @patch("products.tasks.backend.facade.api._trigger_task_processing_workflow")
     @patch("products.tasks.backend.presentation.views.api.cloud_usage_limit_response", return_value=None)

--- a/products/tasks/docs/ORCHESTRATION.md
+++ b/products/tasks/docs/ORCHESTRATION.md
@@ -16,6 +16,16 @@ There is no parent-child field on `Task`. Grouping belongs to channels, and addi
 
 Orchestration has a depth limit of one. A run with `parent_task_id` cannot spawn another child.
 
+## Child capability
+
+`tasks-spawn` accepts a server-managed `delegation_profile` for callers that want to control cost and capability without selecting a runtime-specific model combination:
+
+- `low` uses the cheapest supported implementation configuration.
+- `medium` uses a balanced implementation configuration.
+- `high` uses the strongest supported planning and implementation configuration.
+
+Callers that need an exact configuration can instead provide `runtime_adapter`, `model`, and `reasoning_effort`. Profiles and explicit runtime fields cannot be combined.
+
 ## Wake delivery
 
 Every terminal child status wakes the parent. A child can also wake the parent when its pull request merges by including `pr_merged` in `wake_on` at spawn time.
@@ -27,6 +37,8 @@ The wake service resolves the parent task's current run when it delivers the mes
 3. Resume a cold parent and deliver all queued wakes.
 
 Wake messages are built from task and run records. They include the child's status, error, and pull request URL when available.
+
+Child and CI follow-ups carry trusted source metadata through the agent protocol. Clients render them as automation messages rather than attributing them to the user.
 
 ## Running dependent child tasks
 

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3715,6 +3715,19 @@ export interface SlackThreadContextResponseApi {
 }
 
 /**
+ * * `high` - high
+ * * `medium` - medium
+ * * `low` - low
+ */
+export type TierEnumApi = (typeof TierEnumApi)[keyof typeof TierEnumApi]
+
+export const TierEnumApi = {
+    High: 'high',
+    Medium: 'medium',
+    Low: 'low',
+} as const
+
+/**
  * * `pr_merged` - pr_merged
  */
 export type WakeOnEnumApi = (typeof WakeOnEnumApi)[keyof typeof WakeOnEnumApi]
@@ -3739,6 +3752,12 @@ export interface TaskSpawnRequestApi {
      * @nullable
      */
     repository?: string | null
+    /** Server-managed child capability and cost profile. Choose 'low' for focused implementation, 'medium' for balanced work, or 'high' for difficult planning and implementation. Cannot be combined with explicit runtime_adapter, model, or reasoning_effort fields.
+     *
+     * * `low` - low
+     * * `medium` - medium
+     * * `high` - high */
+    delegation_profile?: TierEnumApi
     runtime_adapter?: RuntimeAdapterEnumApi
     model?: string
     reasoning_effort?: ReasoningEffortEnumApi

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3043,6 +3043,13 @@ export const TasksSpawnCreateBody = /* @__PURE__ */ zod.object({
         .max(tasksSpawnCreateBodyRepositoryMax)
         .nullish()
         .describe('Optional target repository in organization\/repository format.'),
+    delegation_profile: zod
+        .enum(['high', 'medium', 'low'])
+        .describe('\* `high` - high\n\* `medium` - medium\n\* `low` - low')
+        .optional()
+        .describe(
+            "Server-managed child capability and cost profile. Choose 'low' for focused implementation, 'medium' for balanced work, or 'high' for difficult planning and implementation. Cannot be combined with explicit runtime_adapter, model, or reasoning_effort fields.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high"
+        ),
     runtime_adapter: zod.enum(['claude', 'codex']).optional().describe('\* `claude` - claude\n\* `codex` - codex'),
     model: zod.string().optional(),
     reasoning_effort: zod

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -618,6 +618,7 @@ tools:
             - title
             - description
             - repository
+            - delegation_profile
             - runtime_adapter
             - model
             - reasoning_effort

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -72868,6 +72868,12 @@ export namespace Schemas {
          * @nullable
          */
       repository?: string | null;
+      /** Server-managed child capability and cost profile. Choose 'low' for focused implementation, 'medium' for balanced work, or 'high' for difficult planning and implementation. Cannot be combined with explicit runtime_adapter, model, or reasoning_effort fields.
+       *
+       * * `low` - low
+       * * `medium` - medium
+       * * `high` - high */
+      delegation_profile?: TierEnum;
       runtime_adapter?: RuntimeAdapterEnum;
       model?: string;
       reasoning_effort?: ReasoningEffortEnum;

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -1187,6 +1187,13 @@ export const TasksSpawnCreateBody = /* @__PURE__ */ zod.object({
         .max(tasksSpawnCreateBodyRepositoryMax)
         .nullish()
         .describe('Optional target repository in organization\/repository format.'),
+    delegation_profile: zod
+        .enum(['high', 'medium', 'low'])
+        .describe('\* `high` - high\n\* `medium` - medium\n\* `low` - low')
+        .optional()
+        .describe(
+            "Server-managed child capability and cost profile. Choose 'low' for focused implementation, 'medium' for balanced work, or 'high' for difficult planning and implementation. Cannot be combined with explicit runtime_adapter, model, or reasoning_effort fields.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high"
+        ),
     runtime_adapter: zod.enum(['claude', 'codex']).optional().describe('\* `claude` - claude\n\* `codex` - codex'),
     model: zod.string().optional(),
     reasoning_effort: zod

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -687,6 +687,9 @@ const tasksSpawn = (): ToolBase<typeof TasksSpawnSchema, WithPostHogUrl<Schemas.
         if (params.repository !== undefined) {
             body['repository'] = params.repository
         }
+        if (params.delegation_profile !== undefined) {
+            body['delegation_profile'] = params.delegation_profile
+        }
         if (params.runtime_adapter !== undefined) {
             body['runtime_adapter'] = params.runtime_adapter
         }


### PR DESCRIPTION
## Problem

Orchestrated follow-ups look like user-authored messages, child spawn approvals expose raw JSON, and agents must know valid runtime/model/effort combinations to delegate work at a different cost tier.

## Changes

- Carry trusted child and CI origin metadata through Temporal, the agent server, and ACP transcripts, then render those messages as labeled automation cards.
- Render `tasks-spawn` as a focused child-task card with its prompt, repository, capability, and wake behavior.
- Add server-managed `low`, `medium`, and `high` delegation profiles while retaining mutually exclusive explicit runtime/model/effort selection.
- Regenerate OpenAPI and MCP bindings and document the orchestration behavior.

## How did you test this code?

- Backend orchestration, spawn API, and agent-command tests: 126 collected and passed.
- Desktop UI focused tests: 36 passed, including automation metadata and spawn renderer regressions.
- Agent server test suite and typecheck passed.
- Desktop UI typecheck passed.
- OpenAPI and MCP code generation passed; generated `tasks-spawn` schema contains `delegation_profile`.
- `bin/hogli ci:preflight --fix` passed all applicable formatting and lint checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated `products/tasks/docs/ORCHESTRATION.md`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the change with the repository local-MCP testing skill. The routing profiles are server-owned so callers can express cost/capability intent without guessing cross-field-valid model combinations; exact runtime overrides remain available. The live local MCP watcher was not reachable for the final direct probe, so verification used the regenerated direct tool schema rather than claiming a live manual test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*