### PR TITLE
fix(dashboards): tolerate legacy keys in persisted dashboard filters

### DIFF
--- a/posthog/api/services/query.py
+++ b/posthog/api/services/query.py
@@ -33,6 +33,7 @@ from posthog.cloud_utils import is_cloud
 from posthog.event_usage import AnalyticsProps
 from posthog.exceptions import DatabaseSchemaUnavailable
 from posthog.exceptions_capture import capture_exception
+from posthog.hogql_queries.apply_dashboard_filters import normalize_dashboard_filters
 from posthog.hogql_queries.query_runner import CacheMissResponse, ExecutionMode, QueryResponse, get_query_runner_or_none
 from posthog.models import Team, User
 from posthog.rbac.user_access_control import UserAccessControl, UserAccessControlError
@@ -154,7 +155,13 @@ def process_query_dict(
 
     tag_queries(query=upgraded_query_json)
 
-    dashboard_filters = DashboardFilter.model_validate(dashboard_filters_json) if dashboard_filters_json else None
+    # Callers pass persisted `Dashboard.filters` blobs (e.g. cache warming) or merged filter dicts
+    # here, so legacy keys must be normalized away before the extra="forbid" model sees them.
+    dashboard_filters = (
+        DashboardFilter.model_validate(normalize_dashboard_filters(dashboard_filters_json))
+        if dashboard_filters_json
+        else None
+    )
     variables_override = (
         [HogQLVariable.model_validate(n) for n in variables_override_json.values()] if variables_override_json else None
     )

--- a/posthog/caching/calculate_results.py
+++ b/posthog/caching/calculate_results.py
@@ -4,14 +4,17 @@ import orjson
 import structlog
 from pydantic import BaseModel
 
-from posthog.schema import CacheMissResponse, DashboardFilter
+from posthog.schema import CacheMissResponse
 
 from posthog.hogql.constants import LimitContext
 
 from posthog.api.services.query import ExecutionMode, RawCachedQueryResponse, process_query_dict
 from posthog.clickhouse.query_tagging import get_team_query_tags, tag_queries
 from posthog.event_usage import AnalyticsProps
-from posthog.hogql_queries.apply_dashboard_filters import resolve_effective_dashboard_filters
+from posthog.hogql_queries.apply_dashboard_filters import (
+    dashboard_filter_from_dict,
+    resolve_effective_dashboard_filters,
+)
 from posthog.hogql_queries.query_runner import get_query_runner_or_none, response_results_contain_models
 from posthog.models import Team, User
 from posthog.schema_migrations.upgrade_manager import upgrade_query
@@ -66,7 +69,7 @@ def calculate_cache_key(target: Union[DashboardTile, Insight]) -> Optional[str]:
                 if query_runner is None:
                     return None  # Uncacheable query-based insight
                 if dashboard is not None and dashboard.filters:
-                    query_runner.apply_dashboard_filters(DashboardFilter(**dashboard.filters))
+                    query_runner.apply_dashboard_filters(dashboard_filter_from_dict(dashboard.filters))
                 return query_runner.get_cache_key()
 
             if insight.filters:

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -193,8 +193,19 @@ def normalize_dashboard_filters_properties(filters: dict) -> dict:
 
 # Legacy dashboard-filter keys that map 1:1 onto a modern DashboardFilter field. Persisted
 # `Dashboard.filters` blobs and REST clients built against the legacy insight filter format
-# still use the snake_case spelling.
-_LEGACY_FILTER_KEY_ALIASES = {"filter_test_accounts": "filterTestAccounts"}
+# still use the snake_case spelling. Legacy `explicit_date` values are the strings
+# "true"/"false" (see posthog/models/filters/mixins/common.py), which pydantic coerces to bool.
+_LEGACY_FILTER_KEY_ALIASES = {
+    "filter_test_accounts": "filterTestAccounts",
+    "explicit_date": "explicitDate",
+}
+
+
+def dropped_dashboard_filter_keys(filters: dict) -> list[str]:
+    """Keys `normalize_dashboard_filters` drops because they have no modern DashboardFilter field."""
+    return sorted(
+        key for key in filters if _LEGACY_FILTER_KEY_ALIASES.get(key, key) not in DashboardFilter.model_fields
+    )
 
 
 def normalize_dashboard_filters(filters: dict) -> dict:
@@ -302,8 +313,9 @@ def resolve_effective_dashboard_filters(
         else _without_ignore_flag(base_filters or {})
     )
     # `merge_filters_by_priority` can early-return a raw layer (and a single layer is unmerged), so
-    # `properties` may still be a group dict here — normalize before it reaches `DashboardFilter`.
-    effective_filters = normalize_dashboard_filters_properties(effective_filters)
+    # legacy keys may survive and `properties` may still be a group dict here — normalize the whole
+    # dict before it reaches `DashboardFilter` in downstream consumers like `process_query_dict`.
+    effective_filters = normalize_dashboard_filters(effective_filters)
     if effective_filters and not _has_data_warehouse_series(query):
         query = remove_query_properties_overridden_by(query, effective_filters)
     return query, effective_filters
@@ -315,6 +327,8 @@ def dashboard_filter_from_dict(filters: dict) -> DashboardFilter:
     Callers like Insight.get_effective_query pass client-supplied filter dicts here without going
     through the merge functions, so this is the final guard before the extra="forbid" model: the
     tile-only ignoreDashboardFilters flag and legacy keys are normalized away instead of raising.
+    The tolerance is key-level only; invalid values on known fields, and property shapes
+    `flatten_property_leaves` rejects, still raise.
     """
     return DashboardFilter(**normalize_dashboard_filters(filters))
 

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -191,6 +191,34 @@ def normalize_dashboard_filters_properties(filters: dict) -> dict:
     return {**filters, "properties": flattened}
 
 
+# Legacy dashboard-filter keys that map 1:1 onto a modern DashboardFilter field. Persisted
+# `Dashboard.filters` blobs and REST clients built against the legacy insight filter format
+# still use the snake_case spelling.
+_LEGACY_FILTER_KEY_ALIASES = {"filter_test_accounts": "filterTestAccounts"}
+
+
+def normalize_dashboard_filters(filters: dict) -> dict:
+    """Normalize a persisted or client-supplied dashboard filter dict to the DashboardFilter contract.
+
+    `Dashboard.filters` is persisted opaquely and `filters_override` comes straight from clients, so
+    real-world dicts carry legacy keys (snake_case `filter_test_accounts`, top-level `breakdown` /
+    `breakdown_type`) as well as grouped properties. Aliases with a modern equivalent are mapped onto
+    that field, and keys `DashboardFilter` doesn't know are dropped, because its extra="forbid" would
+    otherwise reject the whole filter set and with it every tile on the dashboard. Grouped properties
+    are flattened to the leaf-list contract.
+    """
+    normalized: dict = {}
+    for key, value in filters.items():
+        canonical = _LEGACY_FILTER_KEY_ALIASES.get(key, key)
+        if canonical not in DashboardFilter.model_fields:
+            continue
+        if canonical != key and canonical in filters:
+            # Both spellings are present: the modern one wins regardless of dict order.
+            continue
+        normalized[canonical] = value
+    return normalize_dashboard_filters_properties(normalized)
+
+
 def _without_contradicted(properties: Any, overriding_props: list[dict]) -> Any:
     """Drop leaf property filters that any `overriding_props` filter provably contradicts from a query's
     `properties`, which is either a flat list of leaves or a `PropertyGroupFilter` dict (a group of
@@ -282,14 +310,13 @@ def resolve_effective_dashboard_filters(
 
 
 def dashboard_filter_from_dict(filters: dict) -> DashboardFilter:
-    """Build a dashboard filter while tolerating legacy grouped properties."""
-    # Final guard: callers like Insight.get_effective_query pass client-supplied filter dicts
-    # here without going through the merge functions, and the tile-only flag would trip
-    # DashboardFilter's extra="forbid".
-    filters = _without_ignore_flag(filters)
-    if isinstance(filters.get("properties"), dict):
-        filters = {**filters, "properties": flatten_property_leaves(filters["properties"])}
-    return DashboardFilter(**filters)
+    """Build a dashboard filter from an untrusted dict, tolerating legacy keys and grouped properties.
+
+    Callers like Insight.get_effective_query pass client-supplied filter dicts here without going
+    through the merge functions, so this is the final guard before the extra="forbid" model: the
+    tile-only ignoreDashboardFilters flag and legacy keys are normalized away instead of raising.
+    """
+    return DashboardFilter(**normalize_dashboard_filters(filters))
 
 
 # Apply the filters from the django-style Dashboard object

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -201,6 +201,30 @@ class TestDashboardFilterFromDict(SimpleTestCase):
         ]
         assert built.date_from == "-7d"
 
+    @parameterized.expand(
+        [
+            (
+                "legacy test-accounts alias maps to the modern field",
+                {"filter_test_accounts": True, "date_from": "-7d"},
+                DashboardFilter(filterTestAccounts=True, date_from="-7d"),
+            ),
+            (
+                "unknown legacy keys are dropped",
+                {"breakdown": None, "breakdown_type": None, "insight": "TRENDS", "date_from": "-30d"},
+                DashboardFilter(date_from="-30d"),
+            ),
+            (
+                "modern key wins over its legacy alias",
+                {"filter_test_accounts": True, "filterTestAccounts": False},
+                DashboardFilter(filterTestAccounts=False),
+            ),
+        ]
+    )
+    def test_legacy_keys_are_normalized_instead_of_raising(self, _name, filters, expected):
+        # Persisted `Dashboard.filters` blobs and echoed `filters_override` params carry legacy keys;
+        # DashboardFilter's extra="forbid" used to reject them, breaking every tile on the dashboard.
+        assert dashboard_filter_from_dict(filters) == expected
+
 
 class TestFlattenPropertyLeaves(SimpleTestCase):
     def test_rejects_or_property_group(self):

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -218,6 +218,11 @@ class TestDashboardFilterFromDict(SimpleTestCase):
                 {"filter_test_accounts": True, "filterTestAccounts": False},
                 DashboardFilter(filterTestAccounts=False),
             ),
+            (
+                "legacy explicit-date alias maps with its legacy string value",
+                {"explicit_date": "true", "date_from": "2024-01-01 12:00:00", "date_to": "2024-01-01 14:00:00"},
+                DashboardFilter(explicitDate=True, date_from="2024-01-01 12:00:00", date_to="2024-01-01 14:00:00"),
+            ),
         ]
     )
     def test_legacy_keys_are_normalized_instead_of_raising(self, _name, filters, expected):
