### PR TITLE
fix(data-modeling): stop scheduling v2 saved queries without a node

### DIFF
--- a/products/data_modeling/backend/logic/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/logic/saved_query_dag_sync.py
@@ -254,6 +254,18 @@ class HasDependentsError(Exception):
     pass
 
 
+class MissingDagNodeError(Exception):
+    """Raised when a saved query on a v2 team has no node to schedule through.
+
+    On v2 the node is the unit of execution: the DAG run materializes nodes, so a saved query
+    with no node is not reachable by any schedule. Every caller syncs the query to the DAG before
+    scheduling it, and each one swallows that sync failing, so without this the query would be
+    left claiming to be materialized while nothing refreshes it.
+    """
+
+    pass
+
+
 def get_dependent_saved_queries(saved_query: "DataWarehouseSavedQuery") -> list["DataWarehouseSavedQuery"]:
     """
     Get SavedQueries that depend on this one (immediate dependents only).

--- a/products/data_modeling/backend/logic/saved_query_dag_sync.py
+++ b/products/data_modeling/backend/logic/saved_query_dag_sync.py
@@ -258,9 +258,8 @@ class MissingDagNodeError(Exception):
     """Raised when a saved query on a v2 team has no node to schedule through.
 
     On v2 the node is the unit of execution: the DAG run materializes nodes, so a saved query
-    with no node is not reachable by any schedule. Every caller syncs the query to the DAG before
-    scheduling it, and each one swallows that sync failing, so without this the query would be
-    left claiming to be materialized while nothing refreshes it.
+    with no node is not reachable by any schedule. Without this the query would be left claiming
+    to be materialized while nothing refreshes it.
     """
 
     pass

--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -203,6 +203,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
             UnsatisfiableFrequencyError,
             UnsupportedFrequencyTargetError,
         )
+        from products.data_modeling.backend.logic.saved_query_dag_sync import MissingDagNodeError
         from products.data_modeling.backend.logic.schedule_reconcile import (
             apply_saved_query_frequency_target,
             bootstrap_dag_to_tiers,
@@ -223,21 +224,28 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
             # that, if it fails, we honor the failure contract below rather than leaving
             # is_materialized=True with no schedule backing it.
             on_v2 = self.id in get_v2_saved_query_ids([self.id])
+            node = (
+                Node.objects.filter(team_id=self.team_id, saved_query_id=self.id)
+                .select_related("dag", "dag__team")
+                .first()
+            )
             dag_to_bootstrap = None
             if not on_v2:
                 # Nothing creates a DAG's first v2 schedule outside the migration commands, so a
                 # brand-new team would fall through to v1 forever. Bootstrap it instead — declined
                 # unless the DAG has never been scheduled at all.
-                node = (
-                    Node.objects.filter(team_id=self.team_id, saved_query_id=self.id)
-                    .select_related("dag", "dag__team")
-                    .first()
-                )
                 if node is not None and node.dag is not None and dag_can_bootstrap_to_tiers(node.dag):
                     dag_to_bootstrap = node.dag
                     on_v2 = True
 
             if on_v2:
+                if node is None:
+                    # v2 executes nodes, so scheduling without one would report success while
+                    # nothing ever materializes the query. Fail into the contract below instead,
+                    # which clears is_materialized and captures the error.
+                    raise MissingDagNodeError(
+                        f"Saved query {self.id} is on a v2 team but has no DAG node to schedule through"
+                    )
                 # Tiered v2: the interval is one-shot transport for frequency intent — consume
                 # it into the node target(s) and reconcile. Validation raises before the
                 # nulling below, so a rejected frequency stays visible for retry. A call with

--- a/products/data_modeling/backend/models/datawarehouse_saved_query.py
+++ b/products/data_modeling/backend/models/datawarehouse_saved_query.py
@@ -223,7 +223,7 @@ class DataWarehouseSavedQuery(CreatedMetaFields, UUIDTModel, UpdatedMetaFields, 
             # create or revive a per-query v1 schedule. This Temporal lookup stays inside the try so
             # that, if it fails, we honor the failure contract below rather than leaving
             # is_materialized=True with no schedule backing it.
-            on_v2 = self.id in get_v2_saved_query_ids([self.id])
+            on_v2 = self.id in get_v2_saved_query_ids([self.id], team_id=self.team_id)
             node = (
                 Node.objects.filter(team_id=self.team_id, saved_query_id=self.id)
                 .select_related("dag", "dag__team")

--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -15,7 +15,6 @@ import hashlib
 from collections import defaultdict
 from collections.abc import Collection
 from datetime import timedelta
-from typing import TYPE_CHECKING
 
 from asgiref.sync import async_to_sync
 from temporalio.client import ScheduleCalendarSpec, ScheduleListActionStartWorkflow, ScheduleRange, ScheduleSpec
@@ -31,10 +30,8 @@ from posthog.temporal.common.search_attributes import (
 
 from products.data_modeling.backend.logic.cohort_scheduling import dag_id_from_schedule_id
 from products.data_modeling.backend.models.dag import DAG
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.models.node import Node
-
-if TYPE_CHECKING:
-    from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 
 # v2 (DAG-based) schedules run this workflow; their schedule id is the bare DAG id, or
 # "{dag_id}:{interval_seconds}" for a per-cadence-tier schedule. The v1 backend
@@ -92,21 +89,17 @@ async def get_v2_scheduled_dag_ids(candidate_dag_ids: Collection[str] | None = N
     return dag_ids
 
 
-def _fallback_dag_ids_for_nodeless(saved_query_ids: set[uuid.UUID]) -> dict[uuid.UUID, set[str]]:
+def _team_dag_ids_for_nodeless_queries(saved_query_ids: set[uuid.UUID]) -> dict[uuid.UUID, set[str]]:
     """Stand in the owning team's DAGs for saved queries that have no node to resolve through.
 
     A saved query normally reaches its DAG via its node, but the node can be absent when we are
