### PR TITLE
fix(postgres): skip server-side cursor reads for duckdb-wire sources

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -3032,6 +3032,12 @@ def postgres_source(
                             logger.debug("Checking if source is a read replica...")
                             using_read_replica = _is_read_replica(cursor)
                             logger.debug(f"using_read_replica = {using_read_replica}")
+                            # DuckDB/duckgres-backed Postgres-wire engines don't implement
+                            # `DECLARE CURSOR` (or the `pg_catalog.pg_cursors` check psycopg's
+                            # ServerCursor runs before it), so `get_rows` must skip the
+                            # server-side cursor read path against them.
+                            is_duckdb = _is_duckdb_connection(cursor)
+                            logger.debug(f"is_duckdb = {is_duckdb}")
                             logger.debug("Getting primary keys...")
                             primary_keys = _get_primary_keys(cursor, schema, table_name, logger)
                             if primary_keys:
@@ -3278,7 +3284,7 @@ def postgres_source(
             # the Arrow schema (as the leading field, matching the SELECT) for a clean zip.
             arrow_schema = arrow_schema.insert(0, pa.field(XMIN_PROJECTED_COLUMN, pa.int64(), nullable=False))
         with _tunnel_with_handshake_translation(tunnel) as (host, port):
-            cursor_factory = psycopg.ServerCursor if not using_read_replica else None
+            cursor_factory = psycopg.ServerCursor if not using_read_replica and not is_duckdb else None
 
             def get_connection():
                 try:
@@ -3535,6 +3541,13 @@ def postgres_source(
                 # and failing the whole activity. Only the connect is retried; a drop mid-fetch still
                 # propagates, so a partially read window/partition is never re-yielded.
                 return _connect_with_dropped_retry(get_connection, logger)
+
+            if is_duckdb:
+                # No server-side cursor support (see `is_duckdb` above), so read with the same
+                # LIMIT/OFFSET fallback a read replica uses on a recovery conflict — a plain client
+                # cursor, no DECLARE required.
+                yield from offset_chunking(0, chunk_size)
+                return
 
             if use_per_partition_chunking and incremental_field is not None and incremental_field_type is not None:
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1512,6 +1512,7 @@ class TestSetupStatementTimeoutUnsupported:
             patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(is_setup=False)),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=100),
@@ -2437,6 +2438,7 @@ class TestServerCursorStatementTimeout:
             patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(raise_on_fetch=False)),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=100),
@@ -2559,6 +2561,7 @@ class TestServerCursorCloseStatementTimeout:
             patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(named=False)),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=100),
@@ -2594,6 +2597,110 @@ class TestServerCursorCloseStatementTimeout:
         # QueryTimeoutException should escape teardown.
         gen.close()
         assert connection.closed
+
+
+class TestGetRowsSkipsServerCursorForDuckDB:
+    """DuckDB/duckgres-backed Postgres-wire engines don't implement `DECLARE CURSOR`, nor the
+    `pg_catalog.pg_cursors` check psycopg's ServerCursor runs before it — opening a named cursor
+    against one raises a `Catalog Error: Table with name pg_cursors does not exist!`. `get_rows`
+    must route these connections through the plain-cursor offset-chunking path instead.
+    """
+
+    class _Cursor:
+        def __init__(self, rows: list[tuple[Any, ...]]):
+            self._rows = rows
+            self._fetched = False
+            col = mock.Mock()
+            col.name = "id"
+            self.description = [col]
+
+        def execute(self, *args, **kwargs):
+            return None
+
+        def fetchall(self):
+            if self._fetched:
+                return []
+            self._fetched = True
+            return self._rows
+
+        def fetchmany(self, _n: int):
+            raise AssertionError("a server-side cursor FETCH must not run against a duckdb connection")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    class _Connection:
+        def __init__(self, rows: list[tuple[Any, ...]]):
+            self._rows = rows
+            self.autocommit = False
+            self.closed = False
+            self.broken = False
+            self.adapters = mock.Mock()
+
+        def cursor(self, *args, **kwargs):
+            if "name" in kwargs:
+                raise AssertionError("get_rows must not open a named/server-side cursor against a duckdb connection")
+            return TestGetRowsSkipsServerCursorForDuckDB._Cursor(self._rows)
+
+        def commit(self):
+            return None
+
+        def close(self):
+            self.closed = True
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    def test_duckdb_connection_reads_via_offset_chunking(self):
+        @contextmanager
+        def fake_tunnel():
+            yield ("localhost", 5432)
+
+        fake_table = mock.Mock()
+        fake_table.to_arrow_schema.return_value = pa.schema([pa.field("id", pa.int64())])
+        fake_table.type = "table"
+        fake_table.columns = []
+        fake_table.__contains__ = mock.Mock(return_value=False)
+
+        connection = self._Connection(rows=[(1,)])
+
+        module = "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres"
+        with (
+            patch(f"{module}.psycopg.connect", return_value=connection),
+            patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(rows=[(1,)])),
+            patch(f"{module}._get_table", return_value=fake_table),
+            patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=True),
+            patch(f"{module}._get_primary_keys", return_value=["id"]),
+            patch(f"{module}._is_partitioned_table", return_value=False),
+            patch(f"{module}._get_table_chunk_size", return_value=100),
+            patch(f"{module}._get_rows_to_sync", return_value=10),
+            patch(f"{module}._role_subject_to_rls", return_value=False),
+            patch(f"{module}._get_partition_settings", return_value=None),
+        ):
+            response = postgres_source(
+                tunnel=lambda: fake_tunnel(),
+                user="u",
+                password="p",
+                database="db",
+                sslmode="prefer",
+                schema="public",
+                table_names=["companies"],
+                should_use_incremental_field=False,
+                logger=structlog.get_logger(),
+                db_incremental_field_last_value=None,
+                team_id=1,
+            )
+            tables = list(cast(Iterable[Any], response.items()))
+
+        assert len(tables) == 1
+        assert tables[0].to_pylist() == [{"id": 1}]
 
 
 class TestOffsetChunkingConnectRecoveryConflict:
@@ -2711,6 +2818,7 @@ class TestOffsetChunkingConnectRecoveryConflict:
             patch(f"{module}.psycopg.Cursor", side_effect=lambda _conn: self._OffsetCursor()),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=True),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=1000),
@@ -2779,6 +2887,7 @@ class TestOffsetChunkingConnectTimeout:
             ),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=True),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=1000),
@@ -2892,6 +3001,7 @@ class TestOffsetChunkingRecoveryConflictTimeout:
             patch(f"{module}.psycopg.Cursor", side_effect=lambda _conn: self._OffsetCursor()),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=True),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=1000),
@@ -7223,6 +7333,7 @@ class TestGetRowsInitialReadDropRetry:
             patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(batches=[], drop_on_execute=False)),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=100),
@@ -7370,6 +7481,7 @@ class TestGetRowsInitialReadLockTimeoutRetry:
             patch(f"{module}.psycopg.Cursor", return_value=self._Cursor(batches=[], state={"declare_locks_left": 0})),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=False),
             patch(f"{module}._get_table_chunk_size", return_value=100),
@@ -7531,6 +7643,7 @@ class TestPartitionIterationConnectRetry:
             ),
             patch(f"{module}._get_table", return_value=fake_table),
             patch(f"{module}._is_read_replica", return_value=False),
+            patch(f"{module}._is_duckdb_connection", return_value=False),
             patch(f"{module}._get_primary_keys", return_value=["id"]),
             patch(f"{module}._is_partitioned_table", return_value=True),
             patch(f"{module}.list_child_partitions", return_value=[child]),


### PR DESCRIPTION
## Problem

- The `postgres` data-warehouse source crashed for a DuckDB/duckgres-backed Postgres-wire engine.
- Error tracking issue: [InternalError: pg_cursors does not exist](https://us.posthog.com/project/2/error_tracking/019fd208-bec9-7703-bd99-6af5a7e78535)
- The engine accepts the connection but doesn't implement `DECLARE CURSOR`.
- It also lacks `pg_catalog.pg_cursors`, the table psycopg's `ServerCursor` checks before declaring.
- The DECLARE failure masked as a misleading `Catalog Error: Table with name pg_cursors does not exist!`.
- The real cause, `Parser Error: syntax error at or near "DECLARE"`, only showed up as chained context.

## Changes

- Detect a DuckDB-wire connection in `postgres_source` setup, reusing the existing `_is_duckdb_connection` helper.
- Route detected connections through the existing LIMIT/OFFSET plain-cursor fallback (`offset_chunking`) instead of opening a named/server-side cursor.
- This is the same fallback a read replica already uses on a recovery conflict, so no new read strategy was added.

## How did you test this code?

- Added `TestGetRowsSkipsServerCursorForDuckDB`, which fails if `get_rows` ever opens a named cursor against a duckdb-flagged connection, and asserts rows still come back via the plain-cursor path.
- Updated `_is_duckdb_connection` mocking in the other `get_rows`/setup unit tests that now exercise the new check.
- Ran the full `test_postgres.py` mock-based suite (573 passed; unrelated tests that need a live Postgres error the same way on master).
- Ran `ruff check`/`ruff format` and a repo-wide `mypy` pass — both clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A – no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error-tracking webhook for the `postgres` warehouse source.
- Confirmed the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py` via `query-error-tracking-issue-events`, then read the `get_rows` server-cursor loop and psycopg's `ServerCursor._close_gen`/`_declare_gen` to find the root cause.
- Considered adding this to `get_non_retryable_errors` instead, but the codebase already has extensive DuckDB/duckgres compatibility handling elsewhere in this file, so a real fix (skip the unsupported cursor mode) was the better fit over silencing the sync.
- Searched open PRs for a duplicate fix; none found.