### PR TITLE
chore(experiments): Raise canary mean quota for metric-events bake-in

### DIFF
--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -98,7 +98,10 @@ class ExperimentPrecomputeCanaryInputs:
     experiment_id: int | None = None
     metric_uuids: list[str] | None = None
     funnel_quota: int = 12
-    mean_quota: int = 6
+    # Bake-in level for the new mean metric-events precompute path: ~40% of sampled means are
+    # CUPED/breakdown/DW-ineligible and exercise nothing new, so 20 nominal ≈ 12 effective.
+    # Drop back toward ~10 once the mean table has a few clean weeks of canary history.
+    mean_quota: int = 20
     ratio_quota: int = 4
     per_experiment_cap: int = 3
     time_budget_seconds: int = 5400


### PR DESCRIPTION
## Problem

The precompute canary samples 6 mean metrics per daily run. Mean metric-events precomputation just shipped, so the mean A/B runs now exercise a brand-new table and quota should reflect where correctness risk currently sits. About 40% of sampled means are CUPED/breakdown/DW-ineligible and test nothing new, diluting the effective sample further.

## Changes

Raise `mean_quota` from 6 to 20 (~12 effective samples/day on the new path, matching funnel coverage). Bake-in level, to be lowered once the mean table has a few clean weeks of canary history. Propagates on next deploy via `a_update_schedule`.

## How did you test this code?

`hogli test products/experiments/backend/temporal/test_canary_logic.py` (41 passed). Default-only change, replay-safe (no workflow command changes).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session directed by Juraj. The quota number comes from an eligibility analysis of the first ~12h of mean precompute traffic in the query log: ~60% of mean reads at enrolled teams take the new path, so 20 nominal ≈ 12 effective. Funnel and ratio quotas left unchanged deliberately: funnels are a mature surface whose direct-scan canary arm is the expensive one, and ratio has no metric-events path yet.