### PR TITLE
chore(desktop): add Windows code-signing config for verified auto-updates

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -304,25 +304,6 @@ jobs:
             POSTHOG_SOURCEMAP_API_KEY: ${{ secrets.DESKTOP_POSTHOG_SOURCEMAP_API_KEY }}
             POSTHOG_ENV_ID: ${{ secrets.DESKTOP_POSTHOG_ENV_ID }}
             POSTHOG_HOST: ${{ secrets.DESKTOP_POSTHOG_HOST }}
-            # Windows Authenticode signing (Azure Trusted Signing), mirroring the
-            # macOS CSC_*/APPLE_* wiring in publish-macos. Without these,
-            # electron-builder produces an unsigned installer and electron-updater
-            # skips signature verification of downloaded updates (see
-            # products/desktop/apps/code/electron-builder.ts). electron-builder reads
-            # the AZURE_* credentials via Entra ID EnvironmentCredential and
-            # auto-installs the TrustedSigning module, so no extra step is needed.
-            # The env var names are what electron-builder reads and must stay bare;
-            # only the secret lookups carry the DESKTOP_ prefix, because AZURE_* is
-            # too generic to claim repo-wide (MIGRATION.md transform rule 15).
-            # DESKTOP_WINDOWS_PUBLISHER_NAME must match the certificate subject
-            # exactly, since it is verified on every update.
-            WINDOWS_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_PUBLISHER_NAME }}
-            AZURE_TENANT_ID: ${{ secrets.DESKTOP_AZURE_TENANT_ID }}
-            AZURE_CLIENT_ID: ${{ secrets.DESKTOP_AZURE_CLIENT_ID }}
-            AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_AZURE_CLIENT_SECRET }}
-            AZURE_CODE_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_AZURE_CODE_SIGNING_ENDPOINT }}
-            AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.DESKTOP_AZURE_CODE_SIGNING_ACCOUNT }}
-            AZURE_CERT_PROFILE_NAME: ${{ secrets.DESKTOP_AZURE_CERT_PROFILE_NAME }}
         steps:
             - name: Get app token
               id: app-token
@@ -401,8 +382,35 @@ jobs:
               working-directory: products/desktop/apps/code
               run: pnpm exec electron-vite build
 
+            # Windows Authenticode signing, mirroring the macOS CSC_*/APPLE_*
+            # wiring in publish-macos. Without these, electron-builder produces an
+            # unsigned installer and electron-updater skips signature verification
+            # of downloaded updates (see
+            # products/desktop/apps/code/electron-builder.ts). electron-builder
+            # reads the AZURE_* credentials via Entra ID EnvironmentCredential and
+            # auto-installs the TrustedSigning module, so no extra step is needed;
+            # WIN_CSC_* is the PFX fallback for when no Trusted Signing account
+            # exists. The env var names are what electron-builder reads and must
+            # stay bare; only the secret lookups carry the DESKTOP_ prefix, because
+            # AZURE_* is too generic to claim repo-wide (MIGRATION.md transform
+            # rule 15). DESKTOP_WINDOWS_PUBLISHER_NAME must match the certificate
+            # subject exactly, since it is verified on every update.
+            #
+            # Scoped to this step rather than the job: a signing credential in the
+            # job env is readable by every dependency install script and build
+            # command in the job, and this is the only step that signs.
             - name: Package installer
               working-directory: products/desktop/apps/code
