### PR TITLE
feat(desktop): offer a flag-delivered internal server in the MCP marketplace

### DIFF
--- a/products/desktop/apps/code/.storybook/withAppProviders.tsx
+++ b/products/desktop/apps/code/.storybook/withAppProviders.tsx
@@ -152,6 +152,7 @@ function createProviderStack(): ProviderStack {
   // every flag reads as enabled and useFeatureFlag's state never settles.
   bindings.bind<FeatureFlags>(FEATURE_FLAGS).toConstantValue({
     isEnabled: () => false,
+    getPayload: () => undefined,
     onFlagsLoaded: () => () => {},
   });
   const container = storyContainer(bindings);

--- a/products/desktop/apps/code/src/renderer/di/container.ts
+++ b/products/desktop/apps/code/src/renderer/di/container.ts
@@ -413,9 +413,13 @@ container.bind(CODE_REVIEW_WORKSPACE_CLIENT).toConstantValue({
 container.bind(REVERT_HUNK_SERVICE).to(RevertHunkService).inSingletonScope();
 
 // local MCP servers (~/.claude.json), read for cloud-import classification
+// and written to for flag-delivered marketplace entries
 container.bind(LOCAL_MCP_WORKSPACE_CLIENT).toConstantValue({
   listLocalMcpServers: (cwd?: string) =>
     trpcClient.localMcp.list.query({ cwd }),
+  addUserMcpServer: async (input: { name: string; url: string }) => {
+    await trpcClient.localMcp.addUserServer.mutate(input);
+  },
 } satisfies LocalMcpWorkspaceClient);
 
 // skills (team publish/install reach workspace-server through this slice)

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -511,6 +511,7 @@ container.bind(FEATURE_FLAGS).toConstantValue({
   // same behavior as the old stub, but real flags light up once a key is set.
   isEnabled: (flagKey: string) =>
     flagKey === SYNC_CLOUD_TASKS_FLAG || posthogFeatureFlags.isEnabled(flagKey),
+  getPayload: posthogFeatureFlags.getPayload,
   onFlagsLoaded: posthogFeatureFlags.onFlagsLoaded,
 });
 

--- a/products/desktop/packages/agent/src/adapters/claude/session/mcp-config.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/mcp-config.test.ts
@@ -3,8 +3,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  loadUserClaudeJsonMcpServerDescriptors,
   loadUserClaudeJsonMcpServerEntries,
   loadUserClaudeJsonMcpServers,
+  saveUserClaudeJsonHttpMcpServer,
 } from "./mcp-config";
 
 describe("loadUserClaudeJsonMcpServers", () => {
@@ -185,5 +187,80 @@ describe("loadUserClaudeJsonMcpServerEntries", () => {
     expect(
       loadUserClaudeJsonMcpServerEntries("/cwd", undefined, tmpHome),
     ).toEqual([]);
+  });
+});
+
+describe("saveUserClaudeJsonHttpMcpServer", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "claude-json-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("creates ~/.claude.json when missing and round-trips through the reader", () => {
+    saveUserClaudeJsonHttpMcpServer(
+      "hosthog",
+      "https://example.test/mcp",
+      tmpHome,
+    );
+
+    const descriptors = loadUserClaudeJsonMcpServerDescriptors(
+      undefined,
+      undefined,
+      tmpHome,
+    );
+    expect(descriptors).toEqual([
+      {
+        name: "hosthog",
+        scope: "user",
+        transport: {
+          type: "http",
+          url: "https://example.test/mcp",
+          headers: undefined,
+        },
+      },
+    ]);
+  });
+
+  it("preserves unrelated config and replaces a same-name entry", () => {
+    const cfg = {
+      numStartups: 42,
+      projects: { "/cwd": { mcpServers: { other: { command: "npx" } } } },
+      mcpServers: {
+        hosthog: { type: "http", url: "https://old.test/mcp" },
+        keepme: { type: "stdio", command: "npx", args: ["pkg"] },
+      },
+    };
+    fs.writeFileSync(path.join(tmpHome, ".claude.json"), JSON.stringify(cfg));
+
+    saveUserClaudeJsonHttpMcpServer("hosthog", "https://new.test/mcp", tmpHome);
+
+    const written = JSON.parse(
+      fs.readFileSync(path.join(tmpHome, ".claude.json"), "utf8"),
+    );
+    expect(written.numStartups).toBe(42);
+    expect(written.projects).toEqual(cfg.projects);
+    expect(written.mcpServers).toEqual({
+      hosthog: { type: "http", url: "https://new.test/mcp" },
+      keepme: { type: "stdio", command: "npx", args: ["pkg"] },
+    });
+  });
+
+  it("throws on an unparseable file and leaves it untouched", () => {
+    const claudeJsonPath = path.join(tmpHome, ".claude.json");
+    fs.writeFileSync(claudeJsonPath, "not json");
+
+    expect(() =>
+      saveUserClaudeJsonHttpMcpServer(
+        "hosthog",
+        "https://example.test/mcp",
+        tmpHome,
+      ),
+    ).toThrow();
+    expect(fs.readFileSync(claudeJsonPath, "utf8")).toBe("not json");
   });
 });

