### PR TITLE
chore(warehouse): point OAuth secret deployment at the secrets UI

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -647,7 +647,7 @@ If new:
 3. **Register the client + deploy the credentials.** Registering the OAuth client with the provider,
    the redirect URIs (US/EU/dev/localhost), the **charts** PR (wiring the env vars into both
    `posthog-django-shared-secrets` for the web app and the worker's `secret_env_app_specific` store),
-   and writing the values into AWS Secrets Manager via the `PostHog/secrets` CLI — plus which of these
+   and writing the values into AWS Secrets Manager via the `PostHog/secrets` UI or CLI — plus which of these
    an agent can vs. must not automate — are all in
    [references/oauth-app-deployment.md](references/oauth-app-deployment.md).
 

--- a/.agents/skills/implementing-warehouse-sources/references/oauth-app-deployment.md
+++ b/.agents/skills/implementing-warehouse-sources/references/oauth-app-deployment.md
@@ -64,10 +64,13 @@ vars on the web app and the data-warehouse worker — nothing else.
 
 The [secrets UI](https://secrets-ui.hedgehog-kitefin.ts.net/) is the preferred way to write secrets: it
 only needs the PostHog tailnet (Tailscale) — no local install, AWS profile, or SSO login — and it can add
-a key across environments from one place. For two keys × two stores × three environments, though, the
-CLI's bulk `template` command is fewer steps. Use it with a **local, uncommitted** YAML file (copy
-`template-example.yaml`). App-name keys are the full `-secrets` store names; the same value repeats
-across environments for one shared client:
+a key across environments from one place.
+
+**Two things this step needs are not in the UI yet** (planned, but CLI-only today): bulk multi-store /
+multi-env writes, and the Argo force-sync after a write. For two keys × two stores × three environments
+that makes the CLI's `template` command the fewer-steps option here. Use it with a **local,
+uncommitted** YAML file (copy `template-example.yaml`). App-name keys are the full `-secrets` store
+names; the same value repeats across environments for one shared client:
 
 ```yaml
 secrets:
@@ -105,6 +108,9 @@ Notes:
 - ExternalSecrets sync from AWS SM to Kubernetes hourly; the CLI offers an immediate Argo force-sync
   after writing (needs the PostHog tailnet), else `kubectl annotate es <name> force-sync=$(date +%s) --overwrite -n posthog`.
   The UI does not force-sync — after writing there, force it via ArgoCD or wait for the hourly sync.
+- UI/CLI parity gaps that matter beyond this step: force-sync, search-by-value, `blame`/`--who`
+  attribution, and bulk `template` writes are all CLI-only for now. The wiki tracks the current list
+  and what's planned: [Not yet in the UI](https://runbooks.posthog.com/operations/secrets/application#not-yet-in-the-ui).
 
 ## What an agent can and cannot do here
 

--- a/.agents/skills/implementing-warehouse-sources/references/oauth-app-deployment.md
+++ b/.agents/skills/implementing-warehouse-sources/references/oauth-app-deployment.md
@@ -60,10 +60,14 @@ vars on the web app and the data-warehouse worker — nothing else.
 
 ## 4. Secrets — write the values into AWS Secrets Manager (PostHog/secrets)
 
-`PostHog/secrets` is a **CLI over AWS Secrets Manager — values are never committed to git.** Use the
-bulk `template` command with a **local, uncommitted** YAML file (copy `template-example.yaml`). App-name
-keys are the full `-secrets` store names; the same value repeats across environments for one shared
-client:
+`PostHog/secrets` is a **web UI and CLI over AWS Secrets Manager — values are never committed to git.**
+
+The [secrets UI](https://secrets-ui.hedgehog-kitefin.ts.net/) is the preferred way to write secrets: it
+only needs the PostHog tailnet (Tailscale) — no local install, AWS profile, or SSO login — and it can add
+a key across environments from one place. For two keys × two stores × three environments, though, the
+CLI's bulk `template` command is fewer steps. Use it with a **local, uncommitted** YAML file (copy
+`template-example.yaml`). App-name keys are the full `-secrets` store names; the same value repeats
+across environments for one shared client:
 
 ```yaml
 secrets:
@@ -100,13 +104,15 @@ Notes:
   `terraform/modules/eks/external-secrets.tf` (posthog-cloud-infra).
 - ExternalSecrets sync from AWS SM to Kubernetes hourly; the CLI offers an immediate Argo force-sync
   after writing (needs the PostHog tailnet), else `kubectl annotate es <name> force-sync=$(date +%s) --overwrite -n posthog`.
+  The UI does not force-sync — after writing there, force it via ArgoCD or wait for the hourly sync.
 
 ## What an agent can and cannot do here
 
 - **Can**: the settings code change; the charts PR (both blocks); register the client if the provider
   has a registration API and the user supplies a provider API key; scaffold the `secrets` template YAML
   with **placeholder** values plus the exact `--dry-run`/apply commands for the human to run.
-- **Should not**: run the `secrets template` apply. It needs interactive `aws sso login`, the
-  `secrets-editor` AWS role, and the tailnet for the force-sync — and it handles the **live**
-  `client_secret`, which must never flow through agent tool output or land in any file (committed or
-  scratch). Hand the filled template + commands to the user for that step.
+- **Should not**: write the secret values, by any route. Both the UI and the `secrets template` apply
+  handle the **live** `client_secret`, which must never flow through agent tool output or land in any
+  file (committed or scratch); the CLI additionally needs interactive `aws sso login`, the
+  `secrets-editor` AWS role, and the tailnet. Hand the filled template + commands (or the UI link) to
+  the user for that step.


### PR DESCRIPTION
## Problem

The `implementing-warehouse-sources` skill describes `PostHog/secrets` as a CLI-only tool. It now also has a web UI, which is the preferred way to write application secrets — it needs only the PostHog tailnet, no local install, AWS profile, or SSO login.

The UI is not at parity with the CLI, though, so "prefer the UI" alone would be misleading here.

## Changes

- `references/oauth-app-deployment.md` §4 leads with the secrets UI, then names the two gaps that make the CLI correct for *this* step: bulk multi-store/multi-env writes and the Argo force-sync. Previously the reader had to infer that from step counting.
- Adds a note listing the wider parity gaps (force-sync, search-by-value, `blame`/`--who`, bulk `template`) and links the wiki page that tracks them and what's planned.
- Widens the agent "should not" guard from "don't run the `secrets template` apply" to "don't write the secret values by any route". The reason was always the live `client_secret` passing through agent output, not the CLI specifically — with a UI available, the narrower wording read as a loophole.
- `SKILL.md` step 3 mentions the UI alongside the CLI.

Docs only, no code change.

## How did you test this code?

No automated tests apply — the diff is two agent-facing markdown files. I verified each claim about UI capability against the `PostHog/secrets` web app source rather than its README, since the README overstates parity: force-sync, value search, `blame`/`--who`, `template`, and `--plaintext` are all CLI-only, which is what the wording here reflects.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (PostHog Code). No repo skills applied to a markdown-only diff.

Two judgment calls worth flagging for review:

- **`secrets template` stays.** One YAML apply beats twelve UI writes for two keys × two stores × three environments, and the UI can't force-sync. So this page keeps recommending the CLI while the surrounding docs move to the UI — that's deliberate, not an oversight.
- **The agent guard was the substantive change.** It previously forbade the CLI apply and cited AWS-role friction as part of the reason, which would not have covered a browser-based write. Rephrased around the live credential so it holds regardless of route.

Which gaps are "planned" came from the requester; there's no roadmap doc or open issue in `PostHog/secrets` to source it from, so this page defers to the wiki rather than restating it.

Companion wiki PR carries the full parity table: PostHog/runbooks#591.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
