### PR TITLE
perf(marketing-analytics): let callers inject attribution health into the mapping suggester

### DIFF
--- a/products/marketing_analytics/backend/services/mapping_suggester.py
+++ b/products/marketing_analytics/backend/services/mapping_suggester.py
@@ -16,7 +16,11 @@ from posthog.schema import NativeMarketingSource
 from posthog.models.team.team import Team
 from posthog.sync import database_sync_to_async
 
-from products.marketing_analytics.backend.services.attribution_health import UnmatchedUtmSample, get_attribution_health
+from products.marketing_analytics.backend.services.attribution_health import (
+    AttributionHealthResponse,
+    UnmatchedUtmSample,
+    get_attribution_health,
+)
 from products.marketing_analytics.backend.services.native_integrations import (
     NATIVE_TO_KEY,
     NativeIntegration,
@@ -108,13 +112,22 @@ async def suggest_utm_mappings(
     min_event_count: int = DEFAULT_MIN_EVENT_COUNT,
     max_per_integration: int = MAX_SUGGESTIONS_PER_INTEGRATION,
     lookback_days: int = 90,
+    attribution: AttributionHealthResponse | None = None,
 ) -> UtmMappingSuggestionsResponse:
     """Detect unmatched utm_source values and propose target integrations.
 
     `lookback_days` defaults to 90 (vs attribution_health's 7) to catch typo'd or
     one-off values worth mapping; widen further for catalog-style audits.
+
+    `attribution` lets a caller that already ran `get_attribution_health` hand the
+    result in rather than paying for the same ClickHouse aggregation twice — the
+    setup plan needs both. `lookback_days` is ignored when it's supplied: the
+    reported window comes off the response so it can never disagree with the data
+    the suggestions were actually derived from.
     """
-    attribution = await get_attribution_health(team, lookback_days=lookback_days)
+    if attribution is None:
+        attribution = await get_attribution_health(team, lookback_days=lookback_days)
+    lookback_days = attribution.lookback_days
     current_mappings = await _read_current_mappings(team)
     notes: list[str] = []
 

--- a/products/marketing_analytics/backend/services/test_mapping_suggester.py
+++ b/products/marketing_analytics/backend/services/test_mapping_suggester.py
@@ -199,7 +199,6 @@ class TestSuggestUtmMappings(APIBaseTest):
     async def test_runs_its_own_query_when_attribution_is_absent(self):
         response = await suggest_utm_mappings(self.team, lookback_days=45)
 
-        self.mock_attribution.assert_awaited_once()
-        assert self.mock_attribution.await_args.kwargs["lookback_days"] == 45
+        self.mock_attribution.assert_awaited_once_with(self.team, lookback_days=45)
         # Still reported off the response, which the mock pins at 30.
         assert response.lookback_days_used == 30

--- a/products/marketing_analytics/backend/services/test_mapping_suggester.py
+++ b/products/marketing_analytics/backend/services/test_mapping_suggester.py
@@ -158,3 +158,48 @@ class TestSuggestUtmMappings(APIBaseTest):
         raw_values = [s.raw_utm_source for s in response.source_suggestions]
         assert raw_values.count("paidsocial") == 1
         assert response.source_suggestions[0].suggested_target == "meta_ads"
+
+    @pytest.mark.asyncio
+    async def test_injected_attribution_skips_the_internal_query(self):
+        # The setup plan needs attribution health for its own readiness block, so it
+        # hands the result in rather than paying for the aggregation twice.
+        sample = _sample("facebook_paid", 120, "meta_ads")
+        injected = AttributionHealthResponse(
+            lookback_days=90,
+            integrations=[_entry_with_samples("meta_ads", [sample])],
+            total_events_with_utm=120,
+            total_events_matched_to_any_integration=0,
+            total_events_unmatched=120,
+            sample_globally_unmatched=[sample],
+        )
+
+        response = await suggest_utm_mappings(self.team, attribution=injected)
+
+        self.mock_attribution.assert_not_called()
+        assert [s.raw_utm_source for s in response.source_suggestions] == ["facebook_paid"]
+
+    @pytest.mark.asyncio
+    async def test_injected_attribution_window_wins_over_the_argument(self):
+        # Reporting the caller's `lookback_days` would misdescribe data derived from a
+        # different window, so the reported window comes off the injected response.
+        injected = AttributionHealthResponse(
+            lookback_days=7,
+            integrations=[],
+            total_events_with_utm=0,
+            total_events_matched_to_any_integration=0,
+            total_events_unmatched=0,
+            sample_globally_unmatched=[],
+        )
+
+        response = await suggest_utm_mappings(self.team, lookback_days=365, attribution=injected)
+
+        assert response.lookback_days_used == 7
+
+    @pytest.mark.asyncio
+    async def test_runs_its_own_query_when_attribution_is_absent(self):
+        response = await suggest_utm_mappings(self.team, lookback_days=45)
+
+        self.mock_attribution.assert_awaited_once()
+        assert self.mock_attribution.await_args.kwargs["lookback_days"] == 45
+        # Still reported off the response, which the mock pins at 30.
+        assert response.lookback_days_used == 30


### PR DESCRIPTION
## Why

`suggest_utm_mappings` calls `get_attribution_health` internally. The self-driving Setup tab
needs both results, so as it stands the plan would run that ClickHouse aggregation twice.

The duplicated cost is the boring half. The real problem is that the two calls would use
different lookback windows, so the suggestions could be derived from a different window than
the one displayed next to them — a discrepancy nobody would spot until they tried to
reconcile the numbers.

Second of the prep refactors for the Setup tab.

## What

One optional parameter:

```python
async def suggest_utm_mappings(
    team, ..., attribution: AttributionHealthResponse | None = None,
)
```

Defaults to `None` and falls back to fetching it, so **every existing caller is unaffected**.

When it *is* supplied, `lookback_days` is deliberately ignored and the reported window is read
off the response instead. That makes the window and the data structurally incapable of
disagreeing, rather than relying on callers to pass a matching value.

## Verification

**10 tests pass** (`test_mapping_suggester`), including new coverage for the injected path and
for the window being taken from the response. Ruff and mypy clean.

Cherry-picked onto current master with no conflicts.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*