### PR TITLE
fix(inbox): keep reviewer remove button visible on touch devices

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/SuggestedReviewersSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/SuggestedReviewersSection.tsx
@@ -247,7 +247,7 @@ function ReviewerRow({
 
     return (
         <div className="group grid grid-cols-[minmax(8rem,10rem)_minmax(0,1fr)_auto] items-center gap-2 rounded px-1.5 py-1.5">
-            {/* no row hover: the row isn't clickable, only the remove button (revealed on group hover) is */}
+            {/* no row hover: the row isn't clickable, only the remove button is */}
             <Tooltip
                 title={
                     reviewer.user
@@ -299,7 +299,9 @@ function ReviewerRow({
                 disabledReason={disabled ? 'Updating…' : undefined}
                 onClick={onRemove}
                 tooltip={`Remove ${reviewer.github_login || reviewer.user?.first_name || 'reviewer'}`}
-                className="opacity-0 transition-opacity group-hover:opacity-100"
+                // Hover reveal keeps rows quiet with a mouse, but a coarse pointer (phone, tablet) has no
+                // hover state, so the button stays visible there and whenever the row holds keyboard focus.
+                className="opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100"
             />
         </div>
     )


### PR DESCRIPTION
## Problem

On an inbox report, the "X" that removes a suggested reviewer is hover-only. Phones and tablets have no hover state, so on mobile the button is invisible and reviewers can't be removed.

## Changes

- The remove button on a reviewer row stays visible when the pointer is coarse (`pointer-coarse:opacity-100`).
- It also appears when the row holds keyboard focus (`group-focus-within:opacity-100`).
- Hover-to-reveal is unchanged for mouse users.

This follows the same reveal pattern already used by the notifications menu row actions (`NotificationActionButton.tsx`).

Only the web app's inbox scene is touched. The desktop app's mirror of this component is left as is, since it isn't a touch surface.

## How did you test this code?

Not manually verified. The change is a Tailwind variant swap on one `className`, and `pointer-coarse:` is already used elsewhere in `frontend/src`, so it is a supported variant in this Tailwind version. No automated tests were run, and none were added: the behavior is pure CSS media-feature state, which jsdom can't evaluate.

Manual check for a reviewer: open an inbox report with at least one suggested reviewer, then either load it on a phone or enable device emulation in devtools. The X should be visible without hovering, and tapping it should remove the reviewer.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread by a PostHog employee who couldn't find the remove affordance on a phone. I did not assign them, because I had no verified GitHub handle for them.

Authored by the PostHog Slack app (Claude Code). Skills invoked: `/writing-code-comments`, `/writing-pr-descriptions`.

I considered a permanently visible button, but that adds noise to every row on desktop, so I kept hover-reveal there and gated the always-visible state on the pointer type instead. I also reused the existing repo pattern rather than introducing a new shared helper for a single call site.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785932312416919)*
