### PR TITLE
feat(signals): render scratchpad notes as inbox-style snippets

### DIFF
--- a/frontend/src/scenes/inbox/components/scratchpad/ScratchpadEntryCard.tsx
+++ b/frontend/src/scenes/inbox/components/scratchpad/ScratchpadEntryCard.tsx
@@ -8,6 +8,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+import { stripMarkdown } from 'lib/utils/markdown'
 
 import type { ScratchpadEntryApi } from 'products/signals/frontend/generated/api.schemas'
 
@@ -40,8 +41,12 @@ function splitKey(key: string): { kind: string | null; body: string } {
 /**
  * One scratchpad note the scout fleet has written about this project. Shares the collapse/expand
  * grammar of the scout emission cards: a header (chevron · kind · key · updated time) that stays
- * visible, a 2-line markdown preview when collapsed, the full body plus an attribution footer
+ * visible, a 2-line plain-text snippet when collapsed, the full body plus an attribution footer
  * (which scout created it, when, and how long it's been carried forward) when open.
+ *
+ * Scouts write whatever markdown they like — `#` headings, bold runs, nested lists — so collapsed
+ * cards strip it to plain text (uniform snippets, like an email inbox) and expanded cards render it
+ * low-key (headings as bold text) so one note's formatting can't shout over the list.
  *
  * The list only carries previews, so a long note's tail arrives on expand — until it lands, the
  * preview stays on screen with a skeleton under it rather than the card going blank.
@@ -90,12 +95,15 @@ export function ScratchpadEntryCard({ entry }: { entry: ScratchpadEntryApi }): J
             </button>
 
             <div className="px-3 pb-2 pl-9">
-                <LemonMarkdown
-                    disableImages
-                    className={expanded ? 'text-sm text-primary' : 'text-sm text-primary line-clamp-2'}
-                >
-                    {content || '_No content._'}
-                </LemonMarkdown>
+                {expanded ? (
+                    <LemonMarkdown disableImages lowKeyHeadings className="text-sm text-primary">
+                        {content || '_No content._'}
+                    </LemonMarkdown>
+                ) : (
+                    <p className="mb-0 text-sm text-secondary line-clamp-2">
+                        {content ? stripMarkdown(content).replace(/\s+/g, ' ') : 'No content.'}
+                    </p>
+                )}
 
                 {expanded && isLoadingContent && <LemonSkeleton className="h-4 w-2/3 mt-1" />}
 

--- a/frontend/src/scenes/inbox/components/scratchpad/ScratchpadPanel.stories.tsx
+++ b/frontend/src/scenes/inbox/components/scratchpad/ScratchpadPanel.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import type { ScratchpadEntryApi } from 'products/signals/frontend/generated/api.schemas'
+
+import { ScratchpadPanel } from './ScratchpadPanel'
+
+// Scouts write whatever markdown suits them, so the mock bodies deliberately mix headings,
+// bold runs, nested bullets, and plain prose — the panel has to read evenly across all of it.
+const mockEntries: ScratchpadEntryApi[] = [
+    {
+        key: 'report:slo_monitoring:analytic-platform:export:US',
+        content:
+            'Report 019f94de remains the live pending-input US export SLO report, refreshed 2026-08-05 with continued TableAccessDeniedError-led burn.',
+        created_at: '2026-08-01T06:35:04Z',
+        updated_at: '2026-08-05T12:05:59Z',
+        created_by_run_id: 'run-1',
+        created_by_skill: 'signals-scout-slo-monitoring',
+        created_by_run_url: '/tasks/run-1',
+    },
+    {
+        key: 'dedupe:slo_monitoring:analytic-platform:export:US',
+        content:
+            '## Live-covered breach – refreshed 2026-08-05 11:05 UTC\n\n- Report 019f94de remains canonical and was edited in place.\n- No new report minted for the continuing breach.',
+        created_at: '2026-08-02T06:35:04Z',
+        updated_at: '2026-08-05T12:05:58Z',
+        created_by_run_id: 'run-2',
+        created_by_skill: 'signals-scout-slo-monitoring',
+        created_by_run_url: '/tasks/run-2',
+    },
+    {
+        key: 'pattern:slo_monitoring:latest-summary',
+        content:
+            '# Latest SLO scan – 2026-08-05 11:05 UTC\n\n- Checked all 16 canonical US/EU operation-region pairs with the refreshed 28-day insights.\n- **Latest complete hour** coverage reached across every family.\n- No new breach beyond the live-covered US export burn.',
+        created_at: '2026-08-03T06:35:04Z',
+        updated_at: '2026-08-05T12:05:58Z',
+        created_by_run_id: 'run-3',
+        created_by_skill: 'signals-scout-slo-monitoring',
+        created_by_run_url: '/tasks/run-3',
+    },
+    {
+        key: 'baseline:self_driving_dashboards:insight:WdDay8ev',
+        content:
+            '### MCP p95 latency baseline\n\n- **Refreshed:** 2026-08-05 UTC.\n- Latest reliable complete hour remained populated across families: scouts about **375 ms**, inbox about **2.36 s**, workflows about **1.14 s**.\n- The detector returned no triggered dates for the current 14-day family latency series; no broad p95 regression established.',
+        created_at: '2026-08-01T06:35:04Z',
+        updated_at: '2026-08-05T12:05:36Z',
+        created_by_run_id: 'run-4',
+        created_by_skill: 'signals-scout-self-driving-dashboards',
+        created_by_run_url: '/tasks/run-4',
+    },
+    {
+        key: 'watch:error_tracking:new-release-regression',
+        content:
+            'Watching `TypeError: e.map is not a function` in the dashboard scene after the 1.43 release; volume still under the alert floor but climbing (~40/day).',
+        created_at: '2026-08-04T06:35:04Z',
+        updated_at: '2026-08-05T09:12:00Z',
+        created_by_run_id: null,
+        created_by_skill: 'signals-scout-error-tracking',
+        created_by_run_url: null,
+    },
+    {
+        key: 'tags:errors:taxonomy',
+        content:
+            'Settled vocabulary for error grouping:\n\n1. `ingestion` – capture + pipeline failures\n2. `query` – ClickHouse timeouts and OOMs\n3. `frontend` – scene-level TypeErrors',
+        created_at: '2026-07-20T06:35:04Z',
+        updated_at: '2026-08-05T08:00:00Z',
+        created_by_run_id: 'run-6',
+        created_by_skill: 'signals-scout-general',
+        created_by_run_url: '/tasks/run-6',
+    },
+]
+
+const meta: Meta = {
+    title: 'Scenes-App/Inbox/Scratchpad',
+    component: ScratchpadPanel,
+    parameters: {
+        layout: 'fullscreen',
+        viewMode: 'story',
+        mockDate: '2026-08-05',
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:id/signals/scout/scratchpad/': () => [200, mockEntries],
+            },
+        }),
+    ],
+}
+export default meta
+
+type Story = StoryObj
+
+export const Scratchpad: Story = {}
+
+export const EmptyScratchpad: Story = {
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:id/signals/scout/scratchpad/': () => [200, []],
+            },
+        }),
+    ],
+}


### PR DESCRIPTION
## Problem

Scouts write scratchpad notes in arbitrary markdown, and the scratchpad list rendered each body at full strength. A note starting with `#` or `##` showed up as a large bordered heading inside a small list card, so the list read unevenly — some cards shouting, others plain.

## Changes

- Collapsed cards now show a two-line plain-text snippet (markdown stripped via the existing `stripMarkdown` util), like an email inbox preview — uniform regardless of what the scout wrote.
- Expanded cards still render markdown, but with `LemonMarkdown`'s `lowKeyHeadings`, so headings become bold text instead of full-size h1/h2.
- Added a Storybook story for `ScratchpadPanel` with mock notes covering the messy markdown variants (headings, bold runs, lists, plain prose).

Collapsed list (mock data):

![scratchpad-after-collapsed](https://raw.githubusercontent.com/PostHog/pr-assets/3b4abfaec4e67a4f6bf4c36e6506683ca0c62324/2026/08/d6f203dd-a94f-4a99-8538-9a745dd3c48e.png)

Expanded card with a heading-heavy note (mock data):

![scratchpad-after-expanded](https://raw.githubusercontent.com/PostHog/pr-assets/ba56699ff8fb3d68248aab54f588a0c4b29a344b/2026/08/c5ece48c-4bf2-4136-8b06-c04558f9ccb7.png)

## How did you test this code?

- Rendered the new `ScratchpadPanel` stories in Storybook headless and screenshotted collapsed and expanded states (images above).
- `tsgo --noEmit` clean; `pnpm --filter=@posthog/frontend fix` clean.
- No manual testing against a live project.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude). Skills consulted: `/writing-pr-descriptions`, `/writing-code-comments`. Considered showing raw markdown source in collapsed cards, but stripping to plain text reads cleaner while keeping full (low-key) rendering on expand.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
