### PR TITLE
feat(desktop): capture task ownership and channel type in analytics

### DIFF
--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -983,7 +983,10 @@ export interface ChannelActionProperties {
   surface: ChannelsSurface;
   /** The channel acted on, when one is in scope. */
   channel_id?: string;
-  /** Whether the channel is the private #me space or a shared one, when known. */
+  /**
+   * Personal (#me) vs shared. Absent at capture sites that hold only a
+   * channel_id; set where the full channel is in scope (sidebar/hotkey opens).
+   */
   channel_type?: "public" | "personal";
   /** For file/unfile/archive/open task actions; for copy_link of a thread. */
   task_id?: string;

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -75,6 +75,8 @@ export interface TaskListViewProperties {
 }
 
 export interface TaskCreateProperties {
+  /** Absent when the id wasn't in scope at the capture site. */
+  task_id?: string;
   auto_run: boolean;
   created_from: TaskCreatedFrom;
   repository_provider?: RepositoryProvider;
@@ -96,6 +98,8 @@ export interface TaskCreateProperties {
 
 export interface TaskViewProperties {
   task_id: string;
+  /** Whether the viewer created the task; absent when creator or identity is unknown. */
+  is_own_task?: boolean;
 }
 
 export interface TaskRunProperties {
@@ -979,6 +983,8 @@ export interface ChannelActionProperties {
   surface: ChannelsSurface;
   /** The channel acted on, when one is in scope. */
   channel_id?: string;
+  /** Whether the channel is the private #me space or a shared one, when known. */
+  channel_type?: "public" | "personal";
   /** For file/unfile/archive/open task actions; for copy_link of a thread. */
   task_id?: string;
   /** For file_task: destination channel when different from `channel_id`. */

--- a/products/desktop/packages/shared/src/analytics-events.ts
+++ b/products/desktop/packages/shared/src/analytics-events.ts
@@ -984,8 +984,9 @@ export interface ChannelActionProperties {
   /** The channel acted on, when one is in scope. */
   channel_id?: string;
   /**
-   * Personal (#me) vs shared. Absent at capture sites that hold only a
-   * channel_id; set where the full channel is in scope (sidebar/hotkey opens).
+   * Personal (#me) vs shared. Stamped by trackChannelAction: explicit where
+   * the capture site holds the channel, else resolved from the cached
+   * channels list by channel_id.
    */
   channel_type?: "public" | "personal";
   /** For file/unfile/archive/open task actions; for copy_link of a thread. */

--- a/products/desktop/packages/ui/src/features/canvas/channelAnalytics.ts
+++ b/products/desktop/packages/ui/src/features/canvas/channelAnalytics.ts
@@ -1,0 +1,35 @@
+import { resolveServiceOptional } from "@posthog/di/container";
+import {
+  ANALYTICS_EVENTS,
+  type ChannelActionProperties,
+} from "@posthog/shared/analytics-events";
+import type { TaskChannel } from "@posthog/shared/domain-types";
+import { TASK_CHANNELS_QUERY_KEY } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
+import { track } from "@posthog/ui/shell/analytics";
+import {
+  IMPERATIVE_QUERY_CLIENT,
+  type ImperativeQueryClient,
+} from "@posthog/ui/shell/queryClient";
+
+/**
+ * Every Channel action is captured through here so channel_type is stamped
+ * even at sites that only hold a channel_id — resolved from the cached
+ * channels list rather than threaded through each call site. An explicit
+ * channel_type from the caller wins over the cache.
+ */
+export function trackChannelAction(properties: ChannelActionProperties): void {
+  track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    ...properties,
+    channel_type:
+      properties.channel_type ?? lookupChannelType(properties.channel_id),
+  });
+}
+
+function lookupChannelType(
+  channelId: string | undefined,
+): ChannelActionProperties["channel_type"] {
+  if (!channelId) return undefined;
+  return resolveServiceOptional<ImperativeQueryClient>(IMPERATIVE_QUERY_CLIENT)
+    ?.getQueryData<TaskChannel[]>(TASK_CHANNELS_QUERY_KEY)
+    ?.find((channel) => channel.id === channelId)?.channel_type;
+}

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityHoverCard.tsx
@@ -9,14 +9,13 @@ import {
   PopoverContent,
   Spinner,
 } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { ActivityRow } from "@posthog/ui/features/canvas/components/ActivityView";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
 import { useTaskActivity } from "@posthog/ui/features/canvas/hooks/useTaskActivity";
 import { useInView } from "@posthog/ui/primitives/hooks/useInView";
-import { track } from "@posthog/ui/shell/analytics";
 import { useEffect, useState } from "react";
 import {
   activityReadPayload,
@@ -52,7 +51,7 @@ export function ActivityHoverCard({
   const { mutate: markTasksRead, isPending: isMarkingRead } =
     useMarkTaskActivityRead();
   useEffect(() => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "view_activity",
       surface: "activity_panel",
     });

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityPanel.tsx
@@ -4,8 +4,8 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 import { Button, Tabs, TabsList, TabsTrigger } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { ActivityTimeline } from "@posthog/ui/features/canvas/components/ActivityTimeline";
 import { TaskCard } from "@posthog/ui/features/canvas/components/ChannelFeedView";
 import { TaskArtifactsList } from "@posthog/ui/features/canvas/components/TaskArtifactsList";
@@ -17,7 +17,6 @@ import {
 import { useThreadConversation } from "@posthog/ui/features/canvas/hooks/useThreadConversation";
 import { buildConversationItems } from "@posthog/ui/features/sessions/components/buildConversationItems";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
-import { track } from "@posthog/ui/shell/analytics";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -143,7 +142,7 @@ function ActivityConversation({
   const handleTabChange = useCallback(
     (next: ActivityTab) => {
       setTab(next);
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "activity_tab_change",
         surface: "activity_panel",
         task_id: taskId,

--- a/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ActivityView.tsx
@@ -19,11 +19,11 @@ import {
   Spinner,
 } from "@posthog/quill";
 import { formatRelativeTimeShort } from "@posthog/shared";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { UserBasic } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { UserAvatar } from "@posthog/ui/features/auth/UserAvatar";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { MentionText } from "@posthog/ui/features/canvas/components/MentionText";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useMarkTaskActivityRead } from "@posthog/ui/features/canvas/hooks/useMarkTaskActivityRead";
@@ -43,7 +43,6 @@ import {
   navigateToChannelTask,
   navigateToTaskDetail,
 } from "@posthog/ui/router/navigationBridge";
-import { track } from "@posthog/ui/shell/analytics";
 import { Text } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useMemo } from "react";
@@ -142,7 +141,7 @@ export function ActivityRow({
     item.activityKind === "completed" ||
     (item.activityKind === "message" && !item.author);
   const openTask = () => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "open_task",
       surface,
       channel_id: channelId ?? undefined,
@@ -277,7 +276,7 @@ export function ActivityView() {
     markTasksRead(activityReadPayload(unreadItems));
   }, [markTasksRead, unreadItems]);
   useEffect(() => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "view_activity",
       surface: "activity",
     });

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelBackRow.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
 import { useChannelStarToggle } from "@posthog/ui/features/canvas/hooks/useChannelStars";
 import {
@@ -15,7 +15,6 @@ import {
 } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { showChannelList } from "@posthog/ui/features/canvas/stores/channelPaneStore";
-import { track } from "@posthog/ui/shell/analytics";
 
 // An overlay rather than a sibling: the back button fills the row, and nesting
 // the star inside it would be a button within a button.
@@ -27,7 +26,7 @@ function RowStar({ channel }: { channel: Channel }) {
       size="icon-sm"
       aria-label={isStarred ? "Unstar space" : "Star space"}
       onClick={() => {
-        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        trackChannelAction({
           action_type: isStarred ? "unstar" : "star",
           surface: "sidebar",
           channel_id: channel.id,
@@ -71,7 +70,7 @@ export function ChannelBackRow({ channelId }: { channelId: string }) {
               left
               aria-label="Back to spaces"
               onClick={() => {
-                track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                trackChannelAction({
                   action_type: "browse_channels",
                   surface: "sidebar",
                   channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHomeComposer.tsx
@@ -3,8 +3,9 @@ import type {
   PiThinkingLevel,
 } from "@posthog/core/pi-runtime/piSessionController";
 import { isValidConfigValue } from "@posthog/core/task-detail/configOptions";
-import { type AgentRuntime, ANALYTICS_EVENTS } from "@posthog/shared";
+import type { AgentRuntime } from "@posthog/shared";
 import type { Task } from "@posthog/shared/domain-types";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   forwardRef,
@@ -15,7 +16,6 @@ import {
   useState,
 } from "react";
 import { useConnectivity } from "../../../hooks/useConnectivity";
-import { track } from "../../../shell/analytics";
 import { useFeatureFlag } from "../../feature-flags/useFeatureFlag";
 import { useFeatureFlagsLoaded } from "../../feature-flags/useFeatureFlagsLoaded";
 import { useUserRepositoryIntegration } from "../../integrations/useIntegrations";
@@ -104,7 +104,7 @@ export const ChannelHomeComposer = forwardRef<
     });
 
   const toggleCanvasMode = useCallback(() => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "canvas_mode_toggle",
       surface: "channel_home",
       channel_id: channelId,
@@ -253,7 +253,7 @@ export const ChannelHomeComposer = forwardRef<
     const editor = editorRef.current;
     const instruction = editor?.getText().trim();
     if (!editor || !instruction || isStartingCanvas) return;
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "canvas_generate",
       surface: "channel_home",
       channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHotkeys.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHotkeys.tsx
@@ -39,6 +39,7 @@ export function ChannelHotkeys() {
         action_type: "open_channel",
         surface: "sidebar",
         channel_id: channel.id,
+        channel_type: channel.channelType,
       });
     },
     {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelHotkeys.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelHotkeys.tsx
@@ -1,10 +1,9 @@
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useStarredChannelSlots } from "@posthog/ui/features/canvas/hooks/useStarredChannelSlots";
 import { useCurrentChannelStore } from "@posthog/ui/features/canvas/stores/currentChannelStore";
 import { SHORTCUTS } from "@posthog/ui/features/command/keyboard-shortcuts";
 import { navigateToChannel } from "@posthog/ui/router/navigationBridge";
-import { track } from "@posthog/ui/shell/analytics";
 import { useHotkeys } from "react-hotkeys-hook";
 
 /**
@@ -35,7 +34,7 @@ export function ChannelHotkeys() {
       if (!channel) return;
       setCurrentChannel(channel.id);
       navigateToChannel(channel.id);
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "open_channel",
         surface: "sidebar",
         channel_id: channel.id,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsFab.tsx
@@ -17,7 +17,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { CreateChannelModal } from "@posthog/ui/features/canvas/components/CreateChannelModal";
 import { trackAndCreateCanvas } from "@posthog/ui/features/canvas/createCanvasAnalytics";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
@@ -29,7 +29,6 @@ import {
 import { isContentEmpty } from "@posthog/ui/features/message-editor/content";
 import { useDraftStore } from "@posthog/ui/features/message-editor/draftStore";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
-import { track } from "@posthog/ui/shell/analytics";
 import { useRouterState } from "@tanstack/react-router";
 import { useState } from "react";
 
@@ -55,7 +54,7 @@ export function ChannelsFab({ channelId }: { channelId?: string }) {
   });
 
   const newTask = () => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "new_task_open",
       surface: "sidebar",
       channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -48,7 +48,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
 import { RenameChannelModal } from "@posthog/ui/features/canvas/components/RenameChannelModal";
 import { trackAndCreateCanvas } from "@posthog/ui/features/canvas/createCanvasAnalytics";
@@ -80,7 +80,6 @@ import {
 } from "@posthog/ui/primitives/OverflowTickerText";
 import { toast } from "@posthog/ui/primitives/toast";
 import { openTaskInput } from "@posthog/ui/router/useOpenTask";
-import { track } from "@posthog/ui/shell/analytics";
 import { Box, Flex } from "@radix-ui/themes";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
@@ -223,7 +222,7 @@ function useChannelActions(channel: Channel): {
       if (useCurrentChannelStore.getState().currentChannelId === channel.id) {
         resetCurrentChannel();
       }
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "delete",
         surface: "sidebar",
         channel_id: channel.id,
@@ -235,7 +234,7 @@ function useChannelActions(channel: Channel): {
       }
       return true;
     } catch (error) {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "delete",
         surface: "sidebar",
         channel_id: channel.id,
@@ -254,7 +253,7 @@ function useChannelActions(channel: Channel): {
       label: isStarred ? `Unstar ${noun}` : `Star ${noun}`,
       icon: <StarIcon size={14} weight={isStarred ? "fill" : "regular"} />,
       onSelect: () => {
-        track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+        trackChannelAction({
           action_type: isStarred ? "unstar" : "star",
           surface: "sidebar",
           channel_id: channel.id,
@@ -522,7 +521,7 @@ function ChannelSection({
             >
               <DropdownMenuItem
                 onClick={() => {
-                  track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+                  trackChannelAction({
                     action_type: "new_task_open",
                     surface: "sidebar",
                     channel_id: channel.id,
@@ -644,7 +643,7 @@ function useOpenPersonalChannel(): {
   const openPersonalChannel = () => {
     const channelId = ensureChannelId();
     if (!channelId) return;
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "nav_click",
       surface: "sidebar",
       channel_id: channelId,
@@ -670,7 +669,7 @@ function useOpenChannel(): (channel: Channel) => void {
   const setCurrentChannel = useCurrentChannelStore((s) => s.setCurrentChannel);
 
   return (channel: Channel) => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "nav_click",
       surface: "sidebar",
       channel_id: channel.id,
@@ -708,7 +707,7 @@ function PersonalChannelRow({ hotkeySlot }: { hotkeySlot?: number }) {
   const newTask = () => {
     const channelId = ensureChannelId();
     if (!channelId) return;
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "new_task_open",
       surface: "sidebar",
       channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -644,6 +644,12 @@ function useOpenPersonalChannel(): {
   const openPersonalChannel = () => {
     const channelId = ensureChannelId();
     if (!channelId) return;
+    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      action_type: "nav_click",
+      surface: "sidebar",
+      channel_id: channelId,
+      channel_type: "personal",
+    });
     showChannelPane();
     setCurrentChannel(channelId);
     if (!spacesLayout) {
@@ -668,6 +674,7 @@ function useOpenChannel(): (channel: Channel) => void {
       action_type: "nav_click",
       surface: "sidebar",
       channel_id: channel.id,
+      channel_type: channel.channelType,
     });
     showChannelPane();
     setCurrentChannel(channel.id);

--- a/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/CreateChannelModal.tsx
@@ -18,6 +18,7 @@ import {
   Textarea,
 } from "@posthog/quill";
 import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { RepositoriesField } from "@posthog/ui/features/canvas/components/RepositoriesField";
 import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
@@ -159,7 +160,7 @@ export function CreateChannelModal({
     let contextId: string;
     try {
       const channel = await createChannel(trimmedName);
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "create",
         surface: "sidebar",
         channel_id: channel.id,
@@ -167,7 +168,7 @@ export function CreateChannelModal({
       });
       contextId = channel.id;
     } catch (error) {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "create",
         surface: "sidebar",
         success: false,

--- a/products/desktop/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RenameChannelModal.tsx
@@ -1,13 +1,12 @@
 import { XIcon } from "@phosphor-icons/react";
 import { validateChannelName } from "@posthog/core/canvas/channelName";
 import { Button } from "@posthog/quill";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { channelGlyph } from "@posthog/ui/features/canvas/components/channelGlyph";
 import type { Channel } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelMutations } from "@posthog/ui/features/canvas/hooks/useChannels";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { toast } from "@posthog/ui/primitives/toast";
-import { track } from "@posthog/ui/shell/analytics";
 import { Dialog, Flex, IconButton, Text, TextField } from "@radix-ui/themes";
 import { useEffect, useState } from "react";
 
@@ -43,7 +42,7 @@ export function RenameChannelModal({
     if (!trimmed || unchanged || validationError || isRenaming) return;
     try {
       await renameChannel(channel.id, trimmed);
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "rename",
         surface: "sidebar",
         channel_id: channel.id,
@@ -51,7 +50,7 @@ export function RenameChannelModal({
       });
       onOpenChange(false);
     } catch (error) {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "rename",
         surface: "sidebar",
         channel_id: channel.id,

--- a/products/desktop/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ThreadSidebar.tsx
@@ -1,11 +1,10 @@
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { ActivityPanel } from "@posthog/ui/features/canvas/components/ActivityPanel";
 import { ThreadPanel } from "@posthog/ui/features/canvas/components/ThreadPanel";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useThreadPanelStore } from "@posthog/ui/features/canvas/stores/threadPanelStore";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
-import { track } from "@posthog/ui/shell/analytics";
 import { useState } from "react";
 
 // The right-hand dock for a task's thread (collapsible, resizable). Flag on
@@ -40,7 +39,7 @@ export function ThreadSidebar({
 
   const toggleCollapsed = (next: boolean) => {
     setCollapsed(next);
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: next ? "collapse_thread" : "expand_thread",
       surface: channelsLayout ? "activity_panel" : "thread_panel",
       task_id: taskId,

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelArtifacts.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelArtifacts.tsx
@@ -2,8 +2,8 @@ import { CaretRightIcon } from "@phosphor-icons/react";
 import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas";
 import type { DashboardRecord } from "@posthog/core/canvas/dashboardSchemas";
 import { formatRelativeTimeShort } from "@posthog/shared";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
@@ -12,7 +12,6 @@ import { useDashboards } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { usePrArtifact } from "@posthog/ui/features/git-interaction/usePrArtifact";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
-import { track } from "@posthog/ui/shell/analytics";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { Text } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
@@ -46,7 +45,7 @@ export function WebsiteChannelArtifacts({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "view_artifacts",
       surface: "channel_artifacts",
       channel_id: channelId,
@@ -98,7 +97,7 @@ export function WebsiteChannelArtifacts({ channelId }: { channelId: string }) {
 
   const openCanvas = useCallback(
     (dashboardId: string) => {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "open_artifact",
         surface: "channel_artifacts",
         channel_id: channelId,
@@ -113,7 +112,7 @@ export function WebsiteChannelArtifacts({ channelId }: { channelId: string }) {
 
   const openPr = useCallback(
     (prUrl: string) => {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "open_artifact",
         surface: "channel_artifacts",
         channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHistory.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHistory.tsx
@@ -2,8 +2,8 @@ import { CaretRightIcon } from "@phosphor-icons/react";
 import type { ChannelTaskRecord } from "@posthog/core/canvas/channelTaskSchemas";
 import type { DashboardRecord } from "@posthog/core/canvas/dashboardSchemas";
 import { formatRelativeTimeShort } from "@posthog/shared";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { ChannelHeader } from "@posthog/ui/features/canvas/components/ChannelHeader";
 import { iconForTemplate } from "@posthog/ui/features/canvas/components/canvasTemplateIcon";
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
@@ -11,7 +11,6 @@ import { useChannelTasks } from "@posthog/ui/features/canvas/hooks/useChannelTas
 import { useDashboards } from "@posthog/ui/features/canvas/hooks/useDashboards";
 import { useTasks } from "@posthog/ui/features/tasks/useTasks";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
-import { track } from "@posthog/ui/shell/analytics";
 import { Text } from "@radix-ui/themes";
 import { useNavigate } from "@tanstack/react-router";
 import { type ReactNode, useEffect, useMemo } from "react";
@@ -34,7 +33,7 @@ export function WebsiteChannelHistory({ channelId }: { channelId: string }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "view_history",
       surface: "channel_history",
       channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteChannelHome.tsx
@@ -1,7 +1,7 @@
 import { insertTaskDedup } from "@posthog/core/tasks/taskDelete";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
 import { isTerminalStatus } from "@posthog/shared/domain-types";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
 import {
   ChannelFeedView,
@@ -36,7 +36,6 @@ import { SuggestedPromptCard } from "@posthog/ui/features/task-detail/components
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
 import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { toast } from "@posthog/ui/primitives/toast";
-import { track } from "@posthog/ui/shell/analytics";
 import { Heading, Text } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
@@ -160,7 +159,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
       invalidateFeed();
       void fileTask(channelId, task.id)
         .then(() =>
-          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          trackChannelAction({
             action_type: "file_task",
             surface: "channel_home",
             channel_id: channelId,
@@ -169,7 +168,7 @@ export function WebsiteChannelHome({ channelId }: { channelId: string }) {
           }),
         )
         .catch((error: unknown) => {
-          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          trackChannelAction({
             action_type: "file_task",
             surface: "channel_home",
             channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/WebsiteNewTask.tsx
@@ -1,5 +1,5 @@
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type { Task } from "@posthog/shared/domain-types";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { CHANNEL_TASK_SUGGESTIONS } from "@posthog/ui/features/canvas/channelTaskSuggestions";
 import { ChannelBreadcrumb } from "@posthog/ui/features/canvas/components/ChannelBreadcrumb";
 import { ChannelContextPanel } from "@posthog/ui/features/canvas/components/ChannelContextPanel";
@@ -14,7 +14,6 @@ import { useSetHeaderContent } from "@posthog/ui/hooks/useSetHeaderContent";
 import { ResizableSidebar } from "@posthog/ui/primitives/ResizableSidebar";
 import { toast } from "@posthog/ui/primitives/toast";
 import { useAppView } from "@posthog/ui/router/useAppView";
-import { track } from "@posthog/ui/shell/analytics";
 import { Flex } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
@@ -64,7 +63,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
     // Only count opening the panel, not closing it, so an open→close→open
     // cycle doesn't inflate the metric.
     if (nextOpen) {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "view_context",
         surface: "new_task",
         channel_id: channelId,
@@ -79,7 +78,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
       queryClient.setQueryData(taskDetailQuery(task.id).queryKey, task);
       void fileTask(channelId, task.id)
         .then(() => {
-          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          trackChannelAction({
             action_type: "file_task",
             surface: "new_task",
             channel_id: channelId,
@@ -88,7 +87,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
           });
         })
         .catch((error: unknown) => {
-          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          trackChannelAction({
             action_type: "file_task",
             surface: "new_task",
             channel_id: channelId,
@@ -112,7 +111,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
   // switching survives the navigation.
   const handleSpaceChange = useCallback(
     (nextChannelId: string) => {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "new_task_open",
         surface: "new_task",
         channel_id: nextChannelId,
@@ -154,7 +153,7 @@ export function WebsiteNewTask({ channelId }: { channelId: string }) {
           reportAssociation={view.reportAssociation}
           suggestions={CHANNEL_TASK_SUGGESTIONS}
           onSuggestionSelect={(label) =>
-            track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+            trackChannelAction({
               action_type: "new_task_suggestion",
               surface: "new_task",
               channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useThreadConversation.ts
@@ -6,7 +6,6 @@ import {
   type ThreadAgentStatus,
   type ThreadTimelineRow,
 } from "@posthog/core/canvas/threadTimeline";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import type {
   Task,
   TaskThreadMessage,
@@ -15,6 +14,7 @@ import type {
 import { isTerminalStatus } from "@posthog/shared/domain-types";
 import { useOptionalAuthenticatedClient } from "@posthog/ui/features/auth/authClient";
 import { useCurrentUser } from "@posthog/ui/features/auth/useCurrentUser";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { useOrgMembers } from "@posthog/ui/features/canvas/hooks/useOrgMembers";
 import {
   useDeleteTaskThreadMessage,
@@ -27,7 +27,6 @@ import { useSessionConnection } from "@posthog/ui/features/sessions/hooks/useSes
 import { useSessionViewState } from "@posthog/ui/features/sessions/hooks/useSessionViewState";
 import { usePendingPermissionsForTask } from "@posthog/ui/features/sessions/sessionStore";
 import { toast } from "@posthog/ui/primitives/toast";
-import { track } from "@posthog/ui/shell/analytics";
 import { useCallback, useMemo, useState } from "react";
 
 export type ThreadSurface = "thread_panel" | "activity_panel";
@@ -124,7 +123,7 @@ export function useThreadConversation(
 
   const onMentionInsert = useCallback(
     (member: UserBasic) => {
-      track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+      trackChannelAction({
         action_type: "mention_member",
         surface,
         task_id: taskId,

--- a/products/desktop/packages/ui/src/features/canvas/stores/artifactsViewStore.ts
+++ b/products/desktop/packages/ui/src/features/canvas/stores/artifactsViewStore.ts
@@ -1,5 +1,4 @@
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
-import { track } from "@posthog/ui/shell/analytics";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
@@ -28,7 +27,7 @@ export const useArtifactsViewStore = create<ArtifactsViewStore>()(
       setView: (view, channelId) =>
         set((state) => {
           if (state.view === view) return state;
-          track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+          trackChannelAction({
             action_type: "artifacts_view_change",
             surface: "channel_artifacts",
             channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/canvas/utils/copyChannelLink.ts
+++ b/products/desktop/packages/ui/src/features/canvas/utils/copyChannelLink.ts
@@ -1,9 +1,6 @@
-import {
-  ANALYTICS_EVENTS,
-  type ChannelsSurface,
-} from "@posthog/shared/analytics-events";
+import type { ChannelsSurface } from "@posthog/shared/analytics-events";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { toast } from "@posthog/ui/primitives/toast";
-import { track } from "@posthog/ui/shell/analytics";
 import { channelShareUrl } from "@posthog/ui/utils/posthogLinks";
 
 /**
@@ -30,7 +27,7 @@ export async function copyChannelLink(
     toast.success("Link copied", {
       description: `Anyone with the link can open this ${target}.`,
     });
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "copy_link",
       surface,
       channel_id: channelId,
@@ -41,7 +38,7 @@ export async function copyChannelLink(
     toast.error("Couldn't copy link", {
       description: error instanceof Error ? error.message : String(error),
     });
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "copy_link",
       surface,
       channel_id: channelId,

--- a/products/desktop/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ConfigureAgentsSection.tsx
@@ -349,7 +349,9 @@ function SetupTaskSection() {
         reasoningLevel,
       };
 
+      let createdTaskId: string | undefined;
       const result = await taskService.createTask(input, (output) => {
+        createdTaskId = output.task.id;
         invalidateTasks(output.task);
         void openTask(output.task);
       });
@@ -361,6 +363,7 @@ function SetupTaskSection() {
       });
       if (result.success) {
         track(ANALYTICS_EVENTS.TASK_CREATED, {
+          task_id: createdTaskId,
           auto_run: true,
           created_from: "command-menu",
           repository_provider: "github",

--- a/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
+++ b/products/desktop/packages/ui/src/features/inbox/hooks/useInboxCloudTaskRunner.ts
@@ -226,8 +226,10 @@ export function useInboxCloudTaskRunner({
 
     try {
       let createdTask: Parameters<typeof openTask>[0] | null = null;
+      let createdTaskId: string | undefined;
       const result = await taskService.createTask(input, (output) => {
         createdTask = output.task;
+        createdTaskId = output.task.id;
         invalidateTasks(output.task);
         onTaskCreated?.(output.task);
         if (redirectOnSuccess) {
@@ -252,6 +254,7 @@ export function useInboxCloudTaskRunner({
           });
         }
         track(ANALYTICS_EVENTS.TASK_CREATED, {
+          task_id: createdTaskId,
           auto_run: true,
           created_from: "command-menu",
           ...(cloudRepository ? { repository_provider: "github" } : {}),

--- a/products/desktop/packages/ui/src/features/sidebar/components/TasksHeader.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/TasksHeader.tsx
@@ -24,15 +24,14 @@ import {
   MenuLabel,
 } from "@posthog/quill";
 import { PROJECT_BLUEBIRD_FLAG, type WorkspaceMode } from "@posthog/shared";
-import { ANALYTICS_EVENTS } from "@posthog/shared/analytics-events";
 import { useMeQuery } from "@posthog/ui/features/auth/useMeQuery";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useFolders } from "@posthog/ui/features/folders/useFolders";
 import { useSidebarStore } from "@posthog/ui/features/sidebar/sidebarStore";
 import { useHoldSidebarPeek } from "@posthog/ui/features/sidebar/useHoldSidebarPeek";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { toast } from "@posthog/ui/primitives/toast";
-import { track } from "@posthog/ui/shell/analytics";
 import { useCommandMenuStore } from "@posthog/ui/shell/commandMenuStore";
 import { logger } from "@posthog/ui/shell/logger";
 import { useState } from "react";
@@ -230,11 +229,11 @@ export function TasksHeader() {
   const handleModeChange = (showChannels: boolean) => {
     if (showChannels === channelsEnabled) return;
     setChannelsEnabled(showChannels);
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: "toggle_channels",
       surface: "nav",
     });
-    track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+    trackChannelAction({
       action_type: showChannels ? "enter_space" : "leave_space",
       surface: "nav",
     });

--- a/products/desktop/packages/ui/src/features/sidebar/useStartTaskFromWorktree.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/useStartTaskFromWorktree.ts
@@ -58,6 +58,7 @@ export function useStartTaskFromWorktree(mainRepoPath: string) {
           );
         }
         track(ANALYTICS_EVENTS.TASK_CREATED, {
+          task_id: result.data.task.id,
           auto_run: false,
           created_from: "sidebar-worktree",
           workspace_mode: "worktree",

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -20,6 +20,7 @@ import {
   type WorkspaceMode,
 } from "@posthog/shared";
 import type { ExecutionMode, Task } from "@posthog/shared/domain-types";
+import { trackChannelAction } from "@posthog/ui/features/canvas/channelAnalytics";
 import { useTaskChannels } from "@posthog/ui/features/canvas/hooks/useTaskChannels";
 import { useFeatureFlag } from "@posthog/ui/features/feature-flags/useFeatureFlag";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
@@ -441,7 +442,7 @@ export function useTaskCreation({
               editor.clear();
             }
             if (defaultedChannelId) {
-              track(ANALYTICS_EVENTS.CHANNEL_ACTION, {
+              trackChannelAction({
                 action_type: "file_task",
                 surface: "task_input",
                 channel_id: defaultedChannelId,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useTaskCreation.ts
@@ -123,6 +123,7 @@ async function trackTaskCreated(
   input: TaskCreationInput,
   selectedDirectory: string,
   hostClient: HostTrpcClient,
+  taskId: string | undefined,
 ): Promise<void> {
   try {
     const workspaceMode = input.workspaceMode ?? "local";
@@ -144,6 +145,7 @@ async function trackTaskCreated(
     }
 
     track(ANALYTICS_EVENTS.TASK_CREATED, {
+      task_id: taskId,
       auto_run: !!input.executionMode,
       created_from: "command-menu",
       repository_provider: input.repository ? "github" : "none",
@@ -491,7 +493,12 @@ export function useTaskCreation({
           if (!contentOverride) {
             useDraftStore.getState().actions.setDraft(sessionId, null);
           }
-          void trackTaskCreated(input, selectedDirectory, hostClient);
+          void trackTaskCreated(
+            input,
+            selectedDirectory,
+            hostClient,
+            createdTaskId,
+          );
           // Repo-less channel tasks create no workspace row (the agent runs in
           // a scratch dir surfaced as a synthetic workspace), so the normal
           // workspace.create invalidation never fires. Refresh the workspace

--- a/products/desktop/packages/ui/src/router/useOpenTask.ts
+++ b/products/desktop/packages/ui/src/router/useOpenTask.ts
@@ -8,7 +8,11 @@ import {
 } from "@posthog/ui/features/navigation/taskBinder";
 import { useTaskInputPrefillStore } from "@posthog/ui/features/task-detail/stores/taskInputPrefillStore";
 import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
-import { setActiveTaskContext, track } from "@posthog/ui/shell/analytics";
+import {
+  getIdentifiedUserUuid,
+  setActiveTaskContext,
+  track,
+} from "@posthog/ui/shell/analytics";
 import {
   IMPERATIVE_QUERY_CLIENT,
   type ImperativeQueryClient,
@@ -47,7 +51,14 @@ export async function openTask(
     nav.navigateToTaskDetail(task.id);
   }
   setActiveTaskContext(task);
-  track(ANALYTICS_EVENTS.TASK_VIEWED, { task_id: task.id });
+  const viewerUuid = getIdentifiedUserUuid();
+  track(ANALYTICS_EVENTS.TASK_VIEWED, {
+    task_id: task.id,
+    is_own_task:
+      task.created_by && viewerUuid
+        ? task.created_by.uuid === viewerUuid
+        : undefined,
+  });
 
   const result = await resolveServiceOptional<NavigationTaskBinder>(
     NAVIGATION_TASK_BINDER,

--- a/products/desktop/packages/ui/src/shell/analytics.ts
+++ b/products/desktop/packages/ui/src/shell/analytics.ts
@@ -61,10 +61,19 @@ export function captureException(
   );
 }
 
+// Kept module-level so non-React callers (e.g. openTask) can stamp
+// ownership properties without reaching into the auth query cache.
+let identifiedUserUuid: string | null = null;
+
+export function getIdentifiedUserUuid(): string | null {
+  return identifiedUserUuid;
+}
+
 export function identifyUser(
   userId: string,
   properties?: UserIdentifyProperties,
 ): void {
+  identifiedUserUuid = properties?.uuid ?? null;
   resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).identifyUser(
     userId,
     properties,
@@ -76,6 +85,7 @@ export function setUserGroups(user: AnalyticsUserGroups): void {
 }
 
 export function resetUser(): void {
+  identifiedUserUuid = null;
   resolveService<AnalyticsTracker>(ANALYTICS_TRACKER).resetUser();
 }
 


### PR DESCRIPTION
## Problem

The Spaces UI events can't answer basic adoption questions:

- `Task created` carries no `task_id`, so task opens can't be joined back to creation.
- `Task viewed` doesn't say whether the viewer opened their own task or a teammate's.
- Channel navigation events don't distinguish the private #me space from shared spaces, and opening #me from the sidebar wasn't tracked at all.

## Changes

- `Task created` now carries `task_id` at all four capture sites.
- `Task viewed` gains `is_own_task`, comparing `task.created_by` to the identified user.
- `Channel action` gains `channel_type` (`"public" | "personal"`) on sidebar and hotkey channel opens.
- Clicking the #me sidebar row now emits a `nav_click` channel action.
- The analytics shell keeps the identified user's uuid so non-React capture sites can stamp ownership.

## How did you test this code?

- `pnpm --filter @posthog/shared typecheck` and `pnpm --filter @posthog/ui typecheck` pass.
- Full `@posthog/ui` vitest suite passes (2562 tests).
- Biome lint on touched files reports no issues.
- No manual app testing was done.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — the property interfaces in `analytics-events.ts` are the documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested while setting up a Replay Vision scanner to study Spaces UI usage; these properties let the ownership and space-type questions be answered from events instead of replay scans.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
