### PR TITLE
feat(tasks): capture pr_reviewed from GitHub review submissions

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -132,6 +132,14 @@ def _dispatch_pull_request_event(
     return handle_pull_request_event(payload)
 
 
+def _dispatch_pull_request_review_event(
+    request: HttpRequest, event_type: str, payload: dict[str, Any], delivery_id: str
+) -> HttpResponse:
+    from products.tasks.backend.facade.webhooks import handle_pull_request_review_event
+
+    return handle_pull_request_review_event(payload)
+
+
 def _dispatch_installation_event(
     request: HttpRequest, event_type: str, payload: dict[str, Any], delivery_id: str
 ) -> HttpResponse:
@@ -163,6 +171,9 @@ GITHUB_WEBHOOK_HANDLERS: dict[str, list[tuple[str, GithubWebhookHandler]]] = {
     "pull_request": [
         ("tasks_pr_backstop", _dispatch_pull_request_event),
         ("loops", _dispatch_loop_triggers),
+    ],
+    "pull_request_review": [
+        ("tasks_pr_review", _dispatch_pull_request_review_event),
     ],
     "installation": [
         ("installation_lifecycle", _dispatch_installation_event),

--- a/products/tasks/backend/facade/webhooks.py
+++ b/products/tasks/backend/facade/webhooks.py
@@ -9,6 +9,7 @@ from products.tasks.backend.loop_github_events import handle_github_event_for_lo
 from products.tasks.backend.webhooks import (
     get_github_webhook_secret,
     handle_pull_request_event,
+    handle_pull_request_review_event,
     verify_github_signature,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "get_github_webhook_secret",
     "handle_github_event_for_loops",
     "handle_pull_request_event",
+    "handle_pull_request_review_event",
     "verify_github_signature",
 ]

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -767,6 +767,103 @@ class TestGitHubPRWebhook(TestCase):
         mock_capture.assert_not_called()
 
 
+class TestGitHubPRReviewWebhook(TestCase):
+    organization: ClassVar[Organization]
+    team: ClassVar[Team]
+    user: ClassVar[User]
+    task: ClassVar[Task]
+    task_run: ClassVar[TaskRun]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Test Org")
+        cls.team = Team.objects.create(organization=cls.organization, name="Test Team")
+        cls.user = User.objects.create(email="test@example.com", distinct_id="user-123")
+        cls.task = Task.objects.create(
+            team=cls.team,
+            created_by=cls.user,
+            title="Test Task",
+            description="Test description",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            repository="posthog/posthog",
+        )
+        cls.task_run = TaskRun.objects.create(
+            task=cls.task,
+            team=cls.team,
+            status=TaskRun.Status.COMPLETED,
+            state={"verified_pr_urls": ["https://github.com/posthog/posthog/pull/123"]},
+            output={"pr_url": "https://github.com/posthog/posthog/pull/123"},
+        )
+
+    def setUp(self):
+        self.client = APIClient()
+        self.webhook_secret = "test-webhook-secret"
+
+    def _make_review_webhook_request(self, payload: dict):
+        payload_bytes = json.dumps(payload).encode("utf-8")
+        signature = generate_github_signature(payload_bytes, self.webhook_secret)
+        return self.client.post(
+            "/webhooks/github/pr/",
+            data=payload_bytes,
+            content_type="application/json",
+            headers={"x-hub-signature-256": signature, "x-github-event": "pull_request_review"},
+        )
+
+    def _review_payload(self, reviewer: dict, action: str = "submitted", state: str = "approved") -> dict:
+        return {
+            "action": action,
+            "review": {"id": 99, "state": state, "user": reviewer},
+            "pull_request": {"html_url": "https://github.com/posthog/posthog/pull/123"},
+        }
+
+    @parameterized.expand(
+        [
+            ("resolvable_login", "Octocat", "reviewer-456", "reviewer-456"),
+            ("unresolvable_login", "stranger", None, "user-123"),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_review_submission_attributes_to_reviewer(
+        self, _name, reviewer_login, expected_property, expected_distinct_id, mock_capture, mock_get_secret
+    ):
+        mock_get_secret.return_value = self.webhook_secret
+        reviewer = User.objects.create(email="reviewer@example.com", distinct_id="reviewer-456")
+        OrganizationMembership.objects.create(organization=self.organization, user=reviewer)
+        UserSocialAuth.objects.create(user=reviewer, provider="github", uid="583231", extra_data={"login": "octocat"})
+
+        payload = self._review_payload(
+            {"login": reviewer_login, "id": 583231, "type": "User"}, state="changes_requested"
+        )
+        response = self._make_review_webhook_request(payload)
+
+        self.assertEqual(response.status_code, 200)
+        call_kwargs = mock_capture.call_args[1]
+        self.assertEqual(call_kwargs["event"], "pr_reviewed")
+        self.assertEqual(call_kwargs["distinct_id"], expected_distinct_id)
+        self.assertEqual(call_kwargs["properties"]["pr_review_state"], "changes_requested")
+        self.assertEqual(call_kwargs["properties"]["pr_reviewed_by_login"], reviewer_login)
+        self.assertEqual(call_kwargs["properties"]["pr_reviewed_by_id"], 583231)
+        self.assertEqual(call_kwargs["properties"].get("pr_reviewed_by_distinct_id"), expected_property)
+        self.assertEqual(call_kwargs["properties"]["pr_source"], "task")
+
+    @parameterized.expand(
+        [
+            ("bot_reviewer", {"login": "posthog-stamphog[bot]", "id": 1, "type": "Bot"}, "submitted"),
+            ("non_submitted_action", {"login": "octocat", "id": 583231, "type": "User"}, "dismissed"),
+        ]
+    )
+    @patch("products.tasks.backend.facade.webhooks.get_github_webhook_secret")
+    @patch("products.tasks.backend.models.posthoganalytics.capture")
+    def test_review_events_not_captured(self, _name, reviewer, action, mock_capture, mock_get_secret):
+        mock_get_secret.return_value = self.webhook_secret
+
+        response = self._make_review_webhook_request(self._review_payload(reviewer, action=action))
+
+        self.assertEqual(response.status_code, 200)
+        mock_capture.assert_not_called()
+
+
 class TestGitHubPRWebhookResolvesSignalReports(TestCase):
     """Webhook resolves a SignalReport when its PR merges, and archives it when the PR closes unmerged."""
 

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -244,6 +244,49 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
     return HttpResponse(status=200)
 
 
+def handle_pull_request_review_event(payload: dict) -> HttpResponse:
+    """Process a pre-verified pull_request_review webhook event.
+
+    Called from ``posthog.urls.github_webhook`` (unified dispatcher). Captures a
+    ``pr_reviewed`` analytics event for human review submissions (approved,
+    changes_requested, commented), attributed to the reviewer when their GitHub
+    login resolves to an org member.
+    """
+    if payload.get("action") != "submitted":
+        return HttpResponse(status=200)
+
+    review = payload.get("review") or {}
+    reviewer = review.get("user") or {}
+    pull_request = payload.get("pull_request") or {}
+    pr_url = pull_request.get("html_url")
+    if not pr_url:
+        logger.warning("github_pr_review_webhook_no_pr_url")
+        return HttpResponse(status=200)
+
+    # StampHog, ReviewHog, and CI apps review every self-driving PR, so without this
+    # filter the event stream is mostly bots and the human review signal drowns.
+    if (reviewer.get("type") or "").lower() == "bot":
+        logger.debug("github_pr_review_webhook_bot_review_skipped", pr_url=pr_url)
+        return HttpResponse(status=200)
+
+    branch = (pull_request.get("head") or {}).get("ref")
+    repository_full_name = (payload.get("repository") or {}).get("full_name")
+    task_run = find_task_run(pr_url=pr_url, branch=branch, repository=repository_full_name)
+
+    # One review submission = one event; GitHub redeliveries collapse on the review id.
+    event_uuid = str(uuid.uuid5(uuid.NAMESPACE_URL, f"{pr_url}:pr_reviewed:{review.get('id')}"))
+    _capture_pr_review_event(payload, task_run, event_uuid)
+
+    logger.info(
+        "github_pr_review_webhook_processed",
+        pr_url=pr_url,
+        review_state=review.get("state"),
+        pr_source="task" if task_run else "external",
+        run_id=str(task_run.id) if task_run else None,
+    )
+    return HttpResponse(status=200)
+
+
 def _record_run_pr_url(task_run: TaskRun, pr_url: str) -> None:
     """Persist ``output.pr_url`` for a webhook-matched run when it isn't set yet.
 
@@ -448,6 +491,18 @@ def _pr_payload_properties(payload: dict) -> dict:
     }
 
 
+def _resolve_github_login_distinct_id(login: str | None, team_id: int) -> str | None:
+    """Distinct id of the org member matching a GitHub login, or None when unresolvable."""
+    if not login:
+        return None
+    try:
+        resolved = resolve_org_github_login_to_users(team_id, [login]).get(str(login).strip().lower())
+    except Exception as e:
+        logger.warning("github_webhook_login_resolution_failed", login=login, team_id=team_id, error=str(e))
+        return None
+    return str(resolved.distinct_id) if resolved is not None else None
+
+
 def _merged_by_attribution(payload: dict, team_id: int) -> tuple[dict, str | None]:
     """Identity of the GitHub user who merged the PR, resolved to a PostHog user when possible.
 
@@ -462,15 +517,63 @@ def _merged_by_attribution(payload: dict, team_id: int) -> tuple[dict, str | Non
     if not login:
         return {}, None
     properties: dict = {"pr_merged_by_login": login, "pr_merged_by_id": merged_by.get("id")}
-    distinct_id: str | None = None
-    try:
-        resolved = resolve_org_github_login_to_users(team_id, [login]).get(str(login).strip().lower())
-        if resolved is not None:
-            distinct_id = str(resolved.distinct_id)
-            properties["pr_merged_by_distinct_id"] = distinct_id
-    except Exception as e:
-        logger.warning("github_pr_webhook_merged_by_resolution_failed", login=login, team_id=team_id, error=str(e))
+    distinct_id = _resolve_github_login_distinct_id(login, team_id)
+    if distinct_id is not None:
+        properties["pr_merged_by_distinct_id"] = distinct_id
     return properties, distinct_id
+
+
+def _capture_pr_review_event(payload: dict, task_run: TaskRun | None, event_uuid: str) -> None:
+    review = payload.get("review") or {}
+    reviewer = review.get("user") or {}
+    login = reviewer.get("login")
+    review_properties: dict = {
+        "pr_review_state": review.get("state"),
+        "pr_reviewed_by_login": login,
+        "pr_reviewed_by_id": reviewer.get("id"),
+    }
+    pr_properties = {**_pr_payload_properties(payload), **review_properties}
+
+    if task_run is not None:
+        reviewer_distinct_id = _resolve_github_login_distinct_id(login, task_run.team_id)
+        if reviewer_distinct_id is not None:
+            pr_properties["pr_reviewed_by_distinct_id"] = reviewer_distinct_id
+        task_run.capture_event(
+            "pr_reviewed",
+            {**pr_properties, "pr_source": "task"},
+            event_uuid=event_uuid,
+            distinct_id_override=reviewer_distinct_id,
+        )
+        return
+
+    team = _resolve_external_team(payload)
+    if team is None:
+        logger.debug("github_pr_review_webhook_unresolved_installation", pr_url=pr_properties.get("pr_url"))
+        return
+
+    reviewer_distinct_id = _resolve_github_login_distinct_id(login, team.id)
+    if reviewer_distinct_id is not None:
+        pr_properties["pr_reviewed_by_distinct_id"] = reviewer_distinct_id
+
+    properties: dict = {
+        **pr_properties,
+        "repository": ((payload.get("repository") or {}).get("full_name") or "").strip().lower() or None,
+        "pr_source": "external",
+        "team_id": team.id,
+        # title omitted to avoid leaking customer business context.
+        **dict.fromkeys(_TASK_ATTRIBUTION_KEYS, None),
+    }
+
+    try:
+        posthoganalytics.capture(
+            distinct_id=reviewer_distinct_id or str(team.uuid),
+            event="pr_reviewed",
+            properties=properties,
+            groups=groups(team=team),
+            uuid=event_uuid,
+        )
+    except Exception as e:
+        logger.warning("github_pr_review_webhook_capture_failed", error=str(e))
 
 
 def _capture_pr_event(payload: dict, task_run: TaskRun | None, analytics_event: str, event_uuid: str) -> None:


### PR DESCRIPTION
## Problem

- Human review acts on self-driving PRs (approve, request changes, comment) produce no analytics event.
- The unified GitHub webhook dispatcher never routed `pull_request_review` events.
- The review-shaped events that exist (`stamphog_review_completed`, `reviewhog_finding_outcome`) track the bots, not humans.
- Reviewing is a personal activation act; the funnel between "saw a report" and "merged a PR" is invisible.

## Changes

- `posthog/urls.py` routes `pull_request_review` to a new tasks facade handler.
- `handle_pull_request_review_event` captures a `pr_reviewed` event for submitted reviews, with `pr_review_state` (approved / changes_requested / commented).
- The reviewer's login resolves via `resolve_org_github_login_to_users` (shared with `pr_merged` in the base PR); a match becomes the event's `distinct_id` and `pr_reviewed_by_distinct_id`.
- `pr_reviewed_by_login` and `pr_reviewed_by_id` always ship as properties; fallback attribution is the task's assigned user, or the team UUID for external PRs.
- Bot reviews are skipped, so StampHog and ReviewHog approvals don't drown the human signal.
- The event uuid keys on the review id, so GitHub redeliveries collapse to one event.

> [!NOTE]
> Stacked on #78162 (shares the resolver and `distinct_id_override`).

> [!WARNING]
> Rollout step outside this repo: the PostHog GitHub App (`github.com/apps/posthog`) subscribes to `issues`, `issue_comment`, `pull_request`, and `pull_request_review_comment` today, but not `pull_request_review`. An App admin must tick "Pull request review" under Subscribe to events. The event sits under the Pull requests permission the App already holds, so existing installations get it with no re-approval prompt. Until then the handler is inert; deliveries without the handler are dropped, so the two changes can land in either order.

## How did you test this code?

- Ran the full `products/tasks/backend/tests/test_webhooks.py` (93 passed), repo-wide `mypy --cache-fine-grained .` (clean), and `tach check --dependencies --interfaces` (clean).
- New parameterized test (resolvable vs unresolvable reviewer) catches the dispatcher or handler dropping the event, and attribution regressions; the event is new, so nothing covered it.
- New skip test (bot reviewer, non-submitted action) guards the filter that keeps bot approvals out of the human review stream.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code in the same session as #78162, extending self-driving activation instrumentation from merging to reviewing.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions, /stacking-prs.
- The shared login resolution moved into `_resolve_github_login_distinct_id`, rewiring `_merged_by_attribution` from the base PR onto it.
- `pr_closed` closer attribution (webhook `sender`) was considered and left out to keep the layer reviewable alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
