### PR TITLE
feat(data-warehouse): add Vercel team activity events table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/canonical_descriptions.py
@@ -23,6 +23,23 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "inspectorUrl": "URL of the deployment's inspector page in the Vercel dashboard.",
         },
     },
+    "events": {
+        "description": "A Vercel team activity event: one action taken on the team, such as a deployment being created, a project renamed, or an environment variable changed. Where the other tables hold current state, this one holds the transitions between states.",
+        "docs_url": "https://vercel.com/docs/rest-api/reference/endpoints/user/list-user-events",
+        "columns": {
+            "id": "Unique identifier for the event.",
+            "type": "The type of action the event records, such as deployment-created or env-variable-edit.",
+            "text": "Human-readable summary of the event.",
+            "createdAt": "Time the event was generated, as a Unix timestamp in milliseconds.",
+            "entities": "Spans within the event text marking the entities it refers to, as JSON.",
+            "categories": "Categories grouping this event with related types. An event can belong to more than one.",
+            "payload": "Event-specific detail about the entity acted on, as JSON. The shape varies by event type.",
+            "principalId": "Identifier of the principal that generated the event, usually a user but sometimes an app or integration.",
+            "userId": "Identifier of the user that generated the event, empty when the principal was not a user.",
+            "user": "Metadata about the user that generated the event, as JSON.",
+            "via": "Chain of principals the authority was delegated through, as JSON, when a user acted through an app.",
+        },
+    },
     "projects": {
         "description": "A Vercel project: a codebase connected to Vercel with its build, environment, and deployment configuration.",
         "docs_url": "https://vercel.com/docs/rest-api/reference/endpoints/projects/retrieve-a-list-of-projects",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/settings.py
@@ -36,6 +36,13 @@ class VercelEndpointConfig:
     # `from`/`to` date window instead of the cursor-paginated list envelope every other endpoint
     # uses. Routed through its own transport path in vercel.py.
     is_focus_billing: bool = False
+    # Field holding the row's creation timestamp (Unix ms) for endpoints that return rows but no
+    # `pagination` envelope. The transport pages those by feeding the oldest value on a page back
+    # as the next `until`. None means the endpoint carries the envelope and pages from
+    # `pagination.next`.
+    cursor_from_field: Optional[str] = None
+    # Static query params this endpoint needs on every request, merged over the shared ones.
+    extra_params: dict[str, str] = field(default_factory=dict)
 
 
 # Charges get restated after they first post (usage finalization, plus adjustments, credits, and tax
@@ -67,6 +74,40 @@ VERCEL_ENDPOINTS: dict[str, VercelEndpointConfig] = {
                 "label": "created",
                 "type": IncrementalFieldType.Integer,
                 "field": "created",
+                "field_type": IncrementalFieldType.Integer,
+            },
+        ],
+    ),
+    # Team activity stream: every action taken on the team, across ~600 event types (deployments,
+    # projects, env vars, domains, aliases, certs, flags, firewall config, access groups). The
+    # resource tables above hold current state; this one holds the transitions between them, which
+    # is what deployment frequency, change-failure rate, and config audit trails are built from.
+    "events": VercelEndpointConfig(
+        name="events",
+        path="/v3/events",
+        response_data_key="events",
+        primary_key="id",
+        # /v3/events documents `since`/`until` (Unix ms) as a server-side filter on event creation
+        # time, so this is genuinely incremental rather than a client-side skip. `createdAt` is
+        # immutable, making it both the incremental cursor and the pagination cursor.
+        since_param="since",
+        supports_incremental=True,
+        supports_append=True,
+        # Unlike the resource endpoints this one returns no `pagination` envelope, so pages are
+        # walked from the oldest `createdAt` on each page.
+        cursor_from_field="createdAt",
+        # Without this the response carries only the event's summary text, not the entity it acted
+        # on. The payload shape varies per event type; the pipeline serializes it to a JSON string
+        # column, so the variation doesn't drift the Arrow schema.
+        extra_params={"withPayload": "true"},
+        # Deliberately left unpartitioned. `createdAt` is Unix *milliseconds*, and the datetime
+        # partition mode feeds an int straight to `datetime.fromtimestamp()`, which reads it as
+        # seconds and raises for any ms value. Same reason `deployments.created` is unpartitioned.
+        incremental_fields=[
+            {
+                "label": "createdAt",
+                "type": IncrementalFieldType.Integer,
+                "field": "createdAt",
                 "field_type": IncrementalFieldType.Integer,
             },
         ],

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
@@ -30,6 +30,7 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 @SourceRegistry.register
 class VercelSource(ResumableSource[VercelSourceConfig, VercelResumeConfig]):
     api_docs_url = "https://vercel.com/docs/rest-api"
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
 
     @property
     def source_type(self) -> ExternalDataSourceType:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.vercel.ver
     VercelResumeConfig,
     _billing_window_start,
     _build_params,
+    _cursor_from_page,
     _floor_to_day,
     _focus_charge_id,
     _iso8601_utc,
@@ -81,6 +82,16 @@ class TestBuildParams:
             ("since_and_until", "deployments", None, 123, 456, {"limit": PAGE_SIZE, "since": 123, "until": 456}),
             # projects has no since_param, so a cursor value must not become a query filter.
             ("no_since_param_drops_since", "projects", None, 123, None, {"limit": PAGE_SIZE}),
+            # Without withPayload the response carries only each event's summary text, so the
+            # payload column lands empty and the table loses the detail it exists for.
+            (
+                "events_requests_the_payload",
+                "events",
+                "team_1",
+                None,
+                None,
+                {"limit": PAGE_SIZE, "teamId": "team_1", "withPayload": "true"},
+            ),
         ]
     )
     def test_build_params(
@@ -111,6 +122,22 @@ class TestShouldStopDesc:
         self, _name: str, items: list[dict], field_name: str | None, cutoff: Any, expected: bool
     ) -> None:
         assert _should_stop_desc(items, field_name, cutoff) is expected
