### PR TITLE
fix(desktop): resolve symlinks before repo path containment

### DIFF
--- a/products/desktop/apps/code/src/main/index.ts
+++ b/products/desktop/apps/code/src/main/index.ts
@@ -423,6 +423,8 @@ app.whenReady().then(async () => {
       workspaceClient.fs.readAbsoluteFile.query({ filePath }),
     readFileAsBase64: (filePath) =>
       workspaceClient.fs.readFileAsBase64.query({ filePath }),
+    readRepoFileAsBase64: (repoPath, filePath) =>
+      workspaceClient.fs.readRepoFileAsBase64.query({ repoPath, filePath }),
     writeRepoFile: async (repoPath, filePath, content) => {
       await workspaceClient.fs.writeRepoFile.mutate({
         repoPath,

--- a/products/desktop/apps/web/src/web-host-router.ts
+++ b/products/desktop/apps/web/src/web-host-router.ts
@@ -241,6 +241,11 @@ const fsStubRouter = router({
   readFileAsBase64: publicProcedure
     .input(z.object({ filePath: z.string() }))
     .query(({ input }) => getWebAttachmentBase64(input.filePath)),
+  // Web is cloud-only: no local working tree, so there is no in-repo binary to
+  // read. Present to match the desktop HostRouter shape; always resolves null.
+  readRepoFileAsBase64: publicProcedure
+    .input(z.object({ repoPath: z.string(), filePath: z.string() }))
+    .query(() => null),
 });
 
 const skillsStubRouter = router({

--- a/products/desktop/packages/core/src/code-editor/pathUtils.test.ts
+++ b/products/desktop/packages/core/src/code-editor/pathUtils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { getRelativePath, isInsideRepoPath } from "./pathUtils";
+
+describe("repo path containment", () => {
+  it.each([
+    { name: "file in the repo", abs: "/a/project/src/x.ts", inside: true },
+    { name: "the repo root itself", abs: "/a/project", inside: true },
+    {
+      name: "sibling with a shared prefix",
+      abs: "/a/project2/x.ts",
+      inside: false,
+    },
+    { name: "unrelated path", abs: "/b/other/x.ts", inside: false },
+    { name: "windows separator", abs: "/a/project\\src\\x.ts", inside: true },
+  ])("$name", ({ abs, inside }) => {
+    expect(isInsideRepoPath(abs, "/a/project")).toBe(inside);
+  });
+
+  it.each([null, undefined, ""])("treats %s repo path as outside", (repo) => {
+    expect(isInsideRepoPath("/a/project/x.ts", repo)).toBe(false);
+  });
+
+  // A sibling directory used to slice into a bogus repo-relative path
+  // ("2/logo.png"), which routed the read at the repo reader and failed.
+  it("returns the absolute path for a sibling directory", () => {
+    expect(getRelativePath("/a/project2/logo.png", "/a/project")).toBe(
+      "/a/project2/logo.png",
+    );
+  });
+
+  it("returns the repo-relative path for repo content", () => {
+    expect(getRelativePath("/a/project/src/x.ts", "/a/project")).toBe(
+      "src/x.ts",
+    );
+  });
+
+  it("ignores a trailing separator on the repo path", () => {
+    expect(getRelativePath("/a/project/src/x.ts", "/a/project/")).toBe(
+      "src/x.ts",
+    );
+  });
+});

--- a/products/desktop/packages/core/src/code-editor/pathUtils.ts
+++ b/products/desktop/packages/core/src/code-editor/pathUtils.ts
@@ -1,9 +1,34 @@
+// A path counts as inside the repo only when the repo path is followed by a
+// separator, so a sibling directory whose name merely starts the same way
+// (`/a/project2` against repo `/a/project`) is not taken for repo content. Both
+// separators are accepted because this is host-agnostic and runs on Windows.
+export function isInsideRepoPath(
+  absolutePath: string,
+  repoPath: string | null | undefined,
+): boolean {
+  if (!repoPath) {
+    return false;
+  }
+  const base = stripTrailingSeparator(repoPath);
+  if (absolutePath === base) {
+    return true;
+  }
+  const boundary = absolutePath[base.length];
+  return (
+    absolutePath.startsWith(base) && (boundary === "/" || boundary === "\\")
+  );
+}
+
 export function getRelativePath(
   absolutePath: string,
   repoPath: string | null | undefined,
 ): string {
-  if (!repoPath || !absolutePath.startsWith(repoPath)) {
+  if (!repoPath || !isInsideRepoPath(absolutePath, repoPath)) {
     return absolutePath;
   }
-  return absolutePath.slice(repoPath.length + 1);
+  return absolutePath.slice(stripTrailingSeparator(repoPath).length + 1);
+}
+
+function stripTrailingSeparator(value: string): string {
+  return value.replace(/[/\\]+$/, "");
 }

--- a/products/desktop/packages/host-router/src/routers/fs.router.ts
+++ b/products/desktop/packages/host-router/src/routers/fs.router.ts
@@ -82,6 +82,15 @@ export const fsRouter = router({
         .readFileAsBase64(input.filePath),
     ),
 
+  readRepoFileAsBase64: publicProcedure
+    .input(readRepoFileInput)
+    .output(readRepoFileOutput)
+    .query(({ ctx, input }) =>
+      ctx.container
+        .get<FsCapability>(FS_SERVICE)
+        .readRepoFileAsBase64(input.repoPath, input.filePath),
+    ),
+
   writeRepoFile: publicProcedure
     .input(writeRepoFileInput)
     .mutation(({ ctx, input }) =>

--- a/products/desktop/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
+++ b/products/desktop/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
@@ -30,6 +30,7 @@ import { useCloudFileContent } from "../hooks/useCloudFileContent";
 import {
   useAbsoluteFileContent,
   useFileAsBase64,
+  useRepoFileAsBase64,
   useRepoFileContent,
 } from "../hooks/useFileContent";
 import { useFileEnrichment } from "../hooks/useFileEnrichment";
@@ -184,7 +185,19 @@ export function CodeEditorPanel({
     absolutePath,
     source.absoluteEnabled,
   );
-  const imageQuery = useFileAsBase64(absolutePath, source.imageEnabled);
+  // In-repo images are confined to the repo (symlink-aware); images opened
+  // outside any repo fall back to the absolute read. Both hooks run (React rules)
+  // but only the matching one is enabled.
+  const repoImageQuery = useRepoFileAsBase64(
+    repoPath ?? "",
+    filePath,
+    source.imageEnabled && isInsideRepo,
+  );
+  const absoluteImageQuery = useFileAsBase64(
+    absolutePath,
+    source.imageEnabled && !isInsideRepo,
+  );
+  const imageQuery = isInsideRepo ? repoImageQuery : absoluteImageQuery;
 
   const localQuery = isInsideRepo ? repoQuery : absoluteQuery;
   const {

--- a/products/desktop/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
+++ b/products/desktop/packages/ui/src/features/code-editor/components/CodeEditorPanel.tsx
@@ -4,7 +4,10 @@ import {
   resolveMarkdownLink,
   selectFileSource,
 } from "@posthog/core/code-editor/fileSource";
-import { getRelativePath } from "@posthog/core/code-editor/pathUtils";
+import {
+  getRelativePath,
+  isInsideRepoPath,
+} from "@posthog/core/code-editor/pathUtils";
 import { buildFileLineReferencePrompt } from "@posthog/core/code-review/reviewPrompts";
 import { xmlToContent } from "@posthog/core/message-editor/content";
 import {
@@ -108,7 +111,7 @@ export function CodeEditorPanel({
   absolutePath,
 }: CodeEditorPanelProps) {
   const repoPath = useCwd(taskId);
-  const isInsideRepo = !!repoPath && absolutePath.startsWith(repoPath);
+  const isInsideRepo = isInsideRepoPath(absolutePath, repoPath);
   const filePath = getRelativePath(absolutePath, repoPath);
   const isImage = isRasterImageFile(absolutePath);
   const renderableKind = getRenderableKind(absolutePath);

--- a/products/desktop/packages/ui/src/features/code-editor/hooks/useFileContent.ts
+++ b/products/desktop/packages/ui/src/features/code-editor/hooks/useFileContent.ts
@@ -39,11 +39,35 @@ export function useAbsoluteFileContent(filePath: string, enabled: boolean) {
   );
 }
 
+// Out-of-repo, user-chosen files (attachments, or an image opened outside any
+// repo). For a file inside a repo use useRepoFileAsBase64 so the read is
+// confined to the repo.
 export function useFileAsBase64(filePath: string, enabled: boolean) {
   const trpc = useHostTRPC();
   return useQuery(
     trpc.fs.readFileAsBase64.queryOptions(
       { filePath },
+      {
+        enabled,
+        staleTime: Number.POSITIVE_INFINITY,
+        gcTime: FILE_CONTENT_GC_MS,
+      },
+    ),
+  );
+}
+
+// In-repo binaries (images/video surfaced from the file tree or a code-review
+// diff). The host confines the read to `repoPath` (symlink-aware), so a symlink
+// committed under a binary filename cannot read a file outside the repo.
+export function useRepoFileAsBase64(
+  repoPath: string,
+  filePath: string,
+  enabled: boolean,
+) {
+  const trpc = useHostTRPC();
+  return useQuery(
+    trpc.fs.readRepoFileAsBase64.queryOptions(
+      { repoPath, filePath },
       {
         enabled,
         staleTime: Number.POSITIVE_INFINITY,

--- a/products/desktop/packages/ui/src/features/code-review/components/BinaryFileDiff.tsx
+++ b/products/desktop/packages/ui/src/features/code-review/components/BinaryFileDiff.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from "react";
 import { useInView } from "../../../primitives/hooks/useInView";
 import { SafeImagePreview } from "../../../primitives/SafeImagePreview";
 import { SafeVideoPreview } from "../../../primitives/SafeVideoPreview";
-import { useFileAsBase64 } from "../../code-editor/hooks/useFileContent";
+import { useRepoFileAsBase64 } from "../../code-editor/hooks/useFileContent";
 import { REVIEW_PREFETCH_ROOT_MARGIN } from "../constants";
 import {
   FileHeaderRow,
@@ -28,10 +28,17 @@ function classifyBinaryFile(filePath: string): BinaryMediaKind {
 interface BinaryFileDiffProps {
   filePath: string;
   /**
-   * Absolute path of the working-tree file to preview. Omit when no local file
-   * is available (e.g. branch/PR diffs) — the body falls back to a placeholder.
+   * Absolute path of the working-tree file. Set when a local file is available
+   * to preview; omit when it is not (e.g. branch/PR diffs) to fall back to a
+   * placeholder. Must travel together with `repoPath`.
    */
   absolutePath?: string;
+  /**
+   * Repo root of the working-tree file, required alongside `absolutePath`. The
+   * preview read (`useRepoFileAsBase64`) is confined to it (symlink-aware) so a
+   * symlink committed under a binary filename cannot read a file outside it.
+   */
+  repoPath?: string;
   collapsed: boolean;
   onToggle: () => void;
   onOpenFile?: () => void;
@@ -47,16 +54,20 @@ function BinaryBodyMessage({ children }: { children: ReactNode }) {
 
 function BinaryMediaBody({
   kind,
-  absolutePath,
+  repoPath,
   filePath,
   enabled,
 }: {
   kind: "image" | "video";
-  absolutePath: string;
+  repoPath: string;
   filePath: string;
   enabled: boolean;
 }) {
-  const { data, isLoading, error } = useFileAsBase64(absolutePath, enabled);
+  const { data, isLoading, error } = useRepoFileAsBase64(
+    repoPath,
+    filePath,
+    enabled,
+  );
 
   if (!enabled || isLoading) {
     return <BinaryBodyMessage>Loading preview…</BinaryBodyMessage>;
@@ -97,6 +108,7 @@ function BinaryMediaBody({
 export function BinaryFileDiff({
   filePath,
   absolutePath,
+  repoPath,
   collapsed,
   onToggle,
   onOpenFile,
@@ -127,10 +139,10 @@ export function BinaryFileDiff({
         }
       />
       {!collapsed &&
-        (previewKind && absolutePath ? (
+        (previewKind && absolutePath && repoPath ? (
           <BinaryMediaBody
             kind={previewKind}
-            absolutePath={absolutePath}
+            repoPath={repoPath}
             filePath={filePath}
             enabled={inView}
           />

--- a/products/desktop/packages/ui/src/features/code-review/components/ReviewRows.tsx
+++ b/products/desktop/packages/ui/src/features/code-review/components/ReviewRows.tsx
@@ -97,6 +97,7 @@ export const PatchRow = memo(function PatchRow({
       <BinaryFileDiff
         filePath={filePath}
         absolutePath={`${repoPath}/${filePath}`}
+        repoPath={repoPath}
         collapsed={collapsed}
         onToggle={onToggle}
         onOpenFile={onOpenFile}
@@ -161,6 +162,7 @@ export const UntrackedRow = memo(function UntrackedRow({
       <BinaryFileDiff
         filePath={file.path}
         absolutePath={`${repoPath}/${file.path}`}
+        repoPath={repoPath}
         collapsed={collapsed}
         onToggle={onToggle}
       />

--- a/products/desktop/packages/workspace-server/src/services/fs/identifiers.ts
+++ b/products/desktop/packages/workspace-server/src/services/fs/identifiers.ts
@@ -25,6 +25,10 @@ export interface FsCapability {
   ): Promise<Record<string, BoundedReadResult>>;
   readAbsoluteFile(filePath: string): Promise<string | null>;
   readFileAsBase64(filePath: string): Promise<string | null>;
+  readRepoFileAsBase64(
+    repoPath: string,
+    filePath: string,
+  ): Promise<string | null>;
   writeRepoFile(
     repoPath: string,
     filePath: string,

--- a/products/desktop/packages/workspace-server/src/services/fs/service.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/fs/service.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -109,6 +109,87 @@ describe("FsService repo file IO", () => {
     await expect(
       service.writeRepoFile(repo, "../escape.txt", "x"),
     ).rejects.toThrow(/Access denied/);
+  });
+
+  it("refuses to read through a symlink that escapes the repository", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "fs-service-outside-"));
+    try {
+      await writeFile(path.join(outside, "secret.txt"), "SECRET");
+      // A symlink named like an ordinary repo file, pointing outside the repo:
+      // the path is lexically inside the repo but resolves out of it.
+      await symlink(
+        path.join(outside, "secret.txt"),
+        path.join(repo, "config.json"),
+      );
+      expect(await service.readRepoFile(repo, "config.json")).toBeNull();
+
+      // Also blocked when reached through a symlinked directory.
+      await symlink(outside, path.join(repo, "sub"));
+      expect(await service.readRepoFile(repo, "sub/secret.txt")).toBeNull();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to write through a symlink that escapes the repository", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "fs-service-outside-"));
+    try {
+      await writeFile(path.join(outside, "target.txt"), "original");
+      await symlink(
+        path.join(outside, "target.txt"),
+        path.join(repo, "notes.txt"),
+      );
+
+      await expect(
+        service.writeRepoFile(repo, "notes.txt", "attacker"),
+      ).rejects.toThrow(/Access denied/);
+      // The file outside the repo must be untouched.
+      expect(await readFile(path.join(outside, "target.txt"), "utf-8")).toBe(
+        "original",
+      );
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses to write through a dangling symlink that would create a file outside the repository", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "fs-service-outside-"));
+    try {
+      // A symlink whose target does NOT exist yet, pointing outside the repo.
+      // fs.realpath throws ENOENT on such a link, so a containment check that
+      // only realpaths the deepest existing component mistakes it for an in-repo
+      // new file, so the write follows it and creates the outside file.
+      const danglingTarget = path.join(outside, "brand-new.txt");
+      await symlink(danglingTarget, path.join(repo, "evil.txt"));
+
+      await expect(
+        service.writeRepoFile(repo, "evil.txt", "attacker"),
+      ).rejects.toThrow(/Access denied/);
+      // The outside file must not have been created.
+      await expect(readFile(danglingTarget, "utf-8")).rejects.toThrow();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("confines readRepoFileAsBase64 to the repo (symlink escape blocked)", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "fs-service-outside-"));
+    try {
+      await writeFile(path.join(outside, "id_rsa"), "SSH-KEY");
+      // A symlink committed under a binary filename, pointing outside the repo.
+      await symlink(path.join(outside, "id_rsa"), path.join(repo, "logo.png"));
+
+      // The escaping symlink is blocked.
+      expect(await service.readRepoFileAsBase64(repo, "logo.png")).toBeNull();
+
+      // A legitimate in-repo binary still reads.
+      await writeFile(path.join(repo, "pic.png"), "PICBYTES");
+      expect(await service.readRepoFileAsBase64(repo, "pic.png")).toBe(
+        Buffer.from("PICBYTES").toString("base64"),
+      );
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
   });
 
   it("bounds reads by line count", async () => {

--- a/products/desktop/packages/workspace-server/src/services/fs/service.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/fs/service.test.ts
@@ -172,6 +172,25 @@ describe("FsService repo file IO", () => {
     }
   });
 
+  it("refuses to write through a chain of symlinks ending outside the repository", async () => {
+    const outside = await mkdtemp(path.join(tmpdir(), "fs-service-outside-"));
+    try {
+      // Chaining hides the escape from a single-hop check: resolving `first`
+      // one hop lands on the in-repo name `second`, and because the chain
+      // dangles, realpath cannot see past it to the outside target.
+      const danglingTarget = path.join(outside, "brand-new.txt");
+      await symlink(danglingTarget, path.join(repo, "second"));
+      await symlink(path.join(repo, "second"), path.join(repo, "first"));
+
+      await expect(
+        service.writeRepoFile(repo, "first", "attacker"),
+      ).rejects.toThrow(/Access denied/);
+      await expect(readFile(danglingTarget, "utf-8")).rejects.toThrow();
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
   it("confines readRepoFileAsBase64 to the repo (symlink escape blocked)", async () => {
     const outside = await mkdtemp(path.join(tmpdir(), "fs-service-outside-"));
     try {

--- a/products/desktop/packages/workspace-server/src/services/fs/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/fs/service.ts
@@ -333,7 +333,7 @@ export class FsService {
 // therefore reads as contained while the OS still follows both links out.
 async function realTargetForContainment(resolved: string): Promise<string> {
   let current = resolved;
-  for (let hop = 0; hop <= MAX_SYMLINK_HOPS; hop++) {
+  for (let hop = 0; hop < MAX_SYMLINK_HOPS; hop++) {
     const realParent = await realpathAllowingMissing(path.dirname(current));
     const leaf = path.join(realParent, path.basename(current));
     let stats: Awaited<ReturnType<typeof fs.lstat>>;

--- a/products/desktop/packages/workspace-server/src/services/fs/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/fs/service.ts
@@ -4,6 +4,9 @@ import { getChangedFiles, listAllFiles } from "@posthog/git/queries";
 import { injectable } from "inversify";
 import type { BoundedReadResult, DirectoryEntry, FileEntry } from "./schemas";
 
+// Matches Linux's own MAXSYMLINKS, so any chain we refuse the OS would too.
+const MAX_SYMLINK_HOPS = 40;
+
 @injectable()
 export class FsService {
   private static readonly CACHE_TTL = 30000;
@@ -314,7 +317,7 @@ export class FsService {
   }
 }
 
-// Resolve the real path the OS would open for `resolved`, resolving the parent
+// Resolve the real path the OS would open for `resolved`, resolving each parent
 // directory with realpath but inspecting the final component with lstat.
 // realpath alone cannot tell a not-yet-created file apart from a *dangling*
 // symlink -- one whose own name exists but whose target does not -- because it
@@ -322,21 +325,34 @@ export class FsService {
 // then be mistaken for an in-repo new file, and fs.writeFile would follow it and
 // create a file outside the repo. Resolving the parent and lstat-ing the leaf
 // closes that gap while still allowing legitimate new-file writes.
+//
+// The walk repeats per link because only the terminal target is read or written,
+// and a single hop is not enough to find it: with `a -> b` in the repo and a
+// dangling `b -> /outside/missing`, resolving `a` one hop lands on the in-repo
+// name `b`, which realpath cannot resolve past (the chain dangles) and which
+// therefore reads as contained while the OS still follows both links out.
 async function realTargetForContainment(resolved: string): Promise<string> {
-  const realParent = await realpathAllowingMissing(path.dirname(resolved));
-  const leaf = path.join(realParent, path.basename(resolved));
-  try {
-    const stats = await fs.lstat(leaf);
-    if (stats.isSymbolicLink()) {
-      const linkTarget = path.resolve(realParent, await fs.readlink(leaf));
-      return await realpathAllowingMissing(linkTarget);
+  let current = resolved;
+  for (let hop = 0; hop <= MAX_SYMLINK_HOPS; hop++) {
+    const realParent = await realpathAllowingMissing(path.dirname(current));
+    const leaf = path.join(realParent, path.basename(current));
+    let stats: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+      stats = await fs.lstat(leaf);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      return leaf;
     }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
+    if (!stats.isSymbolicLink()) {
+      return leaf;
     }
+    current = path.resolve(realParent, await fs.readlink(leaf));
   }
-  return leaf;
+  // Only reachable via a symlink cycle or an absurdly long chain, which the OS
+  // would refuse with ELOOP anyway. Fail closed rather than return a guess.
+  throw new Error("Access denied: symlink chain too deep");
 }
 
 // Resolve symlinks on the deepest existing prefix of `target`, then re-append

--- a/products/desktop/packages/workspace-server/src/services/fs/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/fs/service.ts
@@ -93,7 +93,10 @@ export class FsService {
     filePath: string,
   ): Promise<string | null> {
     try {
-      return await fs.readFile(this.resolvePath(repoPath, filePath), "utf-8");
+      return await fs.readFile(
+        await this.resolvePath(repoPath, filePath),
+        "utf-8",
+      );
     } catch {
       return null;
     }
@@ -120,7 +123,7 @@ export class FsService {
   ): Promise<BoundedReadResult> {
     try {
       const content = await fs.readFile(
-        this.resolvePath(repoPath, filePath),
+        await this.resolvePath(repoPath, filePath),
         "utf-8",
       );
       if (exceedsLineLimit(content, maxLines)) {
@@ -158,6 +161,24 @@ export class FsService {
     }
   }
 
+  // Read an in-repo binary (image/video preview) as base64, confined to the repo
+  // so a symlink committed under a binary filename cannot escape it. This is the
+  // only base64 read path for repo files; readFileAsBase64 below is reserved for
+  // genuine out-of-repo, user-chosen files (e.g. attachment upload).
+  async readRepoFileAsBase64(
+    repoPath: string,
+    filePath: string,
+  ): Promise<string | null> {
+    try {
+      const buffer = await fs.readFile(
+        await this.resolvePath(repoPath, filePath),
+      );
+      return buffer.toString("base64");
+    } catch {
+      return null;
+    }
+  }
+
   async readFileAsBase64(filePath: string): Promise<string | null> {
     const resolved = path.resolve(filePath);
     try {
@@ -190,15 +211,38 @@ export class FsService {
     filePath: string,
     content: string,
   ): Promise<void> {
-    await fs.writeFile(this.resolvePath(repoPath, filePath), content, "utf-8");
+    await fs.writeFile(
+      await this.resolvePath(repoPath, filePath),
+      content,
+      "utf-8",
+    );
     this.invalidateCache(repoPath);
   }
 
-  private resolvePath(repoPath: string, filePath: string): string {
+  private async resolvePath(
+    repoPath: string,
+    filePath: string,
+  ): Promise<string> {
     const base = path.resolve(repoPath);
     const resolved = path.resolve(base, filePath);
+    // Lexical containment rejects `../` escapes.
     if (resolved !== base && !resolved.startsWith(base + path.sep)) {
       throw new Error("Access denied: path outside repository");
+    }
+    // Symlink-aware containment: a symlink committed inside the repo can point
+    // outside it, which the lexical check above cannot see. Resolve the real
+    // target the OS would open and confirm it is still inside the repo's real
+    // base.
+    const realBase = await fs.realpath(base);
+    if (resolved === base) {
+      return resolved;
+    }
+    const realTarget = await realTargetForContainment(resolved);
+    if (
+      realTarget !== realBase &&
+      !realTarget.startsWith(realBase + path.sep)
+    ) {
+      throw new Error("Access denied: path escapes repository via symlink");
     }
     return resolved;
   }
@@ -268,6 +312,54 @@ export class FsService {
 
     return results;
   }
+}
+
+// Resolve the real path the OS would open for `resolved`, resolving the parent
+// directory with realpath but inspecting the final component with lstat.
+// realpath alone cannot tell a not-yet-created file apart from a *dangling*
+// symlink -- one whose own name exists but whose target does not -- because it
+// throws ENOENT for both. A dangling symlink pointing outside the repo would
+// then be mistaken for an in-repo new file, and fs.writeFile would follow it and
+// create a file outside the repo. Resolving the parent and lstat-ing the leaf
+// closes that gap while still allowing legitimate new-file writes.
+async function realTargetForContainment(resolved: string): Promise<string> {
+  const realParent = await realpathAllowingMissing(path.dirname(resolved));
+  const leaf = path.join(realParent, path.basename(resolved));
+  try {
+    const stats = await fs.lstat(leaf);
+    if (stats.isSymbolicLink()) {
+      const linkTarget = path.resolve(realParent, await fs.readlink(leaf));
+      return await realpathAllowingMissing(linkTarget);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  return leaf;
+}
+
+// Resolve symlinks on the deepest existing prefix of `target`, then re-append
+// any not-yet-existing tail (which cannot contain symlinks precisely because it
+// does not exist). Lets containment see through a symlink while still allowing
+// writes that create new files or directories.
+async function realpathAllowingMissing(target: string): Promise<string> {
+  const { root } = path.parse(target);
+  const segments = target.slice(root.length).split(path.sep).filter(Boolean);
+  for (let i = segments.length; i >= 0; i--) {
+    const candidate = path.join(root, ...segments.slice(0, i));
+    try {
+      const real = await fs.realpath(candidate);
+      return i === segments.length
+        ? real
+        : path.join(real, ...segments.slice(i));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  return target;
 }
 
 function exceedsLineLimit(content: string, maxLines: number): boolean {

--- a/products/desktop/packages/workspace-server/src/trpc.ts
+++ b/products/desktop/packages/workspace-server/src/trpc.ts
@@ -856,6 +856,13 @@ export function createAppRouter({
         .output(readRepoFileOutput)
         .query(({ input }) => fsService().readFileAsBase64(input.filePath)),
 
+      readRepoFileAsBase64: t.procedure
+        .input(readRepoFileInput)
+        .output(readRepoFileOutput)
+        .query(({ input }) =>
+          fsService().readRepoFileAsBase64(input.repoPath, input.filePath),
+        ),
+
       writeRepoFile: t.procedure
         .input(writeRepoFileInput)
         .mutation(({ input }) =>


### PR DESCRIPTION
## Problem

- `FsService.resolvePath` enforced repo containment with a lexical string check, `resolved.startsWith(base + sep)`.
- It normalized `../` but never resolved symlinks, so a symlink committed inside a repo whose target points outside it passed the check.
- `fs.readFile` and `fs.writeFile` then followed that link.
- Git delivers these as mode `120000` blobs, and `git clone` recreates the link with the attacker's target.

That gave a malicious repo two primitives:

- **Read.** A symlink like `config.json` pointing at `~/.aws/credentials`, surfaced by clicking it in the file tree or by the code-review prefetch.
- **Write.** A symlink like `notes.txt` pointing at `~/.zshrc`, clobbering or creating a file outside the repo.

Separately, the base64 read path for in-repo binaries never went through `resolvePath` at all. `selectFileSource` routes every in-repo image through it, so a symlink under a binary filename (`logo.png` pointing at `~/.ssh/id_rsa`) still read arbitrary files.

Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

## Changes

`resolvePath` is now async and adds a symlink-aware check after the lexical one. It realpaths the repo base, realpaths the parent directory, and inspects the final component with `lstat`.

> [!NOTE]
> Using `lstat` on the leaf rather than `realpath` is what makes this correct for a dangling symlink, one whose own name exists but whose target does not. `realpath` throws `ENOENT` for both a missing file and a dangling link, so a realpath-only check mistakes a dangling link pointing outside the repo for a legitimate new file and lets the write follow it. `lstat` sees the link and rejects it, while genuine new-file writes still work, because a tail that does not exist cannot contain a symlink.

Both the read and write paths funnel through `resolvePath`, so this closes the read escape, the write escape and the dangling-write variant in one place.

For the binary path, a new `readRepoFileAsBase64(repoPath, filePath)` always confines the read. `readFileAsBase64` stays as-is for genuine out-of-repo attachment reads. `repoPath` is required end to end, so the repo read path has no uncontained mode. It is wired through `fs.router.ts`, `trpc.ts`, the desktop adapter in `main/index.ts`, a web stub returning `null`, and the editor and code-review previews.

`readFileAsBase64` and `readAbsoluteFile` stay unguarded by design. They take an intentionally absolute, user-chosen path and are never driven by repo content.

One known residual, out of scope: `resolvePath` validates with realpath and `lstat` but returns the lexical path, which the caller reopens. That is a check-then-use window. Under this threat model, a static malicious repo, there is no actor to win the race and every static symlink case is rejected. `O_NOFOLLOW` or `openat`-relative I/O would close it for a local-attacker model.

## How did you test this code?

I (actually Claude) ran `pnpm --filter @posthog/workspace-server exec vitest run src/services/fs/service.test.ts` (12 passed) and `pnpm typecheck` across all 24 desktop packages, plus Biome.

New cases in `service.test.ts` cover regressions no existing test caught:

- Reading a symlink, and a symlinked directory, that escapes the repo returns `null`.
- Writing through an escaping symlink throws `Access denied`.
- Writing through a dangling symlink is rejected and creates no outside file.
- `readRepoFileAsBase64` blocks an escaping symlink and still reads a legitimate in-repo binary.

The existing `../` rejection, legitimate reads and writes, new-file writes and in-repo symlinks all still pass.

> [!WARNING]
> The full `@posthog/workspace-server` suite has 35 failures in `db/migrate.test.ts` and the repository tests. I confirmed the identical 35 fail on `origin/master`: `better-sqlite3` cannot locate its native binding in my environment, and `scripts/rebuild-better-sqlite3-node.mjs` did not fix it. They are unrelated to this diff. On this branch the suite is 782 passed against master's 778, which is the 4 new cases.

I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.