@@ -248,6 +253,15 @@ class TestResolveEffectiveDashboardFilters(SimpleTestCase):
         )
         assert effective["properties"] == [prop]
         assert effective["date_from"] == "-7d"
+
+    def test_normalizes_legacy_keys_in_effective_filters(self):
+        # The effective filters feed process_query_dict, which validates them with the
+        # extra="forbid" DashboardFilter; a surviving legacy key used to fail every tile compute.
+        query = {"kind": "InsightVizNode", "source": {"kind": "TrendsQuery"}}
+        _, effective = resolve_effective_dashboard_filters(
+            query, {"filter_test_accounts": True, "breakdown": None, "date_from": "-7d"}, None
+        )
+        assert effective == {"filterTestAccounts": True, "date_from": "-7d"}
 
 
 class TestIgnoreDashboardFilters(SimpleTestCase):

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -33,6 +33,7 @@ from django.http.response import HttpResponseBase
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 
+import pydantic
 import structlog
 import posthoganalytics
 from drf_spectacular.types import OpenApiTypes
@@ -45,7 +46,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 from rest_framework.utils.serializer_helpers import ReturnDict
 
-from posthog.schema import InsightVizNode
+from posthog.schema import DashboardFilter, InsightVizNode
 
 from posthog.api.forbid_destroy_model import ForbidDestroyModel
 from posthog.api.monitoring import Feature, monitor
