### PR TITLE
fix(capture): one overflow and rate-limit rule for v0 and v1

### DIFF
--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -187,8 +187,10 @@ Goal: v1 endpoints publish through `dyn Outputs` like every other ingress, so fa
 
 **Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
 
-- The header follows the stamped person-processing flag alone. A burst over the overflow limiter's budget spreads the key without touching it.
-- The key is dropped on the analytics main/overflow and AI overflow lanes when either the person-processing flag or an explicit spread decision is set, and nowhere else. Historical, dlq, custom redirects and the AI main topic keep it regardless.
+- The header follows the stamped person-processing flag alone.
+- The key is dropped on the analytics main/overflow lanes when the person-processing flag is set, and on the AI overflow lane when either the flag or a spread decision is set — nowhere else.
+  The analytics consumers update persons keyed on distinct id, so a person-on burst keeps its key there (spreading one distinct id across partitions contends those updates); the read-only AI overflow consumer takes keyless person-on records safely.
+  Historical, dlq, custom redirects and the AI main topic keep the key regardless.
 
 `overflow_parity.rs` is the oracle: it drives both pipelines over the overflow and rate-limit matrix and pins lane, key presence, and header. Extend it with the mapped v1 destinations rather than reasoning about the two paths separately.
 

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -187,7 +187,8 @@ Goal: v1 endpoints publish through `dyn Outputs` like every other ingress, so fa
 
 **Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
 
-- The header follows the stamped person-processing flag alone.
+- The header follows the stamped person-processing intent: the flag, which a `ForceLimited` reason implies on its own (`person_processing_disabled`), so a v0 stamping site cannot keep person processing on for a force-limited key by forgetting the flag.
+  v1 carries no reason on the event — its one stamping site sets the flag directly.
 - The key is dropped on the analytics main/overflow lanes when the person-processing flag is set, and on the AI overflow lane when either the flag or a spread decision is set — nowhere else.
   The analytics consumers update persons keyed on distinct id, so a person-on burst keeps its key there (spreading one distinct id across partitions contends those updates); the read-only AI overflow consumer takes keyless person-on records safely.
   Historical, dlq, custom redirects and the AI main topic keep the key regardless.

--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -145,7 +145,7 @@ Step 7 absorbs it into the `OutputTable`; the mode-scoped demand is folded in at
 #### Step 11 · v1 converges on the shared strata
 
 - **Goal.** v1's `Destination` bridges to `(Pipeline, Lane)`; v1 topic resolution goes through the shared table; v1's `serialize_batch` uses the Step-4 serializer. The v1 `Sink`/`Router` trait convergence stays gated on the per-event response model, as before.
-- **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified.
+- **Parity proof.** v1_pipeline (17) + v1_sink_integration (10) unmodified, plus `overflow_parity.rs` unmodified. That suite drives both pipelines end to end over the overflow and rate-limit matrix and is the oracle for the ordering-vs-person-processing contract this step has to carry across (see the Hazard note under "v1 convergence on the outputs machinery"). Both paths already share `OrderingGuarantee` from `crate::ordering`.
 - **Size.** M/L.
 
 ### Stage E — prep hoists up; sinks become pure transport
@@ -185,7 +185,12 @@ Goal: v1 endpoints publish through `dyn Outputs` like every other ingress, so fa
 5. **Plan retirement.** The 20c commit deletes this document — the plan must not outlive its last step.
    Anything still load-bearing then (the repartitioning design note, the ordering-vs-person-processing contract) graduates into module docs or `v1/sinks/DESIGN.md` first.
 
-**Hazard.** `pipeline::resolve`'s overflow arm couples `ForceLimited` to `ForceDisablePersonProcessing` (and a null key) — the exact v0 behavior v1 deliberately decoupled. The `Destination::Overflow` → metadata mapping must select `overflow_reason`/flags that keep v1's semantics (event-keyed overflow; person-processing disable only when the operator set it), or `resolve` learns a v1-shaped overflow intent. Verify against v1's kafka sink key handling per destination before choosing.
+**Hazard.** The `Destination::Overflow` → metadata mapping must preserve the split between the two intents that ride together on this lane: whether person processing is disabled (a customer-visible instruction, the `force_disable_person_processing` header) and whether the partition key is dropped (a load decision, `OrderingGuarantee`). Both paths now state the same rule, so the mapping has one contract to satisfy rather than two dialects to reconcile:
+
+- The header follows the stamped person-processing flag alone. A burst over the overflow limiter's budget spreads the key without touching it.
+- The key is dropped on the analytics main/overflow and AI overflow lanes when either the person-processing flag or an explicit spread decision is set, and nowhere else. Historical, dlq, custom redirects and the AI main topic keep it regardless.
+
+`overflow_parity.rs` is the oracle: it drives both pipelines over the overflow and rate-limit matrix and pins lane, key presence, and header. Extend it with the mapped v1 destinations rather than reasoning about the two paths separately.
 
 **Accepted deltas:** `sent_at` fractional-second formatting (parse-equal; v1 adopts v0's serializer) and the v1 sink-stage metrics (`capture_v1_serialize_*`, per-sink publish metrics), superseded by the outputs-layer metrics.
 

--- a/rust/capture/src/events/analytics.rs
+++ b/rust/capture/src/events/analytics.rs
@@ -2768,8 +2768,16 @@ mod tests {
         );
     }
 
+    /// A person-on burst keeps its key on either locality setting: the
+    /// overflow consumer updates persons keyed on distinct id, so spreading
+    /// one distinct id across partitions would contend those updates.
+    #[rstest]
+    #[case::preserving_locality(true)]
+    #[case::spreading(false)]
     #[tokio::test]
-    async fn e2e_rate_limited_preserve_locality_pipeline_to_sink_keeps_key() {
+    async fn e2e_rate_limited_pipeline_to_sink_keeps_key_while_person_on(
+        #[case] preserve_locality: bool,
+    ) {
         let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -2786,8 +2794,8 @@ mod tests {
         ));
         let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
         let historical_cfg = router::HistoricalConfig::new(false, 1);
-        // burst=1, preserve_locality=true => event[1] stamped RateLimited{preserve_locality: true}.
-        let limiter = build_limiter(1, 1, None, true);
+        // burst=1 => event[1] stamped RateLimited { preserve_locality }.
+        let limiter = build_limiter(1, 1, None, preserve_locality);
 
         process_events(
             sink,
@@ -2817,57 +2825,11 @@ mod tests {
         );
         assert!(
             records[1].key.is_some(),
-            "RateLimited{{preserve_locality:true}} must preserve partition key"
+            "a person-on burst must keep its partition key"
         );
         assert!(
             records[1].headers.force_disable_person_processing.is_none(),
             "RateLimited (non-Force) must NOT set force_disable_person_processing"
-        );
-    }
-
-    #[tokio::test]
-    async fn e2e_rate_limited_no_preserve_locality_pipeline_to_sink_drops_key() {
-        let now = DateTime::parse_from_rfc3339("2023-01-01T12:00:00Z")
-            .unwrap()
-            .with_timezone(&Utc);
-        let context = create_test_context(now, None);
-        let events = vec![
-            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
-            create_test_event(Some("2023-01-01T11:00:00Z".to_string()), None, None),
-        ];
-
-        let producer = MockKafkaProducer::new();
-        let sink = Arc::new(KafkaSinkBase::with_producer(
-            producer.clone(),
-            test_topics(),
-        ));
-        let dropper = Arc::new(limiters::token_dropper::TokenDropper::default());
-        let historical_cfg = router::HistoricalConfig::new(false, 1);
-        // burst=1, preserve_locality=false => event[1] stamped RateLimited{preserve_locality: false}.
-        let limiter = build_limiter(1, 1, None, false);
-
-        process_events(
-            sink,
-            dropper,
-            None,
-            historical_cfg,
-            None,
-            Some(limiter),
-            None,
-            None,
-            &AiRouting::Primary,
-            events,
-            &context,
-        )
-        .await
-        .unwrap();
-
-        let records = producer.get_records();
-        assert_eq!(records.len(), 2);
-        assert_eq!(records[1].topic, "events_plugin_ingestion_overflow");
-        assert_eq!(
-            records[1].key, None,
-            "RateLimited{{preserve_locality:false}} must drop partition key"
         );
     }
 

--- a/rust/capture/src/events/overflow_stamping.rs
+++ b/rust/capture/src/events/overflow_stamping.rs
@@ -61,8 +61,9 @@ use crate::v0_request::{DataType, OverflowReason, ProcessedEvent};
 /// * If the lane's limiter is `Some`, `is_limited(event.key())` is consulted
 ///   and the resulting [`OverflowReason`] is stamped, plus the matching
 ///   counter. `ForceLimited` additionally sets `skip_person_processing =
-///   true` so the sink's generic skip-person branch picks up the
-///   `force_disable_person_processing` header without a separate code path.
+///   true` for pipeline-level readers of the flag; the sink derives the
+///   `force_disable_person_processing` header from the reason itself, so
+///   the header does not depend on this stamp.
 ///
 /// Counter labels are intentionally identical to the pre-refactor sink so
 /// existing dashboards (filtering on `capture_events_rerouted_overflow`'s
@@ -101,11 +102,11 @@ pub fn stamp_overflow_reason(
                 )
                 .increment(1);
                 event.metadata.overflow_reason = Some(OverflowReason::ForceLimited);
-                // Self-describing metadata: ForceLimited implies person
-                // processing is skipped, so the flag is stamped alongside the
-                // reason. The sink derives the person-processing header from
-                // this flag alone — a reason stamped without it would keep
-                // person processing on.
+                // ForceLimited implies person processing is skipped; the sink
+                // derives that from the reason itself
+                // (`person_processing_disabled`). The flag is stamped
+                // alongside so pipeline-level readers of the flag see the
+                // same truth.
                 event.metadata.skip_person_processing = true;
             }
             OverflowLimiterResult::Limited => {

--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -12,6 +12,9 @@ pub mod log_util;
 pub mod metrics_middleware;
 pub mod ordering;
 pub mod otel;
+/// Cross-path parity suite for the v0 and v1 overflow / rate-limit matrix.
+#[cfg(test)]
+mod overflow_parity;
 pub mod payload;
 pub mod prometheus;
 pub mod quota_limiters;

--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -10,6 +10,7 @@ pub mod global_rate_limiter;
 pub mod ingestion_warnings;
 pub mod log_util;
 pub mod metrics_middleware;
+pub mod ordering;
 pub mod otel;
 pub mod payload;
 pub mod prometheus;

--- a/rust/capture/src/ordering.rs
+++ b/rust/capture/src/ordering.rs
@@ -1,0 +1,43 @@
+//! The ordering guarantee a produced record preserves.
+//!
+//! Shared by both produce paths so they name one concept: the v0 sink's
+//! `route()` and the v1 `Event::ordering` impls each decide a guarantee, and
+//! each sink realizes it as a Kafka partition key. Keeping the vocabulary in
+//! one place is what lets the two paths be compared case for case by the
+//! cross-path overflow parity suite.
+
+/// The ordering guarantee a route preserves, which is what the customer can
+/// rely on. A sink realizes it as a Kafka partition key; the deciding layer
+/// only chooses the guarantee.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderingGuarantee {
+    /// Ordering preserved per distinct id — the guarantee for every
+    /// non-replay lane. Partitions on the event's canonical key
+    /// ([`common_types::CapturedEvent::key`]): `token:distinct_id`, or
+    /// `token:ip` in cookieless mode, where the ip stands in for the distinct
+    /// id derived later in the pipeline.
+    PerDistinctId,
+    /// Ordering preserved per replay session: partitions on the raw
+    /// `session_id`, no token prefix (a missing id is rejected by the deciding layer).
+    PerSession,
+    /// No guarantee — no partition key, round-robin; ordering is
+    /// intentionally dropped to spread load.
+    None,
+}
+
+/// Drop the guarantee when person processing is skipped, otherwise keep
+/// per-distinct-id ordering.
+///
+/// This is the shared half of the ordering rule both paths implement: on the
+/// analytics and AI main/overflow lanes, taking person processing away also
+/// takes the ordering guarantee away, because the stage that disabled person
+/// processing did so to spread a hot key. Lanes whose consumers need the key
+/// regardless (historical, dlq, custom redirects, the AI main topic) never
+/// consult this.
+pub fn person_ordering(skip_person_processing: bool) -> OrderingGuarantee {
+    if skip_person_processing {
+        OrderingGuarantee::None
+    } else {
+        OrderingGuarantee::PerDistinctId
+    }
+}