--- a/products/desktop/packages/agent/src/adapters/claude/session/mcp-config.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/mcp-config.ts
@@ -69,6 +69,55 @@ export function loadUserClaudeJsonMcpServerEntries(
   return [...byName.values()];
 }
 
+/**
+ * Adds or replaces a user-scoped streamable-HTTP server in ~/.claude.json,
+ * the same entry `claude mcp add --scope user --transport http` writes. The
+ * rest of the file is preserved verbatim. An unparseable file throws instead
+ * of being overwritten, because ~/.claude.json is Claude Code's primary
+ * config and clobbering it would destroy unrelated user settings. The write
+ * goes through a temp file + rename so a crash mid-write can't truncate it.
+ */
+export function saveUserClaudeJsonHttpMcpServer(
+  name: string,
+  url: string,
+  homeDir: string = os.homedir(),
+): void {
+  const claudeJsonPath = path.join(homeDir, ".claude.json");
+
+  let raw: string | undefined;
+  try {
+    raw = fs.readFileSync(claudeJsonPath, "utf8");
+  } catch {
+    // No config yet: start one with just the server entry.
+  }
+
+  let cfg: Record<string, unknown> = {};
+  if (raw !== undefined) {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error("~/.claude.json is not a JSON object");
+    }
+    cfg = parsed as Record<string, unknown>;
+  }
+
+  const servers =
+    cfg.mcpServers !== null &&
+    typeof cfg.mcpServers === "object" &&
+    !Array.isArray(cfg.mcpServers)
+      ? (cfg.mcpServers as Record<string, unknown>)
+      : {};
+  servers[name] = { type: "http", url };
+  cfg.mcpServers = servers;
+
+  const tmpPath = `${claudeJsonPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(cfg, null, 2)}\n`);
+  fs.renameSync(tmpPath, claudeJsonPath);
+}
+
 export function loadUserClaudeJsonMcpServers(
   cwd: string,
   logger?: Logger,

--- a/products/desktop/packages/core/src/local-mcp/localMcpImport.test.ts
+++ b/products/desktop/packages/core/src/local-mcp/localMcpImport.test.ts
@@ -184,6 +184,7 @@ describe("LocalMcpImportService", () => {
           server({ type: "stdio", command: "npx" }, { name: "local" }),
         ];
       },
+      addUserMcpServer: async () => {},
     };
 
     const results = await new LocalMcpImportService(

--- a/products/desktop/packages/core/src/local-mcp/localMcpImport.ts
+++ b/products/desktop/packages/core/src/local-mcp/localMcpImport.ts
@@ -11,6 +11,7 @@ import { LOCAL_MCP_WORKSPACE_CLIENT } from "./identifiers";
 /** The slice of workspace-server this service needs, bound by the host. */
 export interface LocalMcpWorkspaceClient {
   listLocalMcpServers(cwd?: string): Promise<LocalMcpServerDescriptor[]>;
+  addUserMcpServer(input: { name: string; url: string }): Promise<void>;
 }
 
 export type LocalMcpCloudAvailability =
@@ -207,5 +208,18 @@ export class LocalMcpImportService {
   ): Promise<LocalMcpCloudClassification[]> {
     const servers = await this.workspace.listLocalMcpServers(cwd);
     return servers.map(classifyLocalMcpServer);
+  }
+
+  /** The user's ~/.claude.json servers, unclassified. */
+  async listServers(cwd?: string): Promise<LocalMcpServerDescriptor[]> {
+    return this.workspace.listLocalMcpServers(cwd);
+  }
+
+  /**
+   * Adds or replaces a user-scoped streamable-HTTP server in ~/.claude.json,
+   * the same entry `claude mcp add --scope user --transport http` writes.
+   */
+  async addUserHttpServer(input: { name: string; url: string }): Promise<void> {
+    await this.workspace.addUserMcpServer(input);
   }
 }