-    asked: `sync_saved_query_to_dag` deletes it when dependency resolution raises, and a caller
-    that swallows that failure still goes on to schedule the query. Resolving "no node" to "not
-    on v2" mints a v1 per-query schedule beside the team's live tier, and the query then
-    materializes twice on every cycle. Answering from the team is the safe direction, because a
-    team with no v2-scheduled DAG still comes back v1-eligible.
+    asked: `sync_saved_query_to_dag` deletes it when dependency resolution raises. Resolving "no
+    node" to "not on v2" mints a v1 per-query schedule beside the team's live tier, and the query
+    then materializes twice on every cycle. Answering from the team is the safe direction, because
+    a team with no v2-scheduled DAG still comes back v1-eligible.
     """
     if not saved_query_ids:
         return {}
-
-    # schedule.py is imported by the saved query model, so this import cannot be module-level.
-    from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery  # noqa: PLC0415
 
     team_by_saved_query = dict(
         DataWarehouseSavedQuery.objects.filter(id__in=saved_query_ids).values_list("id", "team_id")
@@ -133,6 +126,10 @@ def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -
     A saved query counts as on v2 when any DAG it belongs to has a v2 schedule, because it can sit
     in several DAGs and one v1-scheduled placement does not make a v1 schedule safe to mint.
 
+    A saved query with no node at all counts as on v2 when its team has any v2-scheduled DAG, so a
+    failed DAG sync never routes it to v1. Callers that then need a node must check for one
+    themselves, because this answers about the team rather than about a placement.
+
     Optionally restrict the lookup to `candidate_ids` to keep the query bounded. These saved
     queries must be skipped by v1 schedule commands so we never undo migration progress.
     """
@@ -149,7 +146,7 @@ def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -
                 dag_ids_by_saved_query[saved_query_id].add(str(dag_id))
 
         dag_ids_by_saved_query.update(
-            _fallback_dag_ids_for_nodeless(set(candidate_ids) - dag_ids_by_saved_query.keys())
+            _team_dag_ids_for_nodeless_queries(set(candidate_ids) - dag_ids_by_saved_query.keys())
         )
         if not dag_ids_by_saved_query:
             return set()
