### PR TITLE
fix(desktop/auth): build project map from scoped teams for project-scoped tokens

### DIFF
--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -82,6 +82,7 @@ function mockTokenResponse(
     refreshToken?: string | null;
     expiresIn?: number;
     scopedOrgs?: string[];
+    scopedTeams?: number[];
   } = {},
 ) {
   const refreshToken =
@@ -97,6 +98,7 @@ function mockTokenResponse(
       token_type: "Bearer",
       scope: "",
       scoped_organizations: overrides.scopedOrgs ?? ["org-1"],
+      ...(overrides.scopedTeams ? { scoped_teams: overrides.scopedTeams } : {}),
     },
   };
 }
@@ -1673,6 +1675,73 @@ describe("AuthService", () => {
         expect(service.getState()).toMatchObject(expectedState);
       },
     );
+
+    // Team-scoped tokens are rejected by the server on every endpoint that
+    // isn't project-nested, /api/organizations/* included — the map has to be
+    // assembled from the scoped projects, or login lands on "No projects".
+    it("builds the map from scoped projects when the token carries scoped_teams", async () => {
+      const calls = { org: 0, project: 0 };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | Request) => {
+          const url = typeof input === "string" ? input : input.url;
+
+          if (url.includes("/api/users/@me/")) {
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                uuid: "user-1",
+                organization: { id: "org-1", name: "Org 1" },
+              }),
+            } as unknown as Response;
+          }
+
+          if (/\/api\/organizations\/[^/]+\/$/.test(url)) {
+            calls.org++;
+            return {
+              ok: false,
+              status: 403,
+              json: vi.fn().mockResolvedValue({}),
+            } as unknown as Response;
+          }
+
+          if (/\/api\/projects\/42\/$/.test(url)) {
+            calls.project++;
+            return {
+              ok: true,
+              json: vi.fn().mockResolvedValue({
+                id: 42,
+                name: "Project 42",
+                organization: "org-1",
+              }),
+            } as unknown as Response;
+          }
+
+          return {
+            ok: true,
+            json: vi.fn().mockResolvedValue({ has_access: true }),
+          } as unknown as Response;
+        }) as unknown as typeof fetch,
+      );
+      oauthFlow.startFlow.mockResolvedValue(
+        mockTokenResponse({ scopedOrgs: [], scopedTeams: [42] }),
+      );
+
+      await service.login("us");
+
+      expect(calls).toEqual({ org: 0, project: 1 });
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        currentOrgId: "org-1",
+        currentProjectId: 42,
+        orgProjectsMap: {
+          "org-1": {
+            orgName: "Org 1",
+            projects: [{ id: 42, name: "Project 42" }],
+          },
+        },
+      });
+    });
   });
 
   describe("switchOrg", () => {

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -59,6 +59,7 @@ interface InMemorySession {
   currentOrgId: string | null;
   currentProjectId: number | null;
   orgProjectsIncomplete: boolean;
+  scopedTeamIds: number[];
 }
 
 interface StoredSessionInput {
@@ -709,27 +710,53 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     options: TokenResponseOptions,
   ): Promise<InMemorySession> {
     const scopedOrgIds = tokenResponse.scoped_organizations ?? [];
-    const { accountKey, currentOrgId } = await this.fetchUserContext(
+    const scopedTeamIds = tokenResponse.scoped_teams ?? [];
+    const {
+      accountKey,
+      currentOrgId: userOrgId,
+      orgNames,
+    } = await this.fetchUserContext(
       tokenResponse.access_token,
       options.cloudRegion,
     );
-    // Team-scoped tokens (required_access_level=project) can arrive with an
-    // empty scoped_organizations list — the server only populates scoped_teams.
-    // Fall back to the current org from /api/users/@me/ so the picker isn't
-    // empty; without this the user is stranded on "No projects".
-    const orgIdsToFetch =
-      scopedOrgIds.length > 0
-        ? scopedOrgIds
-        : currentOrgId
-          ? [currentOrgId]
-          : [];
-    const { map: orgProjectsMap, incomplete: orgProjectsIncomplete } =
-      await this.buildOrgProjectsMap(
-        tokenResponse.access_token,
-        options.cloudRegion,
-        orgIdsToFetch,
-        this.session?.orgProjectsMap ?? {},
-      );
+
+    let currentOrgId = userOrgId;
+    let orgProjectsMap: OrgProjectsMap;
+    let orgProjectsIncomplete: boolean;
+    if (scopedTeamIds.length > 0) {
+      // Team-scoped tokens (required_access_level=project) are rejected by the
+      // server on every endpoint that isn't project-nested — including
+      // /api/organizations/*. Build the map from the scoped projects
+      // themselves; going through the org would 403 and strand the user on
+      // "No projects".
+      ({ map: orgProjectsMap, incomplete: orgProjectsIncomplete } =
+        await this.buildScopedTeamProjectsMap(
+          tokenResponse.access_token,
+          options.cloudRegion,
+          scopedTeamIds,
+          orgNames,
+        ));
+      if (!currentOrgId || !orgProjectsMap[currentOrgId]) {
+        currentOrgId = Object.keys(orgProjectsMap)[0] ?? currentOrgId;
+      }
+    } else {
+      // Org-scoped tokens can arrive with an empty scoped_organizations list.
+      // Fall back to the current org from /api/users/@me/ so the picker isn't
+      // empty.
+      const orgIdsToFetch =
+        scopedOrgIds.length > 0
+          ? scopedOrgIds
+          : currentOrgId
+            ? [currentOrgId]
+            : [];
+      ({ map: orgProjectsMap, incomplete: orgProjectsIncomplete } =
+        await this.buildOrgProjectsMap(
+          tokenResponse.access_token,
+          options.cloudRegion,
+          orgIdsToFetch,
+          this.session?.orgProjectsMap ?? {},
+        ));
+    }
     const lastPrefs = accountKey
       ? this.authPreference.get(accountKey, options.cloudRegion)
       : null;
@@ -754,6 +781,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       currentOrgId: selection.currentOrgId,
       currentProjectId: selection.currentProjectId,
       orgProjectsIncomplete,
+      scopedTeamIds,
     };
 
     return session;
@@ -787,6 +815,68 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     );
 
     return { map: Object.fromEntries(entries), incomplete };
+  }
+  private async buildScopedTeamProjectsMap(
+    accessToken: string,
+    cloudRegion: CloudRegion,
+    teamIds: number[],
+    orgNames: Record<string, string>,
+  ): Promise<{ map: OrgProjectsMap; incomplete: boolean }> {
+    const apiHost = getCloudUrlFromRegion(cloudRegion);
+    let incomplete = false;
+    const results = await Promise.all(
+      teamIds.map(async (teamId) => {
+        try {
+          const res = await this.executeAuthenticatedFetch(
+            fetch,
+            `${apiHost}/api/projects/${teamId}/`,
+            {},
+            accessToken,
+          );
+          if (!res.ok) {
+            // 4xx means the scoped project is gone or inaccessible — omit it
+            // rather than retrying forever through the recovery loop.
+            if (res.status >= 500) incomplete = true;
+            return null;
+          }
+          const raw = (await res.json().catch(() => null)) as {
+            id?: unknown;
+            name?: unknown;
+            organization?: unknown;
+          } | null;
+          if (typeof raw?.id !== "number") return null;
+          return {
+            orgId:
+              typeof raw.organization === "string" &&
+              raw.organization.length > 0
+                ? raw.organization
+                : "(unknown)",
+            project: {
+              id: raw.id,
+              name:
+                typeof raw.name === "string" && raw.name.length > 0
+                  ? raw.name
+                  : `Project ${raw.id}`,
+            },
+          };
+        } catch (error) {
+          this.logger.warn("Failed to fetch scoped project", { teamId, error });
+          incomplete = true;
+          return null;
+        }
+      }),
+    );
+
+    const map: OrgProjectsMap = {};
+    for (const result of results) {
+      if (!result) continue;
+      map[result.orgId] ??= {
+        orgName: orgNames[result.orgId] ?? "(unknown)",
+        projects: [],
+      };
+      map[result.orgId].projects.push(result.project);
+    }
+    return { map, incomplete };
   }
   private async fetchOrgProjects(
     accessToken: string,
@@ -978,7 +1068,11 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private async fetchUserContext(
     accessToken: string,
     cloudRegion: CloudRegion,
-  ): Promise<{ accountKey: string | null; currentOrgId: string | null }> {
+  ): Promise<{
+    accountKey: string | null;
+    currentOrgId: string | null;
+    orgNames: Record<string, string>;
+  }> {
     try {
       const response = await this.executeAuthenticatedFetch(
         fetch,
@@ -988,14 +1082,15 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       );
 
       if (!response.ok) {
-        return { accountKey: null, currentOrgId: null };
+        return { accountKey: null, currentOrgId: null, orgNames: {} };
       }
 
       const data = (await response.json().catch(() => ({}))) as {
         uuid?: unknown;
         distinct_id?: unknown;
         email?: unknown;
-        organization?: { id?: unknown } | null;
+        organization?: { id?: unknown; name?: unknown } | null;
+        organizations?: unknown;
       };
 
       let accountKey: string | null = null;
@@ -1014,10 +1109,23 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       const currentOrgId =
         typeof orgId === "string" && orgId.length > 0 ? orgId : null;
 
-      return { accountKey, currentOrgId };
+      const orgNames: Record<string, string> = {};
+      const memberOrgs = Array.isArray(data.organizations)
+        ? data.organizations
+        : [];
+      for (const org of memberOrgs as { id?: unknown; name?: unknown }[]) {
+        if (typeof org?.id === "string" && typeof org.name === "string") {
+          orgNames[org.id] = org.name;
+        }
+      }
+      if (currentOrgId && typeof data.organization?.name === "string") {
+        orgNames[currentOrgId] = data.organization.name;
+      }
+
+      return { accountKey, currentOrgId, orgNames };
     } catch (error) {
       this.logger.warn("Failed to resolve user context", { error });
-      return { accountKey: null, currentOrgId: null };
+      return { accountKey: null, currentOrgId: null, orgNames: {} };
     }
   }
   private requireSession(): InMemorySession {
@@ -1287,13 +1395,29 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
 
       if (!session.orgProjectsIncomplete) return;
 
-      const orgIds = Object.keys(session.orgProjectsMap);
-      const { map, incomplete } = await this.buildOrgProjectsMap(
-        session.accessToken,
-        session.cloudRegion,
-        orgIds,
-        session.orgProjectsMap,
-      );
+      let map: OrgProjectsMap;
+      let incomplete: boolean;
+      if (session.scopedTeamIds.length > 0) {
+        const knownOrgNames = Object.fromEntries(
+          Object.entries(session.orgProjectsMap)
+            .filter(([, org]) => org.orgName !== "(unknown)")
+            .map(([orgId, org]) => [orgId, org.orgName]),
+        );
+        ({ map, incomplete } = await this.buildScopedTeamProjectsMap(
+          session.accessToken,
+          session.cloudRegion,
+          session.scopedTeamIds,
+          knownOrgNames,
+        ));
+      } else {
+        const orgIds = Object.keys(session.orgProjectsMap);
+        ({ map, incomplete } = await this.buildOrgProjectsMap(
+          session.accessToken,
+          session.cloudRegion,
+          orgIds,
+          session.orgProjectsMap,
+        ));
+      }
 
       // The session may have been replaced (logout, re-login) while the fetch
       // was in flight; committing the stale one would resurrect it.

--- a/products/desktop/packages/core/src/auth/oauth.schemas.ts
+++ b/products/desktop/packages/core/src/auth/oauth.schemas.ts
@@ -25,6 +25,7 @@ export const oAuthTokenResponse = z.object({
   scope: z.string().optional().default(""),
   refresh_token: z.string().optional(),
   scoped_organizations: z.array(z.string()).optional(),
+  scoped_teams: z.array(z.number()).optional(),
 });
 export type OAuthTokenResponse = z.infer<typeof oAuthTokenResponse>;
 


### PR DESCRIPTION
## Problem

Project-scoped desktop logins can finish without a selected project, leaving project-dependent actions unavailable.

The OAuth token identifies allowed projects through `scoped_teams`, while organization endpoints reject project-scoped tokens.

## Changes

Desktop now builds its project map from the allowed project endpoints and gets organization names from the current-user response.

This keeps project-scoped OAuth tokens least-privileged instead of broadening their access.

## How did you test this code?

Added coverage for a project-scoped login that rejects organization requests, loads its allowed project, and selects it.

The desktop build, focused auth tests, core type checks, and core lint checks pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This fixes existing login behavior without changing the documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex updated the existing PR against current `master` and removed unrelated UI refactors. Skills used: `/posthog-desktop`, `/writing-tests`, and `/writing-pr-descriptions`.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*