### PR TITLE
fix(desktop): restore artifacts grid views and multi-repo tasks clobbered by canvas port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@
 !.devcontainer
 !.kearc
 !bin
-!common/alerting
 !common/hogvm
 !common/esbuilder
 !common/migration_utils

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -1575,7 +1575,9 @@ export class AgentServer {
         return null;
       }),
     ]);
-    this.taskRepositories = preTask?.repository ? [preTask.repository] : [];
+    this.taskRepositories =
+      preTask?.repositories ??
+      (preTask?.repository ? [preTask.repository] : []);
 
     this.prewarmedRun =
       (preTaskRun?.state as Record<string, unknown> | undefined)?.prewarmed ===

--- a/products/desktop/packages/api-client/src/task-normalization.test.ts
+++ b/products/desktop/packages/api-client/src/task-normalization.test.ts
@@ -112,4 +112,25 @@ describe("task response normalization", () => {
       },
     });
   });
+
+  // Multi-repo handoff and cloud-run instructions read task.repositories, so
+  // dropping this fallback silently degrades every consumer to single-repo.
+  it.each([
+    [
+      "keeps the API's repositories list",
+      { repository: "posthog/posthog", repositories: ["a/b", "c/d"] },
+      ["a/b", "c/d"],
+    ],
+    [
+      "wraps a lone repository",
+      { repository: "posthog/posthog" },
+      ["posthog/posthog"],
+    ],
+    ["defaults to empty", {}, []],
+  ])("populates repositories (%s)", (_label, dto, expected) => {
+    expect(
+      normalizeTaskResponse({ id: "task-1", ...dto }, { teamId: 1 })
+        .repositories,
+    ).toEqual(expected);
+  });
 });

--- a/products/desktop/packages/api-client/src/task-normalization.ts
+++ b/products/desktop/packages/api-client/src/task-normalization.ts
@@ -190,6 +190,7 @@ export function normalizeTaskResponse(
     ...(dto.created_by === undefined ? {} : { created_by: dto.created_by }),
     origin_product: dto.origin_product ?? "",
     ...(dto.repository === undefined ? {} : { repository: dto.repository }),
+    repositories: dto.repositories ?? (dto.repository ? [dto.repository] : []),
     ...(dto.github_integration === undefined
       ? {}
       : { github_integration: dto.github_integration }),

--- a/products/desktop/packages/core/src/sessions/localHandoffService.test.ts
+++ b/products/desktop/packages/core/src/sessions/localHandoffService.test.ts
@@ -194,7 +194,43 @@ describe("LocalHandoffService.start", () => {
     );
   });
 
-  // A task's repository is team-writable via the API, so an unsafe entry must
+  it("reuses local repositories and clones missing ones before handoff", async () => {
+    const deps = makeDeps();
+    const multiRepoTask = {
+      repositories: ["posthog/posthog", "posthog/posthog-js"],
+    } as Task;
+    deps.host.getRepositoryByRemoteUrl = vi
+      .fn()
+      .mockResolvedValueOnce({ path: "/repos/posthog" })
+      .mockResolvedValueOnce(null);
+    deps.sessionService.preflightToLocal.mockResolvedValue({
+      canHandoff: true,
+    });
+
+    await deps.service.start("task-1", multiRepoTask);
+
+    expect(deps.host.cloneRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "https://github.com/posthog/posthog-js.git",
+        targetPath: "/worktrees/linked-repositories/posthog/posthog-js",
+      }),
+    );
+    expect(deps.host.addAdditionalDirectory).toHaveBeenCalledWith({
+      taskId: "task-1",
+      path: "/worktrees/linked-repositories/posthog/posthog-js",
+    });
+    expect(deps.sessionService.handoffToLocal).toHaveBeenCalledWith(
+      "task-1",
+      "/repos/posthog",
+      {
+        "posthog/posthog": "/repos/posthog",
+        "posthog/posthog-js":
+          "/worktrees/linked-repositories/posthog/posthog-js",
+      },
+    );
+  });
+
+  // A task's repositories are team-writable via the API, so an unsafe entry must
   // never reach `git clone` (RCE via git's remote-ext transport) or escape the
   // clone root through path traversal. The safe repo alongside it still clones.
   it.each([
@@ -210,12 +246,44 @@ describe("LocalHandoffService.start", () => {
       canHandoff: true,
     });
 
-    await deps.service.start("task-1", { repository: malicious } as Task);
+    await deps.service.start("task-1", {
+      repositories: ["posthog/posthog", malicious],
+    } as Task);
 
-    expect(deps.host.cloneRepository).not.toHaveBeenCalled();
+    // Only the safe repo is cloned, and always through an explicit https URL.
+    expect(deps.host.cloneRepository).toHaveBeenCalledTimes(1);
+    expect(deps.host.cloneRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoUrl: "https://github.com/posthog/posthog.git",
+      }),
+    );
     expect(deps.notifier.warn).toHaveBeenCalledWith(
       expect.stringContaining(malicious),
     );
