### PR TITLE
chore(dashboards): prototype tile override modal sectioning options

### DIFF
--- a/frontend/src/scenes/dashboard/TileFiltersOverride.prototype.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.prototype.tsx
@@ -1,0 +1,199 @@
+// scenes/dashboard/TileFiltersOverride.prototype.tsx
+//
+// THROWAWAY PROTOTYPE — do not fold into production as-is.
+// Question: how should the "Override tile filters" modal section its controls?
+// Renders five structurally different sectionings of the same wired controls,
+// switchable via `?tileOverrideVariant=` and a dev-only floating bottom bar.
+// Winner gets hand-folded into TileFiltersOverride.tsx; this file + the switcher get deleted.
+// See `/prototype` (UI.md).
+
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect } from 'react'
+
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+import { LemonCard, LemonCollapse, LemonDivider } from '@posthog/lemon-ui'
+
+// The wired control blocks, built once in TileFiltersOverride.tsx and arranged differently per variant.
+export type TileOverrideFields = Record<
+    'scope' | 'dateRange' | 'interval' | 'properties' | 'testAccounts' | 'breakdown',
+    JSX.Element
+>
+
+type Group = { heading: string; fields: JSX.Element[] }
+
+// Same grouping for every variant — only the sectioning chrome around the groups changes.
+function groupsOf(fields: TileOverrideFields): Group[] {
+    return [
+        { heading: 'Scope', fields: [fields.scope] },
+        { heading: 'Time', fields: [fields.dateRange, fields.interval] },
+        { heading: 'Filters', fields: [fields.properties, fields.testAccounts] },
+        { heading: 'Display', fields: [fields.breakdown] },
+    ]
+}
+
+const VARIANTS = [
+    { key: 'A', name: 'Plain dividers' },
+    { key: 'B', name: 'Labeled dividers' },
+    { key: 'C', name: 'Group headings' },
+    { key: 'D', name: 'Bordered cards' },
+    { key: 'E', name: 'Collapse accordion' },
+] as const
+
+type VariantKey = (typeof VARIANTS)[number]['key']
+const VARIANT_KEYS = VARIANTS.map((v) => v.key) as VariantKey[]
+
+function GroupHeading({ children }: { children: string }): JSX.Element {
+    return <h5 className="text-xs font-semibold text-muted uppercase mb-2 mt-0">{children}</h5>
+}
+
+// A — plain dividers between groups (today's production layout).
+function VariantPlainDividers({ groups }: { groups: Group[] }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4">
+            {groups.map((group, i) => (
+                <div key={group.heading} className="flex flex-col gap-4">
+                    {i > 0 && <LemonDivider />}
+                    {group.fields}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+// B — dividers carry the group name in the line itself.
+function VariantLabeledDividers({ groups }: { groups: Group[] }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-4">
+            {groups.map((group) => (
+                <div key={group.heading} className="flex flex-col gap-4">
+                    <LemonDivider label={group.heading} />
+                    {group.fields}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+// C — small left-aligned heading above each group, no hairlines.
+function VariantGroupHeadings({ groups }: { groups: Group[] }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-5">
+            {groups.map((group) => (
+                <div key={group.heading} className="flex flex-col gap-3">
+                    <GroupHeading>{group.heading}</GroupHeading>
+                    {group.fields}
+                </div>
+            ))}
+        </div>
+    )
+}
+
+// D — each group in its own bordered card.
+function VariantBorderedCards({ groups }: { groups: Group[] }): JSX.Element {
+    return (
+        <div className="flex flex-col gap-3">
+            {groups.map((group) => (
+                <LemonCard key={group.heading} className="p-3" hoverEffect={false}>
+                    <GroupHeading>{group.heading}</GroupHeading>
+                    <div className="flex flex-col gap-4">{group.fields}</div>
+                </LemonCard>
+            ))}
+        </div>
+    )
+}
+
+// E — one collapsible panel per group.
+function VariantCollapse({ groups }: { groups: Group[] }): JSX.Element {
+    return (
+        <LemonCollapse
+            multiple
+            defaultActiveKeys={groups.map((g) => g.heading)}
+            panels={groups.map((group) => ({
+                key: group.heading,
+                header: group.heading,
+                content: <div className="flex flex-col gap-4">{group.fields}</div>,
+            }))}
+        />
+    )
+}
+
+function renderVariant(variant: VariantKey, groups: Group[]): JSX.Element {
+    switch (variant) {
+        case 'B':
+            return <VariantLabeledDividers groups={groups} />
+        case 'C':
+            return <VariantGroupHeadings groups={groups} />
+        case 'D':
+            return <VariantBorderedCards groups={groups} />
+        case 'E':
+            return <VariantCollapse groups={groups} />
+        case 'A':
+        default:
+            return <VariantPlainDividers groups={groups} />
+    }
+}
+
+function isVariantKey(value: unknown): value is VariantKey {
+    return typeof value === 'string' && (VARIANT_KEYS as string[]).includes(value)
+}
+
+// Dev-only floating bar: prev / label / next, plus ← → keys. Writes the URL so a variant is reload-stable.
+function VariantSwitcher({ current }: { current: VariantKey }): JSX.Element {
+    const { searchParams, location } = useValues(router)
+
+    const go = (delta: number): void => {
+        const idx = VARIANT_KEYS.indexOf(current)
+        const next = VARIANT_KEYS[(idx + delta + VARIANT_KEYS.length) % VARIANT_KEYS.length]
+        router.actions.replace(location.pathname, { ...searchParams, tileOverrideVariant: next })
+    }
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent): void => {
+            const el = document.activeElement
+            if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || (el as HTMLElement).isContentEditable)) {
+                return
+            }
+            if (e.key === 'ArrowLeft') {
+                go(-1)
+            } else if (e.key === 'ArrowRight') {
+                go(1)
+            }
+        }
+        window.addEventListener('keydown', onKey)
+        return () => window.removeEventListener('keydown', onKey)
+    })
+
+    const name = VARIANTS.find((v) => v.key === current)?.name ?? ''
+
+    return (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[10000] flex items-center gap-2 rounded-full bg-black text-white px-3 py-1.5 shadow-lg pointer-events-auto">
+            <button className="p-1 hover:opacity-70" onClick={() => go(-1)} aria-label="Previous variant">
+                <IconChevronLeft />
+            </button>
+            <span className="text-xs font-semibold whitespace-nowrap">
+                {current} — {name}
+            </span>
+            <button className="p-1 hover:opacity-70" onClick={() => go(1)} aria-label="Next variant">
+                <IconChevronRight />
+            </button>
+        </div>
+    )
+}
+
+// Prototype entry point rendered by TileFiltersOverride. In production it is always variant A with no switcher.
+export function TileFiltersOverrideSections({ fields }: { fields: TileOverrideFields }): JSX.Element {
+    const { searchParams } = useValues(router)
+    const isProto = process.env.NODE_ENV !== 'production'
+    const variant: VariantKey =
+        isProto && isVariantKey(searchParams.tileOverrideVariant) ? searchParams.tileOverrideVariant : 'A'
+
+    const groups = groupsOf(fields)
+
+    return (
+        <>
+            {renderVariant(variant, groups)}
+            {isProto && <VariantSwitcher current={variant} />}
+        </>
+    )
+}

--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -4,7 +4,7 @@ import './TileFiltersOverride.scss'
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconCalendar, IconGear } from '@posthog/icons'
-import { LemonButton, LemonDivider, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
@@ -20,6 +20,7 @@ import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
 import { isInsightQueryWithBreakdown, isInsightQueryWithSeries, isInsightVizNode } from '~/queries/utils'
 import type { DashboardTile, InsightLogicProps, IntervalType, QueryBasedInsightModel } from '~/types'
 
+import { TileFiltersOverrideSections, TileOverrideFields } from './TileFiltersOverride.prototype'
 import { tileLogic } from './tileLogic'
 
 type TestAccountFilterChoice = 'inherit' | 'filter-out' | 'include'
@@ -69,6 +70,163 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
         },
     }
 
