### PR TITLE
feat(experiments): add dogfood A/A test on the experiments list page

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -316,6 +316,7 @@ export const FEATURE_FLAGS = {
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_EXCLUDED_VARIANTS: 'experiments-excluded-variants', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_FREEZE_EXPOSURE_AA_TEST: 'experiments-freeze-exposure-aa-test', // owner: @mp-hog #team-experiments multivariate=control,test, dogfood A/A used to validate the freeze-exposure lifecycle action
+    EXPERIMENTS_LIST_AA_TEST: 'experiments-list-aa-test', // owner: @andehen #team-experiments multivariate=control,test, dogfood A/A exposed on the experiments list page
     EXPERIMENTS_METRICS_RECALCULATION: 'experiments-metrics-recalculation', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_SHOW_SQL: 'experiments-show-sql', // owner: @jurajmajerik #team-experiments
     EXPERIMENTS_SYNC_QUERIES: 'experiments-sync-queries', // owner: @andehen #team-experiments

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -13,6 +13,7 @@ import { MemberMultiSelect } from 'lib/components/MemberMultiSelect'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
 import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
@@ -23,6 +24,7 @@ import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/Le
 import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { addProductIntentForCrossSell } from 'lib/utils/product-intents'
 import { pluralize } from 'lib/utils/strings'
 import stringWithWBR from 'lib/utils/stringWithWBR'
@@ -559,6 +561,7 @@ const ExperimentsTable = ({
 
 export function Experiments(): JSX.Element {
     const { tab } = useValues(experimentsLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { setExperimentsTab, loadExperiments } = useActions(experimentsLogic)
     const [duplicateModalExperiment, setDuplicateModalExperiment] = useState<Experiment | null>(null)
     const [copyToProjectModalExperiment, setCopyToProjectModalExperiment] = useState<Experiment | null>(null)
@@ -692,6 +695,9 @@ export function Experiments(): JSX.Element {
                     isOpen={true}
                     onCancel={() => setSurveyModalExperiment(null)}
                 />
+            )}
+            {featureFlags[FEATURE_FLAGS.EXPERIMENTS_LIST_AA_TEST] === 'test' && (
+                <div data-attr="experiments-list-aa-test-variant" className="hidden" />
             )}
         </SceneContent>
     )


### PR DESCRIPTION
## Problem

We want a live A/A experiment on a real app surface to validate the experimentation engine end to end. Exposure should be scoped to one page, not to every authenticated pageview.

## Changes

- Adds `FEATURE_FLAGS.EXPERIMENTS_LIST_AA_TEST` (`experiments-list-aa-test`).
- The experiments list scene reads the flag through `featureFlagLogic`, which fires the exposure event for visitors of that page.
- The `test` variant renders a hidden marker div, following the existing dogfood A/A pattern in `AuthenticatedShell.tsx`.
- The [flag](https://us.posthog.com/project/2/feature_flags/800537) exists in the US project as multivariate control/test at 50/50, rolled out to 100%.
- No visible UI change, so no screenshot.

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` passes.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) passes.
- No new tests: the change renders a hidden div behind a flag, with no behavior to regress.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code wrote the change; Anders directed it.
- The flag was created through the PostHog MCP `create-feature-flag` tool.
- Skills invoked: /writing-pr-descriptions.
- The marker sits in the experiments list scene instead of `AuthenticatedShell.tsx` to scope exposure to that page.
