### PR TITLE
fix(feature-flags): return 400 for unevaluable blast radius filters

### DIFF
--- a/products/feature_flags/backend/test/test_user_blast_radius.py
+++ b/products/feature_flags/backend/test/test_user_blast_radius.py
@@ -1,0 +1,40 @@
+from django.test import SimpleTestCase
+
+from clickhouse_driver.errors import ServerException
+from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
+
+from posthog.errors import InternalCHQueryError, wrap_clickhouse_query_error
+from posthog.models.property import PropertyValidationError
+
+from products.feature_flags.backend.user_blast_radius import unevaluable_filters_as_validation_errors
+
+
+class TestUnevaluableFiltersAsValidationErrors(SimpleTestCase):
+    def test_property_validation_error_surfaces_as_a_caller_error(self):
+        # Raised by Property.__init__ during query build (e.g. a referenced cohort stored with a
+        # value-less property); a plain ValueError subclass, so it used to escape as a 500.
+        with self.assertRaises(ValidationError) as ctx, unevaluable_filters_as_validation_errors():
+            raise PropertyValidationError("Value must be set for property type person & operator gt")
+        self.assertIn("Value must be set", str(ctx.exception))
+
+    @parameterized.expand(
+        [
+            ("cannot_parse_text", 6),
+            ("cannot_parse_number", 72),
+        ]
+    )
+    def test_clickhouse_value_parse_failure_surfaces_as_a_caller_error(self, _name, code):
+        # A numeric operator against a null/non-numeric filter value fails the Float64 cast at
+        # execution; these codes wrap to InternalCHQueryError (not Exposed), so they used to 500.
+        err = wrap_clickhouse_query_error(ServerException("Cannot parse NaN: converting 'None' to Float64", code=code))
+        with self.assertRaises(ValidationError) as ctx, unevaluable_filters_as_validation_errors():
+            raise err
+        self.assertIn("Cannot parse NaN", str(ctx.exception))
+
+    def test_other_internal_clickhouse_errors_stay_server_faults(self):
+        # Only the deterministic cannot-parse-value codes are the caller's input; anything else
+        # (here LOGICAL_ERROR) must keep surfacing as a 500 so real faults reach error tracking.
+        err = wrap_clickhouse_query_error(ServerException("Logical error: invariant violated", code=49))
+        with self.assertRaises(InternalCHQueryError), unevaluable_filters_as_validation_errors():
+            raise err

--- a/products/feature_flags/backend/test/test_user_blast_radius.py
+++ b/products/feature_flags/backend/test/test_user_blast_radius.py
@@ -27,10 +27,16 @@ class TestUnevaluableFiltersAsValidationErrors(SimpleTestCase):
     def test_clickhouse_value_parse_failure_surfaces_as_a_caller_error(self, _name, code):
         # A numeric operator against a null/non-numeric filter value fails the Float64 cast at
         # execution; these codes wrap to InternalCHQueryError (not Exposed), so they used to 500.
-        err = wrap_clickhouse_query_error(ServerException("Cannot parse NaN: converting 'None' to Float64", code=code))
+        # The 400 body must carry only the useful message: the DB::Exception framing and any
+        # server stack trace tail are stripped, matching what ExposedCHQueryError exposes.
+        raw = "DB::Exception: Cannot parse NaN: converting 'None' to Float64. Stack trace:\n0. DB::Exception::Exception"
+        err = wrap_clickhouse_query_error(ServerException(raw, code=code))
         with self.assertRaises(ValidationError) as ctx, unevaluable_filters_as_validation_errors():
             raise err
