### PR TITLE
fix(mcp): preserve configured CLI project context

### DIFF
--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -232,10 +232,9 @@ export class StateManager {
     }
 
     /**
-     * Resolve an organization id without throwing. Reads the cache, then falls
-     * back to the API key's default-org resolution, then derives the org from
-     * the cached project (matches the team-scoped key path in
-     * `_getDefaultOrganizationAndProject` which intentionally omits the org).
+     * Resolve an organization id without throwing. A cached project is
+     * authoritative because default resolution writes both identifiers and
+     * would otherwise replace a project pinned by the CLI or request headers.
      *
      * The derived org id is written back to the cache so subsequent calls
      * short-circuit on the first read — without this, every team-scoped tool
@@ -246,6 +245,16 @@ export class StateManager {
         const cached = await this._cache.get('orgId')
         if (cached) {
             return cached
+        }
+
+        const cachedProjectId = await this._cache.get('projectId')
+        if (cachedProjectId) {
+            const project = await this.getCachedOrFetchProject().catch(() => undefined)
+            const derived = project?.organization
+            if (derived) {
+                await this._cache.set('orgId', derived)
+            }
+            return derived
         }
 
         const { organizationId } = await this.setDefaultOrganizationAndProject()

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -384,6 +384,25 @@ describe('StateManager', () => {
             expect(result).toBe('cached-org-id')
         })
 
+        it('derives the organization from a configured project without replacing it with user defaults', async () => {
+            await cache.set('projectId', '789')
+            vi.spyOn(stateManager, 'getApiKey').mockResolvedValue(mockApiKey)
+            vi.spyOn(stateManager, 'getUser').mockResolvedValue(mockUser)
+            const projectGet = vi.fn().mockResolvedValue({
+                success: true,
+                data: { id: 789, uuid: 'uuid-789', name: 'Configured Project', organization: 'org-2' },
+            })
+            ;(stateManager as any)._api = {
+                projects: () => ({ get: projectGet }),
+            }
+
+            const result = await stateManager.getOrgID()
+
+            expect(result).toBe('org-2')
+            expect(await cache.get('projectId')).toBe('789')
+            expect(projectGet).toHaveBeenCalledWith({ projectId: '789' })
+        })
+
         it('should call setDefaultOrganizationAndProject when not cached', async () => {
             const spy = vi.spyOn(stateManager, 'setDefaultOrganizationAndProject').mockResolvedValue({
                 organizationId: 'default-org',


### PR DESCRIPTION
## Problem

- `posthog-cli api` replaces a configured project with the active project when the organization ID is omitted.
- Commands can return plausible data from the wrong project.

Closes #75836

## Changes

- Resolve the organization from a configured project before selecting user defaults.
- Keep the configured project when its organization cannot be resolved.

## How did you test this code?

- Added `StateManager` coverage with active project A and configured project B.
- The test failed with `org-1` before the fix and passed with `org-2` afterward.
- Ran the complete MCP unit suite: 2,494 tests passed across 95 files.
- Ran MCP type checking, linting, formatting, and `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update. The fix restores the existing configured-project contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI Codex in the Codex desktop app authored the change with human direction. No public session link is available.
- Invoked `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and the GitHub `yeet` publish workflow.
- Rejected default fallback for configured projects because it can silently switch workspaces.
- GitHub rejected self-assignment for this external PR, so the author remains unassigned despite human-driven autonomy.