--- a/products/desktop/packages/core/src/local-mcp/schemas.test.ts
+++ b/products/desktop/packages/core/src/local-mcp/schemas.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseFlaggedMcpServerPayload } from "./schemas";
+
+describe("parseFlaggedMcpServerPayload", () => {
+  it("parses a valid payload", () => {
+    expect(
+      parseFlaggedMcpServerPayload({
+        name: "hosthog",
+        url: "https://internal.example.test/mcp",
+        displayName: "HostHog",
+        description: "Internal hosting.",
+        iconDomain: "posthog.com",
+      }),
+    ).toEqual({
+      name: "hosthog",
+      url: "https://internal.example.test/mcp",
+      displayName: "HostHog",
+      description: "Internal hosting.",
+      iconDomain: "posthog.com",
+    });
+  });
+
+  it.each([
+    { label: "undefined (flag off)", payload: undefined },
+    { label: "a non-object payload", payload: "https://example.test/mcp" },
+    { label: "a missing url", payload: { name: "hosthog" } },
+    {
+      label: "a non-http url",
+      payload: { name: "hosthog", url: "ftp://example.test/mcp" },
+    },
+    {
+      label: "an unparseable url",
+      payload: { name: "hosthog", url: "not a url" },
+    },
+    {
+      label: "a name that is not identifier-shaped",
+      payload: { name: "host hog!", url: "https://example.test/mcp" },
+    },
+  ])("returns null for $label", ({ payload }) => {
+    expect(parseFlaggedMcpServerPayload(payload)).toBeNull();
+  });
+});

--- a/products/desktop/packages/core/src/local-mcp/schemas.ts
+++ b/products/desktop/packages/core/src/local-mcp/schemas.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+/**
+ * Payload contract for flags that offer an internal MCP server in the
+ * marketplace (HOSTHOG_MCP_FLAG). The server config rides in the flag payload
+ * instead of source so internal endpoints stay out of this public repo.
+ */
+export const flaggedMcpServerPayloadSchema = z.object({
+  // ~/.claude.json server key; keys become MCP tool-name prefixes
+  // (mcp__<name>__*), so keep them identifier-shaped like `claude mcp add`.
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-zA-Z0-9_-]+$/),
+  url: z.url({ protocol: /^https?$/ }),
+  /** Card title in the marketplace; falls back to `name`. */
+  displayName: z.string().optional(),
+  description: z.string().optional(),
+  /** Brand domain for the card icon, resolved via the logo.dev proxy. */
+  iconDomain: z.string().optional(),
+});
+
+export type FlaggedMcpServerPayload = z.infer<
+  typeof flaggedMcpServerPayloadSchema
+>;
+
+/** Parses a flag payload, returning null when missing or malformed. */
+export function parseFlaggedMcpServerPayload(
+  payload: unknown,
+): FlaggedMcpServerPayload | null {
+  const result = flaggedMcpServerPayloadSchema.safeParse(payload);
+  return result.success ? result.data : null;
+}

--- a/products/desktop/packages/host-router/src/routers/local-mcp.router.ts
+++ b/products/desktop/packages/host-router/src/routers/local-mcp.router.ts
@@ -4,6 +4,7 @@ import {
   type LocalMcpService,
 } from "@posthog/workspace-server/services/local-mcp/identifiers";
 import {
+  addUserMcpServerInput,
   listLocalMcpServersInput,
   listLocalMcpServersOutput,
 } from "@posthog/workspace-server/services/local-mcp/schemas";
