### PR TITLE
fix(slack_app): post AI-credits denial where the user sees it

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/billing.py
+++ b/posthog/temporal/ai/slack_app/activities/billing.py
@@ -22,6 +22,8 @@ def enforce_posthog_code_billing_quota_activity(
     """
     from posthog.models.integration import Integration, SlackIntegration
 
+    from products.slack_app.backend.api import mention_is_in_thread
+
     integration = Integration.objects.select_related("team").get(
         id=inputs.integration_id,
         kind="slack",
@@ -35,4 +37,5 @@ def enforce_posthog_code_billing_quota_activity(
         thread_ts=thread_ts,
         slack_user_id=slack_user_id,
         context="task_create",
+        mention_is_threaded=mention_is_in_thread(inputs.event),
     )

--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -525,6 +525,7 @@ def create_posthog_code_task_for_repo_activity(
 ) -> None:
     from posthog.models.integration import Integration, SlackIntegration
 
+    from products.slack_app.backend.api import mention_is_in_thread
     from products.slack_app.backend.models import SlackThreadTaskMapping
     from products.slack_app.backend.slack_thread import SlackThreadContext
     from products.tasks.backend.facade import api as tasks_facade
@@ -566,6 +567,7 @@ def create_posthog_code_task_for_repo_activity(
         thread_ts=thread_ts,
         slack_user_id=slack_user_id,
         context="task_create",
+        mention_is_threaded=mention_is_in_thread(event),
     ):
         return
 
@@ -870,6 +872,9 @@ def forward_posthog_code_followup_activity(
         thread_ts=thread_ts,
         slack_user_id=slack_user_id,
         context="followup",
+        # A follow-up reaches this activity only through a thread mapping, so the
+        # message is by construction a reply inside that thread.
+        mention_is_threaded=True,
     ):
         return True
 

--- a/posthog/temporal/ai/slack_app/helpers.py
+++ b/posthog/temporal/ai/slack_app/helpers.py
@@ -18,6 +18,7 @@ def block_if_team_over_quota(
     thread_ts: str,
     slack_user_id: str,
     context: str,
+    mention_is_threaded: bool,
 ) -> bool:
     """Refuse a Slack-bot turn when the team is over its AI credits quota.
 
@@ -26,6 +27,10 @@ def block_if_team_over_quota(
     activity modules can compose both without each one re-importing
     ``ee.billing``. Returns True when the team was blocked and a denial was
     posted.
+
+    ``mention_is_threaded`` decides where the denial lands — see
+    ``mention_is_in_thread``. Callers derive it from the raw Slack event, not from
+    ``thread_ts``, which folds a top-level mention's own ``ts`` into the anchor.
     """
     from products.slack_app.backend.api import post_quota_exhausted_denial
 
@@ -45,6 +50,7 @@ def block_if_team_over_quota(
         thread_ts=thread_ts,
         slack_user_id=slack_user_id,
         context=context,
+        mention_is_threaded=mention_is_threaded,
     )
     return True
 

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -4,6 +4,7 @@ import time
 import uuid
 import asyncio
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
@@ -258,6 +259,18 @@ QUOTA_EXHAUSTED_MESSAGE = (
 )
 
 
+def mention_is_in_thread(event: Mapping[str, Any]) -> bool:
+    """Whether a Slack event is a reply inside a thread rather than a top-level channel post.
+
+    A thread root carries ``thread_ts == ts``; only a genuine reply carries an older
+    ``thread_ts``. User-facing feedback uses this to pick its surface: a reply anchored to
+    a thread renders for someone already viewing that thread, which is nowhere near the
+    channel view where a top-level mention was just typed.
+    """
+    thread_ts = event.get("thread_ts")
+    return isinstance(thread_ts, str) and thread_ts != event.get("ts")
+
+
 def post_quota_exhausted_denial(
     *,
     integration: Integration,
@@ -266,13 +279,18 @@ def post_quota_exhausted_denial(
     thread_ts: str,
     slack_user_id: str,
     context: str,
+    mention_is_threaded: bool,
 ) -> None:
-    """Post the AI-credits denial message into a Slack thread.
+    """Tell a Slack user their team is out of AI credits.
 
     Called by the workflow's quota gate after it determines the team is over
     quota. Lives in this module so the Slack-posting helpers and the message
     text stay co-located; the quota check itself lives in the temporal layer
     (which is the only side allowed to import ``ee.billing``).
+
+    ``thread_ts`` is the conversation anchor the rest of the pipeline keys on, so it is what
+    the log carries. The denial itself only threads when the mention did — from a top-level
+    mention it goes to the channel root, where the user is actually looking.
     """
     logger.info(
         "slack_app_slack_blocked_by_quota",
@@ -285,7 +303,7 @@ def post_quota_exhausted_denial(
         slack,
         channel,
         slack_user_id,
-        thread_ts,
+        thread_ts if mention_is_threaded else None,
         QUOTA_EXHAUSTED_MESSAGE,
         prefer_thread_message=True,
     )
@@ -295,13 +313,17 @@ def _post_slack_user_feedback(
     slack: SlackIntegration,
     channel: str,
     slack_user_id: str,
-    thread_ts: str,
+    thread_ts: str | None,
     text: str,
     *,
     prefer_thread_message: bool = False,
 ) -> bool:
     """Post feedback to a Slack user. Returns whether anything reached Slack, so callers
-    that report on whether the user was actually told something aren't guessing."""
+    that report on whether the user was actually told something aren't guessing.
+
+    Pass ``thread_ts=None`` for a message that isn't in a thread, so both the channel post
+    and the ephemeral fallback land at the channel root rather than inside a thread the
+    user isn't viewing."""
     if prefer_thread_message:
         try:
             slack.client.chat_postMessage(channel=channel, thread_ts=thread_ts, text=text)
@@ -1910,9 +1932,7 @@ def route_posthog_code_event_to_relevant_region(
         channel_str = event.get("channel") if isinstance(event.get("channel"), str) else None
         thread_ts_value = event.get("thread_ts") or event.get("ts")
         thread_ts_str = thread_ts_value if isinstance(thread_ts_value, str) else None
-        # Whether the message is a reply inside a thread rather than a top-level channel
-        # post. Decides which surface an ephemeral has to be anchored to to be visible.
-        mention_is_threaded = isinstance(event.get("thread_ts"), str) and event.get("thread_ts") != event.get("ts")
+        mention_is_threaded = mention_is_in_thread(event)
 
         # Region routing only needs candidate presence, not user resolution. We
         # defer the Slack ``users.info`` hit and the ``OrganizationMembership``

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -27,9 +27,19 @@ from products.slack_app.backend.api import SlackUserContext
 from products.slack_app.backend.models import SlackThreadTaskMapping
 
 
-def _make_inputs(integration_id: int, slack_team_id: str = "T_SLACK") -> PostHogCodeSlackMentionWorkflowInputs:
+def _make_inputs(
+    integration_id: int,
+    slack_team_id: str = "T_SLACK",
+    event_extra: dict[str, str] | None = None,
+) -> PostHogCodeSlackMentionWorkflowInputs:
     return PostHogCodeSlackMentionWorkflowInputs(
-        event={"channel": "C123", "ts": "1234.5678", "user": "U_ALICE", "text": "<@BOT> do something"},
+        event={
+            "channel": "C123",
+            "ts": "1234.5678",
+            "user": "U_ALICE",
+            "text": "<@BOT> do something",
+            **(event_extra or {}),
+        },
         integration_id=integration_id,
         slack_team_id=slack_team_id,
     )
@@ -48,13 +58,13 @@ def _make_slack_file(**overrides: object) -> dict[str, object]:
     return file
 
 
-def _assert_quota_denial_posted(mock_slack_instance: MagicMock, channel: str, thread_ts: str) -> None:
+def _assert_quota_denial_posted(mock_slack_instance: MagicMock, channel: str, thread_ts: str | None) -> None:
     denial_calls = [
         call
         for call in mock_slack_instance.client.chat_postMessage.call_args_list
         if call.kwargs.get("channel") == channel and call.kwargs.get("thread_ts") == thread_ts
     ]
-    assert denial_calls, "Expected an in-thread denial message when over quota"
+    assert denial_calls, f"Expected a denial message anchored to {thread_ts!r} when over quota"
     assert "PostHog AI credits" in denial_calls[0].kwargs["text"]
 
 
@@ -577,7 +587,7 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
     @patch("products.tasks.backend.facade.temporal.execute_task_processing_workflow")
     @patch("posthog.models.integration.SlackIntegration")
     @patch("ee.billing.quota_limiting.is_team_limited", return_value=True)
-    def test_quota_exceeded_blocks_task_creation_with_thread_message(
+    def test_quota_exceeded_blocks_task_creation_and_tells_the_user(
         self,
         _mock_is_team_limited,
         mock_slack_cls,
@@ -602,7 +612,8 @@ class TestCreatePostHogCodeTaskForRepoActivity(TestCase):
         assert not self.Task.objects.filter(team=self.team).exists()
         mock_execute_workflow.assert_not_called()
 
-        _assert_quota_denial_posted(mock_slack_instance, "C123", "1234.5678")
+        # The mention is top-level, so the denial belongs at the channel root.
+        _assert_quota_denial_posted(mock_slack_instance, "C123", None)
 
 
 class TestForwardPostHogCodeFollowupActivity(TestCase):
@@ -1200,22 +1211,40 @@ class TestEnforcePostHogCodeBillingQuotaActivity(TestCase):
         self.team = Team.objects.create(organization=self.org, name="TestTeam")
         self.integration = Integration.objects.create(team=self.team, kind="slack", integration_id="T_SLACK", config={})
 
+    @parameterized.expand(
+        [
+            # A top-level mention carries only its own ts. The denial must land at the
+            # channel root: anchored to that ts it becomes a threaded reply the user
+            # sitting in the channel never sees, which reads as the bot ignoring them.
+            ("top_level_mention", {}, "1234.5678", None),
+            # A mention inside a real thread carries thread_ts; the denial threads there.
+            ("mention_in_thread", {"ts": "2222.2", "thread_ts": "1234.5678"}, "1234.5678", "1234.5678"),
+        ]
+    )
     @patch("posthog.models.integration.SlackIntegration")
     @patch("ee.billing.quota_limiting.is_team_limited", return_value=True)
-    def test_returns_true_and_posts_denial_when_over_quota(self, _mock_is_team_limited, mock_slack_cls):
+    def test_returns_true_and_posts_denial_where_the_user_sees_it(
+        self,
+        _name,
+        event_extra,
+        thread_ts,
+        expected_denial_thread_ts,
+        _mock_is_team_limited,
+        mock_slack_cls,
+    ):
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
 
-        inputs = _make_inputs(self.integration.id)
+        inputs = _make_inputs(self.integration.id, event_extra=event_extra)
         blocked = enforce_posthog_code_billing_quota_activity(
             inputs,
             "C123",
-            "1234.5678",
+            thread_ts,
             "U_ALICE",
         )
 
         assert blocked is True
-        _assert_quota_denial_posted(mock_slack_instance, "C123", "1234.5678")
+        _assert_quota_denial_posted(mock_slack_instance, "C123", expected_denial_thread_ts)
 
     @patch("posthog.models.integration.SlackIntegration")
     @patch("ee.billing.quota_limiting.is_team_limited", return_value=False)


### PR DESCRIPTION
## Problem

A user whose team is out of AI credits gets no visible response from `@PostHog`.

The quota gate fires correctly — it just replies where nobody is looking. The denial is anchored to `event.thread_ts or event.ts`, so from a top-level mention it opens a thread under the user's own message, and the ephemeral fallback behind it is thread-anchored too. Slack renders neither to someone sitting in the channel's main view, so the bot reads as silent.

Same failure shape as the command-reply fix in #73097, which didn't reach this path.

## Changes

- The denial threads only when the mention was itself a thread reply; otherwise it goes to the channel root.
- `_post_slack_user_feedback` accepts `thread_ts=None`, so the ephemeral fallback follows the message to the root instead of back into the thread.
- New `mention_is_in_thread(event)` shares the predicate with the webhook, which was computing it inline.
- `slack_app_slack_blocked_by_quota` still logs the conversation anchor, so denials stay correlatable to a thread.

## How did you test this code?

Automated only — no manual Slack run.

- Parameterized the entry-gate denial test over both surfaces: a top-level mention must reach the channel root, a threaded one must stay in its thread. Neither anchor was asserted before; the task-creation test pinned the buggy one.
- `pytest products/slack_app/backend/tests` — 754 passed
- `pytest posthog/temporal/tests/ai/slack_app` — 59 passed
- `uv run mypy --cache-fine-grained .` — clean

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). No repo skills invoked.

Started as an audit of whether the Slack app checks AI credits at all. It does — `block_if_team_over_quota` gates the workflow entry, task creation, and follow-up forwarding, all on `QuotaResource.AI_CREDITS`. An early hypothesis that Slack-origin runs bill into `posthog_code_credits` while the gate reads `ai_credits` was wrong and dropped: `interaction_origin="slack"` routes the sandbox agent to the gateway's `slack_app` product, which is `AI_CREDITS`, and the gateway resolves exhaustion from the same Redis zset the gate reads. Bucket alignment is correct end to end; only the reply surface was broken.

Two related gaps found and deliberately left out of this PR: the workflow comment claims a webhook-level quota short-circuit that does not exist, and the mention-command workflow has no quota gate.

