### PR TITLE
refactor(capture): serialization layer behind one seam

### DIFF
--- a/rust/capture/OUTPUTS_REFACTOR_PLAN.md
+++ b/rust/capture/OUTPUTS_REFACTOR_PLAN.md
@@ -264,7 +264,7 @@ When all steps land, the five strata hold:
 | 1 · Routing golden oracle | done | `test(capture): consolidate routing golden oracle with headers and counters` |
 | 2 · Pure `route()` | done | `refactor(capture): extract pure route() from prepare_record` |
 | 3 · `OutputRegistry` + completeness | done | `refactor(capture): output registry with startup completeness check` |
-| 4 · Serialization layer | pending | `refactor(capture): serialization layer — format and envelope behind one seam` |
+| 4 · Serialization layer | done | `refactor(capture): serialization layer behind one seam` |
 | 5 · `Pipeline` + `Lane`; lane resolution | pending | `refactor(capture): pipeline and lane address; lane decision moves to the pipeline layer` |
 | 6 · Kafka sink → backend mechanism | pending | `refactor(capture): narrow the kafka sink to backend mechanism over prepared payloads` |
 | 7 · Outputs layer with policies; composites retired | pending | `feat(capture): outputs layer owns failover and split policies` |

--- a/rust/capture/src/lib.rs
+++ b/rust/capture/src/lib.rs
@@ -21,6 +21,7 @@ pub mod prometheus;
 pub mod quota_limiters;
 pub mod router;
 pub mod s3_client;
+pub mod serialization;
 pub mod server;
 pub mod setup;
 pub mod sinks;