@@ -16,5 +17,12 @@ export const localMcpRouter = router({
       ctx.container
         .get<LocalMcpService>(LOCAL_MCP_SERVICE)
         .listServers(input.cwd),
+    ),
+  addUserServer: publicProcedure
+    .input(addUserMcpServerInput)
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<LocalMcpService>(LOCAL_MCP_SERVICE)
+        .addUserServer(input),
     ),
 });

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -34,6 +34,13 @@ export const SPOKEN_NARRATION_FLAG = "posthog-code-spoken-narration";
 // Gates importing and relaying local MCP servers into cloud task runs.
 export const LOCAL_MCP_IMPORT_FLAG = "posthog-code-local-mcp-import";
 /**
+ * Permanent internal-only gate for the HostHog entry in the MCP marketplace.
+ * The boolean controls visibility; the flag payload carries the server config
+ * (see flaggedMcpServerPayloadSchema in @posthog/core/local-mcp/schemas), so
+ * the internal endpoint never appears in this public repo.
+ */
+export const HOSTHOG_MCP_FLAG = "posthog-code-hosthog-mcp";
+/**
  * Team MCP gateway (shared credentials, per-scope tool policies, agent
  * service accounts, audit log) replacing the per-user MCP marketplace.
  * Owned by the backend rollout in posthog/posthog — same flag key there.

--- a/products/desktop/packages/ui/src/features/feature-flags/identifiers.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/identifiers.ts
@@ -5,6 +5,8 @@
  */
 export interface FeatureFlags {
   isEnabled(flagKey: string): boolean;
+  /** The flag's payload when it evaluates enabled, undefined otherwise. */
+  getPayload(flagKey: string): unknown;
   onFlagsLoaded(handler: () => void): () => void;
 }
 

--- a/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagPayload.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagPayload.ts
@@ -1,0 +1,25 @@
+import { useService } from "@posthog/di/react";
+import { useEffect, useState } from "react";
+import { FEATURE_FLAGS, type FeatureFlags } from "./identifiers";
+
+/**
+ * The flag's payload when it evaluates enabled for the current user,
+ * undefined otherwise. Payloads are remote data: validate with a Zod schema
+ * before use.
+ */
+export function useFeatureFlagPayload(flagKey: string): unknown {
+  const flags = useService<FeatureFlags>(FEATURE_FLAGS);
+  const [payload, setPayload] = useState<unknown>(() =>
+    flags.getPayload(flagKey),
+  );
+
+  useEffect(() => {
+    setPayload(flags.getPayload(flagKey));
+
+    return flags.onFlagsLoaded(() => {
+      setPayload(flags.getPayload(flagKey));
+    });
+  }, [flags, flagKey]);
+
+  return payload;
+}

--- a/products/desktop/packages/ui/src/features/local-mcp/useAddLocalMcpServer.ts
+++ b/products/desktop/packages/ui/src/features/local-mcp/useAddLocalMcpServer.ts
@@ -1,0 +1,46 @@
+import { LOCAL_MCP_IMPORT_SERVICE } from "@posthog/core/local-mcp/identifiers";
+import type { LocalMcpImportService } from "@posthog/core/local-mcp/localMcpImport";
+import { useServiceOptional } from "@posthog/di/react";
+import {
+  useMutation,
+  type UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+export interface AddLocalMcpServerInput {
+  name: string;
+  url: string;
+}
+
+/**
+ * Adds or replaces a user-scoped streamable-HTTP server in the local agent
+ * config (~/.claude.json). Desktop only: the mutation rejects on hosts
+ * without a local workspace.
+ */
+export function useAddLocalMcpServer(): UseMutationResult<
+  void,
+  Error,
+  AddLocalMcpServerInput
+> {
+  const service = useServiceOptional<LocalMcpImportService>(
+    LOCAL_MCP_IMPORT_SERVICE,
+  );
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: AddLocalMcpServerInput) => {
+      if (!service) {
+        throw new Error("Local MCP servers require the desktop app.");
+      }
+      await service.addUserHttpServer(input);
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["local-mcp-servers"] }),
+        queryClient.invalidateQueries({
+          queryKey: ["local-mcp-cloud-availability"],
+        }),
+      ]);
+    },
+  });
+}