+              env:
+                  WINDOWS_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_PUBLISHER_NAME }}
+                  AZURE_TENANT_ID: ${{ secrets.DESKTOP_AZURE_TENANT_ID }}
+                  AZURE_CLIENT_ID: ${{ secrets.DESKTOP_AZURE_CLIENT_ID }}
+                  AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_AZURE_CLIENT_SECRET }}
+                  AZURE_CODE_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_AZURE_CODE_SIGNING_ENDPOINT }}
+                  AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.DESKTOP_AZURE_CODE_SIGNING_ACCOUNT }}
+                  AZURE_CERT_PROFILE_NAME: ${{ secrets.DESKTOP_AZURE_CERT_PROFILE_NAME }}
+                  WIN_CSC_LINK: ${{ secrets.DESKTOP_WIN_CSC_LINK }}
+                  WIN_CSC_KEY_PASSWORD: ${{ secrets.DESKTOP_WIN_CSC_KEY_PASSWORD }}
               run: pnpm exec electron-builder build --win --x64 --publish never --config electron-builder.ts
 
             - name: Verify package

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -304,6 +304,25 @@ jobs:
             POSTHOG_SOURCEMAP_API_KEY: ${{ secrets.DESKTOP_POSTHOG_SOURCEMAP_API_KEY }}
             POSTHOG_ENV_ID: ${{ secrets.DESKTOP_POSTHOG_ENV_ID }}
             POSTHOG_HOST: ${{ secrets.DESKTOP_POSTHOG_HOST }}
+            # Windows Authenticode signing (Azure Trusted Signing), mirroring the
+            # macOS CSC_*/APPLE_* wiring in publish-macos. Without these,
+            # electron-builder produces an unsigned installer and electron-updater
+            # skips signature verification of downloaded updates (see
+            # products/desktop/apps/code/electron-builder.ts). electron-builder reads
+            # the AZURE_* credentials via Entra ID EnvironmentCredential and
+            # auto-installs the TrustedSigning module, so no extra step is needed.
+            # The env var names are what electron-builder reads and must stay bare;
+            # only the secret lookups carry the DESKTOP_ prefix, because AZURE_* is
+            # too generic to claim repo-wide (MIGRATION.md transform rule 15).
+            # DESKTOP_WINDOWS_PUBLISHER_NAME must match the certificate subject
+            # exactly, since it is verified on every update.
+            WINDOWS_PUBLISHER_NAME: ${{ secrets.DESKTOP_WINDOWS_PUBLISHER_NAME }}
+            AZURE_TENANT_ID: ${{ secrets.DESKTOP_AZURE_TENANT_ID }}
+            AZURE_CLIENT_ID: ${{ secrets.DESKTOP_AZURE_CLIENT_ID }}
+            AZURE_CLIENT_SECRET: ${{ secrets.DESKTOP_AZURE_CLIENT_SECRET }}
+            AZURE_CODE_SIGNING_ENDPOINT: ${{ secrets.DESKTOP_AZURE_CODE_SIGNING_ENDPOINT }}
+            AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.DESKTOP_AZURE_CODE_SIGNING_ACCOUNT }}
+            AZURE_CERT_PROFILE_NAME: ${{ secrets.DESKTOP_AZURE_CERT_PROFILE_NAME }}
         steps:
             - name: Get app token
               id: app-token

--- a/products/desktop/MIGRATION.md
+++ b/products/desktop/MIGRATION.md
@@ -268,7 +268,13 @@ ports from source using these rules.
     only; the env var handed to the build keeps its original name, because the app reads it:
     `POSTHOG_ENV_ID: ${{ secrets.DESKTOP_POSTHOG_ENV_ID }}`. Applies to
     `POSTHOG_SOURCEMAP_API_KEY`, `POSTHOG_ENV_ID` and `POSTHOG_HOST` across desktop-release,