--- a/rust/capture/src/serialization/mod.rs
+++ b/rust/capture/src/serialization/mod.rs
@@ -1,0 +1,169 @@
+//! Serialization seam: format × envelope.
+//!
+//! A payload's encoding is a contract with the consumers of a destination,
+//! not a property of a transport. [`Format`] turns an event into payload
+//! bytes; [`Envelope`] wraps payload bytes at the byte level. A
+//! [`Serializer`] composes one of each, and the sink calls it instead of
+//! inlining the JSON conversion and the lz4 branch — so a format cutover
+//! (e.g. protobuf) or a new envelope becomes a per-destination config change
+//! behind this seam, with content headers carrying coexistence on a topic.
+//!
+//! Partition keys, routing headers, and topics are deliberately not here:
+//! this layer produces bytes and content headers only.
+
+use serde::Serialize;
+use tracing::log::error;
+
+use crate::api::CaptureError;
+
+/// Payload format: event → bytes. JSON is the only implementation and stamps
+/// no `content-type` — absence is the wire contract today's consumers read.
+/// A future format must return `Some` so old and new encodings can coexist
+/// on one topic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Json,
+}
+
+impl Format {
+    pub fn serialize<T: Serialize>(&self, event: &T) -> Result<Vec<u8>, CaptureError> {
+        match self {
+            Format::Json => serde_json::to_vec(event).map_err(|e| {
+                error!("failed to serialize event: {e:#}");
+                CaptureError::NonRetryableSinkError
+            }),
+        }
+    }
+
+    pub fn content_type(&self) -> Option<&'static str> {
+        match self {
+            Format::Json => None,
+        }
+    }
+}
+
+/// Byte-level envelope applied after the format. `Lz4` is the session replay
+/// block envelope: lz4 block compression with a 4-byte LE uncompressed-size
+/// prefix, so consumers can decompress without inspecting magic bytes. The
+/// `content-encoding` header signals that unwrapping is required, which lets
+/// enveloped and plain messages coexist on a topic during rollout and
+/// rollback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Envelope {
+    None,
+    Lz4,
+}
+
+impl Envelope {
+    pub fn wrap(&self, payload: Vec<u8>) -> Result<Vec<u8>, CaptureError> {
+        match self {
+            Envelope::None => Ok(payload),
+            Envelope::Lz4 => {
+                let compressed = lz4::block::compress(&payload, None, false).map_err(|e| {
+                    error!("failed to LZ4-compress payload: {e:#}");
+                    CaptureError::NonRetryableSinkError
+                })?;
+                let uncompressed_len = payload.len() as u32;
+                let mut wrapped = Vec::with_capacity(4 + compressed.len());
+                wrapped.extend_from_slice(&uncompressed_len.to_le_bytes());
+                wrapped.extend_from_slice(&compressed);
+                Ok(wrapped)
+            }
+        }
+    }
+
+    pub fn content_encoding(&self) -> Option<&'static str> {
+        match self {
+            Envelope::None => None,
+            Envelope::Lz4 => Some("lz4"),
+        }
+    }
+}
+
+/// One format wrapped in one envelope — a destination's encoding contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Serializer {
+    pub format: Format,
+    pub envelope: Envelope,
+}
+
+impl Serializer {
+    pub const JSON: Self = Self {
+        format: Format::Json,
+        envelope: Envelope::None,
+    };
+    pub const JSON_LZ4: Self = Self {
+        format: Format::Json,
+        envelope: Envelope::Lz4,
+    };
+
+    pub fn serialize<T: Serialize>(&self, event: &T) -> Result<Vec<u8>, CaptureError> {
+        self.envelope.wrap(self.format.serialize(event)?)
+    }
+
+    /// The `content-encoding` a produced record must carry, `None` when the
+    /// payload needs no unwrapping.
+    pub fn content_encoding(&self) -> Option<&'static str> {
+        self.envelope.content_encoding()
+    }
+
+    /// The `content-type` a produced record must carry, `None` for the
+    /// default JSON contract.
+    pub fn content_type(&self) -> Option<&'static str> {
+        self.format.content_type()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::json;
+
+    /// The lz4 envelope's byte layout is a consumer contract: 4-byte LE
+    /// uncompressed length, then the lz4 block. A change to either half
+    /// breaks decompression downstream.
+    #[test]
+    fn lz4_envelope_round_trips_with_le_size_prefix() {
+        let payload = serde_json::to_vec(&json!({"event": "$snapshot", "data": "x".repeat(256)}))
+            .expect("test payload must serialize");
+
+        let wrapped = Envelope::Lz4.wrap(payload.clone()).unwrap();
+
+        let prefix = u32::from_le_bytes(wrapped[..4].try_into().unwrap());
+        assert_eq!(prefix as usize, payload.len());
+        let unwrapped = lz4::block::decompress(&wrapped[4..], Some(prefix as i32)).unwrap();
+        assert_eq!(unwrapped, payload);
+    }
+
+    #[test]
+    fn none_envelope_passes_bytes_through() {
+        let payload = b"{\"event\":\"test\"}".to_vec();
+        assert_eq!(Envelope::None.wrap(payload.clone()).unwrap(), payload);
+    }
+
+    /// Content headers per composition: JSON stamps no content-type, and
+    /// only the lz4 envelope stamps a content-encoding.
+    #[rstest]
+    #[case::json_plain(Serializer::JSON, None, None)]
+    #[case::json_lz4(Serializer::JSON_LZ4, None, Some("lz4"))]
+    fn content_headers_follow_the_composition(
+        #[case] serializer: Serializer,
+        #[case] content_type: Option<&str>,
+        #[case] content_encoding: Option<&str>,
+    ) {
+        assert_eq!(serializer.content_type(), content_type);
+        assert_eq!(serializer.content_encoding(), content_encoding);
+    }
+
+    /// The composed serializer produces exactly format-then-envelope bytes.
+    #[test]
+    fn serializer_composes_format_then_envelope() {
+        let event = json!({"event": "test", "distinct_id": "user-1"});
+        let plain = Serializer::JSON.serialize(&event).unwrap();
+        assert_eq!(plain, serde_json::to_vec(&event).unwrap());
+
+        let wrapped = Serializer::JSON_LZ4.serialize(&event).unwrap();
+        assert_eq!(wrapped, Envelope::Lz4.wrap(plain).unwrap());
+    }
+}

