### PR TITLE
fix(desktop): mark task activity read when the task is open

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityRead.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityRead.ts
@@ -4,8 +4,11 @@ import type {
 } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { TASK_ACTIVITY_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
+import { logger } from "@posthog/ui/shell/logger";
 import type { InfiniteData } from "@tanstack/react-query";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const log = logger.scope("task-activity");
 
 /**
  * Clear the unread flag on specific tasks. Read state lives per task on the server,
@@ -20,6 +23,12 @@ export function useMarkTaskActivityRead() {
       if (!client) throw new Error("Not authenticated");
       if (activities.length === 0) return;
       return client.markTaskActivityRead(activities);
+    },
+    // No rollback or refetch: the optimistic "read" state is what the user
+    // asked for, and the server retries on the next open. Log so a failing
+    // background call leaves a trace.
+    onError: (error) => {
+      log.warn("Failed to mark task activity read", { error });
     },
     onMutate: async (activities: TaskActivityReadMarker[]) => {
       const markedTasks = new Map(

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityReadOnOpen.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityReadOnOpen.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useMarkTaskActivityRead } from "./useMarkTaskActivityRead";
+
+/**
+ * Opening a task counts as reading it: clears the task's activity-feed row
+ * (server read state and the cached feed) once per task the surface shows.
+ */
+export function useMarkTaskActivityReadOnOpen(
+  taskId: string | undefined,
+): void {
+  const { mutate: markTasksRead } = useMarkTaskActivityRead();
+  useEffect(() => {
+    if (!taskId) return;
+    markTasksRead([{ task_id: taskId, seen_before: new Date().toISOString() }]);
+  }, [taskId, markTasksRead]);
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityReadOnOpen.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useMarkTaskActivityReadOnOpen.ts
@@ -1,16 +1,58 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useMarkTaskActivityRead } from "./useMarkTaskActivityRead";
+import { useTaskActivity } from "./useTaskActivity";
 
 /**
  * Opening a task counts as reading it: clears the task's activity-feed row
- * (server read state and the cached feed) once per task the surface shows.
+ * (server read state and the cached feed) when the surface mounts, and keeps
+ * it clear while the task stays on a focused screen. Activity that lands
+ * while the window is unfocused stays unread until focus returns, matching
+ * how the notification bus only births signals read for a focused viewer.
+ *
+ * `seen_before` is the newer of "now" and the row's own `activity_at`: rows
+ * are stamped by the server clock, so a lagging client clock alone must not
+ * leave the row it is clearing out of range.
  */
 export function useMarkTaskActivityReadOnOpen(
   taskId: string | undefined,
 ): void {
+  const { items } = useTaskActivity({ enabled: false });
   const { mutate: markTasksRead } = useMarkTaskActivityRead();
-  useEffect(() => {
+  const row = taskId ? items.find((item) => item.taskId === taskId) : undefined;
+  const latestActivityAt = row?.activityAt;
+  const hasUnread = row?.isUnread ?? false;
+  const latestRef = useRef(latestActivityAt);
+  latestRef.current = latestActivityAt;
+  const marked = useRef<{ taskId: string; seenBefore: string } | null>(null);
+
+  const mark = useCallback(() => {
     if (!taskId) return;
-    markTasksRead([{ task_id: taskId, seen_before: new Date().toISOString() }]);
+    const latest = latestRef.current;
+    const last = marked.current;
+    if (
+      last?.taskId === taskId &&
+      (!latest || Date.parse(latest) <= Date.parse(last.seenBefore))
+    ) {
+      return;
+    }
+    const now = new Date().toISOString();
+    const seenBefore =
+      latest && Date.parse(latest) > Date.parse(now) ? latest : now;
+    marked.current = { taskId, seenBefore };
+    markTasksRead([{ task_id: taskId, seen_before: seenBefore }]);
   }, [taskId, markTasksRead]);
+
+  useEffect(() => {
+    mark();
+  }, [mark]);
+
+  useEffect(() => {
+    if (!hasUnread) return;
+    if (document.hasFocus()) {
+      mark();
+      return;
+    }
+    window.addEventListener("focus", mark);
+    return () => window.removeEventListener("focus", mark);
+  }, [hasUnread, mark]);
 }

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
@@ -287,4 +287,72 @@ describe("task activity hooks", () => {
       { task_id: "task-2", seen_before: expect.any(String) },
     ]);
   });
+
+  it("clears unread activity that lands while the task is open, stamping the row's own timestamp", async () => {
+    mockClient.markTaskActivityRead.mockResolvedValue({
+      marked_read: 1,
+      unread_count: 0,
+    });
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    renderHook(() => useMarkTaskActivityReadOnOpen("task-1"), { wrapper });
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityRead).toHaveBeenCalledOnce(),
+    );
+
+    act(() => {
+      queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, {
+        pages: [
+          {
+            results: [activity({ activity_at: "2099-01-01T00:00:00.000Z" })],
+            unread_count: 1,
+          },
+        ],
+        pageParams: [undefined],
+      });
+    });
+
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityRead).toHaveBeenCalledTimes(2),
+    );
+    expect(mockClient.markTaskActivityRead).toHaveBeenLastCalledWith([
+      { task_id: "task-1", seen_before: "2099-01-01T00:00:00.000Z" },
+    ]);
+    hasFocus.mockRestore();
+  });
+
+  it("defers clearing unread activity to window focus while the app is unfocused", async () => {
+    mockClient.markTaskActivityRead.mockResolvedValue({
+      marked_read: 1,
+      unread_count: 0,
+    });
+    const hasFocus = vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    renderHook(() => useMarkTaskActivityReadOnOpen("task-1"), { wrapper });
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityRead).toHaveBeenCalledOnce(),
+    );
+
+    act(() => {
+      queryClient.setQueryData(TASK_ACTIVITY_QUERY_KEY, {
+        pages: [
+          {
+            results: [activity({ activity_at: "2099-01-01T00:00:00.000Z" })],
+            unread_count: 1,
+          },
+        ],
+        pageParams: [undefined],
+      });
+    });
+    expect(mockClient.markTaskActivityRead).toHaveBeenCalledOnce();
+
+    hasFocus.mockReturnValue(true);
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityRead).toHaveBeenCalledTimes(2),
+    );
+    hasFocus.mockRestore();
+  });
 });

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useTaskActivity.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@posthog/ui/features/auth/authClient", () => ({
 }));
 
 import { useMarkTaskActivityRead } from "./useMarkTaskActivityRead";
