### PR TITLE
fix(mcp-analytics): read the vendor client header under both spellings

### DIFF
--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2748,8 +2748,13 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$mcp_client_user_agent": {
             "label": "MCP client user agent",
-            "description": "Full User-Agent string the MCP client sent on the transport. Often includes the agent name, version, and runtime mode — useful when $mcp_client_name and $mcp_client_version alone don't disambiguate the caller.",
+            "description": "Full User-Agent string the MCP client sent on the transport. Often includes the agent name, version, and runtime mode — useful when $mcp_client_name and $mcp_client_version alone don't disambiguate the caller. One vendor typically reports the same client name across all of its products, so the parenthetical here is what separates them.",
             "examples": ["claude-code/2.1.141 (cli)", "Anthropic/ClaudeAI"],
+        },
+        "$mcp_vendor_client": {
+            "label": "MCP vendor client",
+            "description": "Vendor-specific client header identifying which of a vendor's products made the call, captured by @posthog/mcp. The $-prefixed counterpart of mcp_vendor_client, which PostHog's own MCP server stamps; harness resolution reads either.",
+            "examples": ["ClaudeCode", "ClaudeAI", "Cowork"],
         },
         "$mcp_intent": {
             "label": "MCP intent",
@@ -2931,7 +2936,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "mcp_vendor_client": {
             "label": "MCP vendor client",
-            "description": "Vendor/client identity derived from the request context for the MCP call (e.g. the coding agent or app behind the request).",
+            "description": "Vendor/client identity derived from the request context for the MCP call (e.g. the coding agent or app behind the request). Stamped by PostHog's own MCP server; servers instrumented with @posthog/mcp send the same value as $mcp_vendor_client.",
             "examples": ["ClaudeCode", "ClaudeAI"],
         },
         "mcp_session_client_name": {

--- a/products/mcp_analytics/backend/mcp_harness.py
+++ b/products/mcp_analytics/backend/mcp_harness.py
@@ -38,6 +38,14 @@ controls, never request input.
 # Leading product token of the User-Agent, e.g. "claude-code" from "claude-code/2.1.x (cli)".
 _UA_PRODUCT = "extract(toString(properties.$mcp_client_user_agent), '^([^/]+)')"
 
+# The vendor client header, under either spelling. PostHog's hosted MCP server has
+# always stamped it unprefixed; `@posthog/mcp` stamps the `$`-prefixed name, which is
+# the convention for every property in its public vocabulary. Customer-instrumented
+# servers therefore only reach the vendor branches below through the prefixed name.
+_VENDOR_CLIENT = (
+    "lower(coalesce(nullIf(toString(properties.$mcp_vendor_client), ''), toString(properties.mcp_vendor_client)))"
+)
+
 # Product token + first parenthetical (the surface) with the version dropped,
 # e.g. "claude-code cli", "openai-mcp chatgpt". Used both gated to claude-code
 # (step 2, to keep the CLI/SDK/IDE split) and as the generic fallback (step 4).
@@ -46,10 +54,10 @@ _UA_TOKEN = f"trim(concat({_UA_PRODUCT}, ' ', extract(toString(properties.$mcp_c
 # The ordered resolution steps, mirroring HARNESS_ROWS_QUERY in the frontend.
 _RAW_TOKEN = f"""coalesce(
     multiIf(
-        lower(toString(properties.mcp_vendor_client)) = 'claudecode', 'claude-code',
-        lower(toString(properties.mcp_vendor_client)) = 'claudeai', 'claude-ai',
-        lower(toString(properties.mcp_vendor_client)) = 'cowork', 'cowork',
-        lower(toString(properties.mcp_vendor_client)) = 'claudedesign', 'claude-design',
+        {_VENDOR_CLIENT} = 'claudecode', 'claude-code',
+        {_VENDOR_CLIENT} = 'claudeai', 'claude-ai',
+        {_VENDOR_CLIENT} = 'cowork', 'cowork',
+        {_VENDOR_CLIENT} = 'claudedesign', 'claude-design',
         NULL
     ),
     if(lower({_UA_PRODUCT}) = 'claude-code', {_UA_TOKEN}, NULL),

--- a/products/mcp_analytics/backend/tests/test_harness_breakdown.py
+++ b/products/mcp_analytics/backend/tests/test_harness_breakdown.py
@@ -120,6 +120,18 @@ class TestMCPHarnessBreakdownQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Click
         [
             ("vendor_cowork", {"mcp_vendor_client": "Cowork"}, "Cowork"),
             ("vendor_claudecode", {"mcp_vendor_client": "ClaudeCode"}, "Claude Code"),
+            # `@posthog/mcp` stamps the `$`-prefixed spelling, so a customer-instrumented
+            # server reaches the vendor branches only through this one.
+            ("vendor_prefixed_from_sdk", {"$mcp_vendor_client": "ClaudeCode"}, "Claude Code"),
+            ("vendor_prefixed_cowork_from_sdk", {"$mcp_vendor_client": "Cowork"}, "Cowork"),
+            # The surface split the SDK now makes possible for customers: `clientInfo.name`
+            # is the same "claude-code" for every Anthropic surface, so only the User-Agent
+            # separates the VS Code extension from the CLI.
+            (
+                "sdk_ua_splits_surface_behind_shared_client_name",
+                {"$mcp_client_name": "claude-code", "$mcp_client_user_agent": "claude-code/2.1.0 (claude-vscode)"},
+                "Claude Code (VS Code)",
+            ),
             ("session_codex", {"mcp_session_client_name": "codex-mcp-client"}, "OpenAI Codex"),
             ("session_cursor", {"mcp_session_client_name": "cursor-vscode"}, "Cursor"),
             # The posthog-node MCP analytics SDK reports clientInfo.name as $mcp_client_name,

--- a/products/mcp_analytics/skills/debugging-mcp-analytics/SKILL.md
+++ b/products/mcp_analytics/skills/debugging-mcp-analytics/SKILL.md
@@ -150,11 +150,17 @@ tools. They are declared in `products/mcp_analytics/mcp/tools.yaml`.
 **Harness** is the friendly label for the calling client (Claude Code, Cursor, ChatGPT,
 Windsurf, and ~30 other buckets). It is resolved at query time only, with no stored column:
 `mcp_harness.py::HARNESS_TOKEN_SQL` picks the strongest available signal in priority order
-(`mcp_vendor_client` -> Claude Code user-agent surface -> Grok user-agent -> `$mcp_client_name`
+(vendor client header -> Claude Code user-agent surface -> Grok user-agent -> `$mcp_client_name`
 -> `mcp_session_client_name` -> generic user-agent token -> `$mcp_oauth_client_name`), then
 `harness_label_sql()` buckets it (or `harness_label_or_token_sql()`, which names an
 unrecognized client verbatim instead of collapsing it into "Other" — use it for ranked
 top-N lists, never where labels feed an array or unbounded GROUP BY).
+
+The vendor client header arrives under two spellings — our own server stamps
+`mcp_vendor_client`, `@posthog/mcp` stamps `$mcp_vendor_client` (the SDK `$`-prefixes its
+whole public vocabulary) — and the token SQL coalesces both. The SDK also captures
+`$mcp_client_user_agent`, which is what lets a customer's own dashboard split one
+`clientInfo.name` into its separate surfaces.
 
 **`$mcp_client_name` is one mid-priority input, not a synonym for harness** — grouping by
 it directly gives a different, messier answer. It rides on the session's `initialize` and

--- a/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
+++ b/products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
@@ -70,6 +70,8 @@ And two tools cover what SQL can't express at all: `posthog:mcp-analytics-intent
 
 **Server-stamped extras (PostHog's own server only, not the SDK):** `$mcp_session_id` (transport-level session handle — see "Three identifiers" below), `$mcp_region` (cloud region that handled the request, e.g. `us`/`eu`), `$mcp_mode` (`cli` for single-exec, `tools` for one-tool-per-name), `$mcp_consumer` (upstream surface, e.g. `posthog-code`/`slack`), and the non-`$`-prefixed `mcp_vendor_client` (vendor/client identity from the `x-anthropic-client` header, e.g. `ClaudeCode`/`ClaudeAI` — used to resolve the harness in the bucketing SQL below) and `mcp_runtime` (server runtime, e.g. `hono`).
 
+**Transport identity from the SDK:** `@posthog/mcp` also captures `$mcp_client_user_agent` and `$mcp_vendor_client` (note the `$` — the SDK prefixes every property in its public vocabulary, so the vendor header arrives under a different name than our own server's `mcp_vendor_client`; the bucketing SQL coalesces both). These matter because `clientInfo.name` cannot separate a vendor's surfaces: Anthropic reports `claude-code` from the CLI, the Agent SDK, the VS Code extension and the desktop app alike, and only the User-Agent parenthetical tells them apart.
+
 **Three identifiers, not one.** `$session_id` is the materialised column — `GROUP BY`/join on this one. `$mcp_session_id` is the transport-level handle the MCP SDK observed (MCP `extra.sessionId` or a framework session cookie); it rotates on process restart, reconnect, or framework boundary. `$mcp_conversation_id` is agent-echoed and stable across reconnects — reach for it when a "session" needs to survive a client reconnecting mid-task. In practice `$session_id` and `$mcp_session_id` carry the same value; `$mcp_conversation_id` is the more durable one when they diverge.
 
 **Effective tool name.** New-SDK events wrap the real tool in a single-exec call, so to filter/group by the tool the agent actually invoked, use:
@@ -206,10 +208,12 @@ FROM (
             trim(replaceRegexpAll(lower(
                 coalesce(
                     multiIf(
-                        lower(toString(properties.mcp_vendor_client)) = 'claudecode', 'claude-code',
-                        lower(toString(properties.mcp_vendor_client)) = 'claudeai', 'claude-ai',
-                        lower(toString(properties.mcp_vendor_client)) = 'cowork', 'cowork',
-                        lower(toString(properties.mcp_vendor_client)) = 'claudedesign', 'claude-design',
+                        -- Both spellings: PostHog's own server stamps the unprefixed name,
+                        -- `@posthog/mcp` stamps `$mcp_vendor_client`.
+                        lower(coalesce(nullIf(toString(properties.$mcp_vendor_client), ''), toString(properties.mcp_vendor_client))) = 'claudecode', 'claude-code',
+                        lower(coalesce(nullIf(toString(properties.$mcp_vendor_client), ''), toString(properties.mcp_vendor_client))) = 'claudeai', 'claude-ai',
+                        lower(coalesce(nullIf(toString(properties.$mcp_vendor_client), ''), toString(properties.mcp_vendor_client))) = 'cowork', 'cowork',
+                        lower(coalesce(nullIf(toString(properties.$mcp_vendor_client), ''), toString(properties.mcp_vendor_client))) = 'claudedesign', 'claude-design',
                         NULL
                     ),
                     if(lower(extract(toString(properties.$mcp_client_user_agent), '^([^/]+)')) = 'claude-code',


### PR DESCRIPTION
**What this changes:** customers instrumenting their own MCP server with `@posthog/mcp` currently can't reach the vendor branches of the harness classifier at all, so Anthropic's pooled products (Cowork, Claude.ai, Claude Design) collapse into one bucket for them. After this, they resolve.

**What it doesn't change:** PostHog's own numbers. Our server stamps the unprefixed spelling and keeps resolving exactly as before — this only adds a spelling nothing emits yet, until PostHog/posthog-js#4419 ships.

## Problem

The vendor client header reaches us under two spellings, and the classifier only read one:

| emitter | property |
| --- | --- |
| PostHog's hosted MCP server | `mcp_vendor_client` |
| `@posthog/mcp` (every property is `$`-prefixed) | `$mcp_vendor_client` |

So a customer instrumenting their own server never reached the vendor branches, and Cowork / Claude.ai / Claude Design fell through to whatever weaker signal came next.

## Change

```diff
- lower(toString(properties.mcp_vendor_client)) = 'claudecode', 'claude-code',
+ {_VENDOR_CLIENT} = 'claudecode', 'claude-code',

+ _VENDOR_CLIENT = lower(coalesce(
+     nullIf(toString(properties.$mcp_vendor_client), ''),
+     toString(properties.mcp_vendor_client)))
```

Prefixed first, unprefixed second. Historical events, which only ever carried the unprefixed name, resolve exactly as before — a pure superset.

## Why the vendor header isn't dead weight

I nearly cut it. On our own events the header never changes the resolved label, which reads like proof it's redundant — until you see why: our server **pre-maps** it into `$mcp_client_name` before emitting (`resolveEffectiveClientName`).

The session-pinned column shows the raw value Anthropic actually sends:

| `x-anthropic-client` | raw `clientInfo.name` |
| --- | --- |
| `Cowork` | `Anthropic/ClaudeAI` |
| `ClaudeCode` | `Anthropic/ClaudeAI` |
| `ClaudeAI` | `Anthropic/ClaudeAI` |

Three products, one identical `clientInfo.name`. Only the header separates them — and a customer's SDK does no pre-mapping, by design. Without this coalesce they collapse into one bucket, for exactly the audience the SDK change serves.

## Testing

`pytest products/mcp_analytics/backend/tests/` -> **311 passed** (ClickHouse-backed), ruff clean.

New cases cover the prefixed spelling and the payoff:

```python
# clientInfo.name alone would say "Claude Code"; the UA makes it specific
{"$mcp_client_name": "claude-code",
 "$mcp_client_user_agent": "claude-code/2.1.0 (claude-vscode)"}  -> "Claude Code (VS Code)"
```

## Notes

- Pairs with PostHog/posthog-js#4419, which starts emitting these properties. Landing this first is harmless — it only adds a spelling nothing emits yet.
- Also registers `$mcp_vendor_client` in `taxonomy.py`; without it a new public property shows in the UI as an unlabelled raw key.
- **Draft.** `codex review` (our cross-model gate) is rate-limited until Aug 8, so review was a multi-agent Claude swarm — same-model, weight accordingly.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