@@ -69,7 +70,7 @@ from posthog.helpers.trigram_search import (
     apply_trigram_search,
     drop_similar_when_exact_exists,
 )
-from posthog.hogql_queries.apply_dashboard_filters import normalize_dashboard_filters_properties
+from posthog.hogql_queries.apply_dashboard_filters import normalize_dashboard_filters
 from posthog.hogql_queries.refresh_policy import ComputeSurface
 from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.file_system import FileSystem, create_or_update_file, delete_file, join_path, split_path
@@ -1307,11 +1308,15 @@ class DashboardSerializer(DashboardMetadataSerializer):
     def _validated_filters(request_filters: Any) -> dict:
         """Validate and normalize a raw request `filters` payload before it's persisted.
 
-        `filters` is a read-only SerializerMethodField, so DRF's `validate_filters` never runs —
+        `filters` is a read-only SerializerMethodField, so DRF's `validate_filters` never runs;
         the write paths read `request.data`/`initial_data` directly. `Dashboard.filters` is opaque
-        JSON; this enforces the dict shape and normalizes a `PropertyGroupFilter` dict
-        (`{"type": ..., "values": [...]}`) on `properties` to the flat-list contract
-        (`DashboardFilter.properties`), so the dict form can't be persisted for readers to trip on."""
+        JSON, but readers rebuild the extra="forbid" `DashboardFilter` from it on every tile
+        refresh, so any persisted key or value that model rejects breaks every tile on the
+        dashboard. Normalization maps legacy key aliases (`filter_test_accounts`) onto their
+        modern field, drops keys `DashboardFilter` doesn't know, and flattens a
+        `PropertyGroupFilter` dict on `properties` to the flat-list contract. Constructing
+        `DashboardFilter` afterwards rejects invalid field values with a 400 at write time
+        instead of a broken dashboard at read time."""
         if not isinstance(request_filters, dict):
             raise serializers.ValidationError("Filters must be a dictionary")
         properties = request_filters.get("properties")
@@ -1322,9 +1327,14 @@ class DashboardSerializer(DashboardMetadataSerializer):
         if properties is not None and not isinstance(properties, (list, dict)):
             raise serializers.ValidationError({"properties": "Must be a list of filters or a property group"})
         try:
-            return normalize_dashboard_filters_properties(request_filters)
+            normalized = normalize_dashboard_filters(request_filters)
         except ValueError as error:
             raise serializers.ValidationError({"properties": str(error)}) from error
+        try:
+            DashboardFilter(**normalized)
+        except pydantic.ValidationError as error:
+            raise serializers.ValidationError({"filters": str(error)}) from error
+        return normalized
 
     @monitor(feature=Feature.DASHBOARD, endpoint="dashboard", method="POST")
     def create(self, validated_data: dict, *args: Any, **kwargs: Any) -> Dashboard:

--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -70,7 +70,7 @@ from posthog.helpers.trigram_search import (
     apply_trigram_search,
     drop_similar_when_exact_exists,
 )
-from posthog.hogql_queries.apply_dashboard_filters import normalize_dashboard_filters
+from posthog.hogql_queries.apply_dashboard_filters import dropped_dashboard_filter_keys, normalize_dashboard_filters
 from posthog.hogql_queries.refresh_policy import ComputeSurface
 from posthog.models.file_system.constants import DEFAULT_SURFACE, surface_q
 from posthog.models.file_system.file_system import FileSystem, create_or_update_file, delete_file, join_path, split_path
@@ -1330,6 +1330,11 @@ class DashboardSerializer(DashboardMetadataSerializer):
             normalized = normalize_dashboard_filters(request_filters)
         except ValueError as error:
             raise serializers.ValidationError({"properties": str(error)}) from error
+        dropped_keys = dropped_dashboard_filter_keys(request_filters)
+        if dropped_keys:
+            # Dropping (instead of a 400) keeps saves working for dashboards whose persisted blob
+            # already carries legacy keys, since the app echoes those back on every save.
+            logger.warning("dashboard_filters_dropped_unknown_keys", dropped_keys=dropped_keys)
         try:
             DashboardFilter(**normalized)
         except pydantic.ValidationError as error:
@@ -1691,6 +1696,22 @@ class DashboardSerializer(DashboardMetadataSerializer):
     }
 
     @staticmethod
+    def _validated_tile_filters_overrides(tile_filters: Any) -> dict:
+        """Validate tile `filters_overrides` while preserving the tile-only ignoreDashboardFilters flag.
+
+        Tile overrides carry DashboardFilter's fields plus `ignoreDashboardFilters` (see TileFilters),
+        which `_validated_filters` would drop as an unknown key, so it is set aside and re-attached."""
+        if not isinstance(tile_filters, dict):
+            raise serializers.ValidationError("Filters must be a dictionary")
+        ignore_flag = tile_filters.get("ignoreDashboardFilters")
+        validated = DashboardSerializer._validated_filters(
+            {key: value for key, value in tile_filters.items() if key != "ignoreDashboardFilters"}
+        )
+        if ignore_flag is not None:
+            validated["ignoreDashboardFilters"] = ignore_flag
+        return validated
+
+    @staticmethod
     def _extract_display_defaults(tile_data: dict) -> dict:
         defaults = {k: tile_data[k] for k in DashboardSerializer.TILE_DISPLAY_FIELDS if k in tile_data}
         # `filters_overrides` is opaque JSON with the same `properties` shape ambiguity as dashboard
@@ -1699,7 +1720,7 @@ class DashboardSerializer(DashboardMetadataSerializer):
         if "filters_overrides" in defaults:
             tile_filters = defaults["filters_overrides"]
             if tile_filters is not None:
-                defaults["filters_overrides"] = DashboardSerializer._validated_filters(tile_filters)
+                defaults["filters_overrides"] = DashboardSerializer._validated_tile_filters_overrides(tile_filters)
         return defaults
 
     @staticmethod

--- a/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
+++ b/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
@@ -42,6 +42,18 @@ class TestDashboardFiltersValidation(SimpleTestCase):
             return
         raise AssertionError("expected ValidationError")
 
+    def test_maps_legacy_test_accounts_key_and_drops_unknown_keys(self):
+        # REST clients PATCH the legacy insight-format key, which used to persist opaquely; readers
+        # then rebuilt the extra="forbid" DashboardFilter from the blob and every tile 500ed.
+        result = self._validate(
+            {"filter_test_accounts": True, "breakdown": None, "insight": "TRENDS", "date_from": "-7d"}
+        )
+        assert result == {"filterTestAccounts": True, "date_from": "-7d"}
+
+    def test_rejects_invalid_field_values(self):
+        with self.assertRaises(serializers.ValidationError):
+            self._validate({"interval": "fortnightly"})
+
 
 class TestDashboardTileFiltersOverridesValidation(SimpleTestCase):
     def test_normalizes_property_group_dict_on_tile_filters_overrides(self):

--- a/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
+++ b/products/dashboards/backend/api/test/test_dashboard_filters_validation.py
@@ -70,6 +70,22 @@ class TestDashboardTileFiltersOverridesValidation(SimpleTestCase):
         with self.assertRaises(serializers.ValidationError):
             DashboardSerializer._extract_display_defaults({"filters_overrides": []})
 
+    def test_preserves_ignore_dashboard_filters_flag_and_maps_legacy_keys(self):
+        # `ignoreDashboardFilters` is tile-only (TileFilters), not a DashboardFilter field, so the
+        # unknown-key normalization must not strip it; every tile-override save goes through here.
+        result = DashboardSerializer._extract_display_defaults(
+            {"filters_overrides": {"ignoreDashboardFilters": True, "filter_test_accounts": True, "date_from": "-7d"}}
+        )
+        assert result["filters_overrides"] == {
+            "ignoreDashboardFilters": True,
+            "filterTestAccounts": True,
+            "date_from": "-7d",
+        }
+
+    def test_preserves_false_ignore_dashboard_filters_flag(self):
+        result = DashboardSerializer._extract_display_defaults({"filters_overrides": {"ignoreDashboardFilters": False}})
+        assert result["filters_overrides"] == {"ignoreDashboardFilters": False}
+
     def test_allows_clearing_tile_filters_overrides(self):
         result = DashboardSerializer._extract_display_defaults({"filters_overrides": None})
         assert result["filters_overrides"] is None


### PR DESCRIPTION
## Problem

- `Dashboard.filters` persists opaquely, and readers rebuild the `extra="forbid"` `DashboardFilter` from it on every tile refresh and compute.
- One legacy key in the blob (`filter_test_accounts`, top-level `breakdown`) fails that validation and errors every tile on the dashboard.
- The dashboard UI merges persisted filters into every save, so the app cannot repair a broken blob.
- A support ticket hit exactly this: a REST client wrote the legacy insight-format key `filter_test_accounts`, and the dashboards stayed broken until the blob is rewritten by hand.

## Changes

- New `normalize_dashboard_filters` maps legacy aliases onto their modern field (`filter_test_accounts` to `filterTestAccounts`, `explicit_date` to `explicitDate`), drops unknown keys, and flattens grouped properties.
- Every `DashboardFilter` construction site from a persisted or merged dict now normalizes first: `dashboard_filter_from_dict`, the cache-key path in `calculate_results.py`, `resolve_effective_dashboard_filters`, and the compute chokepoint in `process_query_dict` (which also covers cache warming).
- The dashboards API `_validated_filters` normalizes writes the same way, then constructs `DashboardFilter` so invalid field values fail at write time. Dropped unknown keys are logged.
- Tile `filters_overrides` writes go through a tile-aware validator that preserves the tile-only `ignoreDashboardFilters` flag (it is a `TileFilters` field, not a `DashboardFilter` one).

> [!NOTE]
> Write-path behavior change: `filters` payloads with invalid field values (for example a bad `interval`) now return a 400. Previously they persisted and broke the dashboard on read.

## How did you test this code?

- Ran `pytest` on the two touched test files (56 passed), repo-wide `mypy` (clean, 17,748 files), and `hogli ci:preflight --fix` (no failures).
- A 6-agent QA review (`/qa-team`) of the first commit found two gaps, both fixed here with regression tests: tile-override writes stripped `ignoreDashboardFilters`, and the compute/warming path still strict-validated un-normalized dicts.
- New parameterized `dashboard_filter_from_dict` cases (legacy aliases map, unknown keys drop, modern spelling wins, legacy `explicit_date` string value coerces) catch the read-path regression where one persisted legacy key broke every tile.
- New cases for `_validated_filters` (legacy key normalized on write, invalid `interval` rejected), `_extract_display_defaults` (flag round-trips), and `resolve_effective_dashboard_filters` (legacy keys normalized before the compute chokepoint).
- Not run: DB-backed suites and OpenAPI regeneration (this sandbox has no database). The diff adds no serializer field or schema annotation, so the generated spec is unchanged; the preflight OpenAPI advisory is path-glob triggered.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: no page under `docs/` documents the dashboard `filters` payload.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude, via a PostHog Code cloud task) investigated a support ticket about a dashboard erroring on every tile, traced it to this validation gap, and authored the fix on request.
- Skills invoked: `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`, `/qa-team`.
- The second commit addresses the QA review's convergent findings. Accepted residuals, with reasons: no 400 on unknown keys (the app echoes persisted junk into every save, so rejection would block saving legacy-blob dashboards); no per-layer normalization inside the merge functions (`resolve_filter_layers_by_priority`'s tile layer is client-facing metadata that must keep the ignore flag); no value-level read salvage (rendering data without a filter the user configured is worse than an error tile); `breakdown`/`breakdown_type` dropped rather than mapped (observed blobs carry null values; mapping could resurrect years-dead display config).
- No assignee set: the driver's GitHub handle wasn't verifiable from this session.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
