### PR TITLE
fix(desktop): bind dev OAuth and MCP callback servers to loopback

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/mcp-callback/mcp-callback-server.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-callback/mcp-callback-server.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+const listenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:http", () => {
+  const createServer = vi.fn(() => ({
+    listen: listenMock,
+    close: vi.fn(),
+    on: vi.fn(),
+  }));
+  return { createServer, default: { createServer } };
+});
+
+import { McpCallbackServer } from "./mcp-callback-server";
+
+describe("McpCallbackServer.waitForCallback", () => {
+  it("binds the callback server to the loopback interface only", async () => {
+    listenMock.mockImplementation(
+      (_port: number, _host: string, cb: () => void) => cb(),
+    );
+    const controller = new AbortController();
+    const onListening = vi.fn();
+
+    const promise = new McpCallbackServer().waitForCallback({
+      port: 23456,
+      path: "/mcp-oauth-complete",
+      timeoutMs: 1000,
+      signal: controller.signal,
+      onListening,
+      successWhen: () => true,
+    });
+    // The flow never resolves in this test; swallow the cancel rejection.
+    promise.catch(() => {});
+
+    expect(listenMock).toHaveBeenCalledWith(
+      23456,
+      "127.0.0.1",
+      expect.any(Function),
+    );
+    expect(onListening).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+    await expect(promise).rejects.toThrow("MCP OAuth flow cancelled");
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/mcp-callback/mcp-callback-server.ts
+++ b/products/desktop/packages/workspace-server/src/services/mcp-callback/mcp-callback-server.ts
@@ -95,7 +95,9 @@ export class McpCallbackServer {
         );
       });
 
-      server.listen(port, () => {
+      // Bind to loopback only so the dev callback endpoint is reachable
+      // solely from this machine and not from other hosts on the LAN.
+      server.listen(port, "127.0.0.1", () => {
         onListening?.();
       });
     });

--- a/products/desktop/packages/workspace-server/src/services/oauth-callback/oauth-callback.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/oauth-callback/oauth-callback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+const listenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:http", () => {
+  const createServer = vi.fn(() => ({
+    listen: listenMock,
+    close: vi.fn(),
+    on: vi.fn(),
+  }));
+  return { createServer, default: { createServer } };
+});
+
+import { OAuthCallbackServer } from "./oauth-callback";
+
+describe("OAuthCallbackServer.waitForCode", () => {
+  it("binds the callback server to the loopback interface only", async () => {
+    listenMock.mockImplementation(
+      (_port: number, _host: string, cb: () => void) => cb(),
+    );
+    const controller = new AbortController();
+    const onListening = vi.fn();
+
+    const promise = new OAuthCallbackServer().waitForCode({
+      port: 12345,
+      timeoutMs: 1000,
+      signal: controller.signal,
+      onListening,
+    });
+    // The flow never resolves in this test; swallow the cancel rejection.
+    promise.catch(() => {});
+
+    expect(listenMock).toHaveBeenCalledWith(
+      12345,
+      "127.0.0.1",
+      expect.any(Function),
+    );
+    expect(onListening).toHaveBeenCalledTimes(1);
+
+    controller.abort();
+    await expect(promise).rejects.toThrow("OAuth flow cancelled");
+  });
+});

--- a/products/desktop/packages/workspace-server/src/services/oauth-callback/oauth-callback.ts
+++ b/products/desktop/packages/workspace-server/src/services/oauth-callback/oauth-callback.ts
@@ -108,7 +108,9 @@ export class OAuthCallbackServer {
         );
       });
 
-      server.listen(port, () => {
+      // Bind to loopback only so the dev callback endpoint is reachable
+      // solely from this machine and not from other hosts on the LAN.
+      server.listen(port, "127.0.0.1", () => {
         onListening?.();
       });
     });


### PR DESCRIPTION
## Problem

- The local HTTP servers that receive the OAuth and MCP OAuth redirects during a development sign-in called `server.listen(port, cb)` with no host.
- Node then listens on the unspecified address, so the callback endpoint was reachable from any host on the LAN while a sign-in was pending.
- The endpoint has no origin, CSRF or `state` check, so a reachable attacker could inject their own auth code or abort the flow.
- These servers are dev-build-only. Production uses custom-protocol deep links, gated by `!appMeta.isProduction`.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

Realistic impact is limited. The endpoint is write-only, the pending window is about three minutes, and PKCE binds the code to this client, so the practical harm is griefing an in-progress dev sign-in rather than account takeover.

## Changes

```diff
- server.listen(port, () => {
+ server.listen(port, "127.0.0.1", () => {
```

- Applied in `oauth-callback.ts` and `mcp-callback-server.ts`.
- `127.0.0.1` rather than `localhost` pins the loopback address instead of relying on name resolution.
- Callback handling itself does not change. Local dev sign-in still works, because the browser reaches the server over `http://localhost`.

## How did you test this code?

I (actually Claude) ran `pnpm --filter @posthog/workspace-server exec vitest run` on both new files (2 passed), plus typecheck and Biome.

One test per server was added, covering a regression no existing test caught. Each mocks `node:http` and asserts `listen` is called with `(port, "127.0.0.1", <fn>)` and that `onListening` fires. Without them a future edit could silently drop the host argument and rebind to every interface.

I did not run a dev sign-in manually.
