### PR TITLE
fix(desktop): isolate channel task checkouts

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -158,7 +158,6 @@ vi.mock("node:fs", async (importOriginal) => {
 
 // --- Import after mocks ---
 import { fetchGatewayModels } from "@posthog/agent/gateway-models";
-import type { RegisteredFolder } from "../folders/schemas";
 import {
   AgentService,
   buildAutoApproveOutcome,
@@ -246,9 +245,6 @@ function createMockDependencies() {
     workspaceSettings: {
       getWorktreeLocation: () => "/mock/worktrees",
     },
-    foldersService: {
-      getFolders: vi.fn().mockResolvedValue([]),
-    },
     loggerFactory: {
       scope: () => ({
         info: vi.fn(),
@@ -293,7 +289,6 @@ describe("AgentService", () => {
       deps.storagePaths as never,
       deps.workspaceRepository as never,
       deps.workspaceSettings as never,
-      deps.foldersService as never,
       deps.loggerFactory as never,
     );
     vi.spyOn(service, "emit");
@@ -919,26 +914,10 @@ describe("AgentService", () => {
     });
   });
 
-  describe("channel system prompt local folders", () => {
+  describe("channel system prompt repository isolation", () => {
     const credentials = { apiHost: "https://app.posthog.com", projectId: 1 };
-    const FOLDERS_HEADER =
-      "already has these repositories checked out locally on this machine";
 
-    function makeFolder(
-      overrides: Partial<RegisteredFolder>,
-    ): RegisteredFolder {
-      return {
-        id: "folder-id",
-        path: "/src/example",
-        name: "example",
-        remoteUrl: null,
-        lastAccessed: "2026-01-01T00:00:00.000Z",
-        createdAt: "2026-01-01T00:00:00.000Z",
-        ...overrides,
-      };
-    }
-
-    function buildChannelPrompt(folders: RegisteredFolder[]): string {
+    function buildChannelPrompt(): string {
       return (
         service as unknown as {
           buildSystemPrompt: (
@@ -948,7 +927,6 @@ describe("AgentService", () => {
             additionalDirectories?: string[],
             systemPromptOverride?: string,
             channelMode?: boolean,
-            knownLocalFolders?: RegisteredFolder[],
           ) => { append: string };
         }
       ).buildSystemPrompt(
@@ -958,93 +936,20 @@ describe("AgentService", () => {
         undefined,
         undefined,
         true,
-        folders,
       ).append;
     }
 
-    it.each([
-      {
-        desc: "exists:true with a remoteUrl renders name, path and URL",
-        folder: makeFolder({
-          name: "posthog",
-          path: "/src/posthog",
-          remoteUrl: "git@github.com:PostHog/posthog.git",
-          exists: true,
-        }),
-        included: true,
-        line: "  - posthog — /src/posthog (git@github.com:PostHog/posthog.git)",
-      },
-      {
-        desc: "exists undefined with a null remoteUrl renders without parens",
-        folder: makeFolder({
-          name: "local-only",
-          path: "/src/local-only",
-          remoteUrl: null,
-        }),
-        included: true,
-        line: "  - local-only — /src/local-only",
-      },
-      {
-        desc: "exists:false is filtered out and omits the block",
-        folder: makeFolder({
-          name: "stale",
-          path: "/src/stale",
-          exists: false,
-        }),
-        included: false,
-        line: "  - stale — /src/stale",
-      },
-    ])("$desc", ({ folder, included, line }) => {
-      const prompt = buildChannelPrompt([folder]);
+    it("requires a task-specific clone instead of an existing checkout", () => {
+      const prompt = buildChannelPrompt();
 
-      if (included) {
-        expect(prompt).toContain(FOLDERS_HEADER);
-        expect(prompt).toContain(line);
-        // The reuse-first guidance only appears when a folder is on disk.
-        expect(prompt).toContain("do NOT clone it again");
-      } else {
-        expect(prompt).not.toContain(line);
-        // The only folder was filtered out, so the block is dropped entirely
-        // and the prompt falls back to the "ask for a path" guidance.
-        expect(prompt).not.toContain(FOLDERS_HEADER);
-        expect(prompt).toContain("If the user names a folder or path");
-      }
-    });
-
-    it("lists only existing folders when given a mix", () => {
-      const prompt = buildChannelPrompt([
-        makeFolder({
-          id: "1",
-          name: "posthog",
-          path: "/src/posthog",
-          remoteUrl: "git@github.com:PostHog/posthog.git",
-          exists: true,
-        }),
-        makeFolder({ id: "2", name: "local-only", path: "/src/local-only" }),
-        makeFolder({
-          id: "3",
-          name: "stale",
-          path: "/src/stale",
-          exists: false,
-        }),
-      ]);
-
-      expect(prompt).toContain(FOLDERS_HEADER);
       expect(prompt).toContain(
-        "  - posthog — /src/posthog (git@github.com:PostHog/posthog.git)",
+        "Do not `cd` into or edit an existing checkout elsewhere on the machine",
       );
-      expect(prompt).toContain("  - local-only — /src/local-only");
-      // A null remoteUrl must not render an empty "()" suffix.
-      expect(prompt).not.toContain("/src/local-only (");
-      // exists:false folders never reach the prompt.
-      expect(prompt).not.toContain("stale");
-    });
-
-    it("omits the local-folders block entirely when none are known", () => {
-      const prompt = buildChannelPrompt([]);
-
-      expect(prompt).not.toContain(FOLDERS_HEADER);
-      expect(prompt).toContain("If the user names a folder or path");
+      expect(prompt).toContain("use `clone_repo`");
+      expect(prompt).toContain(
+        "task-specific clone inside the scratch directory",
+      );
+      expect(prompt).not.toContain("Prefer reusing one of these");
     });
   });
 

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -76,9 +76,6 @@ import {
 import { inject, injectable, preDestroy } from "inversify";
 import { WORKSPACE_REPOSITORY } from "../../db/identifiers";
 import type { IWorkspaceRepository } from "../../db/repositories/workspace-repository";
-import type { FoldersService } from "../folders/folders";
-import { FOLDERS_SERVICE } from "../folders/identifiers";
-import type { RegisteredFolder } from "../folders/schemas";
 import { POSTHOG_PLUGIN_SERVICE } from "../posthog-plugin/identifiers";
 import type { PosthogPluginService } from "../posthog-plugin/posthog-plugin";
 import { PROCESS_TRACKING_SERVICE } from "../process-tracking/identifiers";
@@ -432,8 +429,6 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     private readonly workspaceRepository: IWorkspaceRepository,
     @inject(WORKSPACE_SETTINGS_SERVICE)
     private readonly workspaceSettings: IWorkspaceSettings,
-    @inject(FOLDERS_SERVICE)
-    private readonly foldersService: FoldersService,
     @inject(AGENT_LOGGER)
     loggerFactory: AgentLogger,
   ) {
@@ -617,7 +612,6 @@ export class AgentService extends TypedEventEmitter<AgentServiceEvents> {
     additionalDirectories?: string[],
     systemPromptOverride?: string,
     channelMode?: boolean,
-    knownLocalFolders?: RegisteredFolder[],
   ): {
     append: string;
   } {
@@ -670,30 +664,16 @@ Optimize for the fewest shell round trips.
 - Never rerun a command solely to reproduce output you already have.`;
 
     if (channelMode) {
-      const localFolders = (knownLocalFolders ?? []).filter(
-        (f) => f.exists !== false,
-      );
-      const localFoldersBlock = localFolders.length
-        ? `\n\nThe user already has these repositories checked out locally on this machine. Prefer reusing one of these over cloning anything:\n${localFolders
-            .map(
-              (f) =>
-                `  - ${f.name} — ${f.path}${f.remoteUrl ? ` (${f.remoteUrl})` : ""}`,
-            )
-            .join("\n")}`
-        : "";
-
       prompt += `
 
 ## Channel task (no repository attached)
-You are running in a PostHog channel as a general-purpose assistant. This task may NOT need a code repository at all — it could be data analysis via PostHog tools, drafting a message, or answering a question. Do not assume you need a repo.
+You are running in a PostHog channel as a general-purpose assistant. This task may not need a code repository. It could be data analysis via PostHog tools, drafting a message, or answering a question. Do not assume you need a repo.
 
 - Your working directory is a scratch directory, not a git checkout. Treat it as empty.
-- Decide from the user's request (and the channel CONTEXT.md included above, if any) whether the task actually requires working inside a code repository. If it doesn't, just do the work in the scratch directory — do NOT attach a repo.
+- Decide from the user's request and the channel CONTEXT.md, if present, whether the task requires a code repository. If it doesn't, do the work in the scratch directory.
+- Do not \`cd\` into or edit an existing checkout elsewhere on the machine. Another task may be using it.
 
-If a repository IS genuinely required, attach one in this priority order:
-1. **Reuse a folder the user already has locally.** ${localFolders.length ? "Pick the one that best matches the request and the channel CONTEXT.md, then `cd` into its absolute path and do all git and file work there. It is already on disk — do NOT clone it again." : "If the user names a folder or path, `cd` into that absolute path and work there."}
-2. **If you can't confidently pick one** (none clearly match, or it's ambiguous), use the AskUserQuestion tool to ask the user which local folder to use, or for the path where the folder lives on this machine. Do not guess.
-3. **Only as a last resort** — when the user has no local copy, or explicitly wants a fresh checkout — clone from remote. Call \`list_repos\` to see what's available (prefer repos named in CONTEXT.md), then **confirm with the user via AskUserQuestion before cloning**, and use \`clone_repo\` (pass \`owner/repo\`); it clones into a subdirectory of your working directory and returns the path to \`cd\` into.${localFoldersBlock}`;
+If a repository is required, call \`list_repos\` to find it, then use \`clone_repo\` with its \`owner/repo\`. The tool creates a task-specific clone inside the scratch directory and returns the path to use. If you cannot confidently identify the repository, ask the user which repository to clone.`;
     }
 
     if (customInstructions) {
@@ -801,13 +781,6 @@ If a repository IS genuinely required, attach one in this priority order:
       this.workspaceSettings.getWorktreeLocation(),
     );
 
-    // In channel mode the agent decides at runtime whether it needs a repo. Give
-    // it the user's previously-used local folders so it can reuse one (or ask)
-    // instead of cloning from remote. Only fetched for channel sessions.
-    const knownLocalFolders = channelMode
-      ? await this.foldersService.getFolders().catch(() => [])
-      : [];
-
     const additionalDirectories =
       taskId === "__preview__"
         ? []
@@ -866,7 +839,6 @@ If a repository IS genuinely required, attach one in this priority order:
         additionalDirectories,
         systemPromptOverride,
         channelMode,
-        knownLocalFolders,
       );
 
       const bundledSkillsDir = join(


### PR DESCRIPTION
## Problem

Repo-less channel tasks can enter the same existing checkout. Concurrent tasks can then overwrite files or change branches beneath each other.

## Changes

| Behavior | Before | After |
| --- | --- | --- |
| Repository choice | The prompt listed registered local checkouts and told the agent to reuse one. | The prompt no longer exposes or recommends registered local checkout paths. |
| Working directory | The agent left its task scratch directory and entered the shared checkout. | The agent calls `clone_repo` and works in a clone inside its task scratch directory. |
| Concurrent tasks | Two tasks could edit files or change branches in the same checkout. | Each task receives a separate clone, so file and branch changes stay isolated. |
| Existing local work | A task could read, overwrite, or include another task's uncommitted changes. | Channel tasks do not touch existing checkouts or their uncommitted changes. |
| Tradeoff | Reusing a checkout avoided clone time and disk use. | Isolation requires a separate clone for each repo-backed channel task. |

Before:

```mermaid
flowchart LR
    A[Channel task A] --> C[Existing checkout]
    B[Channel task B] --> C
```

After:

```mermaid
flowchart LR
    A[Channel task A] --> C[Task-specific clone A]
    B[Channel task B] --> D[Task-specific clone B]
```

## How did you test this code?

- `agent.test.ts`: 42 tests passed.
- `@posthog/workspace-server` typecheck passed.
- The regression test rejects existing checkouts and requires task-specific clones.
- `hogli ci:preflight --fix` was unavailable in this checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update is required for this internal safety fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and verified this change. It used `/writing-user-facing-copy`, `/writing-tests`, and `/writing-pr-descriptions`.

The fix favors per-task clone isolation until the host supports managed lazy worktree attachment.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
