### PR TITLE
fix(data-warehouse): report distinct Gladly credential failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
@@ -87,8 +87,10 @@ def validate_credentials(organization: str, agent_email: str, api_token: str) ->
             f"{base_url}/agents",
             timeout=15,
         )
-    except Exception as e:
-        return False, f"Could not connect to Gladly at {host}. Check your organization subdomain. {e}"
+    except Exception:
+        # The tracked session already logs the URL and exception class, so the message
+        # stays readable instead of surfacing urllib3 retry and TLS internals.
+        return False, f"Could not connect to Gladly at {host}. Check your organization subdomain."
 
     if response.status_code == 200:
         return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/gladly.py
@@ -44,12 +44,19 @@ def _clean_organization(organization: str) -> str:
     org = organization.strip().removeprefix("https://").removeprefix("http://")
     org = org.split(".")[0].split("/")[0]
     if not re.fullmatch(r"[a-zA-Z0-9-]+", org):
-        raise ValueError(f"Invalid Gladly organization: {organization}")
+        raise ValueError(
+            "Invalid Gladly organization. Use the first part of your Gladly URL, "
+            "with letters, digits, and hyphens only. For myorg.gladly.com enter myorg."
+        )
     return org
 
 
+def _host(organization: str) -> str:
+    return f"{_clean_organization(organization)}.gladly.com"
+
+
 def _base_url(organization: str) -> str:
-    return f"https://{_clean_organization(organization)}.gladly.com/api/v1"
+    return f"https://{_host(organization)}/api/v1"
 
 
 def _format_timestamp(value: Any) -> str:
@@ -61,19 +68,40 @@ def _format_timestamp(value: Any) -> str:
     return str(value)
 
 
-def validate_credentials(organization: str, agent_email: str, api_token: str) -> bool:
-    """Confirm the credentials are valid with a cheap agents probe."""
-    # Resolve the org first so a malformed organization surfaces its own ValueError
-    # rather than being mislabelled as a credentials problem by the caller.
-    base_url = _base_url(organization)
+def validate_credentials(organization: str, agent_email: str, api_token: str) -> tuple[bool, str | None]:
+    """Confirm the credentials are valid with a cheap agents probe.
+
+    A wrong subdomain, an agent missing the API User permission, and a bad token each
+    need a different fix, so they are reported separately. Returning one generic
+    message for every outcome leaves the user nothing to act on, and hides an
+    unreachable host or a Gladly outage behind a credentials error.
+    """
+    try:
+        base_url = _base_url(organization)
+        host = _host(organization)
+    except ValueError as e:
+        return False, str(e)
+
     try:
         response = _get_session(agent_email, api_token).get(
             f"{base_url}/agents",
             timeout=15,
         )
