### PR TITLE
fix(desktop): redact path, query and userinfo secrets in network.log

### DIFF
--- a/products/desktop/apps/code/src/main/utils/network-log.test.ts
+++ b/products/desktop/apps/code/src/main/utils/network-log.test.ts
@@ -65,52 +65,80 @@ describe("shouldLogUrl", () => {
 });
 
 describe("redactUrl", () => {
-  it.each([
-    "secret",
-    "token",
-    "access_token",
-    "refresh_token",
-    "id_token",
-    "code",
-    "signature",
-    "api_key",
-    "apikey",
-    "client_secret",
-    "password",
-    "session",
-    "x-amz-signature",
-    "x-amz-credential",
-    "x-amz-security-token",
-  ])("redacts %s query param", (param) => {
-    const redacted = redactUrl(`https://example.com/path?${param}=hunter2`);
-    expect(redacted).not.toContain("hunter2");
-    expect(redacted).toContain(`${param}=***`);
-  });
-
-  it("redacts case-insensitively", () => {
-    expect(redactUrl("https://s3.aws.com/log?X-Amz-Signature=abc123")).toBe(
-      "https://s3.aws.com/log?X-Amz-Signature=***",
+  it("preserves a plain scheme + host + path url", () => {
+    expect(redactUrl("https://us.posthog.com/api/projects/")).toBe(
+      "https://us.posthog.com/api/projects/",
     );
   });
 
-  it("collapses repeated sensitive params into one redacted value", () => {
-    const redacted = redactUrl("https://example.com/?token=a&token=b");
-    expect(redacted).not.toContain("=a");
-    expect(redacted).not.toContain("=b");
-    expect(redacted).toContain("token=***");
+  it("replaces the entire query string with a marker", () => {
+    // A secret under an arbitrary, non-allowlisted key must not survive.
+    const redacted = redactUrl(
+      "https://api.example.com/data?my_custom_key=supersecret123&limit=50",
+    );
+    expect(redacted).toBe("https://api.example.com/data?<redacted>");
+    expect(redacted).not.toContain("supersecret123");
+    expect(redacted).not.toContain("limit=50");
   });
 
-  it("leaves non-sensitive params untouched", () => {
+  it("redacts the query even for otherwise harmless-looking params", () => {
     expect(redactUrl("https://example.com/api?limit=50&offset=10")).toBe(
-      "https://example.com/api?limit=50&offset=10",
+      "https://example.com/api?<redacted>",
     );
   });
 
-  it("strips the whole query when the url does not parse", () => {
+  it("strips userinfo (user:pass@host) credentials", () => {
+    const redacted = redactUrl("https://alice:s3cr3tp%40ss@example.com/api");
+    expect(redacted).toBe("https://example.com/api");
+    expect(redacted).not.toContain("alice");
+    expect(redacted).not.toContain("s3cr3t");
+  });
+
+  it.each([
+    // Key-shaped path segment (e.g. an MCP endpoint keyed in the path).
+    [
+      "https://mcp.example.com/v1/sk-abc123def456ghi789jkl/messages",
+      "https://mcp.example.com/v1/<redacted>/messages",
+    ],
+    // Long hex digest embedded in the path.
+    [
+      "https://mcp.example.com/mcp/deadbeefdeadbeefdeadbeefdeadbeef/sse",
+      "https://mcp.example.com/mcp/<redacted>/sse",
+    ],
+    // Long high-entropy token mixing letters and digits.
+    [
+      "https://api.example.com/hooks/AKIAIOSFODNN7EXAMPLE/run",
+      "https://api.example.com/hooks/<redacted>/run",
+    ],
+  ])("redacts token-like path segments: %s", (url, expected) => {
+    const redacted = redactUrl(url);
+    expect(redacted).toBe(expected);
+  });
+
+  it("keeps short and uuid path segments for debuggability", () => {
+    expect(
+      redactUrl(
+        "https://us.posthog.com/api/projects/12345/insights/550e8400-e29b-41d4-a716-446655440000/",
+      ),
+    ).toBe(
+      "https://us.posthog.com/api/projects/12345/insights/550e8400-e29b-41d4-a716-446655440000/",
+    );
+  });
+
+  it("redacts a url fragment", () => {
+    expect(redactUrl("https://example.com/cb#access_token=abc123")).toBe(
+      "https://example.com/cb#<redacted>",
+    );
+  });
+
+  it("redacts query and token-like segments when the url does not parse", () => {
     expect(redactUrl("/relative/path?token=abc")).toBe(
       "/relative/path?<redacted>",
     );
     expect(redactUrl("/relative/path")).toBe("/relative/path");
+    expect(redactUrl("/relative/sk-abc123def456ghi789jkl/x")).toBe(
+      "/relative/<redacted>/x",
+    );
   });
 });
 
@@ -178,11 +206,11 @@ describe("formatNetworkLine", () => {
     );
   });
 
-  it("redacts sensitive query params in the line", () => {
+  it("redacts secrets in the url before writing the line", () => {
     const line = formatNetworkLine(
       entry({ url: "https://s3.aws.com/log?X-Amz-Signature=abc123" }),
     );
-    expect(line).toContain("X-Amz-Signature=***");
+    expect(line).toContain("https://s3.aws.com/log?<redacted>");
     expect(line).not.toContain("abc123");
   });
 });

--- a/products/desktop/apps/code/src/main/utils/network-log.ts
+++ b/products/desktop/apps/code/src/main/utils/network-log.ts
@@ -25,39 +25,74 @@ export function shouldLogUrl(url: string): boolean {
   }
 }
 
-const SENSITIVE_QUERY_PARAMS = new Set([
-  "secret",
-  "token",
-  "access_token",
-  "refresh_token",
-  "id_token",
-  "code",
-  "signature",
-  "api_key",
-  "apikey",
-  "client_secret",
-  "password",
-  "session",
-  "x-amz-signature",
-  "x-amz-credential",
-  "x-amz-security-token",
-]);
+// Query strings and URL fragments are treated as entirely sensitive: they
+// routinely carry tokens under arbitrary, caller-chosen keys, so no allowlist
+// can be trusted. We replace the whole component with a marker instead.
+const REDACTED = "<redacted>";
 
+// Credential-shaped path segments to strip even without a query string, e.g. a
+// remote MCP endpoint that embeds its API key in the path.
+const KEY_SHAPED_SEGMENT =
+  /^(?:sk|pk|rk|ghp|gho|ghs|ghr|ghu|xox[baprs]|glpat|shpat|shpss)[_-][A-Za-z0-9]/i;
+const AWS_KEY_SEGMENT = /^(?:AKIA|ASIA)[0-9A-Z]{16}$/;
+const UUID_SEGMENT =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const TOKEN_CHARSET = /^[A-Za-z0-9._~+/=-]+$/;
+
+function safeDecodeSegment(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function looksLikeSecretSegment(segment: string): boolean {
+  const value = safeDecodeSegment(segment);
+  if (KEY_SHAPED_SEGMENT.test(value) || AWS_KEY_SEGMENT.test(value))
+    return true;
+  // Resource identifiers (UUIDs) are not secrets; keep them for debugging.
+  if (UUID_SEGMENT.test(value)) return false;
+  // Long, high-entropy tokens: base64url/hex mixing letters and digits.
+  if (
+    value.length >= 24 &&
+    TOKEN_CHARSET.test(value) &&
+    /[A-Za-z]/.test(value) &&
+    /[0-9]/.test(value)
+  ) {
+    return true;
+  }
+  // Long pure-hex digests (session ids, signatures, etc.).
+  return value.length >= 32 && /^[0-9a-f]+$/i.test(value);
+}
+
+function redactPath(pathname: string): string {
+  return pathname
+    .split("/")
+    .map((segment) => (looksLikeSecretSegment(segment) ? REDACTED : segment))
+    .join("/");
+}
+
+// Logs only scheme + host + coarse path. Userinfo, the entire query string, and
+// any URL fragment are dropped, and credential-shaped path segments are masked,
+// so secrets never reach the world-readable network log.
 export function redactUrl(rawUrl: string): string {
   let parsed: URL;
   try {
     parsed = new URL(rawUrl);
   } catch {
     const [base] = rawUrl.split("?");
-    return rawUrl.includes("?") ? `${base}?<redacted>` : rawUrl;
+    const path = redactPath(base);
+    return rawUrl.includes("?") ? `${path}?${REDACTED}` : path;
   }
 
-  for (const key of new Set(parsed.searchParams.keys())) {
-    if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
-      parsed.searchParams.set(key, "***");
-    }
-  }
-  return parsed.toString();
+  // Strip embedded credentials (user:pass@host).
+  parsed.username = "";
+  parsed.password = "";
+  const path = redactPath(parsed.pathname);
+  const query = parsed.search ? `?${REDACTED}` : "";
+  const fragment = parsed.hash ? `#${REDACTED}` : "";
+  return `${parsed.protocol}//${parsed.host}${path}${query}${fragment}`;
 }
 
 export function parseContentLength(


### PR DESCRIPTION
## Problem

- `network-log.ts` writes every outbound request URL to `~/.posthog-code/logs/network.log`, a file created with default permissions.
- The old `redactUrl` masked only query parameters whose key sat on a hard-coded allowlist.
- Three shapes of secret still landed in the log in cleartext: a credential in the URL path, a token under a non-allowlisted query key, and `user:pass@host` userinfo.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

Exploiting it needs local read access to the victim's log, so this is local disclosure only. There is no remote vector.

## Changes

`redactUrl` now logs the non-sensitive envelope of a URL and treats caller-controlled parts as sensitive by default.

| Part | Before | After |
| --- | --- | --- |
| Userinfo | kept | cleared |
| Query string | allowlisted keys masked | whole query replaced with `?<redacted>` |
| Fragment | kept | replaced with `#<redacted>` |
| Path segments | kept | credential-shaped segments masked |
| Scheme, host, port | kept | kept |

- A path segment is masked when it carries a known key prefix (`sk-`, `ghp_`, `xoxb-`, `AKIA`, `glpat-`), or is a long high-entropy base64url or hex token.
- UUIDs and short numeric ids survive, so host and coarse path stay useful for debugging.
- `SENSITIVE_QUERY_PARAMS` is deleted, since full-query redaction supersedes it.
- Call sites (`formatNetworkLine`, `recordNetworkRequest`) are untouched.

## How did you test this code?

I (actually Claude) ran `pnpm --filter code exec vitest run src/main/utils/network-log.test.ts` (50 passed), plus `pnpm --filter code typecheck` and Biome.

The test file grew cases for the regressions no existing test caught:

- A secret under a non-allowlisted query key is dropped.
- A key-shaped segment, a long hex segment and an AWS key segment are each masked.
- Userinfo is stripped and a fragment is redacted.
- A plain URL, short numeric ids and UUID segments survive verbatim.
- The unparseable-URL fallback still redacts both query and token-like segments.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
