### PR TITLE
fix(experiments): invalidate results fingerprint when excluding variants

### DIFF
--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -390,6 +390,7 @@ def _recalc_fingerprints_for_run(experiment: Experiment, recalc: ExperimentMetri
             stats_method,
             experiment.exposure_criteria,
             only_count_matured_users=experiment.only_count_matured_users,
+            excluded_variants=experiment.excluded_variants,
         )
         fingerprints[metric_uuid] = compute_recalc_fingerprint(config_fp)
     return fingerprints
@@ -453,6 +454,7 @@ def build_timeseries_cold_start_payload(experiment: Experiment) -> dict | None:
                 stats_method,
                 experiment.exposure_criteria,
                 only_count_matured_users=experiment.only_count_matured_users,
+                excluded_variants=experiment.excluded_variants,
             )
             row = (
                 ExperimentMetricResult.objects.filter(

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -599,6 +599,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
             get_experiment_stats_method(experiment),
             experiment.exposure_criteria,
             only_count_matured_users=experiment.only_count_matured_users,
+            excluded_variants=experiment.excluded_variants,
         )
         recalc_fp = compute_recalc_fingerprint(config_fp)
 

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -805,6 +805,40 @@ class TestCalculateActivity(BaseTest):
 
         mock_runner.assert_called_once()
 
+    def test_excluded_variants_change_recomputes(self):
+        # A cached row computed before a variant was excluded must not satisfy the skip check: the exclusion
+        # set feeds the fingerprint, so the stale row's fingerprint no longer matches and the query re-runs.
+        metric = _mean_metric("m1")
+        exp = self._experiment(flag_key="calc-excluded", metrics=[metric])
+        query_to = datetime.fromisoformat(_QUERY_TO)
+        recalc_fp = compute_recalc_fingerprint(
+            compute_metric_fingerprint(
+                metric,
+                exp.start_date,
+                get_experiment_stats_method(exp),
+                exp.exposure_criteria,
+                only_count_matured_users=exp.only_count_matured_users,
+            )
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=query_to,
+            query_to=query_to,
+            status=ExperimentMetricResult.Status.COMPLETED,
+            result={"stale": True},
+        )
+        exp.excluded_variants = ["test"]
+        exp.save(update_fields=["excluded_variants"])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with patch("products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner") as mock_runner:
+            mock_runner.return_value.run.return_value.model_dump.return_value = {}
+            _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO)
+
+        mock_runner.assert_called_once()
+
     def test_store_result_updates_existing_row_with_different_fingerprint_in_place(self):
         # The unique constraint is (experiment, metric_uuid, query_to); fingerprint is not part of it. A row may
         # already occupy that key under a different fingerprint (an earlier run written under the old per-run

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -317,6 +317,7 @@ class TestRecalculationService(BaseTest):
 
     def test_changing_excluded_variants_invalidates_run_results(self):
         exp = self._launched_experiment(flag_key="reuse-excluded")
+        assert exp.start_date is not None  # _launched_experiment always sets it; narrow for the create below
         query_to = datetime(2026, 1, 10, tzinfo=UTC)
         recalc_fp = compute_recalc_fingerprint(
             compute_metric_fingerprint(

--- a/products/experiments/backend/test/test_recalculation_service.py
+++ b/products/experiments/backend/test/test_recalculation_service.py
@@ -315,6 +315,39 @@ class TestRecalculationService(BaseTest):
         assert results[0]["result"] == {"ok": True}
         assert results[0]["error_message"] is None
 
+    def test_changing_excluded_variants_invalidates_run_results(self):
+        exp = self._launched_experiment(flag_key="reuse-excluded")
+        query_to = datetime(2026, 1, 10, tzinfo=UTC)
+        recalc_fp = compute_recalc_fingerprint(
+            compute_metric_fingerprint(
+                _mean_metric("m1"),
+                exp.start_date,
+                get_experiment_stats_method(exp),
+                exp.exposure_criteria,
+                only_count_matured_users=exp.only_count_matured_users,
+                excluded_variants=exp.excluded_variants,
+            )
+        )
+        ExperimentMetricResult.objects.create(
+            experiment=exp,
+            metric_uuid="m1",
+            fingerprint=recalc_fp,
+            query_from=exp.start_date,
+            query_to=query_to,
+            status=ExperimentMetricResult.Status.COMPLETED,
+            result={"some": "result"},
+        )
+        recalc = ExperimentMetricsRecalculation.objects.create(
+            team=self.team, experiment=exp, metric_uuids=["m1"], query_to=query_to
+        )
+        assert [r["metric_uuid"] for r in get_run_results(recalc)] == ["m1"]
+
+        # Excluding a variant alters what the metric computes, so the cached row must stop matching.
+        exp.excluded_variants = ["test"]
+        exp.save(update_fields=["excluded_variants"])
+        recalc.refresh_from_db()
+        assert get_run_results(recalc) == []
+
     def test_get_run_results_strips_step_sessions(self):
         # step_sessions carries per-step person IDs, session IDs, and event UUIDs. It powers the frontend's
         # "view sessions per step" affordance off a separate per-metric query, so it does not belong in the


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

The recalc path computed its metric fingerprint without `excluded_variants`, so changing an experiment's excluded set left the old fingerprint intact, matched a stale `ExperimentMetricResult` cache row, and served results computed against the wrong variant set.

The write path (`experiment_service.py`) and the saved-metric serializer already fold `excluded_variants` into the fingerprint, so recalc was the outlier: it keyed different cache rows than the path that wrote them.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

Passed `excluded_variants=experiment.excluded_variants` into `compute_metric_fingerprint` at the three recalc-path call sites that were missing it, bringing them in line with the write path and serializer.

The three sites are `_recalc_fingerprints_for_run` (recalc run read-back), `build_timeseries_cold_start_payload` (timeseries cold start), and `_calculate_experiment_metric_for_recalculation_sync` (the calc activity). `compute_metric_fingerprint` already omits the key entirely when the list is empty or `None`, so experiments with no exclusions keep their existing hashes and nothing is mass-invalidated; only experiments with a non-empty exclusion set, the ones already being served inconsistent rows, re-fingerprint and recompute.

- `products/experiments/backend/recalculation.py`
- `products/experiments/backend/temporal/recalculation_logic.py`

## How did you test this code?

Added `test_excluded_variants_change_recomputes` (calc activity) and `test_changing_excluded_variants_invalidates_run_results` (`get_run_results`). Each caches a row under the pre-exclusion fingerprint, flips `excluded_variants`, and asserts the stale row stops matching so the query recomputes. The existing `test_get_run_results_scopes_by_recalc_fingerprint` uses a hardcoded mismatched fingerprint and would still pass with the bug present, so it did not cover this. Verified by reverting each production line and confirming the matching test fails.

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/e3798af3-2c22-44ca-9cb1-f99c91d189b2)

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Fixed all three recalc-path fingerprint sites, not just the one the originating branch patched, so `get_run_results`, the cold-start payload, and the calc activity key the same row as each other.
- Relied on the existing `if excluded_variants:` guard in `compute_metric_fingerprint` rather than adding new gating, which keeps the change backward compatible: empty/`None` produces the same hash as today, so only experiments with real exclusions invalidate.
- Skipped a third test for `build_timeseries_cold_start_payload`: it is the same one-line pattern as the two covered sites, so a third case would be redundant coverage rather than a new regression.