-    desktop-build-test, desktop-pr-build-installer and desktop-update-e2e. Left bare:
+    desktop-build-test, desktop-pr-build-installer and desktop-update-e2e. The same
+    treatment covers the Windows Authenticode signing secrets in desktop-release's
+    `publish-windows` job (`WINDOWS_PUBLISHER_NAME`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+    `AZURE_CLIENT_SECRET`, `AZURE_CODE_SIGNING_ENDPOINT`, `AZURE_CODE_SIGNING_ACCOUNT`,
+    `AZURE_CERT_PROFILE_NAME`): `AZURE_*` is far too generic to claim repo-wide, and
+    electron-builder reads the bare names from the environment, so only the `secrets.`
+    lookup is prefixed. Left bare:
     `VITE_POSTHOG_API_KEY` and `VITE_POSTHOG_API_HOST` (already org-wide and shared), names
     that already carry a desktop, twig or code qualifier (`AWS_DESKTOP_*`, `AWS_TWIG_*`,
     `POSTHOG_CODE_E2E_*`) and genuinely repo-wide ones (`TRUNK_API_TOKEN`, `VR_API_TOKEN`,
@@ -303,6 +309,12 @@ the PR's side; that file is the one to follow on merge day.
   `POSTHOG_CODE_E2E_*` (secret + vars), `TRUNK_API_TOKEN`, Discord webhook, App Store
   Connect (mobile). Until they exist, the corresponding workflows red on this PR — that is
   the dry run telling us which are missing.
+- **Windows signing (not yet provisioned)**: `publish-windows` reads
+  `DESKTOP_WINDOWS_PUBLISHER_NAME` plus either the `DESKTOP_AZURE_*` set (Azure Trusted
+  Signing, preferred) or `WIN_CSC_LINK`/`WIN_CSC_KEY_PASSWORD` (PFX). None exist yet, so
+  `windowsSigningOptions()` returns `{}` and Windows builds still ship **unsigned**, which
+  means electron-updater still skips Authenticode verification of downloaded updates. The
+  config plumbing is in place; provisioning a signing identity is what actually closes it.
 - **Required checks**: register `Desktop Build Pass`, `Desktop Typecheck Pass`,
   `Desktop Quality Pass` and `Desktop Tests Pass` as required status checks once this
   merges.

--- a/products/desktop/MIGRATION.md
+++ b/products/desktop/MIGRATION.md
@@ -269,12 +269,14 @@ ports from source using these rules.
     `POSTHOG_ENV_ID: ${{ secrets.DESKTOP_POSTHOG_ENV_ID }}`. Applies to
     `POSTHOG_SOURCEMAP_API_KEY`, `POSTHOG_ENV_ID` and `POSTHOG_HOST` across desktop-release,
     desktop-build-test, desktop-pr-build-installer and desktop-update-e2e. The same
-    treatment covers the Windows Authenticode signing secrets in desktop-release's
-    `publish-windows` job (`WINDOWS_PUBLISHER_NAME`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+    treatment covers the Windows Authenticode signing secrets on desktop-release's
+    `Package installer` step (`WINDOWS_PUBLISHER_NAME`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
     `AZURE_CLIENT_SECRET`, `AZURE_CODE_SIGNING_ENDPOINT`, `AZURE_CODE_SIGNING_ACCOUNT`,
-    `AZURE_CERT_PROFILE_NAME`): `AZURE_*` is far too generic to claim repo-wide, and
-    electron-builder reads the bare names from the environment, so only the `secrets.`
-    lookup is prefixed. Left bare:
+    `AZURE_CERT_PROFILE_NAME`, `WIN_CSC_LINK`, `WIN_CSC_KEY_PASSWORD`): `AZURE_*` is far
+    too generic to claim repo-wide, and electron-builder reads the bare names from the
+    environment, so only the `secrets.` lookup is prefixed. They sit on the step rather
+    than the job so a signing credential is not readable by every dependency install
+    script in the job. Left bare:
     `VITE_POSTHOG_API_KEY` and `VITE_POSTHOG_API_HOST` (already org-wide and shared), names
     that already carry a desktop, twig or code qualifier (`AWS_DESKTOP_*`, `AWS_TWIG_*`,
     `POSTHOG_CODE_E2E_*`) and genuinely repo-wide ones (`TRUNK_API_TOKEN`, `VR_API_TOKEN`,

--- a/products/desktop/apps/code/electron-builder.ts
+++ b/products/desktop/apps/code/electron-builder.ts
@@ -8,6 +8,68 @@ const require = createRequire(import.meta.url);
 const skipNotarize =
   process.env.SKIP_NOTARIZE === "1" || !process.env.APPLE_TEAM_ID;
 
+// --- Windows code signing (security: signed Windows auto-updates) -----------
+// Unsigned Windows installers make electron-updater skip Authenticode
+// verification of downloaded updates: the only integrity check left is the
+// SHA512 in latest.yml, served from the SAME feed, so a compromised feed/CDN or
+// a TLS-MITM can serve a malicious installer that the app runs on next quit.
+// Signing the installer and pinning `publisherName` makes electron-updater
+// verify each downloaded installer's Authenticode signature before applying it
+// (`win.verifyUpdateCodeSignature` defaults to true and checks publisherName).
+//
+// REQUIRED SECRETS (wired in .github/workflows/code-release.yml; see PR):
+//   WINDOWS_PUBLISHER_NAME  - subject CN of the signing certificate, e.g.
+//                             "PostHog, Inc." MUST match the certificate
+//                             exactly; it is written into app-update.yml and
+//                             checked by electron-updater on every update.
+//   Preferred - Azure Trusted Signing (no .pfx to manage on the runner;
+//   electron-builder auto-installs the TrustedSigning PowerShell module):
+//     AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET  (Entra ID auth)
+//     AZURE_CODE_SIGNING_ENDPOINT   - e.g. https://eus.codesigning.azure.net/
+//     AZURE_CODE_SIGNING_ACCOUNT    - Trusted Signing account name
+//     AZURE_CERT_PROFILE_NAME       - certificate profile name
+//   Fallback - PFX certificate via electron-builder's standard env vars:
+//     WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD
+//
+// Local/dev builds without these secrets (or SKIP_WINDOWS_SIGN=1) stay unsigned,
+// mirroring how SKIP_NOTARIZE gates macOS notarization above.
+const windowsPublisherName = process.env.WINDOWS_PUBLISHER_NAME;
+const azureEndpoint = process.env.AZURE_CODE_SIGNING_ENDPOINT;
+const azureAccount = process.env.AZURE_CODE_SIGNING_ACCOUNT;
+const azureCertProfile = process.env.AZURE_CERT_PROFILE_NAME;
+
+function windowsSigningOptions(): Pick<
+  NonNullable<Configuration["win"]>,
+  "azureSignOptions" | "signtoolOptions"
+> {
+  // No publisher name -> nothing for electron-updater to verify against, so
+  // leave the build unsigned (dev/local); CI always supplies the secrets.
+  if (process.env.SKIP_WINDOWS_SIGN === "1" || !windowsPublisherName) {
+    return {};
+  }
+  // Preferred: Azure Trusted Signing.
+  if (azureEndpoint && azureAccount && azureCertProfile) {
+    return {
+      azureSignOptions: {
+        publisherName: windowsPublisherName,
+        endpoint: azureEndpoint,
+        codeSigningAccountName: azureAccount,
+        certificateProfileName: azureCertProfile,
+      },
+    };
+  }
+  // Fallback: signtool reads the .pfx from WIN_CSC_LINK / WIN_CSC_KEY_PASSWORD.
+  if (process.env.WIN_CSC_LINK) {
+    return {
+      signtoolOptions: {
+        publisherName: windowsPublisherName,
+        signingHashAlgorithms: ["sha256"],
+      },
+    };
+  }
+  return {};
+}
+
 const config: Configuration = {
   // Original release bundle id; changing it breaks existing installs' data dir and Keychain entries.
   appId: "com.posthog.array",
@@ -106,6 +168,11 @@ const config: Configuration = {
     // electron-builder generates the multi-size .ico from this 1024px PNG; a real
     // .ico must be >=256px and the committed app-icon.ico is only 32px.
     icon: "build/app-icon.png",
+    // Verify a downloaded update's Authenticode signature (against publisherName)
+    // before installing it. Default is true; set explicitly because it is the
+    // check that closes the unsigned-auto-update RCE. See the signing note above.
+    verifyUpdateCodeSignature: true,
+    ...windowsSigningOptions(),
   },
 
   nsis: {


### PR DESCRIPTION
## Problem

- Windows builds ship unsigned. The `win` block set no certificate, no signing options and no `publisherName`, and `publish-windows` wired no signing secrets.
- Without `publisherName` in `app-update.yml`, electron-updater skips Authenticode verification of downloaded updates.
- The only integrity check left is the SHA512 in `latest.yml`, served from the same feed as the installer.
- Whoever controls the update origin, or holds a trusted-CA or corporate-MITM position, can serve a malicious installer with a matching hash. The app runs it on next quit.
- macOS and Linux are unaffected. macOS is signed and notarized, and no Linux auto-updater consumes the Linux manifests today.
- Reported by an external security auditor against the pre-import PostHog/code tree. The finding still applied to `products/desktop`.

> [!WARNING]
> This PR does not close the vulnerability. It is config plumbing and it is inert until signing secrets exist. `windowsSigningOptions()` returns `{}`, no `publisherName` reaches `app-update.yml`, and the workflow's secret references resolve to empty strings. Windows builds still ship unsigned and verification is still skipped. Treat it as low-risk scaffolding.

## Changes

- `electron-builder.ts` gains a `windowsSigningOptions()` helper that prefers Azure Trusted Signing (`win.azureSignOptions`) and falls back to a PFX certificate (`win.signtoolOptions` with `WIN_CSC_LINK`). When set, it pins `publisherName`, which is the value electron-updater checks a downloaded installer against.
- `win.verifyUpdateCodeSignature: true` is stated explicitly. This is already the electron-builder default and changes nothing by itself.
- Builds with no secrets, or `SKIP_WINDOWS_SIGN=1`, stay unsigned. That mirrors the existing `skipNotarize` gate for macOS, so local and `package:dev` builds keep working.
- `desktop-release.yml`'s `publish-windows` job exports the seven signing variables. No install step is needed, since electron-builder installs the `TrustedSigning` module and authenticates through Entra ID `EnvironmentCredential`.

The secret lookups carry a `DESKTOP_` prefix while the env var names stay bare, because electron-builder reads the bare names and `AZURE_*` is too generic to claim repo-wide. That follows MIGRATION.md transform rule 15, and I recorded the new names there along with a note that Windows builds remain unsigned until an identity is provisioned.

## Remaining work to actually close it

1. Provision an Azure Trusted Signing account, or an EV code-signing certificate.
2. Add `DESKTOP_WINDOWS_PUBLISHER_NAME` plus either the `DESKTOP_AZURE_*` set or the `WIN_CSC_*` pair.
3. Verify end to end: `signtool verify /pa /v` reports a valid signature whose subject CN equals the publisher name, and the packaged `app-update.yml` carries it.
4. Serve a tampered installer with a matching SHA512 and confirm electron-updater refuses it. That is the check that actually closes this, so it must be observed passing.

## How did you test this code?

End-to-end signing cannot be validated without a certificate, so I (actually Claude) verified only what is checkable now:

- `pnpm --filter code typecheck` passes, which confirms `azureSignOptions`, `signtoolOptions`, `verifyUpdateCodeSignature` and `publisherName` all exist on the installed electron-builder 26.15.3 `WindowsConfiguration` type.
- `bin/hogli lint:workflows` passes all 7 checks across 124 workflows, and `actionlint` reports nothing new on `desktop-release.yml`. Its only findings are pre-existing SC2035 notes on `sha256sum` globs I did not touch.
- Biome passes on `electron-builder.ts`.

With no secrets set, `windowsSigningOptions()` returns `{}` and the `win` config is unchanged apart from the default-valued `verifyUpdateCodeSignature`, so an unsigned build behaves exactly as before. No tests were added: the helper is env-var plumbing with no signing identity to exercise, and a test asserting "returns `{}` when env vars are unset" would only restate the branch.

I did not tag a release or run the signing job.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/MIGRATION.md` covers the new secret names under transform rule 15 and the unfinished follow-up.
