### PR TITLE
chore(dev): autorestart frontend unit when vite crashes at startup

### DIFF
--- a/bin/start-frontend
+++ b/bin/start-frontend
@@ -89,6 +89,12 @@ pnpm --filter=@posthog/frontend... install
 # turbo is running (a foreground child would keep bash blocked in turbo's own
 # wait, delaying signal handling). `wait` returns when turbo exits or when a
 # trapped signal interrupts it, at which point shutdown() reaps the subtree.
+#
+# start-vite runs concurrently with --kill-others-on-fail so a Vite crash (e.g.
+# exit 127 when a dep relink races startup) tears down the toolbar watcher too,
+# letting this script exit non-zero instead of hanging while the watcher lives
+# on. That non-zero exit is what the process manager needs to see to autorestart
+# the frontend unit — without it a crashed Vite leaves the unit stuck pending.
 bin/turbo --filter=@posthog/frontend start-vite &
 turbo_pid=$!
 wait "$turbo_pid"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
         "check-toolbar-csp-eval": "node ./bin/check-toolbar-csp-eval.mjs",
         "check-toolbar-graph": "node ./bin/check-toolbar-graph.mjs",
         "check-toolbar-size": "node ./bin/check-toolbar-size.mjs",
-        "start-vite": "pnpm build:products && concurrently -n VITE,TOOLBAR -c green,magenta \"vite --host 0.0.0.0\" \"pnpm watch:toolbar\"",
+        "start-vite": "pnpm build:products && concurrently --kill-others-on-fail -n VITE,TOOLBAR -c green,magenta \"vite --host 0.0.0.0\" \"pnpm watch:toolbar\"",
         "watch:toolbar": "node ./bin/build-toolbar.mjs --dev",
         "mobile-replay:web:schema:build:json": "ts-json-schema-generator -f ./tsconfig.json --path 'node_modules/posthog-js/dist/rrweb-types.d.ts' --type 'eventWithTime' --expose all --no-top-ref --no-type-check --out ./src/scenes/session-recordings/mobile-replay/schema/web/rr-web-schema.json && oxfmt ./src/scenes/session-recordings/mobile-replay/schema/web/rr-web-schema.json",
         "mobile-replay:mobile:schema:build:json": "ts-json-schema-generator -f ./tsconfig.json --path './src/scenes/session-recordings/mobile-replay/mobile.types.ts' --type 'mobileEventWithTime' --expose all --no-top-ref --no-type-check --out ./src/scenes/session-recordings/mobile-replay/schema/mobile/rr-mobile-schema.json && oxfmt ./src/scenes/session-recordings/mobile-replay/schema/mobile/rr-mobile-schema.json",


### PR DESCRIPTION
## Problem

When vite crashes at startup, the frontend unit hangs at "pending" forever and the app serves an empty page.

- `concurrently` keeps waiting on the still-alive toolbar watcher, so `bin/start-frontend` never exits.
- phrocs autorestarts a unit only on a non-zero exit, and the frontend unit already opts in:

https://github.com/PostHog/posthog/blob/cb4f7aa296e70c19a9bb1a6dc2e4505c53ed0ea6/tools/phrocs/internal/process/proc.go#L678

https://github.com/PostHog/posthog/blob/cb4f7aa296e70c19a9bb1a6dc2e4505c53ed0ea6/bin/mprocs.yaml#L164-L167

- Hit in local dev: a workspace `pnpm install` relinked `node_modules/.bin` while the unit spawned vite, which exited 127.

## Changes

- Added `--kill-others-on-fail` to the `start-vite` concurrently call, so a vite failure makes the script exit non-zero.
- Documented the dependency in `bin/start-frontend`, since `package.json` cannot hold a comment.

Before:

```mermaid
flowchart LR
    A[vite crashes] --> B[toolbar watcher keeps running]
    B --> C[start-frontend never exits]
    C --> D[unit stuck pending]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phRed;
    class B,C phGray;
```

After:

```mermaid
flowchart LR
    A[vite crashes] --> B[concurrently kills the toolbar watcher]
    B --> C[start-frontend exits non-zero]
    C --> D[phrocs autorestarts the unit]
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phRed;
    class B,C phGray;
    class D phBlue;
```

> [!NOTE]
> The flag is symmetric: a toolbar watcher crash now also kills vite and restarts the unit. Clean exits and manual stops are unaffected.

## How did you test this code?

- I (actually Claude) diagnosed the failure live on a dev machine: vite exited 127, the unit sat pending, and a manual unit restart recovered it.
- I did not run the changed script end to end; this cloud workspace has no node_modules install.
- The pinned `concurrently` 5.3.0 supports the flag (added in 3.5.0).
- No automated tests: the behavior spans phrocs, turbo, and concurrently process supervision, which no test harness covers.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (PostHog Code cloud task). Diagnosis ran against a live dev environment through the phrocs IPC socket and unit logs.
- Skills invoked: /writing-pr-descriptions.
- I considered fixing this in phrocs instead, restarting when the ready pattern never matches. Rejected: phrocs already autorestarts on crash and only lacked the exit signal.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