+
+
+class TestCursorFromPage:
+    @parameterized.expand(
+        [
+            # The oldest value bounds the next page. Taking the newest would re-request page one.
+            ("oldest_wins", [{"createdAt": 300}, {"createdAt": 100}, {"createdAt": 200}], 100),
+            ("single_row", [{"createdAt": 42}], 42),
+            ("ignores_rows_missing_the_field", [{"createdAt": 300}, {"other": 1}], 300),
+            ("ignores_non_integer_values", [{"createdAt": "300"}, {"createdAt": 200}], 200),
+            ("no_usable_values", [{"other": 1}], None),
+            ("empty_page", [], None),
+        ]
+    )
+    def test_cursor_from_page(self, _name: str, items: list[dict[str, Any]], expected: int | None) -> None:
+        assert _cursor_from_page(items, "createdAt") == expected
 
 
 class TestValidateCredentials:
@@ -226,6 +253,53 @@ class TestGetRows:
         assert rows == []
         assert len(calls) == 1
 
+    def test_events_pages_without_a_pagination_envelope(self, monkeypatch: Any) -> None:
+        # /v3/events returns rows but no `pagination` object. Without the derived cursor the walk
+        # ends after page one and the table silently caps at a single page of history forever.
+        responses: list[dict] = [
+            {"events": [{"id": "e1", "createdAt": 300}, {"id": "e2", "createdAt": 200}]},
+            {"events": [{"id": "e3", "createdAt": 100}]},
+            {"events": []},
+        ]
+        rows, calls = _collect("events", _FakeResumableManager(), monkeypatch, responses)
+
+        assert [r["id"] for r in rows] == ["e1", "e2", "e3"]
+        assert "until=" not in calls[0]
+        # The oldest row on each page bounds the next, so page two asks for until=200, not 300.
+        assert "until=200" in calls[1]
+        assert "until=100" in calls[2]
+
+    def test_events_stop_when_a_whole_page_shares_one_timestamp(self, monkeypatch: Any) -> None:
+        # The derived cursor can't advance past a page whose rows share a timestamp; the walk has
+        # to end there rather than re-request the same page forever.
+        responses = [
+            {"events": [{"id": "e1", "createdAt": 500}, {"id": "e2", "createdAt": 500}]},
+            {"events": [{"id": "e3", "createdAt": 500}]},
+        ]
+        rows, calls = _collect("events", _FakeResumableManager(), monkeypatch, responses)
+
+        assert [r["id"] for r in rows] == ["e1", "e2", "e3"]
+        assert len(calls) == 2
+
+    def test_events_incremental_sends_since_and_stops_at_watermark(self, monkeypatch: Any) -> None:
+        responses = [
+            {"events": [{"id": "e1", "createdAt": 300}, {"id": "e2", "createdAt": 200}]},
+            {"events": [{"id": "e3", "createdAt": 120}]},
+            {"events": [{"id": "e4", "createdAt": 50}]},
+        ]
+        rows, calls = _collect(
+            "events",
+            _FakeResumableManager(),
+            monkeypatch,
+            responses,
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=150,
+        )
+
+        assert [r["id"] for r in rows] == ["e1", "e2", "e3"]
+        assert "since=150" in calls[0]
+        assert len(calls) == 2
+
     def test_mid_page_yield_checkpoints_current_page_not_next(self, monkeypatch: Any) -> None:
         # Regression: a mid-page yield must checkpoint the cursor for the CURRENT page, not the
         # next one. Page two crosses the batcher's 2000-row chunk, so the batch yields while the