--- a/rust/capture/src/overflow_parity.rs
+++ b/rust/capture/src/overflow_parity.rs
@@ -1,0 +1,271 @@
+//! Cross-path parity for overflow and global-rate-limit interaction.
+//!
+//! The v0 and v1 pipelines stamp their overflow and rate-limit decisions in
+//! opposite orders (v0 runs the global rate limiter before the burst limiter,
+//! v1 after) and reach the broker through separate sinks. Both must still put
+//! the same event on the same lane, with the same partition-key presence and
+//! the same person-processing header, because those three things are the wire
+//! contract downstream ingestion reads.
+//!
+//! Each case runs the real pipeline on both paths and asserts both against an
+//! explicit expectation, not merely against each other, so two paths that drift
+//! together still fail.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use limiters::overflow::OverflowLimiter;
+use limiters::token_dropper::TokenDropper;
+use rstest::rstest;
+use std::num::NonZeroU32;
+
+use crate::config::AiRouting;
+use crate::global_rate_limiter::GlobalRateLimiter;
+use crate::router::HistoricalConfig;
+use crate::sinks::kafka::{test_topics, KafkaSinkBase};
+use crate::sinks::producer::MockKafkaProducer;
+use crate::v0_request::ProcessingContext;
+use crate::v1::analytics::process::process_batch;
+use crate::v1::test_utils::{self, TestStateBuilder};
+use common_types::RawEvent;
+
+/// v0's canonical key is `token:distinct_id`; the two paths use different test
+/// tokens and distinct ids, so each side gets a limiter keyed for its own.
+const V0_TOKEN: &str = "test_token";
+const V0_DISTINCT_ID: &str = "test_user";
+const V1_HOT_KEY: &str = "phc_test_token:user-42";
+
+/// The lane an event landed on, independent of each path's test topic names.
+#[derive(Debug, PartialEq, Eq)]
+enum Lane {
+    Main,
+    Overflow,
+    Other(String),
+}
+
+/// The three wire facts downstream ingestion actually reads.
+#[derive(Debug, PartialEq, Eq)]
+struct Observed {
+    lane: Lane,
+    has_key: bool,
+    person_processing_disabled: bool,
+}
+
+#[derive(Clone, Copy)]
+struct Limits {
+    /// The token:distinct_id is over the global rate limit window.
+    globally_limited: bool,
+    /// A burst limiter is armed. `burst` of 1 limits every event after the first.
+    burst_limiter: bool,
+    /// The burst limiter keeps partition keys, as prod-US is configured.
+    preserve_locality: bool,
+    /// The burst limiter force-routes the key outright.
+    force_limited: bool,
+}
+
+impl Limits {
+    const NONE: Self = Self {
+        globally_limited: false,
+        burst_limiter: false,
+        preserve_locality: false,
+        force_limited: false,
+    };
+}
+
+fn v0_overflow_limiter(limits: Limits) -> Option<Arc<OverflowLimiter>> {
+    if !limits.burst_limiter && !limits.force_limited {
+        return None;
+    }
+    let forced = limits.force_limited.then(|| V0_TOKEN.to_string());
+    Some(Arc::new(OverflowLimiter::new(
+        NonZeroU32::new(1).unwrap(),
+        NonZeroU32::new(1).unwrap(),
+        forced,
+        limits.preserve_locality,
+    )))
+}
+
+fn v0_raw_event() -> RawEvent {
+    let mut properties = std::collections::HashMap::new();
+    properties.insert("distinct_id".to_string(), serde_json::json!(V0_DISTINCT_ID));
+    RawEvent {
+        uuid: None,
+        distinct_id: None,
+        event: "test_event".to_string(),
+        properties,
+        timestamp: Some("2026-03-19T14:29:58.123Z".to_string()),
+        offset: None,
+        set: Some(std::collections::HashMap::new()),
+        set_once: Some(std::collections::HashMap::new()),
+        token: Some(V0_TOKEN.to_string()),
+    }
+}
+
+fn v0_context(now: DateTime<Utc>) -> ProcessingContext {
+    ProcessingContext {
+        user_agent: None,
+        sent_at: None,
+        token: V0_TOKEN.to_string(),
+        now,
+        client_ip: "127.0.0.1".to_string(),
+        request_id: "parity".to_string(),
+        path: "/e/".to_string(),
+        is_mirror_deploy: false,
+        historical_migration: false,
+        chatty_debug_enabled: false,
+        capture_mode: crate::config::CaptureMode::Events,
+        sdk_attribution: crate::ingestion_warnings::SdkAttribution::default(),
+    }
+}
+
+/// Drive the real v0 pipeline into a real `KafkaSinkBase` and read the record
+/// at `observe` off the mock producer.
+async fn run_v0(limits: Limits, batch_size: usize, observe: usize) -> Observed {
+    let producer = MockKafkaProducer::new();
+    let sink = Arc::new(KafkaSinkBase::with_producer(
+        producer.clone(),
+        test_topics(),
+    ));
+    let global = limits.globally_limited.then(|| {
+        Arc::new(GlobalRateLimiter::mock_limiting(&[&format!(
+            "{V0_TOKEN}:{V0_DISTINCT_ID}"
+        )]))
+    });
+
+    let now = DateTime::parse_from_rfc3339("2026-03-19T14:30:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    crate::events::analytics::process_events(
+        sink,
+        Arc::new(TokenDropper::default()),
+        None,
+        HistoricalConfig::new(false, 1),
+        global,
+        v0_overflow_limiter(limits),
+        None,
+        None,
+        &AiRouting::Primary,
+        (0..batch_size).map(|_| v0_raw_event()).collect(),
+        &v0_context(now),
+    )
+    .await
+    .expect("v0 pipeline must accept the batch");
+
+    let records = producer.get_records();
+    assert_eq!(records.len(), batch_size, "v0 must produce every event");
+    let record = &records[observe];
+    let topics = test_topics();
+    Observed {
+        lane: if record.topic == topics.main {
+            Lane::Main
+        } else if record.topic == topics.overflow {
+            Lane::Overflow
+        } else {
+            Lane::Other(record.topic.clone())
+        },
+        has_key: record.key.is_some(),
+        person_processing_disabled: record
+            .headers
+            .force_disable_person_processing
+            .unwrap_or(false),
+    }
+}
+
+/// Drive the real v1 pipeline through its sink router and read the record at
+/// `observe` off the mock producer.
+async fn run_v1(limits: Limits, batch_size: usize, observe: usize) -> Observed {
+    let mut builder = TestStateBuilder::new();
+    if limits.burst_limiter || limits.force_limited {
+        builder = builder.with_overflow_limiter(1, 1);
+    }
+    if limits.preserve_locality {
+        builder = builder.with_overflow_preserve_locality();
+    }
+    if limits.force_limited {
+        builder = builder.with_overflow_forced_key("phc_test_token");
+    }
+    if limits.globally_limited {
+        builder = builder
+            .with_global_rate_limiter(Arc::new(GlobalRateLimiter::mock_limiting(&[V1_HOT_KEY])));
+    }
+    let ts = builder.build();
+
+    let mut ctx = test_utils::test_analytics_context();
+    let events: Vec<_> = (0..batch_size).map(|_| test_utils::valid_event()).collect();
+    process_batch(&ts.state, &mut ctx, test_utils::valid_batch(events))
+        .await
+        .expect("v1 pipeline must accept the batch");
+
+    let cfg = test_utils::test_kafka_config();
+    ts.mock_producer.with_records(|records| {
+        assert_eq!(records.len(), batch_size, "v1 must produce every event");
+        let record = &records[observe];
+        Observed {
+            lane: if record.topic == cfg.topic_main {
+                Lane::Main
+            } else if record.topic == cfg.topic_overflow {
+                Lane::Overflow
+            } else {
+                Lane::Other(record.topic.clone())
+            },
+            has_key: record.key.is_some(),
+            person_processing_disabled: record.header("force_disable_person_processing")
+                == Some("true"),
+        }
+    })
+}
+
+/// The matrix. `observe` picks which event of the batch carries the interaction:
+/// with `burst = 1` the first event is within budget and the second is limited,
+/// so the two-event cases assert on index 1.
+#[rstest]
+#[case::no_limits(Limits::NONE, 1, 0, Lane::Main, true, false)]
+#[case::burst_rate_limited(
+    Limits { burst_limiter: true, ..Limits::NONE },
+    2, 1, Lane::Overflow, false, false
+)]
+#[case::burst_rate_limited_preserving_locality(
+    Limits { burst_limiter: true, preserve_locality: true, ..Limits::NONE },
+    2, 1, Lane::Overflow, true, false
+)]
+#[case::force_limited(
+    Limits { force_limited: true, ..Limits::NONE },
+    1, 0, Lane::Overflow, false, true
+)]
+#[case::globally_limited(
+    Limits { globally_limited: true, ..Limits::NONE },
+    1, 0, Lane::Overflow, false, true
+)]
+#[case::globally_limited_and_burst_rate_limited(
+    Limits { globally_limited: true, burst_limiter: true, ..Limits::NONE },
+    2, 1, Lane::Overflow, false, true
+)]
+// The cell the two paths used to disagree on: the global rate limiter has taken
+// person processing away, so the burst limiter's locality preference must not
+// hand the hot key its partition back.
+#[case::globally_limited_and_burst_preserving_locality(
+    Limits { globally_limited: true, burst_limiter: true, preserve_locality: true, ..Limits::NONE },
+    2, 1, Lane::Overflow, false, true
+)]
+#[tokio::test]
+async fn v0_and_v1_agree(
+    #[case] limits: Limits,
+    #[case] batch_size: usize,
+    #[case] observe: usize,
+    #[case] expected_lane: Lane,
+    #[case] expected_has_key: bool,
+    #[case] expected_person_disabled: bool,
+) {
+    let expected = Observed {
+        lane: expected_lane,
+        has_key: expected_has_key,
+        person_processing_disabled: expected_person_disabled,
+    };
+
+    let v0 = run_v0(limits, batch_size, observe).await;
+    let v1 = run_v1(limits, batch_size, observe).await;
+
+    assert_eq!(v0, expected, "v0 diverged from the contract");
+    assert_eq!(v1, expected, "v1 diverged from the contract");
+}

--- a/rust/capture/src/overflow_parity.rs
+++ b/rust/capture/src/overflow_parity.rs
@@ -216,52 +216,45 @@ async fn run_v1(limits: Limits, batch_size: usize, observe: usize) -> Observed {
     })
 }
 
-/// The matrix. `observe` picks which event of the batch carries the interaction:
-/// with `burst = 1` the first event is within budget and the second is limited,
-/// so the two-event cases assert on index 1.
+/// The matrix. Cases with a burst limiter armed send two events and observe
+/// the second (`burst` of 1 admits the first event and limits the rest);
+/// every other case observes its only event.
 #[rstest]
-#[case::no_limits(Limits::NONE, 1, 0, Lane::Main, true, false)]
+#[case::no_limits(
+    Limits::NONE,
+    Observed { lane: Lane::Main, has_key: true, person_processing_disabled: false }
+)]
 #[case::burst_rate_limited(
     Limits { burst_limiter: true, ..Limits::NONE },
-    2, 1, Lane::Overflow, false, false
+    Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: false }
 )]
 #[case::burst_rate_limited_preserving_locality(
     Limits { burst_limiter: true, preserve_locality: true, ..Limits::NONE },
-    2, 1, Lane::Overflow, true, false
+    Observed { lane: Lane::Overflow, has_key: true, person_processing_disabled: false }
 )]
 #[case::force_limited(
     Limits { force_limited: true, ..Limits::NONE },
-    1, 0, Lane::Overflow, false, true
+    Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: true }
 )]
 #[case::globally_limited(
     Limits { globally_limited: true, ..Limits::NONE },
-    1, 0, Lane::Overflow, false, true
+    Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: true }
 )]
 #[case::globally_limited_and_burst_rate_limited(
     Limits { globally_limited: true, burst_limiter: true, ..Limits::NONE },
-    2, 1, Lane::Overflow, false, true
+    Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: true }
 )]
 // The cell the two paths used to disagree on: the global rate limiter has taken
 // person processing away, so the burst limiter's locality preference must not
 // hand the hot key its partition back.
 #[case::globally_limited_and_burst_preserving_locality(
     Limits { globally_limited: true, burst_limiter: true, preserve_locality: true, ..Limits::NONE },
-    2, 1, Lane::Overflow, false, true
+    Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: true }
 )]
 #[tokio::test]