@@ -166,8 +163,8 @@ def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -
 
 
 def partition_saved_queries_by_v2_schedule(
-    saved_queries: list["DataWarehouseSavedQuery"],
-) -> tuple[list["DataWarehouseSavedQuery"], list["DataWarehouseSavedQuery"]]:
+    saved_queries: list[DataWarehouseSavedQuery],
+) -> tuple[list[DataWarehouseSavedQuery], list[DataWarehouseSavedQuery]]:
     """Split saved queries into (v1_eligible, on_v2).
 
     A saved query is "on v2" when any DAG it belongs to already has a `data-modeling-execute-dag`

--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -89,46 +89,21 @@ async def get_v2_scheduled_dag_ids(candidate_dag_ids: Collection[str] | None = N
     return dag_ids
 
 
-def _team_dag_ids_for_nodeless_queries(saved_query_ids: set[uuid.UUID]) -> dict[uuid.UUID, set[str]]:
-    """Stand in the owning team's DAGs for saved queries that have no node to resolve through.
-
-    A saved query normally reaches its DAG via its node, but the node can be absent when we are
-    asked: `sync_saved_query_to_dag` deletes it when dependency resolution raises. Resolving "no
-    node" to "not on v2" mints a v1 per-query schedule beside the team's live tier, and the query
-    then materializes twice on every cycle. Answering from the team is the safe direction, because
-    a team with no v2-scheduled DAG still comes back v1-eligible.
-    """
-    if not saved_query_ids:
-        return {}
-
-    team_by_saved_query = dict(
-        DataWarehouseSavedQuery.objects.filter(id__in=saved_query_ids).values_list("id", "team_id")
-    )
-    if not team_by_saved_query:
-        return {}
-
-    dag_ids_by_team: dict[int, set[str]] = defaultdict(set)
-    for team_id, dag_id in DAG.objects.filter(team_id__in=set(team_by_saved_query.values())).values_list(
-        "team_id", "id"
-    ):
-        dag_ids_by_team[team_id].add(str(dag_id))
-
-    return {
-        saved_query_id: dag_ids_by_team[team_id]
-        for saved_query_id, team_id in team_by_saved_query.items()
-        if dag_ids_by_team.get(team_id)
-    }
-
-
-def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -> set[uuid.UUID]:
+def get_v2_saved_query_ids(
+    candidate_ids: Collection[uuid.UUID] | None = None, *, team_id: int | None = None
+) -> set[uuid.UUID]:
     """Return saved query IDs whose DAG already runs on a v2 schedule.
 
     A saved query counts as on v2 when any DAG it belongs to has a v2 schedule, because it can sit
     in several DAGs and one v1-scheduled placement does not make a v1 schedule safe to mint.
 
-    A saved query with no node at all counts as on v2 when its team has any v2-scheduled DAG, so a
-    failed DAG sync never routes it to v1. Callers that then need a node must check for one
-    themselves, because this answers about the team rather than about a placement.
+    `team_id` extends that to saved queries with no node, answering from the team's DAGs instead.
+    A node can be absent because `sync_saved_query_to_dag` deletes it when dependency resolution
+    raises, and reading "no node" as "not on v2" mints a v1 per-query schedule beside the team's
+    live tier, which then materializes the query twice on every cycle. Only a caller that is about
+    to create a v1 schedule needs this, so it stays opt-in: it answers about the team rather than
+    about a placement, and such a caller must still check for a node before scheduling. Pass the
+    team the candidates belong to, never one derived from the ids themselves.
 
     Optionally restrict the lookup to `candidate_ids` to keep the query bounded. These saved
     queries must be skipped by v1 schedule commands so we never undo migration progress.
@@ -145,9 +120,15 @@ def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -
             if dag_id is not None:
                 dag_ids_by_saved_query[saved_query_id].add(str(dag_id))
 
-        dag_ids_by_saved_query.update(
-            _team_dag_ids_for_nodeless_queries(set(candidate_ids) - dag_ids_by_saved_query.keys())
-        )
+        if team_id is not None:
+            nodeless = set(candidate_ids) - dag_ids_by_saved_query.keys()
+            team_dag_ids = (
+                {str(dag_id) for dag_id in DAG.objects.filter(team_id=team_id).values_list("id", flat=True)}
+                if nodeless
+                else set()
+            )
+            if team_dag_ids:
+                dag_ids_by_saved_query.update(dict.fromkeys(nodeless, team_dag_ids))
         if not dag_ids_by_saved_query:
             return set()
 

--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -12,6 +12,7 @@ Frequency tiers:
 
 import uuid
 import hashlib
+from collections import defaultdict
 from collections.abc import Collection
 from datetime import timedelta
 from typing import TYPE_CHECKING
@@ -29,6 +30,7 @@ from posthog.temporal.common.search_attributes import (
 )
 
 from products.data_modeling.backend.logic.cohort_scheduling import dag_id_from_schedule_id
+from products.data_modeling.backend.models.dag import DAG
 from products.data_modeling.backend.models.node import Node
 
 if TYPE_CHECKING:
