### PR TITLE
feat(warehouse): opt-in profile subscriptions sync for Klaviyo source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/klaviyo.py
@@ -5,6 +5,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 
 @config.config
+class KlaviyoProfileSubscriptionsConfig(config.Config):
+    enabled: bool = config.value(converter=config.str_to_bool, default=False)
+
+
+@config.config
 class KlaviyoSourceConfig(config.Config):
     api_key: str
     conversion_metric_id: str | None = None
+    profile_subscriptions: KlaviyoProfileSubscriptionsConfig | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -168,6 +168,7 @@ def _build_initial_params(
     should_use_incremental_field: bool,
     db_incremental_field_last_value: Any,
     incremental_field: str | None,
+    extra_query_params: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build query params for the initial Klaviyo API request."""
     params: dict[str, Any] = {}
@@ -198,6 +199,9 @@ def _build_initial_params(
         params["sort"] = config.sort
 
     params.update(config.extra_params)
+
+    if extra_query_params:
+        params.update(extra_query_params)
 
     return params
 
@@ -507,6 +511,7 @@ def get_rows(
     db_incremental_field_last_value: Any = None,
     incremental_field: str | None = None,
     conversion_metric_id: str | None = None,
+    extra_query_params: dict[str, str] | None = None,
 ) -> Iterator[Any]:
     config = KLAVIYO_ENDPOINTS[endpoint]
     headers = _get_headers(api_key, api_version)
@@ -516,7 +521,7 @@ def get_rows(
     session = make_tracked_session()
 
     params = _build_initial_params(
-        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field
+        config, should_use_incremental_field, db_incremental_field_last_value, incremental_field, extra_query_params
     )
 
     if config.values_report is not None:
@@ -581,6 +586,7 @@ def klaviyo_source(
     db_incremental_field_last_value: Optional[Any] = None,
     incremental_field: str | None = None,
     conversion_metric_id: str | None = None,
+    extra_query_params: dict[str, str] | None = None,
 ) -> SourceResponse:
     endpoint_config = KLAVIYO_ENDPOINTS[endpoint]
 
@@ -596,6 +602,7 @@ def klaviyo_source(
             db_incremental_field_last_value=db_incremental_field_last_value,
             incremental_field=incremental_field,
             conversion_metric_id=conversion_metric_id,
+            extra_query_params=extra_query_params,
         ),
         primary_keys=endpoint_config.primary_keys,
         # Fan-out runs persist the incremental watermark only at successful job end (desc mode): a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/source.py
@@ -8,6 +8,7 @@ from posthog.schema import (
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
+    SourceFieldSwitchGroupConfig,
 )
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
@@ -112,6 +113,13 @@ The campaign and flow performance tables need a conversion metric. Leave the con
                         placeholder="RESQ6t",
                         secret=False,
                     ),
+                    SourceFieldSwitchGroupConfig(
+                        name="profile_subscriptions",
+                        label="Sync profile subscriptions",
+                        caption="Adds a subscriptions column to the profiles table with each profile's email, SMS, and push consent details. Enabling this requires a full resync of the profiles table to populate existing rows.",
+                        default=False,
+                        fields=[],
+                    ),
                 ],
             ),
         )
@@ -201,4 +209,17 @@ The campaign and flow performance tables need a conversion metric. Leave the con
             else None,
             incremental_field=inputs.incremental_field,
             conversion_metric_id=config.conversion_metric_id,
+            extra_query_params=_resolve_extra_query_params(config, inputs.schema_name),
         )
+
+
+def _resolve_extra_query_params(config: KlaviyoSourceConfig, schema_name: str) -> dict[str, str]:
+    """Opt-in fields Klaviyo excludes unless requested via additional-fields.
+
+    Keyed on the exact schema name so the list_profiles/segment_profiles fan-outs — which
+    restrict profile payloads to joined_group_at via a fields[profile] sparse fieldset —
+    are never expanded.
+    """
+    if schema_name == "profiles" and config.profile_subscriptions is not None and config.profile_subscriptions.enabled:
+        return {"additional-fields[profile]": "subscriptions"}
+    return {}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -29,7 +29,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.klaviyo.se
     KLAVIYO_ENDPOINTS,
     KlaviyoEndpointConfig,
 )
-from products.warehouse_sources.backend.temporal.data_imports.sources.klaviyo.source import KlaviyoSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.klaviyo.source import (
+    KlaviyoSource,
+    _resolve_extra_query_params,
+)
 
 
 class TestFormatIncrementalValue:
@@ -170,6 +173,36 @@ class TestBuildInitialParams:
             incremental_field="joined_group_at",
         )
         assert params["filter"] == "greater-than(joined_group_at,2026-06-14T12:00:00.000Z)"
+
+    def test_extra_query_params_merge_alongside_standard_params(self) -> None:
+        config = KLAVIYO_ENDPOINTS["profiles"]
+        params = _build_initial_params(
+            config,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            incremental_field="updated",
+            extra_query_params={"additional-fields[profile]": "subscriptions"},
+        )
+        assert params["filter"] == "greater-than(updated,2026-03-04T02:58:14.000Z)"
+        assert params["additional-fields[profile]"] == "subscriptions"
+
+    def test_extra_query_params_default_is_a_noop(self) -> None:
+        config = KLAVIYO_ENDPOINTS["profiles"]
+        with_none = _build_initial_params(
+            config,
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            incremental_field=None,
+            extra_query_params=None,
+        )
+        without = _build_initial_params(
+            config,
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            incremental_field=None,
+        )
+        assert with_none == without
+        assert "additional-fields[profile]" not in with_none
 
 
 class TestClampFutureValueToNow:
@@ -1040,3 +1073,57 @@ class TestValidateCredentialsResolvedPin:
 
         headers = session_factory.return_value.get.call_args.kwargs["headers"]
         assert headers["revision"] == api_version
+
+
+class TestProfileSubscriptionsOptIn:
+    def _config(self, enabled: bool | None) -> KlaviyoSourceConfig:
+        payload: dict[str, Any] = {"api_key": "pk_test"}
+        if enabled is not None:
+            # job_inputs round-trips booleans as the strings "True"/"False"
+            payload["profile_subscriptions"] = {"enabled": "True" if enabled else "False"}
+        return KlaviyoSourceConfig.from_dict(payload)
+
+    def test_config_round_trips_the_stored_string_encoding(self) -> None:
+        config = self._config(enabled=True)
+        assert config.profile_subscriptions is not None
+        assert config.profile_subscriptions.enabled is True
+        assert self._config(enabled=False).profile_subscriptions.enabled is False  # type: ignore[union-attr]
+        # A payload without the key materializes the nested config with its default (off),
+        # so pre-existing sources parse to the same "disabled" state as an explicit False.
+        absent = self._config(enabled=None).profile_subscriptions
+        assert absent is not None and absent.enabled is False
+
+    def test_enabled_toggle_requests_subscriptions_on_profiles(self) -> None:
+        params = _resolve_extra_query_params(self._config(enabled=True), "profiles")
+        assert params == {"additional-fields[profile]": "subscriptions"}
+
+    @parameterized.expand([("toggle_off", False), ("toggle_absent", None)])
+    def test_disabled_toggle_requests_nothing(self, _name: str, enabled: bool | None) -> None:
+        assert _resolve_extra_query_params(self._config(enabled=enabled), "profiles") == {}
+
+    @parameterized.expand([("list_profiles",), ("segment_profiles",), ("events",), ("templates",)])
+    def test_other_schemas_are_untouched_even_when_enabled(self, schema_name: str) -> None:
+        # The membership fan-outs restrict profile payloads via fields[profile]=joined_group_at;
+        # expanding them with additional-fields would balloon every fan-out request.
+        assert _resolve_extra_query_params(self._config(enabled=True), schema_name) == {}
+
+    def test_request_url_carries_the_literal_unencoded_param(self, monkeypatch: Any = None) -> None:
+        fetched_urls: list[str] = []
+
+        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any, json_body: Any = None) -> dict:
+            fetched_urls.append(url)
+            return {"data": [], "links": {"next": None}}
+
+        with patch.object(klaviyo, "_fetch_page", fake_fetch):
+            manager = _FakeResumableManager()
+            list(
+                get_rows(
+                    api_key="pk_test",
+                    endpoint="profiles",
+                    logger=MagicMock(),
+                    resumable_source_manager=manager,  # type: ignore[arg-type]
+                    extra_query_params={"additional-fields[profile]": "subscriptions"},
+                )
+            )
+
+        assert fetched_urls == ["https://a.klaviyo.com/api/profiles?additional-fields[profile]=subscriptions"]


### PR DESCRIPTION
## Problem

The Klaviyo source syncs every standard field, but Klaviyo deliberately excludes the profile `subscriptions` object (detailed email/SMS/push consent status) from `GET /api/profiles` unless it's explicitly requested via `additional-fields[profile]=subscriptions`. There's currently no way for users to get this data into their warehouse. (~70 sources sync the Klaviyo profiles table today.)

## Changes

HubSpot-style opt-in on the source config: a **"Sync profile subscriptions"** switch-group toggle.

- `klaviyo/source.py`: new `SourceFieldSwitchGroupConfig` field (rendered by the generic `SourceForm`, no frontend changes) + `_resolve_extra_query_params` which maps the toggle to `additional-fields[profile]=subscriptions` **only for the `profiles` schema** — the `list_profiles`/`segment_profiles` fan-outs restrict profile payloads via `fields[profile]=joined_group_at` and must not be expanded.
- `klaviyo/klaviyo.py`: threads an optional `extra_query_params` dict through `klaviyo_source` → `get_rows` → `_build_initial_params`.
- `generated_configs/klaviyo.py`: regenerated (`pnpm generate:source-configs`). Stored in schemaless `job_inputs`, so no migration; absent key parses to disabled for all existing sources.

Notes:
- `subscriptions` carries **no rate-limit penalty** ([Get Profiles docs](https://developers.klaviyo.com/en/reference/get_profiles)), unlike `predictive_analytics` (75/s → 10/s), which is deliberately out of scope — the plumbing here makes it a trivial follow-up toggle if wanted.
- The toggle caption warns that a full resync of the profiles table is needed to populate existing rows (same messaging-only approach as HubSpot's custom properties).
- The nested object lands as a `subscriptions` dict column via the existing `_flatten_item` path, same as `location`/`properties`.

## How did you test this code?

Added unit tests (113 pass): param resolution per schema (incl. fan-out exclusion), `_build_initial_params` merge, config string-encoding round-trip, and an end-to-end `get_rows` test asserting the literal unencoded `additional-fields[profile]=subscriptions` in the request URL.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*