-    expect(deps.sessionService.handoffToLocal).not.toHaveBeenCalled();
+    const [, , repositoryPaths] =
+      deps.sessionService.handoffToLocal.mock.calls[0];
+    expect(repositoryPaths).toEqual({
+      "posthog/posthog": "/worktrees/linked-repositories/posthog/posthog",
+    });
+  });
+
+  it("de-duplicates case-variant repository aliases before cloning", async () => {
+    const deps = makeDeps();
+    deps.host.getRepositoryByRemoteUrl = vi.fn().mockResolvedValue(null);
+    deps.sessionService.preflightToLocal.mockResolvedValue({
+      canHandoff: true,
+    });
+
+    await deps.service.start("task-1", {
+      repositories: ["PostHog/PostHog", "posthog/posthog"],
+    } as Task);
+
+    // Both collapse to one target, so the racing double-clone can't happen.
+    expect(deps.host.cloneRepository).toHaveBeenCalledTimes(1);
+    const [, , repositoryPaths] =
+      deps.sessionService.handoffToLocal.mock.calls[0];
+    expect(repositoryPaths).toEqual({
+      "posthog/posthog": "/worktrees/linked-repositories/posthog/posthog",
+    });
   });
 });

--- a/products/desktop/packages/core/src/sessions/localHandoffService.ts
+++ b/products/desktop/packages/core/src/sessions/localHandoffService.ts
@@ -132,7 +132,11 @@ export class LocalHandoffService {
 
   public async start(taskId: string, task: Task): Promise<void> {
     try {
-      const repositories = task.repository ? [task.repository] : [];
+      const repositories = task.repositories?.length
+        ? task.repositories
+        : task.repository
+          ? [task.repository]
+          : [];
       const repositoryPaths = await this.resolveRepositoryPaths(repositories);
       const paths = Object.values(repositoryPaths);
       const targetPath =

--- a/products/desktop/packages/shared/src/domain-types.ts
+++ b/products/desktop/packages/shared/src/domain-types.ts
@@ -81,6 +81,7 @@ export interface Task {
   created_by?: UserBasic | null;
   origin_product: string;
   repository?: string | null; // Format: "organization/repository" (e.g., "posthog/posthog-js")
+  repositories?: string[];
   github_integration?: number | null;
   github_user_integration?: string | null;
   json_schema?: Record<string, unknown> | null;

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelArtifacts.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelArtifacts.tsx
@@ -1,22 +1,50 @@
-import { CaretRightIcon } from "@phosphor-icons/react";
+import { CaretRightIcon, FilesIcon, TrashIcon } from "@phosphor-icons/react";
 import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas";
 import type { DashboardRecord } from "@posthog/core/canvas/dashboardSchemas";
+import {
+  Badge,
+  Card,
+  CardContent,
+  cn,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Text,
+} from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { ArtifactsViewToggle } from "@posthog/ui/features/canvas/components/ArtifactsViewToggle";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useChannelTasks } from "@posthog/ui/features/canvas/hooks/useChannelTasks";
 import { useDashboards } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { useArtifactsViewStore } from "@posthog/ui/features/canvas/stores/artifactsViewStore";
+import { useIsCanvasPendingDelete } from "@posthog/ui/features/canvas/stores/pendingCanvasDeleteStore";
+import { masonryPreviewHeight } from "@posthog/ui/features/canvas/utils/masonryPreviewHeight";
 import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifact";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderChip,
+  PageHeaderDescription,
+  PageHeaderHeading,
+  PageHeaderTitle,
+  PageHeaderTitleRow,
+} from "@posthog/ui/primitives/PageHeader";
 import { track } from "@posthog/ui/shell/analytics";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
-import { Text } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
 import { type ReactNode, useCallback, useEffect, useMemo } from "react";
+
+// Uniform media height for the grid: cards line up row to row, and a PR tile
+// (which has nothing to preview) fills the same band as a canvas thumbnail.
+const GRID_PREVIEW_HEIGHT = 176;
 
 // Artifacts are the durable outputs of a channel's work. Canvases for now; PRs
 // are surfaced from each filed task's latest run output. More kinds (reports,
@@ -40,10 +68,12 @@ type ArtifactItem =
 
 // A channel's artifacts: canvases and the pull requests produced by its tasks,
 // most recent first. Sibling of the History tab, but scoped to outputs rather
-// than the full activity stream.
+// than the full activity stream. The view toggle switches between a dense row
+// list and card layouts.
 export function WebsiteChannelArtifacts({ channelId }: { channelId: string }) {
   const spacesLayout = useChannelsLayout();
   const navigate = useNavigate();
+  const view = useArtifactsViewStore((s) => s.view);
 
   useEffect(() => {
     track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
@@ -54,7 +84,10 @@ export function WebsiteChannelArtifacts({ channelId }: { channelId: string }) {
   }, [channelId]);
 
   useSetHeaderContent(
-    useMemo(() => <ChannelHeader channelId={channelId} />, [channelId]),
+    useMemo(
+      () => <ChannelHeader channelId={channelId} page="artifacts" />,
+      [channelId],
+    ),
   );
 
   const { dashboards } = useDashboards(channelId);
@@ -124,47 +157,208 @@ export function WebsiteChannelArtifacts({ channelId }: { channelId: string }) {
   );
 
   return (
-    <div className="h-full overflow-y-auto bg-gray-1">
-      <div className="mx-auto w-full max-w-[680px] px-4 py-6">
-        {items.length === 0 ? (
-          <div className="flex flex-col items-center gap-1 py-24 text-center">
-            <Text className="font-medium text-[14px] text-gray-12">
-              No artifacts yet
-            </Text>
-            <Text className="text-[13px] text-gray-10">
+    <div className="flex h-full min-h-0 flex-col bg-gray-1">
+      {/* Full-bleed header over a container-width body — the Inbox shape. Ships
+          behind the spaces layout like every other space page header; off,
+          the view switcher rides above the list instead. */}
+      {spacesLayout ? (
+        <PageHeader>
+          <PageHeaderHeading>
+            <PageHeaderTitleRow>
+              <PageHeaderTitle>Artifacts</PageHeaderTitle>
+              {items.length > 0 && (
+                <PageHeaderChip icon={<FilesIcon size={12} weight="fill" />}>
+                  {items.length} item{items.length === 1 ? "" : "s"}
+                </PageHeaderChip>
+              )}
+              <PageHeaderActions>
+                <ArtifactsViewToggle channelId={channelId} />
+              </PageHeaderActions>
+            </PageHeaderTitleRow>
+            <PageHeaderDescription>
               Canvases and pull requests from this{" "}
-              {spacesLayout ? "space's" : "channel's"} tasks show up here.
-            </Text>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-0.5">
-            {items.map((item) =>
-              item.kind === "canvas" ? (
-                <ArtifactRow
+              {spacesLayout ? "space's" : "channel's"} tasks.
+            </PageHeaderDescription>
+          </PageHeaderHeading>
+        </PageHeader>
+      ) : null}
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {/* Full width, flush with the page header above it — every layout
+            here (rows and cards alike) is a scannable list, not prose, so a
+            measure cap just strands whitespace on wide windows. */}
+        <div className="w-full px-6 py-6">
+          {!spacesLayout && (
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <Text size="sm" variant="muted">
+                {items.length === 0
+                  ? "Artifacts"
+                  : `${items.length} artifact${items.length === 1 ? "" : "s"}`}
+              </Text>
+              <ArtifactsViewToggle channelId={channelId} />
+            </div>
+          )}
+          {items.length === 0 ? (
+            <Empty className="mx-auto max-w-md py-20">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <FilesIcon size={24} />
+                </EmptyMedia>
+                <EmptyTitle>No artifacts yet</EmptyTitle>
+                <EmptyDescription>
+                  Canvases and pull requests from this{" "}
+                  {spacesLayout ? "space's" : "channel's"} tasks show up here.
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          ) : view === "list" ? (
+            <div className="flex flex-col gap-0.5">
+              {items.map((item) => (
+                <ArtifactListItem
                   key={item.key}
-                  accent="violet"
-                  icon={iconForTemplate(item.templateId, {
-                    size: 15,
-                    className: "text-violet-9",
-                  })}
-                  title={item.title}
-                  subtitle={`Canvas · ${formatRelativeTimeShort(item.ts)}`}
-                  onClick={() => openCanvas(item.dashboardId)}
+                  item={item}
+                  onOpenCanvas={openCanvas}
+                  onOpenPr={openPr}
                 />
-              ) : (
-                <PrArtifactRow
+              ))}
+            </div>
+          ) : view === "grid" ? (
+            // items-stretch + a full-height card: a PR tile (no preview to
+            // show) matches the canvas cards in its row instead of ending
+            // short.
+            <div className="grid grid-cols-1 items-stretch gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4">
+              {items.map((item) => (
+                <ArtifactCard
                   key={item.key}
-                  title={item.title}
-                  prUrl={item.prUrl}
-                  ts={item.ts}
-                  onClick={openPr}
+                  item={item}
+                  previewHeight={GRID_PREVIEW_HEIGHT}
+                  fillHeight
+                  onOpenCanvas={openCanvas}
+                  onOpenPr={openPr}
                 />
-              ),
-            )}
-          </div>
-        )}
+              ))}
+            </div>
+          ) : (
+            // CSS columns rather than a JS masonry: cards are self-contained and
+            // never reflow into each other, so break-inside-avoid is enough. The
+            // trade-off is column-major order — newest runs down column one, not
+            // across the row — which is fine for a browse-y wall of cards.
+            <div className="columns-1 gap-4 sm:columns-2 lg:columns-3 2xl:columns-4">
+              {items.map((item) => (
+                <div key={item.key} className="mb-4 break-inside-avoid">
+                  <ArtifactCard
+                    item={item}
+                    previewHeight={masonryPreviewHeight(item.key)}
+                    onOpenCanvas={openCanvas}
+                    onOpenPr={openPr}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
+  );
+}
+
+function ArtifactListItem({
+  item,
+  onOpenCanvas,
+  onOpenPr,
+}: {
+  item: ArtifactItem;
+  onOpenCanvas: (dashboardId: string) => void;
+  onOpenPr: (safeUrl: string) => void;
+}) {
+  return item.kind === "canvas" ? (
+    <CanvasArtifactRow
+      dashboardId={item.dashboardId}
+      templateId={item.templateId}
+      title={item.title}
+      ts={item.ts}
+      onClick={onOpenCanvas}
+    />
+  ) : (
+    <PrArtifactRow
+      title={item.title}
+      prUrl={item.prUrl}
+      ts={item.ts}
+      onClick={onOpenPr}
+    />
+  );
+}
+
+function ArtifactCard({
+  item,
+  previewHeight,
+  fillHeight,
+  onOpenCanvas,
+  onOpenPr,
+}: {
+  item: ArtifactItem;
+  previewHeight: number;
+  /** Grid only: stretch to the tallest card in the row. */
+  fillHeight?: boolean;
+  onOpenCanvas: (dashboardId: string) => void;
+  onOpenPr: (safeUrl: string) => void;
+}) {
+  return item.kind === "canvas" ? (
+    <CanvasArtifactCard
+      dashboardId={item.dashboardId}
+      templateId={item.templateId}
+      title={item.title}
+      ts={item.ts}
+      previewHeight={previewHeight}
+      fillHeight={fillHeight}
+      onClick={onOpenCanvas}
+    />
+  ) : (
+    <PrArtifactCard
+      title={item.title}
+      prUrl={item.prUrl}
+      ts={item.ts}
+      mediaHeight={fillHeight ? previewHeight : undefined}
+      fillHeight={fillHeight}
+      onClick={onOpenPr}
+    />
+  );
+}
+
+// A canvas artifact row. While the canvas is inside its delete-undo window the
+// row stays put — its template icon becomes a pulsing trash can and the row
+// stops opening — so undoing puts it back exactly where it was.
+function CanvasArtifactRow({
+  dashboardId,
+  templateId,
+  title,
+  ts,
+  onClick,
+}: {
+  dashboardId: string;
+  templateId: string;
+  title: string;
+  ts: number;
+  onClick: (dashboardId: string) => void;
+}) {
+  const deleting = useIsCanvasPendingDelete(dashboardId);
+
+  return (
+    <ArtifactRow
+      accent={deleting ? "red" : "violet"}
+      icon={
+        deleting ? (
+          <TrashIcon size={15} className="animate-pulse text-red-9" />
+        ) : (
+          iconForTemplate(templateId, { size: 15, className: "text-violet-9" })
+        )
+      }
+      title={title}
+      subtitle={
+        deleting ? "Deleting…" : `Canvas · ${formatRelativeTimeShort(ts)}`
+      }
+      onClick={deleting ? undefined : () => onClick(dashboardId)}
+    />
   );
 }
 
@@ -225,7 +419,7 @@ function ArtifactRow({
       type="button"
       onClick={onClick}
       disabled={!onClick}
-      className="group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors enabled:hover:bg-gray-3"
+      className="group flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left transition-colors enabled:hover:bg-fill-hover"
     >
       <span
         className="flex size-7 shrink-0 items-center justify-center rounded-md"
@@ -237,14 +431,193 @@ function ArtifactRow({
         <span className="truncate font-medium text-[13px] text-gray-12 leading-tight">
           {title}
         </span>
-        <span className="truncate text-[11px] text-gray-10 leading-tight">
+        <span className="truncate text-[11px] text-muted-foreground leading-tight">
           {subtitle}
         </span>
       </span>
       <CaretRightIcon
         size={14}
-        className="shrink-0 text-gray-8 opacity-0 transition-opacity group-hover:opacity-100"
+        className="shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
       />
+    </button>
+  );
+}
+
+// The card form of a canvas artifact. Canvas records no longer carry source
+// code (the rendered output lives behind the build lifecycle), so the media
+// slot is a stable placeholder frame until per-card artifact previews are
+// wired up, mirroring WebsiteDashboardsIndex. Same delete-undo behaviour as
+// the row: the card stays in place, dimmed, until the undo window closes.
+function CanvasArtifactCard({
+  dashboardId,
+  templateId,
+  title,
+  ts,
+  previewHeight,
+  fillHeight,
+  onClick,
+}: {
+  dashboardId: string;
+  templateId: string;
+  title: string;
+  ts: number;
+  previewHeight: number;
+  fillHeight?: boolean;
+  onClick: (dashboardId: string) => void;
+}) {
+  const deleting = useIsCanvasPendingDelete(dashboardId);
+
+  return (
+    <ArtifactCardShell
+      media={
+        <>
+          <div
+            className="relative overflow-hidden border-border border-b bg-muted"
+            style={{ height: previewHeight }}
+          >
+            <div className="absolute inset-0 flex items-center justify-center px-4 text-center">
+              <Text size="xs" variant="muted">
+                Canvas preview
+              </Text>
+            </div>
+          </div>
+          {deleting && (
+            <div className="absolute inset-0 flex items-center justify-center gap-2 bg-gray-1/80">
+              <TrashIcon size={18} className="animate-pulse text-red-9" />
+              <Text size="xs" variant="muted">
+                Deleting…
+              </Text>
+            </div>
+          )}
+        </>
+      }
+      icon={iconForTemplate(templateId, {
+        size: 14,
+        className: "text-violet-9",
+      })}
+      title={title}
+      badge="Canvas"
+      subtitle={
+        deleting ? "Deleting…" : `Updated ${formatRelativeTimeShort(ts)}`
+      }
+      dimmed={deleting}
+      fillHeight={fillHeight}
+      onClick={deleting ? undefined : () => onClick(dashboardId)}
+    />
+  );
+}
+
+// The card form of a PR artifact. A PR has nothing to preview, so its media
+// slot is a short tinted band carrying the lifecycle icon — which also keeps PR
+// cards visibly shorter than canvas cards in the masonry layout.
+function PrArtifactCard({
+  title,
+  prUrl,
+  ts,
+  mediaHeight,
+  fillHeight,
+  onClick,
+}: {
+  title: string;
+  prUrl: string;
+  ts: number;
+  /** Grid only: match the canvas cards' band instead of a short strip. */
+  mediaHeight?: number;
+  fillHeight?: boolean;
+  onClick: (safeUrl: string) => void;
+}) {
+  const {
+    safeUrl,
+    title: prTitle,
+    stateLabel,
+    Icon,
+    iconColor,
+    accentColor,
+  } = usePrArtifact(prUrl);
+
+  const subtitle = [prTitle, formatRelativeTimeShort(ts)]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <ArtifactCardShell
+      media={
+        <div
+          className="flex items-center justify-center border-border border-b"
+          style={{
+            backgroundColor: `var(--${accentColor}-3)`,
+            height: mediaHeight ?? 80,
+          }}
+        >
+          <Icon size={28} weight="bold" style={{ color: iconColor }} />
+        </div>
+      }
+      icon={<Icon size={14} weight="bold" style={{ color: iconColor }} />}
+      title={title}
+      badge={stateLabel || "Pull request"}
+      subtitle={subtitle}
+      fillHeight={fillHeight}
+      onClick={safeUrl ? () => onClick(safeUrl) : undefined}
+    />
+  );
+}
+
+function ArtifactCardShell({
+  media,
+  icon,
+  title,
+  badge,
+  subtitle,
+  dimmed,
+  fillHeight,
+  onClick,
+}: {
+  media: ReactNode;
+  icon: ReactNode;
+  title: string;
+  badge: string;
+  subtitle: string;
+  dimmed?: boolean;
+  /** Grid only: fill the row so neighbouring cards end at the same line. */
+  fillHeight?: boolean;
+  /** Absent for a card with nowhere safe to go — a non-github PR link. */
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!onClick}
+      className={cn(
+        // A card with nowhere to go (or mid-delete) takes no pointer events, so
+        // the hover treatment below can key off plain group-hover.
+        "group w-full text-left disabled:pointer-events-none",
+        fillHeight && "h-full",
+        dimmed && "pointer-events-none opacity-60",
+      )}
+    >
+      <Card
+        className={cn(
+          "gap-0 overflow-hidden p-0 transition-colors group-hover:border-accent",
+          fillHeight && "flex h-full flex-col",
+        )}
+      >
+        <div className="relative shrink-0">{media}</div>
+        <CardContent className="flex flex-1 flex-col gap-0.5 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="shrink-0">{icon}</span>
+              <Text size="sm" weight="medium" className="truncate">
+                {title}
+              </Text>
+            </div>
+            <Badge>{badge}</Badge>
+          </div>
+          <Text size="xxs" variant="muted" className="truncate">
+            {subtitle}
+          </Text>
+        </CardContent>
+      </Card>
     </button>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteContext.tsx
@@ -321,22 +321,41 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
         </Box>
       ) : null}
 
-      <ScrollArea
-        type="auto"
-        scrollbars="vertical"
-        className="scroll-area-constrain-width min-h-0 flex-1"
-      >
-        <Box p="4">
-          {selectedVersion ? (
-            <Callout.Root color="gray" size="1">
-              <Callout.Text>
-                Viewing v{selectedVersion.version} metadata. Past content is not
-                fetched today — switch to "Latest" to read or edit current
-                content.
-              </Callout.Text>
-            </Callout.Root>
-          ) : mode === "rendered" ? (
-            hasInstructions ? (
+      {!selectedVersion && mode === "edit" ? (
+        // The editor sits outside the scroll area so it grows with the window
+        // instead of scrolling the page around a fixed-height box.
+        <Box p="4" className="flex min-h-0 flex-1">
+          <TextArea
+            value={draft}
+            onChange={(e) => {
+              setDraft(e.target.value);
+              setHasDraft(true);
+            }}
+            size="2"
+            placeholder={
+              spacesLayout
+                ? "# Space context\n\nWrite markdown describing this space…"
+                : "# Channel context\n\nWrite markdown describing this channel…"
+            }
+            className="min-h-0 flex-1 font-[var(--code-font-family)]"
+          />
+        </Box>
+      ) : (
+        <ScrollArea
+          type="auto"
+          scrollbars="vertical"
+          className="scroll-area-constrain-width min-h-0 flex-1"
+        >
+          <Box p="4">
+            {selectedVersion ? (
+              <Callout.Root color="gray" size="1">
+                <Callout.Text>
+                  Viewing v{selectedVersion.version} metadata. Past content is
+                  not fetched today — switch to "Latest" to read or edit current
+                  content.
+                </Callout.Text>
+              </Callout.Root>
+            ) : hasInstructions ? (
               <Box className="text-[13px]">
                 <MarkdownRenderer content={renderedContent} />
               </Box>
@@ -350,26 +369,10 @@ export function WebsiteContext({ channelId }: WebsiteContextProps) {
                   setMode("edit");
                 }}
               />
-            )
-          ) : (
-            <TextArea
-              value={draft}
-              onChange={(e) => {
-                setDraft(e.target.value);
-                setHasDraft(true);
-              }}
-              size="2"
-              rows={24}
-              placeholder={
-                spacesLayout
-                  ? "# Space context\n\nWrite markdown describing this space…"
-                  : "# Channel context\n\nWrite markdown describing this channel…"
-              }
-              className="font-[var(--code-font-family)]"
-            />
-          )}
-        </Box>
-      </ScrollArea>
+            )}
+          </Box>
+        </ScrollArea>
+      )}
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteLayout.tsx
@@ -4,10 +4,18 @@ import {
   LinkIcon,
   PencilSimpleIcon,
   PushPinIcon,
+  TrashIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
 import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +26,7 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { NewCanvasMenu } from "@posthog/ui/features/canvas/components/NewCanvasMenu";
+import { deleteCanvasWithUndo } from "@posthog/ui/features/canvas/deleteCanvasWithUndo";
 import { CanvasFrameHost } from "@posthog/ui/features/canvas/freeform/CanvasFrameHost";
 import { useCanvasFrameStore } from "@posthog/ui/features/canvas/freeform/canvasFrameStore";
 import { CANVAS_QUERY_KEY } from "@posthog/ui/features/canvas/freeform/freeformDataBridge";
@@ -40,8 +49,13 @@ import { track } from "@posthog/ui/shell/analytics";
 import { useHeaderStore } from "@posthog/ui/shell/headerStore";
 import { Box, Flex } from "@radix-ui/themes";
 import { useIsMutating, useQueryClient } from "@tanstack/react-query";
-import { Outlet, useParams, useRouterState } from "@tanstack/react-router";
-import type { ReactNode } from "react";
+import {
+  Outlet,
+  useNavigate,
+  useParams,
+  useRouterState,
+} from "@tanstack/react-router";
+import { type ReactNode, useState } from "react";
 
 // Edit toggle + autosave status for a canvas. Source is server-versioned now —
 // version browsing and revert live in the canvas view's own toolbar — so the
@@ -53,11 +67,37 @@ function FreeformEditControls({
   channelId: string;
   dashboardId: string;
 }) {
+  const navigate = useNavigate();
+  // Pinning is scoped to whatever holds the canvas; the new layout calls that a
+  // space, the old one a channel.
+  const spacesLayout = useChannelsLayout();
+  const containerNoun = spacesLayout ? "space" : "channel";
   const editing = useIsDashboardEditing(dashboardId);
   const setEditing = useDashboardEditStore((s) => s.setEditing);
   const { dashboard } = useDashboard(dashboardId);
-  const { setPinned } = useDashboardMutations();
+  const { setPinned, invalidateDashboards } = useDashboardMutations();
   const isPinned = dashboard?.pinnedAt != null;
+  // "Delete…" opens a confirmation rather than deleting inline — the canvas and
+  // its version history go away for everyone in the space.
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+
+  // Once confirmed the canvas vanishes from every list and we leave for the
+  // space's artifacts list, but the delete isn't sent until the undo toast's
+  // timer runs out — Undo simply cancels it.
+  const confirmDelete = () => {
+    setConfirmDeleteOpen(false);
+    deleteCanvasWithUndo({
+      dashboardId,
+      channelId,
+      name: dashboard?.name ?? "Canvas",
+      surface: "canvas",
+      invalidate: invalidateDashboards,
+    });
+    void navigate({
+      to: "/website/$channelId/artifacts",
+      params: { channelId },
+    });
+  };
 
   const onTogglePin = () => {
     void setPinned(dashboardId, !isPinned)
@@ -135,7 +175,14 @@ function FreeformEditControls({
             </Button>
           }
         />
-        <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
+        {/* Sized to its longest item — the default width clipped "Unpin from
+            space". Same treatment as the channel-list menus. */}
+        <DropdownMenuContent
+          align="end"
+          side="bottom"
+          sideOffset={4}
+          className="w-auto min-w-fit"
+        >
           <DropdownMenuItem onClick={onRefresh}>
             <ArrowClockwiseIcon size={14} />
             Refresh
@@ -150,10 +197,46 @@ function FreeformEditControls({
           </DropdownMenuItem>
           <DropdownMenuItem onClick={onTogglePin}>
             <PushPinIcon size={14} weight={isPinned ? "fill" : "regular"} />
-            {isPinned ? "Unpin from channel" : "Pin to channel"}
+            {isPinned
+              ? `Unpin from ${containerNoun}`
+              : `Pin to ${containerNoun}`}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={() => setConfirmDeleteOpen(true)}
+          >
+            <TrashIcon size={14} />
+            Delete…
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+      {/* Destructive confirm for "Delete…" — the canvas goes for everyone. */}
+      <AlertDialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
+        <AlertDialogContent className="max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete canvas</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete{" "}
+              <span className="font-medium">{dashboard?.name ?? "Canvas"}</span>
+              ? Its code and version history go for everyone in the{" "}
+              {containerNoun}. You get a few seconds to undo, then it's
+              permanent.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose
+              render={
+                <Button variant="outline" size="sm">
+                  Cancel
+                </Button>
+              }
+            />
+            <Button variant="destructive" size="sm" onClick={confirmDelete}>
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       <Button
         variant="outline"
         size="sm"

--- a/products/desktop/packages/ui/src/features/canvas/freeform/CanvasBuildStatus.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/CanvasBuildStatus.tsx
@@ -11,11 +11,17 @@ import {
   latestFinishedCanvasBuild,
 } from "@posthog/core/canvas/canvasBuildSchemas";
 import { useHostTRPC } from "@posthog/host-router/react";
-import { Button } from "@posthog/quill";
+import {
+  Button,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@posthog/quill";
 import type { CanvasDiagnostic } from "@posthog/shared";
 import { useCanvasBuilds } from "@posthog/ui/features/canvas/hooks/useCanvasBuilds";
 import { toast } from "@posthog/ui/primitives/toast";
-import { Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
@@ -96,9 +102,12 @@ export function CanvasBuildStatus({
   if (active) {
     const elapsed = formatElapsed(Date.now() - Date.parse(active.createdAt));
     return (
-      <Flex align="center" gap="1" data-testid="canvas-build-active">
+      <div
+        className="flex items-center gap-1"
+        data-testid="canvas-build-active"
+      >
         <SpinnerGapIcon size={14} className="animate-spin text-gray-9" />
-        <Text size="1" className="text-gray-10">
+        <Text size="xs" variant="muted">
           {active.buildStatus === "queued" ? "Queued" : "Building"} · {elapsed}
         </Text>
         {active.buildStatus === "queued" && (
@@ -118,7 +127,7 @@ export function CanvasBuildStatus({
             <XIcon size={14} />
           </Button>
         )}
-      </Flex>
+      </div>
     );
   }
 
@@ -132,24 +141,32 @@ export function CanvasBuildStatus({
   if (latest.buildStatus === "failed") {
     const errors = topErrors(latest.diagnostics);
     return (
-      <Flex align="center" gap="1" data-testid="canvas-build-failed">
-        <Tooltip
-          content={
-            <span className="whitespace-pre-wrap">
-              {[
-                "Latest build failed — the previous version stays live.",
-                ...errors,
-              ].join("\n")}
-            </span>
-          }
-        >
-          <Flex align="center" gap="1">
-            <WarningCircleIcon size={14} className="text-red-9" />
-            <Text size="1" className="text-red-10">
-              Build failed
-            </Text>
-          </Flex>
-        </Tooltip>
+      <div
+        className="flex items-center gap-1"
+        data-testid="canvas-build-failed"
+      >
+        <TooltipProvider delay={0}>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <div className="flex items-center gap-1">
+                  <WarningCircleIcon size={14} className="text-red-9" />
+                  <Text size="xs" className="text-red-10">
+                    Build failed
+                  </Text>
+                </div>
+              }
+            />
+            <TooltipContent>
+              <span className="whitespace-pre-wrap">
+                {[
+                  "Latest build failed. The previous version stays live.",
+                  ...errors,
+                ].join("\n")}
+              </span>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         {onAskAgentToFix && (
           <Button
             size="sm"
@@ -182,35 +199,45 @@ export function CanvasBuildStatus({
         >
           <ArrowClockwiseIcon size={14} />
         </Button>
-      </Flex>
+      </div>
     );
   }
 
   if (lifecycle.publishedBuildId === latest.id) {
     return (
-      <Tooltip content="The live build is up to date.">
-        <Flex align="center" gap="1" data-testid="canvas-build-ready">
-          <CheckCircleIcon size={14} className="text-green-9" />
-          <Button
-            size="icon"
-            variant="default"
-            aria-label={latest.pinned ? "Unpin build" : "Pin build"}
-            disabled={action.isPending}
-            onClick={() =>
-              action.mutate({
-                id: dashboardId,
-                buildId: latest.id,
-                action: latest.pinned ? "unpin" : "pin",
-              })
+      <TooltipProvider delay={0}>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div
+                className="flex items-center gap-1"
+                data-testid="canvas-build-ready"
+              >
+                <CheckCircleIcon size={14} className="text-green-9" />
+                <Button
+                  size="icon"
+                  variant="default"
+                  aria-label={latest.pinned ? "Unpin build" : "Pin build"}
+                  disabled={action.isPending}
+                  onClick={() =>
+                    action.mutate({
+                      id: dashboardId,
+                      buildId: latest.id,
+                      action: latest.pinned ? "unpin" : "pin",
+                    })
+                  }
+                >
+                  <PushPinIcon
+                    size={14}
+                    weight={latest.pinned ? "fill" : "regular"}
+                  />
+                </Button>
+              </div>
             }
-          >
-            <PushPinIcon
-              size={14}
-              weight={latest.pinned ? "fill" : "regular"}
-            />
-          </Button>
-        </Flex>
-      </Tooltip>
+          />
+          <TooltipContent>The live build is up to date.</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 
@@ -219,26 +246,38 @@ export function CanvasBuildStatus({
   );
   if (latest.buildStatus === "ready" && published?.pinned) {
     return (
-      <Tooltip content="A newer build is ready, but an older build is pinned live.">
-        <Flex align="center" gap="1" data-testid="canvas-build-pinned-older">
-          <Text size="1">Newer build available</Text>
-          <Button
-            size="icon"
-            variant="default"
-            aria-label="Unpin build"
-            disabled={action.isPending}
-            onClick={() =>
-              action.mutate({
-                id: dashboardId,
-                buildId: published.id,
-                action: "unpin",
-              })
+      <TooltipProvider delay={0}>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div
+                className="flex items-center gap-1"
+                data-testid="canvas-build-pinned-older"
+              >
+                <Text size="xs">Newer build available</Text>
+                <Button
+                  size="icon"
+                  variant="default"
+                  aria-label="Unpin build"
+                  disabled={action.isPending}
+                  onClick={() =>
+                    action.mutate({
+                      id: dashboardId,
+                      buildId: published.id,
+                      action: "unpin",
+                    })
+                  }
+                >
+                  <PushPinIcon size={14} weight="fill" />
+                </Button>
+              </div>
             }
-          >
-            <PushPinIcon size={14} weight="fill" />
-          </Button>
-        </Flex>
-      </Tooltip>
+          />
+          <TooltipContent>
+            A newer build is ready, but an older build is pinned live.
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 


### PR DESCRIPTION
## Problem

PR #76649 ported the canvas build pipeline from a stale snapshot and silently downgraded unrelated desktop code when it merged. #77252 restored part of the damage (space repository linking). Two audit passes over both canvas PRs (#73874, #76649) against the master commits they overwrote found the rest:

- The channel artifacts page lost its page header, list/grid/masonry view toggle, card layouts, and delete-undo handling.
- `Task.repositories` (from #76448) lost its type field and all three consumers, so multi-repo cloud tasks degrade to single-repo: run instructions and git checkpoints cover only one repo, and local handoff clones only the first repository. The covering tests were deleted.
- The canvas toolbar lost its Delete… flow, its space-aware pin label, and its menu width fix; the CONTEXT.md editor stopped filling the viewport.
- The new `CanvasBuildStatus` component shipped with banned `@radix-ui/themes` imports.
- #73874's conflict resolution re-added a stale `!common/alerting` line to `.dockerignore` (the directory no longer exists).

## Changes

- Restores `WebsiteChannelArtifacts.tsx` to its pre-#76649 shape, adapted to the new schema: `DashboardRecord`, PR keys by `taskId`, and quill components instead of the reintroduced Radix import.
- Canvas cards show a placeholder preview frame, matching `WebsiteDashboardsIndex`, because records no longer carry source code.
- Restores `repositories?: string[]` on `Task` and the fallbacks in `normalizeTaskResponse`, `AgentServer`, and `LocalHandoffService.start`.
- Restores the three deleted multi-repo handoff tests, including the unsafe-repository-entry cases.
- Restores the canvas toolbar's Delete… confirm-then-undo flow in `WebsiteLayout.tsx`, with its space/channel pin label and `w-auto min-w-fit` menu width fix.
- Moves the CONTEXT.md edit textarea back out of the scroll area in `WebsiteContext.tsx` so it fills the viewport again.
- Converts `CanvasBuildStatus.tsx` from Radix `Flex`/`Text`/`Tooltip` to quill equivalents.
- Removes the orphaned `!common/alerting` line from `.dockerignore`.

> [!NOTE]
> Still degraded after this PR, left for a product decision: live canvas previews in grid cards (needs per-card artifact URL wiring; `WebsiteDashboardsIndex` has the same deliberate placeholder) and the removed "Save as fork" toolbar action in `WebsiteLayout.tsx`.

## How did you test this code?

- Red-green: restored the three multi-repo handoff tests first and watched 7 cases fail, then applied the fixes; all 16 pass.
- Added a parameterized `normalizeTaskResponse` case asserting the `repositories` fallback, since deleting that line previously broke nothing.
- Ran `@posthog/core` (3064 tests), `@posthog/api-client` (163), and `@posthog/ui` canvas tests (360); all pass, including after the second-pass toolbar and context editor fixes.
- Typecheck passes for `shared`, `api-client`, `core`, `agent`, and `ui`; Biome clean; `hogli ci:preflight --fix` reports 0 failures.
- I could not render the desktop app in this sandbox, so the restored surfaces have no screenshots. The layout code matches what shipped before #76649.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude (PostHog Code cloud task) authored this PR; skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- I diffed both canvas merges against every master commit that touched the same files since the desktop import, then verified each candidate against current HEAD with parallel read-only agents; most apparent reverts were intentional supersession by the new build pipeline.
- A second adversarial pass re-examined the files the first pass cleared and found the toolbar and context editor regressions; zombie-file and sibling-port-PR checks came back clean.
- I kept #76649's intentional changes (DashboardRecord rename, PR keys by taskId, server-provisioned personal channels) and restored only the clobbered behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*