### PR TITLE
fix(desktop): stop auto-running a repo's post-checkout hook on worktree create

### DIFF
--- a/products/desktop/packages/git/src/sagas/worktree.ts
+++ b/products/desktop/packages/git/src/sagas/worktree.ts
@@ -9,7 +9,7 @@ import {
   hasRef,
 } from "../queries";
 import { forceRemove, safeSymlink } from "../utils";
-import { processWorktreeInclude, runPostCheckoutHook } from "../worktree";
+import { processWorktreeInclude } from "../worktree";
 
 export interface CreateWorktreeInput extends GitSagaInput {
   worktreePath: string;
@@ -114,11 +114,10 @@ export class CreateWorktreeSaga extends GitSaga<
       rollback: async () => {},
     });
 
-    await this.step({
-      name: "run-post-checkout-hook",
-      execute: () => runPostCheckoutHook(baseDir, worktreePath),
-      rollback: async () => {},
-    });
+    // The repo's post-checkout hook is intentionally NOT run. Hooks are
+    // suppressed during `git worktree add` (core.hooksPath=/dev/null) because
+    // repo-supplied hooks are untrusted; auto-running one for an app-created
+    // worktree would reintroduce the RCE risk (H4).
 
     return { worktreePath, branchName, baseBranch: base };
   }
@@ -203,11 +202,10 @@ export class CreateWorktreeForBranchSaga extends GitSaga<
       rollback: async () => {},
     });
 
-    await this.step({
-      name: "run-post-checkout-hook",
-      execute: () => runPostCheckoutHook(baseDir, worktreePath),
-      rollback: async () => {},
-    });
+    // The repo's post-checkout hook is intentionally NOT run. Hooks are
+    // suppressed during `git worktree add` (core.hooksPath=/dev/null) because
+    // repo-supplied hooks are untrusted; auto-running one for an app-created
+    // worktree would reintroduce the RCE risk (H4).
 
     return { worktreePath, branchName };
   }

--- a/products/desktop/packages/git/src/worktree.test.ts
+++ b/products/desktop/packages/git/src/worktree.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmod,
   lstat,
   mkdir,
   mkdtemp,
@@ -141,6 +142,15 @@ describe("WorktreeManager.createWorktree fetchBeforeCreate", () => {
 });
 
 async function dirExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(p: string): Promise<boolean> {
   try {
     await stat(p);
     return true;
@@ -336,6 +346,27 @@ describe("WorktreeManager worktree link/include processing", () => {
 
     const linked = await lstat(path.join(info.worktreePath, ".claude"));
     expect(linked.isSymbolicLink()).toBe(true);
+  });
+
+  it("does not run the repo's post-checkout hook when creating a worktree", async () => {
+    // A repo delivered with an executable post-checkout hook must not run it
+    // when the app creates a worktree. Hooks are suppressed during
+    // `git worktree add` because repo-supplied hooks are untrusted, so the app
+    // must not re-run them afterward.
+    const hookPath = path.join(localDir, ".git", "hooks", "post-checkout");
+    await writeFile(hookPath, "#!/bin/sh\ntouch HOOK_RAN\n");
+    await chmod(hookPath, 0o755);
+
+    const manager = new WorktreeManager({
+      mainRepoPath: localDir,
+      worktreeBasePath: worktreeBaseDir,
+    });
+
+    const info = await manager.createWorktree({ baseBranch: "main" });
+
+    expect(await fileExists(path.join(info.worktreePath, "HOOK_RAN"))).toBe(
+      false,
+    );
   });
 });
 

--- a/products/desktop/packages/git/src/worktree.ts
+++ b/products/desktop/packages/git/src/worktree.ts
@@ -12,7 +12,6 @@ import {
   branchExists,
   fetchRef,
   getDefaultBranch,
-  getHeadSha,
   hasRef,
   listWorktrees as listWorktreesRaw,
 } from "./queries";
