### PR TITLE
feat(desktop): remote in-app announcements via feature flag payload

### DIFF
--- a/products/desktop/AGENTS.md
+++ b/products/desktop/AGENTS.md
@@ -119,7 +119,7 @@ For each new file or meaningful change:
 - Bespoke clients that wrap `trpcClient.x` one-to-one.
 - `*Port`, `*_PORT`, or `ports.ts` naming.
 - Business logic in `apps/<host>`.
-- New ad-hoc broad in-app announcement or promo surfaces (flag-gated promo cards, dismissible banners, one-time modals like the Loops announcement). Broad announcements are remotely controlled via the `posthog-desktop-announcements` flag payload — see [docs/ANNOUNCEMENTS.md](./docs/ANNOUNCEMENTS.md). The legacy ad-hoc surfaces (`LoopsPromoCard`, `UsageBillingAnnouncementModal`, `ScoutAlphaBanner`) were deleted once this system shipped — do not reintroduce them.
+- New ad-hoc broad in-app announcement or promo surfaces (flag-gated promo cards, dismissible banners, one-time modals). Broad announcements are remotely controlled via the `posthog-desktop-announcements` flag payload — see [docs/ANNOUNCEMENTS.md](./docs/ANNOUNCEMENTS.md).
 
 ## Host Boundary
 

--- a/products/desktop/AGENTS.md
+++ b/products/desktop/AGENTS.md
@@ -119,6 +119,7 @@ For each new file or meaningful change:
 - Bespoke clients that wrap `trpcClient.x` one-to-one.
 - `*Port`, `*_PORT`, or `ports.ts` naming.
 - Business logic in `apps/<host>`.
+- New ad-hoc broad in-app announcement or promo surfaces (flag-gated promo cards, dismissible banners, one-time modals like the Loops announcement). Broad announcements are remotely controlled via the `posthog-desktop-announcements` flag payload — see [docs/ANNOUNCEMENTS.md](./docs/ANNOUNCEMENTS.md). The legacy ad-hoc surfaces (`LoopsPromoCard`, `UsageBillingAnnouncementModal`, `ScoutAlphaBanner`) were deleted once this system shipped — do not reintroduce them.
 
 ## Host Boundary
 
@@ -327,6 +328,7 @@ See [docs/testing.md](./docs/testing.md).
 - [docs/architecture.md](./docs/architecture.md)
 - [docs/conventions.md](./docs/conventions.md)
 - [docs/testing.md](./docs/testing.md)
+- [docs/ANNOUNCEMENTS.md](./docs/ANNOUNCEMENTS.md)
 - [docs/DEEP-LINKS.md](./docs/DEEP-LINKS.md)
 - [docs/LOCAL-DEVELOPMENT.md](./docs/LOCAL-DEVELOPMENT.md)
 - [docs/UPDATES.md](./docs/UPDATES.md)

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -9,10 +9,8 @@ https://desktop-announcements-admin.hosthog.dev (`tools/announcements-admin/`).
 
 **Do not build new ad-hoc announcement surfaces** (flag-gated promo cards,
 dismissible banners, one-time modals). That is a Forbidden Pattern in
-AGENTS.md. The ad-hoc surfaces that predated this system (`LoopsPromoCard`,
-`UsageBillingAnnouncementModal`, `ScoutAlphaBanner`) have been deleted; the
-only announcement-adjacent surfaces outside it are the What's New changelog
-and the update modals.
+AGENTS.md. The only announcement-adjacent surfaces outside this system are
+the What's New changelog and the update modals.
 
 ## How it works
 

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -1,0 +1,104 @@
+# Remote in-app announcements
+
+Broad in-app announcements are **remote content, not code**. They live in the
+JSON payload of the `posthog-desktop-announcements` feature flag (PostHog
+project 2) and render through `packages/ui/src/features/announcements/`.
+Publishing, changing, or retiring an announcement means editing that flag
+payload — never adding a component. The employee-gated editor is
+https://desktop-announcements-admin.hosthog.dev (`tools/announcements-admin/`).
+
+**Do not build new ad-hoc announcement surfaces** (flag-gated promo cards,
+dismissible banners, one-time modals). That is a Forbidden Pattern in
+AGENTS.md. The ad-hoc surfaces that predated this system (`LoopsPromoCard`,
+`UsageBillingAnnouncementModal`, `ScoutAlphaBanner`) have been deleted; the
+only announcement-adjacent surfaces outside it are the What's New changelog
+and the update modals.
+
+## How it works
+
+- The payload schema is `packages/shared/src/announcements.ts`
+  (`announcementsPayloadSchema`) — shared so authoring tools validate with the
+  exact schema the app parses. Items are validated one by one: a malformed
+  entry drops alone and is counted, never crashing the batch.
+- `selectAnnouncement.ts` is the pure decision function: Zod parse → time
+  window (`startsAt`/`endsAt`) → version gate → per-id dismissals → priority.
+  It returns nothing when the app version is unknown, which is what keeps the
+  web host (no `os.getAppVersion`) announcement-free by construction.
+- Dismissals persist per announcement `id` in `announcementsStore.ts`;
+  changing an announcement's `id` resurfaces it for everyone.
+- Surfaces: `AnnouncementBanner` (top-of-app bar, mounted in `__root.tsx`
+  after `ConnectivityBanner`) and `AnnouncementsHost` (the modal surfaces,
+  mounted in the shell beside the update modals).
+- Modals open with a hero band (`AnnouncementHero`, styled after the Loops
+  promo dialog): a hedgehog on a colored band by default, overridable per item
+  via `hero` — `{ "hedgehog": "<slug>", "color": "#rrggbb" }`,
+  `{ "imageUrl": "https://…" }`, or `{ "none": true }` for a plain modal.
+  The slug is a bundled name (`builder`, `explorer`, `happy`, `loop` — local
+  assets, no network) or any hoggie PNG file name from
+  [PostHog/brand](https://brand.posthog.com/hoggies) — variants are
+  file-name-suffixed (`wizard-3`, `dadd-ai-1`), so the metadata slug alone is
+  not always a valid name; the admin editor's picker lists exactly the valid
+  ones. Non-bundled names load from a CDN copy pinned to the package release
+  (`hoggiePngUrl`) with a fallback to the default hedgehog when unreachable.
+  Banners never render a hero.
+
+## The two kinds
+
+- `kind: "announcement"` — a feature announcement everyone sees,
+  `style: "banner" | "modal"`. Optional `minVersion` means "the announced
+  feature needs at least this version": apps below it get an "Update now"
+  action (`UpdateAction`) in place of the `cta`; apps at or above it get the
+  `cta`. Dismissible unless `requiresAck`.
+  - `requiresAck: true` (modal only — the schema rejects banners) blocks
+    until the user explicitly acts: no dismiss, no Esc. Up-to-date users get
+    the ack button (`ackLabel`, default "OK"); users below `minVersion` get
+    the update action instead, and **updating counts as acknowledging** — the
+    ack records when the restart-to-install handoff begins, so a failed or
+    abandoned download keeps the announcement blocking. The manual-download
+    link (updater-less platforms) never acknowledges; after relaunching on a
+    new-enough version the ack button shows instead.
+- `kind: "required-update"` — shown **only** to apps below its required
+  `minVersion`: a blocking, non-dismissible modal (`RequiredUpdateModal`)
+  that drives the existing update flow. Users already up to date never see
+  it. For "everyone must confirm they saw this" use
+  `announcement` + `requiresAck` instead.
+
+## Precedence
+
+One announcement per app session: the first unmet `required-update` in
+payload order, else the first eligible `announcement`. Dismissing or
+acknowledging one retires announcements for the rest of the session — the
+next eligible item waits for the next launch, so overlapping announcements
+never show back to back. Required updates are exempt: one still blocks even
+after an announcement was handled in the same session.
+
+While an announcement is on stage, the What's New changelog auto-open is
+**cancelled** by default; set `suppressChangelog: false` at the top level of
+the payload to defer it instead so it shows once the announcement clears. A
+blocking announcement also suppresses `UpdateAvailableModal`.
+
+## CTA rules
+
+`cta.url` is either `https://…` (opens the default browser) or a
+`posthog-code://…` deep link, which dispatches **in-app** via the
+`deepLink.open` tRPC forward to the main-process handler — no OS hop, no
+browser. Author payloads with the production scheme; `announcementCta.ts`
+swaps in the dev scheme on dev builds.
+
+## Testing a payload locally
+
+Dev builds expose `window.posthog` in the renderer devtools:
+
+```js
+posthog.featureFlags.overrideFeatureFlags({
+  flags: { "posthog-desktop-announcements": true },
+  payloads: {
+    "posthog-desktop-announcements": {
+      announcements: [
+        { kind: "announcement", id: "test-1", title: "Hello", body: "It works." },
+      ],
+    },
+  },
+});
+// clear with: posthog.featureFlags.overrideFeatureFlags(false)
+```

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -26,9 +26,10 @@ and the update modals.
   web host (no `os.getAppVersion`) announcement-free by construction.
 - Dismissals persist per announcement `id` in `announcementsStore.ts`;
   changing an announcement's `id` resurfaces it for everyone.
-- Surfaces: `AnnouncementBanner` (top-of-app bar, mounted in `__root.tsx`
-  after `ConnectivityBanner`) and `AnnouncementsHost` (the modal surfaces,
-  mounted in the shell beside the update modals).
+- Surfaces: `AnnouncementBanner` (top of the framed content pane in
+  `__root.tsx` — overlays the content, never the sidebar) and
+  `AnnouncementsHost` (the modal surfaces, mounted in the shell beside the
+  update modals).
 - Modals open with a hero band (`AnnouncementHero`, styled after the Loops
   promo dialog): a hedgehog on a colored band by default, overridable per item
   via `hero` — `{ "hedgehog": "<slug>", "color": "#rrggbb" }`,

--- a/products/desktop/docs/ANNOUNCEMENTS.md
+++ b/products/desktop/docs/ANNOUNCEMENTS.md
@@ -50,7 +50,10 @@ and the update modals.
   action (`UpdateAction`) in place of the `cta`; apps at or above it get the
   `cta`. Dismissible unless `requiresAck`.
   - `requiresAck: true` (modal only — the schema rejects banners) blocks
-    until the user explicitly acts: no dismiss, no Esc. Up-to-date users get
+    until the user explicitly acts: no dismiss, no Esc, and the app's
+    keyboard shortcuts are suspended while it is on stage
+    (`useBlockingKeyboardIsolation` — `required-update` gets the same
+    isolation). Up-to-date users get
     the ack button (`ackLabel`, default "OK"); users below `minVersion` get
     the update action instead, and **updating counts as acknowledging** — the
     ack records when the restart-to-install handoff begins, so a failed or

--- a/products/desktop/docs/DEEP-LINKS.md
+++ b/products/desktop/docs/DEEP-LINKS.md
@@ -14,6 +14,8 @@ All schemes route through the same dispatcher. The host portion of the URL selec
 
 If the app is not running, the OS launches it and the link is queued until the renderer is ready. If the app is minimised, it is restored and focused before the link is handled.
 
+Links can also be dispatched from inside the app: the `deepLink.open` tRPC route forwards a URL through the same handlers, with no OS hop. Remote announcement CTAs use this — author payloads with the production scheme; dev builds swap in their scheme automatically.
+
 ## User-facing links
 
 These are the deep links you would share with someone or wire up from another tool.

--- a/products/desktop/docs/UPDATES.md
+++ b/products/desktop/docs/UPDATES.md
@@ -25,6 +25,8 @@ Release CI uploads the binaries and blockmaps to the feed from each platform job
 
 **Linux**: No auto-update. AppImage, deb and rpm packages are manual downloads from the GitHub Release, also mirrored to the S3 feed.
 
+Remote announcements can drive this flow: a `required-update` announcement blocks apps below a version and reuses the updater; where the updater is unavailable it degrades to a manual download link. See [ANNOUNCEMENTS.md](./ANNOUNCEMENTS.md).
+
 ## How It Works
 
 1. A base tag like `v0.15.0` marks the start of a minor version

--- a/products/desktop/packages/shared/package.json
+++ b/products/desktop/packages/shared/package.json
@@ -12,6 +12,10 @@
       "types": "./dist/analytics-events.d.ts",
       "import": "./dist/analytics-events.js"
     },
