### PR TITLE
feat(data-modeling): count which scheduling backend materializations land on

### DIFF
--- a/products/data_modeling/backend/logic/schedule_metrics.py
+++ b/products/data_modeling/backend/logic/schedule_metrics.py
@@ -1,0 +1,26 @@
+"""Which scheduling backend each materialization lands on, and why.
+
+Counting saved queries with a lingering `sync_frequency_interval` tells you a query sits on v1,
+but not which branch put it there, and it cannot distinguish a team that is merely unmigrated
+from a genuine regression. Recording the decision as it is made does both, so "are we still
+minting v1 schedules where we shouldn't" is answerable without a Postgres sweep.
+"""
+
+from posthog.otel_metrics import OtelInstrumentFactory
+
+_otel = OtelInstrumentFactory("data-modeling")
+
+SCHEDULE_BACKEND_METRIC = "data_modeling.materialization.scheduled"
+
+
+def record_schedule_backend(*, backend: str, reason: str) -> None:
+    """Record one materialization against the backend chosen for it.
+
+    `backend` is "v1" or "v2"; `reason` is which branch chose it. Both are closed sets, so the
+    series count stays fixed. Deliberately carries no team id: which teams are on v1 is already
+    a Postgres query, whereas the branch taken exists only at this moment.
+    """
+    _otel.counter(
+        SCHEDULE_BACKEND_METRIC,
+        description="Materializations by the scheduling backend chosen for them, and the reason",
+    ).add(1, {"backend": backend, "reason": reason})

--- a/products/data_modeling/backend/logic/schedule_reconcile.py
+++ b/products/data_modeling/backend/logic/schedule_reconcile.py
@@ -14,6 +14,7 @@ import uuid
 import dataclasses
 from collections.abc import Iterable
 from datetime import timedelta
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -143,8 +144,19 @@ def dag_has_live_v1_schedules(dag: DAG) -> bool:
     return False
 
 
-def dag_can_bootstrap_to_tiers(dag: DAG) -> bool:
-    """Whether this DAG can be born straight onto cadence tiers. Decides only — no side effects.
+class BootstrapDecline(StrEnum):
+    """Why a DAG could not be born onto cadence tiers, and so falls back to a v1 schedule."""
+
+    TIERING_DISABLED = "tiering_disabled"
+    LIVE_V1_SCHEDULES = "live_v1_schedules"
+
+
+def dag_bootstrap_decline_reason(dag: DAG) -> BootstrapDecline | None:
+    """Why this DAG cannot be born straight onto cadence tiers, or None when it can.
+
+    Decides only, no side effects. Returning the reason rather than a bare bool is what lets
+    the caller label its "which backend did this materialization land on" metric, so a v1
+    schedule appearing somewhere unexpected is visible without querying for it after the fact.
 
     Callers reach this only once the v2 lookup has said the DAG has no `execute-dag` schedule.
     Adding "and no live v1 schedules either" identifies a DAG that nothing has ever scheduled —
