### PR TITLE
fix(desktop): deny the git ext transport on all remote operations

### DIFF
--- a/products/desktop/packages/git/src/client.ts
+++ b/products/desktop/packages/git/src/client.ts
@@ -1,4 +1,5 @@
 import { type SimpleGit, type SimpleGitOptions, simpleGit } from "simple-git";
+import { GIT_TRANSPORT_SECURITY_CONFIG } from "./transport-security";
 
 export type GitClient = SimpleGit;
 
@@ -17,9 +18,14 @@ export function createGitClient(
   options?: CreateGitClientOptions,
 ): GitClient {
   const { abortSignal: signal, config: callerConfig, ...rest } = options ?? {};
-  const config = callerConfig
-    ? [...PERFORMANCE_CONFIG, ...callerConfig]
-    : PERFORMANCE_CONFIG;
+  // Transport hardening goes last: git applies later `-c` options over earlier
+  // ones, so this wins over PERFORMANCE_CONFIG, any caller config, and the
+  // repository's own `.git/config` (see transport-security.ts).
+  const config = [
+    ...PERFORMANCE_CONFIG,
+    ...(callerConfig ?? []),
+    ...GIT_TRANSPORT_SECURITY_CONFIG,
+  ];
   return simpleGit({
     baseDir,
     maxConcurrentProcesses: 6,
@@ -30,10 +36,18 @@ export function createGitClient(
     // inherited GIT_EDITOR/PAGER env by default. These are trusted values on the
     // user's own machine, not the untrusted protocol.allow injection the CVEs
     // addressed, so opt in explicitly.
+    //
+    // allowUnsafeProtocolOverride is required to pass any `protocol.*` config at
+    // all: simple-git rejects the whole key space on remote tasks rather than
+    // judging the value, so it blocks the hardening in
+    // GIT_TRANSPORT_SECURITY_CONFIG along with an attacker's `=always`. Its
+    // guard is redundant here because that config is appended last and git
+    // applies the last `-c` for a key, so no caller can widen the policy.
     unsafe: {
       allowUnsafeFsMonitor: true,
       allowUnsafeEditor: true,
       allowUnsafePager: true,
+      allowUnsafeProtocolOverride: true,
     },
     ...rest,
   });

--- a/products/desktop/packages/git/src/signed-commit.ts
+++ b/products/desktop/packages/git/src/signed-commit.ts
@@ -8,6 +8,7 @@ import * as path from "node:path";
 import { mapWithConcurrency } from "./concurrency";
 import { execGh, execGhWithRetry, type GhExecResult } from "./gh";
 import { buildPostHogTrailers } from "./trailers";
+import { gitTransportSecurityArgs } from "./transport-security";
 import { parseGithubUrl } from "./utils";
 
 /**
@@ -104,7 +105,10 @@ function runGit(args: string[], cwd: string): Promise<GitRunResult> {
   return new Promise((resolve) => {
     childProcess.execFile(
       "git",
-      args,
+      // Prefix transport hardening so remote-touching commands routed through
+      // this raw seam (e.g. `ls-remote origin`) can't be turned into RCE by a
+      // malicious `ext::` remote in the repo config. Harmless for local ops.
+      [...gitTransportSecurityArgs(), ...args],
       { cwd, maxBuffer: MAX_GIT_BUFFER, encoding: "buffer" },
       (error, stdout, stderr) => {
         const err = error as (Error & { code?: number | string }) | null;

--- a/products/desktop/packages/git/src/transport-security.test.ts
+++ b/products/desktop/packages/git/src/transport-security.test.ts
@@ -1,0 +1,119 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createGitClient } from "./client";
+import { fetchRef } from "./queries";
+import {
+  GIT_TRANSPORT_SECURITY_CONFIG,
+  gitTransportSecurityArgs,
+} from "./transport-security";
+
+const execFileAsync = promisify(execFile);
+
+describe("git transport security policy", () => {
+  it("denies the ext transport and pins file to user", () => {
+    expect(GIT_TRANSPORT_SECURITY_CONFIG).toEqual([
+      "protocol.ext.allow=never",
+      "protocol.file.allow=user",
+    ]);
+  });
+
+  it("renders `-c key=value` argv for raw git seams", () => {
+    expect(gitTransportSecurityArgs()).toEqual([
+      "-c",
+      "protocol.ext.allow=never",
+      "-c",
+      "protocol.file.allow=user",
+    ]);
+  });
+});
+
+// End-to-end proof that the fetch the app runs on task/worktree creation cannot
+// be turned into RCE by a malicious `.git/config` whose origin is an `ext::`
+// remote (which git would otherwise run as a shell command).
+describe("ext:: remote fetch hardening", () => {
+  let dir: string;
+  let marker: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "posthog-code-transport-"));
+    marker = path.join(dir, "pwned");
+    const script = path.join(dir, "evil.sh");
+    // The ext transport execs this script; if it runs, the marker appears.
+    await writeFile(script, `#!/bin/sh\ntouch "${marker}"\nexit 1\n`);
+    await chmod(script, 0o755);
+    const git = createGitClient(dir);
+    await git.init(["--initial-branch", "main"]);
+    await git.addConfig("user.name", "Test");
+    await git.addConfig("user.email", "test@example.com");
+    await git.raw(["remote", "add", "origin", `ext::${script}`]);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const markerExists = async (): Promise<boolean> => {
+    try {
+      await stat(marker);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  it("positive control: git runs the ext command when the transport is allowed", async () => {
+    // Baseline proving the malicious remote really is wired to execute code, so
+    // the "blocked" assertions below cannot pass vacuously. upload-pack exits 1
+    // after the marker is created; we only assert the command ran.
+    await execFileAsync(
+      "git",
+      [
+        "-c",
+        "protocol.ext.allow=user",
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "origin",
+        "--",
+        "main",
+      ],
+      { cwd: dir },
+    ).catch(() => {});
+    expect(await markerExists()).toBe(true);
+  });
+
+  it("fetchRef refuses the ext transport and runs no command", async () => {
+    const errors: string[] = [];
+    const ok = await fetchRef(createGitClient(dir), "origin", "main", {
+      onError: (message) => errors.push(message),
+    });
+    expect(ok).toBe(false);
+    expect(errors.join("\n")).toMatch(/transport 'ext' not allowed/);
+    expect(await markerExists()).toBe(false);
+  });
+
+  it("caller-supplied config cannot re-enable the ext transport", async () => {
+    // Security config is spread last, so it overrides a caller trying to relax
+    // `protocol.ext.allow` back to the exploitable default.
+    const git = createGitClient(dir, { config: ["protocol.ext.allow=user"] });
+    await expect(
+      git.raw(["fetch", "--quiet", "--no-tags", "origin", "--", "main"]),
+    ).rejects.toThrow(/transport 'ext' not allowed/);
+    expect(await markerExists()).toBe(false);
+  });
+
+  it("still reaches git on a remote task instead of tripping simple-git's guard", async () => {
+    // simple-git refuses `protocol.*` config on remote tasks unless
+    // `unsafe.allowUnsafeProtocolOverride` is set (client.ts). Without it every
+    // fetch, clone and ls-remote in the app throws before git runs, so assert
+    // the rejection comes from git's transport policy and not from that guard.
+    const git = createGitClient(dir);
+    await expect(git.raw(["ls-remote", "origin"])).rejects.not.toThrow(
+      /allowUnsafeProtocolOverride/,
+    );
+  });
+});

--- a/products/desktop/packages/git/src/transport-security.ts
+++ b/products/desktop/packages/git/src/transport-security.ts
@@ -1,0 +1,37 @@
+// Zero-dependency git transport-hardening policy, shared by every seam in this
+// package that shells out to `git`. Kept import-free (no simple-git, no node
+// builtins) so both the simple-git client and the raw execFile/spawn seams can
+// pull it in without dragging extra deps into their bundles.
+//
+// A repository's `.git/config` can point a remote at a URL such as
+// `ext::sh -c "…"`. Git's `ext` transport runs that string as a shell command
+// the next time a fetch/clone/ls-remote resolves the remote. Git's default for
+// `protocol.ext` is `never`, so a bare `ext::` origin alone is refused with
+// `fatal: transport 'ext' not allowed` and does not execute. The attack works
+// because the attacker controls the delivered `.git/config` and can add
+// `protocol.ext.allow=user` (or `always`) there too; then creating a
+// task/worktree from that malicious folder or tarball triggers an automatic
+// `git fetch` that resolves the remote and executes the command, which is remote
+// code execution from untrusted repo contents.
+//
+// Denying `ext` closes that hole. Pinning `file` to `user` keeps user-initiated
+// local-path clones working while still blocking them in submodule/recursive
+// contexts. http/https/ssh are unaffected. These are passed as command-line
+// config (`-c`), which overrides any value a malicious repo config tries to set.
+//
+// Passing these through simple-git needs `unsafe.allowUnsafeProtocolOverride`
+// (see client.ts): it refuses every `protocol.*` config on a remote task without
+// inspecting the value, so it blocks this hardening too.
+export const GIT_TRANSPORT_SECURITY_CONFIG: readonly string[] = [
+  "protocol.ext.allow=never",
+  "protocol.file.allow=user",
+];
+
+/**
+ * The same restrictions as `-c key=value` argv, for raw `git` subprocess seams
+ * (execFile/spawn) that do not go through the simple-git client. Prepend to the
+ * argument list so the flags precede the git subcommand.
+ */
+export function gitTransportSecurityArgs(): string[] {
+  return GIT_TRANSPORT_SECURITY_CONFIG.flatMap((entry) => ["-c", entry]);
+}


### PR DESCRIPTION
## Problem

- A repository's `.git/config` can point a remote at a URL like `ext::sh -c "..."`, which git runs as a shell command.
- Git denies `ext` by default, but the attacker writes that same config file and can add `protocol.ext.allow=user` to it.
- Creating a task or worktree runs an automatic `git fetch`, which resolves the remote and executes the command.
- The repo must arrive as a directory copy or an archive that carries `.git`, because `git clone` does not copy `.git/config`.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

I confirmed the exploit against git 2.50.1 before changing anything. With `protocol.ext.allow=user` in the repo config alone, a plain `git fetch origin` ran the attacker's script.

## Changes

- New `packages/git/src/transport-security.ts` holds the policy in two forms: a config array and `-c` argv.

```diff
+ protocol.ext.allow=never
+ protocol.file.allow=user
```

- `createGitClient` appends the policy last, so it beats `PERFORMANCE_CONFIG`, any caller config, and the repository's own config.
- That one change covers every remote operation flowing through simple-git: fetch, clone, `ls-remote` and `remote get-url`.
- `signed-commit.ts` has its own raw `execFile` seam, so its args now carry the same `-c` flags.
- http, https and ssh are untouched. `protocol.file.allow=user` restates git's own default.

> [!WARNING]
> The monorepo pins simple-git 3.36, which the source tree did not. Version 3.36 rejects every `protocol.*` config on a remote task without reading the value, so it blocks this hardening along with an attacker's. `unsafe.allowUnsafeProtocolOverride` is therefore set in `client.ts`. Its guard is redundant here, because our policy is appended last and git applies the last `-c` for a key, so no caller can widen the policy.

## How did you test this code?

I (actually Claude) ran `pnpm --filter @posthog/git exec vitest run` (348 passed) plus typecheck and Biome.

`transport-security.test.ts` covers regressions no existing test caught:

- A positive control creates a repo whose origin is an `ext::` script, then proves the script runs when the transport is allowed. Without it the blocked assertions could pass vacuously.
- `fetchRef` against that repo returns false, reports `transport 'ext' not allowed`, and creates no marker file.
- A caller passing `protocol.ext.allow=user` stays blocked.
- A remote task reaches git rather than simple-git's guard. This one catches the break described in the warning above, which a simple-git bump could reintroduce.

I checked the last test by removing `allowUnsafeProtocolOverride` and confirming it fails.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
