### PR TITLE
fix(desktop): drop the canvas img-src https: wildcard

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.test.ts
@@ -77,6 +77,64 @@ describe("buildSandboxDocument", () => {
   });
 });
 
+describe("content security policy", () => {
+  // Pull the CSP out of the <meta http-equiv> tag and index it by directive.
+  const cspDirectives = (html: string): Map<string, string[]> => {
+    const match = html.match(
+      /<meta http-equiv="Content-Security-Policy" content="([^"]*)"/,
+    );
+    if (!match) throw new Error("no CSP meta tag in document");
+    const directives = new Map<string, string[]>();
+    for (const part of match[1].split(";")) {
+      const [name, ...values] = part.trim().split(/\s+/).filter(Boolean);
+      if (name) directives.set(name, values);
+    }
+    return directives;
+  };
+
+  it.each([
+    { name: "without analytics host", analyticsApiHost: undefined },
+    { name: "with analytics host", analyticsApiHost: "https://us.posthog.com" },
+  ])(
+    "does not expose a bare https: wildcard on img-src in edit mode ($name)",
+    ({ analyticsApiHost }) => {
+      const directives = cspDirectives(
+        buildSandboxDocument("edit", analyticsApiHost),
+      );
+      const imgSrc = directives.get("img-src") ?? [];
+      // A bare `https:` token allows every https origin, which is the exfiltration
+      // channel, because img loads are not governed by connect-src. Scheme-scoped host
+      // entries like `https://esm.sh` are fine; the standalone `https:` is not.
+      expect(imgSrc).not.toContain("https:");
+    },
+  );
+
+  it.each([
+    { name: "without analytics host", analyticsApiHost: undefined },
+    { name: "with analytics host", analyticsApiHost: "https://us.posthog.com" },
+  ])(
+    "keeps img-src host egress mirrored to connect-src in edit mode ($name)",
+    ({ analyticsApiHost }) => {
+      const directives = cspDirectives(
+        buildSandboxDocument("edit", analyticsApiHost),
+      );
+      const imgSrc = directives.get("img-src") ?? [];
+      const connectSrc = directives.get("connect-src") ?? [];
+      // Inline images may use data:/blob:; every remote host img-src permits must
+      // also be a connect-src host, so image egress can't exceed connect egress.
+      expect(imgSrc).toEqual(expect.arrayContaining(["data:", "blob:"]));
+      const imgHosts = imgSrc.filter((v) => v !== "data:" && v !== "blob:");
+      expect(imgHosts).toEqual(connectSrc);
+    },
+  );
+
+  it("locks img-src to self plus data:/blob: in view mode", () => {
+    const directives = cspDirectives(buildSandboxDocument("view"));
+    expect(directives.get("img-src")).toEqual(["data:", "blob:", "'self'"]);
+    expect(directives.get("img-src")).not.toContain("https:");
+  });
+});
+
 describe("resolveExternalAnchorUrl", () => {
   const clickTarget = (html: string, selector: string): Element => {
     const container = document.createElement("div");

--- a/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/sandboxRuntime.ts
@@ -502,6 +502,12 @@ function contentSecurityPolicy(
       TAILWIND_ENGINE === "v4"
         ? "https://cdn.jsdelivr.net/npm/@tailwindcss/"
         : "https://cdn.tailwindcss.com";
+    // The single egress allowlist shared by `connect-src` and `img-src`. A bare
+    // `https:` wildcard on img-src is an exfiltration channel that connect-src
+    // cannot close, because connect-src does not govern image loads: canvas code
+    // can beacon query results out with `new Image().src` on mount. Keeping the
+    // two directives mirrored means image egress can never exceed connect egress.
+    const egressHosts = `${esm} ${twCdn} ${ph}`;
     return [
       "default-src 'none'",
       // Inline bootstrap + esm.sh modules + the transpiled Blob module + the
@@ -511,11 +517,12 @@ function contentSecurityPolicy(
       `script-src 'unsafe-inline' 'unsafe-eval' blob: ${twCdn} ${esm} ${ph}`,
       `style-src 'unsafe-inline' ${esm}`,
       `font-src data: ${esm}`,
-      "img-src data: blob: https:",
+      // Inline images (data:/blob:) plus the same allowlisted hosts as egress.
+      `img-src data: blob: ${egressHosts}`,
       `worker-src blob:`,
       // esm.sh + Tailwind CDN sub-fetches; canvas DATA goes over postMessage (not
       // connect), but posthog-js events/replay DO use connect to the PostHog hosts.
-      `connect-src ${esm} ${twCdn} ${ph}`,
+      `connect-src ${egressHosts}`,
     ].join("; ");
   }
   // view / published: self-hosted, frozen. Only egress is PostHog analytics.


### PR DESCRIPTION
## Problem

- A freeform canvas runs agent-authored React in a sandboxed, null-origin iframe.
- Its edit-mode CSP locks `connect-src` to esm.sh, the Tailwind CDN and PostHog hosts, so a canvas cannot phone home.
- `img-src` was `data: blob: https:`, a wildcard over every https origin.
- `connect-src` does not govern image loads, so that wildcard reopened the channel `connect-src` was closing.
- Canvas code could beacon `ph.query` results to any host on mount, with no click.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

## Changes

```diff
- img-src data: blob: https:
+ img-src data: blob: ${egressHosts}
```

- A new `egressHosts` const holds the allowlist, and both `connect-src` and `img-src` use it.
- Image egress cannot exceed connect egress by construction.
- `data:` and `blob:` stay, so inline and object-URL images still render.
- `font-src` was already scoped and `media-src` is absent, so neither changes. View mode was already locked and is untouched.

> [!WARNING]
> An edit-mode canvas can no longer load an image from an arbitrary external host. A canvas that references a third-party image URL needs it inlined or served from an allowlisted host.

## How did you test this code?

I (actually Claude) ran `pnpm --filter @posthog/ui exec vitest run src/features/canvas/freeform/sandboxRuntime.test.ts` (24 passed), plus `pnpm --filter @posthog/ui typecheck` and Biome.

Three test groups were added, covering a regression no existing test caught. They parse the CSP out of the `<meta http-equiv>` tag that `buildSandboxDocument` produces, then assert for edit mode both with and without an analytics host:

- `img-src` holds no bare `https:` token.
- `img-src` host entries equal `connect-src` exactly, and `data:` and `blob:` survive.
- View mode keeps `img-src` at `data: blob: 'self'`.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
