### PR TITLE
fix(logs): stop the sparkline row cap truncating a service breakdown

### DIFF
--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -26,6 +26,15 @@ DEFAULT_BREAKDOWN = LogsSparklineBreakdownBy.SEVERITY
 # 60s default so a slow preview surfaces an error promptly instead of appearing to hang.
 SPARKLINE_PREVIEW_MAX_EXECUTION_SECONDS = 30
 
+# The result is one row per (time bucket × breakdown value present in that bucket), and the
+# breakdown is not capped to a top-N — every distinct service in the window comes back, even
+# though callers only chart the top few. With ~50 buckets (BUCKET_TARGET) the old cap of 1000
+# truncated above only ~20 distinct services, and because rows are ordered by time ascending it
+# dropped the *newest* buckets, silently understating recent volume and any total derived from it.
+# Matches ServicesQueryRunner's sparkline cap. Raising this doesn't widen the scan — the
+# aggregation reads the same rows either way; the LIMIT only bounds the returned payload.
+SPARKLINE_MAX_ROWS = 10000
+
 
 class SparklineQueryRunner(LogsQueryRunner):
     @cached_property
@@ -102,10 +111,11 @@ class SparklineQueryRunner(LogsQueryRunner):
                     GROUP BY {breakdown_field}, time
                 ) AS ac ON am.time_bucket = ac.time
                 ORDER BY time asc, {breakdown_field} asc
