### PR TITLE
fix(code): fall back to settings personalization for cloud tasks

### DIFF
--- a/products/desktop/packages/core/src/task-detail/taskCreationHost.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationHost.ts
@@ -104,6 +104,12 @@ export interface ITaskCreationHost {
    */
   resolveLocalSkillCommandPrompt(prompt: string): Promise<string>;
   /**
+   * The user's personalization from settings. Cloud runs have no client-side
+   * system-prompt seam, so the saga folds this into the first message for any
+   * caller that did not supply `customInstructions` of its own.
+   */
+  getCustomInstructions(): string;
+  /**
    * Return-and-clear the pre-warmed sandbox lease matching the composer
    * selection, if one was provisioned while the user typed. The saga uploads
    * first-message attachments (skill bundles, files) to this run before

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.test.ts
@@ -21,6 +21,7 @@ const mockHost = vi.hoisted(() => ({
   detectRepo: vi.fn(),
   getCloudPromptTransport: vi.fn(),
   resolveLocalSkillCommandPrompt: vi.fn(async (prompt: string) => prompt),
+  getCustomInstructions: vi.fn(() => ""),
   takeWarmTaskLease: vi.fn(
     (): { taskId: string; runId: string } | null => null,
   ),
@@ -116,6 +117,7 @@ describe("TaskCreationSaga", () => {
     mockHost.getTaskDirectory.mockResolvedValue(null);
     mockHost.ensureScratchDir.mockResolvedValue("/tmp/scratch/task-123");
     mockHost.getWorkspace.mockResolvedValue(null);
+    mockHost.getCustomInstructions.mockReturnValue("");
     mockHost.getFolders.mockResolvedValue([]);
     mockHost.uploadRunAttachments.mockResolvedValue([]);
     mockHost.linkTaskBranch.mockResolvedValue(undefined);
@@ -283,6 +285,84 @@ describe("TaskCreationSaga", () => {
       "task-123",
       sentMessage,
     );
+  });
+
+  it("falls back to settings personalization when the caller passes no customInstructions", async () => {
+    // Only the composer routes through prepareTaskInput. Callers that build the
+    // input by hand (canvas generation, CONTEXT.md generation, inbox runners)
+    // omit customInstructions, and cloud has no system-prompt seam to recover
+    // it — so without this fallback they run with no personalization at all.
+    const createdTask = createTask();
+    const startTaskRunMock = vi
+      .fn()
+      .mockResolvedValue(createTask({ latest_run: createRun() }));
+    mockHost.getCustomInstructions.mockReturnValue("Speak concisely.");
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: vi.fn().mockResolvedValue(createdTask),
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: vi.fn().mockResolvedValue(createRun()),
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: vi.fn(),
+      } as never,
+      host,
+      sessionService,
+      piRunner,
+      track: vi.fn(),
+    });
+
+    const result = await saga.run({
+      content: "Generate a canvas",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+    });
+
+    expect(result.success).toBe(true);
+    expect(startTaskRunMock.mock.calls[0][2].pendingUserMessage).toContain(
+      "Speak concisely.",
+    );
+  });
+
+  it("prefers caller-supplied customInstructions over settings", async () => {
+    // The loop builder deliberately substitutes its own system instructions;
+    // the settings fallback must not append or override them.
+    const createdTask = createTask();
+    const startTaskRunMock = vi
+      .fn()
+      .mockResolvedValue(createTask({ latest_run: createRun() }));
+    mockHost.getCustomInstructions.mockReturnValue("Speak concisely.");
+
+    const saga = new TaskCreationSaga({
+      posthogClient: {
+        createTask: vi.fn().mockResolvedValue(createdTask),
+        deleteTask: vi.fn(),
+        getTask: vi.fn(),
+        createTaskRun: vi.fn().mockResolvedValue(createRun()),
+        startTaskRun: startTaskRunMock,
+        sendRunCommand: vi.fn(),
+        updateTask: vi.fn(),
+      } as never,
+      host,
+      sessionService,
+      piRunner,
+      track: vi.fn(),
+    });
+
+    const result = await saga.run({
+      content: "Build a loop",
+      repository: "posthog/posthog",
+      workspaceMode: "cloud",
+      customInstructions: "You are the loop builder.",
+    });
+
+    expect(result.success).toBe(true);
+    const sentMessage = startTaskRunMock.mock.calls[0][2]
+      .pendingUserMessage as string;
+    expect(sentMessage).toContain("You are the loop builder.");
+    expect(sentMessage).not.toContain("Speak concisely.");
   });
 
   it("does not fold personalization into a file-only cloud task with no typed text", async () => {

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
@@ -51,12 +51,21 @@ interface WarmActivationPayload {
 // so fold both blocks into the first message here. Order: user's message, then
 // personalization (user-level), then channel context (workspace-level).
 // Personalization is folded only when there is message text to augment.
+//
+// `customInstructions` falls back to settings when the caller left it unset:
+// only the composer routes through prepareTaskInput, so callers that build the
+// input by hand (canvas generation, CONTEXT.md generation, the inbox runners)
+// would otherwise silently run without the user's personalization. A caller
+// that deliberately supplies its own (the loop builder) still wins.
 function buildCloudFirstMessage(
   messageText: string | undefined,
   input: TaskCreationInput,
+  settingsCustomInstructions: string,
 ): { pendingUserMessage?: string; augmented: boolean } {
   const customInstructionsText = messageText
-    ? buildCustomInstructionsText(input.customInstructions)
+    ? buildCustomInstructionsText(
+        input.customInstructions ?? settingsCustomInstructions,
+      )
     : null;
   const channelContextText = buildChannelContextText(
     input.channelContext,
@@ -387,7 +396,11 @@ export class TaskCreationSaga extends Saga<
 
           const { pendingUserMessage, augmented } = warmPayload
             ? warmPayload
-            : buildCloudFirstMessage(transport?.messageText, input);
+            : buildCloudFirstMessage(
+                transport?.messageText,
+                input,
+                this.deps.host.getCustomInstructions(),
+              );
 
           // The sandbox echoes pendingUserMessage back once it boots; until then
           // the optimistic placeholder would show the bare task description with
@@ -725,6 +738,7 @@ export class TaskCreationSaga extends Saga<
     const { pendingUserMessage, augmented } = buildCloudFirstMessage(
       transport.messageText,
       input,
+      this.deps.host.getCustomInstructions(),
     );
     const base: WarmActivationPayload = {
       transport,

--- a/products/desktop/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
@@ -33,6 +33,10 @@ import { resolveLocalSkillPrompt } from "../message-editor/commands";
 import { DEFAULT_PANEL_IDS } from "../panels/panelConstants";
 import { usePanelLayoutStore } from "../panels/panelLayoutStore";
 import { useProvisioningStore } from "../provisioning/store";
+import {
+  getEffectiveCustomInstructions,
+  useSettingsStore,
+} from "../settings/settingsStore";
 import { takeWarmTaskLease } from "./hooks/warmTaskLease";
 
 interface EnvironmentHostClient {
@@ -154,6 +158,10 @@ export class TrpcTaskCreationHost implements ITaskCreationHost {
         hostClient().skills.list.query(),
       )) ?? prompt
     );
+  }
+
+  getCustomInstructions(): string {
+    return getEffectiveCustomInstructions(useSettingsStore.getState());
   }
 
   takeWarmTaskLease(args: {


### PR DESCRIPTION
## Problem

Custom instructions set in settings weren't reaching tasks started from a space.

Cloud runs have no client-side system-prompt seam, so `TaskCreationSaga` folds the user's personalization into the run's first message. That worked only if the caller put `customInstructions` on the `TaskCreationInput` — and only the composer does, via `prepareTaskInput`. Every caller that builds the input by hand silently ran with no personalization:

- canvas generation (`canvasApplicationService`)
- CONTEXT.md generation (`useGenerateContext`)
- the inbox cloud task runners

These are exactly the repo-less, cloud-by-default flows reachable from inside a space, which is why the gap shows up there.

Local runs were never affected — the workspace-server reads live settings when it builds the system prompt.

## Changes

Resolve personalization centrally in the saga rather than trusting each caller. When `input.customInstructions` is unset, fall back to the effective settings value through a new `getCustomInstructions()` capability on `ITaskCreationHost`.

A caller that deliberately supplies its own instructions (the loop builder, which substitutes a crafted system prompt) still wins — the fallback only fills the gap, it never overrides or appends.

## How did you test this code?

Automated tests I ran:

- `pnpm --filter @posthog/core test` — 3064 passed
- `pnpm --filter @posthog/ui test` — 2562 passed
- `pnpm --filter @posthog/core typecheck`, `pnpm --filter @posthog/ui typecheck` — clean
- `biome check` on the changed files — clean

Two new cases in `taskCreationSaga.test.ts`:

- **settings fallback** — a cloud task created without `customInstructions` (the canvas/CONTEXT.md shape) now carries the user's personalization. No existing test covered a caller that omits the field; every prior personalization test passed it explicitly, which is exactly why the gap went unnoticed. I verified this test fails against the unfixed saga.
- **caller precedence** — caller-supplied instructions are used and the settings value is *not* appended, pinning the loop builder's intentional override against a future regression.

I did not manually drive the Electron app; this is verified by automated tests and code tracing only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs affected — this restores intended behavior rather than changing it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a space: opening "create new task" produced a session with no knowledge of the user's custom instructions.

Worth flagging for the reviewer: I traced the plain composer path end to end (`ChannelHomeComposer` and `WebsiteNewTask` → `TaskInput` → `useTaskCreation` → `prepareTaskInput` → saga) and it *does* thread `customInstructions` correctly in both local and cloud mode. I could not reproduce a drop there by reading the code. What I could confirm is the caller-supplied-field fragility above, which affects the generation flows launched from a space. This PR fixes that class of bug centrally, so any current or future caller that forgets the field is covered. If the reporter still sees it on a plain typed task after this lands, the next step is runtime instrumentation of `getEffectiveCustomInstructions` at submit time — a settings-store hydration race on the spaces route is the remaining untested hypothesis.

I considered patching the three call sites individually, but that leaves the same trap for the next caller; putting the fallback behind the host interface keeps the saga the single place personalization is resolved for cloud.

Skills invoked: none of the repo's mandatory skills applied (no DRF, migrations, or user-facing copy changes). Test guidance from `.claude/rules/writing-tests.md` was followed — both new tests were checked against the value gate, and the fallback test was confirmed non-vacuous by reverting the fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