--- a/products/desktop/packages/ui/src/features/local-mcp/useLocalMcpServers.ts
+++ b/products/desktop/packages/ui/src/features/local-mcp/useLocalMcpServers.ts
@@ -1,0 +1,34 @@
+import { LOCAL_MCP_IMPORT_SERVICE } from "@posthog/core/local-mcp/identifiers";
+import type { LocalMcpImportService } from "@posthog/core/local-mcp/localMcpImport";
+import { useServiceOptional } from "@posthog/di/react";
+import type { LocalMcpServerDescriptor } from "@posthog/shared";
+import { useQuery } from "@tanstack/react-query";
+
+// Stable identity so consumers' memo deps don't churn while data is absent.
+const NO_SERVERS: LocalMcpServerDescriptor[] = [];
+
+export interface LocalMcpServersResult {
+  servers: LocalMcpServerDescriptor[];
+  /** False on hosts without a local workspace (web/mobile). */
+  available: boolean;
+}
+
+/** The user's local (~/.claude.json) MCP servers, user scope only. */
+export function useLocalMcpServers(enabled: boolean): LocalMcpServersResult {
+  const service = useServiceOptional<LocalMcpImportService>(
+    LOCAL_MCP_IMPORT_SERVICE,
+  );
+  const queryEnabled = enabled && !!service;
+
+  const query = useQuery({
+    queryKey: ["local-mcp-servers"],
+    queryFn: () => (service ? service.listServers() : NO_SERVERS),
+    enabled: queryEnabled,
+    staleTime: 30_000,
+  });
+
+  return {
+    servers: queryEnabled ? (query.data ?? NO_SERVERS) : NO_SERVERS,
+    available: !!service,
+  };
+}

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/McpServersView.tsx
@@ -4,11 +4,15 @@ import type {
 } from "@posthog/api-client/posthog-client";
 import { MCP_GATEWAY_FLAG } from "@posthog/shared";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
+import { useAddLocalMcpServer } from "@posthog/ui/features/local-mcp/useAddLocalMcpServer";
 import { useLocalMcpCloudServers } from "@posthog/ui/features/local-mcp/useLocalMcpCloudServers";
+import { useLocalMcpServers } from "@posthog/ui/features/local-mcp/useLocalMcpServers";
 import { McpGatewayView } from "@posthog/ui/features/mcp-gateway/components/McpGatewayView";
 import { AddCustomServerForm } from "@posthog/ui/features/mcp-server-manager/AddCustomServerForm";
+import type { InternalServerCardData } from "@posthog/ui/features/mcp-servers/components/parts/InternalServerCard";
 import { MarketplaceView } from "@posthog/ui/features/mcp-servers/components/parts/MarketplaceView";
 import { McpInstalledRail } from "@posthog/ui/features/mcp-servers/components/parts/McpInstalledRail";
