### PR TITLE
fix(ingestion): retry transient event schema enforcement loads

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
@@ -3,7 +3,7 @@ import { Counter } from 'prom-client'
 import { HogFlow } from '~/cdp/schema/hogflow'
 import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
 import { parseJSON } from '~/common/utils/json-parse'
-import { LazyLoader } from '~/common/utils/lazy-loader'
+import { DEFAULT_LOADER_RETRY, LazyLoader } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
 import { captureException } from '~/common/utils/posthog'
 import { PubSub } from '~/common/utils/pubsub'
@@ -64,7 +64,7 @@ export class HogFlowManagerService {
             refreshBackgroundAgeMs: 30 * 1000,
             // Absorb transient Postgres blips inside a single load attempt so failed background
             // refreshes don't re-fire at caller QPS and hard-cap refreshes don't fail the batch.
-            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+            loaderRetry: DEFAULT_LOADER_RETRY,
         }
 
         this.lazyLoaderByTeam = new LazyLoader({

--- a/nodejs/src/common/groups/readonly-group-type-manager.ts
+++ b/nodejs/src/common/groups/readonly-group-type-manager.ts
@@ -1,7 +1,12 @@
 import { GroupReadRepository } from '~/common/groups/repositories/group-repository.interface'
 import { timeoutGuard } from '~/common/utils/db/utils'
-import { LazyLoader } from '~/common/utils/lazy-loader'
+import { LazyLoader, LoaderRetryOptions } from '~/common/utils/lazy-loader'
 import { GroupTypeToColumnIndex, GroupTypesByProjectId, ProjectId } from '~/types'
+
+export interface ReadOnlyGroupTypeManagerOptions {
+    /** Retry transient group-type-load failures (e.g. a Postgres pooler blip) instead of letting them propagate. */
+    loaderRetry?: LoaderRetryOptions
+}
 
 /**
  * Read-only group type manager backed by a GroupReadRepository. Provides
@@ -12,11 +17,15 @@ import { GroupTypeToColumnIndex, GroupTypesByProjectId, ProjectId } from '~/type
 export class ReadOnlyGroupTypeManager {
     private loader: LazyLoader<GroupTypeToColumnIndex>
 
-    constructor(private groupRepository: GroupReadRepository) {
+    constructor(
+        private groupRepository: GroupReadRepository,
+        options?: ReadOnlyGroupTypeManagerOptions
+    ) {
         this.loader = new LazyLoader({
             name: 'ReadOnlyGroupTypeManager',
             refreshAgeMs: 30_000,
             refreshJitterMs: 0,
+            loaderRetry: options?.loaderRetry,
             loader: async (projectIds: string[]) => {
                 const response: Record<string, GroupTypeToColumnIndex> = {}
                 const timeout = timeoutGuard(`Still running "fetchGroupTypes". Timeout warning after 30 sec!`)

--- a/nodejs/src/common/utils/db/postgres.test.ts
+++ b/nodejs/src/common/utils/db/postgres.test.ts
@@ -1,0 +1,31 @@
+import { DependencyUnavailableError } from './error'
+import { PostgresUse, handlePostgresError, isTransientPgError } from './postgres'
+
+describe('transient postgres error classification', () => {
+    test.each([
+        ['connect ECONNREFUSED 10.0.0.1:6543', true],
+        ['connect EHOSTUNREACH 10.0.0.1:6543', true],
+        ['pooler is shutting down', true],
+        ['server conn crashed?', true],
+        ['duplicate key value violates unique constraint', false],
+        ['syntax error at or near "SELCT"', false],
+    ])('isTransientPgError(%s) -> %s', (message, expected) => {
+        expect(isTransientPgError(new Error(message))).toBe(expected)
+    })
+
+    test.each([undefined, null, 'a plain string', new Error()])('isTransientPgError(%p) -> false', (value) => {
+        expect(isTransientPgError(value)).toBe(false)
+    })
+
+    it('wraps transient errors in a retriable DependencyUnavailableError', () => {
+        expect(() => handlePostgresError(new Error('pooler is shutting down'), PostgresUse.PERSONS_WRITE)).toThrow(
+            expect.objectContaining({ name: 'DependencyUnavailableError', isRetriable: true })
+        )
+    })
+
+    it('does nothing for non-transient errors', () => {
+        expect(() =>
+            handlePostgresError(new Error('duplicate key value violates unique constraint'), PostgresUse.PERSONS_WRITE)
+        ).not.toThrow(DependencyUnavailableError)
+    })
+})

--- a/nodejs/src/common/utils/db/postgres.ts
+++ b/nodejs/src/common/utils/db/postgres.ts
@@ -52,9 +52,11 @@ const POSTGRES_UNAVAILABLE_ERROR_MESSAGES = [
     'Connection terminated unexpectedly',
     'ECONNREFUSED',
     'ECONNRESET', // Connection reset by peer, e.g. PgBouncer/PG closed an idle or in-flight connection
+    'EHOSTUNREACH', // No route to host, e.g. the PgBouncer pod's IP vanished during a restart
     'ETIMEDOUT',
     'query_wait_timeout', // Waiting on PG bouncer to give us a slot
     'server login has been failing', // PgBouncer cannot authenticate with upstream PG
+    'pooler is shutting down', // PgBouncer terminating client connections during a restart
 ]
 
 export function isTransientPgError(err: unknown): boolean {

--- a/nodejs/src/common/utils/event-schema-enforcement-manager.ts
+++ b/nodejs/src/common/utils/event-schema-enforcement-manager.ts
@@ -1,7 +1,7 @@
 import { EventSchemaEnforcement } from '~/types'
 
 import { PostgresRouter, PostgresUse } from './db/postgres'
-import { LazyLoader } from './lazy-loader'
+import { LazyLoader, LoaderRetryOptions } from './lazy-loader'
 
 /**
  * Raw row from the database query - one row per property per event.
@@ -23,14 +23,23 @@ interface RawSchemaPropertyRow {
 /** Map from event_name to schema for O(1) lookups */
 export type EventSchemaMap = Map<string, EventSchemaEnforcement>
 
+export interface EventSchemaEnforcementManagerOptions {
+    /** Retry transient schema-load failures (e.g. a Postgres pooler blip) instead of letting them propagate. */
+    loaderRetry?: LoaderRetryOptions
+}
+
 export class EventSchemaEnforcementManager {
     private lazyLoader: LazyLoader<EventSchemaMap>
 
-    constructor(private postgres: PostgresRouter) {
+    constructor(
+        private postgres: PostgresRouter,
+        options?: EventSchemaEnforcementManagerOptions
+    ) {
         this.lazyLoader = new LazyLoader({
             name: 'EventSchemaEnforcementManager',
             refreshAgeMs: 2 * 60 * 1000, // 2 minutes
             refreshJitterMs: 30 * 1000, // 30 seconds
+            loaderRetry: options?.loaderRetry,
             loader: async (teamIds: string[]) => {
                 return await this.fetchSchemas(teamIds)
             },

--- a/nodejs/src/common/utils/lazy-loader.ts
+++ b/nodejs/src/common/utils/lazy-loader.ts
@@ -64,6 +64,16 @@ export type LoaderRetryOptions = {
     maxElapsedMs: number
 }
 
+/**
+ * Shared retry policy for loaders backed by transient-blip-prone dependencies (e.g. Postgres
+ * behind PgBouncer). Sized to ride out a pooler restart without stalling callers for long.
+ */
+export const DEFAULT_LOADER_RETRY: LoaderRetryOptions = {
+    retryIntervalMs: 250,
+    retryJitterMs: 250,
+    maxElapsedMs: 5000,
+}
+
 export type LazyLoaderOptions<T> = {
     name: string
     /** Function to load the values */

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -32,6 +32,7 @@ import {
     EventIngestionRestrictionManagerComponent,
 } from '~/common/utils/event-ingestion-restrictions'
 import { EventSchemaEnforcementManager } from '~/common/utils/event-schema-enforcement-manager'
+import { DEFAULT_LOADER_RETRY } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
 import { PromiseScheduler } from '~/common/utils/promise-scheduler'
 import { TeamManager } from '~/common/utils/team-manager'
@@ -175,7 +176,7 @@ export class IngestionConsumer {
         // Schema loads run detached in the LazyLoader buffer, so an un-retried transient
         // failure can surface as an unhandled rejection and restart the worker.
         this.eventSchemaEnforcementManager = new EventSchemaEnforcementManager(deps.postgres, {
-            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+            loaderRetry: DEFAULT_LOADER_RETRY,
         })
 
         this.name = `ingestion-consumer-${this.topic}`

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -172,7 +172,11 @@ export class IngestionConsumer {
             staticForceOverflowTokens: this.tokenDistinctIdsToForceOverflow,
         })
         this.eventFilterManagerComponent = new EventFilterManagerComponent(deps.postgres)
-        this.eventSchemaEnforcementManager = new EventSchemaEnforcementManager(deps.postgres)
+        // Schema loads run detached in the LazyLoader buffer, so an un-retried transient
+        // failure can surface as an unhandled rejection and restart the worker.
+        this.eventSchemaEnforcementManager = new EventSchemaEnforcementManager(deps.postgres, {
+            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+        })
 
         this.name = `ingestion-consumer-${this.topic}`
 

--- a/nodejs/src/ingestion/pipelines/ai/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/ai/consumer.ts
@@ -197,7 +197,11 @@ export function createAiConsumer(config: AiConsumerConfig, sharedScope: AiShared
             concurrentBatches: config.INGESTION_WORKER_CONCURRENT_BATCHES,
             cdpHogWatcherSampleRate: config.CDP_HOG_WATCHER_SAMPLE_RATE,
             eventSchemaEnforcementEnabled: config.EVENT_SCHEMA_ENFORCEMENT_ENABLED,
-            eventSchemaEnforcementManager: new EventSchemaEnforcementManager(container.postgres),
+            // Schema loads run detached in the LazyLoader buffer, so an un-retried transient
+            // failure can surface as an unhandled rejection and restart the worker.
+            eventSchemaEnforcementManager: new EventSchemaEnforcementManager(container.postgres, {
+                loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+            }),
             topHog: container.topHog,
             aiBlobStore: container.aiBlobStore.store,
             aiBlobOffloadConfig,

--- a/nodejs/src/ingestion/pipelines/ai/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/ai/consumer.ts
@@ -20,6 +20,7 @@ import { PersonHogPersonReadRepository } from '~/common/personhog/personhog-pers
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { EventIngestionRestrictionManagerComponent } from '~/common/utils/event-ingestion-restrictions'
 import { EventSchemaEnforcementManager } from '~/common/utils/event-schema-enforcement-manager'
+import { DEFAULT_LOADER_RETRY } from '~/common/utils/lazy-loader'
 import { TeamManager } from '~/common/utils/team-manager'
 import { CookielessManager } from '~/ingestion/common/cookieless/cookieless-manager'
 import { EventFilterManagerComponent } from '~/ingestion/common/event-filters'
@@ -200,7 +201,7 @@ export function createAiConsumer(config: AiConsumerConfig, sharedScope: AiShared
             // Schema loads run detached in the LazyLoader buffer, so an un-retried transient
             // failure can surface as an unhandled rejection and restart the worker.
             eventSchemaEnforcementManager: new EventSchemaEnforcementManager(container.postgres, {
-                loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+                loaderRetry: DEFAULT_LOADER_RETRY,
             }),
             topHog: container.topHog,
             aiBlobStore: container.aiBlobStore.store,

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -14,6 +14,7 @@ import { ServerCommands } from '~/common/utils/commands'
 import { PostgresRouter } from '~/common/utils/db/postgres'
 import { createRedisPoolFromConfig } from '~/common/utils/db/redis'
 import { GeoIPService } from '~/common/utils/geoip'
+import { DEFAULT_LOADER_RETRY } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
 import { PubSub } from '~/common/utils/pubsub'
 import { TeamManager } from '~/common/utils/team-manager'
@@ -158,7 +159,7 @@ export class ErrorTrackingServer implements NodeServer {
         this.pubsub = new PubSub(this.redisPool)
         await this.pubsub.start()
 
-        const teamManager = new TeamManager(this.postgres)
+        const teamManager = new TeamManager(this.postgres, { loaderRetry: DEFAULT_LOADER_RETRY })
 
         // 2. Services needed by ErrorTrackingConsumer and HogTransformer
         const geoipService = new GeoIPService(this.config.MMDB_FILE_LOCATION)
@@ -213,7 +214,9 @@ export class ErrorTrackingServer implements NodeServer {
                     outputs,
                     teamManager,
                     hogTransformer: createHogTransformerService(this.config, hogTransformerDeps),
-                    groupTypeManager: new ReadOnlyGroupTypeManager(groupRepository),
+                    groupTypeManager: new ReadOnlyGroupTypeManager(groupRepository, {
+                        loaderRetry: DEFAULT_LOADER_RETRY,
+                    }),
                     cookielessManager: this.cookielessManager!,
                     redisPool: this.redisPool!,
                     personRepository,

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -419,7 +419,11 @@ export class IngestionApiServer implements NodeServer {
             aiSubpipelineFactory: createAiEventSubpipeline,
             eventFilterManager: eventFilterManagerStarted.value,
             eventIngestionRestrictionManager,
-            eventSchemaEnforcementManager: new EventSchemaEnforcementManager(this.postgres),
+            // Schema loads run detached in the LazyLoader buffer, so an un-retried transient
+            // failure can surface as an unhandled rejection and restart the worker.
+            eventSchemaEnforcementManager: new EventSchemaEnforcementManager(this.postgres, {
+                loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+            }),
             promiseScheduler: this.promiseScheduler,
             overflowRedirectService,
             overflowLaneTTLRefreshService,

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -20,6 +20,7 @@ import { createRedisPoolFromConfig } from '~/common/utils/db/redis'
 import { EventIngestionRestrictionManagerComponent } from '~/common/utils/event-ingestion-restrictions'
 import { EventSchemaEnforcementManager } from '~/common/utils/event-schema-enforcement-manager'
 import { GeoIPService } from '~/common/utils/geoip'
+import { DEFAULT_LOADER_RETRY } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
 import { PromiseScheduler } from '~/common/utils/promise-scheduler'
 import { PubSub } from '~/common/utils/pubsub'
@@ -235,7 +236,7 @@ export class IngestionApiServer implements NodeServer {
         this.pubsub = new PubSub(this.redisPool)
         await this.pubsub.start()
 
-        const teamManager = new TeamManager(this.postgres)
+        const teamManager = new TeamManager(this.postgres, { loaderRetry: DEFAULT_LOADER_RETRY })
 
         // 2. Ingestion + CDP shared services (geoip, repos, encryption)
         const geoipService = new GeoIPService(this.config.MMDB_FILE_LOCATION)
@@ -285,7 +286,9 @@ export class IngestionApiServer implements NodeServer {
             poolMaxSize: this.config.REDIS_POOL_MAX_SIZE,
         })
 
-        const groupTypeManager = new GroupTypeManager(groupRepository, teamManager)
+        const groupTypeManager = new GroupTypeManager(groupRepository, teamManager, {
+            loaderRetry: DEFAULT_LOADER_RETRY,
+        })
 
         // 4. Kafka producers for pipeline outputs (not consuming from Kafka)
         this.ingestionProducerRegistry = await createIngestionProducerRegistry(this.config.KAFKA_CLIENT_RACK).build(
@@ -422,7 +425,7 @@ export class IngestionApiServer implements NodeServer {
             // Schema loads run detached in the LazyLoader buffer, so an un-retried transient
             // failure can surface as an unhandled rejection and restart the worker.
             eventSchemaEnforcementManager: new EventSchemaEnforcementManager(this.postgres, {
-                loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+                loaderRetry: DEFAULT_LOADER_RETRY,
             }),
             promiseScheduler: this.promiseScheduler,
             overflowRedirectService,

--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -22,6 +22,7 @@ import { ServerCommands } from '~/common/utils/commands'
 import { PostgresRouter, PostgresRouterComponent } from '~/common/utils/db/postgres'
 import { RedisPoolComponent } from '~/common/utils/db/redis'
 import { GeoIPService } from '~/common/utils/geoip'
+import { DEFAULT_LOADER_RETRY } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
 import { PubSub } from '~/common/utils/pubsub'
 import { TeamManagerComponent } from '~/common/utils/team-manager'
@@ -188,7 +189,7 @@ export class IngestionGeneralServer implements NodeServer {
                     // ECONNREFUSED). The team loader runs detached in the LazyLoader buffer, so an un-retried
                     // transient failure can surface as an unhandled rejection and restart the worker.
                     new TeamManagerComponent(container.postgres, {
-                        loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+                        loaderRetry: DEFAULT_LOADER_RETRY,
                     })
                 )
                 .add('cookielessManager', new CookielessManagerComponent(this.config, container.cookielessRedisPool))
@@ -241,7 +242,7 @@ export class IngestionGeneralServer implements NodeServer {
         // detached in the LazyLoader buffer, so an un-retried transient failure can
         // surface as an unhandled rejection and restart the worker.
         const groupTypeManager = new GroupTypeManager(groupRepository, teamManager, {
-            loaderRetry: { retryIntervalMs: 250, retryJitterMs: 250, maxElapsedMs: 5000 },
+            loaderRetry: DEFAULT_LOADER_RETRY,
         })
 
         const serviceLoaders: (() => Promise<PluginServerService>)[] = []


### PR DESCRIPTION
## Problem

- During a PgBouncer restart, ingestion workers crash instead of retrying.
- A transient load failure in a `LazyLoader`-backed manager poisons the batch pipeline and surfaces as an unhandled rejection, which restarts the worker.
- The schema loader in `EventSchemaEnforcementManager` has no `loaderRetry`, unlike the team and group-type managers (#77156).
- `EHOSTUNREACH` and PgBouncer's `pooler is shutting down` error are missing from `POSTGRES_UNAVAILABLE_ERROR_MESSAGES`, so they never classify as retriable.
- The retry policy from #77156 only covers the general ingestion server. The API and error tracking servers construct the same managers without it.

## Changes

- Classify `EHOSTUNREACH` and `pooler is shutting down` as transient in `postgres.ts`.
- Add a `loaderRetry` option to `EventSchemaEnforcementManager` and `ReadOnlyGroupTypeManager`, matching `GroupTypeManager`.
- Add `DEFAULT_LOADER_RETRY` in `lazy-loader.ts` and replace the six copies of the retry literal with it.
- Wire the retry policy into every ingestion consumer site that lacked it: the schema manager (all three sites), and the team and group-type managers in the API and error tracking servers.

> [!NOTE]
> A follow-up candidate is retrying transient errors by default inside `LazyLoader`, which would also cover the CDP and AI observability loaders. This PR keeps retry opt-in to limit blast radius.

## How did you test this code?

- `lazy-loader.test.ts` and the group manager suites pass locally (117 tests). They cover the retry behavior.
- `event-schema-enforcement-manager.test.ts` needs the `test_persons` database, which my environment lacks. It fails identically with and without this change, so CI covers it.
- Added `postgres.test.ts`: parameterized classification cases for the new `EHOSTUNREACH` and `pooler is shutting down` entries. A matcher refactor or list edit that drops either would otherwise pass tests and restore the crash loops.
- The retry wiring itself adds no tests: it passes existing, tested machinery through existing options.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude, via Claude Code) traced production crash logs to schema loads rejecting during a PgBouncer restart, then applied the retry pattern from #77156.
- Skills invoked: /ingestion-pipeline-doctor-nodejs, /writing-pr-descriptions.
- Review feedback flagged the duplicated retry literal. The audit that followed found the unwired manager sites in the API and error tracking servers, which this PR now covers.
- I considered a default `loaderRetry` inside `LazyLoader` and kept the per-manager opt-in to match #77156 and limit blast radius.

