### PR TITLE
fix(data-warehouse): widen stored delta columns instead of failing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -80,11 +80,76 @@ class SchemaColumnTypeChangedException(Exception):
 
     The usual cause is the source column's type being widened upstream (e.g. Postgres
     `integer` → `bigint`) after the Delta table was already created with the narrower type.
-    delta-rs cannot widen an existing column in place, so retrying is futile — the table must
-    be reset and fully re-synced to adopt the new type.
+    Retrying is futile: the values fail the same cast every time. When the widening is lossless
+    the writer converts the stored column instead (see `DeltaColumnWideningRequired`); everything
+    else needs the table rebuilt from scratch.
     """
 
     pass
+
+
+class DeltaColumnWideningRequired(SchemaColumnTypeChangedException):
+    """The incoming values need a wider stored column, and widening it keeps every stored value.
+
+    Carries `promotions` (column name → target type) so a caller holding the Delta table can
+    convert the stored columns and retry the alignment. Subclasses SchemaColumnTypeChangedException
+    on purpose: a caller that can't widen keeps the old terminal behaviour rather than writing the
+    batch anyway, which delta-rs would silently truncate to the stored type.
+    """
+
+    def __init__(self, message: str, promotions: dict[str, pa.DataType]) -> None:
+        super().__init__(message)
+        self.promotions = promotions
+
+
+# Integer digits the widest value of each integer bit width needs, for sizing a decimal promotion.
+_INT_DECIMAL_DIGITS: dict[int, int] = {8: 3, 16: 5, 32: 10, 64: 20}
+
+COLUMN_TYPE_CHANGED_REMEDY = "Use 'Delete table and resync' on this table to rebuild it with the new type."
+
+
+def column_type_changed_message(column_name: str, stored_type: pa.DataType, incoming_type: pa.DataType) -> str:
+    return (
+        f"Source column type changed: '{column_name}' has values that no longer fit its stored type "
+        f"{stored_type} (incoming data is now {incoming_type}). {COLUMN_TYPE_CHANGED_REMEDY}"
+    )
+
+
+def safe_column_promotion(stored_type: pa.DataType, incoming_type: pa.DataType) -> pa.DataType | None:
+    """The wider type a stored Delta column can be converted to so `incoming_type` fits, or None.
+
+    Only conversions that keep every value already stored in the column are offered, and only for
+    the stored integer columns this actually fires for (a narrowing cast into any other stored type
+    either succeeds or is a genuine incompatibility): a wider integer of the same signedness, a
+    float (whose `safe=True` cast rejects integers past the exactly-representable range, so the
+    conversion still fails closed), or a decimal with room for the stored integer range. Text is
+    deliberately never a target — turning a numeric column into strings changes what every query
+    over it means, so that stays a full rebuild.
+    """
+    if stored_type == incoming_type:
+        return None
+
+    if pa.types.is_integer(stored_type):
+        if pa.types.is_integer(incoming_type):
+            if incoming_type.bit_width <= stored_type.bit_width:
+                return None
+            stored_signed = pa.types.is_signed_integer(stored_type)
+            incoming_signed = pa.types.is_signed_integer(incoming_type)
+            # An unsigned value always fits a strictly wider signed type; the reverse loses negatives.
+            return incoming_type if stored_signed == incoming_signed or incoming_signed else None
+        if pa.types.is_floating(incoming_type):
+            return pa.float64()
+        if pa.types.is_decimal(incoming_type):
+            incoming_decimal = cast(pa.Decimal128Type | pa.Decimal256Type, incoming_type)
+            int_digits = _INT_DECIMAL_DIGITS[stored_type.bit_width]
+            precision = max(incoming_decimal.precision, int_digits + incoming_decimal.scale)
+            # Delta Lake caps decimals at precision 38; a wider one can't be stored, so there is
+            # no target that holds both the stored integers and the incoming scale.
+            if precision > DEFAULT_NUMERIC_PRECISION:
+                return None
+            return pa.decimal128(precision, incoming_decimal.scale)
+
+    return None
 
 
 def normalize_column_name(column_name: str) -> str:
@@ -236,6 +301,8 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
 
     # Second pass: align with existing Delta table schema.
     delta_arrow_schema = pyarrow_schema_from_arrow_exportable(delta_schema)
+    pending_promotions: dict[str, pa.DataType] = {}
+    pending_promotion_messages: list[str] = []
     for delta_field in delta_arrow_schema:
         if delta_field.name not in incoming_table.schema.names:
             new_column_data = (
@@ -313,22 +380,30 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
                 except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
                     # Reaching this cast already means the incoming type differs from the stored
                     # Delta type (see the guard above) and the timestamp path didn't apply, so a
-                    # failure here is a deterministic, unretryable incompatibility: the source
-                    # column's type changed under a table created with a narrower type. Common
-                    # shapes are an integer column widened upstream (Postgres `integer` → `bigint`),
-                    # an integer-created column now receiving fractional values ("Float value 19.99
-                    # was truncated converting to int64"), non-numeric text arriving for a numeric
-                    # column ("Failed to parse string: '80-150' as a scalar of type int32"), a
-                    # value that overflows the stored decimal precision, or a cast pyarrow has no
-                    # kernel for at all (raised as ArrowNotImplementedError rather than
-                    # ArrowInvalid). delta-rs cannot change a column's type in place, so
-                    # retrying is futile — surface an actionable error telling the user to reset and
-                    # fully re-sync. Lossless widening (e.g. a whole-valued float into an integer
-                    # column) still casts fine and never reaches here.
+                    # failure here is deterministic: the source column's type changed under a table
+                    # created with a narrower type. Common shapes are an integer column widened
+                    # upstream (Postgres `integer` → `bigint`), an integer-created column now
+                    # receiving fractional values ("Float value 19.99 was truncated converting to
+                    # int64"), non-numeric text arriving for a numeric column ("Failed to parse
+                    # string: '80-150' as a scalar of type int32"), a value that overflows the
+                    # stored decimal precision, or a cast pyarrow has no kernel for at all (raised
+                    # as ArrowNotImplementedError rather than ArrowInvalid). Lossless narrowing
+                    # (e.g. a whole-valued float into an integer column) still casts fine and never
+                    # reaches here.
+                    #
+                    # When the stored column can instead be converted to a type that holds both its
+                    # own values and the incoming ones, collect it: the caller widens the stored
+                    # column and retries. Anything else needs the table rebuilt, and retrying it
+                    # fails identically every time.
+                    promotion = safe_column_promotion(delta_field.type, incoming_column.type)
+                    if promotion is not None:
+                        pending_promotions[delta_field.name] = promotion
+                        pending_promotion_messages.append(
+                            column_type_changed_message(delta_field.name, delta_field.type, incoming_column.type)
+                        )
+                        continue
                     raise SchemaColumnTypeChangedException(
-                        f"Source column type changed: '{delta_field.name}' has values that no longer "
-                        f"fit its stored type {delta_field.type} (incoming data is now "
-                        f"{incoming_column.type}). Reset and fully re-sync this table to adopt the new type."
+                        column_type_changed_message(delta_field.name, delta_field.type, incoming_column.type)
                     ) from e
 
                 incoming_table = incoming_table.set_column(
@@ -354,6 +429,9 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
                 delta_field,
                 filled_nulls_arr.combine_chunks(),
             )
+
+    if pending_promotions:
+        raise DeltaColumnWideningRequired(" ".join(pending_promotion_messages), pending_promotions)
 
     # Change types based on what deltalake tables support
     return incoming_table.cast(ensure_delta_compatible_arrow_schema(incoming_table.schema))

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/evolution.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/evolution.py
@@ -1,12 +1,38 @@
 import asyncio
+import dataclasses
+from collections.abc import Iterator
 
 import pyarrow as pa
 import deltalake
+import pyarrow.compute as pc
 from dlt.common.libs.deltalake import ensure_delta_compatible_arrow_schema
+from structlog.types import FilteringBoundLogger
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    COLUMN_TYPE_CHANGED_REMEDY,
+    DeltaColumnWideningRequired,
+    SchemaColumnTypeChangedException,
+    evolve_pyarrow_schema,
     pyarrow_schema_from_arrow_exportable,
 )
+
+# Rows per streamed record batch while converting a column's type. Bounds peak memory
+# independently of table size, the same way the repartitioner's rewrite does.
+WIDENING_REWRITE_BATCH_SIZE = 50_000
+
+# Largest table (at rest, from the Delta log) whose columns are converted during a sync. The
+# conversion blocks the batch that triggered it, and the loader holds a batch lease while it runs,
+# so this bounds that pause: a few GB of parquet streams through in well under a minute. A bigger
+# table fails with the reset message instead of stalling every batch behind a long rewrite.
+MAX_WIDENING_REWRITE_BYTES = 2 * 1024**3
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class AlignedBatch:
+    """A batch aligned to the Delta table's schema, plus any stored columns widened to get there."""
+
+    table: pa.Table
+    widened_columns: dict[str, str]
 
 
 async def evolve_delta_schema(delta_table: deltalake.DeltaTable, schema: pa.Schema) -> deltalake.DeltaTable:
@@ -32,3 +58,128 @@ async def evolve_delta_schema(delta_table: deltalake.DeltaTable, schema: pa.Sche
         await asyncio.to_thread(delta_table.alter.add_columns, new_fields)
 
     return delta_table
+
+
+async def align_batch_to_delta_schema(
+    delta_table: deltalake.DeltaTable, pa_table: pa.Table, logger: FilteringBoundLogger
+) -> AlignedBatch:
+    """Align `pa_table` to the Delta table, converting stored columns first when they're too narrow.
+
+    A source that starts sending wider values for a column (a cost column that only held whole
+    numbers now carrying fractions, an upstream `integer` widened to `bigint`) otherwise fails the
+    same cast on every run forever. Where the stored column can be converted without losing any of
+    its own values, convert it and align against the new schema; where it can't, the original
+    terminal error stands.
+    """
+    try:
+        return AlignedBatch(table=evolve_pyarrow_schema(pa_table, delta_table.schema()), widened_columns={})
+    except DeltaColumnWideningRequired as e:
+        widened = await widen_delta_columns(delta_table, e.promotions, logger)
+        return AlignedBatch(table=evolve_pyarrow_schema(pa_table, delta_table.schema()), widened_columns=widened)
+
+
+async def widen_delta_columns(
+    delta_table: deltalake.DeltaTable, promotions: dict[str, pa.DataType], logger: FilteringBoundLogger
+) -> dict[str, str]:
+    """Convert `promotions`' stored columns to their wider types, in place, from what's in S3.
+
+    delta-rs has no ALTER COLUMN TYPE and its own schema merge would quietly cast the incoming
+    values down to the stored type instead (dropping the fractions that made the column too narrow
+    in the first place), so the table is streamed through a single atomic overwrite commit that
+    rewrites every file under the wider schema. Nothing is committed until the whole stream lands,
+    so a crash or a value that doesn't survive the conversion leaves the table exactly as it was.
+
+    Returns the columns' new types keyed by name, for logging.
+    """
+    stored_schema = pyarrow_schema_from_arrow_exportable(delta_table.schema())
+    target_schema = stored_schema
+    for column_name, target_type in promotions.items():
+        index = target_schema.get_field_index(column_name)
+        if index >= 0:
+            target_schema = target_schema.set(index, target_schema.field(index).with_type(target_type))
+
+    if target_schema == stored_schema:
+        return {}
+
+    table_bytes = await asyncio.to_thread(_delta_table_bytes, delta_table)
+    if table_bytes > MAX_WIDENING_REWRITE_BYTES:
+        raise SchemaColumnTypeChangedException(
+            f"Source column type changed: {_describe(promotions)} no longer fits the type stored for it, and this "
+            f"table is too large to convert during a sync ({table_bytes / 1024**3:.1f} GB). "
+            f"{COLUMN_TYPE_CHANGED_REMEDY}"
+        )
+
+    await logger.ainfo(
+        "widening stored delta columns so the source's new values fit",
+        columns={name: str(type_) for name, type_ in promotions.items()},
+        table_bytes=table_bytes,
+    )
+
+    cast_failure: Exception | None = None
+
+    def rewrite() -> None:
+        nonlocal cast_failure
+        dataset = delta_table.to_pyarrow_dataset()
+        reader = dataset.scanner(batch_size=WIDENING_REWRITE_BATCH_SIZE).to_reader()
+        partition_columns = list(delta_table.metadata().partition_columns or [])
+
+        def batches() -> Iterator[pa.RecordBatch]:
+            nonlocal cast_failure
+            for batch in reader:
+                try:
+                    yield _cast_batch(batch, target_schema)
+                except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
+                    # Raising aborts the write before it commits, so the table keeps its old type
+                    # and its old values. Recorded because delta-rs re-raises it as an opaque
+                    # DeltaError that the caller can't otherwise tell apart from an S3 failure.
+                    cast_failure = e
+                    raise
+
+        deltalake.write_deltalake(
+            delta_table,
+            pa.RecordBatchReader.from_batches(target_schema, batches()),
+            mode="overwrite",
+            schema_mode="overwrite",
+            partition_by=partition_columns or None,
+        )
+        delta_table.update_incremental()
+
+    try:
+        await asyncio.to_thread(rewrite)
+    except Exception:
+        if cast_failure is None:
+            raise
+        # Values already in the column can't be represented in the wider type (an integer past the
+        # range a double holds exactly). Converting them would change the data, so it stays terminal.
+        raise SchemaColumnTypeChangedException(
+            f"Source column type changed: {_describe(promotions)} no longer fits the type stored for it, and the "
+            f"rows already stored can't be converted without changing their values. {COLUMN_TYPE_CHANGED_REMEDY}"
+        ) from cast_failure
+
+    widened = {name: str(target_schema.field(name).type) for name in promotions if name in target_schema.names}
+    await logger.ainfo("widened stored delta columns", columns=widened)
+    return widened
+
+
+def _describe(promotions: dict[str, pa.DataType]) -> str:
+    return ", ".join(f"'{name}'" for name in promotions)
+
+
+def _delta_table_bytes(delta_table: deltalake.DeltaTable) -> int:
+    """At-rest bytes of the table, read from the Delta log (no S3 LIST, no data scan)."""
+    actions = delta_table.get_add_actions(flatten=True)
+    if "size_bytes" not in actions.schema.names:
+        return 0
+    return sum(size or 0 for size in actions.column("size_bytes").to_pylist())
+
+
+def _cast_batch(batch: pa.RecordBatch, schema: pa.Schema) -> pa.RecordBatch:
+    """Re-type `batch` to `schema`, refusing any cast that wouldn't round-trip the values."""
+    arrays: list[pa.Array] = []
+    for field in schema:
+        index = batch.schema.get_field_index(field.name)
+        if index < 0:
+            raise pa.ArrowInvalid(f"Column '{field.name}' is missing from the stored table's own data")
+        column = batch.column(index)
+        arrays.append(column if column.type == field.type else pc.cast(column, field.type))
+    return pa.RecordBatch.from_arrays(arrays, schema=schema)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_evolution.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_evolution.py
@@ -1,0 +1,154 @@
+from decimal import Decimal
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+import pyarrow as pa
+import deltalake
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    SchemaColumnTypeChangedException,
+    pyarrow_schema_from_arrow_exportable,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta import evolution
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.evolution import (
+    align_batch_to_delta_schema,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.test.helpers import make_logger
+
+
+def _seed(delta_path: str, table: pa.Table, partition_by: str | None = None) -> deltalake.DeltaTable:
+    deltalake.write_deltalake(delta_path, table, partition_by=partition_by)
+    return deltalake.DeltaTable(delta_path)
+
+
+class TestAlignBatchToDeltaSchema:
+    @pytest.mark.asyncio
+    async def test_fractional_values_widen_the_stored_integer_column(self, tmp_path: Path) -> None:
+        # A cost column whose first sync only saw whole numbers is stored as int64; the source then
+        # starts sending fractions. delta-rs would round them into the stored int64, so the loader
+        # must convert the column instead of writing lossy data (or failing the sync forever).
+        delta_path = str(tmp_path / "table")
+        stored = _seed(
+            delta_path,
+            pa.table({"id": pa.array([1, 2], type=pa.int64()), "total_cost": pa.array([3, 4], type=pa.int64())}),
+        )
+
+        aligned = await align_batch_to_delta_schema(
+            stored,
+            pa.table({"id": pa.array([3], type=pa.int64()), "total_cost": pa.array([0.75], type=pa.float64())}),
+            make_logger(),
+        )
+
+        assert aligned.widened_columns == {"total_cost": "double"}
+        assert aligned.table.schema.field("total_cost").type == pa.float64()
+        assert aligned.table.column("total_cost").to_pylist() == [0.75]
+
+        rewritten = deltalake.DeltaTable(delta_path).to_pyarrow_table().sort_by("id")
+        assert rewritten.schema.field("total_cost").type == pa.float64()
+        assert rewritten.column("total_cost").to_pylist() == [3.0, 4.0]
+
+    @pytest.mark.asyncio
+    async def test_widening_keeps_the_table_partitioned(self, tmp_path: Path) -> None:
+        # The conversion rewrites every file, so it has to re-apply the table's partitioning —
+        # losing it would break the partition-by-partition merges every later sync runs.
+        delta_path = str(tmp_path / "table")
+        stored = _seed(
+            delta_path,
+            pa.table(
+                {
+                    "id": pa.array([1, 2], type=pa.int64()),
+                    "amount": pa.array([1, 2], type=pa.int64()),
+                    "_ph_partition_key": pa.array(["a", "b"], type=pa.string()),
+                }
+            ),
+            partition_by="_ph_partition_key",
+        )
+
+        await align_batch_to_delta_schema(
+            stored,
+            pa.table(
+                {
+                    "id": pa.array([3], type=pa.int64()),
+                    "amount": pa.array([1.5], type=pa.float64()),
+                    "_ph_partition_key": pa.array(["a"], type=pa.string()),
+                }
+            ),
+            make_logger(),
+        )
+
+        rewritten = deltalake.DeltaTable(delta_path)
+        assert rewritten.metadata().partition_columns == ["_ph_partition_key"]
+        partition_values = cast(list[str], rewritten.to_pyarrow_table().column("_ph_partition_key").to_pylist())
+        assert sorted(partition_values) == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_stored_integers_beyond_double_precision_are_not_converted(self, tmp_path: Path) -> None:
+        # Widening must never change stored values: an integer past double's exactly-representable
+        # range would come back a different number, so the sync fails instead.
+        delta_path = str(tmp_path / "table")
+        stored = _seed(delta_path, pa.table({"value": pa.array([2**60 + 1], type=pa.int64())}))
+
+        with pytest.raises(SchemaColumnTypeChangedException, match="Delete table and resync"):
+            await align_batch_to_delta_schema(
+                stored, pa.table({"value": pa.array([1.5], type=pa.float64())}), make_logger()
+            )
+
+        untouched = deltalake.DeltaTable(delta_path)
+        assert pyarrow_schema_from_arrow_exportable(untouched.schema()).field("value").type == pa.int64()
+        assert untouched.to_pyarrow_table().column("value").to_pylist() == [2**60 + 1]
+
+    @pytest.mark.asyncio
+    async def test_table_too_large_to_convert_fails_with_the_rebuild_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Converting blocks the batch that triggered it, so an oversized table is refused rather
+        # than stalling the loader; the user still gets the action that fixes it.
+        delta_path = str(tmp_path / "table")
+        stored = _seed(delta_path, pa.table({"value": pa.array([1, 2], type=pa.int64())}))
+        monkeypatch.setattr(evolution, "MAX_WIDENING_REWRITE_BYTES", 1)
+
+        with pytest.raises(SchemaColumnTypeChangedException, match="Delete table and resync"):
+            await align_batch_to_delta_schema(
+                stored, pa.table({"value": pa.array([1.5], type=pa.float64())}), make_logger()
+            )
+
+        assert (
+            pyarrow_schema_from_arrow_exportable(deltalake.DeltaTable(delta_path).schema()).field("value").type
+            == pa.int64()
+        )
+
+    @pytest.mark.asyncio
+    async def test_text_arriving_for_a_numeric_column_stays_terminal(self, tmp_path: Path) -> None:
+        # Storing numbers as text changes what every query over the column means, so this one is
+        # deliberately not converted — it needs the user to rebuild the table.
+        delta_path = str(tmp_path / "table")
+        stored = _seed(delta_path, pa.table({"value": pa.array([1, 2], type=pa.int64())}))
+
+        with pytest.raises(SchemaColumnTypeChangedException, match="Delete table and resync"):
+            await align_batch_to_delta_schema(
+                stored, pa.table({"value": pa.array(["n/a"], type=pa.string())}), make_logger()
+            )
+
+        assert (
+            pyarrow_schema_from_arrow_exportable(deltalake.DeltaTable(delta_path).schema()).field("value").type
+            == pa.int64()
+        )
+
+    @pytest.mark.asyncio
+    async def test_mixed_int_and_decimal_values_widen_to_decimal(self, tmp_path: Path) -> None:
+        # A REST source that mixes ints and floats in one batch arrives as decimal (see
+        # `_process_batch`), and the decimal has to keep room for the stored int64 range.
+        delta_path = str(tmp_path / "table")
+        stored = _seed(delta_path, pa.table({"value": pa.array([10**15], type=pa.int64())}))
+
+        aligned = await align_batch_to_delta_schema(
+            stored,
+            pa.table({"value": pa.array([Decimal("19.99")], type=pa.decimal128(4, 2))}),
+            make_logger(),
+        )
+
+        assert pa.types.is_decimal(aligned.table.schema.field("value").type)
+        rewritten = deltalake.DeltaTable(delta_path).to_pyarrow_table()
+        assert rewritten.column("value").to_pylist() == [Decimal("1000000000000000.00")]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -20,6 +20,7 @@ from posthog.temporal.common.errors import NonReportableError
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import Any_Source_Errors
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     BillingLimitsWillBeReachedException,
+    DeltaColumnWideningRequired,
     SchemaColumnTypeChangedException,
     _get_max_decimal_type,
     _to_list_array,
@@ -731,22 +732,25 @@ def test_evolve_pyarrow_schema_decimal_does_not_widen_unnecessarily_and_can_wide
 
 
 @pytest.mark.parametrize(
-    "delta_type, incoming_type, overflowing_value",
+    "delta_type, incoming_type, overflowing_value, expected_promotion",
     [
-        (pa.int32(), pa.int64(), 6178466636),  # > int32 max (2147483647)
-        (pa.int16(), pa.int64(), 6178466636),  # > int16 max, fits int64
-        (pa.int16(), pa.int32(), 100000),  # > int16 max (32767), fits int32
-        (pa.int64(), pa.float64(), 19.99),  # fractional float into an int column
-        (pa.int64(), pa.decimal128(4, 2), decimal.Decimal("19.99")),  # fractional decimal into an int column
+        (pa.int32(), pa.int64(), 6178466636, pa.int64()),  # > int32 max (2147483647)
+        (pa.int16(), pa.int64(), 6178466636, pa.int64()),  # > int16 max, fits int64
+        (pa.int16(), pa.int32(), 100000, pa.int32()),  # > int16 max (32767), fits int32
+        (pa.int64(), pa.float64(), 19.99, pa.float64()),  # fractional float into an int column
+        # a fractional decimal into an int column keeps room for the stored int64 range
+        (pa.int64(), pa.decimal128(4, 2), decimal.Decimal("19.99"), pa.decimal128(22, 2)),
     ],
 )
-def test_evolve_pyarrow_schema_integer_overflow_raises_actionable_error(
-    delta_type: pa.DataType, incoming_type: pa.DataType, overflowing_value: int | float | decimal.Decimal
+def test_evolve_pyarrow_schema_reports_a_lossless_widening_for_the_stored_column(
+    delta_type: pa.DataType,
+    incoming_type: pa.DataType,
+    overflowing_value: int | float | decimal.Decimal,
+    expected_promotion: pa.DataType,
 ):
-    """An incoming value that doesn't fit the stored integer Delta type — a wider integer
-    that overflows, or a fractional float/decimal that would be truncated — raises a clear,
-    actionable error instructing the user to reset and re-sync, rather than a raw pyarrow
-    ArrowInvalid."""
+    """An incoming value that doesn't fit the stored numeric Delta type asks for the stored column
+    to be widened (the caller rewrites it), rather than failing the sync or letting delta-rs
+    silently truncate the value into the narrower stored type."""
     arrow_table = pa.table(
         {
             "id": pa.array([1, 2], type=pa.int64()),
@@ -757,8 +761,31 @@ def test_evolve_pyarrow_schema_integer_overflow_raises_actionable_error(
         pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", delta_type, nullable=True)])
     )
 
-    with pytest.raises(SchemaColumnTypeChangedException, match="Source column type changed"):
+    with pytest.raises(DeltaColumnWideningRequired, match="Source column type changed") as raised:
         evolve_pyarrow_schema(arrow_table, delta_schema)
+
+    assert raised.value.promotions == {"val": expected_promotion}
+
+
+@pytest.mark.parametrize(
+    "delta_type, incoming_type, incoming_value",
+    [
+        (pa.int64(), pa.string(), "n/a"),  # numbers replaced by text
+        (pa.bool_(), pa.string(), "maybe"),  # a flag column replaced by free text
+    ],
+)
+def test_evolve_pyarrow_schema_unconvertible_column_raises_actionable_error(
+    delta_type: pa.DataType, incoming_type: pa.DataType, incoming_value: str
+):
+    """A change no widening can absorb (text where numbers used to be) still fails with a clear,
+    actionable error naming the action that fixes it, not a raw pyarrow ArrowInvalid."""
+    arrow_table = pa.table({"val": pa.array([incoming_value], type=incoming_type)})
+    delta_schema = deltalake.Schema.from_arrow(pa.schema([pa.field("val", delta_type, nullable=True)]))
+
+    with pytest.raises(SchemaColumnTypeChangedException, match="Delete table and resync") as raised:
+        evolve_pyarrow_schema(arrow_table, delta_schema)
+
+    assert not isinstance(raised.value, DeltaColumnWideningRequired)
 
 
 def test_evolve_pyarrow_schema_integer_narrowing_within_range_is_preserved():

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
@@ -47,6 +47,9 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.async_iterate import async_iterate
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.batcher import Batcher
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.evolution import (
+    align_batch_to_delta_schema,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.maintenance import DeltaMaintenance
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import DeltaTableRef
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.writer import DeltaWriter
@@ -328,7 +331,15 @@ class PipelineNonDLT(Generic[ResumableData]):
 
         pa_table = await setup_partitioning(pa_table, delta_table, self._schema, self._resource, self._logger)
 
-        pa_table = evolve_pyarrow_schema(pa_table, delta_table.schema() if delta_table is not None else None)
+        if delta_table is not None:
+            aligned = await align_batch_to_delta_schema(delta_table, pa_table, self._logger)
+            pa_table = aligned.table
+            if aligned.widened_columns:
+                # Widening rewrote every file, so the snapshot taken above no longer describes the
+                # table this batch is about to be written into.
+                previous_file_uris = await self._delta_table_ref.get_file_uris()
+        else:
+            pa_table = evolve_pyarrow_schema(pa_table, None)
         pa_table = _handle_null_columns_with_definitions(pa_table, self._resource)
 
         write_type: Literal["incremental", "full_refresh", "append"] = "full_refresh"

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -37,10 +37,12 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.l
     supports_partial_data_loading,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
-    evolve_pyarrow_schema,
     pyarrow_schema_from_arrow_exportable,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.evolution import (
+    align_batch_to_delta_schema,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.scd2 import Scd2DeltaWriter
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table import DeltaTableRef
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.writer import DeltaWriter
@@ -795,7 +797,12 @@ def process_message(
         )
 
         if existing_delta_table is not None:
-            pa_table = evolve_pyarrow_schema(pa_table, existing_delta_table.schema())
+            aligned = async_to_sync(align_batch_to_delta_schema)(existing_delta_table, pa_table, logger)
+            pa_table = aligned.table
+            if aligned.widened_columns:
+                # Widening rewrote every file, so the snapshot taken above no longer describes the
+                # table this batch is about to be written into.
+                previous_file_uris = existing_delta_table.file_uris()
 
         if verify_ownership is not None:
             verify_ownership()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -81,8 +81,8 @@ NON_RETRYABLE_ERROR_PATTERNS: tuple[str, ...] = (
     "is too large to store in a Decimal128",
     # schema configured as incremental without a primary key — config error
     "Primary key required for incremental syncs",
-    # incoming values no longer fit the stored Delta column type
-    # (SchemaColumnTypeChangedException) — only a reset and full re-sync can fix it
+    # incoming values no longer fit the stored Delta column type and the stored rows can't be
+    # converted to the wider one (SchemaColumnTypeChangedException) — only a full rebuild fixes it
     "Source column type changed",
     # the schema or job row was deleted mid-sync — no retry can bring it back
     "ExternalDataSchema matching query does not exist",
@@ -94,8 +94,8 @@ NON_RETRYABLE_ERROR_PATTERNS: tuple[str, ...] = (
 # error-tracking capture for these so they don't drown real bugs. Kept deliberately narrow.
 EXPECTED_USER_ERROR_PATTERNS: tuple[str, ...] = (
     # a source column's type changed upstream and no longer fits the stored Delta column
-    # (SchemaColumnTypeChangedException) — delta-rs can't widen in place, so the fix is a
-    # user-driven reset and full re-sync, not a code change
+    # (SchemaColumnTypeChangedException) — the loader already widens the column where the stored
+    # rows survive the conversion, so what's left needs a user-driven rebuild, not a code change
     "Source column type changed",
     # the schema or job was deleted (e.g. the user removed the source) while a batch for it
     # was still in flight — an upstream/customer action, not a pipeline bug

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -215,7 +215,7 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # narrower numeric type) after the destination table was created with the narrower
             # type. Delta Lake can't widen an existing column in place, so retrying won't help —
             # the table must be reset and fully re-synced to adopt the new type.
-            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            "Source column type changed": "A column's type changed in your source and the rows already stored can't be converted to the new type. Use 'Delete table and resync' on this table to rebuild it with the new type.",
             # Raised from `BigQueryImplementation.get_columns` when the service-account OAuth
             # token endpoint returns a non-JSON-object 200 (bad `token_uri`, or an intercepting
             # proxy). Authentication can't succeed until the key file is fixed, so retrying just

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -294,7 +294,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             # the destination table was created with the narrower type. Delta Lake can't widen
             # an existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
-            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            "Source column type changed": "A column's type changed in your source and the rows already stored can't be converted to the new type. Use 'Delete table and resync' on this table to rebuild it with the new type.",
             # Raised from `_get_table` when `system.columns` returns no columns for the
             # configured table — the table no longer exists in the source database at sync
             # time. It was dropped or renamed, or (commonly) the schema points at a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/base.py
@@ -83,9 +83,8 @@ class SQLSource(SimpleSource[ConfigType], Generic[ConfigType]):
         """
         return {
             "Source column type changed": (
-                "A column's type changed in your source database (for example an integer column was widened to bigint) "
-                "and no longer fits the type we stored. We can't widen an existing column in place — please reset and "
-                "fully re-sync this table to adopt the new type."
+                "A column's type changed in your source and the rows already stored can't be converted to the new "
+                "type. Use 'Delete table and resync' on this table to rebuild it with the new type."
             ),
             "Cannot build decimal array from values": (
                 "One of your numeric columns contains values that exceed our decimal storage limits "

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_base.py
@@ -235,7 +235,7 @@ class TestDefaultNonRetryableErrors:
     @pytest.mark.parametrize(
         "key,expected_substring",
         [
-            ("Source column type changed", "reset and fully re-sync"),
+            ("Source column type changed", "Delete table and resync"),
             ("Cannot build decimal array from values", "decimal storage limits"),
         ],
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mssql/source.py
@@ -132,7 +132,7 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # destination table was created with the narrower type. Delta Lake can't widen an
             # existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
-            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            "Source column type changed": "A column's type changed in your source and the rows already stored can't be converted to the new type. Use 'Delete table and resync' on this table to rebuild it with the new type.",
             # Raised by `get_table_metadata` when INFORMATION_SCHEMA.COLUMNS returns no columns for a
             # table we were asked to sync — the table was dropped or renamed at the source after
             # schema discovery. This is the metadata-lookup counterpart of "Invalid object name"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -266,7 +266,7 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # destination table was created with the narrower type. Delta Lake can't widen an
             # existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
-            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            "Source column type changed": "A column's type changed in your source and the rows already stored can't be converted to the new type. Use 'Delete table and resync' on this table to rebuild it with the new type.",
             # MySQL/MariaDB error 1054 (ER_BAD_FIELD_ERROR): a column the sync query references no
             # longer exists in the source table — almost always the configured incremental field
             # after the column was renamed or dropped (schema drift). The streaming query reissues

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -669,7 +669,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # after the destination table was created with the narrower type. Delta Lake can't widen
             # an existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
-            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            "Source column type changed": "A column's type changed in your source and the rows already stored can't be converted to the new type. Use 'Delete table and resync' on this table to rebuild it with the new type.",
             # Raised by the source Postgres when the incremental query compares an integer/bigint
             # column against a non-integer cursor value, e.g. `WHERE "id" > '1.5'` or
             # `WHERE "id" > '2026-04-26T20:58:57.557000'`. `_build_query` renders the stored

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/revenuecat/source.py
@@ -255,9 +255,8 @@ class RevenueCatSource(
             ),
             "Source column type changed": (
                 "A column in this table started receiving values that don't fit the type stored from "
-                "earlier syncs (for example a price column created from whole-number values now "
-                "receiving a decimal price). We can't widen an existing column in place — reset and "
-                "fully re-sync this table to adopt the new type."
+                "earlier syncs, and the rows already stored can't be converted to the new type. Use "
+                "'Delete table and resync' on this table to rebuild it with the new type."
             ),
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -288,7 +288,7 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # to a larger NUMBER/BIGINT) after the destination table was created with the
             # narrower type. Delta Lake can't widen an existing column in place, so retrying
             # won't help — the table must be reset and fully re-synced to adopt the new type.
-            "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
+            "Source column type changed": "A column's type changed in your source and the rows already stored can't be converted to the new type. Use 'Delete table and resync' on this table to rebuild it with the new type.",
             # Snowflake SQL compilation error 002057: a view's declared column list no longer
             # matches the columns its query produces, so the view itself fails to compile. This is
             # a broken object on the source side that retrying can't repair.

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -375,9 +375,10 @@ async def _handle_import_error(
         )
 
     # Raised in shared pipeline code when incoming data can't be cast into the stored (narrower)
-    # Delta column type. delta-rs can't change a column's type in place, so this fails identically
-    # on every retry regardless of source — classify it non-retryable by type here rather than
-    # relying on each source listing the message in get_non_retryable_errors.
+    # Delta column type and the stored rows can't be converted to the wider one either (the loader
+    # widens the column itself when they can). What reaches here fails identically on every retry
+    # regardless of source — classify it non-retryable by type here rather than relying on each
+    # source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error


### PR DESCRIPTION
## Problem

A Delta column stored from the first batch that ever filled it keeps that type forever.
When the source later sends values that no longer fit, the sync fails on the same cast every run and never recovers by itself.

The common shape is a numeric column stored as `int64` because early rows were whole numbers, then carrying fractions later — a cost or price field from a REST source, or an upstream `integer` widened to `bigint`.
Around a hundred failed jobs a day come from this across a handful of connections, with the same schema looping on the same error until someone rebuilds the table by hand.

Until now the loader always failed here: delta-rs has no `ALTER COLUMN TYPE`, so the only cure on offer was a full rebuild.
Letting the write through is not an alternative — a `schema_mode="merge"` write casts `1.5` into the stored `int64` and commits `1`, silently.

## Changes

- The loader converts the stored column when every value already in it survives the conversion, then keeps syncing.
- Safe targets: a wider integer of the same signedness, integer to double, integer to a decimal that still fits Delta's precision 38.
- The conversion streams the table through one atomic overwrite commit that rewrites every file under the wider schema. Nothing commits until the whole stream lands, so a crash or an unconvertible value leaves the table untouched.
- The per-value cast runs with pyarrow's `safe=True`, so an integer past double's exactly-representable range aborts the conversion instead of rounding.
- Text is never a widening target. A numeric column turning into strings changes what every query over it means, so it stays a full rebuild.
- Tables over 2 GB at rest are refused rather than converted, since the conversion blocks the batch that triggered it while the loader holds its batch lease.
- What stays terminal now says what to do: "Use 'Delete table and resync' on this table to rebuild it with the new type", matching the button in the schema's danger zone. Replaces copy that told users we could never widen a column.

## How did you test this code?

Automated, run locally in a Python 3.13 worktree venv:

- `products/warehouse_sources/.../core/delta/test/test_evolution.py` (new, 6 cases against real local Delta tables) — catches: fractional values silently rounding into a stored `int64`; the conversion dropping the table's partitioning; a stored integer past double's exact range being changed by the conversion; oversized tables being converted anyway; text for a numeric column being converted instead of failing.
- `products/warehouse_sources/.../core/test/test_utils.py` — the existing overflow matrix now asserts which widening each mismatch asks for, plus a case pinning "text where numbers used to be" as terminal and not a widening.
- Full local runs: `pipelines/core/` (496 passed), `pipelines/pipeline_v2/` + `pipeline_v3/load/` (81 passed), `delta/test/` and `sources/common/sql/tests/test_base.py`.
- `ruff check` / `ruff format` clean, `mypy --cache-fine-grained .` clean repo-wide, `hogli ci:preflight --fix` reports 0 failures.

Not run: no manual sync against a real source, and no ClickHouse or S3-backed run.
Tests that need the local dev stack (`delta/test/test_table.py`, which talks to object storage) or an up-to-date local test database error out in this checkout for reasons unrelated to this change.

I verified the delta-rs behavior this change relies on directly against `deltalake==1.6.1` (the pinned version) in a scratch environment: no `TypeWidening` table feature, `schema_mode="merge"` silently truncating `1.5` to `1`, and the streaming overwrite preserving rows, partitioning and the old version.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs describe this failure mode; the in-product error message is the surface that changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`.

The first instinct was to classify the error as non-retryable and move on, but that leaves the sync permanently broken for a change the data can absorb.
Two cheaper fixes were tried and rejected against the pinned `deltalake==1.6.1`: the Delta `typeWidening` table feature is not implemented, and `write_deltalake(schema_mode="merge")` — plus `merge(merge_schema=True)` — casts the incoming values down to the stored type and commits the truncated values without an error, which is worse than failing.
That left rewriting the table, which is cheaper than the reset it replaces: it re-reads what is already in S3 rather than re-pulling every row from the source.

The widening is triggered by the alignment step failing rather than by a schema comparison, so a batch that would have cast cleanly never pays for a rewrite, and a column is only ever rewritten once.
`DeltaColumnWideningRequired` subclasses the existing `SchemaColumnTypeChangedException` on purpose: a caller that can't widen (the repartitioner, any future path) keeps today's terminal behavior instead of writing a batch delta-rs would truncate.

The 2 GB ceiling is a judgement call. It is sized against the batch lease the loader holds during the conversion, not against a measured limit, and it is a single constant if that proves too conservative.