-        return response.status_code == 200
-    except Exception:
-        return False
+    except Exception as e:
+        return False, f"Could not connect to Gladly at {host}. Check your organization subdomain. {e}"
+
+    if response.status_code == 200:
+        return True, None
+    if response.status_code == 401:
+        return False, "Gladly authentication failed. Check your agent email and API token."
+    if response.status_code == 403:
+        return False, (
+            "Gladly denied access. Check that the agent has the API User permission, "
+            "under Settings > API Tokens in Gladly."
+        )
+    if response.status_code == 404:
+        return False, f"No Gladly organization found at {host}. Check your organization subdomain."
+    return False, f"Gladly returned an unexpected status: {response.status_code}"
 
 
 def get_rows(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/source.py
@@ -125,15 +125,7 @@ Your organization is the first part of your Gladly URL — for `myorg.gladly.com
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        try:
-            if validate_gladly_credentials(config.organization, config.agent_email, config.api_token):
-                return True, None
-        except ValueError as e:
-            # A malformed organization is a distinct, actionable error — surface it
-            # instead of the generic credentials message.
-            return False, str(e)
-
-        return False, "Invalid Gladly credentials"
+        return validate_gladly_credentials(config.organization, config.agent_email, config.api_token)
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[GladlyResumeConfig]:
         return ResumableSourceManager[GladlyResumeConfig](inputs, GladlyResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly.py
@@ -4,6 +4,8 @@ from typing import Any
 import pytest
 from unittest import mock
 
+import requests
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.gladly.gladly import (
     CHUNK_SIZE,
     GladlyResumeConfig,
@@ -70,20 +72,47 @@ class TestCleanOrganization:
 
 class TestValidateCredentials:
     @pytest.mark.parametrize(
-        "status_code, expected",
+        "status_code, expected_valid, expected_message_fragment",
         [
-            (200, True),
-            (401, False),
-            (403, False),
+            (200, True, None),
+            (401, False, "agent email and API token"),
+            (403, False, "API User permission"),
+            (404, False, "No Gladly organization found at myorg.gladly.com"),
+            (500, False, "unexpected status: 500"),
         ],
     )
     @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_validate_credentials_status_mapping(self, mock_session, status_code, expected):
+    def test_validate_credentials_status_mapping(
+        self, mock_session, status_code, expected_valid, expected_message_fragment
+    ):
         response = mock.MagicMock()
         response.status_code = status_code
         mock_session.return_value.get.return_value = response
 
-        assert validate_credentials("myorg", "agent@x.com", "token") is expected
+        is_valid, message = validate_credentials("myorg", "agent@x.com", "token")
+
+        assert is_valid is expected_valid
+        if expected_message_fragment is None:
+            assert message is None
+        else:
+            assert expected_message_fragment in (message or "")
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_unreachable_host_is_not_reported_as_bad_credentials(self, mock_session):
+        mock_session.return_value.get.side_effect = requests.ConnectionError("nodename nor servname provided")
+
+        is_valid, message = validate_credentials("myorg", "agent@x.com", "token")
+
+        assert is_valid is False
+        assert "Could not connect to Gladly at myorg.gladly.com" in (message or "")
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_malformed_organization_is_reported_without_a_probe(self, mock_session):
+        is_valid, message = validate_credentials("my org", "agent@x.com", "token")
+
+        assert is_valid is False
+        assert "Invalid Gladly organization" in (message or "")
+        mock_session.assert_not_called()
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_session_uses_basic_auth(self, mock_session):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/test_gladly_source.py
@@ -82,35 +82,20 @@ class TestGladlySource:
         assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
 
     @pytest.mark.parametrize(
-        "mock_return, expected_valid",
+        "mock_return",
         [
-            (True, True),
-            (False, False),
+            (True, None),
+            (False, "probe failure message"),
         ],
     )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.gladly.source.validate_gladly_credentials"
     )
-    def test_validate_credentials(self, mock_validate, mock_return, expected_valid):
+    def test_validate_credentials_passes_the_probe_result_through(self, mock_validate, mock_return):
         mock_validate.return_value = mock_return
 
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
-
-        assert is_valid is expected_valid
-        if not expected_valid:
-            assert error_message == "Invalid Gladly credentials"
+        assert self.source.validate_credentials(self.config, self.team_id) == mock_return
         mock_validate.assert_called_once_with("myorg", "agent@x.com", "token")
-
-    @mock.patch(
-        "products.warehouse_sources.backend.temporal.data_imports.sources.gladly.source.validate_gladly_credentials"
-    )
-    def test_validate_credentials_surfaces_invalid_organization(self, mock_validate):
-        mock_validate.side_effect = ValueError("Invalid Gladly organization: bad org")
-
-        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
-
-        assert is_valid is False
-        assert error_message == "Invalid Gladly organization: bad org"
 
     def test_get_resumable_source_manager_binds_resume_config(self):
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

- Adding a Gladly source probes `GET /api/v1/agents` and reports every failure as `Invalid Gladly credentials`.
- That one string covers a bad token, an agent without the API User permission, a wrong organization subdomain, an unreachable host, and a Gladly outage.
- Each has a different fix, so the message gives the user nothing to act on and gives support nothing to triage.

## Changes

`validate_credentials` returns `tuple[bool, str | None]` instead of `bool`, carrying the reason. `GladlySource.validate_credentials` passes it straight through to the wizard, matching the Gorgias source.

| Outcome | Message |
| --- | --- |
| Malformed organization | Invalid Gladly organization. Use the first part of your Gladly URL, with letters, digits, and hyphens only. For myorg.gladly.com enter myorg. |
| Connection failure | Could not connect to Gladly at `{host}`. Check your organization subdomain. |
| 401 | Gladly authentication failed. Check your agent email and API token. |
| 403 | Gladly denied access. Check that the agent has the API User permission, under Settings > API Tokens in Gladly. |
| 404 | No Gladly organization found at `{host}`. Check your organization subdomain. |
| Other status | Gladly returned an unexpected status: `{code}` |

> [!NOTE]
> Sync-time behavior is unchanged. `get_non_retryable_errors` already mapped 401 and 403 to friendly messages; this PR only fixes the pre-creation probe.

The malformed-organization error now describes a valid subdomain instead of echoing the user's input back.

## How did you test this code?

Automated only. I could not exercise the wizard against a live Gladly org, so the probe's real HTTP behavior is unverified.

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/gladly/tests/` passes (43 tests).
- `ruff check` and `ruff format --check` pass on the changed package.
- New cases cover 404, 500, an unreachable host, and a malformed organization. Each fails if that outcome collapses back into a generic credentials error, which is the regression this PR fixes.
- The malformed-organization case also asserts no probe is sent, so credentials never reach a bogus host.
- Dropped the source-level test asserting the hardcoded `Invalid Gladly credentials` string, since the message now comes from the probe. Its replacement asserts passthrough and argument order.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The Gladly setup steps are unchanged; only error text differs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a report that a customer could not authenticate when adding Gladly. No error text, subdomain, or project was available, so I traced the wizard path in code instead of guessing a root cause.

- Confirmed `database_schema` calls `validate_credentials` unconditionally for Gladly, so clicking Next always runs the live probe. `lists_tables_without_credentials` does not bypass it.
- Fixed diagnosability rather than a specific cause: the current message cannot distinguish the candidates, so neither the customer nor support can narrow it down. A follow-up needs the real error text.
- Rejected `.gladly.qa` sandbox support. The connector hardcodes `.gladly.com` and Gladly documents a sandbox domain, so a sandbox org can never authenticate. Worth a separate PR.
- Rejected adding a 404 entry to `get_non_retryable_errors`, to keep sync-time behavior out of this diff.
- Tools: Claude Code (Explore subagents, Read, Edit, Bash) and the PostHog MCP `docs-search` tool for Gladly's documented auth model.
- Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-pr-descriptions`.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
