### PR TITLE
fix(phai): hand homepage prompts to the new PostHog AI surface

### DIFF
--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.test.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.test.ts
@@ -1,6 +1,7 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { maxLogic } from 'scenes/max/maxLogic'
 import { urls } from 'scenes/urls'
@@ -49,5 +50,29 @@ describe('aiFirstHomepageLogic', () => {
 
         expect(maxLogic({ panelId: HOMEPAGE_TAB_ID }).values.question).toEqual('what is my dau')
         expect(sidePanelStateLogic.values.sidePanelOpen).toBe(false)
+    })
+
+    // The homepage chat only drives the legacy runtime. Without the handoff, a prompt submitted by a
+    // user on the new PostHog AI surface starts a LangGraph conversation that surface never renders,
+    // so the submit looks like it did nothing.
+    it.each([
+        ['legacy view', false, '/project/997/home', 'ai'],
+        ['new view', true, '/project/997/ai', 'idle'],
+    ])('submitting a prompt on the %s', async (_case, sandboxFlagOn, expectedPathname, expectedMode) => {
+        if (sandboxFlagOn) {
+            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.PHAI_SANDBOX_MODE], {
+                [FEATURE_FLAGS.PHAI_SANDBOX_MODE]: true,
+            })
+        }
+        router.actions.push(urls.projectHomepage())
+
+        logic.actions.setQuery('what is my dau')
+        logic.actions.submitQuery('ai')
+        await expectLogic(logic).delay(1)
+
+        expect(router.values.location.pathname).toEqual(expectedPathname)
+        expect(logic.values.mode).toEqual(expectedMode)
+        // The prompt rides along as `ask`, which the new surface's composer seeds and submits.
+        expect(router.values.searchParams.ask).toEqual(sandboxFlagOn ? 'what is my dau' : undefined)
     })
 })

--- a/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
+++ b/frontend/src/scenes/project-homepage/ai-first/aiFirstHomepageLogic.ts
@@ -12,6 +12,7 @@ import {
     capabilitiesForGrouping,
     capabilityGroupingFromVariant,
 } from 'scenes/max/maxCapabilities'
+import { type PhaiViewMode, maxGlobalLogic } from 'scenes/max/maxGlobalLogic'
 import { maxLogic, parseCommandString } from 'scenes/max/maxLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -88,6 +89,7 @@ export interface aiFirstHomepageLogicValues {
     dashboardsLoading: boolean // dashboardsModel
     pinnedDashboards: (DashboardBasicType | DashboardType<QueryBasedInsightModel<Node<Record<string, any>>>>)[] // dashboardsModel
     featureFlags: FeatureFlagsSet // featureFlagLogic
+    effectivePhaiView: PhaiViewMode // maxGlobalLogic
     conversationId: string | null // maxLogic
     threadLogicKey: string // maxLogic
     cachedStarred: FileSystemEntry[] // projectTreeDataLogic
@@ -221,6 +223,8 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             ['chatDraftFor'],
             featureFlagLogic,
             ['featureFlags'],