--- a/rust/capture/src/serialization/mod.rs
+++ b/rust/capture/src/serialization/mod.rs
@@ -164,6 +164,8 @@ mod tests {
     }
 
     /// The composed serializer produces exactly format-then-envelope bytes.
+    /// The lz4 half decodes the output independently rather than calling
+    /// `wrap` again, so a composition bug cannot cancel itself out.
     #[test]
     fn serializer_composes_format_then_envelope() {
         let event = json!({"event": "test", "distinct_id": "user-1"});
@@ -171,6 +173,9 @@ mod tests {
         assert_eq!(plain, serde_json::to_vec(&event).unwrap());
 
         let wrapped = Serializer::JSON_LZ4.serialize(&event).unwrap();
-        assert_eq!(wrapped, Envelope::Lz4.wrap(plain).unwrap());
+        let prefix = u32::from_le_bytes(wrapped[..4].try_into().unwrap());
+        assert_eq!(prefix as usize, plain.len());
+        let unwrapped = lz4::block::decompress(&wrapped[4..], Some(prefix as i32)).unwrap();
+        assert_eq!(unwrapped, plain);
     }
 }

--- a/rust/capture/src/serialization/mod.rs
+++ b/rust/capture/src/serialization/mod.rs
@@ -16,9 +16,18 @@
 //! this layer produces bytes and content headers only.
 
 use serde::Serialize;
-use tracing::log::error;
+use thiserror::Error;
 
