### PR TITLE
fix(cdp): confirm SNS subscriptions by reading the top-level SubscribeURL

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto'
+
 import { defaultConfig } from '~/common/config/config'
 
 import { SesWebhookHandler } from './ses'
@@ -5,6 +7,9 @@ import { EmailTrackingCodeSigner } from './tracking-code'
 
 // Hardcoded (not imported) so a change to the header constant fails this test.
 const TRACKING_CODE_HEADER = 'X-PostHog-Tracking-Code'
+
+const signingKeys = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 })
+const signingCertPem = signingKeys.publicKey.export({ type: 'spki', format: 'pem' }).toString()
 
 const signer = new EmailTrackingCodeSigner(defaultConfig.ENCRYPTION_SALT_KEYS, 'http://localhost:8010')
 
@@ -437,62 +442,68 @@ describe('SesWebhookHandler', () => {
         expect(result.metrics).toEqual([])
     })
 
-    it('confirms SubscriptionConfirmation with valid SNS SubscribeURL', async () => {
-        const fetchSpy = jest.spyOn(handler as any, 'fetchText').mockResolvedValue('')
-        const snsEnvelope = {
+    // Shaped like what SNS actually posts: SubscribeURL is a sibling of Message, and Message holds
+    // prose rather than JSON. Signed with a real key and verified with verifySignature on, because
+    // production always verifies and the confirmation envelope's signed string differs from a
+    // notification's (it covers Token and SubscribeURL).
+    const snsConfirmation = (subscribeUrl: string): Record<string, string> => {
+        const envelope: Record<string, string> = {
             Type: 'SubscriptionConfirmation',
             MessageId: 'sns-msg-1',
             Token: 'token-123',
             TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
-            Message: JSON.stringify({
-                SubscribeURL:
-                    'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:us-east-1:123456789012:ses-topic&Token=token-123',
-            }),
+            Message:
+                'You have chosen to subscribe to the topic arn:aws:sns:us-east-1:123456789012:ses-topic.\nTo confirm the subscription, visit the SubscribeURL included in this message.',
+            SubscribeURL: subscribeUrl,
             Timestamp: '2025-10-03T12:10:00Z',
             SignatureVersion: '1',
-            Signature: 'fake',
             SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
         }
-        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
+        // The canonical string AWS signs: these keys in this order, each as "key\nvalue\n".
+        const canonical = ['Message', 'MessageId', 'SubscribeURL', 'Timestamp', 'Token', 'TopicArn', 'Type']
+            .map((key) => `${key}\n${envelope[key]}\n`)
+            .join('')
+        return {
+            ...envelope,
+            Signature: crypto.createSign('RSA-SHA1').update(canonical, 'utf8').sign(signingKeys.privateKey, 'base64'),
+        }
+    }
+
+    it('confirms a signed SubscriptionConfirmation by fetching its SubscribeURL', async () => {
+        const certSpy = jest.spyOn(handler as any, 'fetchCert').mockResolvedValue(signingCertPem)
+        const fetchSpy = jest.spyOn(handler as any, 'fetchText').mockResolvedValue('')
+        const subscribeUrl =
+            'https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:us-east-1:123456789012:ses-topic&Token=token-123'
+
+        const result = await handler.handleWebhook({
+            body: snsConfirmation(subscribeUrl),
+            headers: {},
+            verifySignature: true,
+        })
+
         expect(result.status).toBe(200)
-        expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining('https://sns.us-east-1.amazonaws.com/'))
+        expect(fetchSpy).toHaveBeenCalledWith(subscribeUrl)
+        certSpy.mockRestore()
         fetchSpy.mockRestore()
     })
 
-    it('rejects SubscriptionConfirmation with non-SNS SubscribeURL', async () => {
-        const snsEnvelope = {
-            Type: 'SubscriptionConfirmation',
-            MessageId: 'sns-msg-1',
-            Token: 'token-123',
-            TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
-            Message: JSON.stringify({
-                SubscribeURL: 'https://evil.lhr.life/latest/meta-data/iam/security-credentials/role',
-            }),
-            Timestamp: '2025-10-03T12:10:00Z',
-            SignatureVersion: '1',
-            Signature: 'fake',
-            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
-        }
-        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
-        expect(result.status).toBe(403)
-    })
+    it.each([
+        ['a host outside SNS', 'https://evil.lhr.life/latest/meta-data/iam/security-credentials/role'],
+        ['plaintext http', 'http://sns.us-east-1.amazonaws.com/subscribe'],
+    ])('refuses to fetch a SubscribeURL pointing at %s', async (_case, subscribeUrl) => {
+        const certSpy = jest.spyOn(handler as any, 'fetchCert').mockResolvedValue(signingCertPem)
+        const fetchSpy = jest.spyOn(handler as any, 'fetchText').mockResolvedValue('')
 
-    it('rejects SubscriptionConfirmation with HTTP SubscribeURL', async () => {
-        const snsEnvelope = {
-            Type: 'SubscriptionConfirmation',
-            MessageId: 'sns-msg-1',
-            Token: 'token-123',
-            TopicArn: 'arn:aws:sns:us-east-1:123456789012:ses-topic',
-            Message: JSON.stringify({
-                SubscribeURL: 'http://sns.us-east-1.amazonaws.com/subscribe',
-            }),
-            Timestamp: '2025-10-03T12:10:00Z',
-            SignatureVersion: '1',
-            Signature: 'fake',
-            SigningCertURL: 'https://sns.us-east-1.amazonaws.com/cert.pem',
-        }
-        const result = await handler.handleWebhook({ body: snsEnvelope, headers: {}, verifySignature: false })
+        const result = await handler.handleWebhook({
+            body: snsConfirmation(subscribeUrl),
+            headers: {},
+            verifySignature: true,
+        })
+
         expect(result.status).toBe(403)
+        expect(fetchSpy).not.toHaveBeenCalled()
+        certSpy.mockRestore()
+        fetchSpy.mockRestore()
     })
 
     it('propagates parentRunId from the tracking code so batch runs get correct attribution', async () => {

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -24,6 +24,9 @@ const SnsEnvelopeSchema = z.object({
     Signature: z.string(),
     SigningCertURL: z.string().url(),
     UnsubscribeURL: z.string().url().optional(),
+    // Confirmation envelopes only. This has to stay declared: zod strips undeclared keys, and without
+    // it the field is missing from the signed string, so every confirmation fails signature checks.
+    SubscribeURL: z.string().url().optional(),
 })
 
 export type SnsEnvelope = z.infer<typeof SnsEnvelopeSchema>
@@ -394,7 +397,7 @@ export class SesWebhookHandler {
         } else if (m.Type === 'SubscriptionConfirmation' || m.Type === 'UnsubscribeConfirmation') {
             pushKV('Message', m.Message)
             pushKV('MessageId', m.MessageId)
-            pushKV('SubscribeURL', (m as any).SubscribeURL) // present in confirmation payload body, not in envelope schema
+            pushKV('SubscribeURL', m.SubscribeURL)
             pushKV('Timestamp', m.Timestamp)
             pushKV('Token', m.Token!)
             pushKV('TopicArn', m.TopicArn)
@@ -483,19 +486,18 @@ export class SesWebhookHandler {
         // Handle confirmation flow
         if (parsed.mode === 'sns' && 'envelope' in parsed && parsed.envelope?.Type === 'SubscriptionConfirmation') {
             logger.info('[SesWebhookHandler] confirming subscription', { envelope: parsed.envelope })
-            // Confirm by visiting SubscribeURL (contained in the *message JSON*, not envelope.Message field here)
-            // We need to fetch the inner message JSON to get SubscribeURL
-            const env = parsed.envelope
-            const inner = parseJSON(env.Message) as { SubscribeURL?: string }
-            logger.info('[SesWebhookHandler] confirming subscription', { inner })
-            if (inner.SubscribeURL) {
-                if (!this.isValidSnsSubscribeUrl(inner.SubscribeURL)) {
+            // SNS holds the subscription in PendingConfirmation until someone fetches SubscribeURL,
+            // so responding 200 is not what confirms it. On a confirmation envelope SubscribeURL is
+            // a top-level field, while Message carries prose for a human rather than JSON.
+            const subscribeUrl = parsed.envelope.SubscribeURL
+            if (subscribeUrl) {
+                if (!this.isValidSnsSubscribeUrl(subscribeUrl)) {
                     logger.warn('[SesWebhookHandler] Invalid SubscribeURL, rejecting', {
-                        url: inner.SubscribeURL,
+                        url: subscribeUrl,
                     })
                     return { status: 403, body: { error: 'Invalid SubscribeURL' } }
                 }
-                await this.fetchText(inner.SubscribeURL)
+                await this.fetchText(subscribeUrl)
             }
             return { status: 200, body: { ok: true } }
         }


### PR DESCRIPTION
## Problem

A new HTTPS SNS subscription is not live until someone fetches the one-time `SubscribeURL` that SNS posts to the endpoint. Our SES webhook is meant to do that for itself, and it never has, because it looks for `SubscribeURL` in the wrong place.

AWS puts `SubscribeURL` at the top level of a `SubscriptionConfirmation` payload. `Message` holds prose for a human, not JSON. Two failures follow from that one wrong assumption:

1. `SnsEnvelopeSchema` does not declare `SubscribeURL`, and zod strips undeclared keys, so the field is gone before `buildStringToSign` runs. The signed string is missing a line, RSA verification fails, and the handler returns 403 before reaching the confirmation branch. This is the one that fires in practice.
2. Even past that, the branch reads the URL via `parseJSON(env.Message)`. `parseJSON` is a bare `JSON.parse`, and `Message` is a sentence, so it throws. Fixing only the schema turns the 403 into a 500.

Nothing caught this because confirmation runs exactly once per subscription, when it is created. A subscription that is never confirmed reads back as absent, which shows up as a permanent `1 to add` in the Terraform plan for the topic, and no SES events reach the webhook for messages sent through that configuration set.

## Changes

Declare `SubscribeURL` on the envelope schema so it survives parsing and reaches the signed string, and read it from `parsed.envelope.SubscribeURL` instead of parsing `Message`. The existing `isValidSnsSubscribeUrl` host check is unchanged, so we still refuse to fetch anything that is not an `https` SNS host.

> [!NOTE]
> Deploying this does not confirm an existing pending subscription. AWS sends the handshake once and does not resend it. Each affected topic needs a fresh `Subscribe`, so apply the owning Terraform stack after this ships, not before.

## How did you test this code?

Automated only. I have not exercised this against real AWS.

The new test builds a confirmation envelope in the shape SNS actually posts, signs it with an RSA key generated in the test, and runs with `verifySignature: true`. Reverting either source change makes it fail, the schema change with `Received: 403` and the read change with a `SyntaxError`, so it covers both defects rather than just the visible one.

The three tests it replaces could not catch either. They built `Message: JSON.stringify({ SubscribeURL })`, encoding the same wrong shape as the bug, and passed `verifySignature: false`, so the signature path never ran. The two rejection cases are kept as one parameterized test, now with verification on and asserting we never fetch the URL, which is the SSRF property worth guarding.

```
Tests:       44 passed, 44 total
```

Typecheck clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code wrote this while I was chasing a recurring SNS subscription drift in a Terraform plan. It started from the plan output, found the rejected handshake in the webhook logs, and traced it to the schema strip. The second defect only turned up when I asked it to explain how the fix would actually work end to end, which is a good argument for making it explain the mechanism rather than accepting the first one-line diff.

Invoked `/writing-tests` and `/writing-code-comments`. The test approach was chosen over mocking `verifySnsSignature`, since mocking the verifier would have left the canonical-string bug invisible, which is exactly how this shipped in the first place. The canonical key order is written literally in the test because it encodes the AWS spec rather than our implementation.

Left out deliberately: a counter and alert on rejected confirmations, so a silent 403 is visible next time. Worth a follow-up.