+            maxGlobalLogic,
+            ['effectivePhaiView'],
         ],
         actions: [
             maxLogic({ panelId: HOMEPAGE_TAB_ID }),
@@ -406,6 +410,18 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
             // resurrect it as "unsent input" the next time the homepage is mounted.
             actions.setChatDraftForTab(HOMEPAGE_IDLE_DRAFT_KEY, '')
 
+            // The homepage chat only drives the legacy runtime, so on the new PostHog AI surface a prompt
+            // submitted here would start a LangGraph conversation that surface never shows. Hand it to
+            // /ai instead, which seeds its composer from `ask` and submits it. An AI submit with no
+            // prompt is a chat being restored from `?mode=ai&chat=…` — that still opens here.
+            if (mode === 'ai' && values.effectivePhaiView === 'new' && values.query.trim()) {
+                router.actions.push(urls.ai(undefined, values.query))
+                // Undo the mode flip the reducers just made, so the legacy homepage thread never mounts
+                // and fires a second, competing send while the route change lands.
+                actions.returnToIdle()
+                return
+            }
+
             if (mode === 'ai' && !values.conversationId) {
                 actions.startNewConversation()
             }
@@ -456,8 +472,15 @@ export const aiFirstHomepageLogic = kea<aiFirstHomepageLogicType>([
     })),
 
     actionToUrl(({ values }) => ({
-        submitQuery: () => {
+        submitQuery: ({ mode: submittedMode }) => {
             const { mode, query } = values
+            // On the new PostHog AI surface the homepage never owns an AI route: a submit with a prompt
+            // is navigated to /ai by the listener (which reads the query before clearing it), and one
+            // without is a restore that arrived on this URL already. Keyed off the submitted mode rather
+            // than `values.mode`, which the listener may already have reset.
+            if (submittedMode === 'ai' && values.effectivePhaiView === 'new') {
+                return undefined
+            }
             if (mode === 'ai') {
                 return [
                     urls.projectHomepage(),


### PR DESCRIPTION
## Problem

- On the new PostHog AI surface, a prompt submitted on `/home` looks like it does nothing.
- The AI-first homepage drives only the legacy LangGraph chat. It mounts `maxLogic` and `maxThreadLogic` directly.
- Every other entry point branches on `effectivePhaiView`: `/ai`, the side panel, the Max scene. The homepage does not.
- So the submit starts a LangGraph conversation that the new surface never renders.

```mermaid
flowchart LR
    A[/home submit/] --> B{effectivePhaiView}
    B --> C[maxThreadLogic.askMax]
    C --> D[POST /conversations/ LangGraph]
    D --> E[not rendered by the new surface]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    class A phYellow;
    class B,C phBlue;
    class D,E phRed;
```

```mermaid
flowchart LR
    A[/home submit/] --> B{effectivePhaiView}
    B -->|legacy| C[maxThreadLogic.askMax]
    B -->|new| F[push /ai?ask=prompt]
    F --> G[composer seeds and submits]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C,F phBlue;
    class G phGray;
```

**Before**


https://github.com/user-attachments/assets/842ad102-e7a8-46a7-9fa2-43707b1677bf

**After**

https://github.com/user-attachments/assets/7d2348e9-b3ea-4e28-b9af-96f0305c2018



## Changes

- `submitQuery('ai')` navigates to `/ai?ask=<prompt>` when `effectivePhaiView` is `new`.
- `phaiAiComposerSeedLogic` seeds that composer from `ask` and submits it. `askSidePanelMax` already uses this handoff.
- The listener resets the homepage to idle, so the legacy thread never mounts and sends a second time.
- An AI submit carrying no prompt restores a chat from `?mode=ai&chat=…`, so that still opens on the homepage.

> [!NOTE]
> This is the interim fix. Typing `/` or `@` on the homepage calls `enterAiMode` and still drops the user into the legacy chat. Routing that path needs `?ask=` to carry a prompt without auto-submitting, which `#panel=max:<prompt>` links depend on. I left it for a follow-up.

## How did you test this code?

- I added 2 parameterized cases to `aiFirstHomepageLogic.test.ts`. They assert the target URL and the resulting mode for each view.
- The regression: if someone drops the `effectivePhaiView` guard, a flagged user's prompt reaches LangGraph again. No existing test covered `submitQuery`.
- I ran `jest src/scenes/project-homepage/ai-first/`. All 3 tests pass.
- I did not run the app. The dev stack was not up in this session.

<details>
<summary>How I confirmed the bug first</summary>

I rendered `AiFirstHomepage` in a throwaway test, submitted a prompt, and spied on the API. Both view modes produced an identical call:

```
flag off  stream: 1  open: 0   (no is_sandbox in the body)
flag on   stream: 1  open: 0   (no is_sandbox in the body)
```

I deleted that test. The two cases in `aiFirstHomepageLogic.test.ts` cover the fix at the logic level.
</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, via Claude Code) investigated and wrote this. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

I looked at three fixes. Forcing the sandbox runtime on the homepage thread keeps the inline chat, but `Thread.tsx` gates on `conversation?.agent_runtime === 'sandbox'` and `maxThreadLogic.conversation` is null for a new chat, so the first turn renders an empty legacy thread. Embedding `EmbeddedRunner` pulls the whole TaskTracker scene, which routes through its own `/tasks/:id` URLs and does not fit the homepage layout. Georgiy picked the handoff as the interim step.

One detail worth a look: the `actionToUrl` guard keys off the submitted mode, not `values.mode`. The listener may already have reset the mode, and the order between the two is not fixed.

Related: `SandboxModeToggle.tsx` is rendered nowhere in the app. I did not touch it in this PR.