-use crate::api::CaptureError;
+/// What can go wrong producing payload bytes. The caller owns the mapping
+/// into its own error vocabulary and the logging, with the context (topic,
+/// team, event) this layer does not have.
+#[derive(Debug, Error)]
+pub enum SerializationError {
+    #[error("failed to serialize event: {0}")]
+    Format(#[from] serde_json::Error),
+    #[error("failed to apply envelope: {0}")]
+    Envelope(#[from] std::io::Error),
+}
 
 /// Payload format: event → bytes. JSON is the only implementation and stamps
 /// no `content-type` — absence is the wire contract today's consumers read.
@@ -30,12 +39,9 @@ pub enum Format {
 }
 
 impl Format {
-    pub fn serialize<T: Serialize>(&self, event: &T) -> Result<Vec<u8>, CaptureError> {
+    pub fn serialize<T: Serialize>(&self, event: &T) -> Result<Vec<u8>, SerializationError> {
         match self {
-            Format::Json => serde_json::to_vec(event).map_err(|e| {
-                error!("failed to serialize event: {e:#}");
-                CaptureError::NonRetryableSinkError
-            }),
+            Format::Json => Ok(serde_json::to_vec(event)?),
         }
     }
 
@@ -59,14 +65,11 @@ pub enum Envelope {
 }
 
 impl Envelope {
-    pub fn wrap(&self, payload: Vec<u8>) -> Result<Vec<u8>, CaptureError> {
+    pub fn wrap(&self, payload: Vec<u8>) -> Result<Vec<u8>, SerializationError> {
         match self {
             Envelope::None => Ok(payload),
             Envelope::Lz4 => {
-                let compressed = lz4::block::compress(&payload, None, false).map_err(|e| {
-                    error!("failed to LZ4-compress payload: {e:#}");
-                    CaptureError::NonRetryableSinkError
-                })?;
+                let compressed = lz4::block::compress(&payload, None, false)?;
                 let uncompressed_len = payload.len() as u32;
                 let mut wrapped = Vec::with_capacity(4 + compressed.len());
                 wrapped.extend_from_slice(&uncompressed_len.to_le_bytes());
@@ -101,7 +104,7 @@ impl Serializer {
         envelope: Envelope::Lz4,
     };
 
-    pub fn serialize<T: Serialize>(&self, event: &T) -> Result<Vec<u8>, CaptureError> {
+    pub fn serialize<T: Serialize>(&self, event: &T) -> Result<Vec<u8>, SerializationError> {
         self.envelope.wrap(self.format.serialize(event)?)
     }
 

--- a/rust/capture/src/serialization/mod.rs
+++ b/rust/capture/src/serialization/mod.rs
@@ -1,12 +1,16 @@
 //! Serialization seam: format × envelope.
 //!
-//! A payload's encoding is a contract with the consumers of a destination,
-//! not a property of a transport. [`Format`] turns an event into payload
-//! bytes; [`Envelope`] wraps payload bytes at the byte level. A
-//! [`Serializer`] composes one of each, and the sink calls it instead of
-//! inlining the JSON conversion and the lz4 branch — so a format cutover
-//! (e.g. protobuf) or a new envelope becomes a per-destination config change
-//! behind this seam, with content headers carrying coexistence on a topic.
+//! [`Format`] turns an event into payload bytes; [`Envelope`] wraps payload
+//! bytes at the byte level. A [`Serializer`] composes one of each, and the
+//! sink calls it instead of inlining the JSON conversion and the lz4 branch —
+//! so a format cutover (e.g. protobuf) or a new envelope becomes a config
+//! change behind this seam, with content headers carrying coexistence on a
+//! topic.
+//!
+//! The sink resolves the composition by `data_type`, before routing: a replay
+//! event redirected to the DLQ or a custom topic keeps the lz4 envelope, with
+//! its `content-encoding` header travelling along. Resolution per routed
+//! destination belongs to the outputs layer, not this seam.
 //!
 //! Partition keys, routing headers, and topics are deliberately not here:
 //! this layer produces bytes and content headers only.

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -20,6 +20,7 @@
 use crate::api::CaptureError;
 use crate::config::{EnvelopeCompression, KafkaConfig};
 use crate::ordering::{person_ordering, OrderingGuarantee};
+use crate::serialization::Serializer;
 use crate::sinks::producer::{KafkaProducer, ProduceRecord};
 use crate::sinks::registry::{Output, OutputRegistry};
 use crate::sinks::Event;
@@ -834,32 +835,15 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
     fn prepare_record(&self, event: ProcessedEvent) -> Result<ProduceRecord, CaptureError> {
         let (event, metadata) = (event.event, event.metadata);
 
-        let json = serde_json::to_string(&event).map_err(|e| {
-            error!("failed to serialize event: {e:#}");
-            CaptureError::NonRetryableSinkError
-        })?;
-
-        // Apply envelope-level compression for session replay when configured.
-        // Block format is used with a 4-byte LE uncompressed-size prefix so
-        // consumers can decompress without needing to inspect magic bytes —
-        // the `content-encoding` Kafka header signals that decompression is
-        // required. This allows compressed and uncompressed messages to coexist
-        // during rollout and rollback.
-        let payload = match (metadata.data_type, self.replay_envelope_compression) {
-            (DataType::SnapshotMain, EnvelopeCompression::Lz4) => {
-                let json_bytes = json.as_bytes();
-                let compressed = lz4::block::compress(json_bytes, None, false).map_err(|e| {
-                    error!("failed to LZ4-compress payload: {e:#}");
-                    CaptureError::NonRetryableSinkError
-                })?;
-                let uncompressed_len = json_bytes.len() as u32;
-                let mut payload = Vec::with_capacity(4 + compressed.len());
-                payload.extend_from_slice(&uncompressed_len.to_le_bytes());
-                payload.extend_from_slice(&compressed);
-                payload
-            }
-            _ => json.into_bytes(),
+        // Encoding is a consumer contract resolved per destination: session
+        // replay gets the lz4 envelope when configured, everything else the
+        // plain JSON contract. See `crate::serialization` for the formats,
+        // the envelope byte layout, and the coexistence story.
+        let serializer = match (metadata.data_type, self.replay_envelope_compression) {
+            (DataType::SnapshotMain, EnvelopeCompression::Lz4) => Serializer::JSON_LZ4,
+            _ => Serializer::JSON,
         };
+        let payload = serializer.serialize(&event)?;
 
         let event_key = event.key();
 
@@ -926,10 +910,8 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             _ => {}
         }
 
-        if matches!(self.replay_envelope_compression, EnvelopeCompression::Lz4)
-            && matches!(metadata.data_type, DataType::SnapshotMain)
-        {
-            headers.set_content_encoding("lz4".to_string());
+        if let Some(encoding) = serializer.content_encoding() {
+            headers.set_content_encoding(encoding.to_string());
         }
 
         Ok(ProduceRecord {

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -835,9 +835,11 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
     fn prepare_record(&self, event: ProcessedEvent) -> Result<ProduceRecord, CaptureError> {
         let (event, metadata) = (event.event, event.metadata);
 
-        // Encoding is a consumer contract resolved per destination: session
-        // replay gets the lz4 envelope when configured, everything else the
-        // plain JSON contract. See `crate::serialization` for the formats,
+        // Encoding is resolved by data_type, not by the routed destination:
+        // session replay gets the lz4 envelope when configured, everything
+        // else the plain JSON contract — so a replay event redirected to the
+        // DLQ or a custom topic keeps the envelope, with its content-encoding
+        // header travelling along. See `crate::serialization` for the formats,
         // the envelope byte layout, and the coexistence story.
         let serializer = match (metadata.data_type, self.replay_envelope_compression) {
             (DataType::SnapshotMain, EnvelopeCompression::Lz4) => Serializer::JSON_LZ4,

--- a/rust/capture/src/sinks/kafka.rs
+++ b/rust/capture/src/sinks/kafka.rs
@@ -845,7 +845,13 @@ impl<P: KafkaProducer> KafkaSinkBase<P> {
             (DataType::SnapshotMain, EnvelopeCompression::Lz4) => Serializer::JSON_LZ4,
             _ => Serializer::JSON,
         };
-        let payload = serializer.serialize(&event)?;
+        let payload = serializer.serialize(&event).map_err(|e| {
+            error!(
+                "failed to serialize {} event payload: {e:#}",
+                metadata.event_name
+            );
+            CaptureError::NonRetryableSinkError
+        })?;
 
         let event_key = event.key();
 


### PR DESCRIPTION
## Problem

Step 4 of the outputs refactor plan (`rust/capture/OUTPUTS_REFACTOR_PLAN.md`): the sink inlines JSON serialization and the replay lz4 branch inside `prepare_record`, so a format cutover (protobuf) or a new envelope means editing the sink.

## Changes

> [!NOTE]
> Prototype for plan Step 4, based on #78014 (which stacks on #74228) so it targets the final `prepare_record` and the diff stays one commit. Not managed as part of that stack: it merges on its own after the parents land (GitHub retargets the base when the parent branch is deleted), and it stays a draft until then.

- New `capture::serialization`: `Format` (event to bytes, `Json` only) and `Envelope` (bytes to bytes, `None` and `Lz4` moved verbatim) compose into a `Serializer`.
- `prepare_record` resolves the composition per destination and calls the serializer. The `content-encoding` header now comes from the serializer.
- The seam exposes `content_type()`. `Json` returns `None`, so no new header ships today.
- Partition keys, routing headers, and topics stay out of the seam.

## How did you test this code?

- The routing goldens pass unmodified, including the lz4 `content-encoding` cases.
- New unit tests pin the envelope byte layout (4-byte LE size prefix, then the lz4 block) and the content headers per composition.
- Full capture lib suite: 1212 tests. Clippy `-D warnings` and fmt clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The outputs plan doc already describes this step. The tracker flips when this graduates. No user-facing docs are affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Fable 5 implemented Step 4 from the plan doc, directed by Paweł. Prototyped on the #78014 stack head so the extraction does not need re-deriving after the stack merges.

