### PR TITLE
feat(warehouse): always sync profile subscriptions in Klaviyo source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/settings.py
@@ -221,6 +221,11 @@ KLAVIYO_ENDPOINTS: dict[str, KlaviyoEndpointConfig] = {
         path="/profiles",
         default_incremental_field="updated",
         partition_key="created",
+        # Klaviyo omits the subscriptions object (email/SMS/push consent detail) unless requested.
+        # Carries no rate-limit penalty, unlike predictive_analytics (75/s -> 10/s), which stays
+        # excluded. The list_profiles/segment_profiles fan-outs are unaffected: their own
+        # extra_params restrict profile payloads to joined_group_at via a fields[profile] fieldset.
+        extra_params={"additional-fields[profile]": "subscriptions"},
         incremental_fields=[
             {
                 "label": "updated",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -925,6 +925,31 @@ class TestEndpointRequestParams:
         )
         assert params["filter"] == "greater-or-equal(created,2026-03-04T02:58:14.000Z)"
 
+    def test_profiles_request_the_omitted_subscriptions_object(self) -> None:
+        # Klaviyo excludes subscriptions (consent detail) unless additional-fields asks for it;
+        # dropping this param silently loses the column for every synced profile.
+        params = _build_initial_params(
+            KLAVIYO_ENDPOINTS["profiles"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
+            incremental_field="updated",
+        )
+        assert params["additional-fields[profile]"] == "subscriptions"
+        assert params["filter"] == "greater-than(updated,2026-03-04T02:58:14.000Z)"
+
+    @parameterized.expand([("list_profiles",), ("segment_profiles",)])
+    def test_membership_fan_outs_keep_their_restrictive_fieldset(self, endpoint: str) -> None:
+        # The fan-outs only need joined_group_at; expanding them with additional-fields would
+        # balloon every per-parent request.
+        params = _build_initial_params(
+            KLAVIYO_ENDPOINTS[endpoint],
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            incremental_field=None,
+        )
+        assert params["fields[profile]"] == "joined_group_at"
+        assert "additional-fields[profile]" not in params
+
 
 class TestNewSchemas:
     @parameterized.expand(


### PR DESCRIPTION
## Problem

Klaviyo deliberately omits the profile `subscriptions` object (detailed email/SMS/push consent status) from `GET /api/profiles` unless requested via `additional-fields[profile]=subscriptions` ([Get Profiles docs](https://developers.klaviyo.com/en/reference/get_profiles)). Our profiles sync never requests it, so the data can't reach the warehouse.

Supersedes [#78097](https://github.com/PostHog/posthog/pull/78097), which gated this behind a source config toggle — feedback was to drop the option and just sync it for everyone.

## Changes

One `extra_params` entry on the `profiles` endpoint config: every profiles request now carries `additional-fields[profile]=subscriptions`, landing as a `subscriptions` dict column via the existing `_flatten_item` path (same as `location`/`properties`). No config, no migration, no frontend changes.

- No rate-limit penalty — `subscriptions` keeps the standard 75/s (unlike `predictive_analytics`, which drops it to 10/s and stays excluded).
- The `list_profiles`/`segment_profiles` membership fan-outs are unaffected; they keep their restrictive `fields[profile]=joined_group_at` fieldset.
- Existing incrementally-synced profiles tables gain the column for rows touched after this ships; a full resync backfills history. The delta table evolves to accept the new column as usual.

## How did you test this code?

Added unit tests (105 pass): profiles params carry the `additional-fields` entry alongside the incremental filter, and both membership fan-outs keep their restrictive fieldset with no `additional-fields` leakage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*