### PR TITLE
feat(experiments): tag $experiment_exposure queries as experiments

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -684,6 +684,7 @@ _EVENT_TO_TAGS: tuple[tuple[frozenset[str], FallbackTags], ...] = (
     (frozenset({"$exception"}), {"product": Product.ERROR_TRACKING}),
     (frozenset({"$web_vitals"}), {"product": Product.WEB_ANALYTICS}),
     (frozenset({"$feature_flag_called"}), {"product": Product.FEATURE_FLAGS}),
+    (frozenset({"$experiment_exposure"}), {"product": Product.EXPERIMENTS}),
 )
 
 # Union of every event the fallback can match — exposed so HogQLFeatureExtractor can use it as

--- a/posthog/clickhouse/test/test_query_tagging.py
+++ b/posthog/clickhouse/test/test_query_tagging.py
@@ -643,6 +643,7 @@ class TestAddFallbackQueryTags(BaseTest):
             ("exception", ["$exception"], Product.ERROR_TRACKING),
             ("web_vitals", ["$web_vitals"], Product.WEB_ANALYTICS),
             ("feature_flag_called", ["$feature_flag_called"], Product.FEATURE_FLAGS),
+            ("experiment_exposure", ["$experiment_exposure"], Product.EXPERIMENTS),
         ]
     )
     def test_hogql_features_event_fills_product(self, _name, events, expected_product):


### PR DESCRIPTION
## Problem

Experiment queries are moving from `$feature_flag_called` to `$experiment_exposure` events.
Query tagging has no entry for `$experiment_exposure`, so those queries fall through to the table-level fallback and get attributed to product analytics.

## Changes

- Add a `$experiment_exposure` → `Product.EXPERIMENTS` entry to `_EVENT_TO_TAGS` in `posthog/clickhouse/query_tagging.py`.

## How did you test this code?

- Added a parameterized case to `test_hogql_features_event_fills_product`. It fails if the mapping is dropped or typo'd; no existing case covered `$experiment_exposure`.
- Ran the `experiment_exposure` and `feature_flag_called` cases locally, both passed.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, this only changes internal query cost attribution.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) authored the change under Anders' direction.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