+import { useFlaggedMcpServer } from "@posthog/ui/features/mcp-servers/hooks/useFlaggedMcpServer";
 import { useMcpServers } from "@posthog/ui/features/mcp-servers/hooks/useMcpServers";
 import {
   AlertDialog,
@@ -71,6 +75,29 @@ function McpMarketplaceView() {
   } = useMcpServers();
 
   const { servers: localServers } = useLocalMcpCloudServers(true);
+
+  // Flag-delivered internal server (HOSTHOG_MCP_FLAG). Connecting writes a
+  // user-scoped local server config, so it needs the desktop workspace.
+  const flaggedServer = useFlaggedMcpServer();
+  const addLocalServer = useAddLocalMcpServer();
+  const { servers: localServerList, available: localMcpAvailable } =
+    useLocalMcpServers(flaggedServer !== null);
+  const internalServer: InternalServerCardData | undefined =
+    flaggedServer && localMcpAvailable
+      ? {
+          server: flaggedServer,
+          installed: localServerList.some(
+            (server) => server.name === flaggedServer.name,
+          ),
+          isInstalling: addLocalServer.isPending,
+          hasError: addLocalServer.isError,
+          onConnect: () =>
+            addLocalServer.mutate({
+              name: flaggedServer.name,
+              url: flaggedServer.url,
+            }),
+        }
+      : undefined;
 
   useEffect(() => {
     const refreshMcpState = () => {
@@ -263,6 +290,7 @@ function McpMarketplaceView() {
         }
         onConnect={handleConnect}
         onAddCustom={() => setView({ kind: "add-custom" })}
+        internalServer={internalServer}
       />
     );
   })();

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/parts/InternalServerCard.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/parts/InternalServerCard.tsx
@@ -1,0 +1,77 @@
+import { CheckCircle } from "@phosphor-icons/react";
+import type { FlaggedMcpServerPayload } from "@posthog/core/local-mcp/schemas";
+import { Badge, Button, Spinner, Text } from "@posthog/quill";
+import { ServerIcon } from "./icons";
+
+export interface InternalServerCardData {
+  server: FlaggedMcpServerPayload;
+  installed: boolean;
+  isInstalling: boolean;
+  hasError: boolean;
+  onConnect: () => void;
+}
+
+/**
+ * Marketplace card for a flag-delivered internal server. Connecting writes a
+ * user-scoped entry to the local agent config instead of creating a cloud
+ * installation, so unlike ServerCard there is no detail view and the card is
+ * not clickable.
+ */
+export function InternalServerCard({
+  server,
+  installed,
+  isInstalling,
+  hasError,
+  onConnect,
+}: InternalServerCardData) {
+  return (
+    <div className="relative rounded-md border border-gray-5 bg-gray-2">
+      <div className="flex w-full flex-col gap-3 p-4">
+        <div className="flex w-full items-center gap-3">
+          <ServerIcon iconDomain={server.iconDomain} size={36} />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <Text className="truncate font-medium text-base">
+                {server.displayName ?? server.name}
+              </Text>
+              {installed && (
+                <CheckCircle
+                  size={14}
+                  weight="fill"
+                  className="shrink-0 text-green-10"
+                />
+              )}
+            </div>
+            {server.description && (
+              <Text variant="muted" className="line-clamp-2 text-[13px]">
+                {server.description}
+              </Text>
+            )}
+          </div>
+          {/* Spacer to reserve room for the action button overlay */}
+          <div style={{ width: installed ? 100 : 84 }} />
+        </div>
+        <div className="flex w-full items-center gap-2">
+          <Badge variant="info">Internal</Badge>
+          {hasError && (
+            <Text variant="muted" className="text-[13px]">
+              Couldn't add the server. Try again.
+            </Text>
+          )}
+        </div>
+      </div>
+      <div className="absolute top-4 right-4">
+        {installed ? (
+          <Button variant="outline" disabled>
+            Connected
+          </Button>
+        ) : (
+          <Button variant="primary" onClick={onConnect} disabled={isInstalling}>
+            {isInstalling ? <Spinner /> : null}
+            Connect
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/mcp-servers/components/parts/MarketplaceView.tsx
+++ b/products/desktop/packages/ui/src/features/mcp-servers/components/parts/MarketplaceView.tsx
@@ -5,6 +5,7 @@ import {
   type McpRecommendedServer,
   type McpServerInstallation,
 } from "@posthog/api-client/posthog-client";
+import type { FlaggedMcpServerPayload } from "@posthog/core/local-mcp/schemas";
 import {
   filterServersByCategory,
   filterServersByQuery,
@@ -19,6 +20,10 @@ import {
   TextField,
 } from "@radix-ui/themes";
 import { useMemo } from "react";
+import {
+  InternalServerCard,
+  type InternalServerCardData,
+} from "./InternalServerCard";
 import { ServerCard } from "./ServerCard";
 
 interface MarketplaceViewProps {
@@ -34,6 +39,16 @@ interface MarketplaceViewProps {
   onOpenInstallation: (installationId: string) => void;
   onConnect: (server: McpRecommendedServer) => void;
   onAddCustom: () => void;
+  /** Flag-delivered internal server rendered ahead of the cloud catalog. */
+  internalServer?: InternalServerCardData;
+}
+
+function matchesQuery(server: FlaggedMcpServerPayload, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return [server.displayName, server.name, server.description].some((field) =>
+    field?.toLowerCase().includes(q),
+  );
 }
 
 export function MarketplaceView({
@@ -49,6 +64,7 @@ export function MarketplaceView({
   onOpenInstallation,
   onConnect,
   onAddCustom,
+  internalServer,
 }: MarketplaceViewProps) {
   const installationByTemplateId = useMemo(() => {
     const map = new Map<string, string>();
@@ -64,6 +80,13 @@ export function MarketplaceView({
     const byCategory = filterServersByCategory(servers, category);
     return filterServersByQuery(byCategory, query);
   }, [servers, category, query]);
+
+  // The internal server has no catalog category, so it only shows under "All".
+  const internalVisible =
+    internalServer !== undefined &&
+    category === "all" &&
+    matchesQuery(internalServer.server, query);
+  const visibleCount = visibleServers.length + (internalVisible ? 1 : 0);
 
   const hasFilters = query !== "" || category !== "all";
 
@@ -129,8 +152,7 @@ export function MarketplaceView({
 
       <Flex align="center" justify="between">
         <Text color="gray" className="text-[13px]">
-          {visibleServers.length}{" "}
-          {visibleServers.length === 1 ? "server" : "servers"}
+          {visibleCount} {visibleCount === 1 ? "server" : "servers"}
         </Text>
         {hasFilters && (
           <Button
@@ -151,7 +173,7 @@ export function MarketplaceView({
         <Flex align="center" justify="center" py="6">
           <Spinner size="2" />
         </Flex>
-      ) : visibleServers.length === 0 ? (
+      ) : visibleCount === 0 ? (
         <Flex
           align="center"
           justify="center"
@@ -167,6 +189,7 @@ export function MarketplaceView({
         </Flex>
       ) : (
         <Flex direction="column" gap="3">
+          {internalVisible && <InternalServerCard {...internalServer} />}
           {visibleServers.map((server) => {
             const installationId = installationByTemplateId.get(server.id);
             return (

--- a/products/desktop/packages/ui/src/features/mcp-servers/hooks/useFlaggedMcpServer.ts
+++ b/products/desktop/packages/ui/src/features/mcp-servers/hooks/useFlaggedMcpServer.ts
@@ -1,0 +1,17 @@
+import {
+  type FlaggedMcpServerPayload,
+  parseFlaggedMcpServerPayload,
+} from "@posthog/core/local-mcp/schemas";
+import { HOSTHOG_MCP_FLAG } from "@posthog/shared";
+import { useFeatureFlagPayload } from "@posthog/ui/features/feature-flags/useFeatureFlagPayload";
+import { useMemo } from "react";
+
+/**
+ * The internal marketplace server delivered by HOSTHOG_MCP_FLAG's payload.
+ * Null when the flag is off for the user or the payload doesn't match the
+ * schema.
+ */
+export function useFlaggedMcpServer(): FlaggedMcpServerPayload | null {
+  const payload = useFeatureFlagPayload(HOSTHOG_MCP_FLAG);
+  return useMemo(() => parseFlaggedMcpServerPayload(payload), [payload]);
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
@@ -13,6 +13,7 @@ import { UserMessage } from "./UserMessage";
 function renderWithFlags(node: ReactNode, bluebirdEnabled: boolean) {
   const flags: FeatureFlags = {
     isEnabled: () => bluebirdEnabled,
+    getPayload: () => undefined,
     onFlagsLoaded: () => () => {},
   };
   const container = new Container();

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -354,6 +354,19 @@ export function isFeatureFlagEnabled(flagKey: string): boolean {
 }
 
 /**
+ * The flag's payload when it evaluates enabled for the current user.
+ * Returns undefined if PostHog is not initialized, the flag is off, or it
+ * carries no payload.
+ */
+export function getFeatureFlagPayload(flagKey: string): unknown {
+  if (!isInitialized) {
+    return undefined;
+  }
+
+  return posthog.getFeatureFlagPayload(flagKey) ?? undefined;
+}
+
+/**
  * Subscribe to feature flag changes.
  * Callback is called when flags are loaded or updated.
  * Returns unsubscribe function.
@@ -405,6 +418,7 @@ export const posthogAnalyticsTracker: AnalyticsTracker = {
  */
 export const posthogFeatureFlags: FeatureFlags = {
   isEnabled: isFeatureFlagEnabled,
+  getPayload: getFeatureFlagPayload,
   onFlagsLoaded: onFeatureFlagsLoaded,
 };
 

--- a/products/desktop/packages/workspace-server/src/services/local-mcp/identifiers.ts
+++ b/products/desktop/packages/workspace-server/src/services/local-mcp/identifiers.ts
@@ -1,4 +1,5 @@
 import type { LocalMcpServerDescriptor } from "@posthog/shared";
+import type { AddUserMcpServerInput } from "./schemas";
 
 export const LOCAL_MCP_SERVICE = Symbol.for("posthog.workspace.localMcp");
 
@@ -8,4 +9,9 @@ export interface LocalMcpService {
    * the project-scoped section for `cwd` over the user-scoped one when given.
    */
   listServers(cwd?: string): Promise<LocalMcpServerDescriptor[]>;
+  /**
+   * Adds or replaces a user-scoped streamable-HTTP server in ~/.claude.json,
+   * the same entry `claude mcp add --scope user --transport http` writes.
+   */
+  addUserServer(input: AddUserMcpServerInput): Promise<void>;
 }

--- a/products/desktop/packages/workspace-server/src/services/local-mcp/local-mcp.ts
+++ b/products/desktop/packages/workspace-server/src/services/local-mcp/local-mcp.ts
@@ -1,11 +1,19 @@
-import { loadUserClaudeJsonMcpServerDescriptors } from "@posthog/agent/adapters/claude/session/mcp-config";
+import {
+  loadUserClaudeJsonMcpServerDescriptors,
+  saveUserClaudeJsonHttpMcpServer,
+} from "@posthog/agent/adapters/claude/session/mcp-config";
 import type { LocalMcpServerDescriptor } from "@posthog/shared";
 import { injectable } from "inversify";
 import type { LocalMcpService } from "./identifiers";
+import type { AddUserMcpServerInput } from "./schemas";
 
 @injectable()
 export class LocalMcpServiceImpl implements LocalMcpService {
   async listServers(cwd?: string): Promise<LocalMcpServerDescriptor[]> {
     return loadUserClaudeJsonMcpServerDescriptors(cwd);
+  }
+
+  async addUserServer(input: AddUserMcpServerInput): Promise<void> {
+    saveUserClaudeJsonHttpMcpServer(input.name, input.url);
   }
 }

--- a/products/desktop/packages/workspace-server/src/services/local-mcp/schemas.ts
+++ b/products/desktop/packages/workspace-server/src/services/local-mcp/schemas.ts
@@ -32,3 +32,16 @@ export const listLocalMcpServersInput = z.object({
 export const listLocalMcpServersOutput = z.array(
   localMcpServerDescriptorSchema,
 );
+
+export const addUserMcpServerInput = z.object({
+  // Server keys become MCP tool-name prefixes (mcp__<name>__*), so keep them
+  // identifier-shaped like `claude mcp add` does.
+  name: z
+    .string()
+    .min(1)
+    .max(100)
+    .regex(/^[a-zA-Z0-9_-]+$/),
+  url: z.url({ protocol: /^https?$/ }),
+});
+
+export type AddUserMcpServerInput = z.infer<typeof addUserMcpServerInput>;


### PR DESCRIPTION
## Problem

Internal-only MCP servers can't be listed in the desktop marketplace today.

- The cloud MCP store proxies installs through PostHog cloud, which can't reach or authenticate to servers gated by network identity.
- Internal endpoints must stay out of this public repo, so a catalog entry can't carry them.

The first user is an internal PostHog hosting tool, requested in the PostHog Code channel.

## Changes

- The marketplace renders one extra card when the permanent `posthog-code-hosthog-mcp` flag is on ([flag](https://us.posthog.com/project/2/feature_flags/800779), internal users only).
- The flag payload carries the server config (`name`, `url`, `displayName`, `description`, `iconDomain`), validated by `flaggedMcpServerPayloadSchema`. No internal endpoint lands in the repo.
- Connect writes a user-scoped streamable-HTTP entry to `~/.claude.json`, the same entry `claude mcp add --scope user --transport http` writes. Agent sessions already read that file.
- The `FeatureFlags` port gains `getPayload` (posthog-js `getFeatureFlagPayload`), with a `useFeatureFlagPayload` hook.
- A new `localMcp.addUserServer` mutation goes through the existing local-mcp seam (host-router → workspace-server → `@posthog/agent` writer). The writer preserves the rest of `~/.claude.json` and refuses to overwrite an unparseable file.
- The card only renders on hosts with a local workspace, so web and mobile never show it.

> [!NOTE]
> The cloud-import classifier already treats `.ts.net` hosts as desktop-only, so cloud task runs reach this server through the desktop relay, not the sandbox.

## How did you test this code?

- New writer tests: round-trips through the existing reader, preserves unrelated config keys, and leaves a corrupt `~/.claude.json` untouched. No prior test covered writes.
- New schema tests: one valid payload plus five malformed shapes return null, so a bad remote payload can't render a card or write config.
- Ran the agent, core, ui, and workspace-server suites, the full workspace typecheck, Biome lint and format, and the host-boundary check.
- Not done: a manual run of the Electron app and a card screenshot. The sandbox has no display and `hogli pr:upload-image` needs the Python env it lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The surface is internal-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - directed by Adam B via a PostHog Code task. Left unassigned because I can't verify a GitHub handle from this session.

- I (Claude, PostHog Code cloud task) first scoped this as a cloud MCP store catalog entry (`products/mcp_store`), then rejected it: the target server authenticates by network position only, so the store's cloud proxy can never reach it, and its endpoint can't live in a public catalog file.
- The flag exists in US project 2, active, tagged `posthog-code` and `permanent`, targeting internal users, with the payload set.
- Skills invoked: /adding-mcp-store-servers, /writing-code-comments, /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
