### PR TITLE
chore(batch-exports): Revert setting CH compatibility

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -602,9 +602,6 @@ async def _write_batch_export_record_batches_to_internal_stage(
         min_insert_block_size_bytes=settings.BATCH_EXPORTS_CLICKHOUSE_MAX_INSERT_BLOCK_SIZE_BYTES,
         # Disable all of these so only the bytes limits counts.
         min_insert_block_size_rows=0,
-        # TEMPORARY: pin batch export queries to ClickHouse 26.6 semantics to ensure compatibility
-        # after upgrade
-        compatibility="26.6",
     ) as client:
         if not await client.is_alive():
             raise ConnectionError("Cannot establish connection to ClickHouse")


### PR DESCRIPTION
This reverts commit 407bc4d7cc56e4018da89f43bec9d2284db2f836 (PR #76757)

## Problem

Pinning ClickHouse compatibility didn't have any effect, so let's revert it.

## Changes

Revert the ClickHouse `compatibility` setting for batch export queries.

## How did you test this code?

I didn't

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Human-powered