### PR TITLE
fix(hogql): expose unsupported warehouse join keys as query errors

### DIFF
--- a/posthog/hogql/database/test/test_lazy_join_resolvers.py
+++ b/posthog/hogql/database/test/test_lazy_join_resolvers.py
@@ -19,8 +19,9 @@ from posthog.hogql.database.schema.groups import join_with_group_n_table
 from posthog.hogql.database.warehouse_join_resolvers import (
     data_warehouse_resolver_params,
     resolve_data_warehouse_experiments_join,
+    resolve_data_warehouse_join,
 )
-from posthog.hogql.errors import ResolutionError
+from posthog.hogql.errors import QueryError, ResolutionError
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
 
@@ -43,6 +44,35 @@ class TestLazyJoinResolvers(SimpleTestCase):
         lazy_join = LazyJoin(from_field=["id"], join_table="x", resolver="does_not_exist")
         with self.assertRaises(ValueError):
             lazy_join.resolve_join_to_add(None, None, None)  # type: ignore[arg-type]
+
+    def test_unsupported_join_key_is_an_exposed_query_error(self):
+        # A join key that doesn't root in a field fails deterministically for every query
+        # touching the join. It must surface as an exposed QueryError (a 400 at API
+        # boundaries, e.g. blast radius sizing over a warehouse-joined person property)
+        # naming the key and where it applies, not as an internal 500.
+        lazy_join = LazyJoin(
+            from_field=["id"],
+            join_table="crm_accounts",
+            resolver=DATA_WAREHOUSE,
+            resolver_params=data_warehouse_resolver_params(
+                source_table_key="'not-a-field'",
+                joining_table_key="id",
+                joining_table_name="crm_accounts",
+            ),
+        )
+        join_to_add = LazyJoinToAdd(
+            from_table="events",
+            to_table="crm_accounts",
+            lazy_join=lazy_join,
+            lazy_join_type=None,  # type: ignore[arg-type]
+            fields_accessed={"name": ["name"]},
+        )
+
+        with self.assertRaises(QueryError) as ctx:
+            resolve_data_warehouse_join(join_to_add, HogQLContext(team_id=1), ast.SelectQuery(select=[]))
+        message = str(ctx.exception)
+        assert "'not-a-field'" in message
+        assert "events" in message
 
     def test_group_n_join_requires_group_index(self):
         lazy_join = LazyJoin(from_field=["key"], join_table="groups", resolver=GROUP_N)

--- a/posthog/hogql/database/warehouse_join_resolvers.py
+++ b/posthog/hogql/database/warehouse_join_resolvers.py
@@ -4,13 +4,21 @@ from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import LazyJoinToAdd
 from posthog.hogql.database.utils import qualify_join_key_expr
-from posthog.hogql.errors import ResolutionError
+from posthog.hogql.errors import QueryError, ResolutionError
 
 
 def _qualified_key_expr(table_key: str, table_name: str) -> ast.Expr:
     expr = qualify_join_key_expr(table_key, table_name)
     if expr is None:
-        raise ResolutionError("Data Warehouse Join HogQL expression should be a Field or Call node")
+        # A join key that doesn't root in a Field or Call fails deterministically for every
+        # query touching the join - it's the join's configuration, not a server fault, so
+        # raise an exposed error naming what to fix instead of an internal 500.
+        raise QueryError(
+            f"Data warehouse join key {table_key!r} on '{table_name}' can't be used in a query. "
+            "A join key must be a field or a function call on a field, like properties.email or "
+            "lower(properties.email). Update the join's key expression, or remove references to "
+            "its joined fields."
+        )
     return expr
 
 


### PR DESCRIPTION
## Problem

A data warehouse join whose configured key expression doesn't root in a `Field` or `Call` node raises `ResolutionError("Data Warehouse Join HogQL expression should be a Field or Call node")` at query resolution time. `ResolutionError` is an `InternalHogQLError`, so every query touching the join — including workflows/flags blast radius sizing over a warehouse-joined person property — surfaces an opaque 500, and the message names nothing actionable.

Refs #78174.

## Changes

- The raise becomes an exposed `QueryError` naming the offending key expression, the table it applies to, the supported shapes (a field, or a function call on a field), and the fix.
- `user_blast_radius` already converts `ExposedHogQLError` to a DRF 400, so blast radius picks this up with no further change; other query surfaces get their standard exposed-error handling instead of a 500.
- The construction-time guards in `database.py` (which skip un-parseable joins) are untouched — this covers keys that pass construction but fail at resolution.

## How did you test this code?

- `pytest posthog/hogql/database/test/test_lazy_join_resolvers.py` — 9 passed.
- New test locks in: an unsupported join key raises `QueryError` (exposed, so a 400 at API boundaries) and the message names the key and the table. Previously asserted-nowhere; the old behavior was the internal error class.
- `ruff` and `hogli ci:preflight --fix` — clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None — error classification fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored via PostHog Code (Claude). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/writing-user-facing-copy`.
- Chose to fix the error class at the raise site rather than pattern-match the message inside blast radius: the failure is the join's configuration, deterministic for every caller, and message-matching would be brittle. The other `ResolutionError`s in the resolver (internal invariants) are unchanged.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