@@ -250,7 +324,14 @@ class TestGetRows:
 
 class TestVercelSource:
     @parameterized.expand(
-        [("deployments", "uid"), ("projects", "id"), ("teams", "id"), ("domains", "id"), ("aliases", "uid")]
+        [
+            ("deployments", "uid"),
+            ("events", "id"),
+            ("projects", "id"),
+            ("teams", "id"),
+            ("domains", "id"),
+            ("aliases", "uid"),
+        ]
     )
     def test_source_response_primary_key_and_sort(self, endpoint: str, expected_pk: str) -> None:
         response = vercel_source(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
@@ -65,13 +65,29 @@ class TestVercelSource:
 
     def test_get_schemas_sync_capabilities_per_endpoint(self) -> None:
         schemas = {s.name: s for s in self.source.get_schemas(self.config, team_id=1)}
-        assert set(schemas) == {"deployments", "projects", "teams", "domains", "aliases", "billing_charges"}
+        assert set(schemas) == {
+            "deployments",
+            "events",
+            "projects",
+            "teams",
+            "domains",
+            "aliases",
+            "billing_charges",
+        }
 
         deployments = schemas["deployments"]
         assert deployments.supports_incremental is True
         assert deployments.supports_append is True
         assert [f["field"] for f in deployments.incremental_fields] == ["created"]
         assert deployments.incremental_fields[0]["field_type"] == IncrementalFieldType.Integer
+
+        # The activity stream cursors on the event's own creation time, which never changes, and
+        # supports append because events are immutable once emitted.
+        events = schemas["events"]
+        assert events.supports_incremental is True
+        assert events.supports_append is True
+        assert [f["field"] for f in events.incremental_fields] == ["createdAt"]
+        assert events.incremental_fields[0]["field_type"] == IncrementalFieldType.Integer
 
         # Billing supports incremental merge but not append (append would duplicate restated charges),
         # cursors on the charge period, and carries a lookback so restatements get re-read and merged.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
@@ -75,7 +75,7 @@ def _build_params(
     since_value: Any,
     until: int | None,
 ) -> dict[str, Any]:
-    params: dict[str, Any] = {"limit": PAGE_SIZE}
+    params: dict[str, Any] = {"limit": PAGE_SIZE, **config.extra_params}
 
     if config.team_scoped and team_id:
         params["teamId"] = team_id
@@ -125,6 +125,19 @@ def _should_stop_desc(items: list[dict[str, Any]], field_name: str | None, cutof
     if not field_name or cutoff is None or not items:
         return False
     return any(item.get(field_name) is not None and item[field_name] <= cutoff for item in items)
+
+
+def _cursor_from_page(items: list[dict[str, Any]], field_name: str) -> int | None:
+    """Next `until` cursor for an endpoint that returns rows but no `pagination` envelope.
+
+    Rows arrive newest-first, so the oldest timestamp on this page bounds the next one. The value is
+    fed back unmodified rather than decremented: `until` is inclusive, so the boundary row is
+    re-fetched and merge dedupes it on the primary key, whereas stepping back a millisecond would
+    drop any row sharing that exact timestamp. A page whose rows all share one timestamp can't
+    advance the cursor; the caller's non-advancing-cursor guard ends the walk there.
+    """
+    timestamps = [item[field_name] for item in items if isinstance(item.get(field_name), int)]
+    return min(timestamps) if timestamps else None
 
 
 def validate_credentials(access_token: str) -> tuple[bool, str | None]:
@@ -193,6 +206,8 @@ def get_rows(
             break
 
         next_until = (data.get("pagination") or {}).get("next")
+        if next_until is None and config.cursor_from_field:
+            next_until = _cursor_from_page(items, config.cursor_from_field)
         stop_after_page = _should_stop_desc(items, field_name, cutoff)
 
         for item in items:


### PR DESCRIPTION
## Problem

The Vercel source syncs six resource tables, all of which hold current state. None of them hold the transitions between states, so you can't answer deployment frequency, change-failure rate, or "who changed that env var".

This started as an investigation into building Vercel webhooks, now that HogVM supports HMAC. Two findings redirected it:

- Vercel webhook payloads are a reduced shape, not the resource. `deployment.created` carries `deployment.{id,meta,url,name}` and no `uid`, `created`, or `state`. The Delta writer merges with `when_matched_update_all()`, so routing those into `deployments` would overwrite complete rows with mostly-null ones.
- `GET /v3/events` already exposes the same activity stream as a pull endpoint, with ~600 event types against the webhook API's ~115, and a server-side `since` filter.

So the pull endpoint is both safer and strictly richer. It also avoids the Pro/Enterprise gate on account webhooks and the 20-webhooks-per-team cap.

## Changes

- New `events` schema on `/v3/events`, incremental on `createdAt` with append supported.
- `withPayload=true` is requested, so each row carries the entity acted on. The payload shape varies per event type; the pipeline serializes it to a JSON string column, so the variation can't drift the Arrow schema.
- Two new fields on `VercelEndpointConfig`: `cursor_from_field` and `extra_params`.
- `lists_tables_without_credentials = True`, so the table catalog renders on posthog.com. `get_schemas` is a static catalog with no I/O, which is the bar for that flag.
- Canonical descriptions for the new table and its columns.

### Pagination

Unlike the resource endpoints, `/v3/events` returns no `pagination` envelope, so pages are walked from the oldest `createdAt` on each page.

```mermaid
flowchart TD
    A[GET /v3/events] --> B{pagination envelope?}
    B -->|yes, resource endpoints| C[next = pagination.next]
    B -->|no, /v3/events| D[next = min createdAt on page]
    C --> E[until = next]
    D --> E
    E --> F{cursor advanced?}
    F -->|yes| A
    F -->|no| G[stop]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,E phBlue;
    class C,D phGray;
    class G phYellow;
```

The cursor is fed back unmodified. `until` is inclusive, so the boundary row is re-fetched and merge dedupes it on `id`. Decrementing by a millisecond would instead drop any row sharing that exact timestamp.

> [!NOTE]
> The table is deliberately unpartitioned. `createdAt` is epoch **milliseconds**, and the datetime partition mode passes an int straight to `datetime.fromtimestamp()`, which reads it as seconds and raises `ValueError: year 57045 is out of range`. That is a live trap for any source setting `partition_key` to an epoch-ms field, and is why `deployments.created` is unpartitioned too. Worth fixing separately in `partitioning.py`.

## How did you test this code?

I have no Vercel credentials, so nothing here ran against the live API. Everything about the endpoint's contract comes from Vercel's machine-readable OpenAPI spec at `https://openapi.vercel.sh/`, which documents `since`/`until`/`types`/`withPayload`, the `{events: [...]}` envelope with no `pagination` object, and the `UserEvent` field set. Two behaviors I could not verify and that the code is written to fail safe on: that rows arrive newest-first, and that `until` is inclusive. A wrong assumption on either ends the walk early via the existing non-advancing-cursor guard rather than looping or corrupting the watermark.

Automated tests I ran:

- `pytest .../sources/vercel` - 80 passed.
- `uv run mypy --cache-fine-grained .` - no issues in 17731 files.
- `ruff check` and `ruff format` - clean.
- Called `VercelSource().get_documented_tables()` directly and confirmed `events` renders with its description, primary key, incremental fields, and sync methods.

New tests, one regression each:

| Test | Regression it catches |
| --- | --- |
| `test_events_pages_without_a_pagination_envelope` | Losing the derived cursor caps the table at one page of history, silently and forever. |
| `test_events_stop_when_a_whole_page_shares_one_timestamp` | A page that can't advance the cursor re-requests itself forever. |
| `test_events_incremental_sends_since_and_stops_at_watermark` | The watermark stops working, so every sync re-walks all history. |
| `TestCursorFromPage` | Taking the newest rather than oldest timestamp re-requests page one; non-integer values crash or corrupt the cursor. |
| `test_build_params` (new case) | Dropping `withPayload` empties the payload column, which is the reason the table exists. |

I verified each by mutating the source and confirming the matching test fails:

<details>
<summary>Mutations checked</summary>

| Mutation | Result |
| --- | --- |
| Remove the `cursor_from_field` fallback | 3 events pagination tests fail |
| `min()` to `max()` in `_cursor_from_page` | `TestCursorFromPage` + pagination test fail |
| Drop `extra_params` from the query | `test_build_params` events case fails |

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The posthog.com source doc lives in the other repo. `lists_tables_without_credentials` makes `<SourceTables />` pick the new table up automatically, so no manual table list to maintain there.