### PR TITLE
fix(data-imports): attach source/schema identity to repartition exceptions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -56,6 +56,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     DELTA_REPARTITION_DURATION_SECONDS,
     DELTA_REPARTITION_TOTAL,
 )
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.job_context import bind_job_context
 
 LOGGER = get_logger(__name__)
 
@@ -297,6 +298,20 @@ def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: Filterin
             job_id=inputs.job_id,
         )
         return
+
+    # Attach the same source/schema identity the import activity does, so an exception captured
+    # anywhere below (budget exhaustion, an unexpected rewrite failure) can be attributed to a
+    # connector and table instead of landing in error tracking with no sync context.
+    bind_job_context(
+        team_id=inputs.team_id,
+        source_type=schema.source.source_type,
+        external_data_source_id=inputs.source_id,
+        external_data_schema_id=inputs.schema_id,
+        external_data_job_id=inputs.job_id,
+        schema_name=schema.name,
+        sync_type=schema.sync_type,
+        pipeline_version=job.pipeline_version,
+    )
 
     # `resolved_s3_folder_name` is authoritative for the Delta folder, not the row's own name: a row
     # renamed during the multi-schema migration keeps its folder pinned to the original path (name

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -1,10 +1,13 @@
 import uuid
 import datetime as dt
+import contextvars
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from parameterized import parameterized
+
+from posthog.exceptions_capture import ambient_exception_properties
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
     TransientObjectStoreError,
@@ -103,6 +106,57 @@ class TestRepartitionActivityDeltaFolder:
         assert await_args is not None
         assert await_args.kwargs["table_ref"] is mock_helper_cls.return_value
         assert mock_job_model.objects.get.call_args.kwargs == {"id": JOB_ID}
+
+
+class TestJobContextBinding:
+    """The import activity tags every captured exception with the sync's source/schema identity
+    (`warehouse_sources_*` properties) via `bind_job_context`; this activity previously never called
+    it, so an exception captured here (e.g. `RepartitionBudgetExceededError`) landed in error
+    tracking with no way to attribute it to a connector, table, or sync mode."""
+
+    @patch(f"{MODULE}.capture_repartition_event")
+    @patch(f"{MODULE}.HeartbeaterSync")
+    @patch(f"{MODULE}.repartition_table_in_place", new_callable=AsyncMock)
+    @patch(f"{MODULE}.DeltaTableRef")
+    @patch(f"{MODULE}.is_auto_repartition_enabled", return_value=True)
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.ExternalDataSchema")
+    def test_activity_binds_source_and_schema_identity_for_captured_exceptions(
+        self,
+        mock_schema_model: MagicMock,
+        mock_job_model: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_helper_cls: MagicMock,
+        mock_repartition: AsyncMock,
+        _mock_heartbeater: MagicMock,
+        _mock_capture_event: MagicMock,
+    ) -> None:
+        schema = _schema(name="public.charges", s3_folder_name="charges")
+        schema.source = MagicMock(source_type="Stripe")
+        schema.sync_type = "incremental"
+        mock_schema_model.objects.select_related.return_value.get.return_value = schema
+        mock_job_model.objects.get.return_value.pipeline_version = "v3"
+        mock_repartition.return_value = {"outcome": "completed"}
+
+        # Runs in a copied context so the ambient exception properties `bind_job_context` sets
+        # don't leak into other tests sharing this interpreter thread.
+        ctx = contextvars.copy_context()
+        captured_props: dict = {}
+
+        def _run() -> None:
+            _maybe_repartition_table(
+                RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
+                MagicMock(),
+            )
+            captured_props.update(ambient_exception_properties())
+
+        ctx.run(_run)
+
+        assert captured_props["warehouse_sources_source_type"] == "Stripe"
+        assert captured_props["warehouse_sources_schema_name"] == "public.charges"
+        assert captured_props["warehouse_sources_sync_type"] == "incremental"
+        assert captured_props["warehouse_sources_pipeline_version"] == "v3"
+        assert captured_props["warehouse_sources_job_id"] == JOB_ID
 
 
 NO_ACTIVITY_CONTEXT = object()


### PR DESCRIPTION
## Problem

- Error tracking reported [`RepartitionBudgetExceededError`](https://us.posthog.com/project/2/error_tracking/019fd042-667c-7a72-921b-7b22ebebf130): a repartition rewrite ran out of its activity time budget on a very large table.
- That condition is already handled correctly: the activity never fails the sync, records a bounded attempt (`MAX_REPARTITION_ATTEMPTS`), and backs off with a cooldown. No fix needed there.
- But the captured exception carried none of the `warehouse_sources_*` properties (source type, schema name, sync type, pipeline version) the rest of the pipeline attaches to exceptions - there was no way to tell which connector or table it came from.
- Root cause: `maybe_repartition_table_activity` never calls `bind_job_context`, unlike its sibling `import_data_activity_sync`.

## Changes

- Bind job context (source type, schema name, sync type, pipeline version) right after the job is fetched in `_maybe_repartition_table`.
- Every exception this activity captures downstream (budget exhaustion, an unpartitionable table, an unexpected rewrite failure) now carries the same source/schema attribution as import-activity exceptions.

## How did you test this code?

- Added `test_activity_binds_source_and_schema_identity_for_captured_exceptions`, asserting the ambient exception properties after the activity runs - this fails if the binding is missing or wired to the wrong fields.
- Ran the full `test_repartition_table.py` suite: 16 passed.
- `ruff check` / `ruff format --check`: clean.
- `uv run mypy --cache-fine-grained .`: clean across the repo.

## Docs update

None - internal instrumentation only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the linked error-tracking issue. Read the stack trace and `products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition.py` end to end to confirm the budget-exceeded path is deliberate, non-fatal, and already attempt-limited - so no behavior change was warranted there. Searched open PRs (including the maintainer's own) for prior fixes; found none addressing this. While pulling the event's `warehouse_sources_*` properties for scoping (as instructed), found they were absent and traced it to the missing `bind_job_context` call, which is the actual gap this PR closes.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*