### PR TITLE
chore(temporal): restore structlog config after temporal test fixtures

### DIFF
--- a/posthog/temporal/common/logger.py
+++ b/posthog/temporal/common/logger.py
@@ -30,6 +30,7 @@ import json
 import typing
 import asyncio
 import functools
+import contextlib
 import contextvars
 import collections.abc
 
@@ -628,6 +629,28 @@ def configure_logger(
         await asyncio.wait([listen_task])
 
     create_background_task(handle_worker_shutdown(), loop or asyncio.get_running_loop(), name="handle_worker_shutdown")
+
+
+@contextlib.contextmanager
+def temporary_logger_configuration(**kwargs: typing.Any) -> collections.abc.Iterator[None]:
+    """Configure the Temporal logger, restoring the previous configuration on exit.
+
+    `configure_logger` resets structlog and installs Temporal's logger factory for the
+    whole process, which is what a worker wants and what a test suite does not: the
+    project's own configuration routes structlog through stdlib logging, and that
+    routing is what `caplog` and `structlog.testing.capture_logs` read. A test that
+    swaps it out and leaves it swapped strands every later test in the same process
+    with assertions that silently observe no logs at all.
+
+    Accepts the same arguments as `configure_logger`.
+    """
+    previous = structlog.get_config().copy()
+    configure_logger(**kwargs)
+    try:
+        yield
+    finally:
+        structlog.reset_defaults()
+        structlog.configure(**previous)
 
 
 CoroRetType = typing.TypeVar("CoroRetType")

--- a/posthog/temporal/tests/common/test_logger.py
+++ b/posthog/temporal/tests/common/test_logger.py
@@ -4,6 +4,7 @@ import random
 import asyncio
 import datetime as dt
 import operator
+import contextlib
 import dataclasses
 from typing import cast
 
@@ -31,7 +32,7 @@ from posthog.clickhouse.log_entries import (
 )
 from posthog.kafka_client.client import _AsyncKafkaProducer
 from posthog.kafka_client.topics import KAFKA_LOG_ENTRIES
-from posthog.temporal.common.logger import BACKGROUND_LOGGER_TASKS, configure_logger, resolve_log_source
+from posthog.temporal.common.logger import BACKGROUND_LOGGER_TASKS, resolve_log_source, temporary_logger_configuration
 
 pytestmark = pytest.mark.asyncio
 
@@ -159,23 +160,26 @@ async def configure_logger_auto(log_capture, queue, producer):
     we need in these tests.
     """
     loop = asyncio.get_running_loop()
-    with override_settings(TEST=False, DEBUG=False):
-        configure_logger(
-            extra_processors=[log_capture],
-            queue=queue,
-            producer=producer,
-            cache_logger_on_first_use=False,
-            loop=loop,
-            raise_on_producer_error=True,
-        )
+    with contextlib.ExitStack() as stack:
+        with override_settings(TEST=False, DEBUG=False):
+            stack.enter_context(
+                temporary_logger_configuration(
+                    extra_processors=[log_capture],
+                    queue=queue,
+                    producer=producer,
+                    cache_logger_on_first_use=False,
+                    loop=loop,
+                    raise_on_producer_error=True,
+                )
+            )
 
-    yield
+        yield
 
-    for task in BACKGROUND_LOGGER_TASKS.values():
-        # Clean up logger tasks to avoid leaking/warnings.
-        task.cancel()
+        for task in BACKGROUND_LOGGER_TASKS.values():
+            # Clean up logger tasks to avoid leaking/warnings.
+            task.cancel()
 
-    await asyncio.wait(BACKGROUND_LOGGER_TASKS.values())
+        await asyncio.wait(BACKGROUND_LOGGER_TASKS.values())
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -950,3 +954,24 @@ def test_resolve_log_source_cdc_extraction():
 
     assert source == "external_data_jobs"
     assert source_id == "019bdc25-3569-0000-9f32-e7d02775304b"
+
+
+def test_temporary_logger_configuration_restores_the_previous_configuration():
+    # `configure_logger` swaps structlog's logger factory process-wide, and the project's
+    # own configuration routes structlog through stdlib logging — which is what `caplog`
+    # and `capture_logs` read. A test fixture that configures the Temporal logger and
+    # never puts the old configuration back leaves every later test in the same process
+    # asserting against logs it can no longer see.
+    original = structlog.get_config()
+    try:
+        sentinel = structlog.stdlib.LoggerFactory()
+        structlog.configure(logger_factory=sentinel)
+        expected = structlog.get_config()
+
+        with temporary_logger_configuration(cache_logger_on_first_use=False):
+            assert structlog.get_config()["logger_factory"] is not sentinel
+
+        assert structlog.get_config() == expected
+    finally:
+        structlog.reset_defaults()
+        structlog.configure(**original)

--- a/posthog/temporal/tests/conftest.py
+++ b/posthog/temporal/tests/conftest.py
@@ -1,6 +1,7 @@
 import random
 import signal
 import asyncio
+import collections.abc
 
 import pytest
 
@@ -17,7 +18,7 @@ from posthog.models import Organization, Team
 from posthog.models.user import User
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.common.client import connect
-from posthog.temporal.common.logger import configure_logger
+from posthog.temporal.common.logger import temporary_logger_configuration
 
 
 @pytest.fixture(autouse=True)
@@ -176,9 +177,10 @@ async def temporal_worker(temporal_client, workflows, activities):
 
 
 @pytest_asyncio.fixture(autouse=True, scope="module", loop_scope="module")
-async def configure_logger_auto() -> None:
+async def configure_logger_auto() -> collections.abc.AsyncIterator[None]:
     """Configure logger for running temporal tests."""
-    configure_logger(cache_logger_on_first_use=False)
+    with temporary_logger_configuration(cache_logger_on_first_use=False):
+        yield
 
 
 @pytest_asyncio.fixture

--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -2,6 +2,7 @@ import uuid
 import random
 import asyncio
 import datetime as dt
+import collections.abc
 
 import pytest
 
@@ -22,7 +23,7 @@ from posthog.models.team.util import delete_batch_exports
 from posthog.models.utils import uuid7
 from posthog.temporal.common.clickhouse import ClickHouseClient
 from posthog.temporal.common.client import connect
-from posthog.temporal.common.logger import configure_logger
+from posthog.temporal.common.logger import temporary_logger_configuration
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
 from products.batch_exports.backend.temporal import ACTIVITIES, WORKFLOWS
@@ -173,9 +174,10 @@ async def temporal_client():
 
 
 @pytest_asyncio.fixture(autouse=True, scope="module", loop_scope="module")
-async def configure_logger_auto() -> None:
+async def configure_logger_auto() -> collections.abc.AsyncIterator[None]:
     """Configure logger when running in a Temporal activity environment."""
-    configure_logger(cache_logger_on_first_use=False)
+    with temporary_logger_configuration(cache_logger_on_first_use=False):
+        yield
 
 
 @pytest.fixture

--- a/products/tasks/backend/temporal/conftest.py
+++ b/products/tasks/backend/temporal/conftest.py
@@ -1,13 +1,14 @@
 import os
 import time
 import random
+import collections.abc
 
 import pytest
 
 from temporalio.testing import ActivityEnvironment
 
 from posthog.models import Integration, OAuthApplication, Organization, OrganizationMembership, Team, User
-from posthog.temporal.common.logger import configure_logger
+from posthog.temporal.common.logger import temporary_logger_configuration
 
 from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxConfig, SandboxTemplate
 from products.tasks.backend.models import SandboxSnapshot, Task, TaskRun
@@ -195,9 +196,10 @@ def snapshot_context(github_integration, team) -> SnapshotContext:
 
 
 @pytest.fixture(autouse=True)
-def configure_logger_auto() -> None:
+def configure_logger_auto() -> collections.abc.Iterator[None]:
     """Configure logger when running in a Temporal activity environment."""
-    configure_logger(cache_logger_on_first_use=False)
+    with temporary_logger_configuration(cache_logger_on_first_use=False):
+        yield
 
 
 def get_or_create_test_snapshots(github_integration):


### PR DESCRIPTION
## Problem

`configure_logger` resets structlog and installs Temporal's logger factory **process-wide**. Three autouse fixtures called it and never restored the previous configuration.

PostHog's own config routes structlog through stdlib logging. That routing is what `caplog` and `structlog.testing.capture_logs` read. So once any Temporal test runs, log capture is dead for the rest of that process.

Reproduces on master today — run two trees in one pytest process:

```
pytest posthog/temporal/tests/ai/slack_app/activities/ \
       posthog/security/test/test_command_exec_audit.py \
       products/slack_app/backend/tests/test_posthog_code_event_handler.py ...
→ 16 failed, 278 passed
```

15 of the 16 are the command-execution **audit** tests. Which tests break depends on which happen to share the process.

Both failure directions matter:

- `assert X was logged` → finds nothing → **fails loudly**. All 16 are this shape.
- `assert X was NOT logged` → finds nothing → **passes vacuously**. Silently stops guarding anything.

## Changes

| File | Change |
|---|---|
| `posthog/temporal/common/logger.py` | Adds `temporary_logger_configuration`, a scoped `configure_logger` that restores the prior config on exit |
| `posthog/temporal/tests/conftest.py` | Fixture moved onto it |
| `products/batch_exports/backend/tests/temporal/conftest.py` | Same |
| `products/tasks/backend/temporal/conftest.py` | Same |
| `posthog/temporal/tests/common/test_logger.py` | Shadowing fixture moved onto it, plus a regression test |

All three conftests carried the identical defect. Fixing one leaves the bug reachable through the other two.

`override_settings` keeps its original narrow scope in `test_logger.py` — wrapping only the configure call, not the test body — via `ExitStack`.

## How did you test this code?

A/B on the same command, only the fix differing:

| | Result |
|---|---|
| Without fix | **16 failed**, 278 passed, 1 skipped |
| With fix | **294 passed**, 1 skipped |

Nothing goes pass → fail. No test was relying on the broken capture.

Wider runs, both green with the fix: `posthog/temporal/tests/ai/slack_app/ + products/slack_app/backend/tests/` (812 passed), and the activities-only variant (785 passed, was 1 failed).

The new test asserts the previous structlog config is restored. I confirmed it fails when the restore is removed. No existing test caught this, because the symptom only ever surfaces in a later, unrelated test.

**No behavior change in CI.** `ci-backend.yml` runs Core with `--ignore=posthog/temporal` and Temporal as a separate job — separate processes, so the poisoning was never reachable there. This fixes local runs and removes the trap.

Not verified locally: `products/tasks/` and `products/batch_exports/` temporal suites need sandbox/ClickHouse infra I don't have. Both collect cleanly (1018 and 1599 tests) and a 16-test tasks subset passes. Six `test_oauth.py` errors in that tree are pre-existing — identical with the fix reverted.

Untouched: `test_zz_resolve_slack_user_with_link_no_access.py` guards a *different* mechanism (project-wide `cache_logger_on_first_use=True` caching a logger within one directory). Keep its `zz_` prefix.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while rebasing an unrelated Slack app branch: a combined run failed in files that branch never touched. Confirmed pre-existing, then split out here off master.

Diagnosed through the mechanism rather than bisecting ~800 tests. Two candidates — structlog's logger-factory swap and its `cache_logger_on_first_use` caching. Reading `configure_logger` against `posthog/settings/logs.py` showed the factory swap was sufficient alone; the A/B confirmed it.

Rejected: restoring inline in each of the three fixtures — copy-pasted teardown, and the next `configure_logger` caller repeats the bug. The context manager puts the restore next to the global state it protects.

Tools: Claude Code (Opus 5). Skills invoked: `/writing-tests`.