+    // Field blocks wired once here; the sectioning prototype arranges them per `?tileOverrideVariant=`.
+    // In production this always renders variant A (plain dividers) with no switcher.
+    const fields: TileOverrideFields = {
+        scope: (
+            <div>
+                <LemonSwitch
+                    checked={!!overrides.ignoreDashboardFilters}
+                    onChange={setIgnoreDashboardFilters}
+                    label="Ignore dashboard filters"
+                    bordered
+                    fullWidth
+                    data-attr="tile-ignore-dashboard-filters"
+                />
+                <p className="text-xs text-muted mt-1 mb-0">
+                    When on, none of the dashboard's filters apply to this insight. The overrides below still do.
+                </p>
+            </div>
+        ),
+        dateRange: (
+            <div>
+                <label className="text-sm font-medium mb-2 block">Date range</label>
+                <DateFilter
+                    showCustom
+                    showExplicitDateToggle
+                    dateFrom={overrides.date_from ?? null}
+                    dateTo={overrides.date_to ?? null}
+                    explicitDate={overrides.explicitDate}
+                    onChange={(from, to, explicitDate) => setDates(from, to, explicitDate)}
+                    makeLabel={(key) => (
+                        <>
+                            <IconCalendar />
+                            <span className="hide-when-small"> {key}</span>
+                        </>
+                    )}
+                />
+            </div>
+        ),
+        interval: (
+            <div>
+                <label className="text-sm font-medium mb-2 block">Interval</label>
+                <LemonSelect<IntervalType | null>
+                    size="small"
+                    value={overrides.interval ?? null}
+                    dropdownMatchSelectWidth={false}
+                    disabledReason={
+                        supportsInterval ? undefined : "This insight type doesn't support an interval override"
+                    }
+                    onChange={(interval) => setInterval(interval)}
+                    options={[
+                        { value: null, label: 'inherit' },
+                        { value: 'hour', label: 'hour' },
+                        { value: 'day', label: 'day' },
+                        { value: 'week', label: 'week' },
+                        { value: 'month', label: 'month' },
+                    ]}
+                    data-attr="tile-override-interval"
+                />
+            </div>
+        ),
+        properties: (
+            <div>
+                <label className="text-sm font-medium mb-2 block">Properties</label>
+                <PropertyFilters
+                    onChange={(properties) => setProperties(properties)}
+                    pageKey={`tile_${tile.id}_properties`}
+                    propertyFilters={overrides.properties ?? []}
+                    taxonomicGroupTypes={[
+                        TaxonomicFilterGroupType.EventProperties,
+                        TaxonomicFilterGroupType.PersonProperties,
+                        TaxonomicFilterGroupType.EventFeatureFlags,
+                        TaxonomicFilterGroupType.EventMetadata,
+                        ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
+                        ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
+                        TaxonomicFilterGroupType.EmailAddresses,
+                        ...groupsTaxonomicTypes,
+                        TaxonomicFilterGroupType.Cohorts,
+                        TaxonomicFilterGroupType.Elements,
+                        TaxonomicFilterGroupType.SessionProperties,
+                        TaxonomicFilterGroupType.HogQLExpression,
+                        TaxonomicFilterGroupType.DataWarehousePersonProperties,
+                    ]}
+                />
+            </div>
+        ),
+        testAccounts: (
+            <div>
+                <div className="flex items-center gap-1 mb-2">
+                    <label className="text-sm font-medium">Test account filtering</label>
+                    <LemonButton
+                        icon={<IconGear />}
+                        size="xsmall"
+                        noPadding
+                        to={urls.settings('project-product-analytics', 'internal-user-filtering')}
+                        tooltip="Configure internal and test account filters"
+                    />
+                </div>
+                <LemonSegmentedButton<TestAccountFilterChoice>
+                    size="small"
+                    value={testAccountChoice}
+                    onChange={(next) => setFilterTestAccounts(CHOICE_TO_FILTER[next])}
+                    options={[
+                        {
+                            value: 'inherit',
+                            label: 'Inherit',
+                            tooltip: "Use the dashboard's setting, or the insight's own",
+                            'data-attr': 'tile-test-account-filter-inherit',
+                        },
+                        {
+                            value: 'filter-out',
+                            label: 'Filter out',
+                            tooltip: 'Force test account filtering on for this insight',
+                            disabledReason: !hasTestAccountFilters
+                                ? "You haven't set any internal test filters. Click the gear icon to configure."
+                                : undefined,
+                            'data-attr': 'tile-test-account-filter-out',
+                        },
+                        {
+                            value: 'include',
+                            label: 'Include',
+                            tooltip: 'Force test account filtering off for this insight',
+                            'data-attr': 'tile-test-account-filter-include',
+                        },
+                    ]}
+                />
+                <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
+            </div>
+        ),
+        breakdown: (
+            <div>
+                <label className="text-sm font-medium mb-2 block">Breakdown</label>
+                <BindLogic logic={insightLogic} props={breakdownInsightProps}>
+                    <TaxonomicBreakdownFilter
+                        insightProps={breakdownInsightProps}
+                        breakdownFilter={overrides.breakdown_filter}
+                        isTrends={false}
+                        isFunnels={false}
+                        showLabel={false}
+                        disabledReason={
+                            supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
+                        }
+                        updateBreakdownFilter={(breakdown_filter) => {
+                            let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
+                            // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
+                            if (breakdown_filter && !breakdown_filter.breakdown_type && !breakdown_filter.breakdowns) {
+                                newBreakdownFilter = null
+                            }
+                            setBreakdown(newBreakdownFilter)
+                        }}
+                        updateDisplay={() => {}}
+                        disablePropertyInfo
+                        size="small"
+                    />
+                </BindLogic>
+            </div>
+        ),
+    }
+
     return (
         <div className="space-y-4 tile-filters-override">
             <div>
@@ -78,163 +236,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                 </p>
             </div>
 
-            <div className="flex flex-col gap-4">
-                <div>
-                    <LemonSwitch
-                        checked={!!overrides.ignoreDashboardFilters}
-                        onChange={setIgnoreDashboardFilters}
-                        label="Ignore dashboard filters"
-                        bordered
-                        fullWidth
-                        data-attr="tile-ignore-dashboard-filters"
-                    />
-                    <p className="text-xs text-muted mt-1 mb-0">
-                        When on, none of the dashboard's filters apply to this insight. The overrides below still do.
-                    </p>
-                </div>
-
-                <LemonDivider className="mb-2" />
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Date range</label>
-                    <DateFilter
-                        showCustom
-                        showExplicitDateToggle
-                        dateFrom={overrides.date_from ?? null}
-                        dateTo={overrides.date_to ?? null}
-                        explicitDate={overrides.explicitDate}
-                        onChange={(from, to, explicitDate) => setDates(from, to, explicitDate)}
-                        makeLabel={(key) => (
-                            <>
-                                <IconCalendar />
-                                <span className="hide-when-small"> {key}</span>
-                            </>
-                        )}
-                    />
-                </div>
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Interval</label>
-                    <LemonSelect<IntervalType | null>
-                        size="small"
-                        value={overrides.interval ?? null}
-                        dropdownMatchSelectWidth={false}
-                        disabledReason={
-                            supportsInterval ? undefined : "This insight type doesn't support an interval override"
-                        }
-                        onChange={(interval) => setInterval(interval)}
-                        options={[
-                            { value: null, label: 'inherit' },
-                            { value: 'hour', label: 'hour' },
-                            { value: 'day', label: 'day' },
-                            { value: 'week', label: 'week' },
-                            { value: 'month', label: 'month' },
-                        ]}
-                        data-attr="tile-override-interval"
-                    />
-                </div>
-
-                <LemonDivider className="mb-2" />
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Properties</label>
-                    <PropertyFilters
-                        onChange={(properties) => setProperties(properties)}
-                        pageKey={`tile_${tile.id}_properties`}
-                        propertyFilters={overrides.properties ?? []}
-                        taxonomicGroupTypes={[
-                            TaxonomicFilterGroupType.EventProperties,
-                            TaxonomicFilterGroupType.PersonProperties,
-                            TaxonomicFilterGroupType.EventFeatureFlags,
-                            TaxonomicFilterGroupType.EventMetadata,
-                            ...(hasPageview ? [TaxonomicFilterGroupType.PageviewUrls] : []),
-                            ...(hasScreen ? [TaxonomicFilterGroupType.Screens] : []),
-                            TaxonomicFilterGroupType.EmailAddresses,
-                            ...groupsTaxonomicTypes,
-                            TaxonomicFilterGroupType.Cohorts,
-                            TaxonomicFilterGroupType.Elements,
-                            TaxonomicFilterGroupType.SessionProperties,
-                            TaxonomicFilterGroupType.HogQLExpression,
-                            TaxonomicFilterGroupType.DataWarehousePersonProperties,
-                        ]}
-                    />
-                </div>
-
-                <div>
-                    <div className="flex items-center gap-1 mb-2">
-                        <label className="text-sm font-medium">Test account filtering</label>
-                        <LemonButton
-                            icon={<IconGear />}
-                            size="xsmall"
-                            noPadding
-                            to={urls.settings('project-product-analytics', 'internal-user-filtering')}
-                            tooltip="Configure internal and test account filters"
-                        />
-                    </div>
-                    <LemonSegmentedButton<TestAccountFilterChoice>
-                        size="small"
-                        value={testAccountChoice}
-                        onChange={(next) => setFilterTestAccounts(CHOICE_TO_FILTER[next])}
-                        options={[
-                            {
-                                value: 'inherit',
-                                label: 'Inherit',
-                                tooltip: "Use the dashboard's setting, or the insight's own",
-                                'data-attr': 'tile-test-account-filter-inherit',
-                            },
-                            {
-                                value: 'filter-out',
-                                label: 'Filter out',
-                                tooltip: 'Force test account filtering on for this insight',
-                                disabledReason: !hasTestAccountFilters
-                                    ? "You haven't set any internal test filters. Click the gear icon to configure."
-                                    : undefined,
-                                'data-attr': 'tile-test-account-filter-out',
-                            },
-                            {
-                                value: 'include',
-                                label: 'Include',
-                                tooltip: 'Force test account filtering off for this insight',
-                                'data-attr': 'tile-test-account-filter-include',
-                            },
-                        ]}
-                    />
-                    <p className="text-xs text-muted mt-1 mb-0">{CHOICE_HINTS[testAccountChoice]}</p>
-                </div>
-
-                <LemonDivider className="mb-2" />
-
-                <div>
-                    <label className="text-sm font-medium mb-2 block">Breakdown</label>
-                    <BindLogic logic={insightLogic} props={breakdownInsightProps}>
-                        <TaxonomicBreakdownFilter
-                            insightProps={breakdownInsightProps}
-                            breakdownFilter={overrides.breakdown_filter}
-                            isTrends={false}
-                            isFunnels={false}
-                            showLabel={false}
-                            disabledReason={
-                                supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
-                            }
-                            updateBreakdownFilter={(breakdown_filter) => {
-                                let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
-                                // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
-                                if (
-                                    breakdown_filter &&
-                                    !breakdown_filter.breakdown_type &&
-                                    !breakdown_filter.breakdowns
-                                ) {
-                                    newBreakdownFilter = null
-                                }
-                                setBreakdown(newBreakdownFilter)
-                            }}
-                            updateDisplay={() => {}}
-                            disablePropertyInfo
-                            size="small"
-                        />
-                    </BindLogic>
-                </div>
-            </div>
+            <TileFiltersOverrideSections fields={fields} />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The tile override modal from #77361 groups its controls with plain dividers. I'm not sure that's the clearest way to section it. Rather than argue over static mockups, this stacks a throwaway prototype on top of that PR so we can flip through five sectioning styles live in the browser and pick one.

Stacked on #77361. Throwaway: the winner gets hand-folded back into #77361, then this branch and the switcher get deleted.

## Changes

The six wired control blocks in `TileFiltersOverride.tsx` move into a `fields` record. Layout is delegated to a new throwaway `TileFiltersOverride.prototype.tsx`, which renders one of five sectionings of those same controls.

| Key | Variant | What it does |
| --- | --- | --- |
| A | Plain dividers | Today's layout: groups split by a bare `LemonDivider` |
| B | Labeled dividers | The group name sits inside the divider line |
| C | Group headings | Small left-aligned heading above each group, no hairlines |
| D | Bordered cards | Each group in its own `LemonCard` |
| E | Collapse accordion | One `LemonCollapse` panel per group |

Same grouping in every variant (Scope / Time / Filters / Display) so only the sectioning chrome differs.

Switch with the `?tileOverrideVariant=A..E` search param or the dev-only floating bar (prev/next arrows, `←` / `→` keys). The bar and the variant logic are gated on `NODE_ENV !== 'production'`, so production always renders variant A with no switcher. Production behavior is unchanged.

> [!NOTE]
> To view: open a dashboard, a tile's ⋯ menu → "Set override", then use the floating bar at the bottom of the screen (or append `?tileOverrideVariant=C` to the URL).

## How did you test this code?

- `tsgo --noEmit` and `oxlint` + `oxfmt` pass on both changed files. The only typecheck errors in the tree are pre-existing `@posthog/quill` module-resolution failures, unrelated to this change.
- I (Claude) did not stand up the dev stack in this cloud environment, so I have not rendered the variants myself. Flip through them locally with the switcher.
- No automated tests: this is throwaway prototype code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not applicable — throwaway prototype, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas drove this: he asked for options to section the override modal, I listed five, and he asked to prototype them in a stacked PR. Built by Claude (Opus) in Claude Code.

Skills invoked: `/prototype` (the UI branch — several radically different variations on one route, switchable via a search param and a floating bar).

Decisions:
- Sub-shape A (embed variants in the existing modal, gated by a search param) over a standalone throwaway route — a modal in isolation hides density problems the real dashboard exposes.
- Kept production pinned to variant A behind a `NODE_ENV` gate so a stray merge can't ship the switcher.
- Delegated layout to a separate `.prototype.tsx` so folding the winner into #77361 is a clean move and deleting the rest is one file plus one import.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