-async fn v0_and_v1_agree(
-    #[case] limits: Limits,
-    #[case] batch_size: usize,
-    #[case] observe: usize,
-    #[case] expected_lane: Lane,
-    #[case] expected_has_key: bool,
-    #[case] expected_person_disabled: bool,
-) {
-    let expected = Observed {
-        lane: expected_lane,
-        has_key: expected_has_key,
-        person_processing_disabled: expected_person_disabled,
-    };
+async fn v0_and_v1_agree(#[case] limits: Limits, #[case] expected: Observed) {
+    let batch_size = if limits.burst_limiter { 2 } else { 1 };
+    let observe = batch_size - 1;
 
     let v0 = run_v0(limits, batch_size, observe).await;
     let v1 = run_v1(limits, batch_size, observe).await;

--- a/rust/capture/src/overflow_parity.rs
+++ b/rust/capture/src/overflow_parity.rs
@@ -224,9 +224,13 @@ async fn run_v1(limits: Limits, batch_size: usize, observe: usize) -> Observed {
     Limits::NONE,
     Observed { lane: Lane::Main, has_key: true, person_processing_disabled: false }
 )]
+// A person-on burst keeps its key on either locality setting: the analytics
+// overflow consumer updates persons keyed on distinct id, so spreading one
+// distinct id across partitions would contend those updates. Person
+// processing stays on — a burst says nothing about identity resolution.
 #[case::burst_rate_limited(
     Limits { burst_limiter: true, ..Limits::NONE },
-    Observed { lane: Lane::Overflow, has_key: false, person_processing_disabled: false }
+    Observed { lane: Lane::Overflow, has_key: true, person_processing_disabled: false }
 )]
 #[case::burst_rate_limited_preserving_locality(
     Limits { burst_limiter: true, preserve_locality: true, ..Limits::NONE },

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -261,7 +261,13 @@ fn route(
                         preserve_locality: true,
                     }) => Route {
                         target: Output::AnalyticsOverflow,
-                        ordering: OrderingGuarantee::PerDistinctId,
+                        // The locality preference does not outrank a stage that
+                        // already took person processing away. The global rate
+                        // limiter stamps its verdict before the overflow
+                        // limiter, which then overwrites the reason, so without
+                        // this a key the rate limiter declared too hot would go
+                        // back to hashing onto one partition.
+                        ordering: person_ordering(metadata.skip_person_processing),
                     },
                     Some(OverflowReason::RateLimited {
                         preserve_locality: false,
@@ -304,7 +310,8 @@ fn route(
                         preserve_locality: true,
                     }) => Route {
                         target: Output::AiOverflow,
-                        ordering: OrderingGuarantee::PerDistinctId,
+                        // Same precedence as the analytics overflow lane above.
+                        ordering: person_ordering(metadata.skip_person_processing),
                     },
                     Some(OverflowReason::RateLimited {
                         preserve_locality: false,
@@ -367,6 +374,7 @@ fn route(
 #[cfg(test)]
 mod route_tests {
     use super::*;
+    use rstest::rstest;
 
     fn meta(data_type: DataType) -> ProcessedEventMetadata {
         ProcessedEventMetadata {
@@ -493,6 +501,40 @@ mod route_tests {
         let mut replay = base;
         replay.overflow_reason = Some(OverflowReason::ReplayLimited);
         assert_eq!(route(&replay, false).unwrap().target, Output::AnalyticsMain);
+    }
+
+    /// The global rate limiter stamps `skip_person_processing` before the
+    /// overflow limiter runs, and the overflow limiter overwrites the reason it
+    /// stamped. Without this precedence a key the rate limiter declared too hot
+    /// would go back to hashing onto a single overflow partition whenever the
+    /// limiter preserves locality, which is how prod-US is configured.
+    #[rstest]
+    #[case::analytics(DataType::AnalyticsMain, Outputs::AnalyticsOverflow)]
+    #[case::ai(DataType::AiEvents, Outputs::AiOverflow)]
+    fn person_processing_off_outranks_preserve_locality(
+        #[case] data_type: DataType,
+        #[case] expected_target: Outputs<'static>,
+    ) {
+        let armed = data_type == DataType::AiEvents;
+        let mut m = meta(data_type);
+        m.overflow_reason = Some(OverflowReason::RateLimited {
+            preserve_locality: true,
+        });
+
+        assert_eq!(
+            route(&m, armed).ordering,
+            OrderingGuarantee::PerDistinctId,
+            "locality is preserved while person processing is on"
+        );
+
+        m.skip_person_processing = true;
+        assert_eq!(
+            route(&m, armed),
+            Route {
+                target: expected_target,
+                ordering: OrderingGuarantee::None,
+            }
+        );
     }
 
     #[test]
@@ -3052,6 +3094,37 @@ mod tests {
                     topic: OVERFLOW_TOPIC,
                     has_key: false,
                     force_disable_person_processing: None,
+                    ..Default::default()
+                },
+            )
+            .await;
+        }
+
+        /// The wire outcome for the combination the global rate limiter and the
+        /// overflow limiter produce together on prod-US, where locality
+        /// preservation is on: the record keeps the person-processing header and
+        /// loses the partition key.
+        #[rstest]
+        #[case::analytics(DataType::AnalyticsMain, OVERFLOW_TOPIC)]
+        #[case::ai(DataType::AiEvents, AI_EVENTS_OVERFLOW_TOPIC)]
+        #[tokio::test]
+        async fn overflow_reason_rate_limited_preserving_drops_key_when_person_off(
+            #[case] data_type: DataType,
+            #[case] expected_topic: &str,
+        ) {
+            assert_routing(
+                EventInput {
+                    data_type,
+                    skip_person_processing: true,
+                    overflow_reason: Some(OverflowReason::RateLimited {
+                        preserve_locality: true,
+                    }),
+                    ..Default::default()
+                },
+                ExpectedRouting {
+                    topic: expected_topic,
+                    has_key: false,
+                    force_disable_person_processing: Some(true),
                     ..Default::default()
                 },
             )

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -19,6 +19,7 @@
 //! + topics) rather than deep copies of limiter state.
 use crate::api::CaptureError;
 use crate::config::{EnvelopeCompression, KafkaConfig};
+use crate::ordering::{person_ordering, OrderingGuarantee};
 use crate::sinks::producer::{KafkaProducer, ProduceRecord};
 use crate::sinks::registry::{Output, OutputRegistry};
 use crate::sinks::Event;
@@ -195,25 +196,6 @@ impl<P: KafkaProducer> Clone for KafkaSinkBase<P> {
     }
 }
 
-/// The ordering guarantee a route preserves — what the customer can rely on.
-/// The sink realizes it as a Kafka partition key; `route` only decides the
-/// guarantee from metadata.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OrderingGuarantee {
-    /// Ordering preserved per distinct id — the guarantee for every
-    /// non-replay lane. Partitions on the event's canonical key
-    /// ([`CapturedEvent::key`]): `token:distinct_id`, or `token:ip` in
-    /// cookieless mode, where the ip stands in for the distinct id derived
-    /// later in the pipeline.
-    PerDistinctId,
-    /// Ordering preserved per replay session: partitions on the raw
-    /// `session_id`, no token prefix (a missing id is rejected by `route()`).
-    PerSession,
-    /// No guarantee — no partition key, round-robin; ordering is
-    /// intentionally dropped to spread load.
-    None,
-}
-
 /// The pure routing decision for a single event: which output, and which
 /// ordering guarantee. Depends only on [`ProcessedEventMetadata`] (stamped
 /// upstream by the pipeline) and the AI overflow valve — the one piece of
@@ -227,17 +209,6 @@ enum OrderingGuarantee {
 struct Route {
     target: Output,
     ordering: OrderingGuarantee,
-}
-
-/// Ordering shared by the AnalyticsMain default and force-overflow paths:
-/// drop the guarantee when person processing is skipped, otherwise keep
-/// per-distinct-id ordering.
-fn person_ordering(skip_person_processing: bool) -> OrderingGuarantee {
-    if skip_person_processing {
-        OrderingGuarantee::None
-    } else {
-        OrderingGuarantee::PerDistinctId
-    }
 }
 
 /// Decide an event's route from its metadata. DLQ and custom-topic redirects

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -257,23 +257,19 @@ fn route(
                         target: Output::AnalyticsOverflow,
                         ordering: OrderingGuarantee::None,
                     },
-                    Some(OverflowReason::RateLimited {
-                        preserve_locality: true,
-                    }) => Route {
+                    // The person flag alone decides the key here, in both
+                    // directions. A burst keeps its key while person processing
+                    // is on — the overflow consumer updates persons keyed on
+                    // distinct id, so spreading one distinct id across
+                    // partitions turns a hot key into contended person-row
+                    // updates — which makes the locality preference irrelevant
+                    // on this lane. And a key whose person processing is
+                    // already off (the global rate limiter stamps its verdict
+                    // before the overflow limiter overwrites the reason) must
+                    // not get its partition back.
+                    Some(OverflowReason::RateLimited { .. }) => Route {
                         target: Output::AnalyticsOverflow,
-                        // The locality preference does not outrank a stage that
-                        // already took person processing away. The global rate
-                        // limiter stamps its verdict before the overflow
-                        // limiter, which then overwrites the reason, so without
-                        // this a key the rate limiter declared too hot would go
-                        // back to hashing onto one partition.
                         ordering: person_ordering(metadata.skip_person_processing),
-                    },
-                    Some(OverflowReason::RateLimited {
-                        preserve_locality: false,
-                    }) => Route {
-                        target: Output::AnalyticsOverflow,
-                        ordering: OrderingGuarantee::None,
                     },
                     // ReplayLimited is stamped only by the recordings pipeline,
                     // so an analytics event cannot carry it — the shared
@@ -287,8 +283,11 @@ fn route(
             }
         }
         DataType::AiEvents => {
-            // Valve armed: mirror the analytics main lane's overflow handling
-            // onto the AI lanes. Valve unarmed: AI events never overflow —
+            // Valve armed: the AI lanes route overflow like analytics, except
+            // that a burst may spread while person processing is on — the AI
+            // consumer reads persons without writing them, so keyless
+            // person-on records cause no person-update contention there.
+            // Valve unarmed: AI events never overflow —
             // force_overflow and stamped reasons are deliberately ignored
             // (the pipeline never stamps a reason on this lane anyway). The
             // default route keeps the event key regardless of
@@ -482,17 +481,25 @@ mod route_tests {
             Output::AnalyticsOverflow
         );
 
+        // The locality preference is irrelevant on the analytics lane: a
+        // person-on burst keeps its key either way, because the overflow
+        // consumer writes persons keyed on distinct id.
         let mut no_preserve = base.clone();
         no_preserve.overflow_reason = Some(OverflowReason::RateLimited {
             preserve_locality: false,
         });
         assert_eq!(
             route(&no_preserve, false).unwrap().ordering,
-            OrderingGuarantee::None
+            OrderingGuarantee::PerDistinctId
         );
         assert_eq!(
             route(&no_preserve, false).unwrap().target,
             Output::AnalyticsOverflow
+        );
+        no_preserve.skip_person_processing = true;
+        assert_eq!(
+            route(&no_preserve, false).unwrap().ordering,
+            OrderingGuarantee::None
         );
 
         // ReplayLimited cannot be stamped on analytics events (only the
@@ -509,11 +516,11 @@ mod route_tests {
     /// would go back to hashing onto a single overflow partition whenever the
     /// limiter preserves locality, which is how prod-US is configured.
     #[rstest]
-    #[case::analytics(DataType::AnalyticsMain, Outputs::AnalyticsOverflow)]
-    #[case::ai(DataType::AiEvents, Outputs::AiOverflow)]
+    #[case::analytics(DataType::AnalyticsMain, Output::AnalyticsOverflow)]
+    #[case::ai(DataType::AiEvents, Output::AiOverflow)]
     fn person_processing_off_outranks_preserve_locality(
         #[case] data_type: DataType,
-        #[case] expected_target: Outputs<'static>,
+        #[case] expected_target: Output,
     ) {
         let armed = data_type == DataType::AiEvents;
         let mut m = meta(data_type);
@@ -522,14 +529,14 @@ mod route_tests {
         });
 
         assert_eq!(
-            route(&m, armed).ordering,
+            route(&m, armed).unwrap().ordering,
             OrderingGuarantee::PerDistinctId,
             "locality is preserved while person processing is on"
         );
 
         m.skip_person_processing = true;
         assert_eq!(
-            route(&m, armed),
+            route(&m, armed).unwrap(),
             Route {
                 target: expected_target,
                 ordering: OrderingGuarantee::None,
@@ -2689,9 +2696,11 @@ mod tests {
             .await;
         }
 
-        /// Stamped overflow reasons on the AI lane route exactly like the
-        /// analytics main lane, including the preserve-partition-locality
-        /// key handling mirrored from the limiter config.
+        /// Stamped overflow reasons on the AI lane, where — unlike the
+        /// analytics lane — a burst without locality preservation spreads
+        /// while person processing is on: the AI consumer reads persons
+        /// without writing them, so keyless person-on records contend
+        /// nothing downstream.
         #[rstest]
         #[case::force_limited(OverflowReason::ForceLimited, false, None)]
         #[case::rate_limited_preserving(
@@ -2709,7 +2718,7 @@ mod tests {
             None
         )]
         #[tokio::test]
-        async fn ai_events_stamped_overflow_mirrors_analytics(
+        async fn ai_events_stamped_overflow_routing(
             #[case] reason: OverflowReason,
             #[case] has_key: bool,
             #[case] force_disable_person_processing: Option<bool>,
@@ -3060,14 +3069,21 @@ mod tests {
             .await;
         }
 
+        /// A person-on burst keeps its key on the analytics lane regardless of
+        /// the locality preference: the overflow consumer updates persons
+        /// keyed on distinct id, and spreading one distinct id across
+        /// partitions contends those updates.
+        #[rstest]
+        #[case::preserving_locality(true)]
+        #[case::spreading(false)]
         #[tokio::test]
-        async fn overflow_reason_rate_limited_preserves_key_when_preserve_locality() {
+        async fn overflow_reason_rate_limited_keeps_key_while_person_processing_on(
+            #[case] preserve_locality: bool,
+        ) {
             assert_routing(
                 EventInput {
                     data_type: DataType::AnalyticsMain,
-                    overflow_reason: Some(OverflowReason::RateLimited {
-                        preserve_locality: true,
-                    }),
+                    overflow_reason: Some(OverflowReason::RateLimited { preserve_locality }),
                     ..Default::default()
                 },
                 ExpectedRouting {
@@ -3080,45 +3096,26 @@ mod tests {
             .await;
         }
 
-        #[tokio::test]
-        async fn overflow_reason_rate_limited_drops_key_when_not_preserve_locality() {
-            assert_routing(
-                EventInput {
-                    data_type: DataType::AnalyticsMain,
-                    overflow_reason: Some(OverflowReason::RateLimited {
-                        preserve_locality: false,
-                    }),
-                    ..Default::default()
-                },
-                ExpectedRouting {
-                    topic: OVERFLOW_TOPIC,
-                    has_key: false,
-                    force_disable_person_processing: None,
-                    ..Default::default()
-                },
-            )
-            .await;
-        }
-
         /// The wire outcome for the combination the global rate limiter and the
-        /// overflow limiter produce together on prod-US, where locality
-        /// preservation is on: the record keeps the person-processing header and
-        /// loses the partition key.
+        /// overflow limiter produce together (the GRL stamps the person flag,
+        /// the burst limiter overwrites the reason): the record keeps the
+        /// person-processing header and loses the partition key, on either
+        /// locality setting.
         #[rstest]
-        #[case::analytics(DataType::AnalyticsMain, OVERFLOW_TOPIC)]
-        #[case::ai(DataType::AiEvents, AI_EVENTS_OVERFLOW_TOPIC)]
+        #[case::analytics_preserving(DataType::AnalyticsMain, true, OVERFLOW_TOPIC)]
+        #[case::analytics_spreading(DataType::AnalyticsMain, false, OVERFLOW_TOPIC)]
+        #[case::ai_preserving(DataType::AiEvents, true, AI_EVENTS_OVERFLOW_TOPIC)]
         #[tokio::test]
-        async fn overflow_reason_rate_limited_preserving_drops_key_when_person_off(
+        async fn overflow_reason_rate_limited_drops_key_when_person_off(
             #[case] data_type: DataType,
+            #[case] preserve_locality: bool,
             #[case] expected_topic: &str,
         ) {
             assert_routing(
                 EventInput {
                     data_type,
                     skip_person_processing: true,
-                    overflow_reason: Some(OverflowReason::RateLimited {
-                        preserve_locality: true,
-                    }),
+                    overflow_reason: Some(OverflowReason::RateLimited { preserve_locality }),
                     ..Default::default()
                 },
                 ExpectedRouting {

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -202,9 +202,9 @@ impl<P: KafkaProducer> Clone for KafkaSinkBase<P> {
 /// sink config that changes a routing decision rather than a topic name.
 /// Side effects are not part of the decision: the dlq header set and the
 /// reroute counters follow from the target, and the person-processing header
-/// follows from the stamped `skip_person_processing` flag (which the
-/// pipeline sets alongside `OverflowReason::ForceLimited` — the metadata is
-/// self-describing).
+/// follows from [`ProcessedEventMetadata::person_processing_disabled`] —
+/// the stamped flag, or a `ForceLimited` reason, which implies the skip on
+/// its own.
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Route {
     target: Output,
@@ -249,7 +249,7 @@ fn route(
             if metadata.force_overflow {
                 Route {
                     target: Output::AnalyticsOverflow,
-                    ordering: person_ordering(metadata.skip_person_processing),
+                    ordering: person_ordering(metadata.person_processing_disabled()),
                 }
             } else {
                 match &metadata.overflow_reason {
@@ -269,7 +269,7 @@ fn route(
                     // not get its partition back.
                     Some(OverflowReason::RateLimited { .. }) => Route {
                         target: Output::AnalyticsOverflow,
-                        ordering: person_ordering(metadata.skip_person_processing),
+                        ordering: person_ordering(metadata.person_processing_disabled()),
                     },
                     // ReplayLimited is stamped only by the recordings pipeline,
                     // so an analytics event cannot carry it — the shared
@@ -277,7 +277,7 @@ fn route(
                     // impossible stamp as unstamped.
                     Some(OverflowReason::ReplayLimited) | None => Route {
                         target: Output::AnalyticsMain,
-                        ordering: person_ordering(metadata.skip_person_processing),
+                        ordering: person_ordering(metadata.person_processing_disabled()),
                     },
                 }
             }
@@ -297,7 +297,7 @@ fn route(
             if ai_events_overflow_armed && metadata.force_overflow {
                 Route {
                     target: Output::AiOverflow,
-                    ordering: person_ordering(metadata.skip_person_processing),
+                    ordering: person_ordering(metadata.person_processing_disabled()),
                 }
             } else if ai_events_overflow_armed {
                 match &metadata.overflow_reason {
@@ -310,7 +310,7 @@ fn route(
                     }) => Route {
                         target: Output::AiOverflow,
                         // Same precedence as the analytics overflow lane above.
-                        ordering: person_ordering(metadata.skip_person_processing),
+                        ordering: person_ordering(metadata.person_processing_disabled()),
                     },
                     Some(OverflowReason::RateLimited {
                         preserve_locality: false,
@@ -868,8 +868,9 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
 
         drop(event); // Events can be EXTREMELY memory hungry
 
-        // Apply skip_person_processing from event restrictions / upstream decisions
-        if metadata.skip_person_processing {
+        // The stamped flag (event restrictions / upstream decisions) or a
+        // ForceLimited reason, which implies the skip on its own.
+        if metadata.person_processing_disabled() {
             headers.set_force_disable_person_processing(true);
         }
 
@@ -2700,9 +2701,10 @@ mod tests {
         /// analytics lane — a burst without locality preservation spreads
         /// while person processing is on: the AI consumer reads persons
         /// without writing them, so keyless person-on records contend
-        /// nothing downstream.
+        /// nothing downstream. `ForceLimited` implies the person-processing
+        /// header on its own, flag or no flag.
         #[rstest]
-        #[case::force_limited(OverflowReason::ForceLimited, false, None)]
+        #[case::force_limited(OverflowReason::ForceLimited, false, Some(true))]
         #[case::rate_limited_preserving(
             OverflowReason::RateLimited {
                 preserve_locality: true
@@ -3040,17 +3042,16 @@ mod tests {
         // analytics_main_force_overflow / snapshot_main_force_overflow cases
         // above (force_overflow short-circuits the overflow_reason branch).
 
-        /// The person-processing header comes from the stamped
-        /// `skip_person_processing` flag alone — the pipeline sets it
-        /// alongside `ForceLimited` (self-describing metadata), so the sink
-        /// adds nothing for a reason stamped without the flag.
+        /// `ForceLimited` implies person processing is off on its own: the
+        /// header is set whether or not the stamping site also set the flag,
+        /// so a keyless force-limited record can never reach person
+        /// processing with identity resolution still on.
         #[rstest]
-        #[case::stamped_with_flag(true, Some(true))]
-        #[case::reason_only(false, None)]
+        #[case::stamped_with_flag(true)]
+        #[case::reason_only(false)]
         #[tokio::test]
         async fn overflow_reason_force_limited_routes_to_overflow_with_null_key(
             #[case] skip_person_processing: bool,
-            #[case] force_disable_person_processing: Option<bool>,
         ) {
             assert_routing(
                 EventInput {
@@ -3062,7 +3063,7 @@ mod tests {
                 ExpectedRouting {
                     topic: OVERFLOW_TOPIC,
                     has_key: false,
-                    force_disable_person_processing,
+                    force_disable_person_processing: Some(true),
                     ..Default::default()
                 },
             )
@@ -3196,7 +3197,10 @@ mod tests {
         #[tokio::test]
         async fn overflow_reason_redirect_to_dlq_wins_over_overflow_reason() {
             // DLQ routing is the highest-priority routing decision: it wins
-            // over both force_overflow and overflow_reason.
+            // over both force_overflow and overflow_reason. The
+            // person-processing header still travels with the ForceLimited
+            // reason — routing precedence changes the topic, not the skip
+            // (production stamps the flag alongside the reason anyway).
             assert_routing(
                 EventInput {
                     data_type: DataType::AnalyticsMain,
@@ -3207,7 +3211,7 @@ mod tests {
                 ExpectedRouting {
                     topic: DLQ_TOPIC,
                     has_key: true,
-                    force_disable_person_processing: None,
+                    force_disable_person_processing: Some(true),
                     dlq_headers: true,
                     rerouted: Rerouted::Dlq,
                     ..Default::default()
@@ -3231,7 +3235,9 @@ mod tests {
                 ExpectedRouting {
                     topic: "custom_topic",
                     has_key: true,
-                    force_disable_person_processing: None,
+                    // The header travels with the reason regardless of the
+                    // routing precedence, as in the dlq case above.
+                    force_disable_person_processing: Some(true),
                     rerouted: Rerouted::CustomTopic,
                     ..Default::default()
                 },

--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -284,9 +284,14 @@ pub struct ProcessedEvent {
 /// for overflow beyond this mapping.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OverflowReason {
-    /// Governor matched a configured `keys_to_reroute` entry for this event's
-    /// key. Events in this state always have `skip_person_processing = true`
-    /// and are routed to the overflow topic with a null partition key.
+    /// The overflow governor matched a configured `keys_to_reroute` entry
+    /// for this event's key, or the global rate limiter put the key over its
+    /// window. Routed to the overflow topic with a null partition key, with
+    /// person processing off: the reason itself implies the skip
+    /// ([`ProcessedEventMetadata::person_processing_disabled`]), so a
+    /// stamping site cannot keep person processing on for a force-limited
+    /// key by forgetting the flag. Stamping sites still set
+    /// `skip_person_processing = true` alongside for pipeline-level readers.
     ForceLimited,
     /// Per-key rate exceeded the configured governor quota. Routed to the
     /// overflow topic. `preserve_locality` mirrors the
@@ -325,6 +330,17 @@ pub struct ProcessedEventMetadata {
     /// Feeds the `distinct_id_truncated` ingestion warning; nothing routes on
     /// it.
     pub distinct_id_truncated_from: Option<usize>,
+}
+
+impl ProcessedEventMetadata {
+    /// Whether person processing is off for this event: the stamped flag, or
+    /// a `ForceLimited` reason — force-limiting implies the skip, so the
+    /// sink's header and ordering cannot silently keep person processing on
+    /// for a force-limited key whose stamping site forgot the flag.
+    pub fn person_processing_disabled(&self) -> bool {
+        self.skip_person_processing
+            || matches!(self.overflow_reason, Some(OverflowReason::ForceLimited))
+    }
 }
 
 #[cfg(test)]

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -154,8 +154,13 @@ pub async fn process_batch(
     // to reconcile here — a future routing refactor must not assume parity:
     //   1. Ordering: v1 runs this GRL step AFTER burst overflow stamping (above);
     //      legacy runs its GRL BEFORE overflow stamping. Both set overflow on
-    //      AnalyticsMain/Destination::Overflow only, so the end state matches,
-    //      but the pass order differs.
+    //      AnalyticsMain/Destination::Overflow only, so the destination matches,
+    //      but the pass order differs and the partition key can too: legacy's
+    //      burst limiter overwrites the GRL's stamp, so a key the GRL wanted
+    //      spread is restored when the limiter preserves locality, whereas here
+    //      the GRL stamps last and wins. Only reachable with
+    //      OVERFLOW_PRESERVE_PARTITION_LOCALITY on. The
+    //      `overflow_grl_parity` suite pins the whole cross-path matrix.
     //   2. Lane assignment is assign-then-reroute in v1 versus a single
     //      `DataType::from_event_name` match in legacy.
     // Both paths consult the same shared limiter for every non-dropped event, so
@@ -505,6 +510,7 @@ fn validate_events(
                             details: Some(DETAIL_INVALID_OPTIONS),
                             destination,
                             force_disable_person_processing: false,
+                            spread_partitions: false,
                             is_gateway_verified: false,
                         });
                         continue;
@@ -534,6 +540,7 @@ fn validate_events(
                     },
                     destination,
                     force_disable_person_processing: illegal,
+                    spread_partitions: false,
                     is_gateway_verified: false,
                 });
             }
@@ -547,6 +554,7 @@ fn validate_events(
                     details: Some(err.tag()),
                     destination,
                     force_disable_person_processing: false,
+                    spread_partitions: false,
                     is_gateway_verified: false,
                 });
             }
@@ -714,16 +722,21 @@ fn apply_overflow_stamping(
         match limiter.is_limited(&key) {
             OverflowLimiterResult::ForceLimited => {
                 event.destination = overflow_destination;
-                // Disables person processing AND nulls partition key at sink.
+                // A force-limited key is hot enough that we both spread it and
+                // stop paying for identity resolution on it, matching v0's
+                // ForceLimited arm.
                 event.force_disable_person_processing = true;
+                event.spread_partitions = true;
                 metrics::counter!(CAPTURE_V1_OVERFLOW_ROUTED, "reason" => "force_limited")
                     .increment(1);
             }
             OverflowLimiterResult::Limited => {
                 event.destination = overflow_destination;
                 if !limiter.should_preserve_locality() {
-                    // Nulls partition key at sink -- spreads across partitions.
-                    event.force_disable_person_processing = true;
+                    // Spread only. Person processing stays on, because a burst
+                    // over the per-second budget says nothing about whether the
+                    // customer wants identity resolution for this event.
+                    event.spread_partitions = true;
                 }
                 metrics::counter!(CAPTURE_V1_OVERFLOW_ROUTED, "reason" => "rate_limited")
                     .increment(1);
@@ -847,11 +860,15 @@ async fn apply_token_distinct_id_limits(
         let limited = limiter.is_limited(&cache_key, 1).await.is_some();
 
         // Person processing is already off for this event (illegal distinct_id,
-        // an ops restriction, or burst overflow stamping upstream). Its volume
+        // an ops restriction, or a force-limited key upstream). Its volume
         // still counts toward the shared window above -- v0 and v1 feed one
         // limiter instance, so both must consult it for every non-dropped event
         // to keep the per-key counts identical. The stamps below would be
         // redundant here, so skip them.
+        //
+        // A merely rate-limited burst does NOT land here: it sets
+        // `spread_partitions` without touching person processing, so such an
+        // event still gets its warning stamped below, as it does on the v0 path.
         if event.force_disable_person_processing {
             already_disabled_count += 1;
             continue;
@@ -859,7 +876,8 @@ async fn apply_token_distinct_id_limits(
 
         if limited {
             event.result = EventResult::Warning;
-            // Disables person processing -- sink will null partition key for Main/Overflow.
+            // Disabling person processing also drops the ordering guarantee on
+            // the main/overflow lanes, via `WrappedEvent::ordering`.
             event.force_disable_person_processing = true;
             event.details = Some(DETAIL_PERSON_PROCESSING_DISABLED);
             // Reroute to overflow to spread a hot token:distinct_id across
@@ -3064,6 +3082,7 @@ mod tests {
         apply_overflow_stamping(Some(&limiter), None, &ctx, &mut events);
 
         assert_eq!(events[0].destination, Destination::Overflow);
+        assert!(events[0].spread_partitions);
         assert!(events[0].force_disable_person_processing);
     }
 
@@ -3077,11 +3096,12 @@ mod tests {
         apply_overflow_stamping(Some(&limiter), None, &ctx, &mut events);
 
         assert_eq!(events[0].destination, Destination::Overflow);
+        assert!(events[0].spread_partitions);
         assert!(events[0].force_disable_person_processing);
     }
 
     #[test]
-    fn overflow_rate_limited_disables_person_processing() {
+    fn overflow_rate_limited_spreads_without_disabling_person_processing() {
         let mut ctx = test_utils::test_context();
         ctx.api_token = "phc_tok".to_string();
         // burst=1 means only 1 event allowed, the second will be limited
@@ -3094,9 +3114,18 @@ mod tests {
         apply_overflow_stamping(Some(&limiter), None, &ctx, &mut events);
 
         assert_eq!(events[0].destination, Destination::AnalyticsMain);
+        assert!(!events[0].spread_partitions);
         assert!(!events[0].force_disable_person_processing);
+
         assert_eq!(events[1].destination, Destination::Overflow);
-        assert!(events[1].force_disable_person_processing);
+        assert!(
+            events[1].spread_partitions,
+            "a bursting key must be spread across the overflow partitions"
+        );
+        assert!(
+            !events[1].force_disable_person_processing,
+            "exceeding the burst budget must not skip identity resolution"
+        );
     }
 
     #[test]
@@ -3113,9 +3142,10 @@ mod tests {
 
         assert_eq!(events[1].destination, Destination::Overflow);
         assert!(
-            !events[1].force_disable_person_processing,
-            "preserve_locality=true means person processing stays enabled"
+            !events[1].spread_partitions,
+            "preserve_locality=true keeps the partition key"
         );
+        assert!(!events[1].force_disable_person_processing);
     }
 
     #[test]
@@ -3191,9 +3221,31 @@ mod tests {
         assert_eq!(events[0].destination, Destination::AiEvents);
         assert_eq!(events[1].destination, Destination::AiEventsOverflow);
         assert!(
-            !events[1].force_disable_person_processing,
-            "preserve_locality=true means person processing stays enabled"
+            !events[1].spread_partitions,
+            "preserve_locality=true keeps the partition key"
         );
+        assert!(!events[1].force_disable_person_processing);
+    }
+
+    /// The AI lane gets the same decoupling as the analytics lane: a burst over
+    /// the budget spreads the key without disabling person processing.
+    #[test]
+    fn overflow_ai_events_rate_limited_spreads_without_disabling_person_processing() {
+        let mut ctx = test_utils::test_context();
+        ctx.api_token = "phc_tok".to_string();
+        let limiter = overflow_limiter(1, 1, None);
+        let mut events = vec![
+            wrapped_event("$ai_generation", "user-1"),
+            wrapped_event("$ai_generation", "user-1"),
+        ];
+        events[0].destination = Destination::AiEvents;
+        events[1].destination = Destination::AiEvents;
+
+        apply_overflow_stamping(None, Some(&limiter), &ctx, &mut events);
+
+        assert_eq!(events[1].destination, Destination::AiEventsOverflow);
+        assert!(events[1].spread_partitions);
+        assert!(!events[1].force_disable_person_processing);
     }
 
     /// The two lanes consult separate limiter instances: a key the analytics

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -153,14 +153,12 @@ pub async fn process_batch(
     // DIVERGENCE from legacy (`events::analytics`), intentional and out of scope
     // to reconcile here — a future routing refactor must not assume parity:
     //   1. Ordering: v1 runs this GRL step AFTER burst overflow stamping (above);
-    //      legacy runs its GRL BEFORE overflow stamping. Both set overflow on
-    //      AnalyticsMain/Destination::Overflow only, so the destination matches,
-    //      but the pass order differs and the partition key can too: legacy's
-    //      burst limiter overwrites the GRL's stamp, so a key the GRL wanted
-    //      spread is restored when the limiter preserves locality, whereas here
-    //      the GRL stamps last and wins. Only reachable with
-    //      OVERFLOW_PRESERVE_PARTITION_LOCALITY on. The
-    //      `overflow_grl_parity` suite pins the whole cross-path matrix.
+    //      legacy runs its GRL BEFORE overflow stamping. The pass order differs,
+    //      but the observable outcome does not: both reroute only
+    //      AnalyticsMain/Destination::Overflow, and both drop the partition key
+    //      once person processing is off, so a key the GRL wanted spread stays
+    //      spread on either path even when the burst limiter preserves locality.
+    //      `crate::overflow_parity` pins that across the whole matrix.
     //   2. Lane assignment is assign-then-reroute in v1 versus a single
     //      `DataType::from_event_name` match in legacy.
     // Both paths consult the same shared limiter for every non-dropped event, so

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -2489,6 +2489,45 @@ mod tests {
         assert_eq!(limited.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
     }
 
+    /// The two stages run in v1's production order: the burst limiter first,
+    /// then the global rate limiter. A key that trips both must still get its
+    /// warning, because the global limiter skips events whose person processing
+    /// is already off, and a burst used to leave that flag set on its way past.
+    /// The legacy path always warns here (its global limiter runs first), so
+    /// swallowing it would drop a customer-visible warning on v1 only.
+    ///
+    /// Spreading itself is covered by
+    /// `overflow_rate_limited_spreads_without_disabling_person_processing`; this
+    /// case exists for the warning and the tally.
+    #[tokio::test]
+    async fn burst_overflow_then_global_limit_still_warns() {
+        let mut ctx = test_utils::test_context();
+        ctx.api_token = "phc_tok".to_string();
+        let burst = overflow_limiter(1, 1, None);
+        let global = mock_limiter(vec!["phc_tok:user-1"]);
+        let mut events = vec![
+            wrapped_event("$pageview", "user-1"),
+            wrapped_event("$pageview", "user-1"),
+        ];
+
+        apply_overflow_stamping(Some(&burst), None, &ctx, &mut events);
+        let tally = apply_token_distinct_id_limits(&global, &ctx, None, &mut events).await;
+
+        // events[1] is the one the burst limiter sent to overflow.
+        let spread = &events[1];
+        assert_eq!(
+            spread.result,
+            EventResult::Warning,
+            "a spread key must still be warned about when the global limiter hits it"
+        );
+        assert_eq!(spread.details, Some(DETAIL_PERSON_PROCESSING_DISABLED));
+        assert_eq!(
+            tally.already_disabled, 0,
+            "spreading must not look like person processing was already off"
+        );
+        assert_eq!(tally.limited, 2);
+    }
+
     #[tokio::test]
     async fn td_limits_evaluates_but_does_not_restamp_force_disable_pp() {
         // An event that already has person processing disabled (illegal

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -733,7 +733,10 @@ fn apply_overflow_stamping(
                 if !limiter.should_preserve_locality() {
                     // Spread only. Person processing stays on, because a burst
                     // over the per-second budget says nothing about whether the
-                    // customer wants identity resolution for this event.
+                    // customer wants identity resolution for this event. On the
+                    // person-writing analytics lane the sink holds the key
+                    // until person processing is off (`WrappedEvent::ordering`);
+                    // the read-only AI overflow lane spreads immediately.
                     event.spread_partitions = true;
                 }
                 metrics::counter!(CAPTURE_V1_OVERFLOW_ROUTED, "reason" => "rate_limited")
@@ -2494,9 +2497,9 @@ mod tests {
     /// The legacy path always warns here (its global limiter runs first), so
     /// swallowing it would drop a customer-visible warning on v1 only.
     ///
-    /// Spreading itself is covered by
-    /// `overflow_rate_limited_spreads_without_disabling_person_processing`; this
-    /// case exists for the warning and the tally.
+    /// The spread stamp itself is covered by
+    /// `overflow_rate_limited_stamps_spread_without_disabling_person_processing`;
+    /// this case exists for the warning and the tally.
     #[tokio::test]
     async fn burst_overflow_then_global_limit_still_warns() {
         let mut ctx = test_utils::test_context();
@@ -3138,7 +3141,7 @@ mod tests {
     }
 
     #[test]
-    fn overflow_rate_limited_spreads_without_disabling_person_processing() {
+    fn overflow_rate_limited_stamps_spread_without_disabling_person_processing() {
         let mut ctx = test_utils::test_context();
         ctx.api_token = "phc_tok".to_string();
         // burst=1 means only 1 event allowed, the second will be limited
@@ -3157,7 +3160,7 @@ mod tests {
         assert_eq!(events[1].destination, Destination::Overflow);
         assert!(
             events[1].spread_partitions,
-            "a bursting key must be spread across the overflow partitions"
+            "a bursting key must carry the spread stamp"
         );
         assert!(
             !events[1].force_disable_person_processing,

--- a/rust/capture/src/v1/analytics/response.rs
+++ b/rust/capture/src/v1/analytics/response.rs
@@ -184,6 +184,7 @@ mod tests {
             details,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         }
     }

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -23,6 +23,7 @@ impl io::Write for StringWriter<'_> {
     }
 }
 
+use crate::ordering::{person_ordering, OrderingGuarantee};
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::event::Event as SinkEvent;
 use crate::v1::sinks::Destination;
@@ -217,6 +218,13 @@ pub struct WrappedEvent {
     pub details: Option<&'static str>,
     pub destination: Destination,
     pub force_disable_person_processing: bool,
+    /// Set when the overflow limiter decided this key is bursting and must be
+    /// spread across the overflow topic's partitions. Deliberately separate
+    /// from `force_disable_person_processing`: spreading a hot key is a
+    /// partitioning decision, while disabling person processing is a
+    /// customer-visible instruction to skip identity resolution, and the
+    /// overflow limiter only means the former. Consumed by `ordering()`.
+    pub spread_partitions: bool,
     /// Set by the gateway-provenance step when a valid signature was verified;
     /// read by the quota shim to exempt the event from the llm_events limiter.
     pub is_gateway_verified: bool,
@@ -248,10 +256,10 @@ impl SinkEvent for WrappedEvent {
     // backend-specific format (e.g. OwnedHeaders for Kafka) via the From impl
     // in common_types — same conversion legacy capture uses.
     fn headers(&self, ctx: &RequestContext) -> CapturedEventHeaders {
-        // v0 compat: downstream consumers key on "force_disable_person_processing".
-        // v1 decouples overflow routing from person-processing (unlike v0 where
-        // overflow ForceLimited unconditionally sets this); operators configure
-        // this flag alongside ForceOverflow when needed.
+        // Downstream treats this header as absolute: `decideProcessPerson` in
+        // nodejs/src/common/persons/person-utils.ts skips person processing
+        // outright when it is set. So it carries only the person-processing
+        // decision, never the partitioning one, which travels as `ordering()`.
         let force_disable_person_processing = if self.force_disable_person_processing {
             Some(true)
         } else {
@@ -317,6 +325,28 @@ impl SinkEvent for WrappedEvent {
             }
         }
         buf
+    }
+
+    /// Computed here rather than stamped during processing because it depends
+    /// on the final destination: `apply_restrictions` can disable person
+    /// processing while an event is still `AnalyticsMain`, and
+    /// `apply_historical_rerouting` may afterwards move it to
+    /// `AnalyticsHistorical`, whose consumers need the key. Deciding late
+    /// keeps the rule correct no matter how the stages are ordered.
+    fn ordering(&self) -> OrderingGuarantee {
+        match self.destination {
+            // Only the lanes that exist to absorb hot keys give up ordering.
+            Destination::AnalyticsMain | Destination::Overflow | Destination::AiEventsOverflow => {
+                if self.spread_partitions {
+                    OrderingGuarantee::None
+                } else {
+                    person_ordering(self.force_disable_person_processing)
+                }
+            }
+            // Historical, dlq, custom redirects and the AI main topic keep the
+            // key even with person processing off, matching v0's route().
+            _ => OrderingGuarantee::PerDistinctId,
+        }
     }
 
     fn serialize(&self, ctx: &RequestContext) -> anyhow::Result<bytes::Bytes> {
@@ -1024,6 +1054,82 @@ mod tests {
         test_utils::wrapped_event(event_name, distinct_id)
     }
 
+    /// The ordering rule, per lane and per reason for giving ordering up. The
+    /// `spread`-without-`force_disable` rows are the ones that matter most:
+    /// a bursting key must lose its partition key without also losing person
+    /// processing, which is a customer-visible instruction.
+    #[rstest::rstest]
+    #[case::main_untouched(
+        Destination::AnalyticsMain,
+        false,
+        false,
+        OrderingGuarantee::PerDistinctId
+    )]
+    #[case::main_person_off(Destination::AnalyticsMain, true, false, OrderingGuarantee::None)]
+    #[case::main_spread(Destination::AnalyticsMain, false, true, OrderingGuarantee::None)]
+    #[case::overflow_untouched(
+        Destination::Overflow,
+        false,
+        false,
+        OrderingGuarantee::PerDistinctId
+    )]
+    #[case::overflow_person_off(Destination::Overflow, true, false, OrderingGuarantee::None)]
+    #[case::overflow_spread(Destination::Overflow, false, true, OrderingGuarantee::None)]
+    #[case::ai_overflow_spread(Destination::AiEventsOverflow, false, true, OrderingGuarantee::None)]
+    #[case::ai_overflow_person_off(
+        Destination::AiEventsOverflow,
+        true,
+        false,
+        OrderingGuarantee::None
+    )]
+    // Lanes whose consumers need the key regardless: person processing being
+    // off must not spread them, matching v0's route().
+    #[case::ai_main_person_off(
+        Destination::AiEvents,
+        true,
+        false,
+        OrderingGuarantee::PerDistinctId
+    )]
+    #[case::historical_person_off(
+        Destination::AnalyticsHistorical,
+        true,
+        false,
+        OrderingGuarantee::PerDistinctId
+    )]
+    #[case::dlq_person_off(Destination::Dlq, true, false, OrderingGuarantee::PerDistinctId)]
+    #[case::custom_person_off(
+        Destination::Custom("t".into()),
+        true,
+        false,
+        OrderingGuarantee::PerDistinctId
+    )]
+    fn ordering_per_lane(
+        #[case] destination: Destination,
+        #[case] force_disable_person_processing: bool,
+        #[case] spread_partitions: bool,
+        #[case] expected: OrderingGuarantee,
+    ) {
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.destination = destination;
+        ev.force_disable_person_processing = force_disable_person_processing;
+        ev.spread_partitions = spread_partitions;
+        assert_eq!(ev.ordering(), expected);
+    }
+
+    #[test]
+    fn spreading_does_not_disable_person_processing() {
+        let ctx = test_utils::test_context();
+        let mut ev = ok_wrapped("$pageview", "user-1");
+        ev.destination = Destination::Overflow;
+        ev.spread_partitions = true;
+
+        assert_eq!(ev.ordering(), OrderingGuarantee::None);
+        assert!(
+            ev.headers(&ctx).force_disable_person_processing.is_none(),
+            "spreading a hot key must not tell downstream to skip person processing"
+        );
+    }
+
     #[rstest::rstest]
     #[case::ok_main(EventResult::Ok, Destination::AnalyticsMain)]
     #[case::ok_historical(EventResult::Ok, Destination::AnalyticsHistorical)]
@@ -1329,6 +1435,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         }
     }
@@ -1511,6 +1618,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1553,6 +1661,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1594,6 +1703,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1632,6 +1742,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1673,6 +1784,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1792,6 +1904,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: true,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1835,6 +1948,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1876,6 +1990,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 
@@ -1913,6 +2028,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         };
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -218,12 +218,14 @@ pub struct WrappedEvent {
     pub details: Option<&'static str>,
     pub destination: Destination,
     pub force_disable_person_processing: bool,
-    /// Set when the overflow limiter decided this key is bursting and must be
-    /// spread across the overflow topic's partitions. Deliberately separate
+    /// Set when the overflow limiter decided this key is bursting and should
+    /// be spread across the overflow topic's partitions. Deliberately separate
     /// from `force_disable_person_processing`: spreading a hot key is a
     /// partitioning decision, while disabling person processing is a
     /// customer-visible instruction to skip identity resolution, and the
-    /// overflow limiter only means the former. Consumed by `ordering()`.
+    /// overflow limiter only means the former. Consumed by `ordering()`,
+    /// which realizes it only on lanes whose consumers do not write persons —
+    /// elsewhere the key holds until person processing is off.
     pub spread_partitions: bool,
     /// Set by the gateway-provenance step when a valid signature was verified;
     /// read by the quota shim to exempt the event from the llm_events limiter.
@@ -337,11 +339,11 @@ impl SinkEvent for WrappedEvent {
         if !self.destination.absorbs_hot_keys() {
             return OrderingGuarantee::PerDistinctId;
         }
-        // Two independent reasons to give the guarantee up on a lane that can:
-        // the overflow limiter found the key bursting, or a stage took person
-        // processing away and with it the ordering that person processing is
-        // what needs.
-        if self.spread_partitions {
+        // A spread decision takes effect on its own only where the consumer
+        // does not write persons; on person-writing lanes the key holds until
+        // person processing is off, so the person flag alone decides there
+        // (see `Destination::writes_persons`).
+        if self.spread_partitions && !self.destination.writes_persons() {
             return OrderingGuarantee::None;
         }
         person_ordering(self.force_disable_person_processing)
@@ -1054,8 +1056,10 @@ mod tests {
 
     /// The ordering rule, per lane and per reason for giving ordering up. The
     /// `spread`-without-`force_disable` rows are the ones that matter most:
-    /// a bursting key must lose its partition key without also losing person
-    /// processing, which is a customer-visible instruction.
+    /// on the person-writing analytics lanes a bursting key must keep its
+    /// partition key while person processing is on (spreading one distinct id
+    /// across partitions contends the consumer's person updates), while the
+    /// read-only AI overflow lane spreads it immediately.
     #[rstest::rstest]
     #[case::main_untouched(
         Destination::AnalyticsMain,
@@ -1064,7 +1068,12 @@ mod tests {
         OrderingGuarantee::PerDistinctId
     )]
     #[case::main_person_off(Destination::AnalyticsMain, true, false, OrderingGuarantee::None)]
-    #[case::main_spread(Destination::AnalyticsMain, false, true, OrderingGuarantee::None)]
+    #[case::main_spread(
+        Destination::AnalyticsMain,
+        false,
+        true,
+        OrderingGuarantee::PerDistinctId
+    )]
     #[case::overflow_untouched(
         Destination::Overflow,
         false,
@@ -1072,7 +1081,8 @@ mod tests {
         OrderingGuarantee::PerDistinctId
     )]
     #[case::overflow_person_off(Destination::Overflow, true, false, OrderingGuarantee::None)]
-    #[case::overflow_spread(Destination::Overflow, false, true, OrderingGuarantee::None)]
+    #[case::overflow_spread(Destination::Overflow, false, true, OrderingGuarantee::PerDistinctId)]
+    #[case::overflow_spread_person_off(Destination::Overflow, true, true, OrderingGuarantee::None)]
     #[case::ai_overflow_spread(Destination::AiEventsOverflow, false, true, OrderingGuarantee::None)]
     #[case::ai_overflow_person_off(
         Destination::AiEventsOverflow,

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -334,19 +334,17 @@ impl SinkEvent for WrappedEvent {
     /// `AnalyticsHistorical`, whose consumers need the key. Deciding late
     /// keeps the rule correct no matter how the stages are ordered.
     fn ordering(&self) -> OrderingGuarantee {
-        match self.destination {
-            // Only the lanes that exist to absorb hot keys give up ordering.
-            Destination::AnalyticsMain | Destination::Overflow | Destination::AiEventsOverflow => {
-                if self.spread_partitions {
-                    OrderingGuarantee::None
-                } else {
-                    person_ordering(self.force_disable_person_processing)
-                }
-            }
-            // Historical, dlq, custom redirects and the AI main topic keep the
-            // key even with person processing off, matching v0's route().
-            _ => OrderingGuarantee::PerDistinctId,
+        if !self.destination.absorbs_hot_keys() {
+            return OrderingGuarantee::PerDistinctId;
         }
+        // Two independent reasons to give the guarantee up on a lane that can:
+        // the overflow limiter found the key bursting, or a stage took person
+        // processing away and with it the ordering that person processing is
+        // what needs.
+        if self.spread_partitions {
+            return OrderingGuarantee::None;
+        }
+        person_ordering(self.force_disable_person_processing)
     }
 
     fn serialize(&self, ctx: &RequestContext) -> anyhow::Result<bytes::Bytes> {
@@ -1109,24 +1107,19 @@ mod tests {
         #[case] spread_partitions: bool,
         #[case] expected: OrderingGuarantee,
     ) {
+        let ctx = test_utils::test_context();
         let mut ev = ok_wrapped("$pageview", "user-1");
         ev.destination = destination;
         ev.force_disable_person_processing = force_disable_person_processing;
         ev.spread_partitions = spread_partitions;
+
         assert_eq!(ev.ordering(), expected);
-    }
-
-    #[test]
-    fn spreading_does_not_disable_person_processing() {
-        let ctx = test_utils::test_context();
-        let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.destination = Destination::Overflow;
-        ev.spread_partitions = true;
-
-        assert_eq!(ev.ordering(), OrderingGuarantee::None);
-        assert!(
-            ev.headers(&ctx).force_disable_person_processing.is_none(),
-            "spreading a hot key must not tell downstream to skip person processing"
+        // The header tracks the person-processing flag and nothing else, so
+        // spreading a key never asks downstream to skip identity resolution.
+        assert_eq!(
+            ev.headers(&ctx).force_disable_person_processing,
+            force_disable_person_processing.then_some(true),
+            "the header must follow the person flag alone"
         );
     }
 

--- a/rust/capture/src/v1/analytics/types.rs
+++ b/rust/capture/src/v1/analytics/types.rs
@@ -1054,81 +1054,96 @@ mod tests {
         test_utils::wrapped_event(event_name, distinct_id)
     }
 
+    /// One row of the ordering matrix: the lane, plus the two event stamps
+    /// `ordering()` consults — `person_off` mirrors
+    /// `force_disable_person_processing`, `spread` mirrors `spread_partitions`.
+    struct Stamps {
+        destination: Destination,
+        person_off: bool,
+        spread: bool,
+    }
+
+    impl Stamps {
+        fn on(destination: Destination) -> Self {
+            Self {
+                destination,
+                person_off: false,
+                spread: false,
+            }
+        }
+    }
+
     /// The ordering rule, per lane and per reason for giving ordering up. The
-    /// `spread`-without-`force_disable` rows are the ones that matter most:
+    /// `spread`-without-`person_off` rows are the ones that matter most:
     /// on the person-writing analytics lanes a bursting key must keep its
     /// partition key while person processing is on (spreading one distinct id
     /// across partitions contends the consumer's person updates), while the
     /// read-only AI overflow lane spreads it immediately.
     #[rstest::rstest]
     #[case::main_untouched(
-        Destination::AnalyticsMain,
-        false,
-        false,
+        Stamps::on(Destination::AnalyticsMain),
         OrderingGuarantee::PerDistinctId
     )]
-    #[case::main_person_off(Destination::AnalyticsMain, true, false, OrderingGuarantee::None)]
+    #[case::main_person_off(
+        Stamps { person_off: true, ..Stamps::on(Destination::AnalyticsMain) },
+        OrderingGuarantee::None
+    )]
     #[case::main_spread(
-        Destination::AnalyticsMain,
-        false,
-        true,
+        Stamps { spread: true, ..Stamps::on(Destination::AnalyticsMain) },
         OrderingGuarantee::PerDistinctId
     )]
-    #[case::overflow_untouched(
-        Destination::Overflow,
-        false,
-        false,
+    #[case::overflow_untouched(Stamps::on(Destination::Overflow), OrderingGuarantee::PerDistinctId)]
+    #[case::overflow_person_off(
+        Stamps { person_off: true, ..Stamps::on(Destination::Overflow) },
+        OrderingGuarantee::None
+    )]
+    #[case::overflow_spread(
+        Stamps { spread: true, ..Stamps::on(Destination::Overflow) },
         OrderingGuarantee::PerDistinctId
     )]
-    #[case::overflow_person_off(Destination::Overflow, true, false, OrderingGuarantee::None)]
-    #[case::overflow_spread(Destination::Overflow, false, true, OrderingGuarantee::PerDistinctId)]
-    #[case::overflow_spread_person_off(Destination::Overflow, true, true, OrderingGuarantee::None)]
-    #[case::ai_overflow_spread(Destination::AiEventsOverflow, false, true, OrderingGuarantee::None)]
+    #[case::overflow_spread_person_off(
+        Stamps { person_off: true, spread: true, ..Stamps::on(Destination::Overflow) },
+        OrderingGuarantee::None
+    )]
+    #[case::ai_overflow_spread(
+        Stamps { spread: true, ..Stamps::on(Destination::AiEventsOverflow) },
+        OrderingGuarantee::None
+    )]
     #[case::ai_overflow_person_off(
-        Destination::AiEventsOverflow,
-        true,
-        false,
+        Stamps { person_off: true, ..Stamps::on(Destination::AiEventsOverflow) },
         OrderingGuarantee::None
     )]
     // Lanes whose consumers need the key regardless: person processing being
     // off must not spread them, matching v0's route().
     #[case::ai_main_person_off(
-        Destination::AiEvents,
-        true,
-        false,
+        Stamps { person_off: true, ..Stamps::on(Destination::AiEvents) },
         OrderingGuarantee::PerDistinctId
     )]
     #[case::historical_person_off(
-        Destination::AnalyticsHistorical,
-        true,
-        false,
+        Stamps { person_off: true, ..Stamps::on(Destination::AnalyticsHistorical) },
         OrderingGuarantee::PerDistinctId
     )]
-    #[case::dlq_person_off(Destination::Dlq, true, false, OrderingGuarantee::PerDistinctId)]
+    #[case::dlq_person_off(
+        Stamps { person_off: true, ..Stamps::on(Destination::Dlq) },
+        OrderingGuarantee::PerDistinctId
+    )]
     #[case::custom_person_off(
-        Destination::Custom("t".into()),
-        true,
-        false,
+        Stamps { person_off: true, ..Stamps::on(Destination::Custom("t".into())) },
         OrderingGuarantee::PerDistinctId
     )]
-    fn ordering_per_lane(
-        #[case] destination: Destination,
-        #[case] force_disable_person_processing: bool,
-        #[case] spread_partitions: bool,
-        #[case] expected: OrderingGuarantee,
-    ) {
+    fn ordering_per_lane(#[case] stamps: Stamps, #[case] expected: OrderingGuarantee) {
         let ctx = test_utils::test_context();
         let mut ev = ok_wrapped("$pageview", "user-1");
-        ev.destination = destination;
-        ev.force_disable_person_processing = force_disable_person_processing;
-        ev.spread_partitions = spread_partitions;
+        ev.destination = stamps.destination;
+        ev.force_disable_person_processing = stamps.person_off;
+        ev.spread_partitions = stamps.spread;
 
         assert_eq!(ev.ordering(), expected);
         // The header tracks the person-processing flag and nothing else, so
         // spreading a key never asks downstream to skip identity resolution.
         assert_eq!(
             ev.headers(&ctx).force_disable_person_processing,
-            force_disable_person_processing.then_some(true),
+            stamps.person_off.then_some(true),
             "the header must follow the person flag alone"
         );
     }

--- a/rust/capture/src/v1/quota_limiter_shim.rs
+++ b/rust/capture/src/v1/quota_limiter_shim.rs
@@ -342,6 +342,7 @@ mod tests {
             details: None,
             destination: Destination::AnalyticsMain,
             force_disable_person_processing: false,
+            spread_partitions: false,
             is_gateway_verified: false,
         }
     }

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -624,13 +624,11 @@ If `producer.send()` returns `QueueFull`, the event is failed immediately
 as a retriable error. Backpressure is handled by librdkafka's internal
 queue and the client-level retry mechanism, not an app-level sleep loop.
 
-`effective_partition_key()` (`kafka/sink.rs`) decides whether the
-prepared key should be nulled. Prepared events always carry a key;
-the sink nulls it when
-`force_disable_person_processing` is set and the destination is
-`AnalyticsMain` or `Overflow`. In that case `None` is passed to rdkafka
-so it round-robins; passing `Some("")` would hash to a single
-deterministic partition via murmur2, creating a hot partition.
+Prepared events always carry a key; the sink uses it unless
+`PreparedEvent::ordering` is `OrderingGuarantee::None`, in which case
+`None` is passed to rdkafka so it round-robins. Passing `Some("")` would
+hash to a single deterministic partition via murmur2, creating a hot
+partition. See §9 for how the guarantee is decided.
 
 ### Phase 2 — Drain
 
@@ -1133,29 +1131,38 @@ and the sink:
   └───────────────────────────────────────────────────┘
 ```
 
-2. **`should_null_partition_key()`** (`kafka/sink.rs`) decides whether
-   the prepared key should be nulled before sending to the producer:
+2. **`PreparedEvent::ordering`** decides whether the prepared key is used.
+   `Event::ordering()` returns an `OrderingGuarantee` (`crate::ordering`,
+   shared with the v0 sink) and the sink passes `None` to rdkafka for
+   `OrderingGuarantee::None`, `Some(prepared.partition_key)` otherwise.
 
-```rust
-fn should_null_partition_key(
-    force_disable_person_processing: bool,
-    destination: &Destination,
-) -> bool
-```
-
-   If `force_disable_person_processing` is set and the destination is
-   `AnalyticsMain` or `Overflow`, it returns `true` and the sink passes
-   `None` to rdkafka. Otherwise the sink passes
-   `Some(prepared.partition_key)`.
+   `WrappedEvent::ordering` gives up the guarantee only on the lanes that
+   exist to absorb hot keys (`AnalyticsMain`, `Overflow`,
+   `AiEventsOverflow`), and only when either `spread_partitions` or
+   `force_disable_person_processing` is set. It is computed at prepare
+   time rather than stamped during processing because it depends on the
+   final destination, which `apply_historical_rerouting` can still change
+   after `apply_restrictions` has disabled person processing.
 
 Key design choices:
 
+- **The person-processing header is not a control channel.** Nulling the
+  key is driven by `ordering`, never by reading
+  `headers.force_disable_person_processing` back out. That header is an
+  instruction to downstream to skip identity resolution, so using it to
+  request partition spreading silently disabled person processing for
+  every rate-limited overflow event.
+- **`spread_partitions` is separate from person processing.** The overflow
+  limiter sets it alone when a key merely exceeds its burst budget, which
+  spreads the key while leaving person processing on. A `ForceLimited`
+  verdict sets both, matching v0.
 - **`None` = round-robin.** `None` is passed to rdkafka, which
   round-robins across partitions. Passing `Some("")` would hash to a
   single deterministic partition via murmur2, creating a hot spot.
-- **DLQ/Historical/Custom retain key** even when
-  `force_disable_person_processing` is set — only Main and Overflow
-  drop the key, matching v0 behavior.
+- **DLQ/Historical/Custom/AI-main retain key** even when
+  `force_disable_person_processing` is set. Only the analytics main and
+  overflow lanes and the AI overflow lane drop it, matching v0's
+  `route()`.
 - **Cookieless mode** uses `token:client_ip` as partition key instead
   of `token:distinct_id`, with IP redacted to `127.0.0.1` for
   `capture_internal` requests.

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -1138,11 +1138,14 @@ and the sink:
 
    `WrappedEvent::ordering` gives up the guarantee only on the lanes that
    exist to absorb hot keys (`AnalyticsMain`, `Overflow`,
-   `AiEventsOverflow`), and only when either `spread_partitions` or
-   `force_disable_person_processing` is set. It is computed at prepare
-   time rather than stamped during processing because it depends on the
-   final destination, which `apply_historical_rerouting` can still change
-   after `apply_restrictions` has disabled person processing.
+   `AiEventsOverflow`). On the person-writing lanes (`AnalyticsMain`,
+   `Overflow`) that takes `force_disable_person_processing`; a
+   `spread_partitions` stamp alone takes effect only on the read-only
+   `AiEventsOverflow` lane (`Destination::writes_persons`). It is computed
+   at prepare time rather than stamped during processing because it
+   depends on the final destination, which `apply_historical_rerouting`
+   can still change after `apply_restrictions` has disabled person
+   processing.
 
 Key design choices:
 
@@ -1153,9 +1156,12 @@ Key design choices:
   request partition spreading silently disabled person processing for
   every rate-limited overflow event.
 - **`spread_partitions` is separate from person processing.** The overflow
-  limiter sets it alone when a key merely exceeds its burst budget, which
-  spreads the key while leaving person processing on. A `ForceLimited`
-  verdict sets both, matching v0.
+  limiter sets it alone when a key merely exceeds its burst budget, leaving
+  person processing on. The sink realizes the spread only where the
+  consumer does not write persons (the AI overflow lane); on the analytics
+  lanes the key holds until person processing is off, because spreading one
+  distinct id across partitions contends the consumer's person updates. A
+  `ForceLimited` verdict sets both flags, matching v0.
 - **`None` = round-robin.** `None` is passed to rdkafka, which
   round-robins across partitions. Passing `Some("")` would hash to a
   single deterministic partition via murmur2, creating a hot spot.

--- a/rust/capture/src/v1/sinks/event.rs
+++ b/rust/capture/src/v1/sinks/event.rs
@@ -1,6 +1,7 @@
 use common_types::CapturedEventHeaders;
 use uuid::Uuid;
 
+use crate::ordering::OrderingGuarantee;
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::Destination;
 
@@ -27,10 +28,15 @@ pub trait Event: Send + Sync {
     /// `common_types`).
     fn headers(&self, ctx: &RequestContext) -> CapturedEventHeaders;
 
-    /// Return the partition key for this event.
-    /// The sink decides whether to use it or null it based on routing policy
-    /// (e.g. force_disable_person_processing).
+    /// Return the partition key for this event. Whether the sink actually uses
+    /// it is decided by [`Event::ordering`], not by inspecting headers.
     fn partition_key(&self, ctx: &RequestContext) -> String;
+
+    /// The ordering guarantee this event's destination must preserve. The sink
+    /// realizes [`OrderingGuarantee::None`] by publishing without a partition
+    /// key so the broker round-robins; every other guarantee uses
+    /// [`Event::partition_key`], which supplies the value that preserves it.
+    fn ordering(&self) -> OrderingGuarantee;
 
     /// Serialize the event payload and return the raw bytes. `Bytes` (not
     /// `String`) so non-UTF-8 / binary payloads (e.g. replay) share this

--- a/rust/capture/src/v1/sinks/kafka/mock.rs
+++ b/rust/capture/src/v1/sinks/kafka/mock.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use rdkafka::error::KafkaError;
+use rdkafka::message::{Headers, OwnedHeaders};
 
 use crate::v1::sinks::kafka::producer::{ProduceError, ProduceRecord};
 use crate::v1::sinks::SinkName;
@@ -18,15 +19,36 @@ pub struct OwnedProduceRecord {
     pub topic: String,
     pub key: Option<String>,
     pub payload: String,
+    pub headers: Vec<(String, Option<String>)>,
+}
+
+impl OwnedProduceRecord {
+    /// The value of a wire header, or `None` when it was not stamped.
+    pub fn header(&self, key: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k == key)
+            .and_then(|(_, v)| v.as_deref())
+    }
+}
+
+/// Headers travel to the broker as bytes, so tests read them back the way a
+/// consumer would rather than trusting the typed struct they came from.
+fn owned_headers(headers: &OwnedHeaders) -> Vec<(String, Option<String>)> {
+    (0..headers.count())
+        .map(|i| {
+            let h = headers.get(i);
+            (
+                h.key.to_owned(),
+                h.value.map(|v| String::from_utf8_lossy(v).into_owned()),
+            )
+        })
+        .collect()
 }
 
 impl<'a> From<ProduceRecord<'a>> for OwnedProduceRecord {
     fn from(r: ProduceRecord<'a>) -> Self {
-        Self {
-            topic: r.topic.to_owned(),
-            key: r.key.map(str::to_owned),
-            payload: String::from_utf8_lossy(r.payload).into_owned(),
-        }
+        Self::from(&r)
     }
 }
 
@@ -36,6 +58,7 @@ impl<'a> From<&ProduceRecord<'a>> for OwnedProduceRecord {
             topic: r.topic.to_owned(),
             key: r.key.map(str::to_owned),
             payload: String::from_utf8_lossy(r.payload).into_owned(),
+            headers: owned_headers(&r.headers),
         }
     }
 }

--- a/rust/capture/src/v1/sinks/kafka/sink.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink.rs
@@ -13,30 +13,16 @@ use tracing::Level;
 use uuid::Uuid;
 
 use crate::config::CaptureMode;
+use crate::ordering::OrderingGuarantee;
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::sink::Sink;
-use crate::v1::sinks::types::{BatchSummary, Destination, Outcome, PreparedEvent, SinkResult};
+use crate::v1::sinks::types::{BatchSummary, Outcome, PreparedEvent, SinkResult};
 use crate::v1::sinks::{Config, SinkName};
 
 use super::constants::*;
 use super::producer::ProduceRecord;
 use super::types::{KafkaResult, KafkaSinkError};
 use super::KafkaProducerTrait;
-
-/// Returns true when the partition key should be nulled — i.e. when person
-/// processing is force-disabled for Main/Overflow-shaped destinations
-/// (including the AI lane's own overflow), spreading load across partitions
-/// instead of hotspotting on a single key.
-fn should_null_partition_key(
-    force_disable_person_processing: bool,
-    destination: &Destination,
-) -> bool {
-    force_disable_person_processing
-        && matches!(
-            destination,
-            Destination::AnalyticsMain | Destination::Overflow | Destination::AiEventsOverflow
-        )
-}
 
 /// Shared label values for metrics emitted within a single `publish_batch` call.
 struct MetricLabels {
@@ -158,16 +144,12 @@ impl<P: KafkaProducerTrait + 'static> KafkaSink<P> {
                 None => continue,
             };
 
-            let key = if should_null_partition_key(
-                event
-                    .headers
-                    .force_disable_person_processing
-                    .unwrap_or(false),
-                &event.destination,
-            ) {
-                None
-            } else {
-                Some(event.partition_key.as_str())
+            // `None` is passed to rdkafka so it round-robins. Passing
+            // `Some("")` would hash to a single deterministic partition via
+            // murmur2, which is the hot partition this is meant to avoid.
+            let key = match event.ordering {
+                OrderingGuarantee::None => None,
+                _ => Some(event.partition_key.as_str()),
             };
 
             let headers: rdkafka::message::OwnedHeaders = event.headers.clone().into();
@@ -450,26 +432,6 @@ impl<P: KafkaProducerTrait + 'static> Sink for KafkaSink<P> {
         })
         .await
         .map_err(|e| anyhow::anyhow!("flush task panicked: {e:#}"))?
-    }
-}
-
-#[cfg(test)]
-mod should_null_partition_key_tests {
-    use super::*;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case::main_disabled(true, Destination::AnalyticsMain, true)]
-    #[case::overflow_disabled(true, Destination::Overflow, true)]
-    #[case::ai_overflow_disabled(true, Destination::AiEventsOverflow, true)]
-    #[case::ai_disabled(true, Destination::AiEvents, false)]
-    #[case::dlq_disabled(true, Destination::Dlq, false)]
-    #[case::historical_disabled(true, Destination::AnalyticsHistorical, false)]
-    #[case::custom_disabled(true, Destination::Custom("t".into()), false)]
-    #[case::main_not_disabled(false, Destination::AnalyticsMain, false)]
-    #[case::ai_overflow_not_disabled(false, Destination::AiEventsOverflow, false)]
-    fn policy(#[case] force_disable: bool, #[case] dest: Destination, #[case] expected: bool) {
-        assert_eq!(should_null_partition_key(force_disable, &dest), expected);
     }
 }
 

--- a/rust/capture/src/v1/sinks/kafka/sink_tests.rs
+++ b/rust/capture/src/v1/sinks/kafka/sink_tests.rs
@@ -8,6 +8,7 @@ use rstest::rstest;
 use uuid::Uuid;
 
 use crate::config::CaptureMode;
+use crate::ordering::OrderingGuarantee;
 use crate::v1::context::RequestContext;
 use crate::v1::sinks::event::Event;
 use crate::v1::sinks::sink::Sink;
@@ -52,6 +53,7 @@ struct FakeEvent {
     partition_key: Option<String>,
     payload: Result<String, String>,
     event_headers: CapturedEventHeaders,
+    ordering: OrderingGuarantee,
 }
 
 impl FakeEvent {
@@ -63,7 +65,13 @@ impl FakeEvent {
             partition_key: Some(format!("phc_test:{uuid}")),
             payload: Ok(r#"{"event":"test"}"#.to_string()),
             event_headers: empty_captured_headers(),
+            ordering: OrderingGuarantee::PerDistinctId,
         }
+    }
+
+    fn with_ordering(mut self, o: OrderingGuarantee) -> Self {
+        self.ordering = o;
+        self
     }
 
     fn with_destination(mut self, d: Destination) -> Self {
@@ -106,6 +114,10 @@ impl Event for FakeEvent {
 
     fn partition_key(&self, _ctx: &RequestContext) -> String {
         self.partition_key.clone().unwrap_or_default()
+    }
+
+    fn ordering(&self) -> OrderingGuarantee {
+        self.ordering
     }
 
     fn serialize(&self, _ctx: &RequestContext) -> anyhow::Result<bytes::Bytes> {
@@ -736,30 +748,36 @@ async fn health_refreshed_on_partial_success() {
 }
 
 // ---------------------------------------------------------------------------
-// Partition key: null-key policy × destination
+// Partition key: the ordering guarantee decides it
 // ---------------------------------------------------------------------------
 
+/// The sink realizes the guarantee and nothing else. Which lanes give up
+/// ordering is decided upstream (`WrappedEvent::ordering`), and the
+/// person-processing header must not influence the key here: reading it back
+/// out of the headers is the bug this indirection removes.
 #[rstest]
-#[case::analytics_main(Destination::AnalyticsMain, true, None)]
-#[case::overflow(Destination::Overflow, true, None)]
-#[case::dlq(Destination::Dlq, true, Some("phc_test:user-1"))]
-#[case::historical(Destination::AnalyticsHistorical, true, Some("phc_test:user-1"))]
-#[case::custom(Destination::Custom("my_topic".into()), true, Some("phc_test:user-1"))]
-#[case::analytics_main_no_disable(Destination::AnalyticsMain, false, Some("phc_test:user-1"))]
+#[case::none_drops_key(OrderingGuarantee::None, true, None)]
+#[case::per_distinct_id_keeps_key(OrderingGuarantee::PerDistinctId, false, Some("phc_test:user-1"))]
+#[case::per_session_keeps_key(OrderingGuarantee::PerSession, false, Some("phc_test:user-1"))]
+#[case::header_alone_does_not_drop_key(
+    OrderingGuarantee::PerDistinctId,
+    true,
+    Some("phc_test:user-1")
+)]
 #[tokio::test]
-async fn force_disable_null_key_policy(
-    #[case] destination: Destination,
-    #[case] force_disable: bool,
+async fn ordering_decides_partition_key(
+    #[case] ordering: OrderingGuarantee,
+    #[case] force_disable_header: bool,
     #[case] expected_key: Option<&str>,
 ) {
     let h = TestHarness::new();
     let mut headers = empty_captured_headers();
-    if force_disable {
+    if force_disable_header {
         headers.force_disable_person_processing = Some(true);
     }
     let event = FakeEvent::ok("evt-1")
         .with_partition_key(Some("phc_test:user-1"))
-        .with_destination(destination)
+        .with_ordering(ordering)
         .with_headers(headers);
     let events = prepared(&[&event], &h.ctx);
 

--- a/rust/capture/src/v1/sinks/prepare.rs
+++ b/rust/capture/src/v1/sinks/prepare.rs
@@ -63,6 +63,7 @@ fn prepare_one<E: Event>(ev: &E, ctx: &RequestContext) -> anyhow::Result<Option<
         payload,
         headers: ev.headers(ctx),
         partition_key: ev.partition_key(ctx),
+        ordering: ev.ordering(),
     }))
 }
 
@@ -197,6 +198,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::ordering::OrderingGuarantee;
     use crate::v1::sinks::types::{Destination, Outcome};
     use crate::v1::test_utils::test_context;
 
@@ -274,6 +276,10 @@ mod tests {
 
         fn partition_key(&self, _ctx: &RequestContext) -> String {
             self.partition_key.clone()
+        }
+
+        fn ordering(&self) -> OrderingGuarantee {
+            OrderingGuarantee::PerDistinctId
         }
 
         fn serialize(&self, _ctx: &RequestContext) -> anyhow::Result<bytes::Bytes> {

--- a/rust/capture/src/v1/sinks/router.rs
+++ b/rust/capture/src/v1/sinks/router.rs
@@ -117,6 +117,8 @@ mod tests {
     use common_types::CapturedEventHeaders;
     use uuid::Uuid;
 
+    use crate::ordering::OrderingGuarantee;
+
     use crate::config::CaptureMode;
     use crate::v1::context::RequestContext;
     use crate::v1::sinks::event::Event;
@@ -179,6 +181,9 @@ mod tests {
         }
         fn partition_key(&self, _ctx: &RequestContext) -> String {
             format!("key:{}", self.uuid())
+        }
+        fn ordering(&self) -> OrderingGuarantee {
+            OrderingGuarantee::PerDistinctId
         }
         fn serialize(&self, _ctx: &RequestContext) -> anyhow::Result<bytes::Bytes> {
             Ok(bytes::Bytes::from(r#"{"event":"test"}"#.to_string()))

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -6,6 +6,7 @@ use common_types::CapturedEventHeaders;
 use uuid::Uuid;
 
 use crate::event_restrictions::Pipeline;
+use crate::ordering::OrderingGuarantee;
 
 /// Kafka topic routing for a processed event.
 /// `Drop` means the event should not be produced at all.
@@ -205,8 +206,11 @@ pub struct PreparedEvent {
     pub destination: Destination,
     pub payload: bytes::Bytes,
     pub headers: CapturedEventHeaders,
-    /// Raw key; the Sink decides whether to use or null it per routing policy.
+    /// Raw key; whether the Sink uses it is decided by `ordering`.
     pub partition_key: String,
+    /// The guarantee `partition_key` exists to preserve.
+    /// [`OrderingGuarantee::None`] means publish without a key.
+    pub ordering: OrderingGuarantee,
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -58,6 +58,31 @@ impl Destination {
         }
     }
 
+    /// Whether this lane exists to absorb hot keys, and so may publish without
+    /// a partition key to spread load across partitions.
+    ///
+    /// Everything else keeps its key even when person processing is off,
+    /// because its consumers rely on per-distinct-id ordering: historical
+    /// backfills, the dlq, admin custom redirects, and the AI main topic.
+    /// Matches the lanes legacy `route()` resolves through `person_ordering`.
+    ///
+    /// Exhaustive on purpose: a new destination has to state which side it is
+    /// on rather than silently inheriting "keeps its key".
+    pub fn absorbs_hot_keys(&self) -> bool {
+        match self {
+            Self::AnalyticsMain | Self::Overflow | Self::AiEventsOverflow => true,
+            Self::AnalyticsHistorical
+            | Self::Dlq
+            | Self::Custom(_)
+            | Self::ExceptionErrorTracking
+            | Self::HeatmapMain
+            | Self::ClientIngestionWarning
+            | Self::AiEvents => false,
+            // Never published, so it never reaches a partition key.
+            Self::Drop => false,
+        }
+    }
+
     /// Stable, low-cardinality metric tag. `Custom(_)` collapses to "custom"
     /// so admin-configured topic names never become label values.
     pub fn as_tag(&self) -> &'static str {

--- a/rust/capture/src/v1/sinks/types.rs
+++ b/rust/capture/src/v1/sinks/types.rs
@@ -83,6 +83,34 @@ impl Destination {
         }
     }
 
+    /// Whether this lane's consumer runs person processing with writes. On
+    /// such a lane one distinct id must stay on one partition while person
+    /// processing is on — spreading it turns a hot key into contended
+    /// person-row updates — so a spread decision only takes effect once the
+    /// person-processing flag is set. Read-only consumers (the AI lanes,
+    /// error tracking) and lanes with no person processing at all (heatmaps,
+    /// client warnings) can take keyless records at any time. The dlq and
+    /// custom redirects replay into analytics ingestion, so they count as
+    /// person-writing.
+    ///
+    /// Exhaustive for the same reason as [`Self::absorbs_hot_keys`].
+    pub fn writes_persons(&self) -> bool {
+        match self {
+            Self::AnalyticsMain
+            | Self::AnalyticsHistorical
+            | Self::Overflow
+            | Self::Dlq
+            | Self::Custom(_) => true,
+            Self::AiEvents
+            | Self::AiEventsOverflow
+            | Self::ExceptionErrorTracking
+            | Self::HeatmapMain
+            | Self::ClientIngestionWarning => false,
+            // Never published, so it never reaches a consumer.
+            Self::Drop => false,
+        }
+    }
+
     /// Stable, low-cardinality metric tag. `Custom(_)` collapses to "custom"
     /// so admin-configured topic names never become label values.
     pub fn as_tag(&self) -> &'static str {

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -28,6 +28,7 @@ pub fn prepared<E: SinkEvent + ?Sized>(events: &[&E], ctx: &RequestContext) -> V
             payload: e.serialize(ctx).expect("test payload must serialize"),
             headers: e.headers(ctx),
             partition_key: e.partition_key(ctx),
+            ordering: e.ordering(),
         })
         .collect()
 }
@@ -104,6 +105,7 @@ pub fn wrapped_event(event_name: &str, distinct_id: &str) -> WrappedEvent {
         details: None,
         destination: Destination::default(),
         force_disable_person_processing: false,
+        spread_partitions: false,
         is_gateway_verified: false,
     }
 }
@@ -128,6 +130,7 @@ pub fn wrapped_event_at(timestamp: DateTime<Utc>) -> WrappedEvent {
         details: None,
         destination: Destination::default(),
         force_disable_person_processing: false,
+        spread_partitions: false,
         is_gateway_verified: false,
     }
 }
@@ -152,6 +155,7 @@ pub fn malformed_wrapped_event() -> WrappedEvent {
         details: Some("missing_event_name"),
         destination: Destination::default(),
         force_disable_person_processing: false,
+        spread_partitions: false,
         is_gateway_verified: false,
     }
 }
@@ -226,6 +230,7 @@ pub fn realistic_pageview(distinct_id: &str) -> WrappedEvent {
         details: None,
         destination: Destination::AnalyticsMain,
         force_disable_person_processing: false,
+        spread_partitions: false,
         is_gateway_verified: false,
     }
 }
@@ -264,6 +269,7 @@ pub fn realistic_identify(distinct_id: &str) -> WrappedEvent {
         details: None,
         destination: Destination::AnalyticsMain,
         force_disable_person_processing: false,
+        spread_partitions: false,
         is_gateway_verified: false,
     }
 }
@@ -302,6 +308,7 @@ pub fn realistic_custom(distinct_id: &str, event_name: &str) -> WrappedEvent {
         details: None,
         destination: Destination::AnalyticsMain,
         force_disable_person_processing: false,
+        spread_partitions: false,
         is_gateway_verified: false,
     }
 }

--- a/rust/capture/src/v1/test_utils.rs
+++ b/rust/capture/src/v1/test_utils.rs
@@ -459,6 +459,16 @@ pub fn assert_round_trip(
 // ---------------------------------------------------------------------------
 
 /// Serialize a list of Events into a valid V1 batch JSON payload.
+/// A non-historical batch wrapping `events`, the shape `process_batch` takes.
+pub fn valid_batch(events: Vec<Event>) -> crate::v1::analytics::types::Batch {
+    crate::v1::analytics::types::Batch {
+        created_at: "2026-03-19T14:30:00.000Z".to_string(),
+        historical_migration: false,
+        capture_internal: None,
+        batch: events,
+    }
+}
+
 pub fn batch_payload(events: &[Event]) -> Vec<u8> {
     let batch_json = serde_json::json!({
         "created_at": "2026-03-19T14:30:00.000Z",
@@ -685,6 +695,8 @@ pub struct TestState {
 pub struct TestStateBuilder {
     quota_limited: bool,
     overflow_limiter: Option<(NonZeroU32, NonZeroU32)>,
+    overflow_preserve_locality: bool,
+    overflow_forced_key: Option<String>,
     ai_events_overflow_limiter: Option<(NonZeroU32, NonZeroU32)>,
     historical_threshold_days: Option<i64>,
     restriction_service: Option<EventRestrictionService>,
@@ -707,6 +719,8 @@ impl TestStateBuilder {
         Self {
             quota_limited: false,
             overflow_limiter: None,
+            overflow_preserve_locality: false,
+            overflow_forced_key: None,
             ai_events_overflow_limiter: None,
             historical_threshold_days: None,
             restriction_service: None,
@@ -743,6 +757,20 @@ impl TestStateBuilder {
             NonZeroU32::new(per_second).expect("per_second must be > 0"),
             NonZeroU32::new(burst).expect("burst must be > 0"),
         ));
+        self
+    }
+
+    /// Keep partition keys when rerouting to overflow, as prod-US does via
+    /// `OVERFLOW_PRESERVE_PARTITION_LOCALITY`. Applies to both lanes' limiters
+    /// because production derives both from that one setting.
+    pub fn with_overflow_preserve_locality(mut self) -> Self {
+        self.overflow_preserve_locality = true;
+        self
+    }
+
+    /// Force-route this key outright, as an ops-configured hot key does.
+    pub fn with_overflow_forced_key(mut self, key: impl Into<String>) -> Self {
+        self.overflow_forced_key = Some(key.into());
         self
     }
 
@@ -843,13 +871,23 @@ impl TestStateBuilder {
             None => HistoricalConfig::new(false, 1),
         };
 
-        let overflow_limiter = self
-            .overflow_limiter
-            .map(|(per_sec, burst)| Arc::new(OverflowLimiter::new(per_sec, burst, None, false)));
+        let overflow_limiter = self.overflow_limiter.map(|(per_sec, burst)| {
+            Arc::new(OverflowLimiter::new(
+                per_sec,
+                burst,
+                self.overflow_forced_key.clone(),
+                self.overflow_preserve_locality,
+            ))
+        });
 
-        let ai_events_overflow_limiter = self
-            .ai_events_overflow_limiter
-            .map(|(per_sec, burst)| Arc::new(OverflowLimiter::new(per_sec, burst, None, false)));
+        let ai_events_overflow_limiter = self.ai_events_overflow_limiter.map(|(per_sec, burst)| {
+            Arc::new(OverflowLimiter::new(
+                per_sec,
+                burst,
+                self.overflow_forced_key.clone(),
+                self.overflow_preserve_locality,
+            ))
+        });
         let ai_events_overflow_enabled = ai_events_overflow_limiter.is_some();
 
         // Build the v1 sink router with a MockProducer-backed KafkaSink

--- a/rust/capture/tests/events.rs
+++ b/rust/capture/tests/events.rs
@@ -901,14 +901,13 @@ async fn it_overflows_events_on_burst() -> Result<()> {
 
     topic.assert_empty();
 
-    // Third event should be in overflow topic, but has no
-    // message key as overflow locality is off for this test
-    assert_json_include!(
-        actual: overflow_topic.next_event()?,
-        expected: json!({
-            "token": token,
-            "distinct_id": distinct_id,
-        })
+    // Third event should be in overflow topic. Locality is off for this
+    // test, but a person-on burst keeps its key anyway: the overflow
+    // consumer updates persons keyed on distinct id, so the key only drops
+    // once person processing is off.
+    assert_eq!(
+        overflow_topic.next_message_key()?.unwrap(),
+        format!("{token}:{distinct_id}")
     );
 
     overflow_topic.assert_empty();


### PR DESCRIPTION
## Problem

Reviewing #74228 turned up **two bugs, one in each path**, both in how the overflow limiter and the global rate limiter interact:

- **v1 bug, data quality.** Burst-overflow events silently lost person processing. Fixed in v1, legacy untouched.
- **v0 bug, partition skew.** The burst limiter overwrites the global rate limiter's decision and hands a hot key its partition back. Fixed in v0, and this is the prod-US behavior change called out below.

Taking them in turn. The v1 sink was reading its **partition-key** decision out of the outbound **Kafka header**:

```rust
should_null_partition_key(headers.force_disable_person_processing, dest)
```

So the only way a v1 stage could ask for "spread this key across partitions" was to set the header that tells downstream to skip person processing. `apply_overflow_stamping` did exactly that for a merely rate-limited burst, and its own comment gave the intent away: `// Nulls partition key at sink -- spreads across partitions.`

Downstream treats that header as absolute ([`decideProcessPerson`](https://github.com/PostHog/posthog/blob/master/nodejs/src/common/persons/person-utils.ts#L17)), so with `OVERFLOW_PRESERVE_PARTITION_LOCALITY` off (the default) every burst-overflow event served by v1 silently lost identity resolution, where v0 keeps it. v1 carries little traffic today, so present impact is small; it becomes a silent data-quality regression as v1 ramps.

Both paths had unit tests asserting **opposite** semantics for the same input, so this was coded intent on both sides rather than an accident on one:

| | v0 | v1 |
|---|---|---|
| burst rate-limited, locality off | key dropped, person processing **on** | key dropped, person processing **off** |
| test pinning it | `tests/events.rs` "should NOT have force_disable_person_processing header" | `overflow_rate_limited_disables_person_processing` |

> [!WARNING]
> The third commit changes live v0 behavior where `OVERFLOW_PRESERVE_PARTITION_LOCALITY` is on, which today is prod-US capture-analytics, capture-ai, capture-import and capture-mirrored (prod-EU omits it deliberately). Affected traffic is the intersection of both limiters firing on one key. Those records move from keyed to round-robin on the overflow topic, so watch overflow partition skew after deploy.

## Changes

Stacked on #74228, which supplies the vocabulary this needs. Five commits:

1. **`OrderingGuarantee` promoted** out of the v0 kafka sink into `crate::ordering`, with `person_ordering`, so both paths name one concept. Pure relocation.
2. **v1 separates the two intents.** `WrappedEvent::spread_partitions` carries the partitioning decision; `Event::ordering()` returns the guarantee the sink realizes as a key. The header is no longer a control channel. A `Limited` verdict sets spread alone; `ForceLimited` sets both, matching v0.
3. **v0 makes its own rule uniform.** `route()` gave a rate-limited overflow record `PerDistinctId` whenever the limiter preserves locality, even with person processing already off. The global rate limiter stamps first and the overflow limiter then overwrites the reason (no already-stamped guard), so a key the rate limiter had declared too hot went back to hashing onto one partition.
4. **Cross-path parity table** driving both real pipelines over the matrix.
5. **Doc corrections.** The Step 20 hazard note in the plan doc had the coupling backwards and missed the rate-limiter ordering case.

Both paths now state one rule:

> The header follows the stamped person-processing flag alone. The key is dropped on the analytics main/overflow and AI overflow lanes when either that flag or an explicit spread decision is set, and nowhere else.

One design note worth flagging: `ordering()` is computed at prepare time rather than stamped during processing. Stamping it eagerly would be a bug, because `apply_restrictions` can disable person processing while an event is still `AnalyticsMain` and `apply_historical_rerouting` may afterwards move it to `AnalyticsHistorical`, whose consumers need the key. Deciding late is correct regardless of stage order, and mirrors v0's `route()`.

## How did you test this code?

All automated, run locally by the agent. No manual or staging testing was done.

- `cargo test -p capture` fully green: 1143 lib tests plus every integration binary, including the real-Kafka suites (`events.rs`, `kafka_headers.rs`, `v1_sink_integration`, `v1_pipeline`).
- `cargo clippy -p capture --all-targets -- -D warnings` and `cargo fmt` clean. `hogli ci:preflight --strict` passes.

New and changed tests, and the regression each catches:

- **`overflow_parity.rs`** (new, 7 cases) is the one that matters. Both deltas here were invisible to every existing test, because each path only tested itself. It drives the real v0 pipeline and the real v1 pipeline over the overflow / rate-limit matrix and asserts the produced record's lane, key presence, and header against an explicit expectation, so two paths that drift *together* still fail. I verified it earns its place by reverting each fix in turn: restoring v1's header-as-key-signal fails `burst_rate_limited` alone ("v1 diverged from the contract"), and restoring v0's unconditional `PerDistinctId` fails `globally_limited_and_burst_preserving_locality` alone ("v0 diverged").
- **`ordering_per_lane`** (12 cases) replaces the sink-level `should_null_partition_key` matrix, since the lane rule moved. Catches a lane being wrongly added to or dropped from the spreading set, and separates the two reasons a lane gives up ordering.
- **`ordering_decides_partition_key`** replaces `force_disable_null_key_policy`. Its fourth case is the point: the header **alone** no longer drops the key.
- **`overflow_rate_limited_spreads_without_disabling_person_processing`** (both lanes) rewrites the two tests that pinned the bug. Catches a future stamping site reaching for the person flag to get key nulling.
- **v0 goldens are additive**: 75 insertions, 2 deletions in `sinks/kafka.rs`, and both deletions are production `route()` arms. No existing case or assertion changed, which is the reviewable safety property for commit 3.

Supporting test infra: v1's `OwnedProduceRecord` now captures wire headers (it was silently discarding them, so no v1 test could assert on a header the sink produced), and `TestStateBuilder` gained `with_overflow_preserve_locality` / `with_overflow_forced_key` to reproduce the prod-US configuration.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`v1/sinks/DESIGN.md` §9 and the outputs plan doc are updated in this PR. No user-facing docs are affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude Code (Opus 5) did the investigation and the code. It started as a review pass over #74228 and the bug fell out of asking whether that refactor could affect v1. It can't, and #74228 is safe to ship on its own, which is why this is a separate PR stacked on top rather than changes folded into it.

Skills invoked: `/stacking-prs`, `/writing-tests`, `/writing-code-comments`.

Decisions worth knowing about:

- **Which side is authoritative.** v0. v1's disablement is a side effect of an overloaded boolean, not a semantic choice, and nothing argues for dropping identity resolution on a burst. The alternative (make v0 match v1) would have disabled person processing for all legacy overflow traffic and required editing the goldens #74228 just established.
- **Δ2 unconditional vs flagged.** The agent recommended gating commit 3 behind a config flag, default off, since prod-US has locality preservation on and this is the highest-traffic path. I chose to ship it unconditionally: a key that hot pinned to one overflow partition is the exact problem overflow exists to relieve, and the affected volume needs both limiters to fire. The warning callout above is the tradeoff.
- **Rejected:** a guard in `stamp_overflow_reason` to stop the burst limiter clobbering the rate limiter's stamp. It would have recorded a misleading reason. Resolving ordering through `person_ordering` in the two arms is two lines and keeps the reason honest.

The parity table is also the oracle the plan doc's Step 11 now points at, so v1's convergence onto shared routing has something to prove itself against.



---

## Update 2026-08-05: person-on bursts keep their key

Four commits added on top of the original five (Paweł, with Claude Fable 5), after checking each lane's consumer in the Node pipelines and the AI lane cutover in Grafana:

- The analytics main/overflow consumers update persons keyed on distinct id. Spreading a person-on burst fans one person's rows across concurrent workers - contended person updates. The read-only AI overflow consumer has no such writes.
- On the person-writing analytics lanes the key now drops only when person processing is off. A person-on burst keeps its key. `Destination::writes_persons` names the classification; v0's analytics `RateLimited` arms collapse into `person_ordering`, so the locality preference no longer affects the analytics lane.
- `ForceLimited` now implies person processing off on its own (`ProcessedEventMetadata::person_processing_disabled`). The header and ordering derive from the reason as well as the flag, so a stamping site cannot ship a keyless person-on record by forgetting the flag.

This supersedes two statements in the rule above:

- "The header follows the stamped person-processing flag alone" -> the flag, or a v0 `ForceLimited` reason.
- "The key is dropped ... when either that flag or an explicit spread decision is set" -> a spread decision alone only takes effect on the read-only AI overflow lane. The parity matrix's burst cells now expect keyed.

> [!WARNING]
> This adds a second regional behavior change, opposite in direction to the one above: on prod-EU (locality preservation off), person-on bursts move from round-robin to keyed, so a hot key concentrates on one overflow partition. Watch EU overflow partition skew after deploy. The prod-US warning above still applies. The global rate limiter and `ForceLimited` paths keep spreading keyless in both regions.

Also in the update: the parity and ordering test matrices use named structs per case, and the branch is rebased onto #74228's current head (`Output` rename, fallible `route()`). Full suite at head: 1207 capture lib tests, real-Kafka integration binaries, clippy `-D warnings`, fmt.
