### PR TITLE
fix(data-warehouse): name unnamed Google Sheets columns instead of failing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/naming_convention.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/naming_convention.py
@@ -53,7 +53,11 @@ class NamingConvention:
             raise ValueError("`name` is None")
         identifier = identifier.strip()
         if not identifier:
-            raise ValueError(identifier)
+            # DLT raises this with the (empty) identifier as the only argument, which leaves
+            # `str(exc)` empty. An empty message reaches the user as Temporal's placeholder
+            # "Application error", so say what happened instead. The normalized output for every
+            # other identifier is unchanged, which is what has to stay compatible.
+            raise ValueError("`name` is empty or contains only whitespace")
         return _normalize_identifier(identifier, max_length)
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -1,7 +1,8 @@
 import time
 import random
+from collections import Counter
 from collections.abc import Callable
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, TypeVar, cast
 
 from django.conf import settings
 
@@ -10,6 +11,7 @@ import requests
 from cachetools import Cache, TTLCache, cached
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2 import service_account
+from gspread.utils import numericise_all
 
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import table_from_py_list
@@ -101,7 +103,7 @@ def _assert_unique_normalized_column_names(headers: list[str]) -> None:
     same column. gspread only rejects *exact* duplicate headers, so these near-duplicates slip past it
     and fail much later with an opaque "duplicate column name" deep in table creation, after the sync
     has already started. Detect the collision up front and raise an actionable message naming the
-    offending headers instead. Exact duplicates are left to gspread's own check."""
+    offending headers instead. Exact duplicates are left to `_resolve_column_names`."""
     seen: dict[str, str] = {}
     for header in headers:
         if not header or not header.strip():
@@ -112,9 +114,55 @@ def _assert_unique_normalized_column_names(headers: list[str]) -> None:
             raise Exception(
                 f'Column headers "{previous}" and "{header}" collapse to the same column name '
                 f'"{normalized}" when synced. Column headers must stay unique after PostHog normalizes '
-                f"them (it ignores case, spaces, and punctuation). Rename one of them and resync."
+                f"them (it ignores case and punctuation, and drops characters outside a-z and 0-9, so "
+                f"headers written entirely in another script all end up with the same name). Give one of "
+                f"them a name that differs in its letters or digits, then resync."
             )
         seen[normalized] = header
+
+
+def _resolve_column_names(headers: list[str]) -> list[str]:
+    """Turn a worksheet's header row into a usable column name per position.
+
+    Header cells are routinely blank: the Sheets API pads every row out to the width of the widest
+    row, so a single stray value typed to the right of the header row invents columns with nothing
+    in their header cell. gspread keys its records straight off the raw cells, which turns one blank
+    header into a column literally named "" (rejected later by the naming convention with an empty
+    error message) and two or more into its "contains duplicates" error. Name the unnamed columns
+    after their position instead, so the sync completes with the data intact. Duplicated *named*
+    headers still fail: there the user has two real names, and only they can decide which is which."""
+    named = [header for header in headers if header and header.strip()]
+    duplicates = sorted({header for header, count in Counter(named).items() if count > 1})
+    if duplicates:
+        # Keep gspread's wording — the source registers its user-facing message against this text.
+        raise Exception(f"the header row in the worksheet contains duplicates: {duplicates}")
+
+    taken = set(named)
+    resolved: list[str] = []
+
+    for position, header in enumerate(headers, start=1):
+        if header and header.strip():
+            resolved.append(header)
+            continue
+
+        name = f"column_{position}"
+        while name in taken:
+            name = f"_{name}"
+        taken.add(name)
+        resolved.append(name)
+
+    return resolved
+
+
+def _records_from_grid(grid: list[list[str]]) -> list[dict[str, Any]]:
+    if not grid or grid == [[]]:
+        return []
+
+    column_names = _resolve_column_names(list(grid[0]))
+
+    # default_blank defaults to "", which turns empty cells into strings and breaks numeric
+    # columns that legitimately have gaps. None lets blank cells import as null instead.
+    return [dict(zip(column_names, numericise_all(row, default_blank=None))) for row in grid[1:]]
 
 
 def _is_retryable_api_error(e: gspread.exceptions.APIError) -> bool:
@@ -147,7 +195,7 @@ def _retry_on_transient_api_error(execute: Callable[[], T]) -> T:
     by quota limits dont all retry at the same time.
 
     This wraps every gspread call that hits the API — worksheet acquisition *and* the
-    cell-reading calls (`get_all_values`/`get_all_records`). The reads issue their own
+    cell-reading calls (`get_all_values`/`get`). The reads issue their own
     requests, so a transient 5xx there must be retried too rather than failing the sync."""
 
     attempts = 1
