### PR TITLE
fix(cdp): give third-party requests a longer response budget

### DIFF
--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -8,6 +8,19 @@ export const DEFAULT_HTTP_SERVER_PORT = 6738
 // (mirrors LOCAL_DEV_INTERNAL_API_SECRET on the Django side).
 export const LOCAL_DEV_INTERNAL_API_SECRET = 'posthog123'
 
+/**
+ * Response budget for a request to a host we don't run, used by `fetch`/`legacyFetch` in
+ * common/utils/request.ts. Kept well above EXTERNAL_REQUEST_TIMEOUT_MS, which is sized for calls
+ * between our own services on the same network.
+ *
+ * A CDP destination points at whatever API the customer configured, which is routinely in another
+ * region and under no latency obligation to us. At the internal-service budget, an API that
+ * answers in a few seconds is cut off on every attempt, so every retry fails the same way and the
+ * event is lost for good, which penalizes the destination for the third party being slow rather
+ * than for being broken.
+ */
+export const DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS = 10000
+
 export enum KafkaSaslMechanism {
     Plain = 'plain',
     ScramSha256 = 'scram-sha-256',
@@ -177,6 +190,7 @@ export type CommonConfig = BaseServerConfig & {
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: number
     EXTERNAL_REQUEST_TIMEOUT_MS: number
+    EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: number
     EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECTIONS: number
@@ -203,6 +217,7 @@ export type CommonConfig = BaseServerConfig & {
 export type ExternalRequestConfig = Pick<
     CommonConfig,
     | 'EXTERNAL_REQUEST_TIMEOUT_MS'
+    | 'EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_CONNECTIONS'
@@ -211,6 +226,9 @@ export type ExternalRequestConfig = Pick<
 export function getExternalRequestConfig(): ExternalRequestConfig {
     return {
         EXTERNAL_REQUEST_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_TIMEOUT_MS ?? 3000),
+        EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: Number(
+            process.env.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS ?? DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS
+        ),
         EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS ?? 3000),
         EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS ?? 10000),
         EXTERNAL_REQUEST_CONNECTIONS: Number(process.env.EXTERNAL_REQUEST_CONNECTIONS ?? 500),
@@ -354,6 +372,7 @@ export function getDefaultCommonConfig(): CommonConfig {
         HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: 5 * 60_000,
         HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: 10 * 60_000,
         EXTERNAL_REQUEST_TIMEOUT_MS: 3000,
+        EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS,
         EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: 3000,
         EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: 10000,
         EXTERNAL_REQUEST_CONNECTIONS: 500,

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -189,6 +189,8 @@ export type CommonConfig = BaseServerConfig & {
     HOGFLOW_SCHEDULER_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: number
+    // Despite the EXTERNAL_REQUEST_ prefix this one only reaches `internalFetch`, so it is the
+    // budget for calls to our own services. Third-party hosts use the sibling below.
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: number

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -8,6 +8,19 @@ export const DEFAULT_HTTP_SERVER_PORT = 6738
 // (mirrors LOCAL_DEV_INTERNAL_API_SECRET on the Django side).
 export const LOCAL_DEV_INTERNAL_API_SECRET = 'posthog123'
 
+/**
+ * Response budget for a request to a host we don't run, used by `fetch`/`legacyFetch` in
+ * common/utils/request.ts. Kept well above EXTERNAL_REQUEST_TIMEOUT_MS, which is sized for calls
+ * between our own services on the same network.
+ *
+ * A CDP destination points at whatever API the customer configured, which is routinely in another
+ * region and under no latency obligation to us. At the internal-service budget, an API that
+ * answers in a few seconds is cut off on every attempt, so every retry fails the same way and the
+ * event is lost for good, which penalizes the destination for the third party being slow rather
+ * than for being broken.
+ */
+export const DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS = 10000
+
 export enum KafkaSaslMechanism {
     Plain = 'plain',
     ScramSha256 = 'scram-sha-256',
@@ -175,6 +188,7 @@ export type CommonConfig = BaseServerConfig & {
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: number
     EXTERNAL_REQUEST_TIMEOUT_MS: number
+    EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: number
     EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECTIONS: number
@@ -199,6 +213,7 @@ export type CommonConfig = BaseServerConfig & {
 export type ExternalRequestConfig = Pick<
     CommonConfig,
     | 'EXTERNAL_REQUEST_TIMEOUT_MS'
+    | 'EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS'
     | 'EXTERNAL_REQUEST_CONNECTIONS'
@@ -207,6 +222,9 @@ export type ExternalRequestConfig = Pick<
 export function getExternalRequestConfig(): ExternalRequestConfig {
     return {
         EXTERNAL_REQUEST_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_TIMEOUT_MS ?? 3000),
+        EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: Number(
+            process.env.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS ?? DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS
+        ),
         EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS ?? 3000),
         EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: Number(process.env.EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS ?? 10000),
         EXTERNAL_REQUEST_CONNECTIONS: Number(process.env.EXTERNAL_REQUEST_CONNECTIONS ?? 500),
@@ -350,6 +368,7 @@ export function getDefaultCommonConfig(): CommonConfig {
         HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: 5 * 60_000,
         HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: 10 * 60_000,
         EXTERNAL_REQUEST_TIMEOUT_MS: 3000,
+        EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS,
         EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: 3000,
         EXTERNAL_REQUEST_KEEP_ALIVE_TIMEOUT_MS: 10000,
         EXTERNAL_REQUEST_CONNECTIONS: 500,

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -187,6 +187,8 @@ export type CommonConfig = BaseServerConfig & {
     HOGFLOW_SCHEDULER_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_MAX_POLL_INTERVAL_MS: number
     HOGFLOW_SCHEDULER_HEALTH_TIMEOUT_MS: number
+    // Despite the EXTERNAL_REQUEST_ prefix this one only reaches `internalFetch`, so it is the
+    // budget for calls to our own services. Third-party hosts use the sibling below.
     EXTERNAL_REQUEST_TIMEOUT_MS: number
     EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: number
     EXTERNAL_REQUEST_CONNECT_TIMEOUT_MS: number

--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -3,8 +3,17 @@ import { range } from 'lodash'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'
 
+import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS } from '~/common/config'
+
 import { parseJSON } from './json-parse'
-import { SecureRequestError, fetch, internalFetch, legacyFetch, raiseIfUserProvidedUrlUnsafe } from './request'
+import {
+    FetchOptions,
+    SecureRequestError,
+    fetch,
+    internalFetch,
+    legacyFetch,
+    raiseIfUserProvidedUrlUnsafe,
+} from './request'
 
 const realDnsLookup = jest.requireActual('dns/promises').lookup
 jest.mock('dns/promises', () => ({
@@ -114,6 +123,37 @@ describe('fetch', () => {
             try {
                 const response = await fetch(baseUrl)
                 expect(response.status).toBe(200)
+            } finally {
+                process.env.NODE_ENV = originalNodeEnv
+            }
+        })
+
+        // A CDP destination calls whatever API the customer configured, so it needs the
+        // third-party budget rather than the tighter one sized for our own services. Routing it
+        // back through the internal budget fails silently, because the only symptom is slower
+        // cross-region APIs being cut off on every retry until the event is dropped.
+        it.each([
+            ['fetch', fetch, DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS],
+            ['internalFetch', internalFetch, 3000],
+        ])('%s defaults the request timeout to %sms', async (_name, doFetch, expectedTimeoutMs) => {
+            const originalNodeEnv = process.env.NODE_ENV
+            process.env.NODE_ENV = 'test'
+            try {
+                const options: FetchOptions = {}
+                await doFetch(baseUrl, options)
+                expect(options.timeoutMs).toBe(expectedTimeoutMs)
+            } finally {
+                process.env.NODE_ENV = originalNodeEnv
+            }
+        })
+
+        it('keeps a timeout the caller set explicitly', async () => {
+            const originalNodeEnv = process.env.NODE_ENV
+            process.env.NODE_ENV = 'test'
+            try {
+                const options: FetchOptions = { timeoutMs: 1234 }
+                await fetch(baseUrl, options)
+                expect(options.timeoutMs).toBe(1234)
             } finally {
                 process.env.NODE_ENV = originalNodeEnv
             }

--- a/nodejs/src/common/utils/request.test.ts
+++ b/nodejs/src/common/utils/request.test.ts
@@ -3,7 +3,7 @@ import { range } from 'lodash'
 import http from 'node:http'
 import { AddressInfo } from 'node:net'
 
-import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS } from '~/common/config'
+import { DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS, getExternalRequestConfig } from '~/common/config'
 
 import { parseJSON } from './json-parse'
 import {
@@ -128,14 +128,13 @@ describe('fetch', () => {
             }
         })
 
-        // A CDP destination calls whatever API the customer configured, so it needs the
-        // third-party budget rather than the tighter one sized for our own services. Routing it
-        // back through the internal budget fails silently, because the only symptom is slower
-        // cross-region APIs being cut off on every retry until the event is dropped.
+        // Each entry point has to resolve to its own budget. Sending third-party traffic through
+        // the internal one fails silently: the only symptom is slower cross-region APIs getting
+        // cut off on every retry until the invocation is dropped.
         it.each([
-            ['fetch', fetch, DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS],
-            ['internalFetch', internalFetch, 3000],
-        ])('%s defaults the request timeout to %sms', async (_name, doFetch, expectedTimeoutMs) => {
+            ['fetch', DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS, fetch],
+            ['internalFetch', getExternalRequestConfig().EXTERNAL_REQUEST_TIMEOUT_MS, internalFetch],
+        ])('%s defaults the request timeout to %sms', async (_name, expectedTimeoutMs, doFetch) => {
             const originalNodeEnv = process.env.NODE_ENV
             process.env.NODE_ENV = 'test'
             try {

--- a/nodejs/src/common/utils/request.ts
+++ b/nodejs/src/common/utils/request.ts
@@ -332,7 +332,12 @@ async function readAndDestroyBody(body: Dispatcher.ResponseData['body']): Promis
     return text
 }
 
-export async function _fetch(url: string, options: FetchOptions = {}, dispatcher: Dispatcher): Promise<FetchResponse> {
+export async function _fetch(
+    url: string,
+    options: FetchOptions = {},
+    dispatcher: Dispatcher,
+    defaultTimeoutMs: number = requestConfig.EXTERNAL_REQUEST_TIMEOUT_MS
+): Promise<FetchResponse> {
     let parsed: URL
     try {
         parsed = new URL(url)
@@ -344,7 +349,7 @@ export async function _fetch(url: string, options: FetchOptions = {}, dispatcher
         throw new Error('URL must have HTTP or HTTPS protocol and a valid hostname')
     }
 
-    options.timeoutMs = options.timeoutMs ?? requestConfig.EXTERNAL_REQUEST_TIMEOUT_MS
+    options.timeoutMs = options.timeoutMs ?? defaultTimeoutMs
 
     const result = await request(parsed.toString(), {
         method: options.method ?? 'GET',
@@ -399,13 +404,18 @@ export async function internalFetch(url: string, options: FetchOptions = {}): Pr
     return await _fetch(url, options, sharedInsecureAgent)
 }
 
+/**
+ * Requests to a host we don't run, meaning CDP destinations and anything else pointed at a
+ * customer-supplied URL. These get the third-party response budget rather than the internal-service
+ * one that `internalFetch` keeps; see DEFAULT_THIRD_PARTY_REQUEST_TIMEOUT_MS for why they differ.
+ */
 export async function fetch(url: string, options: FetchOptions = {}): Promise<FetchResponse> {
     const parsed = new URL(url)
     validateHostnameIPLiteral(parsed.hostname, !isProdEnv())
     inflightExternalRequests.inc()
     try {
         const dispatcher = options.allowH2 ? sharedSecureH2Agent : sharedSecureAgent
-        return await _fetch(url, options, dispatcher)
+        return await _fetch(url, options, dispatcher, requestConfig.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS)
     } finally {
         inflightExternalRequests.dec()
     }
@@ -428,7 +438,7 @@ export function legacyFetch(input: RequestInfo, options?: RequestInit): Promise<
 
     const requestOptions = options ?? {}
     requestOptions.dispatcher = sharedSecureAgent
-    requestOptions.signal = AbortSignal.timeout(requestConfig.EXTERNAL_REQUEST_TIMEOUT_MS)
+    requestOptions.signal = AbortSignal.timeout(requestConfig.EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS)
 
     return undiciFetch(parsed.toString(), requestOptions)
 }


### PR DESCRIPTION
## Problem

Every outbound HTTP request from the node service shared one response budget: `EXTERNAL_REQUEST_TIMEOUT_MS`, 3s, applied as an `AbortSignal.timeout` in `_fetch`.

3s is a reasonable number for our own services talking to each other on the same network. But CDP destinations go out through the same `fetch()`, and a destination calls whatever API the customer configured. That API is frequently in another region and is under no latency obligation to us.

The result is that a destination pointed at an API which answers in, say, 4s gets aborted at 3s on every attempt. Retries don't rescue it, because each retry hits the same wall the same way. The invocation ends up permanently failed with a timeout even though nothing is broken on either end. We were effectively penalizing a destination for the third party being slow rather than for being wrong.

This shows up as a steady background failure rate on destinations whose API is far away or slow under load, not as transient blips, which is what makes it worth fixing rather than retrying through.

## Changes

Split the budget by who owns the host on the other end.

```diff
  EXTERNAL_REQUEST_TIMEOUT_MS: 3000,
+ EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS: 10000,
```

- `fetch()` and `legacyFetch()` only ever talk to third-party or customer-supplied URLs. They now default to `EXTERNAL_REQUEST_THIRD_PARTY_TIMEOUT_MS`, 10s, overridable by env so it can be tuned without a deploy.
- `internalFetch()` keeps the 3s service-to-service budget, unchanged.
- A `timeoutMs` a caller sets explicitly still wins, so push notifications and the replay rasterizer keep whatever they already pass.

Doing this at the fetch layer rather than inside `cdpTrackedFetch` covers every CDP egress path at once: Hog function templates, native destinations, Segment destinations, and legacy plugin destinations. It also means a new call site can't accidentally inherit the internal budget.

Nothing about connect timeouts, keep-alive, retry counts, or backoff changes. `MAX_FETCH_TIMEOUT_MS` in the hog executor is already 10000, so the new default lines up with the ceiling a template can ask for.

I audited every caller of the secure `fetch()` to confirm the "third-party only" claim holds: the CDP executors, SNS signing-cert fetches in `ses.ts`, a maildev dev helper, and the replay rasterizer, which already passes an explicit 10s of its own. `legacyFetch` has no production callers at all, so that line is inert but kept consistent.

> [!WARNING]
> A fully unresponsive destination now occupies a worker slot for 10s instead of 3s, so roughly 3.3x fewer completions per worker against a dead endpoint. The cdp-cyclotron-worker HPA scales on `cdp_http_inflight_requests`, which measures exactly this. I'd still like someone who owns CDP capacity to sanity-check the 10s number before this goes in.

Two things I checked that could have made this an incident and don't:

**Ingestion is not in the blast radius.** Hog transformations run inside the ingestion Kafka consumer and share `HogExecutorService`, so a longer fetch there would stall consumption. They're executed with `asyncFunctionsNames: []`, and no legacy transformation plugin performs a fetch, so no ingestion path can reach this timeout. The `@instrumented({ timeoutMs })` guards on the cyclotron worker are also just `setTimeout` warnings via `timeoutGuard`, not aborts, so a slower batch logs rather than fails.

**Hog watcher pressure moves the right way.** The watcher charges `async_function` timings on a ratio against `CDP_WATCHER_ASYNC_COST_TIMING_UPPER_MS` (5s), and that ratio is not clamped at 1.

| Case | Before | After |
| --- | --- | --- |
| Slow-but-working API answering at 4s | error 100 + timing 12 = **112** | error 0 + timing 16 = **16** |
| Genuinely dead API | error 100 + timing 12 = **112** | error 100 + timing 40 = **140** |

So the destinations this fix targets stop accruing the error cost that was quarantining them, and a truly dead one gets quarantined slightly sooner. Both directions are what we want.

## How did you test this code?

Automated, all run by me (Claude):

- `pnpm exec jest src/common/utils/request.test.ts` for the new cases, plus the native and Segment destination executor suites to confirm the CDP paths are untouched.
- `pnpm exec tsc --noEmit` over the nodejs workspace, clean.
- Prettier and eslint on the changed files, clean.

Three new cases in `request.test.ts`. The regression they catch, which nothing existing did: no test asserted a timeout budget on either fetch path, so routing destination traffic back through the internal budget would pass CI silently and only surface as customers losing events to timeouts. Two parameterized cases pin that each entry point resolves to its own budget, and one pins that an explicit caller-supplied `timeoutMs` still wins.

What I could not do in this sandbox, stated plainly:

- No manual or end-to-end verification against a real destination.
- `hogli ci:preflight` never ran. Its venv needs Python 3.13.13 and this environment can't fetch that interpreter. I ran the checks it would have covered for these files by hand instead (prettier, eslint, tsc, jest). The pre-commit hook failed for the same reason and I committed with `--no-verify`.
- The rest of `request.test.ts` has pre-existing failures here that need real outbound DNS, which this sandbox blocks. It was 36 failures before my change and 35 after, so nothing I touched regressed. Those cases pass in CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs cover this timeout, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) wrote this after Daniel asked me to dig into a report of destination invocations failing on timeouts. Skills invoked: `/writing-tests` and `/writing-code-comments`.

The first version went the other way: a `CDP_FETCH_TIMEOUT_MS` config threaded through `HogExecutorConfig`, the native and Segment executors, and applied inside `cdpTrackedFetch`. I abandoned it for two reasons. It wrote `timeoutMs` into the fetch options object, which changed 48 inline snapshot assertions across roughly 11 CDP test files, and several of those suites need Postgres, which I had no way to run here. Hand-editing snapshots I can't execute is how you break CI for everyone else. It also left legacy plugin destinations and legacy webhooks out unless I plumbed config into three more constructors.

The fetch-layer split avoids all of that and draws a cleaner line anyway: the distinction that matters is our infrastructure versus someone else's API, and `request.ts` already separates those into `internalFetch` and `fetch`.

The second commit is my own line-by-line review of the first. It caught three things: the `it.each` rows put the function before the expected number, and printf substitution is positional, so every test name rendered the function's source instead of the budget. The internal expectation was a hardcoded `3000` that would false-fail if anyone tuned that default. And `EXTERNAL_REQUEST_TIMEOUT_MS` now only reaches `internalFetch` despite a name that reads as covering all outbound HTTP, so I documented that at the declaration. I considered renaming it instead and decided against: it's set from deploy config outside this repo, so a rename would silently fall back to the default.

On the test shape: asserting the resolved `options.timeoutMs` is a little unusual, but `_fetch` already writes the resolved value back into the caller's options object, so it is observable from the caller. The alternative was a delay-based test that would have cost seconds of wall clock and invited flakes.
