### PR TITLE
fix(replay-vision): show event property filters in scanner config

### DIFF
--- a/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.component.test.tsx
+++ b/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.component.test.tsx
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { initKeaTests } from '~/test/init'
+import { ActionFilter, PropertyFilterType, PropertyOperator } from '~/types'
+
+import { UniversalFilterButton } from './UniversalFilterButton'
+
+describe('UniversalFilterButton', () => {
+    beforeEach(() => {
+        initKeaTests()
+        cohortsModel.mount()
+        propertyDefinitionsModel.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    const EVENT_WITH_PROPERTIES: ActionFilter = {
+        id: '$pageview',
+        name: '$pageview',
+        type: 'events',
+        order: 0,
+        properties: [
+            {
+                key: '$current_url',
+                value: ['/checkout'],
+                operator: PropertyOperator.Exact,
+                type: PropertyFilterType.Event,
+            },
+        ],
+    }
+
+    function renderButton(onClick?: () => void): void {
+        render(
+            <Provider>
+                <UniversalFilterButton filter={EVENT_WITH_PROPERTIES} onClick={onClick} />
+            </Provider>
+        )
+    }
+
+    it('offers the property filter button when there is a handler to open the properties', () => {
+        renderButton(() => {})
+        expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('renders no button when read-only, so the property count is not a dead click target', () => {
+        renderButton()
+        expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.tsx
+++ b/frontend/src/lib/components/UniversalFilters/UniversalFilterButton.tsx
@@ -113,16 +113,20 @@ const EventLabel = ({
     return (
         <div className="flex truncate  items-center deprecated-space-x-1">
             <EntityFilterInfo filter={filter} />
-            <LemonButton
-                size="xsmall"
-                icon={
-                    <IconWithCount count={filter.properties?.length || 0} showZero={false}>
-                        <IconFilter />
-                    </IconWithCount>
-                }
-                className="p-0.5"
-                onClick={onClick}
-            />
+            {/* The count button is the only way into an event's property filters, so without a handler to open
+                them it would be a dead button — read-only consumers render the properties themselves instead. */}
+            {onClick && (
+                <LemonButton
+                    size="xsmall"
+                    icon={
+                        <IconWithCount count={filter.properties?.length || 0} showZero={false}>
+                            <IconFilter />
+                        </IconWithCount>
+                    }
+                    className="p-0.5"
+                    onClick={onClick}
+                />
+            )}
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -12,8 +12,10 @@ import {
 } from '@posthog/icons'
 import { LemonCard, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
+import { PropertyFilterButton } from 'lib/components/PropertyFilters/components/PropertyFilterButton'
 import { TZLabel } from 'lib/components/TZLabel'
 import { UniversalFilterButton } from 'lib/components/UniversalFilters/UniversalFilterButton'
+import { isEntityFilter } from 'lib/components/UniversalFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { humanFriendlyDurationFilter } from 'scenes/session-recordings/filters/DurationFilter'
@@ -24,7 +26,7 @@ import {
 import { filtersFromUniversalFilterGroups } from 'scenes/session-recordings/utils'
 
 import { RecordingsQuery } from '~/queries/schema/schema-general'
-import { FilterLogicalOperator } from '~/types'
+import { FilterLogicalOperator, UniversalFilterValue } from '~/types'
 
 import { BooleanTag } from '../../components/BooleanTag'
 import { CardHeader } from '../../components/CardHeader'
@@ -72,6 +74,25 @@ function OptionTags({
                     </LemonTag>
                 )
             })}
+        </div>
+    )
+}
+
+/** One recording filter, read-only. An event or action filter carries its own property filters, which the
+ * editable UI keeps behind a popover — there's nothing to open here, so show them alongside the event. */
+function ReadonlyFilter({ filter }: { filter: UniversalFilterValue }): JSX.Element {
+    const properties = isEntityFilter(filter) ? (filter.properties ?? []) : []
+    return (
+        <div className="flex flex-wrap items-center gap-1.5">
+            <UniversalFilterButton filter={filter} />
+            {properties.length > 0 && (
+                <>
+                    <span className="text-xs">where</span>
+                    {properties.map((property, i) => (
+                        <PropertyFilterButton key={i} item={property} compact />
+                    ))}
+                </>
+            )}
         </div>
     )
 }
@@ -323,7 +344,7 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                                                 <span className="text-xs">Match {matchWord} of</span>
                                             )}
                                             {filters.map((filter, i) => (
-                                                <UniversalFilterButton key={i} filter={filter} />
+                                                <ReadonlyFilter key={i} filter={filter} />
                                             ))}
                                         </div>
                                     )}


### PR DESCRIPTION
## Problem

On a scanner's Configuration tab, under Scan conditions → Recording filters, an event filter that has property filters showed a filter icon with a count badge — but clicking it did nothing, and the properties themselves were never displayed. So a scanner could look like it filtered on `$pageview` when it actually filtered on `$pageview where $current_url = /checkout`.

The read-only card renders `UniversalFilterButton` with no `onClick`. In the editable UI that button is what opens the properties popover; with no handler it is a dead click target, and an event's properties have no other rendering.

## Changes

- Read-only card now renders an event or action filter's property filters inline, as `where <chip> <chip>` next to the event.
- `UniversalFilterButton` no longer renders the property count button when no `onClick` is passed, so it can't present an affordance that does nothing.

Editable surfaces (the scanner editor, session recordings filters) always pass `onClick` and are unchanged.

## How did you test this code?

Automated, run locally:

- New `UniversalFilterButton.component.test.tsx` — covers the regression that a read-only button renders a dead click target, which no existing test caught. Both cases pass.
- Existing `src/lib/components/UniversalFilters` suite (34 tests) passes, confirming the editable path still renders the button.
- `tsgo --noEmit` reports no errors in either changed file (the repo has pre-existing errors from the unbuilt quill workspace).

Verified visually in Storybook (scanner Configuration tab rendered with a mock scanner whose `$pageview` event filter carries two property filters). Also confirmed in the scanner editor that the count button still renders and clicking it still opens the properties popover.

## Screenshots

| Before | After |
| --- | --- |
| ![before: property filters hidden behind a dead button](https://raw.githubusercontent.com/PostHog/pr-assets/7a157bd05fc1d20bb5a1ca4938be418a8e5d3d68/2026/08/3da0c9c7-b472-431f-8260-94cbee48b12e.png) | ![after: property filters shown inline](https://raw.githubusercontent.com/PostHog/pr-assets/188d91a3a5429e114db7e67c1939f736ab4d0538/2026/08/b41d7b34-9d1d-4757-86be-f462be39a0ed.png) |

Before, the badge on `Pageview` was a dead click target and the two property filters were invisible (note `Autocapture`, with zero properties, also drew a dead button). After, the properties render inline as `where` chips and no dead buttons remain.

<details>
<summary>Full Configuration tab (after)</summary>

![after: full configuration tab](https://raw.githubusercontent.com/PostHog/pr-assets/486466af1fc7485ba6d7268d6b034826222e7d81/2026/08/08792335-6b48-44fd-8d4b-0a99e1519317.png)

</details>

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a bug report in Slack. No repo skills were needed beyond the frontend conventions in `AGENTS.md` / `frontend/src/CLAUDE.md`.

Considered fixing this purely inside `UniversalFilterButton` by making the count button open a read-only popover of the properties. Rejected it: a config summary shouldn't hide information behind an interaction, and it would have added popover state to a shared presentational component. Showing the properties inline and dropping the dead button keeps the shared component dumber.

Left unassigned because I couldn't verify the reporter's GitHub handle from the thread — please assign the DRI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1785936948115039?thread_ts=1785936948.115039&cid=C0ACRAMJUAG)*

