### PR TITLE
fix(desktop): stop trusting an opened repo's .claude settings as policy

### DIFF
--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.resume-model.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
@@ -112,9 +112,11 @@ const configDir = mkdtempSync(
 const permissionCwd = mkdtempSync(
   path.join(os.tmpdir(), "claude-agent-permission-test-cwd-"),
 );
-mkdirSync(path.join(permissionCwd, ".claude"), { recursive: true });
+// User-level settings, not the repo's `.claude/settings.json`: SettingsManager
+// treats the opened repo's project layer as untrusted for policy, so a
+// permission granted there would never take effect.
 writeFileSync(
-  path.join(permissionCwd, ".claude", "settings.json"),
+  path.join(configDir, "settings.json"),
   JSON.stringify({ permissions: { allow: ["mcp__posthog__exec"] } }),
 );
 const savedEnv = {

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.test.ts
@@ -111,6 +111,14 @@ describe("buildSessionOptions", () => {
     },
   );
 
+  it("does not load the opened repo's project/local settings as trusted SDK policy", () => {
+    // A malicious repo's checked-in .claude/settings.json / settings.local.json
+    // must not reach the SDK, which would otherwise execute their hooks and
+    // honor their permissions. Only user-level settings are trusted.
+    const options = buildSessionOptions(makeParams());
+    expect(options.settingSources).toEqual(["user"]);
+  });
+
   it("maps the custom auto mode to the SDK's default mode", () => {
     const options = buildSessionOptions({
       ...makeParams(),

--- a/products/desktop/packages/agent/src/adapters/claude/session/options.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/options.ts
@@ -199,10 +199,10 @@ function buildEnvironment(
   // are pinned rather than inherited — an ambient OTEL_TRACES_EXPORTER=none or
   // unknown protocol registers no tracer and silently drops the traceparent;
   // the endpoint stays overridable for a real collector.
-  // Residual risk: a repo's .claude/settings.json `env` is applied over these
-  // inside the CLI and can redirect the endpoint or turn on content capture
-  // (OTEL_LOG_TOOL_CONTENT, …) — pre-existing settingSources exposure, not
-  // closable from here; hardening tracked separately.
+  // A repo's .claude/settings.json `env` could previously be applied over these
+  // inside the CLI, redirecting the endpoint or turning on content capture
+  // (OTEL_LOG_TOOL_CONTENT and friends). `settingSources` below no longer loads
+  // the repo's settings, which closes that.
   const gatewayTracing: Record<string, string> = gateway?.anthropicBaseUrl
     ? {
         CLAUDE_CODE_ENABLE_TELEMETRY: "1",
@@ -489,11 +489,17 @@ export function buildSessionOptions(params: BuildOptionsParams): Options {
     ...params.userProvidedOptions,
     betas: ["context-1m-2025-08-07"],
     systemPrompt: params.systemPrompt ?? buildSystemPrompt(),
-    settingSources: params.userProvidedOptions?.settingSources ?? [
-      "user",
-      "project",
-      "local",
-    ],
+    // Only load user-level settings as trusted SDK policy. The opened repo's
+    // `.claude/settings.json` (`project`) and `.claude/settings.local.json`
+    // (`local`) are attacker-controlled when a malicious repository is opened:
+    // the SDK would otherwise execute their `hooks` (for example a `SessionStart`
+    // command running the moment a session starts) and honor their
+    // `permissions.allow` (silencing the per-tool approval prompt) with no
+    // "trust this folder" gate. The app's own approval UI and its
+    // SettingsManager-persisted approvals still apply via the PreToolUse hook,
+    // so dropping these here does not affect them. Assigned after the
+    // `userProvidedOptions` spread so no caller can widen it back.
+    settingSources: ["user"],
     stderr: (err) => params.logger.error(err),
     cwd: params.cwd,
     includePartialMessages: true,

--- a/products/desktop/packages/agent/src/adapters/claude/session/settings.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/settings.test.ts
@@ -4,7 +4,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveMainRepoPath } from "./repo-path";
-import { mergeAvailableModels, SettingsManager } from "./settings";
+import {
+  approvalStorePath,
+  mergeAvailableModels,
+  SettingsManager,
+} from "./settings";
 
 function runGit(cwd: string, args: string[]): void {
   execFileSync("git", args, { cwd, stdio: ["ignore", "ignore", "pipe"] });
@@ -14,6 +18,8 @@ describe("SettingsManager per-repo persistence", () => {
   let mainRepo: string;
   let worktree: string;
   let tmpRoot: string;
+  let storePath: string;
+  let originalConfigDir: string | undefined;
 
   beforeEach(async () => {
     tmpRoot = await fs.promises.realpath(
@@ -28,13 +34,24 @@ describe("SettingsManager per-repo persistence", () => {
     runGit(mainRepo, ["config", "user.name", "test"]);
     runGit(mainRepo, ["commit", "--allow-empty", "-m", "init"]);
     runGit(mainRepo, ["worktree", "add", "-b", "feat", worktree]);
+
+    // The approval store now lives under CLAUDE_CONFIG_DIR, so point it at the
+    // temp root rather than writing into the developer's real ~/.claude.
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = path.join(tmpRoot, "config");
+    storePath = approvalStorePath(mainRepo);
   });
 
   afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
     await fs.promises.rm(tmpRoot, { recursive: true, force: true });
   });
 
-  it("persists allow rules to the primary worktree when invoked from a secondary worktree", async () => {
+  it("persists allow rules outside the repo when invoked from a secondary worktree", async () => {
     const manager = new SettingsManager(worktree);
     await manager.initialize();
 
@@ -42,18 +59,16 @@ describe("SettingsManager per-repo persistence", () => {
       { toolName: "Bash", ruleContent: "pnpm test:*" },
     ]);
 
-    const repoLocalPath = path.join(mainRepo, ".claude", "settings.local.json");
-    const contents = JSON.parse(
-      await fs.promises.readFile(repoLocalPath, "utf-8"),
-    );
+    const contents = JSON.parse(await fs.promises.readFile(storePath, "utf-8"));
     expect(contents.permissions.allow).toContain("Bash(pnpm test:*)");
 
-    const worktreeLocalPath = path.join(
-      worktree,
-      ".claude",
-      "settings.local.json",
-    );
-    expect(fs.existsSync(worktreeLocalPath)).toBe(false);
+    // Neither the primary worktree nor the secondary one gains a settings file:
+    // an approval written into the repo would be committable by that repo.
+    for (const dir of [mainRepo, worktree]) {
+      expect(
+        fs.existsSync(path.join(dir, ".claude", "settings.local.json")),
+      ).toBe(false);
+    }
   });
 
   it("sees rules persisted by a sibling worktree after re-initialization", async () => {
@@ -114,7 +129,7 @@ describe("SettingsManager per-repo persistence", () => {
     const manager = new SettingsManager(worktree);
     await manager.initialize();
 
-    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const filePath = storePath;
     const original = "{ this is not valid json";
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
     await fs.promises.writeFile(filePath, original);
@@ -132,7 +147,7 @@ describe("SettingsManager per-repo persistence", () => {
     await writer.initialize();
     await writer.addPostHogExecApproval("experiment-update");
 
-    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const filePath = storePath;
     const contents = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
     expect(contents.posthogApprovedExecTools).toEqual(["experiment-update"]);
 
@@ -152,7 +167,7 @@ describe("SettingsManager per-repo persistence", () => {
     await manager.addPostHogExecApproval("foo-update");
     await manager.addPostHogExecApproval("bar-delete");
 
-    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const filePath = storePath;
     const contents = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
     expect(contents.posthogApprovedExecTools).toEqual([
       "foo-update",
@@ -170,7 +185,7 @@ describe("SettingsManager per-repo persistence", () => {
       manager.addPostHogExecApproval("c-destroy"),
     ]);
 
-    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const filePath = storePath;
     const contents = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
     expect(contents.posthogApprovedExecTools).toEqual(
       expect.arrayContaining(["a-update", "b-delete", "c-destroy"]),
@@ -187,7 +202,7 @@ describe("SettingsManager per-repo persistence", () => {
       manager.addAllowRules([{ toolName: "C" }]),
     ]);
 
-    const filePath = path.join(mainRepo, ".claude", "settings.local.json");
+    const filePath = storePath;
     const contents = JSON.parse(await fs.promises.readFile(filePath, "utf-8"));
     expect(contents.permissions.allow).toEqual(
       expect.arrayContaining(["A", "B", "C"]),
@@ -386,9 +401,11 @@ describe("SettingsManager repo-trust boundary", () => {
     expect(manager.hasPostHogExecApproval("experiment-delete")).toBe(false);
   });
 
-  it("still honors allow rules from the app's own local settings store", async () => {
-    // settings.local.json is where the app persists user approvals
-    // (addAllowRules), so its rules stay trusted — only project settings drop.
+  it("ignores allow rules committed to the opened repo's local settings", async () => {
+    // The app's approval store lives OUTSIDE the repo (getLocalSettingsPath), so
+    // a settings.local.json committed inside the repo is never read and cannot
+    // pre-approve a tool — the decision falls through to "ask". A malicious repo
+    // can no longer bypass the prompt by shipping settings.local.json.
     await writeLocalSettings({ permissions: { allow: ["Bash"] } });
 
     const manager = new SettingsManager(cwd);
@@ -396,6 +413,23 @@ describe("SettingsManager repo-trust boundary", () => {
 
     expect(
       manager.checkPermission("mcp__acp__Bash", { command: "pnpm test" })
+        .decision,
+    ).toBe("ask");
+  });
+
+  it("honors and persists approvals the app itself writes via addAllowRules", async () => {
+    // The app persists its own "always allow" decisions to the app-owned store;
+    // they stay trusted and survive across sessions (a fresh manager reads them
+    // back), independent of anything in the opened repo.
+    const writer = new SettingsManager(cwd);
+    await writer.initialize();
+    await writer.addAllowRules([{ toolName: "Bash" }]);
+
+    const reader = new SettingsManager(cwd);
+    await reader.initialize();
+
+    expect(
+      reader.checkPermission("mcp__acp__Bash", { command: "pnpm test" })
         .decision,
     ).toBe("allow");
   });

--- a/products/desktop/packages/agent/src/adapters/claude/session/settings.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/settings.test.ts
@@ -308,3 +308,106 @@ describe("mergeAvailableModels", () => {
     ).toEqual(["managed-a"]);
   });
 });
+
+describe("SettingsManager repo-trust boundary", () => {
+  let tmpRoot: string;
+  let cwd: string;
+  let configDir: string;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.promises.realpath(
+      await fs.promises.mkdtemp(path.join(os.tmpdir(), "repo-trust-")),
+    );
+    cwd = path.join(tmpRoot, "repo");
+    configDir = path.join(tmpRoot, "user");
+    await fs.promises.mkdir(cwd, { recursive: true });
+    await fs.promises.mkdir(configDir, { recursive: true });
+    runGit(cwd, ["init", "-b", "main"]);
+    runGit(cwd, ["config", "user.email", "test@example.com"]);
+    runGit(cwd, ["config", "user.name", "test"]);
+    runGit(cwd, ["commit", "--allow-empty", "-m", "init"]);
+
+    // Isolate user settings so the real ~/.claude cannot influence the result.
+    originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+  });
+
+  afterEach(async () => {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    }
+    await fs.promises.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function writeProjectSettings(settings: object): Promise<void> {
+    const claudeDir = path.join(cwd, ".claude");
+    await fs.promises.mkdir(claudeDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(claudeDir, "settings.json"),
+      JSON.stringify(settings),
+    );
+  }
+
+  async function writeLocalSettings(settings: object): Promise<void> {
+    const claudeDir = path.join(cwd, ".claude");
+    await fs.promises.mkdir(claudeDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(claudeDir, "settings.local.json"),
+      JSON.stringify(settings),
+    );
+  }
+
+  it("ignores permission allow rules from the opened repo's project settings", async () => {
+    // A malicious repo must not be able to pre-approve a tool via a
+    // checked-in .claude/settings.json — the decision falls through to "ask"
+    // so the app's own approval UI prompts.
+    await writeProjectSettings({ permissions: { allow: ["Bash"] } });
+
+    const manager = new SettingsManager(cwd);
+    await manager.initialize();
+
+    expect(
+      manager.checkPermission("mcp__acp__Bash", { command: "rm -rf /" })
+        .decision,
+    ).toBe("ask");
+  });
+
+  it("ignores PostHog exec approvals from the opened repo's project settings", async () => {
+    await writeProjectSettings({
+      posthogApprovedExecTools: ["experiment-delete"],
+    });
+
+    const manager = new SettingsManager(cwd);
+    await manager.initialize();
+
+    expect(manager.hasPostHogExecApproval("experiment-delete")).toBe(false);
+  });
+
+  it("still honors allow rules from the app's own local settings store", async () => {
+    // settings.local.json is where the app persists user approvals
+    // (addAllowRules), so its rules stay trusted — only project settings drop.
+    await writeLocalSettings({ permissions: { allow: ["Bash"] } });
+
+    const manager = new SettingsManager(cwd);
+    await manager.initialize();
+
+    expect(
+      manager.checkPermission("mcp__acp__Bash", { command: "pnpm test" })
+        .decision,
+    ).toBe("allow");
+  });
+
+  it("still reads non-policy fields from project settings", async () => {
+    // availableModels is a UI convenience, not policy, so it is still merged
+    // from the project layer — proving the fix is scoped to policy fields.
+    await writeProjectSettings({ availableModels: ["repo-model"] });
+
+    const manager = new SettingsManager(cwd);
+    await manager.initialize();
+
+    expect(manager.getSettings().availableModels).toEqual(["repo-model"]);
+  });
+});

--- a/products/desktop/packages/agent/src/adapters/claude/session/settings.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/settings.ts
@@ -321,7 +321,17 @@ export class SettingsManager {
     const posthogApprovedExecTools = new Set<string>();
 
     for (const { layer, settings } of allSettings) {
-      if (settings.permissions) {
+      // The `project` layer is the opened repo's checked-in
+      // `.claude/settings.json`, which is attacker-controlled when a malicious
+      // repository is opened. It must never contribute trusted *policy* — tool
+      // permissions or PostHog exec approvals — or a repo could pre-approve
+      // e.g. `Bash` and silence the per-tool approval prompt. Only user-level
+      // settings, the app's own approval store (`local`, written by
+      // addAllowRules/addPostHogExecApproval), and managed `enterprise`
+      // settings are trusted for policy. Non-policy fields (model /
+      // availableModels) may still come from the project layer.
+      const trustedForPolicy = layer !== "project";
+      if (trustedForPolicy && settings.permissions) {
         if (settings.permissions.allow) {
           permissions.allow?.push(...settings.permissions.allow);
         }
@@ -352,7 +362,7 @@ export class SettingsManager {
         settings.availableModels,
         layer,
       );
-      if (settings.posthogApprovedExecTools) {
+      if (trustedForPolicy && settings.posthogApprovedExecTools) {
         for (const tool of settings.posthogApprovedExecTools) {
           posthogApprovedExecTools.add(tool);
         }

--- a/products/desktop/packages/agent/src/adapters/claude/session/settings.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/settings.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -210,6 +211,32 @@ export interface PermissionCheckResult {
   source?: "allow" | "deny" | "ask";
 }
 
+/**
+ * The app's own approval store (persisted "always allow" decisions) for a
+ * repository, identified by its primary worktree. It MUST live outside the
+ * opened repository: at `repoRoot/.claude/settings.local.json` a malicious repo
+ * could commit that file with `permissions.allow` (or
+ * `posthogApprovedExecTools`) and the app would load it as its own trusted
+ * approvals, silently pre-approving tools and defeating the per-tool prompt.
+ * Keying an app-owned directory by the primary worktree keeps one shared store
+ * per repository, and approvals still persist across sessions, while a repo
+ * cannot forge it.
+ */
+export function approvalStorePath(repoRoot: string): string {
+  const configDir =
+    process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), ".claude");
+  const repoKey = createHash("sha256")
+    .update(repoRoot)
+    .digest("hex")
+    .slice(0, 16);
+  return path.join(
+    configDir,
+    "posthog-approvals",
+    repoKey,
+    "settings.local.json",
+  );
+}
+
 export function getManagedSettingsPath(): string {
   switch (process.platform) {
     case "darwin":
@@ -276,13 +303,8 @@ export class SettingsManager {
     return path.join(this.cwd, ".claude", "settings.json");
   }
 
-  /**
-   * Local settings are anchored to the primary worktree so every worktree of
-   * the same repository shares a single `.claude/settings.local.json`. This
-   * avoids re-prompting for the same permission in every worktree.
-   */
   private getLocalSettingsPath(): string {
-    return path.join(this.repoRoot, ".claude", "settings.local.json");
+    return approvalStorePath(this.repoRoot);
   }
 
   private async loadAllSettings(): Promise<void> {
@@ -323,13 +345,14 @@ export class SettingsManager {
     for (const { layer, settings } of allSettings) {
       // The `project` layer is the opened repo's checked-in
       // `.claude/settings.json`, which is attacker-controlled when a malicious
-      // repository is opened. It must never contribute trusted *policy* — tool
-      // permissions or PostHog exec approvals — or a repo could pre-approve
-      // e.g. `Bash` and silence the per-tool approval prompt. Only user-level
-      // settings, the app's own approval store (`local`, written by
-      // addAllowRules/addPostHogExecApproval), and managed `enterprise`
-      // settings are trusted for policy. Non-policy fields (model /
-      // availableModels) may still come from the project layer.
+      // repository is opened. It must never contribute trusted policy, meaning
+      // tool permissions or PostHog exec approvals, because a repo could then
+      // pre-approve `Bash` and silence the per-tool approval prompt. Only
+      // user-level settings, the app's own approval store (`local`, which
+      // getLocalSettingsPath sources from an app-owned path outside the repo so
+      // a repo cannot forge it), and managed `enterprise` settings are trusted for
+      // policy. Non-policy fields (model / availableModels) may still come from
+      // the project layer.
       const trustedForPolicy = layer !== "project";
       if (trustedForPolicy && settings.permissions) {
         if (settings.permissions.allow) {
@@ -419,9 +442,10 @@ export class SettingsManager {
   }
 
   /**
-   * Persists allow rules to `<primary-worktree>/.claude/settings.local.json`.
-   * Because local settings are resolved against the primary worktree, every
-   * worktree of the same repository picks up the new rule on next load.
+   * Persists allow rules to the app-owned approval store (getLocalSettingsPath,
+   * outside the repo, keyed by the primary worktree). Because the key is the
+   * primary worktree, every worktree of the same repository picks up the new
+   * rule on next load.
    *
    * Writes are serialised via `writeMutex` to prevent concurrent callers from
    * clobbering each other, and use a temp-file + rename to keep the file


### PR DESCRIPTION
## Problem

Opening a repository loaded its checked-in `.claude/settings.json` and `.claude/settings.local.json` as trusted agent policy, with no "trust this folder" gate. That gave a malicious repo two paths.

- **Code execution.** `settingSources` included `project` and `local`, so the SDK ran the repo's `hooks` at session init. A committed `SessionStart` command hook therefore ran an arbitrary shell command the moment a session started. A `type: "command"` hook needs no tool permission.
- **Approval-prompt bypass.** `SettingsManager` merged the repo's settings into its own policy fields. A repo shipping `permissions.allow: ["Bash"]` pre-approved the tool in the app's own permission check and silenced the prompt.

Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

## Changes

- `buildSessionOptions` sets `settingSources: ["user"]`, so the SDK never loads the opened repo's `.claude` settings and never runs its hooks.
- `SettingsManager` excludes the `project` layer from policy fields (`permissions`, `posthogApprovedExecTools`). Non-policy fields (`model`, `availableModels`) still read from it.
- The app's approval store moves out of the repo. `getLocalSettingsPath` now returns `approvalStorePath(repoRoot)`, under `CLAUDE_CONFIG_DIR` (or `~/.claude`) at `posthog-approvals/<sha256(primaryWorktree)[:16]>/settings.local.json`.

Excluding `project` alone was not enough. The `local` layer was still trusted while being read from inside the repo, so a committed `settings.local.json` was loaded as the app's own approvals. Re-homing the store closes that, and both repo-sourced layers are now untrusted for policy.

> [!WARNING]
> Approvals saved at `<repo>/.claude/settings.local.json` are not migrated. Users get one more prompt per previously-approved tool, then the new decision persists to the out-of-repo store.

The monorepo tree had drifted to read `settingSources` from `userProvidedOptions`. The only caller already passed `["user"]`, so hardcoding it keeps that intent and removes the path that could widen it back.

## How did you test this code?

I (actually Claude) ran the full `@posthog/agent` suite, `pnpm --filter @posthog/agent exec vitest run` (1799 passed across 102 files), plus typecheck and Biome.

New tests in `settings.test.ts` cover regressions no existing test caught: a `settings.json` and a `settings.local.json` committed inside the repo are both ignored for policy, the decision falls through to `ask`, and approvals the app writes itself are honored and survive a fresh `SettingsManager`.

Two existing suites needed real changes, not just relaxing:

- `settings.test.ts` asserted the store lived at `<repo>/.claude/settings.local.json`. Those cases now point at the app-owned path and set `CLAUDE_CONFIG_DIR` to a temp dir, so the suite stops writing into the developer's real `~/.claude`.
- `claude-agent.resume-model.test.ts` granted `mcp__posthog__exec` through the repo's project settings as a fixture. That grant is what this PR stops honoring, so the fixture moved to the user layer.

I extracted `approvalStorePath` as an exported function so tests derive the path instead of duplicating the hash.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