@@ -44,7 +43,6 @@ const noopLogger: SagaLogger = {
 const WORKTREE_FOLDER_NAME = ".posthog-code";
 
 const WORKTREE_ADD_TIMEOUT_MS = 120_000;
-const POST_CHECKOUT_HOOK_TIMEOUT_MS = 300_000;
 const GIT_FETCH_TIMEOUT_MS = 120_000;
 export const KILL_GRACE_MS = 5_000;
 
@@ -404,8 +402,13 @@ export class WorktreeManager {
 
   /**
    * Runs the post-create steps shared by every worktree: link local Claude
-   * instructions, then process the worktree link/include files and the
-   * post-checkout hook.
+   * instructions, then process the worktree link/include files.
+   *
+   * The repository's `post-checkout` hook is intentionally NOT run. Hooks are
+   * suppressed during `git worktree add` (via `core.hooksPath=/dev/null`)
+   * because a repo-supplied hook is untrusted code, so auto-running it
+   * afterward for an app-created worktree would reintroduce that code-execution
+   * risk. Repos relying on `post-checkout` side effects must run them manually.
    */
   private async finalizeWorktree(
     worktreePath: string,
@@ -425,17 +428,6 @@ export class WorktreeManager {
     );
     for (const warning of [...linkWarnings, ...includeWarnings]) {
       this.log.warn("Worktree setup warning", { worktreePath, ...warning });
-    }
-    const hookWarning = await runPostCheckoutHook(
-      this.mainRepoPath,
-      worktreePath,
-      { onOutput },
-    );
-    if (hookWarning) {
-      this.log.warn("post-checkout hook failed", {
-        worktreePath,
-        ...hookWarning,
-      });
     }
     this.log.info("Worktree finalized", { worktreePath });
   }
@@ -1067,101 +1059,4 @@ export async function processWorktreeLink(
   }
 
   return warnings;
-}
-
-function findPostCheckoutHook(mainRepoPath: string): Promise<string | null> {
-  return new Promise((resolve) => {
-    execFile(
-      "git",
-      ["rev-parse", "--git-path", "hooks/post-checkout"],
-      { cwd: mainRepoPath },
-      async (error, stdout) => {
-        if (error || !stdout.trim()) {
-          resolve(null);
-          return;
-        }
-        const resolved = stdout.trim();
-        const hookPath = path.isAbsolute(resolved)
-          ? resolved
-          : path.join(mainRepoPath, resolved);
-
-        try {
-          await fs.access(hookPath, fs.constants.X_OK);
-          resolve(hookPath);
-        } catch {
-          resolve(null);
-        }
-      },
-    );
-  });
-}
-
-/**
- * run post-checkout hook in the worktree
- *
- * hooks are intentionally skipped during worktree creation to avoid
- * potentially wonky behavior
- */
-export async function runPostCheckoutHook(
-  mainRepoPath: string,
-  worktreePath: string,
-  options?: { onOutput?: (data: string) => void },
-): Promise<WorktreeSetupWarning | null> {
-  const hookPath = await findPostCheckoutHook(mainRepoPath);
-  if (!hookPath) return null;
-
-  options?.onOutput?.(`Running post-checkout hook...\n`);
-
-  const head = await getHeadSha(worktreePath);
-  const nullSha = "0000000000000000000000000000000000000000";
-
-  return new Promise((resolve) => {
-    const chunks: string[] = [];
-    const shell = process.env.SHELL || "/bin/sh";
-    const proc = spawn(shell, ["-lc", `${hookPath} ${nullSha} ${head} 1`], {
-      cwd: worktreePath,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const handleData = (data: Buffer) => {
-      const text = data.toString();
-      chunks.push(text);
-      options?.onOutput?.(text);
-    };
-
-    proc.stdout.on("data", handleData);
-    proc.stderr.on("data", handleData);
-
-    const timeout = armProcessTimeout(proc, POST_CHECKOUT_HOOK_TIMEOUT_MS);
-
-    const warn = (error: string): WorktreeSetupWarning => {
-      options?.onOutput?.(`Warning: ${error}\n`);
-      return { path: hookPath, error };
-    };
-
-    proc.on("error", (err) => {
-      timeout.clear();
-      resolve(warn(`post-checkout hook failed to spawn: ${err.message}`));
-    });
-    proc.on("close", (code) => {
-      timeout.clear();
-      if (timeout.timedOut()) {
-        resolve(
-          warn(
-            `post-checkout hook timed out after ${POST_CHECKOUT_HOOK_TIMEOUT_MS}ms`,
-          ),
-        );
-        return;
-      }
-      if (code !== 0) {
-        resolve(
-          warn(
-            `post-checkout hook exited with code ${code}: ${chunks.join("")}`.trim(),
-          ),
-        );
-        return;
-      }
-      resolve(null);
-    });
-  });
 }


### PR DESCRIPTION
## Problem

- The app suppresses git hooks during `git worktree add` with `core.hooksPath=/dev/null`, which treats a repo-supplied hook as untrusted.
- It then re-ran that repo's `post-checkout` hook itself, which defeated the suppression.
- Opening a repo with an executable `.git/hooks/post-checkout` and starting a task therefore ran attacker code.
- The repo must arrive as a directory copy or an archive that carries `.git`, because `git clone` does not propagate hooks.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

## Changes

- `WorktreeManager.finalizeWorktree` no longer calls `runPostCheckoutHook`.
- The now-unused `runPostCheckoutHook` and `findPostCheckoutHook` helpers are deleted, along with `POST_CHECKOUT_HOOK_TIMEOUT_MS` and a `getHeadSha` import.
- Both worktree sagas drop their `run-post-checkout-hook` step, which used the same suppress-then-re-run pattern.
- The `core.hooksPath=/dev/null` suppression during `worktree add` stays.

> [!WARNING]
> This is a deliberate behavior change. A repo that relies on `post-checkout` side effects, such as a bootstrap or install step, no longer gets them for app-created worktrees. Those steps must be run manually.

Other call sites still run `git checkout` without hook suppression, in `sagas/branch.ts`, `sagas/head.ts` and `handoff.ts`. Those are separate hardening work, not a gap in this fix.

## How did you test this code?

I (actually Claude) ran `pnpm --filter @posthog/git exec vitest run` (343 passed) plus typecheck and Biome.

One test was added to `worktree.test.ts`, covering a regression no existing test caught. It installs an executable `.git/hooks/post-checkout` that would create a marker file, creates a worktree through `WorktreeManager.createWorktree`, then asserts the marker is absent. No existing test asserted the hook ran, so nothing had to be relaxed.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
