### PR TITLE
fix(desktop): force strictMcpConfig so a repo's .mcp.json cannot auto-spawn servers

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -189,6 +189,21 @@ describe("buildSessionOptions", () => {
     expect(options.fallbackModel).toBe("claude-sonnet-5");
   });
 
+  it("forces strictMcpConfig so a repo's .mcp.json cannot auto-spawn stdio servers", () => {
+    const options = buildSessionOptions(makeParams());
+
+    expect(options.strictMcpConfig).toBe(true);
+  });
+
+  it("keeps strictMcpConfig on even when userProvidedOptions tries to relax it", () => {
+    const options = buildSessionOptions({
+      ...makeParams(),
+      userProvidedOptions: { strictMcpConfig: false },
+    });
+
+    expect(options.strictMcpConfig).toBe(true);
+  });
+
   it("threads onEnsureLocalToolsConnected into the signed-commit guard (cloud)", async () => {
     const healSpy = vi.fn().mockResolvedValue(true);
     await runPreToolUseHooks(

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -494,6 +494,13 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
       "project",
       "local",
     ],
+    // Honor only the MCP servers passed explicitly via `mcpServers` (plus any
+    // declared by explicitly-passed `agents`), so the CLI ignores an opened
+    // repo's checked-in `.mcp.json`. Without this, a repo shipping a stdio
+    // server there has its `command` spawned at MCP-connection init, before the
+    // first tool call and with no approval prompt. Assigned after the
+    // `userProvidedOptions` spread so a caller cannot relax it back to false.
+    strictMcpConfig: true,
     stderr: (err) => params.logger.error(err),
     cwd: params.cwd,
     includePartialMessages: true,


### PR DESCRIPTION
## Problem

- The agent session sets `settingSources` to `["user", "project", "local"]`, so the Claude CLI loads an opened repo's checked-in config.
- A repo can ship a `.mcp.json` that declares a stdio MCP server with any `command`.
- MCP servers connect at session init, so that command runs before the first tool call and without an approval prompt.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

## Changes

- `buildSessionOptions` now sets `strictMcpConfig: true`.
- The CLI then honors only the servers we pass in `mcpServers`, and ignores project `.mcp.json`, plugins and on-disk agent frontmatter MCP.
- The assignment sits after the `userProvidedOptions` spread, so a caller cannot relax it.
- App-supplied servers are unaffected. They already flow through `mcpServers`, which `strictMcpConfig` still honors.

## How did you test this code?

I (actually Claude) ran `pnpm --filter @posthog/agent exec vitest run src/adapters/claude/session/options.test.ts` (52 passed) and `pnpm --filter @posthog/agent typecheck`.

Two tests were added, covering a regression no existing test caught:

- `buildSessionOptions` sets `strictMcpConfig` to true by default.
- A caller passing `strictMcpConfig: false` cannot turn it off.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
