### PR TITLE
fix(sharing): send the id-less principal reference to the async worker

### DIFF
--- a/posthog/clickhouse/client/execute_async.py
+++ b/posthog/clickhouse/client/execute_async.py
@@ -15,7 +15,12 @@ from posthog.hogql.constants import LimitContext
 from posthog.hogql.errors import ExposedHogQLError
 
 from posthog import celery, redis
-from posthog.clickhouse.client.async_principal import PrincipalRef, rebuild_principal, record_principal_loss
+from posthog.clickhouse.client.async_principal import (
+    PrincipalRef,
+    rebuild_principal,
+    record_principal_loss,
+    serialize_principal,
+)
 from posthog.clickhouse.client.async_task_chain import add_task_to_on_commit
 from posthog.clickhouse.client.limit import ConcurrencyLimitExceeded
 from posthog.clickhouse.query_tagging import get_query_tags, tag_queries
@@ -368,6 +373,10 @@ def enqueue_process_query_task(
     query_tags = get_query_tags().model_dump()
     manager.store_query_status(query_status)
 
+    # Past the early returns (so a deduplicated or already-answered query does no work) but ahead of
+    # the Redis writes below, so a failure here cannot leave a registered cache key with no task.
+    principal = serialize_principal(user)
+
     if cache_key:
         try:
             manager.register_cache_key_mapping(cache_key)
@@ -379,10 +388,11 @@ def enqueue_process_query_task(
     from posthog.tasks.tasks import process_query_task  # noqa: PLC0415
 
     limit_context = LimitContext.POSTHOG_AI if is_posthog_ai else LimitContext.QUERY_ASYNC
-    # No `principal` kwarg yet, deliberately: a worker running the previous release cannot bind it and
-    # rejects the task with a TypeError, which `autoretry_for` does not cover. This deploy teaches
-    # every worker to accept and rebuild a reference (see `serialize_principal`, which the follow-up
-    # calls here); producing one only once they all can means there is no deploy ordering to get right.
+    # The consumer deploy taught every worker to accept and rebuild this reference, so producing one
+    # is now safe. It is still omitted when there is no principal, keeping the real-user path
+    # byte-identical on the wire, and a principal that cannot be rebuilt on the worker falls back to
+    # the userless (denied) path rather than over-granting.
+    extra_kwargs = {"principal": principal} if principal is not None else {}
     task_signature = process_query_task.si(
         team.id,
         user_id,
@@ -392,6 +402,7 @@ def enqueue_process_query_task(
         is_query_service,
         limit_context,
         analytics_props=analytics_props,
+        **extra_kwargs,
     )
 
     if _test_only_bypass_celery:

--- a/posthog/clickhouse/client/test/test_execute_async.py
+++ b/posthog/clickhouse/client/test/test_execute_async.py
@@ -211,20 +211,24 @@ class TestExecuteProcessQuery(TestCase):
 
     @patch("posthog.clickhouse.client.execute_async.redis.get_client")
     @patch("posthog.tasks.tasks.process_query_task")
-    def test_enqueue_does_not_send_a_principal_reference_yet(self, mock_process_query_task, mock_redis_client):
-        # This deploy only teaches the worker to accept a reference. Sending one waits for the
-        # follow-up, because a worker on the previous release cannot bind the kwarg and rejects the
-        # task with a TypeError that `autoretry_for` does not cover.
+    def test_enqueue_sends_a_principal_reference_only_for_principals_without_a_user_id(
+        self, mock_process_query_task, mock_redis_client
+    ):
+        # A real user travels as `user_id`, so the kwarg stays absent for them — keeping the wire
+        # byte-identical for the common case. An id-less principal is the only one that needs it.
         mock_redis_client.return_value = MagicMock()
         sharing_configuration = SharingConfiguration.objects.create(team=self.team, enabled=True)
 
-        for principal in [self.user, SharedLinkUser(sharing_configuration)]:
+        for principal, expected in [
+            (self.user, None),
+            (SharedLinkUser(sharing_configuration), {"kind": "shared_link", "id": sharing_configuration.pk}),
+        ]:
             with self.subTest(principal=type(principal).__name__):
                 mock_process_query_task.si.reset_mock()
                 client.enqueue_process_query_task(
                     self.team, principal, build_query("SELECT 1"), _test_only_bypass_celery=True
                 )
-                self.assertNotIn("principal", mock_process_query_task.si.call_args.kwargs)
+                self.assertEqual(mock_process_query_task.si.call_args.kwargs.get("principal"), expected)
 
 
 class ClickhouseClientTestCase(TestCase, ClickhouseTestMixin):


### PR DESCRIPTION
## Problem

The [consumer PR](https://github.com/PostHog/posthog/pull/76824) taught every async query worker to accept and rebuild an id-less principal (shared-link viewer, project/team secret key), but it deliberately stops short of sending one. Until a producer does, a shared dashboard whose tile queries a data warehouse table still goes blank with `You don't have access to table X` when the tile misses cache and falls onto the async Celery path — the original symptom. This PR is the producer.

## Changes

- `enqueue_process_query_task` now serializes the principal (after the dedup and stored-result early returns, before the Redis writes) and puts the reference on the `process_query_task` signature.
- The kwarg is still omitted when there is no principal, so every real-user query is byte-identical on the wire. A reference that cannot be rebuilt on the worker falls back to the userless (denied) path rather than over-granting — the worker-side re-authorization landed in the consumer PR.

That is the whole change: one call site plus its test. Everything it relies on — `serialize_principal`, `rebuild_principal`, the RBAC deny for id-less principals, and unknown-kwarg tolerance on `process_query_task` — already shipped in the consumer PR.

## Deployment note

**Must not merge until [#76824](https://github.com/PostHog/posthog/pull/76824) is deployed and workers have rolled.** A worker that predates the consumer deploy cannot bind the `principal` kwarg and would reject the task with a `TypeError` that `autoretry_for` does not cover. Once the consumer PR is live, every worker accepts and drops (or rebuilds) the kwarg, so there is no ordering left to get wrong. This PR is stacked on that branch; GitHub retargets its base to `master` when the consumer PR merges.

## How did you test this code?

Ran against a real Postgres from `hogli start`:

- `pytest posthog/clickhouse/client/test/test_execute_async.py posthog/clickhouse/client/test/test_async_principal.py` — 54 passed. The enqueue test now asserts the reference is sent for an id-less principal and stays absent for a real user; the round-trip tests confirm the worker rebuilds what this PR serializes.
- `mypy --cache-fine-grained .` repo-wide — `Success: no issues found in 17423 source files`.
- `ruff check` / `ruff format` clean.

Not exercisable end to end here: this environment has no warehouse credentials to attach.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing behavior or config change to document — this restores existing, documented sharing behavior.

## 🤖 Agent context

**Autonomy:** Supervised — a human directed the review and the decision to split this into two deploys.

This is the second half of a change that was split after review. The single-PR version tried to carry the reference in a way that needed no deploy ordering (a sibling Redis key); that was reverted because a key keyed on the recurring `query_id`/cache key was not bound to the dispatched task and could hand a later userless task a stale reference, and its TTL could expire mid-chain on a long shared dashboard and reintroduce the very bug. The kwarg has neither problem; its only cost is the deploy ordering, which this split removes by landing the consumer first.

Skills invoked while producing this PR: `/writing-tests`, `/writing-code-comments`.

I checked for existing PRs and issues covering this and found none beyond the consumer PR this is stacked on.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
