### PR TITLE
fix(data-imports): tolerate a Delta table already created by a racing writer

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_writer.py
@@ -508,6 +508,49 @@ class TestIncrementalBatchDeduplication:
         assert final.column("name").to_pylist() == ["second_copy"]
 
 
+class TestCreateRaceWithExistingTable:
+    """DeltaTable.create() defaults to mode="error", raising "table already exists at that
+    location" whenever the destination is non-empty. get_delta_table() can report "no table
+    yet" while one already exists there — e.g. a zombie Temporal activity attempt (heartbeat-
+    timed-out but still running while its retry starts, same unfenced race this package's
+    README documents for repartition) races another writer that already created it. write()
+    must tolerate that race instead of failing the sync.
+    """
+
+    @pytest.mark.parametrize(
+        "write_type,expected_ids",
+        [("full_refresh", {2, 3}), ("append", {1, 2, 3})],
+        ids=["full_refresh", "append"],
+    )
+    @pytest.mark.asyncio
+    async def test_create_tolerates_a_table_already_created_by_a_racing_writer(
+        self, write_type: str, expected_ids: set[int], tmp_path: Path
+    ):
+        delta_path = str(tmp_path / "table")
+        # A concurrent writer (e.g. a zombie retry) has already created the table at this location.
+        deltalake.write_deltalake(delta_path, pa.table({"id": [1]}))
+
+        helper = make_local_table_ref(delta_path)
+        real_get_delta_table = helper.get_delta_table
+        calls = {"n": 0}
+
+        async def flaky_first_check():
+            calls["n"] += 1
+            return None if calls["n"] == 1 else await real_get_delta_table()
+
+        batch = pa.table({"id": [2, 3]})
+
+        with patch.object(helper, "get_delta_table", AsyncMock(side_effect=flaky_first_check)):
+            result = await DeltaWriter(helper).write(
+                data=batch,
+                write_type=write_type,  # type: ignore[arg-type]
+                should_overwrite_table=write_type == "full_refresh",
+                primary_keys=None,
+            )
+
+        assert set(result.to_pyarrow_table().column("id").to_pylist()) == expected_ids
+
+
 class TestUnpartitionedTableWithPartitionKeyColumn:
     """A Delta table can carry `_ph_partition_key` in its schema while its
     partition_columns metadata is empty `[]` — e.g. the SchemaMismatchError fallback in

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
@@ -447,12 +447,18 @@ class DeltaWriter:
             if delta_table is None:
                 storage_options = self._table.get_storage_options()
                 delta_uri = await self._table.get_table_uri()
+                # mode="ignore": a zombie Temporal attempt (heartbeat-timed-out but still running
+                # while its retry starts — see this package's README) or a stale get_delta_table()
+                # check can race another writer that already created this table. "ignore" opens
+                # the winner's table instead of erroring; the write below then applies our data on
+                # top of it, so the race can only change who created the table, never the outcome.
                 delta_table = await asyncio.to_thread(
                     deltalake.DeltaTable.create,
                     table_uri=delta_uri,
                     schema=data.schema,
                     storage_options=storage_options,
                     partition_by=PARTITION_KEY if use_partitioning else None,
+                    mode="ignore",
                 )
 
             try:
@@ -482,12 +488,14 @@ class DeltaWriter:
             if delta_table is None:
                 storage_options = self._table.get_storage_options()
                 delta_uri = await self._table.get_table_uri()
+                # See the full_refresh branch above for why mode="ignore" is required here.
                 delta_table = await asyncio.to_thread(
                     deltalake.DeltaTable.create,
                     table_uri=delta_uri,
                     schema=data.schema,
                     storage_options=storage_options,
                     partition_by=PARTITION_KEY if use_partitioning else None,
+                    mode="ignore",
                 )
             else:
                 # An append re-casts each source column to its stored type, same as a merge. A decimal


### PR DESCRIPTION
## Problem

- [Error tracking](https://us.posthog.com/project/2/error_tracking/019fd164-7b6a-7732-aa07-e6e7719c5f9d) caught a `DeltaError`: "A Delta Lake table already exists at that location", during a Stripe full refresh sync.
- The stack trace lands in `DeltaTable.create()`, called from the shared Delta writer, not the Stripe connector.
- `DeltaTable.create()` defaults to `mode="error"` and raises whenever the destination already has a table.
- `get_delta_table()` can report "no table yet" for a table another writer already created in the same window.
- This package's README documents the same unfenced race for repartition: a Temporal activity attempt that heartbeat-times-out keeps running as a zombie while its retry starts, and S3 has no locking. The initial `DeltaTable.create()` call never got the same tolerance.

## Changes

- Pass `mode="ignore"` to both `DeltaTable.create()` call sites in `writer.py` (the full_refresh/first-sync branch and the append branch).
- A race now opens the winner's table instead of failing the sync; the write that follows applies our batch on top of it either way.

## How did you test this code?

- Added a regression test (`TestCreateRaceWithExistingTable` in `test_writer.py`) that seeds a table at the destination, forces the first `get_delta_table()` check to return `None`, and asserts the write succeeds instead of raising `DeltaError`.
- Verified the new test reproduces the exact production stack trace (`_internal.DeltaError: Generic error: A Delta Lake table already exists at that location`, raised from `deltalake/table.py:316`) when run against the code before this fix, and passes after it.
- Ran the full `test_writer.py` suite (52 passed) and `mypy` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error tracking issue end to end (issue lookup, stack trace, root cause, fix, regression test, PR).
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Considered treating this as a transient/non-retryable infra error instead, but the create race is fixable at the source (idempotent create), so that's the general fix rather than a retry-classification workaround.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*