@@ -157,8 +169,10 @@ def dag_can_bootstrap_to_tiers(dag: DAG) -> bool:
     materialize everything twice. It stays for a migration command to convert and sweep.
     """
     if not tiered_schedules_enabled(dag.team):
-        return False
-    return not dag_has_live_v1_schedules(dag)
+        return BootstrapDecline.TIERING_DISABLED
+    if dag_has_live_v1_schedules(dag):
+        return BootstrapDecline.LIVE_V1_SCHEDULES
+    return None
 
 
 def bootstrap_dag_to_tiers(dag: DAG) -> None:
@@ -166,8 +180,8 @@ def bootstrap_dag_to_tiers(dag: DAG) -> None:
 
     Everything here is a side effect, and `transaction.on_commit` runs the callback immediately
     for callers that are not inside an atomic block — so call this only once
-    `dag_can_bootstrap_to_tiers` has said yes, and only after whatever frequency validation the
-    caller does, never before.
+    `dag_bootstrap_decline_reason` has returned None, and only after whatever frequency
+    validation the caller does, never before.
 
     Reconciles without `require_tiered`, because this is the pass that creates the DAG's first
     tier schedules: `maybe_reconcile_dag` cannot stand in for it, since it declines a DAG that

--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -203,10 +203,11 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
             UnsatisfiableFrequencyError,
             UnsupportedFrequencyTargetError,
         )
+        from products.data_modeling.backend.logic.schedule_metrics import record_schedule_backend
         from products.data_modeling.backend.logic.schedule_reconcile import (
             apply_saved_query_frequency_target,
             bootstrap_dag_to_tiers,
-            dag_can_bootstrap_to_tiers,
+            dag_bootstrap_decline_reason,
             tiered_schedules_enabled,
         )
         from products.data_modeling.backend.models.node import Node
@@ -224,6 +225,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
             # is_materialized=True with no schedule backing it.
             on_v2 = self.id in get_v2_saved_query_ids([self.id])
             dag_to_bootstrap = None
+            backend_reason = "existing_v2_schedule"
             if not on_v2:
                 # Nothing creates a DAG's first v2 schedule outside the migration commands, so a
                 # brand-new team would fall through to v1 forever. Bootstrap it instead — declined
@@ -233,9 +235,17 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
                     .select_related("dag", "dag__team")
                     .first()
                 )
-                if node is not None and node.dag is not None and dag_can_bootstrap_to_tiers(node.dag):
-                    dag_to_bootstrap = node.dag
-                    on_v2 = True
+                if node is None or node.dag is None:
+                    backend_reason = "no_dag_node"
+                else:
+                    decline = dag_bootstrap_decline_reason(node.dag)
+                    if decline is None:
+                        dag_to_bootstrap = node.dag
+                        on_v2 = True
+                        backend_reason = "bootstrapped"
+                    else:
+                        backend_reason = decline.value
+            record_schedule_backend(backend="v2" if on_v2 else "v1", reason=backend_reason)
 
             if on_v2:
                 # Tiered v2: the interval is one-shot transport for frequency intent — consume

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -3,9 +3,12 @@ from datetime import timedelta
 from posthog.test.base import BaseTest
 from unittest import mock
 
+from parameterized import parameterized
+
 from products.data_modeling.backend.logic.cohort_scheduling import is_tier_schedule_id
 from products.data_modeling.backend.logic.freshness import UnsupportedFrequencyTargetError
 from products.data_modeling.backend.logic.node_frequency import get_declared_target, set_declared_target
+from products.data_modeling.backend.logic.schedule_reconcile import BootstrapDecline, dag_bootstrap_decline_reason
 from products.data_modeling.backend.models import DAG, Node
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.models.node import NodeType
@@ -125,6 +128,26 @@ class TestScheduleMaterializationV2Guard(BaseTest):
         ):
             self.sq.schedule_materialization()
         sync_wf.assert_called_once()
+
+    @parameterized.expand(
+        [
+            ("virgin", True, False, None),
+            ("flag_off", False, False, BootstrapDecline.TIERING_DISABLED),
+            ("unmigrated", True, True, BootstrapDecline.LIVE_V1_SCHEDULES),
+        ]
+    )
+    def test_bootstrap_decline_reason_names_the_blocker(
+        self, _name: str, tiering_enabled: bool, has_v1_schedule: bool, expected: BootstrapDecline | None
+    ):
+        # this reason labels the backend metric, so reporting the wrong one points the migration
+        # drive at the wrong blocker: an unmigrated team reading as "tiering is off" looks like a
+        # flag problem to go fix, when the DAG is in fact correctly declined until it is migrated
+        with (
+            mock.patch(f"{RECONCILE}.feature_enabled_or_false", return_value=tiering_enabled),
+            mock.patch(f"{RECONCILE}.schedule_exists", return_value=has_v1_schedule),
+            mock.patch(f"{RECONCILE}.sync_connect"),
+        ):
+            assert dag_bootstrap_decline_reason(self.dag) == expected
 
     def test_rejected_frequency_leaves_a_virgin_dag_unbootstrapped(self):
         # the bootstrap is all side effects, and on_commit fires immediately for the callers that


### PR DESCRIPTION
## Problem

We just stopped new teams being born on v1 per-query schedules ([#76635](https://github.com/PostHog/posthog/pull/76635)).
Confirming that it stayed fixed currently means sweeping Postgres for saved queries with a lingering `sync_frequency_interval`.

That sweep answers the wrong question. It tells you a query sits on v1, but not which branch put it there, and it cannot separate the two cases that matter:

- an unmigrated team, where declining to bootstrap is **correct** and the query should be on v1
- a regression, where a DAG that should have been born on tiers fell through to v1

Those look identical after the fact. The branch taken exists only at the moment the decision is made.

## Changes

One counter, `data_modeling.materialization.scheduled`, recorded at the decision point in `schedule_materialization`:

| backend | reason | meaning |
| --- | --- | --- |
| `v2` | `existing_v2_schedule` | the DAG already had an execute-dag schedule |
| `v2` | `bootstrapped` | a never-scheduled DAG was born onto cadence tiers |
| `v1` | `live_v1_schedules` | unmigrated team, correctly declined |
| `v1` | `tiering_disabled` | the tiered-schedules flag is off for the team |
| `v1` | `no_dag_node` | the saved query has no DAG node to bootstrap from |

Two of those are structurally zero today, which is what makes this alertable rather than merely observable.
`tiering_disabled` can only fire if the tiered-schedules flag regresses, since it is rolled out to every organization.
`no_dag_node` can only fire if DAG sync failed to create a node for a saved query.
The third v1 series is the expected one, and doubles as a burn-down for the migration work.

`dag_can_bootstrap_to_tiers` becomes `dag_bootstrap_decline_reason` and returns why it declined instead of a bare bool.
The label is then the decision itself, so a new decline branch cannot be added without giving it a label.

Five fixed series, and deliberately no team id.
Which teams sit on v1 is already a Postgres query; the branch taken is not recoverable any other way.

> [!NOTE]
> This covers the runtime path only. `create_missing_saved_query_schedules` also creates v1 schedules, and is not counted - it is operator-run and explicit, so it is not part of "where are we minting these unexpectedly".

Routed to the PostHog Metrics product through `OtelInstrumentFactory`.
The surrounding code uses `prometheus_client`, but per the metrics guidance a prom instrument is for keeping an existing Grafana series alive, and no dashboard depends on a metric that did not exist.

## How did you test this code?

Automated tests only. I have not observed the metric arrive in the Metrics product, since the OTel factory no-ops locally without `OTEL_METRICS_EXPORT_URL`/`_TOKEN`.

Three parameterized cases in `test_bootstrap_decline_reason_names_the_blocker`, one per branch.
The regression they catch: a wrong reason points the migration work at the wrong blocker.
An unmigrated team reported as `tiering_disabled` reads as a flag problem to go fix, when the DAG is in fact correctly declined until it is migrated.
No existing test asserted on the reason, only on which schedule got created, so all of them pass with the labels swapped.

Suite: `products/data_modeling/backend/` 584 passed, 1 skipped.
`ruff` clean, and repo-wide `mypy` reports no errors in the changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - this adds internal instrumentation with no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) built this after verifying in production that new teams are now born on tiered schedules.
The verification itself was the motivation: proving it took a Postgres sweep plus a control window either side of the deploy, and even then the result was a proxy rather than the decision.

The design choice worth reviewing is returning a reason from the decision function rather than emitting the metric from inside it.
Emitting from inside `schedule_reconcile` would have kept the caller unchanged, but the caller also owns two branches the reconcile module cannot see (`existing_v2_schedule` and `no_dag_node`), so the counter would have been split across two modules with no single place showing the full set.

I also considered adding `team_id` as an attribute. Rejected: roughly 178 teams currently carry v1 schedules, so the cardinality is survivable, but it duplicates something Postgres already answers better, and it grows without bound as teams are added.

Skills invoked: `/instrumenting-first-party-metrics` (which is what settled OTel over `prometheus_client` here, and the no-high-cardinality-attributes rule) and `/writing-tests`.