-        self.assertIn("Cannot parse NaN", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("Cannot parse NaN", message)
+        self.assertNotIn("Stack trace", message)
+        self.assertNotIn("DB::Exception", message)
 
     def test_other_internal_clickhouse_errors_stay_server_faults(self):
         # Only the deterministic cannot-parse-value codes are the caller's input; anything else

--- a/products/feature_flags/backend/user_blast_radius.py
+++ b/products/feature_flags/backend/user_blast_radius.py
@@ -16,9 +16,9 @@ from posthog.hogql.errors import (
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
-from posthog.errors import ExposedCHQueryError
+from posthog.errors import ExposedCHQueryError, InternalCHQueryError
 from posthog.models.filters import Filter
-from posthog.models.property import GroupTypeIndex, Property, PropertyGroup
+from posthog.models.property import GroupTypeIndex, Property, PropertyGroup, PropertyValidationError
 from posthog.models.team.team import Team
 from posthog.queries.base import relative_date_parse_for_feature_flag_matching
 
@@ -31,6 +31,13 @@ class BlastRadiusResult:
     total: int
 
 
+# ClickHouse codes for "this literal can't be parsed as the column's type": 6 CANNOT_PARSE_TEXT,
+# 72 CANNOT_PARSE_NUMBER — e.g. a numeric operator (gt/lt) against a null or non-numeric filter
+# value casts 'None' to Float64 and fails deterministically. Both are classified USER_ERROR in
+# posthog/errors.py but not user_safe, so they wrap to InternalCHQueryError, not Exposed.
+_VALUE_PARSE_CH_ERROR_CODES = frozenset({6, 72})
+
+
 @contextmanager
 def unevaluable_filters_as_validation_errors() -> Iterator[None]:
     # Sizing runs caller-supplied condition filters through HogQL and ClickHouse. Shapes those
@@ -38,10 +45,13 @@ def unevaluable_filters_as_validation_errors() -> Iterator[None]:
     # malformed regexes, values that don't cast to the property's type - fail deterministically
     # on every request, so they're the caller's input, not a server fault: surface them as a 400
     # carrying the layer's own message instead of an opaque 500. Only deliberately-exposed error
-    # types (plus ObjectDoesNotExist from cohort lookups) are converted across query build and
-    # execution; caller-shaped ValueError is converted separately in the parse phase
+    # types are converted across query build and execution - plus ObjectDoesNotExist from cohort
+    # lookups, PropertyValidationError from Property construction during query build (its message
+    # already names the offending property), and the ClickHouse cannot-parse-value codes above.
+    # Caller-shaped ValueError is converted separately in the parse phase
     # (replace_proxy_properties), so a bare ValueError from HogQL internals or team config
-    # during build/execution still surfaces as a server fault.
+    # during build/execution still surfaces as a server fault, as does any other
+    # InternalCHQueryError.
     try:
         yield
     except (
@@ -49,7 +59,12 @@ def unevaluable_filters_as_validation_errors() -> Iterator[None]:
         HogQLNotImplementedError,
         ExposedCHQueryError,
         ObjectDoesNotExist,
+        PropertyValidationError,
     ) as e:
+        raise ValidationError({"filters": str(e) or "These filters cannot be evaluated."}) from e
+    except InternalCHQueryError as e:
+        if e.code not in _VALUE_PARSE_CH_ERROR_CODES:
+            raise
         raise ValidationError({"filters": str(e) or "These filters cannot be evaluated."}) from e
 
 

--- a/products/feature_flags/backend/user_blast_radius.py
+++ b/products/feature_flags/backend/user_blast_radius.py
@@ -65,7 +65,11 @@ def unevaluable_filters_as_validation_errors() -> Iterator[None]:
     except InternalCHQueryError as e:
         if e.code not in _VALUE_PARSE_CH_ERROR_CODES:
             raise
-        raise ValidationError({"filters": str(e) or "These filters cannot be evaluated."}) from e
+        # Unlike ExposedCHQueryError, InternalCHQueryError's str() keeps the raw server message.
+        # Rewrap so ExposedCHQueryError.__str__ strips the DB::Exception framing and any stack
+        # trace tail before the message is echoed back to the caller.
+        sanitized = str(ExposedCHQueryError(e.message, code=e.code, code_name=e.code_name))
+        raise ValidationError({"filters": sanitized or "These filters cannot be evaluated."}) from e
 
 
 def _normalize_property_value(prop: Property) -> None:


### PR DESCRIPTION
## Problem

Two deterministic caller-input failures surface as opaque 500s on `user_blast_radius` (used by feature flag rollout preview and workflows audience preview):

- `PropertyValidationError` — raised by `Property.__init__` during query build (e.g. an audience filter or referenced cohort with a value-less property). It's a plain `ValueError` subclass, so `unevaluable_filters_as_validation_errors` doesn't convert it, despite its message already naming the problem.
- ClickHouse `Cannot parse NaN: converting 'None' to Float64` — a numeric operator against a null/non-numeric filter value. Codes 6/72 are classified `USER_ERROR` in `posthog/errors.py` but not `user_safe`, so they wrap to `InternalCHQueryError` and escape the conversion.

Refs #78174.

## Changes

- `unevaluable_filters_as_validation_errors` also catches `PropertyValidationError`, returning its existing message as a DRF 400.
- It converts `InternalCHQueryError` only for the two cannot-parse-value codes (6 `CANNOT_PARSE_TEXT`, 72 `CANNOT_PARSE_NUMBER`); every other code re-raises.
- Bare `ValueError` from build/execution still surfaces as a server fault (existing test covers this).
- Covers both blast radius paths and the workflows batch-audience path, which share the context manager.

## How did you test this code?

- `pytest products/feature_flags/backend/test/test_user_blast_radius.py` — 4 passed.
- New tests lock in: PropertyValidationError → 400; CH parse-failure codes 6/72 → 400 (parameterized); other internal CH codes (LOGICAL_ERROR) still raise, so real faults keep reaching error tracking. No existing test caught any of these.
- `ruff` and `hogli ci:preflight --fix` — clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None — error-status behavior fix, no documented API shape change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored via PostHog Code (Claude). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Converted at the shared context-manager boundary rather than per raise-site, so cohort-stored bad properties and all three callers (flags blast radius, workflows blast radius, batch audience) are covered by one change.
- Kept the `InternalCHQueryError` conversion allowlisted to codes 6/72 — a blanket catch would mask genuine server faults as caller errors.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