@@ -90,8 +92,46 @@ async def get_v2_scheduled_dag_ids(candidate_dag_ids: Collection[str] | None = N
     return dag_ids
 
 
+def _fallback_dag_ids_for_nodeless(saved_query_ids: set[uuid.UUID]) -> dict[uuid.UUID, set[str]]:
+    """Stand in the owning team's DAGs for saved queries that have no node to resolve through.
+
+    A saved query normally reaches its DAG via its node, but the node can be absent when we are
+    asked: `sync_saved_query_to_dag` deletes it when dependency resolution raises, and a caller
+    that swallows that failure still goes on to schedule the query. Resolving "no node" to "not
+    on v2" mints a v1 per-query schedule beside the team's live tier, and the query then
+    materializes twice on every cycle. Answering from the team is the safe direction, because a
+    team with no v2-scheduled DAG still comes back v1-eligible.
+    """
+    if not saved_query_ids:
+        return {}
+
+    # schedule.py is imported by the saved query model, so this import cannot be module-level.
+    from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery  # noqa: PLC0415
+
+    team_by_saved_query = dict(
+        DataWarehouseSavedQuery.objects.filter(id__in=saved_query_ids).values_list("id", "team_id")
+    )
+    if not team_by_saved_query:
+        return {}
+
+    dag_ids_by_team: dict[int, set[str]] = defaultdict(set)
+    for team_id, dag_id in DAG.objects.filter(team_id__in=set(team_by_saved_query.values())).values_list(
+        "team_id", "id"
+    ):
+        dag_ids_by_team[team_id].add(str(dag_id))
+
+    return {
+        saved_query_id: dag_ids_by_team[team_id]
+        for saved_query_id, team_id in team_by_saved_query.items()
+        if dag_ids_by_team.get(team_id)
+    }
+
+
 def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -> set[uuid.UUID]:
     """Return saved query IDs whose DAG already runs on a v2 schedule.
+
+    A saved query counts as on v2 when any DAG it belongs to has a v2 schedule, because it can sit
+    in several DAGs and one v1-scheduled placement does not make a v1 schedule safe to mint.
 
     Optionally restrict the lookup to `candidate_ids` to keep the query bounded. These saved
     queries must be skipped by v1 schedule commands so we never undo migration progress.
@@ -101,18 +141,21 @@ def get_v2_saved_query_ids(candidate_ids: Collection[uuid.UUID] | None = None) -
             return set()
         # Resolve the candidate saved queries to their DAGs first so the Temporal lookup is scoped
         # to just those DAGs rather than listing every schedule in the namespace.
-        dag_id_by_saved_query = {
-            saved_query_id: str(dag_id)
-            for saved_query_id, dag_id in Node.objects.filter(
-                saved_query_id__in=candidate_ids, saved_query_id__isnull=False
-            ).values_list("saved_query_id", "dag_id")
-            if dag_id is not None
-        }
-        if not dag_id_by_saved_query:
+        dag_ids_by_saved_query: dict[uuid.UUID, set[str]] = defaultdict(set)
+        for saved_query_id, dag_id in Node.objects.filter(
+            saved_query_id__in=candidate_ids, saved_query_id__isnull=False
+        ).values_list("saved_query_id", "dag_id"):
+            if dag_id is not None:
+                dag_ids_by_saved_query[saved_query_id].add(str(dag_id))
+
+        dag_ids_by_saved_query.update(
+            _fallback_dag_ids_for_nodeless(set(candidate_ids) - dag_ids_by_saved_query.keys())
+        )
+        if not dag_ids_by_saved_query:
             return set()
 
-        v2_dag_ids = get_v2_scheduled_dag_ids(set(dag_id_by_saved_query.values()))
-        return {saved_query_id for saved_query_id, dag_id in dag_id_by_saved_query.items() if dag_id in v2_dag_ids}
+        v2_dag_ids = get_v2_scheduled_dag_ids({dag_id for ids in dag_ids_by_saved_query.values() for dag_id in ids})
+        return {saved_query_id for saved_query_id, ids in dag_ids_by_saved_query.items() if ids & v2_dag_ids}
 
     v2_dag_ids = get_v2_scheduled_dag_ids()
     if not v2_dag_ids:

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -353,6 +353,43 @@ class TestV2ScheduleGuard(BaseTest):
         assert eligible == []
         assert on_v2 == []
 
+    def _saved_query(self, name: str) -> DataWarehouseSavedQuery:
+        return DataWarehouseSavedQuery.objects.create(
+            name=name,
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        )
+
+    def test_saved_query_without_a_node_is_not_reported_as_v1_eligible(self):
+        nodeless = self._saved_query("sync_failed")
+        with mock.patch(
+            "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
+            return_value={str(self.v2_dag.id)},
+        ):
+            result = get_v2_saved_query_ids([nodeless.id])
+        assert result == {nodeless.id}
+
+    def test_saved_query_without_a_node_stays_v1_eligible_when_the_team_has_no_v2_dag(self):
+        nodeless = self._saved_query("sync_failed_on_v1_team")
+        with mock.patch(
+            "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
+            return_value=set(),
+        ):
+            result = get_v2_saved_query_ids([nodeless.id])
+        assert result == set()
+
+    @parameterized.expand([("v2_node_created_first", True), ("v1_node_created_first", False)])
+    def test_saved_query_in_two_dags_is_on_v2_when_either_dag_is(self, _name: str, v2_first: bool):
+        shared = self._saved_query("in_two_dags")
+        for dag in [self.v2_dag, self.v1_dag] if v2_first else [self.v1_dag, self.v2_dag]:
+            Node.objects.create(team=self.team, dag=dag, saved_query=shared, type=NodeType.VIEW)
+        with mock.patch(
+            "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
+            return_value={str(self.v2_dag.id)},
+        ):
+            result = get_v2_saved_query_ids([shared.id])
+        assert result == {shared.id}
+
 
 class TestGetV2ScheduledDagIds:
     def _listing(self, schedule_id: str, workflow: str):

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -366,7 +366,7 @@ class TestV2ScheduleGuard(BaseTest):
             "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
             return_value={str(self.v2_dag.id)},
         ):
-            result = get_v2_saved_query_ids([nodeless.id])
+            result = get_v2_saved_query_ids([nodeless.id], team_id=self.team.pk)
         assert result == {nodeless.id}
 
     def test_saved_query_without_a_node_stays_v1_eligible_when_no_dag_is_v2_scheduled(self):
@@ -375,7 +375,7 @@ class TestV2ScheduleGuard(BaseTest):
             "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
             return_value=set(),
         ):
-            result = get_v2_saved_query_ids([nodeless.id])
+            result = get_v2_saved_query_ids([nodeless.id], team_id=self.team.pk)
         assert result == set()
 
     @parameterized.expand([("v2_node_created_first", True), ("v1_node_created_first", False)])
@@ -387,7 +387,7 @@ class TestV2ScheduleGuard(BaseTest):
             "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
             return_value={str(self.v2_dag.id)},
         ):
-            result = get_v2_saved_query_ids([shared.id])
+            result = get_v2_saved_query_ids([shared.id], team_id=self.team.pk)
         assert result == {shared.id}
 
 

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -369,7 +369,7 @@ class TestV2ScheduleGuard(BaseTest):
             result = get_v2_saved_query_ids([nodeless.id])
         assert result == {nodeless.id}
 
-    def test_saved_query_without_a_node_stays_v1_eligible_when_the_team_has_no_v2_dag(self):
+    def test_saved_query_without_a_node_stays_v1_eligible_when_no_dag_is_v2_scheduled(self):
         nodeless = self._saved_query("sync_failed_on_v1_team")
         with mock.patch(
             "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -60,6 +60,24 @@ class TestScheduleMaterializationV2Guard(BaseTest):
         self.sq.refresh_from_db()
         assert self.sq.sync_frequency_interval is None
 
+    def test_saved_query_whose_node_vanished_does_not_mint_a_v1_schedule(self):
+        nodeless = DataWarehouseSavedQuery.objects.create(
+            name="sync_failed",
+            team=self.team,
+            query={"query": "SELECT 1", "kind": "HogQLQuery"},
+            sync_frequency_interval=timedelta(hours=12),
+        )
+        with (
+            mock.patch(GET_V2_DAG_IDS, return_value={str(self.dag.id)}),
+            mock.patch(f"{SERVICE}.sync_saved_query_workflow") as sync_wf,
+            mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=False),
+            mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths"),
+            mock.patch(f"{NODE_MAT}.sync_connect"),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            nodeless.schedule_materialization()
+        sync_wf.assert_not_called()
+
     def test_creates_v1_schedule_when_dag_not_on_v2(self):
         # an unmigrated v1 DAG: a live per-query schedule already covers this query, so the
         # bootstrap below must not fire and stack tiers on top of it

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -60,12 +60,13 @@ class TestScheduleMaterializationV2Guard(BaseTest):
         self.sq.refresh_from_db()
         assert self.sq.sync_frequency_interval is None
 
-    def test_saved_query_whose_node_vanished_does_not_mint_a_v1_schedule(self):
+    def test_saved_query_whose_node_vanished_is_refused_instead_of_scheduled(self):
         nodeless = DataWarehouseSavedQuery.objects.create(
             name="sync_failed",
             team=self.team,
             query={"query": "SELECT 1", "kind": "HogQLQuery"},
             sync_frequency_interval=timedelta(hours=12),
+            is_materialized=True,
         )
         with (
             mock.patch(GET_V2_DAG_IDS, return_value={str(self.dag.id)}),
@@ -77,6 +78,8 @@ class TestScheduleMaterializationV2Guard(BaseTest):
         ):
             nodeless.schedule_materialization()
         sync_wf.assert_not_called()
+        nodeless.refresh_from_db()
+        assert nodeless.is_materialized is False
 
     def test_creates_v1_schedule_when_dag_not_on_v2(self):
         # an unmigrated v1 DAG: a live per-query schedule already covers this query, so the

--- a/products/data_modeling/backend/test/test_schedule_materialization.py
+++ b/products/data_modeling/backend/test/test_schedule_materialization.py
@@ -72,8 +72,6 @@ class TestScheduleMaterializationV2Guard(BaseTest):
             mock.patch(GET_V2_DAG_IDS, return_value={str(self.dag.id)}),
             mock.patch(f"{SERVICE}.sync_saved_query_workflow") as sync_wf,
             mock.patch(f"{SERVICE}.saved_query_workflow_exists", return_value=False),
-            mock.patch.object(DataWarehouseSavedQuery, "setup_model_paths"),
-            mock.patch(f"{NODE_MAT}.sync_connect"),
             self.captureOnCommitCallbacks(execute=True),
         ):
             nodeless.schedule_materialization()

--- a/products/data_warehouse/backend/models/test/test_managed_viewset.py
+++ b/products/data_warehouse/backend/models/test/test_managed_viewset.py
@@ -81,6 +81,36 @@ class TestDataWarehouseManagedViewSetModel(BaseTest):
 
         reconcile.assert_called_once()
 
+    def test_failed_dag_sync_does_not_mint_a_v1_schedule(self):
+        managed_viewset = DataWarehouseManagedViewSet.objects.create(
+            team=self.team,
+            kind=DataWarehouseManagedViewSetKind.REVENUE_ANALYTICS,
+        )
+
+        with (
+            patch(
+                "products.data_modeling.backend.logic.saved_query_dag_sync.sync_saved_query_to_dag",
+                side_effect=Exception("dependency resolution failed"),
+            ),
+            patch(
+                "products.data_modeling.backend.schedule.get_v2_scheduled_dag_ids",
+                side_effect=lambda candidate_dag_ids=None: set(candidate_dag_ids or []),
+            ),
+            patch(
+                "products.data_warehouse.backend.logic.data_load.saved_query_service.sync_saved_query_workflow"
+            ) as sync_wf,
+            patch(
+                "products.data_warehouse.backend.logic.data_load.saved_query_service.saved_query_workflow_exists",
+                return_value=False,
+            ),
+        ):
+            managed_viewset.sync_views()
+
+        sync_wf.assert_not_called()
+        assert not DataWarehouseSavedQuery.objects.filter(
+            managed_viewset=managed_viewset, is_materialized=True
+        ).exists()
+
     def test_sync_views_creates_views(self):
         """Test that enabling managed viewset creates the expected views"""
         managed_viewset = DataWarehouseManagedViewSet.objects.create(

--- a/products/endpoints/backend/logic/materialization.py
+++ b/products/endpoints/backend/logic/materialization.py
@@ -254,6 +254,13 @@ class EndpointMaterializationService:
                 # delivers) — a request problem, not a server one.
                 raise ValidationError(str(e))
 
+            # schedule_materialization applies a disable-on-failure contract rather than raising,
+            # so a failure to schedule shows up only as is_materialized flipping back. Checking it
+            # is what stops the enable reporting success on an endpoint nothing will ever refresh.
+            saved_query.refresh_from_db(fields=["is_materialized"])
+            if not saved_query.is_materialized:
+                raise APIException(f"Failed to schedule materialization for endpoint {endpoint.name}.")
+
     def _get_or_build_saved_query(self, version: EndpointVersion) -> DataWarehouseSavedQuery:
         """Find this version's saved query, or build a new (unsaved) one.
 

--- a/products/endpoints/backend/logic/materialization.py
+++ b/products/endpoints/backend/logic/materialization.py
@@ -225,9 +225,11 @@ class EndpointMaterializationService:
 
             # The DAG node must exist before scheduling: the v2 detection and the freshness-target
             # write-through both resolve this saved query through its Node row.
+            sync_error: Exception | None = None
             try:
                 sync_saved_query_to_dag(saved_query)
             except Exception as e:
+                sync_error = e
                 logger.exception(
                     "Failed to sync endpoint node to DAG",
                     endpoint_name=endpoint.name,
@@ -259,6 +261,11 @@ class EndpointMaterializationService:
             # is what stops the enable reporting success on an endpoint nothing will ever refresh.
             saved_query.refresh_from_db(fields=["is_materialized"])
             if not saved_query.is_materialized:
+                if sync_error is not None:
+                    # The node is missing because the query's dependencies did not resolve, which
+                    # the author fixes by editing the query. Reporting that as a server error would
+                    # tell them to retry, and would page on-call through the status="error" metric.
+                    raise ValidationError(f"Cannot materialize endpoint. Reason: {sync_error}")
                 raise APIException(f"Failed to schedule materialization for endpoint {endpoint.name}.")
 
     def _get_or_build_saved_query(self, version: EndpointVersion) -> DataWarehouseSavedQuery:

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -1883,7 +1883,7 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         with (
             mock.patch(
                 "products.data_modeling.backend.schedule.get_v2_saved_query_ids",
-                side_effect=lambda ids: set(ids),
+                side_effect=lambda ids, **_kwargs: set(ids),
             ),
             mock.patch(
                 "products.data_modeling.backend.logic.node_materialization.sync_connect",

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -162,10 +162,11 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
             DataWarehouseSavedQuery.objects.filter(team=self.team, name=f"{endpoint.name}_v{version.version}").exists()
         )
 
-    def test_enable_fails_when_the_dag_sync_leaves_no_node(self):
+    def test_enable_fails_as_a_request_error_when_the_dag_sync_leaves_no_node(self):
         # the endpoint path swallows a dag sync failure, and scheduling then disables itself rather
         # than raising, so without a check the enable reports success on an endpoint that nothing
-        # will ever refresh
+        # will ever refresh. an unresolvable dependency is the author's to fix, so it must not
+        # report as a server error and page on-call
         DAG.objects.create(team=self.team, name="Default")
         self.mock_v2_dag_ids.side_effect = lambda candidate_dag_ids=None: set(candidate_dag_ids or [])
         endpoint = create_endpoint_with_version(
@@ -188,7 +189,7 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
                 format="json",
             )
 
-        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR, response.json())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
         version.refresh_from_db()
         self.assertIsNone(version.saved_query)
 

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -25,7 +25,7 @@ from posthog.sync import database_sync_to_async
 
 from products.data_modeling.backend.facade.api import UnsatisfiableFrequencyError
 from products.data_modeling.backend.facade.modeling import DataWarehouseModelPath
-from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery, Node
+from products.data_modeling.backend.facade.models import DAG, DataModelingJob, DataWarehouseSavedQuery, Node
 from products.data_warehouse.backend.facade.api import get_saved_query_schedule
 from products.endpoints.backend.logic.execution import EndpointExecutionService
 from products.endpoints.backend.logic.materialization import (
@@ -161,6 +161,36 @@ class TestEndpointMaterialization(ClickhouseTestMixin, APIBaseTest):
         self.assertFalse(
             DataWarehouseSavedQuery.objects.filter(team=self.team, name=f"{endpoint.name}_v{version.version}").exists()
         )
+
+    def test_enable_fails_when_the_dag_sync_leaves_no_node(self):
+        # the endpoint path swallows a dag sync failure, and scheduling then disables itself rather
+        # than raising, so without a check the enable reports success on an endpoint that nothing
+        # will ever refresh
+        DAG.objects.create(team=self.team, name="Default")
+        self.mock_v2_dag_ids.side_effect = lambda candidate_dag_ids=None: set(candidate_dag_ids or [])
+        endpoint = create_endpoint_with_version(
+            name="nodeless_endpoint",
+            team=self.team,
+            query=self.sample_hogql_query,
+            created_by=self.user,
+            is_active=True,
+        )
+        version = endpoint.versions.first()
+        assert version is not None
+
+        with mock.patch(
+            "products.endpoints.backend.logic.materialization.sync_saved_query_to_dag",
+            side_effect=Exception("dependency resolution failed"),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/endpoints/{endpoint.name}/",
+                {"is_materialized": True, "data_freshness_seconds": 86400},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR, response.json())
+        version.refresh_from_db()
+        self.assertIsNone(version.saved_query)
 
     def test_data_freshness_updates_saved_query_sync_interval(self):
         """Test that updating data_freshness_seconds updates the SavedQuery's sync_interval."""


### PR DESCRIPTION
## Problem

`get_v2_saved_query_ids` decides whether a saved query already runs on a v2 DAG schedule. `schedule_materialization` mints a v1 per-query schedule when the answer is no. The lookup returned no for two reasons that were not true.

- The lookup resolves a saved query to its DAG through its node.
- `sync_saved_query_to_dag` deletes the node when dependency resolution raises.
- All three callers sync the query to the DAG before scheduling it, and all three swallow that sync failing.
- With no node the lookup returned an empty map and answered "not on v2".
- The v1 schedule then ran beside the DAG tier that already materializes the query, so the query materialized twice on every cycle.
- Separately, the lookup mapped each saved query to a single DAG, so a query in two DAGs resolved to whichever row the database returned last.

The second defect contradicts the contract stated on `partition_saved_queries_by_v2_schedule` in the same module: a saved query is on v2 when any DAG it belongs to has a schedule.

## Changes

Three parts. The first stops the wrong answer, the second and third stop a wrong answer from being silent.

**1. The lookup no longer fails open.**

| Case | Before | After |
| --- | --- | --- |
| No node, team has a v2-scheduled DAG | v1 schedule minted | on v2 |
| No node, team has no v2-scheduled DAG | v1 eligible | v1 eligible |
| Node in a v2 DAG and in a v1 DAG | depends on row order | on v2 |

- `get_v2_saved_query_ids` maps each saved query to every DAG it belongs to.
- A saved query counts as on v2 when any of those DAGs has a v2 schedule.
- A saved query with no node resolves against the DAGs of its owning team.
- The fallback runs only when a candidate has no node, so the common path costs no extra queries.
- The fallback is opt-in via `team_id`, which the caller supplies. Only `schedule_materialization` passes it, because it is the only caller that can mint a v1 schedule.
- Everything else (the `run` action, and the three v1 remediation commands) resolves through nodes exactly as before, so their behavior is unchanged.

**2. `schedule_materialization` refuses to schedule a v2 saved query with no node.**

On v2 the DAG run materializes nodes, so a query with no node is not reachable by any schedule. Part 1 alone would have replaced a double materialization with no materialization at all, and nothing would have reported it: `apply_saved_query_frequency_target` documents that it writes the target nowhere, and `materialize_saved_query` logs a warning and returns.

- The v2 path raises `MissingDagNodeError` when the saved query has no node.
- The error lands in the existing failure contract, which captures it and clears `is_materialized`.
- The v1 path is unchanged, because v1 schedules run off the saved query and need no node.

**3. Enabling endpoint materialization fails when scheduling failed.**

`schedule_materialization` applies its disable-on-failure contract instead of raising, so the endpoints caller could not tell success from failure. It reported success while `is_materialized` was false and nothing would ever refresh the endpoint.

- `_enable_materialization_inner` checks the flag after scheduling and fails.
- The failure unwinds the enclosing atomic block, so no half-enabled saved query or version link survives.
- The saved-query `materialize` action already did this; the managed viewset self-heals on its next sync.

> [!NOTE]
> The endpoints caller already documents the invariant part 2 enforces: "The DAG node must exist before scheduling: the v2 detection and the freshness-target write-through both resolve this saved query through its Node row."

## How did you test this code?

Automated tests only. I did not run this against a real Temporal namespace.

Each new test fails without its fix:

- `test_saved_query_whose_node_vanished_is_refused_instead_of_scheduled` fails by calling `sync_saved_query_workflow(create=True)`, the mint this PR prevents. It also asserts `is_materialized` ends up false.
- `test_failed_dag_sync_does_not_mint_a_v1_schedule` drives the real managed-viewset path: the sync raises, `sync_views` swallows it and schedules anyway. Fails on master the same way. This is the production shape.
- `test_enable_fails_when_the_dag_sync_leaves_no_node` fails on the branch without part 3, by returning 200 on an endpoint that will never materialize.
- `test_saved_query_without_a_node_is_not_reported_as_v1_eligible` fails by returning an empty set.
- `test_saved_query_in_two_dags_is_on_v2_when_either_dag_is` is parameterized over node creation order. Only the order that writes the v2 node first fails on master; the other passes by luck, which is the defect.
- `test_saved_query_without_a_node_stays_v1_eligible_when_no_dag_is_v2_scheduled` holds the fallback to its intended scope.

No existing test covered a saved query without a node, or a saved query in two DAGs.

<details><summary>Suites run</summary>

| Suite | Result |
| --- | --- |
| `products/data_modeling/backend` | 586 passed, 1 skipped |
| `products/endpoints/backend/tests` | 714 passed, 32 snapshots |
| `products/data_warehouse/backend/tests/api/test_saved_query.py` | 90 passed |
| `test_managed_viewset.py` | 16 passed |
| `ruff check` and `ruff format` | clean |
| `uv run mypy --cache-fine-grained .` | Success, 17757 files |

</details>

## Known boundaries

One case this deliberately does not close: a brand-new team whose *first* managed view fails to sync has no node to bootstrap from, so it still mints v1. Closing it would mean refusing to schedule node-less queries on genuinely v1 teams, which changes behavior for teams still on v1 for no benefit.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) wrote this after an audit of live v1 schedules found saved queries running a v1 per-query schedule and a v2 DAG tier at the same time. Every confirmed case came through one caller, which pointed at this lookup.

Three directions were rejected. Tracking failed syncs in each caller loop was rejected because there are three callers with the same shape. Shipping part 1 alone was rejected once Jovan asked what actually runs a saved query with no node: it converts a visible double materialization into an invisible absence of one. Stopping `sync_saved_query_to_dag` deleting the node is the deeper fix but changes what the DAG materializes against a wrong parent set, so it stays a separate piece of work.

Two Claude subagents reviewed the branch independently, one for correctness and regressions and one for design and test value. Part 3 and the "Sync now" note come from that review, as does removing a deferred import whose stated justification (a circular import) did not exist. I verified both claims myself before acting on them.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

