### PR TITLE
fix(data-imports): retry delta compaction on byte-array offset overflow

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -98,6 +98,23 @@ def is_transient_delta_maintenance_error(error: BaseException) -> bool:
     return "File not found" in text and "_delta_log/" in text
 
 
+# `optimize.compact` bins files to rewrite by their on-disk (compressed) size, targeting
+# `target_size` bytes per bin, then reads every file in a bin into memory as Arrow batches before
+# writing them back out as one file. `Batcher` (pipelines/core/batcher.py) already keeps each
+# *written* file's string/binary columns under its 32-bit-offset limit, so no single file can
+# overflow on its own — but that guard doesn't cover compaction, which can bin together several
+# already-safe files whose combined column bytes cross the 2^31 (~2.1 GB) offset limit, especially
+# for highly-compressible text (e.g. JSON payloads) where on-disk size understates decompressed
+# size by a wide margin. delta-rs surfaces this as a Rust task panic wrapped in a generic DeltaError
+# rather than a typed error. Retrying the same bin changes nothing, so this isn't transient — the
+# caller instead retries compaction with a smaller `target_size` to shrink the bins.
+DELTA_OFFSET_OVERFLOW_ERROR_NEEDLE = "byte array offset overflow"
+
+
+def is_offset_overflow_compaction_error(error: BaseException) -> bool:
+    return isinstance(error, deltalake.exceptions.DeltaError) and DELTA_OFFSET_OVERFLOW_ERROR_NEEDLE in str(error)
+
+
 def is_transient_maintenance_error(error: BaseException) -> bool:
     """Infra blips seen during delta maintenance that aren't a maintenance bug.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/maintenance.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/maintenance.py
@@ -1,11 +1,12 @@
 import json
 import asyncio
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 
 import deltalake
 import posthoganalytics
+import deltalake.exceptions
 
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
@@ -13,6 +14,7 @@ from posthog.utils import get_machine_id
 
 from products.warehouse_sources.backend.models.external_data_schema import update_sync_type_config_keys
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
+    is_offset_overflow_compaction_error,
     is_transient_maintenance_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.ops import (
@@ -45,6 +47,15 @@ if TYPE_CHECKING:
 DEFAULT_COMPACT_FILES_PER_PARTITION_THRESHOLD = 200
 DEFAULT_COMPACT_TOTAL_FILES_THRESHOLD = 5000
 
+# delta-rs's own default target size for a compaction rewrite bin when none is given (see
+# `delta.targetFileSize`, or 100MB absent that table property). Starting the retry ladder here
+# instead of passing None keeps every attempt's size explicit and halvable.
+DEFAULT_COMPACT_TARGET_SIZE_BYTES = 100 * 1024 * 1024
+# Halving the bin size on a byte-array-offset-overflow panic (see is_offset_overflow_compaction_error)
+# shrinks how many files get concatenated into one Arrow batch. Bounded so a table whose overflow
+# can't be avoided at any reasonable bin size still surfaces to error tracking instead of looping.
+COMPACT_OFFSET_OVERFLOW_RETRIES = 3
+
 
 class DeltaMaintenance:
     """Compaction, vacuuming, and the vacuum-watermark cadence for one schema's Delta table.
@@ -74,9 +85,30 @@ class DeltaMaintenance:
 
     async def _compact(self, table: deltalake.DeltaTable) -> None:
         await self._logger.adebug("Compacting table...")
-        compact_stats = await execute_with_conflict_retry(
-            table, lambda: table.optimize.compact(), "compact_table", self._logger
-        )
+        target_size = DEFAULT_COMPACT_TARGET_SIZE_BYTES
+        attempt = 0
+        while True:
+
+            def _compact_op(size: int = target_size) -> dict[str, Any]:
+                return table.optimize.compact(target_size=size)
+
+            try:
+                compact_stats = await execute_with_conflict_retry(
+                    table,
+                    _compact_op,
+                    "compact_table",
+                    self._logger,
+                )
+                break
+            except deltalake.exceptions.DeltaError as e:
+                if not is_offset_overflow_compaction_error(e) or attempt >= COMPACT_OFFSET_OVERFLOW_RETRIES:
+                    raise
+                attempt += 1
+                target_size //= 2
+                await self._logger.awarning(
+                    f"compact_table: byte array offset overflow, retrying with smaller "
+                    f"target_size={target_size} (attempt {attempt}/{COMPACT_OFFSET_OVERFLOW_RETRIES})"
+                )
         await self._logger.adebug(json.dumps(compact_stats))
 
     async def compact_table(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
     TransientObjectStoreError,
+    is_offset_overflow_compaction_error,
     is_transient_delta_maintenance_error,
     is_transient_maintenance_error,
     is_transient_object_store_error,
@@ -154,3 +155,25 @@ class TestIsTransientMaintenanceError:
     )
     def test_classifies_transient_errors(self, _name: str, error: Exception, expected: bool):
         assert is_transient_maintenance_error(error) is expected