+import { useMarkTaskActivityReadOnOpen } from "./useMarkTaskActivityReadOnOpen";
 import { TASK_ACTIVITY_QUERY_KEY, useTaskActivity } from "./useTaskActivity";
 
 function activity(overrides: Partial<TaskActivity>): TaskActivity {
@@ -256,5 +257,34 @@ describe("task activity hooks", () => {
       true,
     ]);
     expect(cached?.pages[0]?.unread_count).toBe(2);
+  });
+
+  it("marks a task's activity read once per opened task", async () => {
+    mockClient.markTaskActivityRead.mockResolvedValue({
+      marked_read: 1,
+      unread_count: 0,
+    });
+
+    const hook = renderHook(
+      ({ taskId }: { taskId: string }) => useMarkTaskActivityReadOnOpen(taskId),
+      { wrapper, initialProps: { taskId: "task-1" } },
+    );
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityRead).toHaveBeenCalledOnce(),
+    );
+    expect(mockClient.markTaskActivityRead).toHaveBeenCalledWith([
+      { task_id: "task-1", seen_before: expect.any(String) },
+    ]);
+
+    hook.rerender({ taskId: "task-1" });
+    expect(mockClient.markTaskActivityRead).toHaveBeenCalledOnce();
+
+    hook.rerender({ taskId: "task-2" });
+    await waitFor(() =>
+      expect(mockClient.markTaskActivityRead).toHaveBeenCalledTimes(2),
+    );
+    expect(mockClient.markTaskActivityRead).toHaveBeenLastCalledWith([
+      { task_id: "task-2", seen_before: expect.any(String) },
+    ]);
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
@@ -7,6 +7,12 @@ import type {
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { type InfiniteData, QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const markTaskActivityRead = vi.hoisted(() => vi.fn());
+vi.mock("@posthog/ui/features/auth/authClientImperative", () => ({
+  getAuthenticatedClient: () => Promise.resolve({ markTaskActivityRead }),
+}));
+
 import { TaskActivityContribution } from "./taskActivity.contribution";
 
 let activityListener: ((signal: TaskActivitySignal) => void) | undefined;
@@ -208,6 +214,27 @@ describe("TaskActivityContribution", () => {
       "task-activity",
     ]);
     expect(cached?.pages[0]?.results[0]?.channel_id).toBeNull();
+  });
+
+  it.each([
+    ["born-read activity advances the server read cursor", false, 1],
+    ["unread activity leaves the server cursor alone", true, 0],
+  ])("%s", async (_label, isUnread, persistCalls) => {
+    activityListener?.({
+      taskId: "task-1",
+      taskTitle: "Channel task",
+      activityKind: "completed",
+      activityAt: "2026-07-27T10:00:00Z",
+      isUnread,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(markTaskActivityRead).toHaveBeenCalledTimes(persistCalls);
+    if (persistCalls > 0) {
+      expect(markTaskActivityRead).toHaveBeenCalledWith([
+        { task_id: "task-1", seen_before: "2026-07-27T10:00:00Z" },
+      ]);
+    }
   });
 
   it("does not recreate activity data after the authenticated query is removed", () => {

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
@@ -61,6 +61,7 @@ describe("TaskActivityContribution", () => {
       taskTitle: "Channel task",
       activityKind: "awaiting_input",
       activityAt: "2026-07-27T10:00:00Z",
+      isUnread: true,
     });
 
     const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
@@ -75,6 +76,56 @@ describe("TaskActivityContribution", () => {
           channel_id: null,
           activity_kind: "awaiting_input",
           is_unread: true,
+        },
+      ],
+    });
+  });
+
+  it("replaces an unread row with read activity without increasing the count", () => {
+    queryClient.setQueryDefaults(["task-activity"], {
+      meta: AUTH_SCOPED_QUERY_META,
+    });
+    queryClient.setQueryData<InfiniteData<TaskActivityPage>>(
+      ["task-activity"],
+      {
+        pages: [
+          {
+            results: [
+              {
+                id: "activity-1",
+                task_id: "task-1",
+                task_title: "Channel task",
+                activity_at: "2026-07-27T09:00:00Z",
+                activity_kind: "awaiting_input",
+                snippet: "",
+                is_unread: true,
+              },
+            ],
+            unread_count: 1,
+          },
+        ],
+        pageParams: [undefined],
+      },
+    );
+
+    activityListener?.({
+      taskId: "task-1",
+      taskTitle: "Channel task",
+      activityKind: "completed",
+      activityAt: "2026-07-27T10:00:00Z",
+      isUnread: false,
+    });
+
+    const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
+      "task-activity",
+    ]);
+    expect(cached?.pages[0]).toMatchObject({
+      unread_count: 0,
+      results: [
+        {
+          task_id: "task-1",
+          activity_kind: "completed",
+          is_unread: false,
         },
       ],
     });
