### PR TITLE
feat(workflows): show open rate and CTR in email metrics

### DIFF
--- a/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
@@ -22,7 +22,7 @@ import {
 } from './workflowMetricsSummaryLogic'
 
 const TRACKED_SENDS_TOOLTIP =
-    'Untracked sends can never record opens or clicks, so engagement is shown against tracked sends (sent minus untracked).'
+    'Untracked sends can never record opens or clicks, so engagement is shown against tracked sends (sent minus untracked). Counts and rates compare activity within the selected date range, so opens of emails sent before the range can push a rate above 100%.'
 
 // Opens and clicks are only possible on tracked sends, so pair the raw count with the denominator it
 // should be read against, plus the rate over that denominator. A step with no tracked sends shows a

--- a/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
+++ b/products/workflows/frontend/Workflows/WorkflowMetricsSummary.tsx
@@ -25,8 +25,8 @@ const TRACKED_SENDS_TOOLTIP =
     'Untracked sends can never record opens or clicks, so engagement is shown against tracked sends (sent minus untracked).'
 
 // Opens and clicks are only possible on tracked sends, so pair the raw count with the denominator it
-// should be read against. A step that tracked every send shows the count alone, because its Sent
-// column is already the right denominator.
+// should be read against, plus the rate over that denominator. A step with no tracked sends shows a
+// dash instead of a rate.
 function trackedEngagementColumn(value: number, row: EmailMetricRow): JSX.Element {
     return (
         <span>
@@ -34,6 +34,10 @@ function trackedEngagementColumn(value: number, row: EmailMetricRow): JSX.Elemen
             {row.untracked > 0 && (
                 <span className="text-muted"> of {row.trackedSends.toLocaleString()} tracked sends</span>
             )}
+            <span className="text-muted">
+                {' '}
+                ({row.trackedSends > 0 ? `${((value / row.trackedSends) * 100).toFixed(1)}%` : '-'})
+            </span>
         </span>
     )
 }


### PR DESCRIPTION
## Problem

The email table on the workflow metrics tab shows Sent, Delivered, Opened, and Clicked as raw counts only. Open rate and CTR are the numbers people compare campaigns on, and today they do the division by hand.

Untracked sends (consent-gated, see #74191) can never record an open or click, so a rate over `sent` or `delivered` would understate engagement.

## Changes

- The Opened and Clicked columns append the rate after the count, dividing by `trackedSends`.
- Fully tracked step: `1,234 (12.3%)`. Partially tracked: `45 of 1,000 tracked sends (4.5%)`.
- Zero tracked sends renders a muted `-` instead of a percentage, so `NaN%` cannot appear.
- Formatting matches the existing conversion rate display (one decimal place).

## How did you test this code?

- `workflowMetricsSummaryLogic.test.ts` with `--runInBand`: 30 passed. The `trackedSends` derivation the rates divide by is covered there.
- No new test: the change is a render-only division with a ternary zero guard.
- Frontend typecheck and oxfmt: clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Directed by Harley

Built by Claude Code from [this inbox report](https://us.posthog.com/project/2/inbox/reports/019fb2e8-c53d-7d14-ab9a-d1e7136dc0ac), replacing closed #75418 (its action-type half landed via #75546; the rate columns were the report's remaining ask). Rates divide by `trackedSends`, never `sent` or `delivered`, per the tracked-sends groundwork in #74191. Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`.