+
+
+class TestIsOffsetOverflowCompactionError:
+    @parameterized.expand(
+        [
+            # delta-rs's Rust task panicking mid-compaction, surfaced as a generic DeltaError
+            # rather than a typed one — see errors.py for why binning already-safe files together
+            # can still overflow a 32-bit string/binary column offset.
+            (
+                "byte_array_offset_overflow_panic",
+                deltalake.exceptions.DeltaError(
+                    'Generic error: task 1237385 panicked with message "byte array offset overflow"'
+                ),
+                True,
+            ),
+            ("unrelated_delta_error", deltalake.exceptions.DeltaError("no protocol found in delta log"), False),
+            # Same message shape but not the DeltaError type delta-rs actually raises for it.
+            ("wrong_exception_type", RuntimeError('panicked with message "byte array offset overflow"'), False),
+        ]
+    )
+    def test_classifies_offset_overflow_errors(self, _name: str, error: Exception, expected: bool):
+        assert is_offset_overflow_compaction_error(error) is expected

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_maintenance.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_maintenance.py
@@ -4,7 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import deltalake
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.maintenance import DeltaMaintenance
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.maintenance import (
+    COMPACT_OFFSET_OVERFLOW_RETRIES,
+    DeltaMaintenance,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.test.helpers import make_logger
 
 _MAINTENANCE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.maintenance"
@@ -166,6 +169,57 @@ class TestCompactTable:
 
         assert mock_delta.optimize.compact.call_count == 2
         mock_delta.update_incremental.assert_called_once()
+
+
+class TestCompactOffsetOverflow:
+    """Regression coverage for the byte-array-offset-overflow panic (delta-rs binning several
+    already-safe files into one rewrite whose combined text column crosses the 32-bit offset
+    limit — see errors.is_offset_overflow_compaction_error)."""
+
+    @pytest.mark.asyncio
+    async def test_retries_with_smaller_target_size_then_succeeds(self):
+        mock_delta = MagicMock()
+        mock_delta.optimize.compact = MagicMock(
+            side_effect=[
+                deltalake.exceptions.DeltaError(
+                    'Generic error: task 1237385 panicked with message "byte array offset overflow"'
+                ),
+                {"numFilesAdded": 1},
+            ]
+        )
+        mock_delta.vacuum = MagicMock(return_value=[])
+
+        await _make_maintenance(mock_delta).compact_table()
+
+        assert mock_delta.optimize.compact.call_count == 2
+        first_target_size = mock_delta.optimize.compact.call_args_list[0].kwargs["target_size"]
+        second_target_size = mock_delta.optimize.compact.call_args_list[1].kwargs["target_size"]
+        assert second_target_size == first_target_size // 2
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_exhausting_retries(self):
+        # A table whose overflow can't be avoided at any reasonable bin size must still surface to
+        # error tracking instead of looping the retry ladder forever.
+        overflow_error = deltalake.exceptions.DeltaError(
+            'Generic error: task 42 panicked with message "byte array offset overflow"'
+        )
+        mock_delta = MagicMock()
+        mock_delta.optimize.compact = MagicMock(side_effect=overflow_error)
+
+        with pytest.raises(deltalake.exceptions.DeltaError):
+            await _make_maintenance(mock_delta)._compact(mock_delta)
+
+        assert mock_delta.optimize.compact.call_count == COMPACT_OFFSET_OVERFLOW_RETRIES + 1
+
+    @pytest.mark.asyncio
+    async def test_unrelated_delta_error_is_not_retried(self):
+        mock_delta = MagicMock()
+        mock_delta.optimize.compact = MagicMock(side_effect=deltalake.exceptions.DeltaError("no protocol found"))
+
+        with pytest.raises(deltalake.exceptions.DeltaError):
+            await _make_maintenance(mock_delta)._compact(mock_delta)
+
+        mock_delta.optimize.compact.assert_called_once()
 
 
 class TestVacuum:


### PR DESCRIPTION
## Problem

A Sentry sync (schema `issue_events`, incremental) hit a `DeltaError` during post-load compaction: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd003-9082-7032-b15b-3cbe6e63aa0c).

- delta-rs panics with `byte array offset overflow` inside `optimize.compact()`.
- `optimize.compact()` bins already-written files by on-disk (compressed) size, then reads a whole bin into one Arrow batch before rewriting it.
- `Batcher` already keeps each *written* file's string/binary columns under the 32-bit offset limit (~2.1 GB), but that guard doesn't cover compaction.
- Binning several already-safe files together can still push a combined column past the limit, especially for highly-compressible text like JSON payloads.
- The maintenance code already catches and captures this failure instead of raising it, so the sync itself doesn't fail. But the table never compacts, and the same panic gets captured on every subsequent run.

## Changes

- Add `is_offset_overflow_compaction_error` in `errors.py` to recognize the panic message.
- `DeltaMaintenance._compact` retries `optimize.compact()` with a halved `target_size` (starting at delta-rs's own 100MB default) up to 3 times when this error occurs.
- Smaller bins mean fewer files get concatenated into one Arrow batch per rewrite.
- Still raises (captured as before) if the error persists after all retries.

## How did you test this code?

- Added regression tests: the classifier in `test_delta_errors.py`, and retry-then-succeed / retries-exhausted / unrelated-error-not-retried cases in `test_maintenance.py`.
- Ran the delta package's pytest suite; all pass except pre-existing failures in `test_table.py` that require a live object-storage endpoint unavailable in this sandbox (confirmed these also fail on `master` without this change).
- Ran `ruff check`, `ruff format --check`, and a repo-wide `mypy` — all clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging a webhook-delivered error tracking alert.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the stack trace to `maintenance.py`'s `_compact` → `optimize.compact()`, then cross-referenced `Batcher`'s own comment predicting this exact delta-rs concatenation overflow to find the root cause and scope the fix to the shared compaction path.
- Considered classifying the error as transient (skip and retry as-is) but rejected it: retrying an identical bin changes nothing, so instead retry with a smaller `target_size`.
- Searched open PRs (by error text, module path, and the maintainer's own PRs) for a duplicate fix; found none.

---

Created with [PostHog Code](https://posthog.com/code?ref=pr)