-                LIMIT 1000
+                LIMIT {max_rows}
         """,
             placeholders={
                 **self.query_date_range.to_placeholders(),
+                "max_rows": ast.Constant(value=SPARKLINE_MAX_ROWS),
                 # The sparkline projection is aggregated over "toStartOfMinute(timestamp)"
                 # so if we use `timestamp` we don't use the projection (even if we're calling toStartOfInterval on it)
                 # explicitly use toStartOfMinute(timestamp) as the time field unless we're using a sub-minute interval

--- a/products/logs/backend/test/test_sparkline_query_runner.py
+++ b/products/logs/backend/test/test_sparkline_query_runner.py
@@ -1,8 +1,12 @@
 import os
 import json
+import uuid
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from django.urls import get_resolver
 
 from rest_framework import status
 
@@ -15,6 +19,13 @@ class TestSparklineQueryRunner(ClickhouseTestMixin, APIBaseTest):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+        # Import the URL tree before any test freezes time. Every test here requests under
+        # freeze_time, and the first such request is what imports the URL conf — which reaches
+        # pydantic.v1, whose ConstrainedDate subclasses `date`. freezegun has swapped that for
+        # FakeDate by then, so the import dies with a metaclass conflict and whichever test happens
+        # to run first fails.
+        assert get_resolver().url_patterns is not None
+
         with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
             sql = ""
             for line in f:
@@ -55,3 +66,53 @@ class TestSparklineQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual(len(response), 49)
         self.assertEqual(sum(r["count"] for r in response), 900)
+
+    @freeze_time("2026-03-02T00:10:00Z")
+    def test_service_breakdown_over_a_day_is_not_truncated_by_the_row_cap(self):
+        # A row is (time bucket × service present in it) and the breakdown isn't capped to a top-N,
+        # so a 24h range (30-minute buckets) crosses the old 1000-row cap above ~20 services. Rows
+        # come back time-ascending, so the cap dropped the *newest* buckets — silently understating
+        # recent volume and any total derived from it.
+        service_count = 25
+        bucket_count = 48
+        self._insert_logs_across_services(
+            start="2026-03-01T00:00:00", service_count=service_count, bucket_count=bucket_count
+        )
+
+        response = self._make_sparkline_api_request(
+            {
+                "dateRange": {"date_from": "2026-03-01T00:00:00.000000Z", "date_to": "2026-03-02T00:00:00.000000Z"},
+                "filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+                "sparklineBreakdownBy": "service",
+            }
+        )
+
+        self.assertGreater(len(response), 1000)
+        self.assertEqual(sum(r["count"] for r in response), service_count * bucket_count)
+        # Every service keeps its whole trend rather than losing its later buckets.
+        self.assertEqual(len({r["service"] for r in response}), service_count)
+        for service in {r["service"] for r in response}:
+            self.assertEqual(sum(1 for r in response if r["service"] == service and r["count"] > 0), bucket_count)
+
+    def _insert_logs_across_services(self, start: str, service_count: int, bucket_count: int) -> None:
+        """One log per (service, 30-minute bucket), cloned off the fixture so the schema stays valid."""
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            template = json.loads(f.readline())
+        start_at = datetime.fromisoformat(start)
+        rows = ""
+        for service_index in range(service_count):
+            for bucket_index in range(bucket_count):
+                log_item = dict(template)
+                log_item["team_id"] = self.team.id
+                log_item["uuid"] = str(uuid.uuid4())
+                log_item["service_name"] = f"service-{service_index:03d}"
+                # Land mid-bucket so bucket rounding can't move a log into a neighbour.
+                timestamp = start_at + timedelta(minutes=30 * bucket_index, seconds=61)
+                log_item["timestamp"] = timestamp.strftime("%Y-%m-%d %H:%M:%S.%f")
+                log_item["observed_timestamp"] = log_item["timestamp"]
+                rows += json.dumps(log_item) + "\n"
+        sync_execute(f"""
+            INSERT INTO logs
+            FORMAT JSONEachRow
+            {rows}
+        """)

--- a/products/logs/frontend/components/LogsFilterPreview/logsFilterVolumePreview.test.ts
+++ b/products/logs/frontend/components/LogsFilterPreview/logsFilterVolumePreview.test.ts
@@ -1,4 +1,12 @@
-import { LogsFilterPreviewPoint, buildSparklineSeries, formatBytes } from './logsFilterVolumePreview'
+import fs from 'fs'
+import path from 'path'
+
+import {
+    LogsFilterPreviewPoint,
+    SPARKLINE_ROW_LIMIT,
+    buildSparklineSeries,
+    formatBytes,
+} from './logsFilterVolumePreview'
 
 const point = (time: string, service: string, count: number, bytes?: number): LogsFilterPreviewPoint => ({
     time,
@@ -9,6 +17,18 @@ const point = (time: string, service: string, count: number, bytes?: number): Lo
 
 const T1 = '2026-08-04T11:00:00Z'
 const T2 = '2026-08-04T11:30:00Z'
+
+describe('SPARKLINE_ROW_LIMIT', () => {
+    it('matches the backend cap it is used to detect', () => {
+        // The truncation caveat in the UI is driven by `points.length >= SPARKLINE_ROW_LIMIT`, so if
+        // these drift the preview either stops warning about truncated data or warns when there is
+        // none. Read the backend constant rather than restate it.
+        const runner = fs.readFileSync(path.join(__dirname, '../../../backend/sparkline_query_runner.py'), 'utf-8')
+        const match = runner.match(/^SPARKLINE_MAX_ROWS = (\d+)$/m)
+        expect(match).not.toBeNull()
+        expect(Number(match![1])).toEqual(SPARKLINE_ROW_LIMIT)
+    })
+})
 
 describe('buildSparklineSeries', () => {
     it('stacks one series per service in bucket order', () => {

--- a/products/logs/frontend/components/LogsFilterPreview/logsFilterVolumePreview.ts
+++ b/products/logs/frontend/components/LogsFilterPreview/logsFilterVolumePreview.ts
@@ -5,11 +5,11 @@ import { dayjs } from 'lib/dayjs'
 export const TOP_SERVICES_LIMIT = 10
 
 /**
- * Mirrors the `LIMIT 1000` in `products/logs/backend/sparkline_query_runner.py`. Rows are
+ * Must match `SPARKLINE_MAX_ROWS` in `products/logs/backend/sparkline_query_runner.py`. Rows are
  * (bucket × service), and the query orders by time ascending — so once the cap is hit it's the
  * *newest* buckets that get dropped, and any total derived from the response is an undercount.
  */
-export const SPARKLINE_ROW_LIMIT = 1000
+export const SPARKLINE_ROW_LIMIT = 10000
 
 export type LogsFilterPreviewMetric = 'count' | 'bytes'
 

--- a/products/logs/frontend/components/LogsRetention/retentionStorageProjection.test.ts
+++ b/products/logs/frontend/components/LogsRetention/retentionStorageProjection.test.ts
@@ -1,4 +1,7 @@
-import { LogsFilterPreviewPoint } from 'products/logs/frontend/components/LogsFilterPreview/logsFilterVolumePreview'
+import {
+    LogsFilterPreviewPoint,
+    SPARKLINE_ROW_LIMIT,
+} from 'products/logs/frontend/components/LogsFilterPreview/logsFilterVolumePreview'
 
 import { buildRetentionProjection, retentionProjectionText } from './retentionStorageProjection'
 
@@ -46,11 +49,13 @@ describe('buildRetentionProjection', () => {
         // Row cap hit, so `now` is hours past the newest bucket we got back — using it would
         // stretch the window and understate the daily rate.
         const nowMs = Date.UTC(2026, 7, 4, 12, 0, 0)
-        const points = buckets(lastBucketMs, 10 * GB, 1000)
+        // Derived from the cap rather than restated, so raising the backend limit can't silently
+        // stop this from exercising the truncated path.
+        const points = buckets(lastBucketMs, 10 * GB, SPARKLINE_ROW_LIMIT)
         const projection = buildRetentionProjection(points, 14, nowMs)!
 
         expect(projection.truncated).toBe(true)
-        expect(projection.windowSeconds).toEqual(1000 * 1800)
+        expect(projection.windowSeconds).toEqual(SPARKLINE_ROW_LIMIT * 1800)
         expect(retentionProjectionText(projection, 14)).toContain('actual volume may be higher')
     })
 


### PR DESCRIPTION
Follow-up to [#77166](https://github.com/PostHog/posthog/pull/77166). Split out of a combined PR; the tooltip-hover fix is [#77557](https://github.com/PostHog/posthog/pull/77557). Independent of it — no shared files.

## Why the 1000-row cap was being hit far sooner than expected

The intuitive math says 48 buckets × ~11 rows ≈ 500, comfortably under 1000. But that 11 is the number of *displayed* series — top 10 services plus the "Others" rollup — and that rollup happens client-side. The query caps nothing:

```sql
GROUP BY {breakdown_field}, time   -- no LIMIT BY, no top-N
```

So a row is (time bucket × **every distinct service** in the window). Two corrections to the estimate:

- The spine is **49** buckets, not 48 — `floor(1440/30 + 1)`. The pre-existing `test_sparkline_near_full` already asserts 49.
- Distinct services is unbounded, not ~11.

So the cap bites above `1000/49 ≈ 20` distinct services — routine for a team with any microservice sprawl.

Worse, rows come back `ORDER BY time asc`, so truncation dropped the **newest** buckets. The preview understated recent volume and the storage projection derived from it, with no error — just quietly wrong numbers.

`LIMIT 1000` dates from the MVP (`ea6c3a3d655`) when severity was the only breakdown: ~7 bounded values × 49 buckets ≈ 343 rows, safely under. It was never revisited when [#44331](https://github.com/PostHog/posthog/pull/44331) added the unbounded `service` breakdown that this preview hardcodes.

## The fix

Raised to **10000**, matching `ServicesQueryRunner`'s sparkline cap — which also pre-scopes to its top 25 services precisely to avoid this, with a comment saying so. Headroom is now ~200 services.

**This does not widen the scan.** The aggregation reads the same rows either way; the `LIMIT` only bounds the returned payload (worst case ~1MB of JSON). The 30s execution cap and the `_bytes_uncompressed` projection concern are untouched.

Beyond ~200 services the UI's truncation caveat still applies. The deeper fix would be a server-side top-N with an "Others" rollup — rows would become buckets × 11, exactly the original mental model — but that duplicates the client-side rollup and changes the response shape for the logs viewer too, so it's deliberately out of scope.

## Testing

- **New backend test** inserts 25 services × 48 buckets against real ClickHouse and asserts the response exceeds 1000 rows and that every service retains a full trend. Verified it's a genuine regression test, not a tautology: with the cap back at 1000 it fails with `AssertionError: 1000 not greater than 1000`.
- **Constant-sync guard**: the frontend's `SPARKLINE_ROW_LIMIT` drives the UI's truncation caveat, so a new test reads `SPARKLINE_MAX_ROWS` out of the Python source and asserts they match. Restating the number in a comment wouldn't have caught drift.
- The projection test's truncation case now derives its fixture size from `SPARKLINE_ROW_LIMIT` instead of a hardcoded 1000 — it started failing when I raised the cap, which is exactly the signal I wanted, but it means the test would otherwise have silently stopped exercising the truncated path.
- 527/527 logs frontend tests pass (30 suites); 3/3 backend sparkline tests pass against local ClickHouse. ruff (check + format), oxlint, and `tsgo` all clean.

Also warms the URL conf in the sparkline test's `setUpTestData`. Every test there requests under `freeze_time`, and the first to do so imported the URL tree, reaching `pydantic.v1`'s `ConstrainedDate(date)` after freezegun had swapped `date` for `FakeDate` — so whichever test ran first died on a metaclass conflict. Pre-existing (the existing `test_sparkline_near_full` fails identically when run alone) and local-only, but it blocked verifying the new test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*