+    "./announcements": {
+      "types": "./dist/announcements.d.ts",
+      "import": "./dist/announcements.js"
+    },
     "./agent-platform-types": {
       "types": "./dist/agent-platform-types.d.ts",
       "import": "./dist/agent-platform-types.js"

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -1271,6 +1271,23 @@ export interface LoopLinkCopiedProperties {
   visibility: "personal" | "team";
 }
 
+export interface AnnouncementProperties {
+  announcement_id: string;
+  announcement_kind: "announcement" | "required-update";
+  announcement_style: "banner" | "modal";
+}
+
+export interface AnnouncementCtaClickedProperties
+  extends AnnouncementProperties {
+  cta_type: "external" | "deeplink" | "update";
+}
+
+export interface AnnouncementAcknowledgedProperties
+  extends AnnouncementProperties {
+  /** "ok" = the ack button; "update" = an update action counted as the ack. */
+  ack_type: "ok" | "update";
+}
+
 // Event names as constants
 export const ANALYTICS_EVENTS = {
   // App lifecycle
@@ -1437,6 +1454,12 @@ export const ANALYTICS_EVENTS = {
   // Autoresearch events
   AUTORESEARCH_ARMED: "Autoresearch armed",
   AUTORESEARCH_RUN_STARTED: "Autoresearch run started",
+
+  // Remote in-app announcement events
+  ANNOUNCEMENT_SHOWN: "Announcement shown",
+  ANNOUNCEMENT_DISMISSED: "Announcement dismissed",
+  ANNOUNCEMENT_CTA_CLICKED: "Announcement CTA clicked",
+  ANNOUNCEMENT_ACKNOWLEDGED: "Announcement acknowledged",
 
   // Loops events
   LOOP_LIST_VIEWED: "Loop list viewed",
@@ -1610,6 +1633,12 @@ export type EventPropertyMap = {
   // Autoresearch events
   [ANALYTICS_EVENTS.AUTORESEARCH_ARMED]: AutoresearchArmedProperties;
   [ANALYTICS_EVENTS.AUTORESEARCH_RUN_STARTED]: AutoresearchRunStartedProperties;
+
+  // Remote in-app announcement events
+  [ANALYTICS_EVENTS.ANNOUNCEMENT_SHOWN]: AnnouncementProperties;
+  [ANALYTICS_EVENTS.ANNOUNCEMENT_DISMISSED]: AnnouncementProperties;
+  [ANALYTICS_EVENTS.ANNOUNCEMENT_CTA_CLICKED]: AnnouncementCtaClickedProperties;
+  [ANALYTICS_EVENTS.ANNOUNCEMENT_ACKNOWLEDGED]: AnnouncementAcknowledgedProperties;
 
   // Loops events
   [ANALYTICS_EVENTS.LOOP_LIST_VIEWED]: LoopListViewedProperties;

--- a/products/desktop/packages/shared/src/announcements.test.ts
+++ b/products/desktop/packages/shared/src/announcements.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  announcementSchema,
+  announcementsEnvelopeSchema,
+  announcementsPayloadSchema,
+  readSuppressChangelog,
+} from "./announcements";
+
+const validAnnouncement = {
+  kind: "announcement",
+  id: "loops-launch",
+  title: "Introducing Loops",
+  body: "Recurring agent jobs are here.",
+};
+
+const validRequiredUpdate = {
+  kind: "required-update",
+  id: "breaking-2026-08",
+  title: "Update required",
+  body: "This version can no longer talk to the backend.",
+  minVersion: "1.42.0",
+};
+
+describe("announcements schema", () => {
+  it.each([
+    ["minimal announcement", validAnnouncement],
+    ["announcement with modal style", { ...validAnnouncement, style: "modal" }],
+    [
+      "announcement with https cta",
+      {
+        ...validAnnouncement,
+        cta: { label: "Learn more", url: "https://posthog.com/code" },
+      },
+    ],
+    [
+      "announcement with deep-link cta",
+      {
+        ...validAnnouncement,
+        cta: { label: "Open loops", url: "posthog-code://loop/abc" },
+      },
+    ],
+    [
+      "announcement with dev deep-link cta",
+      {
+        ...validAnnouncement,
+        cta: { label: "Open", url: "posthog-code-dev://inbox/123" },
+      },
+    ],
+    [
+      "announcement with schedule",
+      {
+        ...validAnnouncement,
+        startsAt: "2026-08-05T10:00:00Z",
+        endsAt: "2026-08-12T10:00:00+02:00",
+      },
+    ],
+    [
+      "announcement with minVersion nudge",
+      { ...validAnnouncement, minVersion: "1.40.0" },
+    ],
+    [
+      "requiresAck modal",
+      {
+        ...validAnnouncement,
+        style: "modal",
+        requiresAck: true,
+        ackLabel: "I understand",
+      },
+    ],
+    [
+      "hedgehog hero with color",
+      { ...validAnnouncement, hero: { hedgehog: "builder", color: "#2f80fa" } },
+    ],
+    [
+      "brand-catalog hoggie hero",
+      { ...validAnnouncement, hero: { hedgehog: "dr-manhattan" } },
+    ],
+    [
+      "image hero",
+      { ...validAnnouncement, hero: { imageUrl: "https://posthog.com/x.png" } },
+    ],
+    ["suppressed hero", { ...validAnnouncement, hero: { none: true } }],
+    ["required update", validRequiredUpdate],
+  ])("accepts %s", (_name, input) => {
+    expect(announcementSchema.safeParse(input).success).toBe(true);
+  });
+
+  it("defaults announcement style to banner", () => {
+    const parsed = announcementSchema.parse(validAnnouncement);
+    expect(parsed.kind === "announcement" && parsed.style).toBe("banner");
+  });
+
+  it.each([
+    ["unknown kind", { ...validAnnouncement, kind: "promo" }],
+    ["missing id", { ...validAnnouncement, id: undefined }],
+    ["empty id", { ...validAnnouncement, id: "" }],
+    ["missing title", { ...validAnnouncement, title: undefined }],
+    ["missing body", { ...validAnnouncement, body: undefined }],
+    [
+      "http cta url",
+      { ...validAnnouncement, cta: { label: "Go", url: "http://x.com" } },
+    ],
+    [
+      "relative cta url",
+      { ...validAnnouncement, cta: { label: "Go", url: "/settings" } },
+    ],
+    ["non-ISO startsAt", { ...validAnnouncement, startsAt: "tomorrow" }],
+    ["date-only startsAt", { ...validAnnouncement, startsAt: "2026-08-05" }],
+    ["two-part minVersion", { ...validAnnouncement, minVersion: "1.42" }],
+    ["prefixed minVersion", { ...validAnnouncement, minVersion: "v1.42.0" }],
+    [
+      "required update without minVersion",
+      { ...validRequiredUpdate, minVersion: undefined },
+    ],
+    [
+      "required update with bad minVersion",
+      { ...validRequiredUpdate, minVersion: "latest" },
+    ],
+    [
+      "requiresAck banner (implicit style)",
+      { ...validAnnouncement, requiresAck: true },
+    ],
+    [
+      "requiresAck banner (explicit style)",
+      { ...validAnnouncement, style: "banner", requiresAck: true },
+    ],
+    [
+      "empty ackLabel",
+      { ...validAnnouncement, style: "modal", requiresAck: true, ackLabel: "" },
+    ],
+    [
+      "non-slug hero hedgehog",
+      { ...validAnnouncement, hero: { hedgehog: "Not A Slug" } },
+    ],
+    ["empty hero hedgehog", { ...validAnnouncement, hero: { hedgehog: "" } }],
+    [
+      "inverted schedule window",
+      {
+        ...validAnnouncement,
+        startsAt: "2026-08-12T10:00:00Z",
+        endsAt: "2026-08-05T10:00:00Z",
+      },
+    ],
+    [
+      "zero-length schedule window",
+      {
+        ...validAnnouncement,
+        startsAt: "2026-08-05T10:00:00Z",
+        endsAt: "2026-08-05T10:00:00Z",
+      },
+    ],
+    [
+      "non-hex hero color",
+      { ...validAnnouncement, hero: { hedgehog: "happy", color: "blue" } },
+    ],
+    [
+      "http hero image",
+      { ...validAnnouncement, hero: { imageUrl: "http://posthog.com/x.png" } },
+    ],
+  ])("rejects %s", (_name, input) => {
+    expect(announcementSchema.safeParse(input).success).toBe(false);
+  });
+
+  it("envelope accepts malformed items for per-item validation", () => {
+    const result = announcementsEnvelopeSchema.safeParse({
+      announcements: [validAnnouncement, { garbage: true }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("strict payload rejects a single malformed item", () => {
+    const result = announcementsPayloadSchema.safeParse({
+      announcements: [validAnnouncement, { garbage: true }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("strict payload rejects duplicate ids across kinds", () => {
+    const result = announcementsPayloadSchema.safeParse({
+      announcements: [
+        validAnnouncement,
+        { ...validRequiredUpdate, id: validAnnouncement.id },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("strict payload accepts distinct ids", () => {
+    const result = announcementsPayloadSchema.safeParse({
+      announcements: [validAnnouncement, validRequiredUpdate],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    ["absent field", { announcements: [] }, true],
+    ["explicit false", { announcements: [], suppressChangelog: false }, false],
+    ["non-object payload", "garbage", true],
+    ["non-boolean value", { suppressChangelog: "yes" }, true],
+  ])("readSuppressChangelog: %s → %s", (_name, payload, expected) => {
+    expect(readSuppressChangelog(payload)).toBe(expected);
+  });
+});

--- a/products/desktop/packages/shared/src/announcements.ts
+++ b/products/desktop/packages/shared/src/announcements.ts
@@ -56,7 +56,8 @@ const baseAnnouncementShape = {
   /** Stable per-user dismissal key. Changing it resurfaces the announcement. */
   id: z.string().min(1),
   title: z.string().min(1),
-  /** Markdown. Modals render it in full; banners show only the first line. */
+  /** Markdown. Modals render it in full; banners render only the first line
+   * (inline markdown — block structure flattens away). */
   body: z.string().min(1),
   startsAt: z.iso.datetime({ offset: true }).optional(),
   endsAt: z.iso.datetime({ offset: true }).optional(),

--- a/products/desktop/packages/shared/src/announcements.ts
+++ b/products/desktop/packages/shared/src/announcements.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+import { isPostHogCodeDeeplink } from "./deep-links";
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+const versionSchema = z.string().regex(/^\d+\.\d+\.\d+$/);
+
+// https:// opens the default browser; posthog-code:// dispatches in-app.
+const ctaUrlSchema = z
+  .string()
+  .refine((value) => isHttpsUrl(value) || isPostHogCodeDeeplink(value), {
+    message: "must be an https:// URL or a posthog-code:// deep link",
+  });
+
+/** Hedgehogs bundled into the app — these render without any network. */
+export const HERO_HEDGEHOGS = ["builder", "explorer", "happy", "loop"] as const;
+
+/**
+ * Hoggie PNGs for hero hedgehogs beyond the bundled four, pinned to the npm
+ * release of PostHog/brand so the URLs stay immutable. Browse the catalog at
+ * https://brand.posthog.com/hoggies.
+ */
+export function hoggiePngUrl(slug: string): string {
+  return `https://cdn.jsdelivr.net/npm/@posthog/brand@0.9.0/dist/generated/hoggies/png/${slug}.png`;
+}
+
+/**
+ * The modal's hero band. Absent = a default hedgehog; "none" = plain modal.
+ * Banners never render a hero.
+ */
+const heroSchema = z.union([
+  z.object({
+    /**
+     * A bundled name (HERO_HEDGEHOGS) or any hoggie slug from PostHog/brand.
+     * Non-bundled slugs load from the pinned CDN copy (hoggiePngUrl) and fall
+     * back to the default hedgehog when unreachable.
+     */
+    hedgehog: z.string().regex(/^[a-z0-9][a-z0-9-]*$/),
+    /** Band background, hex only. Defaults to PostHog blue. */
+    color: z
+      .string()
+      .regex(/^#[0-9a-fA-F]{6}$/)
+      .optional(),
+  }),
+  z.object({ imageUrl: z.url({ protocol: /^https$/ }) }),
+  z.object({ none: z.literal(true) }),
+]);
+
+const baseAnnouncementShape = {
+  /** Stable per-user dismissal key. Changing it resurfaces the announcement. */
+  id: z.string().min(1),
+  title: z.string().min(1),
+  /** Markdown. Modals render it in full; banners show only the first line. */
+  body: z.string().min(1),
+  startsAt: z.iso.datetime({ offset: true }).optional(),
+  endsAt: z.iso.datetime({ offset: true }).optional(),
+  hero: heroSchema.optional(),
+};
+
+export const announcementSchema = z
+  .discriminatedUnion("kind", [
+    z.object({
+      ...baseAnnouncementShape,
+      kind: z.literal("announcement"),
+      style: z.enum(["banner", "modal"]).default("banner"),
+      cta: z.object({ label: z.string().min(1), url: ctaUrlSchema }).optional(),
+      /**
+       * The announced feature needs at least this app version. Apps below it
+       * show an "Update now" action in place of the cta; apps at or above it
+       * show the cta.
+       */
+      minVersion: versionSchema.optional(),
+      /**
+       * Blocks until explicitly acknowledged: no dismiss, no Esc — only the
+       * ack button, or the update action when the app is below minVersion
+       * (the ack records at the restart-to-install handoff). Modal style
+       * only.
+       */
+      requiresAck: z.boolean().default(false),
+      /** Ack button label; the app defaults it to "OK". */
+      ackLabel: z.string().min(1).optional(),
+    }),
+    z.object({
+      ...baseAnnouncementShape,
+      kind: z.literal("required-update"),
+      /**
+       * Rendered only when the running app is below this version — blocking and
+       * non-dismissible. Users already at or above it never see anything.
+       */
+      minVersion: versionSchema,
+    }),
+  ])
+  .superRefine((item, ctx) => {
+    if (
+      item.kind === "announcement" &&
+      item.requiresAck &&
+      item.style !== "modal"
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["style"],
+        message: 'requiresAck announcements must use style: "modal"',
+      });
+    }
+    // An inverted window passes per-field validation but can never become
+    // eligible — the announcement would silently never show.
+    if (
+      item.startsAt &&
+      item.endsAt &&
+      Date.parse(item.startsAt) >= Date.parse(item.endsAt)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["endsAt"],
+        message: "endsAt must be after startsAt",
+      });
+    }
+  });
+
+/**
+ * Loose envelope: items are validated one by one with announcementSchema so a
+ * single malformed entry drops alone instead of killing the whole payload.
+ */
+export const announcementsEnvelopeSchema = z.object({
+  announcements: z.array(z.unknown()),
+});
+
+/** Strict payload shape — what authoring tools validate before publishing. */
+export const announcementsPayloadSchema = z
+  .object({
+    announcements: z.array(announcementSchema),
+    /**
+     * An on-stage announcement cancels the auto-opened What's New changelog.
+     * Set false to defer it instead, showing both back to back.
+     */
+    suppressChangelog: z.boolean().default(true),
+  })
+  .superRefine((payload, ctx) => {
+    // Dismissals persist per id, so a duplicate would let dismissing one
+    // item silently hide the other.
+    const seenAt = new Map<string, number>();
+    payload.announcements.forEach((item, index) => {
+      if (seenAt.has(item.id)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["announcements", index, "id"],
+          message: `duplicate id "${item.id}": dismissals are keyed per id, so ids must be unique`,
+        });
+        return;
+      }
+      seenAt.set(item.id, index);
+    });
+  });
+
+const changelogInterplaySchema = z.object({
+  suppressChangelog: z.boolean().default(true),
+});
+
+/** Tolerant read of the payload's changelog policy — garbage means default. */
+export function readSuppressChangelog(payload: unknown): boolean {
+  const result = changelogInterplaySchema.safeParse(payload);
+  return result.success ? result.data.suppressChangelog : true;
+}
+
+export type Announcement = z.infer<typeof announcementSchema>;
+export type AnnouncementHero = z.infer<typeof heroSchema>;
+export type AnnouncementsPayload = z.infer<typeof announcementsPayloadSchema>;

--- a/products/desktop/packages/shared/src/flags.ts
+++ b/products/desktop/packages/shared/src/flags.ts
@@ -42,3 +42,10 @@ export const TASK_COST_FLAG = "posthog-code-task-cost";
  * the legacy stop-polling-once-staged behavior.
  */
 export const STAGED_UPDATES_FLAG = "posthog-desktop-staged-updates";
+/**
+ * Remote in-app announcements. The flag's JSON payload carries the
+ * announcements (schema: `announcements.ts`); rollout % arms the system.
+ * All broad announcements go through this — do not add ad-hoc promo
+ * surfaces (see docs/ANNOUNCEMENTS.md).
+ */
+export const ANNOUNCEMENTS_FLAG = "posthog-desktop-announcements";

--- a/products/desktop/packages/shared/tsup.config.ts
+++ b/products/desktop/packages/shared/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     "src/index.ts",
     "src/agent-platform-types.ts",
     "src/analytics-events.ts",
+    "src/announcements.ts",
     "src/constants.ts",
     "src/deeplink.ts",
     "src/dismissalReasons.ts",

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.stories.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.stories.tsx
@@ -1,0 +1,75 @@
+import {
+  type Announcement,
+  announcementSchema,
+} from "@posthog/shared/announcements";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BannerRow } from "./AnnouncementBanner";
+
+type BannerAnnouncement = Extract<Announcement, { kind: "announcement" }>;
+
+/** Parse through the real schema so fixtures stay valid payload examples. */
+function bannerAnnouncement(
+  overrides: Record<string, unknown> = {},
+): BannerAnnouncement {
+  const parsed = announcementSchema.parse({
+    kind: "announcement",
+    id: "storybook-banner",
+    title: "Loops are here",
+    body: "Schedule recurring agent jobs and route the results to your inbox.\nBanners only show this first line.",
+    cta: { label: "Try loops", url: "posthog-code://loop/storybook" },
+    ...overrides,
+  });
+  if (parsed.kind !== "announcement") {
+    throw new Error("fixture must be an announcement");
+  }
+  return parsed;
+}
+
+const meta: Meta<typeof BannerRow> = {
+  title: "Announcements/AnnouncementBanner",
+  component: BannerRow,
+  args: { needsUpdate: false },
+  // The banner spans the top of the app shell; give it a realistic width.
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 960, margin: "1rem auto" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BannerRow>;
+
+/** Title, the body's first line, a CTA, and the dismiss button. */
+export const Default: Story = {
+  args: { announcement: bannerAnnouncement() },
+};
+
+/** No CTA: just the message and dismiss. */
+export const NoCta: Story = {
+  args: { announcement: bannerAnnouncement({ cta: undefined }) },
+};
+
+/**
+ * Below `minVersion` the CTA swaps for the update action. Storybook has no
+ * updater, so the action degrades to the manual-download link.
+ */
+export const NeedsUpdate: Story = {
+  args: {
+    announcement: bannerAnnouncement({ minVersion: "9.9.9" }),
+    needsUpdate: true,
+  },
+};
+
+/** Long copy truncates rather than growing the banner. */
+export const LongCopy: Story = {
+  args: {
+    announcement: bannerAnnouncement({
+      title:
+        "A very long announcement title that should still keep the banner to a single compact row",
+      body: "An even longer first body line that is truncated with an ellipsis instead of wrapping onto multiple lines and pushing the actions around.",
+    }),
+  },
+};

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.stories.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.stories.tsx
@@ -15,7 +15,7 @@ function bannerAnnouncement(
     kind: "announcement",
     id: "storybook-banner",
     title: "Loops are here",
-    body: "Schedule recurring agent jobs and route the results to your inbox.\nBanners only show this first line.",
+    body: "Schedule **recurring agent jobs** and route results to your [inbox](posthog-code://inbox/demo).\nBanners render only this first line.",
     cta: { label: "Try loops", url: "posthog-code://loop/storybook" },
     ...overrides,
   });

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
@@ -31,7 +31,9 @@ export function AnnouncementBanner() {
   );
 }
 
-function BannerRow({
+/** The pure banner row — exported for Storybook; the app renders it through
+ * AnnouncementBanner's selection gate above. */
+export function BannerRow({
   announcement,
   needsUpdate,
 }: {

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
@@ -1,0 +1,102 @@
+import { MegaphoneIcon, XIcon } from "@phosphor-icons/react";
+import { Button } from "@posthog/quill";
+import {
+  ANALYTICS_EVENTS,
+  type AnnouncementProperties,
+} from "@posthog/shared/analytics-events";
+import type { Announcement } from "@posthog/shared/announcements";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect } from "react";
+import { openAnnouncementCta } from "./announcementCta";
+import { useAnnouncementsStore } from "./announcementsStore";
+import { UpdateAction } from "./UpdateAction";
+import { useActiveAnnouncement } from "./useActiveAnnouncement";
+
+type BannerAnnouncement = Extract<Announcement, { kind: "announcement" }>;
+
+export function AnnouncementBanner() {
+  const active = useActiveAnnouncement();
+  if (
+    !active ||
+    active.announcement.kind !== "announcement" ||
+    active.announcement.style !== "banner"
+  ) {
+    return null;
+  }
+  return (
+    <BannerRow
+      announcement={active.announcement}
+      needsUpdate={active.needsUpdate}
+    />
+  );
+}
+
+function BannerRow({
+  announcement,
+  needsUpdate,
+}: {
+  announcement: BannerAnnouncement;
+  needsUpdate: boolean;
+}) {
+  const dismiss = useAnnouncementsStore((state) => state.dismiss);
+  const analytics: AnnouncementProperties = {
+    announcement_id: announcement.id,
+    announcement_kind: announcement.kind,
+    announcement_style: "banner",
+  };
+
+  useEffect(() => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_SHOWN, {
+      announcement_id: announcement.id,
+      announcement_kind: announcement.kind,
+      announcement_style: "banner",
+    });
+  }, [announcement.id, announcement.kind]);
+
+  const handleDismiss = () => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_DISMISSED, analytics);
+    dismiss(announcement.id);
+  };
+
+  const handleCta = (url: string) => {
+    const ctaType = openAnnouncementCta(url);
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_CTA_CLICKED, {
+      ...analytics,
+      cta_type: ctaType,
+    });
+  };
+
+  return (
+    <div className="no-drag shrink-0 px-2 py-2">
+      <div className="flex w-full items-center gap-2.5 rounded-md border border-(--accent-6) bg-(--accent-3) px-3 py-2 text-(--accent-11) text-[13px]">
+        <MegaphoneIcon size={16} weight="duotone" className="shrink-0" />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="font-medium">{announcement.title}</span>
+          <span className="truncate text-(--accent-a11) text-[11px]">
+            {announcement.body.split("\n")[0]}
+          </span>
+        </div>
+        {needsUpdate ? (
+          <UpdateAction analytics={analytics} />
+        ) : announcement.cta ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => announcement.cta && handleCta(announcement.cta.url)}
+          >
+            {announcement.cta.label}
+          </Button>
+        ) : null}
+        <button
+          type="button"
+          aria-label="Dismiss announcement"
+          title="Dismiss"
+          className="shrink-0 rounded-full p-1 text-(--accent-11) transition-colors hover:bg-(--accent-a4)"
+          onClick={handleDismiss}
+        >
+          <XIcon size={12} weight="bold" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
@@ -8,7 +8,7 @@ import type { Announcement } from "@posthog/shared/announcements";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect } from "react";
 import { AnnouncementInlineMarkdown } from "./AnnouncementMarkdown";
-import { openAnnouncementCta } from "./announcementCta";
+import { useOpenAnnouncementCta } from "./announcementCta";
 import { useAnnouncementsStore } from "./announcementsStore";
 import { UpdateAction } from "./UpdateAction";
 import { useActiveAnnouncement } from "./useActiveAnnouncement";
@@ -42,6 +42,7 @@ export function BannerRow({
   needsUpdate: boolean;
 }) {
   const dismiss = useAnnouncementsStore((state) => state.dismiss);
+  const openCta = useOpenAnnouncementCta();
   const analytics: AnnouncementProperties = {
     announcement_id: announcement.id,
     announcement_kind: announcement.kind,
@@ -62,7 +63,7 @@ export function BannerRow({
   };
 
   const handleCta = (url: string) => {
-    const ctaType = openAnnouncementCta(url);
+    const ctaType = openCta(url);
     track(ANALYTICS_EVENTS.ANNOUNCEMENT_CTA_CLICKED, {
       ...analytics,
       cta_type: ctaType,

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
@@ -69,7 +69,7 @@ export function BannerRow({
   };
 
   return (
-    <div className="no-drag shrink-0 px-2 py-2">
+    <div className="no-drag shrink-0 px-2 pt-2 pb-1">
       <div className="flex w-full items-center gap-2.5 rounded-md border border-(--accent-6) bg-(--accent-3) px-3 py-2 text-(--accent-11) text-[13px]">
         <MegaphoneIcon size={16} weight="duotone" className="shrink-0" />
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementBanner.tsx
@@ -7,6 +7,7 @@ import {
 import type { Announcement } from "@posthog/shared/announcements";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect } from "react";
+import { AnnouncementInlineMarkdown } from "./AnnouncementMarkdown";
 import { openAnnouncementCta } from "./announcementCta";
 import { useAnnouncementsStore } from "./announcementsStore";
 import { UpdateAction } from "./UpdateAction";
@@ -75,7 +76,9 @@ export function BannerRow({
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <span className="font-medium">{announcement.title}</span>
           <span className="truncate text-(--accent-a11) text-[11px]">
-            {announcement.body.split("\n")[0]}
+            <AnnouncementInlineMarkdown
+              content={announcement.body.split("\n")[0]}
+            />
           </span>
         </div>
         {needsUpdate ? (

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementHero.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementHero.tsx
@@ -190,9 +190,8 @@ function ImageHero({
 }
 
 /**
- * Modal hero band, styled after the Loops promo dialog: a colored band with a
- * hedgehog by default, a remote image when the payload provides one, nothing
- * when the payload opts out.
+ * Modal hero band: a colored band with a hedgehog by default, a remote image
+ * when the payload provides one, nothing when the payload opts out.
  */
 export function AnnouncementHero({
   hero,

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementHero.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementHero.tsx
@@ -1,0 +1,229 @@
+import {
+  type HERO_HEDGEHOGS,
+  type AnnouncementHero as HeroConfig,
+  hoggiePngUrl,
+} from "@posthog/shared/announcements";
+import {
+  builderHog,
+  explorerHog,
+  happyHog,
+  loopHog,
+} from "@posthog/ui/assets/hedgehogs";
+import { useState } from "react";
+
+type HedgehogName = (typeof HERO_HEDGEHOGS)[number];
+
+const HEDGEHOG_SRC: Record<HedgehogName, string> = {
+  builder: builderHog,
+  explorer: explorerHog,
+  happy: happyHog,
+  loop: loopHog,
+};
+
+const DEFAULT_COLOR = "#2f80fa";
+
+function bundledSrc(slug: string): string | undefined {
+  return (HEDGEHOG_SRC as Record<string, string | undefined>)[slug];
+}
+
+function GeometricPattern() {
+  return (
+    <svg
+      className="absolute inset-0 h-full w-full text-white"
+      viewBox="0 0 232 96"
+      preserveAspectRatio="xMidYMid slice"
+      aria-hidden="true"
+    >
+      <circle cx="26" cy="22" r="11" fill="currentColor" opacity="0.25" />
+      <circle
+        cx="204"
+        cy="66"
+        r="17"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        opacity="0.3"
+      />
+      <rect
+        x="176"
+        y="10"
+        width="15"
+        height="15"
+        rx="2"
+        transform="rotate(18 183 17)"
+        fill="currentColor"
+        opacity="0.2"
+      />
+      <polygon points="64,10 75,30 53,30" fill="currentColor" opacity="0.3" />
+      <path
+        d="M8 62 l7 -8 7 8 7 -8 7 8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.35"
+      />
+      <circle cx="118" cy="14" r="4" fill="currentColor" opacity="0.35" />
+      <path
+        d="M148 78 h12 M154 72 v12"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        opacity="0.3"
+      />
+      <circle
+        cx="52"
+        cy="78"
+        r="6"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        opacity="0.25"
+      />
+      <rect
+        x="96"
+        y="70"
+        width="10"
+        height="10"
+        transform="rotate(-12 101 75)"
+        fill="currentColor"
+        opacity="0.18"
+      />
+      <polygon
+        points="206,18 214,32 198,32"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+        opacity="0.3"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Any hoggie by slug: bundled names render from local assets, everything else
+ * streams from the pinned PostHog/brand CDN copy and falls back to the
+ * kind-default hedgehog when unreachable (offline, unknown slug).
+ */
+function HoggieImage({
+  slug,
+  fallback,
+}: {
+  slug: string;
+  fallback: HedgehogName;
+}) {
+  const [failed, setFailed] = useState(false);
+  const local = bundledSrc(slug);
+  const src = local ?? (failed ? HEDGEHOG_SRC[fallback] : hoggiePngUrl(slug));
+  return (
+    <img
+      src={src}
+      alt=""
+      className="relative h-28 w-auto object-contain"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+/** The colored band with pattern and hoggie — also the landing spot when a
+ * remote hero image fails to load. */
+function HedgehogBand({
+  hedgehog,
+  fallbackHedgehog,
+  color,
+}: {
+  hedgehog: string;
+  fallbackHedgehog: HedgehogName;
+  color: string;
+}) {
+  return (
+    <div
+      className="relative flex h-40 items-center justify-center"
+      style={{ backgroundColor: color }}
+    >
+      <GeometricPattern />
+      <HoggieImage key={hedgehog} slug={hedgehog} fallback={fallbackHedgehog} />
+      <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-(--background)" />
+    </div>
+  );
+}
+
+/**
+ * Remote hero image with the same graceful degradation as remote hoggies: an
+ * expired URL or offline session falls back to the default hedgehog band
+ * instead of a broken-image glyph. Keyed on the URL by the caller so the
+ * failure state resets when the payload changes.
+ */
+function ImageHero({
+  url,
+  fallbackHedgehog,
+  fallbackColor,
+}: {
+  url: string;
+  fallbackHedgehog: HedgehogName;
+  fallbackColor: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return (
+      <HedgehogBand
+        hedgehog={fallbackHedgehog}
+        fallbackHedgehog={fallbackHedgehog}
+        color={fallbackColor}
+      />
+    );
+  }
+  return (
+    <div className="relative h-40 overflow-hidden">
+      <img
+        src={url}
+        alt=""
+        referrerPolicy="no-referrer"
+        className="h-full w-full object-cover"
+        onError={() => setFailed(true)}
+      />
+      <div className="absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent to-(--background)" />
+    </div>
+  );
+}
+
+/**
+ * Modal hero band, styled after the Loops promo dialog: a colored band with a
+ * hedgehog by default, a remote image when the payload provides one, nothing
+ * when the payload opts out.
+ */
+export function AnnouncementHero({
+  hero,
+  defaultHedgehog,
+  defaultColor = DEFAULT_COLOR,
+}: {
+  hero: HeroConfig | undefined;
+  defaultHedgehog: HedgehogName;
+  defaultColor?: string;
+}) {
+  if (hero && "none" in hero) return null;
+
+  if (hero && "imageUrl" in hero) {
+    return (
+      <ImageHero
+        key={hero.imageUrl}
+        url={hero.imageUrl}
+        fallbackHedgehog={defaultHedgehog}
+        fallbackColor={defaultColor}
+      />
+    );
+  }
+
+  const hedgehog = hero && "hedgehog" in hero ? hero.hedgehog : defaultHedgehog;
+  const color =
+    (hero && "hedgehog" in hero ? hero.color : undefined) ?? defaultColor;
+  return (
+    <HedgehogBand
+      hedgehog={hedgehog}
+      fallbackHedgehog={defaultHedgehog}
+      color={color}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementMarkdown.tsx
@@ -1,57 +1,72 @@
+import { isPostHogCodeDeeplink } from "@posthog/shared";
 import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { useMemo } from "react";
 import type { Components } from "react-markdown";
-import { openAnnouncementCta } from "./announcementCta";
+import { useOpenAnnouncementCta } from "./announcementCta";
+
+type OpenCta = (url: string) => "deeplink" | "external";
 
 // Announcement bodies render inside a quill dialog, where the app's default
 // markdown link (Radix accent color plus an external-link glyph) has no theme
 // vars — the glyph draws invisibly and leaves a blank gap. Plain anchors let
 // quill's own dialog-description link styling take over, and clicks route
 // through the announcement CTA opener so https and posthog-code:// both work.
-const announcementComponents: Partial<Components> = {
-  a: ({ href, children }) => (
-    <a
-      href={href}
-      className="underline underline-offset-2"
-      onClick={(event) => {
-        event.preventDefault();
-        if (href) openAnnouncementCta(href);
-      }}
-    >
-      {children}
-    </a>
-  ),
-};
+function buildComponents(openCta: OpenCta): Partial<Components> {
+  return {
+    a: ({ href, children }) => {
+      // Body links follow the same contract as CTAs: https or a posthog-code
+      // deep link. Anything else renders as plain text.
+      if (
+        !href ||
+        !(href.startsWith("https://") || isPostHogCodeDeeplink(href))
+      ) {
+        return <>{children}</>;
+      }
+      return (
+        <a
+          href={href}
+          className="underline underline-offset-2"
+          onClick={(event) => {
+            event.preventDefault();
+            openCta(href);
+          }}
+        >
+          {children}
+        </a>
+      );
+    },
+  };
+}
 
 export function AnnouncementMarkdown({ content }: { content: string }) {
-  return (
-    <MarkdownRenderer
-      content={content}
-      componentsOverride={announcementComponents}
-    />
-  );
+  const openCta = useOpenAnnouncementCta();
+  const components = useMemo(() => buildComponents(openCta), [openCta]);
+  return <MarkdownRenderer content={content} componentsOverride={components} />;
 }
 
 // Block elements collapse to their inline content so the result fits a
 // single truncating line.
-const inlineComponents: Partial<Components> = {
-  ...announcementComponents,
-  p: ({ children }) => <>{children}</>,
-  h1: ({ children }) => <>{children}</>,
-  h2: ({ children }) => <>{children}</>,
-  h3: ({ children }) => <>{children}</>,
-  h4: ({ children }) => <>{children}</>,
-  h5: ({ children }) => <>{children}</>,
-  h6: ({ children }) => <>{children}</>,
-  blockquote: ({ children }) => <>{children}</>,
-  ul: ({ children }) => <>{children}</>,
-  ol: ({ children }) => <>{children}</>,
-  li: ({ children }) => <>{children}</>,
-  hr: () => null,
-};
+function buildInlineComponents(openCta: OpenCta): Partial<Components> {
+  return {
+    ...buildComponents(openCta),
+    p: ({ children }) => <>{children}</>,
+    h1: ({ children }) => <>{children}</>,
+    h2: ({ children }) => <>{children}</>,
+    h3: ({ children }) => <>{children}</>,
+    h4: ({ children }) => <>{children}</>,
+    h5: ({ children }) => <>{children}</>,
+    h6: ({ children }) => <>{children}</>,
+    blockquote: ({ children }) => <>{children}</>,
+    ul: ({ children }) => <>{children}</>,
+    ol: ({ children }) => <>{children}</>,
+    li: ({ children }) => <>{children}</>,
+    hr: () => null,
+  };
+}
 
 /** One-line markdown for the banner's body excerpt. */
 export function AnnouncementInlineMarkdown({ content }: { content: string }) {
-  return (
-    <MarkdownRenderer content={content} componentsOverride={inlineComponents} />
-  );
+  const openCta = useOpenAnnouncementCta();
+  const components = useMemo(() => buildInlineComponents(openCta), [openCta]);
+  return <MarkdownRenderer content={content} componentsOverride={components} />;
 }

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementMarkdown.tsx
@@ -1,0 +1,31 @@
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import type { Components } from "react-markdown";
+import { openAnnouncementCta } from "./announcementCta";
+
+// Announcement bodies render inside a quill dialog, where the app's default
+// markdown link (Radix accent color plus an external-link glyph) has no theme
+// vars — the glyph draws invisibly and leaves a blank gap. Plain anchors let
+// quill's own dialog-description link styling take over, and clicks route
+// through the announcement CTA opener so https and posthog-code:// both work.
+const announcementComponents: Partial<Components> = {
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      onClick={(event) => {
+        event.preventDefault();
+        if (href) openAnnouncementCta(href);
+      }}
+    >
+      {children}
+    </a>
+  ),
+};
+
+export function AnnouncementMarkdown({ content }: { content: string }) {
+  return (
+    <MarkdownRenderer
+      content={content}
+      componentsOverride={announcementComponents}
+    />
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementMarkdown.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementMarkdown.tsx
@@ -11,6 +11,7 @@ const announcementComponents: Partial<Components> = {
   a: ({ href, children }) => (
     <a
       href={href}
+      className="underline underline-offset-2"
       onClick={(event) => {
         event.preventDefault();
         if (href) openAnnouncementCta(href);
@@ -27,5 +28,30 @@ export function AnnouncementMarkdown({ content }: { content: string }) {
       content={content}
       componentsOverride={announcementComponents}
     />
+  );
+}
+
+// Block elements collapse to their inline content so the result fits a
+// single truncating line.
+const inlineComponents: Partial<Components> = {
+  ...announcementComponents,
+  p: ({ children }) => <>{children}</>,
+  h1: ({ children }) => <>{children}</>,
+  h2: ({ children }) => <>{children}</>,
+  h3: ({ children }) => <>{children}</>,
+  h4: ({ children }) => <>{children}</>,
+  h5: ({ children }) => <>{children}</>,
+  h6: ({ children }) => <>{children}</>,
+  blockquote: ({ children }) => <>{children}</>,
+  ul: ({ children }) => <>{children}</>,
+  ol: ({ children }) => <>{children}</>,
+  li: ({ children }) => <>{children}</>,
+  hr: () => null,
+};
+
+/** One-line markdown for the banner's body excerpt. */
+export function AnnouncementInlineMarkdown({ content }: { content: string }) {
+  return (
+    <MarkdownRenderer content={content} componentsOverride={inlineComponents} />
   );
 }

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.stories.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.stories.tsx
@@ -1,0 +1,97 @@
+import {
+  type Announcement,
+  announcementSchema,
+} from "@posthog/shared/announcements";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { AnnouncementModal } from "./AnnouncementModal";
+
+type ModalAnnouncement = Extract<Announcement, { kind: "announcement" }>;
+
+const MARKDOWN_BODY = [
+  "PostHog Code now runs **recurring agent jobs** straight from your project.",
+  "",
+  "- Schedule a prompt on any cadence",
+  "- Route the results to your inbox or a channel",
+  "- Pause or rewire a loop without a release",
+  "",
+  "Read the [docs](https://posthog.com/docs) for the full tour.",
+].join("\n");
+
+/** Parse through the real schema so fixtures stay valid payload examples. */
+function modalAnnouncement(
+  overrides: Record<string, unknown> = {},
+): ModalAnnouncement {
+  const parsed = announcementSchema.parse({
+    kind: "announcement",
+    id: "storybook-announcement",
+    title: "Loops are here",
+    body: MARKDOWN_BODY,
+    style: "modal",
+    cta: { label: "Try loops", url: "posthog-code://loop/storybook" },
+    ...overrides,
+  });
+  if (parsed.kind !== "announcement") {
+    throw new Error("fixture must be an announcement");
+  }
+  return parsed;
+}
+
+const meta: Meta<typeof AnnouncementModal> = {
+  title: "Announcements/AnnouncementModal",
+  component: AnnouncementModal,
+  args: { needsUpdate: false },
+};
+
+export default meta;
+type Story = StoryObj<typeof AnnouncementModal>;
+
+/** The default look: hero band with the default hedgehog, markdown body, CTA. */
+export const Default: Story = {
+  args: { announcement: modalAnnouncement() },
+};
+
+/** Payload-driven hero: custom band color and a hoggie from the brand catalog (CDN-loaded). */
+export const CatalogHeroHoggie: Story = {
+  args: {
+    announcement: modalAnnouncement({
+      hero: { hedgehog: "dr-manhattan", color: "#1d4aff" },
+    }),
+  },
+};
+
+/** `hero: { none: true }` drops the band for a plain modal. */
+export const NoHero: Story = {
+  args: { announcement: modalAnnouncement({ hero: { none: true } }) },
+};
+
+/** `requiresAck` blocks: no close button, no Esc, no dismiss — only the ack button. */
+export const BlockingAck: Story = {
+  args: {
+    announcement: modalAnnouncement({
+      requiresAck: true,
+      ackLabel: "I understand",
+      title: "Billing has changed",
+      body: "Usage-based billing replaces seat-based plans. You only pay for what you use.",
+    }),
+  },
+};
+
+/**
+ * Below `minVersion` the CTA swaps for the update action. Storybook has no
+ * updater, so the action degrades to the manual-download link.
+ */
+export const NeedsUpdate: Story = {
+  args: {
+    announcement: modalAnnouncement({ minVersion: "9.9.9" }),
+    needsUpdate: true,
+  },
+};
+
+/** A remote-length body scrolls inside the dialog body; the footer stays reachable. */
+export const LongBody: Story = {
+  args: {
+    announcement: modalAnnouncement({
+      body: Array.from({ length: 12 }, () => MARKDOWN_BODY).join("\n\n"),
+    }),
+  },
+};

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
@@ -12,10 +12,10 @@ import {
   type AnnouncementProperties,
 } from "@posthog/shared/analytics-events";
 import type { Announcement } from "@posthog/shared/announcements";
-import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect } from "react";
 import { AnnouncementHero } from "./AnnouncementHero";
+import { AnnouncementMarkdown } from "./AnnouncementMarkdown";
 import { openAnnouncementCta } from "./announcementCta";
 import { useAnnouncementsStore } from "./announcementsStore";
 import { UpdateAction } from "./UpdateAction";
@@ -82,8 +82,14 @@ export function AnnouncementModal({
     >
       {/* DialogBody caps and scrolls the remote-length body so the actions in
           DialogFooter stay reachable on short windows — essential when the
-          modal is blocking and the footer is the only way out. */}
-      <DialogContent className="sm:max-w-md" showCloseButton={!blocking}>
+          modal is blocking and the footer is the only way out. initialFocus
+          off: default initial focus lands on the body's first link and draws
+          a focus ring on open. */}
+      <DialogContent
+        className="announcement-dialog sm:max-w-md"
+        showCloseButton={!blocking}
+        initialFocus={false}
+      >
         <AnnouncementHero hero={announcement.hero} defaultHedgehog="happy" />
         <DialogBody>
           <DialogTitle className="font-semibold text-[17px] text-gray-12 tracking-tight">
@@ -93,10 +99,10 @@ export function AnnouncementModal({
             render={<div />}
             className="mt-1.5 text-[13px] text-gray-11 leading-relaxed"
           >
-            <MarkdownRenderer content={announcement.body} />
+            <AnnouncementMarkdown content={announcement.body} />
           </DialogDescription>
         </DialogBody>
-        <DialogFooter>
+        <DialogFooter className="border-t-0 bg-transparent">
           {blocking ? (
             needsUpdate ? (
               <UpdateAction

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
@@ -16,7 +16,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { useEffect } from "react";
 import { AnnouncementHero } from "./AnnouncementHero";
 import { AnnouncementMarkdown } from "./AnnouncementMarkdown";
-import { openAnnouncementCta } from "./announcementCta";
+import { useOpenAnnouncementCta } from "./announcementCta";
 import { useAnnouncementsStore } from "./announcementsStore";
 import { UpdateAction } from "./UpdateAction";
 import { useBlockingKeyboardIsolation } from "./useBlockingKeyboardIsolation";
@@ -31,6 +31,8 @@ export function AnnouncementModal({
   needsUpdate: boolean;
 }) {
   const dismiss = useAnnouncementsStore((state) => state.dismiss);
+  const undismiss = useAnnouncementsStore((state) => state.undismiss);
+  const openCta = useOpenAnnouncementCta();
   const analytics: AnnouncementProperties = {
     announcement_id: announcement.id,
     announcement_kind: announcement.kind,
@@ -52,7 +54,7 @@ export function AnnouncementModal({
 
   // Engaging with the CTA retires the announcement the same way closing does.
   const handleCta = (url: string) => {
-    const ctaType = openAnnouncementCta(url);
+    const ctaType = openCta(url);
     track(ANALYTICS_EVENTS.ANNOUNCEMENT_CTA_CLICKED, {
       ...analytics,
       cta_type: ctaType,
@@ -113,6 +115,7 @@ export function AnnouncementModal({
                 analytics={analytics}
                 showProgress
                 onInstallHandoff={() => acknowledge("update")}
+                onInstallFailed={() => undismiss(announcement.id)}
               />
             ) : (
               <Button

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
@@ -1,0 +1,140 @@
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@posthog/quill";
+import {
+  ANALYTICS_EVENTS,
+  type AnnouncementProperties,
+} from "@posthog/shared/analytics-events";
+import type { Announcement } from "@posthog/shared/announcements";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect } from "react";
+import { AnnouncementHero } from "./AnnouncementHero";
+import { openAnnouncementCta } from "./announcementCta";
+import { useAnnouncementsStore } from "./announcementsStore";
+import { UpdateAction } from "./UpdateAction";
+
+type ModalAnnouncement = Extract<Announcement, { kind: "announcement" }>;
+
+export function AnnouncementModal({
+  announcement,
+  needsUpdate,
+}: {
+  announcement: ModalAnnouncement;
+  needsUpdate: boolean;
+}) {
+  const dismiss = useAnnouncementsStore((state) => state.dismiss);
+  const analytics: AnnouncementProperties = {
+    announcement_id: announcement.id,
+    announcement_kind: announcement.kind,
+    announcement_style: "modal",
+  };
+
+  useEffect(() => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_SHOWN, {
+      announcement_id: announcement.id,
+      announcement_kind: announcement.kind,
+      announcement_style: "modal",
+    });
+  }, [announcement.id, announcement.kind]);
+
+  const handleClose = () => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_DISMISSED, analytics);
+    dismiss(announcement.id);
+  };
+
+  // Engaging with the CTA retires the announcement the same way closing does.
+  const handleCta = (url: string) => {
+    const ctaType = openAnnouncementCta(url);
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_CTA_CLICKED, {
+      ...analytics,
+      cta_type: ctaType,
+    });
+    dismiss(announcement.id);
+  };
+
+  const acknowledge = (ackType: "ok" | "update") => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_ACKNOWLEDGED, {
+      ...analytics,
+      ack_type: ackType,
+    });
+    dismiss(announcement.id);
+  };
+
+  const blocking = announcement.requiresAck;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={
+        blocking
+          ? undefined
+          : (open) => {
+              if (!open) handleClose();
+            }
+      }
+    >
+      {/* DialogBody caps and scrolls the remote-length body so the actions in
+          DialogFooter stay reachable on short windows — essential when the
+          modal is blocking and the footer is the only way out. */}
+      <DialogContent className="sm:max-w-md" showCloseButton={!blocking}>
+        <AnnouncementHero hero={announcement.hero} defaultHedgehog="happy" />
+        <DialogBody>
+          <DialogTitle className="font-semibold text-[17px] text-gray-12 tracking-tight">
+            {announcement.title}
+          </DialogTitle>
+          <DialogDescription
+            render={<div />}
+            className="mt-1.5 text-[13px] text-gray-11 leading-relaxed"
+          >
+            <MarkdownRenderer content={announcement.body} />
+          </DialogDescription>
+        </DialogBody>
+        <DialogFooter>
+          {blocking ? (
+            needsUpdate ? (
+              <UpdateAction
+                analytics={analytics}
+                showProgress
+                onInstallHandoff={() => acknowledge("update")}
+              />
+            ) : (
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => acknowledge("ok")}
+              >
+                {announcement.ackLabel ?? "OK"}
+              </Button>
+            )
+          ) : (
+            <>
+              <Button variant="outline" size="sm" onClick={handleClose}>
+                Dismiss
+              </Button>
+              {needsUpdate ? (
+                <UpdateAction analytics={analytics} showProgress />
+              ) : announcement.cta ? (
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={() =>
+                    announcement.cta && handleCta(announcement.cta.url)
+                  }
+                >
+                  {announcement.cta.label}
+                </Button>
+              ) : null}
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementModal.tsx
@@ -19,6 +19,7 @@ import { AnnouncementMarkdown } from "./AnnouncementMarkdown";
 import { openAnnouncementCta } from "./announcementCta";
 import { useAnnouncementsStore } from "./announcementsStore";
 import { UpdateAction } from "./UpdateAction";
+import { useBlockingKeyboardIsolation } from "./useBlockingKeyboardIsolation";
 
 type ModalAnnouncement = Extract<Announcement, { kind: "announcement" }>;
 
@@ -68,6 +69,9 @@ export function AnnouncementModal({
   };
 
   const blocking = announcement.requiresAck;
+  // Blocking means the whole app: the overlay stops the pointer, this stops
+  // the app's keyboard shortcuts from operating the app behind the modal.
+  useBlockingKeyboardIsolation(blocking);
 
   return (
     <Dialog

--- a/products/desktop/packages/ui/src/features/announcements/AnnouncementsHost.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/AnnouncementsHost.tsx
@@ -1,0 +1,26 @@
+import { AnnouncementModal } from "./AnnouncementModal";
+import { RequiredUpdateModal } from "./RequiredUpdateModal";
+import { useActiveAnnouncement } from "./useActiveAnnouncement";
+
+/**
+ * Mounts the modal announcement surfaces (the banner mounts separately in the
+ * shell).
+ */
+export function AnnouncementsHost() {
+  const active = useActiveAnnouncement();
+  if (!active) return null;
+
+  const { announcement } = active;
+  if (announcement.kind === "required-update") {
+    return <RequiredUpdateModal announcement={announcement} />;
+  }
+  if (announcement.style === "modal") {
+    return (
+      <AnnouncementModal
+        announcement={announcement}
+        needsUpdate={active.needsUpdate}
+      />
+    );
+  }
+  return null;
+}

--- a/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.stories.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.stories.tsx
@@ -1,0 +1,52 @@
+import {
+  type Announcement,
+  announcementSchema,
+} from "@posthog/shared/announcements";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RequiredUpdateModal } from "./RequiredUpdateModal";
+
+type RequiredUpdate = Extract<Announcement, { kind: "required-update" }>;
+
+/** Parse through the real schema so fixtures stay valid payload examples. */
+function requiredUpdate(
+  overrides: Record<string, unknown> = {},
+): RequiredUpdate {
+  const parsed = announcementSchema.parse({
+    kind: "required-update",
+    id: "storybook-required-update",
+    title: "Update required",
+    body: "This version can no longer talk to the PostHog backend. Update to keep your tasks and loops running.",
+    minVersion: "9.9.9",
+    ...overrides,
+  });
+  if (parsed.kind !== "required-update") {
+    throw new Error("fixture must be a required update");
+  }
+  return parsed;
+}
+
+const meta: Meta<typeof RequiredUpdateModal> = {
+  title: "Announcements/RequiredUpdateModal",
+  component: RequiredUpdateModal,
+};
+
+export default meta;
+type Story = StoryObj<typeof RequiredUpdateModal>;
+
+/**
+ * Fully blocking: no close button, Esc and outside clicks do nothing — the
+ * update action is the only way forward. Storybook has no updater, so the
+ * action degrades to the manual-download link.
+ */
+export const Default: Story = {
+  args: { announcement: requiredUpdate() },
+};
+
+/** The hero band follows the payload here too. */
+export const CustomHero: Story = {
+  args: {
+    announcement: requiredUpdate({
+      hero: { hedgehog: "explorer", color: "#111827" },
+    }),
+  },
+};

--- a/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.tsx
@@ -13,6 +13,7 @@ import { useEffect } from "react";
 import { AnnouncementHero } from "./AnnouncementHero";
 import { AnnouncementMarkdown } from "./AnnouncementMarkdown";
 import { UpdateAction } from "./UpdateAction";
+import { useBlockingKeyboardIsolation } from "./useBlockingKeyboardIsolation";
 
 type RequiredUpdate = Extract<Announcement, { kind: "required-update" }>;
 
@@ -35,6 +36,10 @@ export function RequiredUpdateModal({
       announcement_style: "modal",
     });
   }, [announcement.id, announcement.kind]);
+
+  // Blocking means the whole app: the overlay stops the pointer, this stops
+  // the app's keyboard shortcuts from operating the app behind the modal.
+  useBlockingKeyboardIsolation(true);
 
   return (
     <Dialog open>

--- a/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.tsx
@@ -1,0 +1,71 @@
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from "@posthog/quill";
+import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import type { Announcement } from "@posthog/shared/announcements";
+import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
+import { track } from "@posthog/ui/shell/analytics";
+import { useEffect } from "react";
+import { AnnouncementHero } from "./AnnouncementHero";
+import { UpdateAction } from "./UpdateAction";
+
+type RequiredUpdate = Extract<Announcement, { kind: "required-update" }>;
+
+/**
+ * Blocking: stays open until the user updates. Controlled `open` with no
+ * onOpenChange means Esc and outside clicks change nothing, and the close
+ * button is suppressed — the only way forward is the update action. That is
+ * also why the body renders inside DialogBody: the remote-length content must
+ * scroll rather than push the sole update action out of a short viewport.
+ */
+export function RequiredUpdateModal({
+  announcement,
+}: {
+  announcement: RequiredUpdate;
+}) {
+  useEffect(() => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_SHOWN, {
+      announcement_id: announcement.id,
+      announcement_kind: announcement.kind,
+      announcement_style: "modal",
+    });
+  }, [announcement.id, announcement.kind]);
+
+  return (
+    <Dialog open>
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <AnnouncementHero
+          hero={announcement.hero}
+          defaultHedgehog="builder"
+          defaultColor="#f54e00"
+        />
+        <DialogBody>
+          <DialogTitle className="font-semibold text-[17px] text-gray-12 tracking-tight">
+            {announcement.title}
+          </DialogTitle>
+          <DialogDescription
+            render={<div />}
+            className="mt-1.5 text-[13px] text-gray-11 leading-relaxed"
+          >
+            <MarkdownRenderer content={announcement.body} />
+          </DialogDescription>
+        </DialogBody>
+        <DialogFooter>
+          <UpdateAction
+            analytics={{
+              announcement_id: announcement.id,
+              announcement_kind: announcement.kind,
+              announcement_style: "modal",
+            }}
+            showProgress
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/RequiredUpdateModal.tsx
@@ -8,10 +8,10 @@ import {
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Announcement } from "@posthog/shared/announcements";
-import { MarkdownRenderer } from "@posthog/ui/features/editor/components/MarkdownRenderer";
 import { track } from "@posthog/ui/shell/analytics";
 import { useEffect } from "react";
 import { AnnouncementHero } from "./AnnouncementHero";
+import { AnnouncementMarkdown } from "./AnnouncementMarkdown";
 import { UpdateAction } from "./UpdateAction";
 
 type RequiredUpdate = Extract<Announcement, { kind: "required-update" }>;
@@ -38,7 +38,11 @@ export function RequiredUpdateModal({
 
   return (
     <Dialog open>
-      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+      <DialogContent
+        className="announcement-dialog sm:max-w-md"
+        showCloseButton={false}
+        initialFocus={false}
+      >
         <AnnouncementHero
           hero={announcement.hero}
           defaultHedgehog="builder"
@@ -52,10 +56,10 @@ export function RequiredUpdateModal({
             render={<div />}
             className="mt-1.5 text-[13px] text-gray-11 leading-relaxed"
           >
-            <MarkdownRenderer content={announcement.body} />
+            <AnnouncementMarkdown content={announcement.body} />
           </DialogDescription>
         </DialogBody>
-        <DialogFooter>
+        <DialogFooter className="border-t-0 bg-transparent">
           <UpdateAction
             analytics={{
               announcement_id: announcement.id,

--- a/products/desktop/packages/ui/src/features/announcements/UpdateAction.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/UpdateAction.tsx
@@ -24,6 +24,7 @@ export function UpdateAction({
   analytics,
   showProgress = false,
   onInstallHandoff,
+  onInstallFailed,
 }: {
   analytics: AnnouncementProperties;
   showProgress?: boolean;
@@ -36,6 +37,12 @@ export function UpdateAction({
    * retirement is left to the version gate after relaunch.
    */
   onInstallHandoff?: () => void;
+  /**
+   * The handoff's companion: fired when the install fails before the app
+   * quits, so state committed at the handoff (an acknowledgement) can be
+   * reverted. On success the app is gone before this could fire.
+   */
+  onInstallFailed?: () => void;
 }) {
   const { status, isEnabled, downloadPercent } = useUpdateView();
   const installUpdate = useInstallUpdate();
@@ -106,7 +113,9 @@ export function UpdateAction({
         onClick={() => {
           trackClick();
           onInstallHandoff?.();
-          void installUpdate();
+          void installUpdate().then((installed) => {
+            if (!installed) onInstallFailed?.();
+          });
         }}
       >
         Restart to update

--- a/products/desktop/packages/ui/src/features/announcements/UpdateAction.tsx
+++ b/products/desktop/packages/ui/src/features/announcements/UpdateAction.tsx
@@ -1,0 +1,179 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { Button, Progress } from "@posthog/quill";
+import {
+  ANALYTICS_EVENTS,
+  type AnnouncementProperties,
+} from "@posthog/shared/analytics-events";
+import {
+  useInstallUpdate,
+  useUpdateView,
+} from "@posthog/ui/features/updates/updateStore";
+import { track } from "@posthog/ui/shell/analytics";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { useMutation } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+
+const MANUAL_DOWNLOAD_URL = "https://github.com/PostHog/code/releases/latest";
+
+/**
+ * The announcement-side entry into the existing update flow: kicks a check,
+ * then walks available → downloading → restart. Where the updater is
+ * unavailable (Linux, dev builds), degrades to a manual-download link.
+ */
+export function UpdateAction({
+  analytics,
+  showProgress = false,
+  onInstallHandoff,
+}: {
+  analytics: AnnouncementProperties;
+  showProgress?: boolean;
+  /**
+   * Fired when the restart-to-install handoff begins — the last point before
+   * the app quits to apply the update. Blocking announcements record their
+   * acknowledgement here, not on earlier clicks: a failed or abandoned
+   * download must keep the announcement blocking. The manual-download link
+   * never fires this — a browser download can't confirm an install, so
+   * retirement is left to the version gate after relaunch.
+   */
+  onInstallHandoff?: () => void;
+}) {
+  const { status, isEnabled, downloadPercent } = useUpdateView();
+  const installUpdate = useInstallUpdate();
+  const hostTRPC = useHostTRPC();
+  // The updater's async failures aren't exposed through useUpdateView (a
+  // failed download collapses back to idle), so failures are tracked here:
+  // mutation errors directly, stream failures via the downloading→idle
+  // transition below. Without this a failed download silently re-renders
+  // the ordinary "Check for updates" state.
+  const [actionError, setActionError] = useState<string | null>(null);
+  const { mutate: runCheck, isPending: isCheckPending } = useMutation({
+    ...hostTRPC.updates.check.mutationOptions(),
+    onError: () => setActionError("Couldn't check for updates."),
+  });
+  const { mutate: runDownload, isPending: isDownloadPending } = useMutation({
+    ...hostTRPC.updates.download.mutationOptions(),
+    onError: () => setActionError("The download failed."),
+  });
+
+  const previousStatus = useRef(status);
+  useEffect(() => {
+    const previous = previousStatus.current;
+    previousStatus.current = status;
+    if (previous === "downloading" && status === "idle") {
+      setActionError("The download didn't finish.");
+    } else if (status !== "idle") {
+      setActionError(null);
+    }
+  }, [status]);
+
+  // This surface exists because an update is wanted, so make the state
+  // actionable immediately instead of waiting for the hourly poll.
+  const kicked = useRef(false);
+  useEffect(() => {
+    if (!isEnabled || kicked.current || status !== "idle") return;
+    kicked.current = true;
+    runCheck(undefined);
+  }, [isEnabled, status, runCheck]);
+
+  const trackClick = () => {
+    track(ANALYTICS_EVENTS.ANNOUNCEMENT_CTA_CLICKED, {
+      ...analytics,
+      cta_type: "update",
+    });
+  };
+
+  if (!isEnabled) {
+    return (
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={() => {
+          trackClick();
+          openExternalUrl(MANUAL_DOWNLOAD_URL);
+        }}
+      >
+        Download the latest version
+      </Button>
+    );
+  }
+
+  if (status === "ready" || status === "installing") {
+    return (
+      <Button
+        variant="primary"
+        size="sm"
+        disabled={status === "installing"}
+        onClick={() => {
+          trackClick();
+          onInstallHandoff?.();
+          void installUpdate();
+        }}
+      >
+        Restart to update
+      </Button>
+    );
+  }
+
+  if (status === "downloading") {
+    const percent = Math.round(downloadPercent ?? 0);
+    if (showProgress) {
+      return (
+        <div className="flex min-w-40 flex-col gap-1">
+          <span className="text-[11px] text-gray-11">
+            Downloading… {percent}%
+          </span>
+          <Progress value={percent} />
+        </div>
+      );
+    }
+    return (
+      <Button variant="outline" size="sm" disabled>
+        Downloading… {percent}%
+      </Button>
+    );
+  }
+
+  if (status === "available") {
+    return (
+      <Button
+        variant="primary"
+        size="sm"
+        disabled={isDownloadPending}
+        onClick={() => {
+          trackClick();
+          runDownload(undefined);
+        }}
+      >
+        Update now
+      </Button>
+    );
+  }
+
+  if (status === "checking" || isCheckPending) {
+    return (
+      <Button variant="outline" size="sm" disabled>
+        Checking for updates…
+      </Button>
+    );
+  }
+
+  // Idle after the kicked check means it found nothing or failed — leave the
+  // user a way to retry, and say so when we know something went wrong.
+  return (
+    <div className="flex flex-col items-end gap-1">
+      {actionError && (
+        <span className="text-(--red-11) text-[11px]">{actionError}</span>
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => {
+          setActionError(null);
+          runCheck(undefined);
+        }}
+      >
+        {actionError ? "Try again" : "Check for updates"}
+      </Button>
+    </div>
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/announcementCta.ts
+++ b/products/desktop/packages/ui/src/features/announcements/announcementCta.ts
@@ -1,0 +1,31 @@
+import { resolveService } from "@posthog/di/container";
+import {
+  HOST_TRPC_CLIENT,
+  type HostTrpcClient,
+} from "@posthog/host-router/client";
+import { getDeeplinkProtocol, isPostHogCodeDeeplink } from "@posthog/shared";
+import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+
+// Payloads are authored with the production scheme; dev builds register
+// posthog-code-dev://, and the dispatcher only accepts the active one.
+function toActiveScheme(url: string): string {
+  return url.replace(
+    /^posthog-code(-dev)?:\/\//,
+    `${getDeeplinkProtocol(import.meta.env.DEV)}://`,
+  );
+}
+
+/**
+ * Routes a CTA url: posthog-code:// deep links dispatch in-app through the
+ * main-process handler (no OS hop, no browser), https opens the browser.
+ */
+export function openAnnouncementCta(url: string): "deeplink" | "external" {
+  if (isPostHogCodeDeeplink(url)) {
+    void resolveService<HostTrpcClient>(HOST_TRPC_CLIENT).deepLink.open.mutate({
+      url: toActiveScheme(url),
+    });
+    return "deeplink";
+  }
+  openExternalUrl(url);
+  return "external";
+}

--- a/products/desktop/packages/ui/src/features/announcements/announcementCta.ts
+++ b/products/desktop/packages/ui/src/features/announcements/announcementCta.ts
@@ -1,10 +1,7 @@
-import { resolveService } from "@posthog/di/container";
-import {
-  HOST_TRPC_CLIENT,
-  type HostTrpcClient,
-} from "@posthog/host-router/client";
+import { useHostTRPCClient } from "@posthog/host-router/react";
 import { getDeeplinkProtocol, isPostHogCodeDeeplink } from "@posthog/shared";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
+import { useCallback } from "react";
 
 // Payloads are authored with the production scheme; dev builds register
 // posthog-code-dev://, and the dispatcher only accepts the active one.
@@ -19,13 +16,19 @@ function toActiveScheme(url: string): string {
  * Routes a CTA url: posthog-code:// deep links dispatch in-app through the
  * main-process handler (no OS hop, no browser), https opens the browser.
  */
-export function openAnnouncementCta(url: string): "deeplink" | "external" {
-  if (isPostHogCodeDeeplink(url)) {
-    void resolveService<HostTrpcClient>(HOST_TRPC_CLIENT).deepLink.open.mutate({
-      url: toActiveScheme(url),
-    });
-    return "deeplink";
-  }
-  openExternalUrl(url);
-  return "external";
+export function useOpenAnnouncementCta(): (
+  url: string,
+) => "deeplink" | "external" {
+  const client = useHostTRPCClient();
+  return useCallback(
+    (url: string) => {
+      if (isPostHogCodeDeeplink(url)) {
+        void client.deepLink.open.mutate({ url: toActiveScheme(url) });
+        return "deeplink";
+      }
+      openExternalUrl(url);
+      return "external";
+    },
+    [client],
+  );
 }

--- a/products/desktop/packages/ui/src/features/announcements/announcementsStore.ts
+++ b/products/desktop/packages/ui/src/features/announcements/announcementsStore.ts
@@ -1,0 +1,51 @@
+import {
+  electronStorage,
+  flushRendererStateWrites,
+} from "@posthog/ui/shell/rendererStorage";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+interface AnnouncementsState {
+  dismissedIds: Record<string, true>;
+  // One announcement per app session: dismissing or acknowledging anything
+  // parks the remaining announcements until the next launch. In-memory only —
+  // partialize keeps it out of storage so a relaunch resets it.
+  handledThisSession: boolean;
+  // Hydration is async (Electron storage over IPC); announcements must not
+  // flash for users whose persisted dismissals haven't been read back yet.
+  _hasHydrated: boolean;
+  dismiss: (id: string) => void;
+  setHasHydrated: (hydrated: boolean) => void;
+}
+
+export const useAnnouncementsStore = create<AnnouncementsState>()(
+  persist(
+    (set) => ({
+      dismissedIds: {},
+      handledThisSession: false,
+      _hasHydrated: false,
+      // Flushed immediately: the debounced write could otherwise be lost if
+      // the window closes right after the click, resurrecting the announcement.
+      dismiss: (id) => {
+        set((state) => ({
+          dismissedIds: { ...state.dismissedIds, [id]: true },
+          handledThisSession: true,
+        }));
+        void flushRendererStateWrites();
+      },
+      setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
+    }),
+    {
+      name: "posthog-desktop-announcements-dismissed",
+      storage: electronStorage,
+      partialize: (state) => ({ dismissedIds: state.dismissedIds }),
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          state.setHasHydrated(true);
+          return;
+        }
+        useAnnouncementsStore.setState({ _hasHydrated: true });
+      },
+    },
+  ),
+);

--- a/products/desktop/packages/ui/src/features/announcements/announcementsStore.ts
+++ b/products/desktop/packages/ui/src/features/announcements/announcementsStore.ts
@@ -15,6 +15,7 @@ interface AnnouncementsState {
   // flash for users whose persisted dismissals haven't been read back yet.
   _hasHydrated: boolean;
   dismiss: (id: string) => void;
+  undismiss: (id: string) => void;
   setHasHydrated: (hydrated: boolean) => void;
 }
 
@@ -31,6 +32,17 @@ export const useAnnouncementsStore = create<AnnouncementsState>()(
           dismissedIds: { ...state.dismissedIds, [id]: true },
           handledThisSession: true,
         }));
+        void flushRendererStateWrites();
+      },
+      // Reverts a dismissal committed at the update handoff when the install
+      // fails before the app quits — the blocking announcement must come
+      // back, this session included.
+      undismiss: (id) => {
+        set((state) => {
+          const dismissedIds = { ...state.dismissedIds };
+          delete dismissedIds[id];
+          return { dismissedIds, handledThisSession: false };
+        });
         void flushRendererStateWrites();
       },
       setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),

--- a/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.test.ts
+++ b/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { selectAnnouncement } from "./selectAnnouncement";
+
+const NOW = Date.parse("2026-08-05T12:00:00Z");
+const APP_VERSION = "1.40.0";
+
+function announcement(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "announcement",
+    id: "a1",
+    title: "Hello",
+    body: "World",
+    ...overrides,
+  };
+}
+
+function requiredUpdate(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "required-update",
+    id: "r1",
+    title: "Update required",
+    body: "Please update.",
+    minVersion: "2.0.0",
+    ...overrides,
+  };
+}
+
+function select(
+  payload: unknown,
+  {
+    now = NOW,
+    appVersion = APP_VERSION as string | null,
+    dismissedIds = new Set<string>(),
+    handledThisSession = false,
+  } = {},
+) {
+  return selectAnnouncement({
+    payload,
+    now,
+    appVersion,
+    dismissedIds,
+    handledThisSession,
+  });
+}
+
+describe("selectAnnouncement", () => {
+  it("selects nothing when the app version is unknown", () => {
+    const result = select(
+      { announcements: [announcement(), requiredUpdate()] },
+      { appVersion: null },
+    );
+    expect(result.active).toBeNull();
+  });
+
+  it.each([
+    ["undefined payload", undefined],
+    ["null payload", null],
+    ["empty list", { announcements: [] }],
+  ])("selects nothing for %s without a parse error", (_name, payload) => {
+    const result = select(payload);
+    expect(result.active).toBeNull();
+    expect(result.parseError).toBe(false);
+  });
+
+  it.each([
+    ["a string", "nope"],
+    ["missing announcements key", { items: [] }],
+    ["non-array announcements", { announcements: "all" }],
+  ])("reports a parse error for %s", (_name, payload) => {
+    const result = select(payload);
+    expect(result.active).toBeNull();
+    expect(result.parseError).toBe(true);
+  });
+
+  it("drops an invalid item but keeps its valid sibling", () => {
+    const result = select({
+      announcements: [{ garbage: true }, announcement()],
+    });
+    expect(result.invalidItems).toBe(1);
+    expect(result.active?.announcement.id).toBe("a1");
+  });
+
+  it.each([
+    ["before startsAt", { startsAt: "2026-08-06T00:00:00Z" }, false],
+    ["after endsAt", { endsAt: "2026-08-04T00:00:00Z" }, false],
+    [
+      "inside window",
+      { startsAt: "2026-08-01T00:00:00Z", endsAt: "2026-08-10T00:00:00Z" },
+      true,
+    ],
+    ["no bounds", {}, true],
+  ])("time window: %s", (_name, bounds, shown) => {
+    const result = select({ announcements: [announcement(bounds)] });
+    expect(result.active !== null).toBe(shown);
+  });
+
+  it("flags a schedule so callers re-evaluate on a timer", () => {
+    expect(select({ announcements: [announcement()] }).hasSchedule).toBe(false);
+    expect(
+      select({
+        announcements: [announcement({ startsAt: "2026-09-01T00:00:00Z" })],
+      }).hasSchedule,
+    ).toBe(true);
+  });
+
+  it.each([
+    ["below minVersion", "2.0.0", true],
+    ["at minVersion", APP_VERSION, false],
+    ["above minVersion", "1.0.0", false],
+  ])("required-update %s → shown %s", (_name, minVersion, shown) => {
+    const result = select({ announcements: [requiredUpdate({ minVersion })] });
+    expect(result.active !== null).toBe(shown);
+    if (shown) expect(result.active?.needsUpdate).toBe(true);
+  });
+
+  it("required-update ignores dismissals", () => {
+    const result = select(
+      { announcements: [requiredUpdate()] },
+      { dismissedIds: new Set(["r1"]) },
+    );
+    expect(result.active?.announcement.id).toBe("r1");
+  });
+
+  it.each([
+    ["below minVersion", "2.0.0", true],
+    ["at minVersion", APP_VERSION, false],
+  ])("announcement %s → needsUpdate %s", (_name, minVersion, needsUpdate) => {
+    const result = select({ announcements: [announcement({ minVersion })] });
+    expect(result.active?.needsUpdate).toBe(needsUpdate);
+  });
+
+  it("retires an acknowledged requiresAck announcement", () => {
+    const result = select(
+      {
+        announcements: [announcement({ style: "modal", requiresAck: true })],
+      },
+      { dismissedIds: new Set(["a1"]) },
+    );
+    expect(result.active).toBeNull();
+  });
+
+  it("skips dismissed announcements and falls through to the next on a fresh session", () => {
+    const result = select(
+      { announcements: [announcement(), announcement({ id: "a2" })] },
+      { dismissedIds: new Set(["a1"]) },
+    );
+    expect(result.active?.announcement.id).toBe("a2");
+  });
+
+  it("shows no further announcement once one was handled this session", () => {
+    const result = select(
+      { announcements: [announcement(), announcement({ id: "a2" })] },
+      { dismissedIds: new Set(["a1"]), handledThisSession: true },
+    );
+    expect(result.active).toBeNull();
+  });
+
+  it("still blocks on a required-update after an announcement was handled this session", () => {
+    const result = select(
+      { announcements: [announcement(), requiredUpdate()] },
+      { dismissedIds: new Set(["a1"]), handledThisSession: true },
+    );
+    expect(result.active?.announcement.id).toBe("r1");
+  });
+
+  it("prefers an unmet required-update over an earlier announcement", () => {
+    const result = select({
+      announcements: [announcement(), requiredUpdate()],
+    });
+    expect(result.active?.announcement.id).toBe("r1");
+  });
+
+  it("uses payload order among equals", () => {
+    const result = select({
+      announcements: [announcement({ id: "first" }), announcement()],
+    });
+    expect(result.active?.announcement.id).toBe("first");
+  });
+
+  it("ignores a satisfied required-update and shows the announcement", () => {
+    const result = select({
+      announcements: [requiredUpdate({ minVersion: "1.0.0" }), announcement()],
+    });
+    expect(result.active?.announcement.id).toBe("a1");
+  });
+});

--- a/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.ts
+++ b/products/desktop/packages/ui/src/features/announcements/selectAnnouncement.ts
@@ -1,0 +1,125 @@
+import { isVersionNewer } from "@posthog/core/updates/version";
+import {
+  type Announcement,
+  announcementSchema,
+  announcementsEnvelopeSchema,
+} from "@posthog/shared/announcements";
+
+export interface ActiveAnnouncement {
+  announcement: Announcement;
+  /** The app is below the announcement's minVersion — show an update action. */
+  needsUpdate: boolean;
+}
+
+export interface SelectAnnouncementInput {
+  /** Raw flag payload, exactly as PostHog returned it. */
+  payload: unknown;
+  now: number;
+  /** null = version unknown (web host, query unresolved) — nothing is shown. */
+  appVersion: string | null;
+  dismissedIds: ReadonlySet<string>;
+  /**
+   * An announcement was already dismissed or acknowledged this session — the
+   * rest wait for the next launch. Required-updates are exempt: they block
+   * regardless.
+   */
+  handledThisSession?: boolean;
+}
+
+export interface SelectAnnouncementResult {
+  active: ActiveAnnouncement | null;
+  /** Items that failed per-item validation and were dropped. */
+  invalidItems: number;
+  /** The envelope itself failed to parse. */
+  parseError: boolean;
+  /** Any valid item carries a time bound — callers re-evaluate on a timer. */
+  hasSchedule: boolean;
+}
+
+function none(overrides?: Partial<SelectAnnouncementResult>) {
+  return {
+    active: null,
+    invalidItems: 0,
+    parseError: false,
+    hasSchedule: false,
+    ...overrides,
+  };
+}
+
+function isInWindow(announcement: Announcement, now: number): boolean {
+  if (announcement.startsAt && now < Date.parse(announcement.startsAt)) {
+    return false;
+  }
+  if (announcement.endsAt && now > Date.parse(announcement.endsAt)) {
+    return false;
+  }
+  return true;
+}
+
+export function selectAnnouncement(
+  input: SelectAnnouncementInput,
+): SelectAnnouncementResult {
+  const {
+    payload,
+    now,
+    appVersion,
+    dismissedIds,
+    handledThisSession = false,
+  } = input;
+
+  if (appVersion === null) return none();
+  if (payload === undefined || payload === null) return none();
+
+  const envelope = announcementsEnvelopeSchema.safeParse(payload);
+  if (!envelope.success) return none({ parseError: true });
+
+  let invalidItems = 0;
+  const items: Announcement[] = [];
+  for (const raw of envelope.data.announcements) {
+    const item = announcementSchema.safeParse(raw);
+    if (item.success) {
+      items.push(item.data);
+    } else {
+      invalidItems++;
+    }
+  }
+
+  const hasSchedule = items.some((item) => item.startsAt || item.endsAt);
+  const eligible = items.filter((item) => isInWindow(item, now));
+
+  const requiredUpdate = eligible.find(
+    (item): item is Extract<Announcement, { kind: "required-update" }> =>
+      item.kind === "required-update" &&
+      isVersionNewer(item.minVersion, appVersion),
+  );
+  if (requiredUpdate) {
+    return {
+      active: { announcement: requiredUpdate, needsUpdate: true },
+      invalidItems,
+      parseError: false,
+      hasSchedule,
+    };
+  }
+
+  const announcement = handledThisSession
+    ? undefined
+    : eligible.find(
+        (item): item is Extract<Announcement, { kind: "announcement" }> =>
+          item.kind === "announcement" && !dismissedIds.has(item.id),
+      );
+  if (announcement) {
+    return {
+      active: {
+        announcement,
+        needsUpdate:
+          announcement.minVersion !== undefined &&
+          isVersionNewer(announcement.minVersion, appVersion),
+      },
+      invalidItems,
+      parseError: false,
+      hasSchedule,
+    };
+  }
+
+  return none({ invalidItems, hasSchedule });
+}

--- a/products/desktop/packages/ui/src/features/announcements/useActiveAnnouncement.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useActiveAnnouncement.ts
@@ -1,0 +1,69 @@
+import { useHostTRPC } from "@posthog/host-router/react";
+import { ANNOUNCEMENTS_FLAG } from "@posthog/shared";
+import { logger } from "@posthog/ui/shell/logger";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useFeatureFlag } from "../feature-flags/useFeatureFlag";
+import { useFeatureFlagPayload } from "../feature-flags/useFeatureFlagPayload";
+import { useAnnouncementsStore } from "./announcementsStore";
+import {
+  type ActiveAnnouncement,
+  selectAnnouncement,
+} from "./selectAnnouncement";
+
+const log = logger.scope("announcements");
+
+export function useActiveAnnouncement(): ActiveAnnouncement | null {
+  const armed = useFeatureFlag(ANNOUNCEMENTS_FLAG);
+  const payload = useFeatureFlagPayload(ANNOUNCEMENTS_FLAG);
+  const hostTRPC = useHostTRPC();
+  const { data: appVersion } = useQuery(
+    hostTRPC.os.getAppVersion.queryOptions(),
+  );
+  const dismissedIds = useAnnouncementsStore((state) => state.dismissedIds);
+  const handledThisSession = useAnnouncementsStore(
+    (state) => state.handledThisSession,
+  );
+  const hasHydrated = useAnnouncementsStore((state) => state._hasHydrated);
+  const [now, setNow] = useState(() => Date.now());
+
+  const dismissedSet = useMemo(
+    () => new Set(Object.keys(dismissedIds)),
+    [dismissedIds],
+  );
+  const result = useMemo(
+    () =>
+      selectAnnouncement({
+        payload,
+        now,
+        appVersion: appVersion ?? null,
+        dismissedIds: dismissedSet,
+        handledThisSession,
+      }),
+    [payload, now, appVersion, dismissedSet, handledThisSession],
+  );
+
+  // A scheduled item can cross its startsAt/endsAt while the app sits open;
+  // a minute of slack is fine for announcements, so tick only then.
+  useEffect(() => {
+    if (!result.hasSchedule) return;
+    const interval = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(interval);
+  }, [result.hasSchedule]);
+
+  const lastLoggedPayload = useRef<unknown>(undefined);
+  useEffect(() => {
+    if (payload === undefined || lastLoggedPayload.current === payload) return;
+    lastLoggedPayload.current = payload;
+    if (result.parseError) {
+      log.error("Announcements flag payload failed to parse");
+    } else if (result.invalidItems > 0) {
+      log.warn(
+        `Dropped ${result.invalidItems} invalid announcement(s) from flag payload`,
+      );
+    }
+  }, [payload, result]);
+
+  if (!armed || !hasHydrated) return null;
+  return result.active;
+}

--- a/products/desktop/packages/ui/src/features/announcements/useAnnouncementVisible.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useAnnouncementVisible.ts
@@ -1,0 +1,17 @@
+import { useActiveAnnouncement } from "./useActiveAnnouncement";
+
+/** Any remote announcement is on stage — lower-priority surfaces defer. */
+export function useAnnouncementVisible(): boolean {
+  return useActiveAnnouncement() !== null;
+}
+
+/** A blocking announcement (required-update or requiresAck) is on stage. */
+export function useBlockingAnnouncementVisible(): boolean {
+  const active = useActiveAnnouncement();
+  if (active === null) return false;
+  const { announcement } = active;
+  return (
+    announcement.kind === "required-update" ||
+    (announcement.kind === "announcement" && announcement.requiresAck)
+  );
+}

--- a/products/desktop/packages/ui/src/features/announcements/useBlockingKeyboardIsolation.test.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useBlockingKeyboardIsolation.test.ts
@@ -1,0 +1,42 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useBlockingKeyboardIsolation } from "./useBlockingKeyboardIsolation";
+
+// Real key events start at the focused element and bubble up through
+// document to window; the hook intercepts them on the way down (capture).
+function pressKey() {
+  document.body.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }),
+  );
+}
+
+describe("useBlockingKeyboardIsolation", () => {
+  it("starves document-level shortcut listeners while active, restores on unmount", () => {
+    const shortcut = vi.fn();
+    document.addEventListener("keydown", shortcut);
+
+    pressKey();
+    expect(shortcut).toHaveBeenCalledTimes(1);
+
+    const { unmount } = renderHook(() => useBlockingKeyboardIsolation(true));
+    pressKey();
+    expect(shortcut).toHaveBeenCalledTimes(1);
+
+    unmount();
+    pressKey();
+    expect(shortcut).toHaveBeenCalledTimes(2);
+
+    document.removeEventListener("keydown", shortcut);
+  });
+
+  it("does nothing while inactive", () => {
+    const shortcut = vi.fn();
+    document.addEventListener("keydown", shortcut);
+
+    renderHook(() => useBlockingKeyboardIsolation(false));
+    pressKey();
+    expect(shortcut).toHaveBeenCalledTimes(1);
+
+    document.removeEventListener("keydown", shortcut);
+  });
+});

--- a/products/desktop/packages/ui/src/features/announcements/useBlockingKeyboardIsolation.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useBlockingKeyboardIsolation.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+
+/**
+ * While a blocking announcement modal is on stage, swallow every keyboard
+ * event at the window capture phase. The dialog overlay already blocks the
+ * pointer, but the app's shortcuts (command menu, tab switching, hotkeys)
+ * listen on document or window and fire regardless of the modal — capturing
+ * at the window, ahead of them all, starves them. The modal itself stays
+ * fully operable: Tab traversal and Enter/Space activation of the focused
+ * button or link are native default actions, not listener-driven. Electron
+ * menu accelerators live in the main process and are out of reach here.
+ */
+export function useBlockingKeyboardIsolation(active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    const swallow = (event: KeyboardEvent) => {
+      event.stopImmediatePropagation();
+    };
+    const options = { capture: true } as const;
+    window.addEventListener("keydown", swallow, options);
+    window.addEventListener("keyup", swallow, options);
+    window.addEventListener("keypress", swallow, options);
+    return () => {
+      window.removeEventListener("keydown", swallow, options);
+      window.removeEventListener("keyup", swallow, options);
+      window.removeEventListener("keypress", swallow, options);
+    };
+  }, [active]);
+}

--- a/products/desktop/packages/ui/src/features/announcements/useSuppressChangelog.ts
+++ b/products/desktop/packages/ui/src/features/announcements/useSuppressChangelog.ts
@@ -1,0 +1,9 @@
+import { ANNOUNCEMENTS_FLAG } from "@posthog/shared";
+import { readSuppressChangelog } from "@posthog/shared/announcements";
+import { useFeatureFlagPayload } from "../feature-flags/useFeatureFlagPayload";
+
+/** The payload's changelog policy: on-stage announcements cancel it (default). */
+export function useSuppressChangelog(): boolean {
+  const payload = useFeatureFlagPayload(ANNOUNCEMENTS_FLAG);
+  return readSuppressChangelog(payload);
+}

--- a/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/editor/components/MarkdownRenderer.tsx
@@ -107,7 +107,10 @@ export const baseComponents: Components = {
           height="10"
           viewBox="0 0 12 12"
           fill="none"
-          stroke="var(--accent-11)"
+          // Radix accent vars don't reach portalled surfaces (quill dialogs);
+          // without the fallback the glyph draws invisibly, leaving a blank
+          // icon-sized gap after the link.
+          stroke="var(--accent-11, currentColor)"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/products/desktop/packages/ui/src/features/updates/UpdateAvailableModal.tsx
+++ b/products/desktop/packages/ui/src/features/updates/UpdateAvailableModal.tsx
@@ -1,5 +1,6 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { useBlockingAnnouncementVisible } from "@posthog/ui/features/announcements/useAnnouncementVisible";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import { parseReleaseNotes } from "@posthog/ui/features/updates/releaseNotes";
 import { useUpdateModalStore } from "@posthog/ui/features/updates/updateModalStore";
@@ -49,6 +50,9 @@ function ReleaseNotesSkeleton() {
 export function UpdateAvailableModal() {
   const isOpen = useUpdateModalStore((state) => state.isOpen);
   const close = useUpdateModalStore((state) => state.close);
+  // The blocking required-update announcement subsumes this dialog — never
+  // stack the two update prompts.
+  const blockingAnnouncementVisible = useBlockingAnnouncementVisible();
   const {
     status,
     version,
@@ -91,7 +95,7 @@ export function UpdateAvailableModal() {
 
   return (
     <Dialog.Root
-      open={isOpen}
+      open={isOpen && !blockingAnnouncementVisible}
       onOpenChange={(open) => {
         if (!open) close();
       }}

--- a/products/desktop/packages/ui/src/features/updates/WhatsNewModal.tsx
+++ b/products/desktop/packages/ui/src/features/updates/WhatsNewModal.tsx
@@ -1,5 +1,7 @@
 import { X } from "@phosphor-icons/react";
 import { useHostTRPC } from "@posthog/host-router/react";
+import { useAnnouncementVisible } from "@posthog/ui/features/announcements/useAnnouncementVisible";
+import { useSuppressChangelog } from "@posthog/ui/features/announcements/useSuppressChangelog";
 import { ReleaseNotesSections } from "@posthog/ui/features/updates/ReleaseNotesSections";
 import {
   groupReleases,
@@ -17,6 +19,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
 
 function ChangelogSkeleton() {
   return (
@@ -42,6 +45,17 @@ function ChangelogSkeleton() {
 export function WhatsNewModal() {
   const isOpen = useWhatsNewStore((state) => state.isOpen);
   const close = useWhatsNewStore((state) => state.close);
+  // A remote announcement takes the stage alone — the post-update auto-open
+  // waits here until it clears.
+  const announcementVisible = useAnnouncementVisible();
+  const suppressChangelog = useSuppressChangelog();
+
+  // By default an on-stage announcement cancels the pending auto-open
+  // outright; suppressChangelog: false in the payload defers it instead, so
+  // the changelog shows once the announcement clears.
+  useEffect(() => {
+    if (isOpen && announcementVisible && suppressChangelog) close();
+  }, [isOpen, announcementVisible, suppressChangelog, close]);
   const prefetchForActiveUpdate = useHasActiveUpdate();
   const hostTRPC = useHostTRPC();
   const { data: currentVersion, isError: isVersionError } = useQuery(
@@ -63,7 +77,7 @@ export function WhatsNewModal() {
 
   return (
     <Dialog.Root
-      open={isOpen}
+      open={isOpen && !announcementVisible}
       onOpenChange={(open) => {
         if (!open) close();
       }}

--- a/products/desktop/packages/ui/src/features/updates/updateStore.ts
+++ b/products/desktop/packages/ui/src/features/updates/updateStore.ts
@@ -48,12 +48,18 @@ export function useHasActiveUpdate(): boolean {
   );
 }
 
-export function useInstallUpdate(): () => Promise<void> {
+/**
+ * Returns whether the install handoff succeeded. On success the app quits to
+ * apply the update, so only the failure result is typically observable —
+ * callers that commit state at the handoff (announcement acknowledgements)
+ * use it to revert.
+ */
+export function useInstallUpdate(): () => Promise<boolean> {
   const client = useService<UpdatesClient>(UPDATES_CLIENT);
 
   return async () => {
     if (getUpdateUiStatus() === "installing") {
-      return;
+      return false;
     }
 
     updateStore.getState().setStatus("installing");
@@ -64,9 +70,11 @@ export function useInstallUpdate(): () => Promise<void> {
         log.error("Update install returned not installed");
         updateStore.getState().setStatus("ready");
       }
+      return result.installed;
     } catch (error) {
       log.error("Failed to install update", { error });
       updateStore.getState().setStatus("ready");
+      return false;
     }
   };
 }

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -14,6 +14,8 @@ import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { isContentlessTask } from "@posthog/shared/domain-types";
 import { DeepLinkApprovalModal } from "@posthog/ui/features/agent-applications/components/DeepLinkApprovalModal";
 import { useApprovalDeepLink } from "@posthog/ui/features/agent-applications/hooks/useApprovalDeepLink";
+import { AnnouncementBanner } from "@posthog/ui/features/announcements/AnnouncementBanner";
+import { AnnouncementsHost } from "@posthog/ui/features/announcements/AnnouncementsHost";
 import { useAuthStateValue } from "@posthog/ui/features/auth/store";
 import { UsageButton } from "@posthog/ui/features/billing/UsageButton";
 import { UsageLimitModal } from "@posthog/ui/features/billing/UsageLimitModal";
@@ -330,6 +332,7 @@ function RootLayout() {
     return (
       <Flex direction="column" height="100%">
         <ConnectivityBanner />
+        <AnnouncementBanner />
         <Outlet />
         <CommandMenu open={commandMenuOpen} onOpenChange={setCommandMenuOpen} />
         <GlobalFilePicker />
@@ -345,6 +348,7 @@ function RootLayout() {
             was stopping Cmd+W from closing the window. */}
         <TabShortcutFallback enabled />
         {billingEnabled && <UsageLimitModal />}
+        <AnnouncementsHost />
         <UpdateAvailableModal />
         <WhatsNewModal />
         <RemoteBranchCheckoutDialog />
@@ -465,6 +469,7 @@ function RootLayout() {
           )}
         </Flex>
         <ConnectivityBanner />
+        <AnnouncementBanner />
         <Flex flexGrow="1" overflow="hidden" className="relative">
           {/* Scrim under the peeked nav: dims the content while the overlay is
               out. Purely visual (pointer-transparent) and paired with the
@@ -528,6 +533,7 @@ function RootLayout() {
         />
         <TourOverlay />
         {billingEnabled && <UsageLimitModal />}
+        <AnnouncementsHost />
         <UpdateAvailableModal />
         <WhatsNewModal />
         <RemoteBranchCheckoutDialog />

--- a/products/desktop/packages/ui/src/router/routes/__root.tsx
+++ b/products/desktop/packages/ui/src/router/routes/__root.tsx
@@ -469,7 +469,6 @@ function RootLayout() {
           )}
         </Flex>
         <ConnectivityBanner />
-        <AnnouncementBanner />
         <Flex flexGrow="1" overflow="hidden" className="relative">
           {/* Scrim under the peeked nav: dims the content while the overlay is
               out. Purely visual (pointer-transparent) and paired with the
@@ -495,6 +494,9 @@ function RootLayout() {
               }`}
             >
               <Flex direction="column" height="100%">
+                {/* Inside the framed pane, not the app column: announcements
+                    overlay the content, never the sidebar. */}
+                <AnnouncementBanner />
                 {/* The /website space renders its own header (WebsiteLayout);
                       everywhere else the shared header carries the view title
                       and, on a task, its action row. */}

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -820,11 +820,11 @@ body {
   translate: 50% -50%;
 }
 
-/* No focus rings anywhere inside announcement modals — clicking the scroll
-   body, links, or buttons kept drawing them. The surface has at most three
-   controls, all reachable by Tab; activation feedback comes from hover and
-   pressed states instead. box-shadow also carries Tailwind ring utilities. */
-.quill-dialog__content.announcement-dialog :is(:focus, :focus-visible) {
+/* No focus rings for pointer interaction inside announcement modals —
+   clicking the scroll body, links, or buttons kept drawing them. Keyboard
+   focus (:focus-visible) keeps its indicators for accessibility. box-shadow
+   also carries Tailwind ring utilities. */
+.quill-dialog__content.announcement-dialog :focus:not(:focus-visible) {
   outline: none !important;
   box-shadow: none !important;
 }

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -797,7 +797,9 @@ body {
 }
 
 .markdown-link {
-  color: var(--accent-11);
+  /* currentColor fallback: Radix accent vars don't reach portalled surfaces
+     (quill dialogs), and an unresolvable var would drop the declaration. */
+  color: var(--accent-11, currentColor);
   text-decoration: none;
   cursor: pointer;
 }

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -806,6 +806,18 @@ body {
   text-decoration: underline;
 }
 
+/* Announcement modals center vertically; quill dialogs otherwise anchor near
+   the top of the window. Doubled selector to outrank .quill-dialog__content. */
+.quill-dialog__content.announcement-dialog {
+  top: 50%;
+  translate: -50% -50%;
+  max-height: calc(100dvh - 2rem);
+}
+
+[dir="rtl"] .quill-dialog__content.announcement-dialog {
+  translate: 50% -50%;
+}
+
 .rich-text-editor-content {
   /* font-family inherited from --font-sans via the global cascade */
   line-height: 1.6;

--- a/products/desktop/packages/ui/src/styles/globals.css
+++ b/products/desktop/packages/ui/src/styles/globals.css
@@ -820,6 +820,15 @@ body {
   translate: 50% -50%;
 }
 
+/* No focus rings anywhere inside announcement modals — clicking the scroll
+   body, links, or buttons kept drawing them. The surface has at most three
+   controls, all reachable by Tab; activation feedback comes from hover and
+   pressed states instead. box-shadow also carries Tailwind ring utilities. */
+.quill-dialog__content.announcement-dialog :is(:focus, :focus-visible) {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
 .rich-text-editor-content {
   /* font-family inherited from --font-sans via the global cascade */
   line-height: 1.6;


### PR DESCRIPTION
## Problem

Announcing anything to Desktop users meant shipping a component (`LoopsPromoCard`, `UsageBillingAnnouncementModal`, `ScoutAlphaBanner`): a release each, no scheduling, no way to force an update.

## Changes

| normal announcement | blocking announcement (requires ack) | banner | required update |
| --- | --- | --- | --- |
| ![Screenshot 2026-08-06 at 10.58.03 AM.png](https://app.graphite.com/user-attachments/assets/08755812-acca-4e70-becc-7f0bf0088995.png)<br> | ![Screenshot 2026-08-06 at 11.00.14 AM.png](https://app.graphite.com/user-attachments/assets/8c9c4f6a-dcce-443c-8b2e-549e60e043b8.png) | ![Screenshot 2026-08-06 at 10.48.59 AM.png](https://app.graphite.com/user-attachments/assets/f6a2eb9d-8c18-4fdb-bcee-8969c0f18dda.png)<br> | ![Screenshot 2026-08-06 at 10.30.19 AM.png](https://app.graphite.com/user-attachments/assets/8618420c-b475-4b89-bcac-a5419782e2c1.png)<br> |

Announcements live in the JSON payload of the [`posthog-desktop-announcements` flag](https://us.posthog.com/project/2/feature_flags/800905) (currently 0% / empty payload), validated by a shared Zod schema. Shipping, editing, or retiring one is a payload edit, not a release.

- `announcement` — banner or modal, per-user dismissal, optional schedule window and CTA (`https://` opens the browser, `posthog-code://` dispatches in-app).
- `requiresAck` makes an announcement blocking; `minVersion` swaps its CTA for the update flow, and updating acknowledges.
- `required-update` — blocking modal for apps below `minVersion`, driving the existing updater.
- One announcement per session. Blocking ones suppress the changelog, the update modal, and app keyboard shortcuts.
- Desktop-only: selection bails without an app version (the web host), and mobile doesn't consume `packages/ui`.

Storybook stories under "Announcements". Docs: `products/desktop/docs/ANNOUNCEMENTS.md`. The payload editor is #78657, deployed at https://desktop-announcements-admin.hosthog.dev.

## How did you test this code?

Schema and selection-logic unit tests plus the full ui/core/shared suites, typecheck, and biome. Exercised visually in Storybook and in a dev build via `posthog.featureFlags.overrideFeatureFlags`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`products/desktop/docs/ANNOUNCEMENTS.md` added.

## 🤖 Agent context

**Autonomy:** Human-driven — built with Claude in a PostHog Code task, directed by Adam Bowker.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)

> **Stack (read bottom-up):** #78660 (plumbing, merged) → #78886 (delete legacy surfaces, merged) → this PR → #78657 (admin editor).
