### PR TITLE
feat(conversations): stamp assignment on ticket-created event

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -61,6 +61,18 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["properties"]["customer_email"] == "test@example.com"
 
     @patch("products.conversations.backend.events.capture_internal")
+    def test_capture_ticket_created_stamps_current_assignment(self, mock_capture):
+        role = Role.objects.create(name="Team Warehouse Sources", organization=self.organization)
+        TicketAssignment.objects.create(ticket=self.ticket, role=role)
+
+        capture_ticket_created(self.ticket)
+
+        properties = mock_capture.call_args.kwargs["properties"]
+        assert properties["assignee_type"] == "role"
+        assert properties["assignee_id"] == str(role.id)
+        assert properties["assignee_role_name"] == "Team Warehouse Sources"
+
+    @patch("products.conversations.backend.events.capture_internal")
     def test_capture_ticket_status_changed_uses_team_token(self, mock_capture):
         capture_ticket_status_changed(self.ticket, "new", "pending", actor=self.user, actor_type="user")
 

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -426,6 +426,7 @@ def _get_sla_properties(ticket: Ticket, now: datetime) -> dict:
 def capture_ticket_created(ticket: Ticket) -> None:
     properties = _get_ticket_base_properties(ticket)
     properties.update(_get_customer_properties(ticket))
+    properties.update(_get_assignment_properties(ticket))
 
     team = ticket.team
     team_id = team.id


### PR DESCRIPTION
## Problem

Support tickets can't be broken down by the team that handles them using the ticket-created event. `$conversation_ticket_created` omits assignment, so slicing support volume by team — for example the data-stack teams (Data Modeling, Data Tools, Managed Warehouse, Warehouse Sources) — is only reachable via the later `$conversation_ticket_assigned` event, and downstream events that carry assignment can't be joined back to a created-with-team baseline.

## Changes

- `capture_ticket_created` now stamps the current assignment (`assignee_type`, `assignee_id`, `assignee_role_name`) via the existing `_get_assignment_properties` helper.
- Assignment is now emitted consistently across all ticket lifecycle events; created was the only one missing it (status-changed, priority-changed, assigned, and message events already stamp it).
- Adds one `TicketAssignment` lookup on the low-frequency ticket-creation path (which already runs org-group resolution queries).

## How did you test this code?

- Added `test_capture_ticket_created_stamps_current_assignment`: a role-assigned ticket produces a created event carrying `assignee_role_name`. Catches the regression that the created event drops the routed team — no existing created-event test asserted assignment.
- `ruff check` clean; both files compile.
- Could not run the Django test suite: the dev stack is not bootstrapped in this environment. Relying on CI to run `products/conversations/backend/api/tests/test_events.py`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs affected — this adds properties to an internal analytics event.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Came out of an analytics investigation into whether support (Conversations) load could be sliced by data-stack area. Found team routing already rides on `$conversation_ticket_assigned.assignee_role_name`, but the created event omitted it, so newly-created tickets weren't attributable to a team.

Chose the minimal fix — reuse the existing `_get_assignment_properties` helper on the created event. Rejected two alternatives: folding assignment into `_get_ticket_base_properties` (would add a DB lookup to the high-frequency message-event path), and adding ticket tags (no cheap tags field on the model; left as follow-up).

Tool: Claude Code. Repo skills (`/writing-pr-descriptions`, `/writing-tests`) were not runnable in this environment, so their conventions were applied manually.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