@@ -101,6 +152,7 @@ describe("TaskActivityContribution", () => {
       taskTitle: "Channel task",
       activityKind: "completed",
       activityAt: "2026-07-27T10:00:00Z",
+      isUnread: true,
     });
 
     const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
@@ -149,6 +201,7 @@ describe("TaskActivityContribution", () => {
       taskTitle: "Channel task",
       activityKind: "completed",
       activityAt: "2026-07-27T10:00:00Z",
+      isUnread: true,
     });
 
     const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
@@ -163,6 +216,7 @@ describe("TaskActivityContribution", () => {
       taskTitle: "Previous user's task",
       activityKind: "completed",
       activityAt: "2026-07-27T10:00:00Z",
+      isUnread: true,
     });
 
     expect(queryClient.getQueryData(["task-activity"])).toBeUndefined();

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
@@ -1,10 +1,12 @@
 import type { Contribution } from "@posthog/di/contribution";
 import type { Task, TaskActivityPage } from "@posthog/shared/domain-types";
+import { getAuthenticatedClient } from "@posthog/ui/features/auth/authClientImperative";
 import {
   NotificationBus,
   type TaskActivitySignal,
 } from "@posthog/ui/features/notifications/notifications";
 import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
+import { logger } from "@posthog/ui/shell/logger";
 import {
   IMPERATIVE_QUERY_CLIENT,
   type ImperativeQueryClient,
@@ -12,6 +14,8 @@ import {
 import type { InfiniteData } from "@tanstack/react-query";
 import { inject, injectable } from "inversify";
 import { TASK_ACTIVITY_QUERY_KEY } from "./taskActivityQuery";
+
+const log = logger.scope("task-activity");
 
 @injectable()
 export class TaskActivityContribution implements Contribution {
@@ -25,7 +29,23 @@ export class TaskActivityContribution implements Contribution {
   start(): void {
     this.notificationBus.subscribeToTaskActivity((signal) => {
       this.apply(signal);
+      if (!signal.isUnread) this.persistRead(signal);
     });
+  }
+
+  // A born-read row only exists in this session's cache; without advancing
+  // the server's read cursor too, the activity comes back unread on the next
+  // cold load even though the user watched it happen.
+  private persistRead(signal: TaskActivitySignal): void {
+    getAuthenticatedClient()
+      .then((client) =>
+        client?.markTaskActivityRead([
+          { task_id: signal.taskId, seen_before: signal.activityAt },
+        ]),
+      )
+      .catch((error) => {
+        log.warn("Failed to persist watched task activity as read", { error });
+      });
   }
 
   private apply(signal: TaskActivitySignal): void {

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
@@ -60,22 +60,25 @@ export class TaskActivityContribution implements Contribution {
           snippet: "",
           latest_author: null,
           latest_message_id: null,
-          is_unread: true,
+          is_unread: signal.isUnread,
         };
         if (!data) {
           return {
-            pages: [{ results: [activity], unread_count: 1 }],
+            pages: [
+              { results: [activity], unread_count: signal.isUnread ? 1 : 0 },
+            ],
             pageParams: [undefined],
           };
         }
-        const unreadIncrement = previous?.is_unread ? 0 : 1;
+        const unreadDelta =
+          Number(signal.isUnread) - Number(previous?.is_unread ?? false);
         return {
           ...data,
           pages: data.pages.map((page, index) => ({
             ...page,
             unread_count:
               index === 0
-                ? page.unread_count + unreadIncrement
+                ? Math.max(0, page.unread_count + unreadDelta)
                 : page.unread_count,
             results:
               index === 0

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -130,6 +130,7 @@ describe("notifyPromptComplete", () => {
         taskId: TASK_ID,
         taskTitle: "My task",
         activityKind: "completed",
+        isUnread: true,
       }),
     );
 
@@ -150,7 +151,23 @@ describe("notifyPromptComplete", () => {
         taskId: TASK_ID,
         taskTitle: "My task",
         activityKind: "awaiting_input",
+        isUnread: true,
       }),
+    );
+  });
+
+  it("emits activity born read when the task is already on screen", () => {
+    const { bus } = makeBus({
+      hasFocus: true,
+      activeTarget: taskTarget(TASK_ID),
+    });
+    const listener = vi.fn();
+    bus.subscribeToTaskActivity(listener);
+
+    bus.notifyPromptComplete("My task", "end_turn", TASK_ID);
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: TASK_ID, isUnread: false }),
     );
   });
 

--- a/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.test.ts
@@ -156,9 +156,12 @@ describe("notifyPromptComplete", () => {
     );
   });
 
-  it("emits activity born read when the task is already on screen", () => {
+  it.each([
+    ["focused on the task → born read", true, false],
+    ["task on screen but app unfocused → unread", false, true],
+  ])("emits activity: %s", (_label, hasFocus, isUnread) => {
     const { bus } = makeBus({
-      hasFocus: true,
+      hasFocus,
       activeTarget: taskTarget(TASK_ID),
     });
     const listener = vi.fn();
@@ -167,7 +170,7 @@ describe("notifyPromptComplete", () => {
     bus.notifyPromptComplete("My task", "end_turn", TASK_ID);
 
     expect(listener).toHaveBeenCalledWith(
-      expect.objectContaining({ taskId: TASK_ID, isUnread: false }),
+      expect.objectContaining({ taskId: TASK_ID, isUnread }),
     );
   });
 

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -57,9 +57,9 @@ export interface TaskActivitySignal {
   taskTitle: string;
   activityKind: Extract<TaskActivityKind, "awaiting_input" | "completed">;
   activityAt: string;
-  // False when the user already has the task on screen: the feed row should
-  // still update, but activity they are watching happen must not light the
-  // unread badge.
+  // False when the user is watching the task happen (app focused and the task
+  // on screen, the same pair routeNotification uses to suppress delivery): the
+  // feed row should still update, but it must not light the unread badge.
   isUnread: boolean;
 }
 
@@ -229,10 +229,10 @@ export class NotificationBus {
       taskTitle,
       activityKind,
       activityAt: new Date().toISOString(),
-      isUnread: !targetsEqual(this.view.getActiveTarget(), {
-        kind: "task",
-        taskId,
-      }),
+      isUnread: !(
+        this.view.hasFocus() &&
+        targetsEqual(this.view.getActiveTarget(), { kind: "task", taskId })
+      ),
     };
     for (const listener of this.taskActivityListeners) {
       try {

--- a/products/desktop/packages/ui/src/features/notifications/notifications.ts
+++ b/products/desktop/packages/ui/src/features/notifications/notifications.ts
@@ -20,7 +20,7 @@ import {
   type INotificationSettings,
   NOTIFICATION_SETTINGS_PROVIDER,
 } from "./identifiers";
-import { routeNotification } from "./routeNotification";
+import { routeNotification, targetsEqual } from "./routeNotification";
 
 const MAX_TITLE_LENGTH = 50;
 const log = logger.scope("notifications");
@@ -57,6 +57,10 @@ export interface TaskActivitySignal {
   taskTitle: string;
   activityKind: Extract<TaskActivityKind, "awaiting_input" | "completed">;
   activityAt: string;
+  // False when the user already has the task on screen: the feed row should
+  // still update, but activity they are watching happen must not light the
+  // unread badge.
+  isUnread: boolean;
 }
 
 // The single channel every app notification flows through. Reads focus + the
@@ -225,6 +229,10 @@ export class NotificationBus {
       taskTitle,
       activityKind,
       activityAt: new Date().toISOString(),
+      isUnread: !targetsEqual(this.view.getActiveTarget(), {
+        kind: "task",
+        taskId,
+      }),
     };
     for (const listener of this.taskActivityListeners) {
       try {

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -144,6 +144,14 @@ export function TaskDetail({
 
   useBlurOnEscape();
   useWorkspaceEvents(taskId);
+
+  // Mounting TaskDetail means the task was actually rendered in front of the
+  // user — that, not any API fetch of the task, is what clears the unread
+  // activity flag ("the agent is waiting for your reply"). Now-based rather
+  // than row-versioned since everything up to mount has been seen; a waiting
+  // flag landing after mount re-flags unread. Marking client-side rather than
+  // in the retrieve endpoint: a task fetch (list refresh, poll, prefetch)
+  // isn't a view.
   useMarkTaskActivityReadOnOpen(taskId);
 
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -14,7 +14,7 @@ import { logger } from "../../../shell/logger";
 import { useArchiveTask } from "../../archive/useArchiveTask";
 import { ChannelBreadcrumb } from "../../canvas/components/ChannelBreadcrumb";
 import { CopyThreadLinkButton } from "../../canvas/components/CopyThreadLinkButton";
-import { useMarkTaskActivityRead } from "../../canvas/hooks/useMarkTaskActivityRead";
+import { useMarkTaskActivityReadOnOpen } from "../../canvas/hooks/useMarkTaskActivityReadOnOpen";
 import {
   LazyCloudReviewPage as CloudReviewPage,
   LazyReviewPage as ReviewPage,
@@ -134,19 +134,6 @@ export function TaskDetail({
     };
   }, [enableScope, disableScope]);
 
-  // Mounting TaskDetail means the task was actually rendered in front of the
-  // user — that, not any API fetch of the task, is what clears the unread
-  // activity flag ("the agent is waiting for your reply"). Now-based rather
-  // than row-versioned since everything up to mount has been seen; a waiting
-  // flag landing after mount re-flags unread. Marking client-side rather than
-  // in the retrieve endpoint: a task fetch (list refresh, poll, prefetch)
-  // isn't a view.
-
-  const { mutate: markTasksRead } = useMarkTaskActivityRead();
-  useEffect(() => {
-    markTasksRead([{ task_id: taskId, seen_before: new Date().toISOString() }]);
-  }, [markTasksRead, taskId]);
-
   useHotkeys("mod+p", () => openFilePicker(), {
     enableOnContentEditable: true,
     enableOnFormTags: true,
@@ -157,6 +144,7 @@ export function TaskDetail({
 
   useBlurOnEscape();
   useWorkspaceEvents(taskId);
+  useMarkTaskActivityReadOnOpen(taskId);
 
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const isEditingTitle = editingTaskId === taskId;


### PR DESCRIPTION
[Robot] This existing PR was refreshed by an AI coding agent and stacked on #84021.

## Problem

Opening a task must clear its unread Activity row. Activity that arrives while the user is already watching that task must not add to the unread badge.

## Changes

- Replace the one-shot task detail mutation with a focused read-on-open hook.
- Mark the task read when its detail view opens.
- Keep clearing new activity while the user watches the task.
- Wait until window focus returns before clearing activity that arrived in the background.
- Treat real-time activity as read when the focused app already shows that task.
- Save that read state on the server so it survives a cold reload.
- Log failures from background read-state updates.

## Stack

- Depends on #84021, which adds the saved **Show my activity** filter.
- This is the second PR in the requested stack.

## Tests

- 59 focused Vitest tests passed across Activity filters, task activity hooks, real-time activity, and notifications.
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check` on all changed files