@@ -289,9 +337,9 @@ def google_sheets_source(
         primary_keys = ["id"]
 
     # Note: this source intentionally remains a SimpleSource rather than a ResumableSource.
-    # gspread's get_all_records() performs a single Sheets API call that returns every row at
-    # once, with no pagination cursor, continuation token, or range handle exposed to the
-    # caller. The loop below yields exactly one batch, so there is no intermediate checkpoint
+    # The grid read below performs a single Sheets API call that returns every row at once,
+    # with no pagination cursor, continuation token, or range handle exposed to the caller.
+    # The loop below yields exactly one batch, so there is no intermediate checkpoint
     # where some rows have been emitted and others are still pending — the two states are
     # "nothing yielded yet" and "fully done". A ResumableSource would have no cursor to
     # persist and would still have to re-download the entire sheet on restart, so it adds no
@@ -301,9 +349,11 @@ def google_sheets_source(
     def get_rows():
         worksheet = _get_worksheet(config.spreadsheet_url, worksheet_id, api_version)
 
-        # default_blank defaults to "", which turns empty cells into strings and breaks numeric
-        # columns that legitimately have gaps. None lets blank cells import as null instead.
-        values = _retry_on_transient_api_error(lambda: worksheet.get_all_records(default_blank=None))
+        # Read the raw grid and build the records ourselves rather than calling
+        # `get_all_records`, which can't cope with a blank header cell. `pad_values=True` mirrors
+        # what `get_all_records` asks for, so every row is the same width as the widest one.
+        grid = cast(list[list[str]], _retry_on_transient_api_error(lambda: worksheet.get(pad_values=True)))
+        values = _records_from_grid(grid)
 
         if should_use_incremental_field and db_incremental_field_last_value is not None:
             values = [value for value in values if value.get("id", 0) > db_incremental_field_last_value]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -51,7 +51,7 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            "the header row in the worksheet contains duplicates": "Import failed: There exists duplicate column headers. Please make sure all column headers have values and aren't duplicated.",
+            "the header row in the worksheet contains duplicates": "Import failed: two or more columns in the worksheet share the same header. Give each one a distinct name and resync.",
             # Raised by `_assert_unique_normalized_column_names`: two headers that look distinct
             # collapse to the same normalized column name. Deterministic — retrying can't recover, and
             # the message already names the offending headers, so keep it as-is.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -376,18 +376,17 @@ def test_retry_on_transient_api_error_bubbles_network_error_after_max_retries(er
 
 
 def test_google_sheets_source_retries_transient_error_on_data_reads():
-    """A transient 5xx on the cell-reading calls (`get_all_values`/`get_all_records`)
-    must be retried, not surfaced on the first occurrence. These reads issue their own
-    Sheets API requests separate from worksheet acquisition, so they need the same
-    backoff — otherwise a "[503]: The service is currently unavailable." blip fails the
-    sync."""
+    """A transient 5xx on the cell-reading calls (`get_all_values`/`get`) must be retried,
+    not surfaced on the first occurrence. These reads issue their own Sheets API requests
+    separate from worksheet acquisition, so they need the same backoff — otherwise a
+    "[503]: The service is currently unavailable." blip fails the sync."""
     config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
 
     mock_worksheet = mock.MagicMock()
     # First header read hits a transient 503, then succeeds on retry.
     mock_worksheet.get_all_values.side_effect = [_api_error(503), [["id"]]]
-    # The data read also hits a transient 503 once before returning rows.
-    mock_worksheet.get_all_records.side_effect = [_api_error(503), [{"id": 1}]]
+    # The data read also hits a transient 503 once before returning the grid.
+    mock_worksheet.get.side_effect = [_api_error(503), [["id"], ["1"]]]
 
     with (
         mock.patch(
@@ -406,18 +405,15 @@ def test_google_sheets_source_retries_transient_error_on_data_reads():
         list(cast(Iterable[Any], response.items()))
 
     assert mock_worksheet.get_all_values.call_count == 2
-    assert mock_worksheet.get_all_records.call_count == 2
+    assert mock_worksheet.get.call_count == 2
 
 
-def test_google_sheets_source_reads_blank_cells_as_null():
+def _read_sheet(header_row: list[str], data_rows: list[list[str]]) -> list[Any]:
     config = GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
 
     mock_worksheet = mock.MagicMock()
-    mock_worksheet.get_all_values.return_value = [["id", "NumericColumnWithBlanks"]]
-    mock_worksheet.get_all_records.return_value = [
-        {"id": 1, "NumericColumnWithBlanks": 1.5},
-        {"id": 2, "NumericColumnWithBlanks": None},
-    ]
+    mock_worksheet.get_all_values.return_value = [header_row]
+    mock_worksheet.get.return_value = [header_row, *data_rows]
 
     with (
         mock.patch(
@@ -432,9 +428,51 @@ def test_google_sheets_source_reads_blank_cells_as_null():
         response = google_sheets_source(
             config, "sheet1", db_incremental_field_last_value=None, api_version=GOOGLE_SHEETS_API_VERSION_V4
         )
-        list(cast(Iterable[Any], response.items()))
+        return list(cast(Iterable[Any], response.items()))
 
-    mock_worksheet.get_all_records.assert_called_once_with(default_blank=None)
+
+def test_google_sheets_source_reads_blank_cells_as_null():
+    """Blank cells must import as null, not as "" — an empty string in an otherwise numeric column
+    turns it into a text column. The source numericises the grid itself, so this covers that wiring."""
+    tables = _read_sheet(["id", "NumericColumnWithBlanks"], [["1", "1.5"], ["2", ""]])
+
+    assert tables[0].to_pylist() == [
+        {"id": 1, "NumericColumnWithBlanks": 1.5},
+        {"id": 2, "NumericColumnWithBlanks": None},
+    ]
+
+
+@pytest.mark.parametrize(
+    "header_row,expected_columns",
+    [
+        pytest.param(["id", "", "name"], ["id", "column_2", "name"], id="blank_header_between_named"),
+        pytest.param(["id", "name", "   "], ["id", "name", "column_3"], id="whitespace_only_header"),
+        # Google pads every row out to the width of the widest one, so a stray value to the right of
+        # the header row can invent several unnamed columns at once.
+        pytest.param(["id", "", ""], ["id", "column_2", "column_3"], id="several_blank_headers"),
+        # A generated name must not steal a name a real header already uses.
+        pytest.param(["", "column_1"], ["_column_1", "column_1"], id="generated_name_avoids_real_header"),
+    ],
+)
+def test_google_sheets_source_names_columns_with_blank_headers(header_row, expected_columns):
+    """A header cell with nothing in it used to produce a column named "", which the naming
+    convention rejected with an empty error message — the sync failed permanently and the user was
+    told only "Application error". Every column must come out with a usable name instead."""
+    tables = _read_sheet(header_row, [["1"] * len(header_row)])
+
+    # Sorted because the pipeline decides the column order in the arrow table, not the source.
+    assert sorted(tables[0].column_names) == sorted(expected_columns)
+    assert tables[0].num_rows == 1
+
+
+def test_google_sheets_source_rejects_duplicate_named_headers():
+    """Two columns under the same name would silently collapse into one, so the sync must fail with
+    a message the framework knows is permanent. This check used to be gspread's, and is now ours."""
+    with pytest.raises(Exception) as exc_info:
+        _read_sheet(["id", "name", "name"], [["1", "a", "b"]])
+
+    non_retryable_errors = GoogleSheetsSource().get_non_retryable_errors()
+    assert any(key in str(exc_info.value) for key in non_retryable_errors)
 
 
 @pytest.mark.parametrize(
@@ -509,6 +547,9 @@ def test_reraises_spreadsheet_not_found_with_non_retryable_message(call_site):
         pytest.param(["task_id", "task-id"], id="punctuation_only"),
         pytest.param(["Name", "name"], id="case_only"),
         pytest.param(["id", "customer name", "Customer Name"], id="collision_among_distinct"),
+        # Normalization drops everything outside a-z and 0-9, so headers written entirely in another
+        # script all reduce to the same name however different they look.
+        pytest.param(["Дата", "Клиент"], id="distinct_non_latin_headers"),
     ],
 )
 def test_assert_unique_normalized_column_names_raises_on_normalized_collision(headers):
@@ -696,7 +737,7 @@ def test_source_for_pipeline_threads_resolved_api_version_to_worksheet(pinned_ve
 
     worksheet = mock.MagicMock()
     worksheet.get_all_values.return_value = [["id"]]
-    worksheet.get_all_records.return_value = [{"id": 1}]
+    worksheet.get.return_value = [["id"], ["1"]]
 
     inputs = mock.MagicMock()
     inputs.schema_name = "sheet1"

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_naming_convention.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_naming_convention.py
@@ -94,7 +94,9 @@ class TestNamingConvention:
 
     @pytest.mark.parametrize("value", ["", " ", "   ", "\t\n"])
     def test_empty_after_strip_raises(self, value):
-        with pytest.raises(ValueError):
+        # The message has to say something: an exception with an empty str() reaches the user as
+        # Temporal's "Application error" placeholder, which tells them nothing at all.
+        with pytest.raises(ValueError, match="empty"):
             NamingConvention.normalize_identifier(value)
 
     @pytest.mark.parametrize("source,expected", HAND_VERIFIED_CASES)


### PR DESCRIPTION
## Problem

Google Sheets syncs fail with `ValueError: Application error`, the least actionable error in the fleet. It affects connections in both regions.

The message is Temporal's placeholder for an exception whose `str()` is empty. The stack trace ends in `NamingConvention.normalize_identifier`, which rejects an empty identifier with `raise ValueError(identifier)` — and `identifier` is `""`.

The empty identifier is a column name. Two things combine:

- The Sheets API pads every row out to the width of the widest row, so one stray value typed to the right of the header row invents columns whose header cell is empty.
- `gspread.get_all_records` keys each record straight off the raw header cells, so a blank header becomes a column literally named `""`.

One blank header produced the `ValueError`. Two or more collided into gspread's "the header row contains duplicates" error instead, so the same underlying sheet shape failed two different ways.

## Changes

- Read the raw grid and build the records in the source, instead of calling `get_all_records`. Unnamed columns get a positional name (`column_3`), so the sync completes with the data intact. `pad_values=True` and the `default_blank=None` numericising match what `get_all_records` did, so blank cells still import as null.
- Duplicated *named* headers still fail, with the same wording the source already maps to a permanent failure. Two real names are the user's to tell apart, and silently collapsing one into the other would lose data.
- Give the naming convention's empty-identifier `ValueError` a real message. Any source that hits it now says what happened instead of "Application error". Normalized output is unchanged, which is the part that has to stay byte-for-byte compatible with DLT.
- Reword two user-facing messages: the duplicate-header one no longer tells users to give headers values, and the colliding-header one now says normalization drops characters outside `a-z0-9`. That last one covers a related production failure where two distinct Cyrillic headers collapsed to the same name — the old copy said "rename one of them", which does not help when renaming to another Cyrillic word collides just the same.

Non-Latin headers still fail when they collide, deliberately. The naming convention is a byte-for-byte port of DLT's `snake_case`; teaching it to transliterate would rewrite existing column names across every warehouse source, not just Google Sheets.

Overlaps with #72040, which sits in draft and fixes the same two symptoms with a wider blast radius. Close whichever loses.

## How did you test this code?

Automated tests only, run locally in a 3.13 venv in this worktree: `pytest .../google_sheets/tests/test_google_sheets.py .../tests/test_naming_convention.py` — 192 passed. No manual sync against a live sheet. `ruff check` and `ruff format` clean; `hogli ci:preflight --fix` reports no failures.

New and changed coverage:

- `test_google_sheets_source_names_columns_with_blank_headers` — four cases (blank between named headers, whitespace-only, several blanks, generated name colliding with a real header). Catches the production crash directly: no existing test drove the data read with a blank header cell.
- `test_google_sheets_source_rejects_duplicate_named_headers` — the duplicate check moved from gspread into our code, so without this a regression would silently collapse two columns into one.
- `test_google_sheets_source_reads_blank_cells_as_null` rewritten to assert the produced rows rather than that `get_all_records` was called with `default_blank=None`. The source numericises the grid itself now, so the assertion is on behavior instead of on a call.
- A Cyrillic case added to the existing collision test, and a `match="empty"` added to the existing empty-identifier test — that one pins the exact bug, since an empty message is what surfaced as "Application error".

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from a production sweep of failed `ExternalDataJob` rows. The error string appears nowhere in the repo, so the origin came from the worker's structured exception logs, which carried the frame list ending in `naming_convention.py`.

Fixing the classification rather than the cause was rejected: marking "Application error" non-retryable would have left every affected sheet permanently broken with an equally opaque message, when a blank header cell is something we can simply name. The fix sits in the source rather than in shared pipeline normalization, because only the source knows a blank name came from an empty header cell and what a sensible substitute is.

Skills invoked: `/writing-tests`.

