### PR TITLE
fix(deps): bump desktop agent tar to 7.5.22 and minimatch to 10.2.5 (CVE fixes)

### DIFF
--- a/products/desktop/packages/agent/package.json
+++ b/products/desktop/packages/agent/package.json
@@ -184,9 +184,9 @@
     "fflate": "^0.8.2",
     "hono": "^4.11.7",
     "jsonwebtoken": "^9.0.2",
-    "minimatch": "^10.0.3",
+    "minimatch": "^10.2.5",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "tar": "^7.5.19",
+    "tar": "^7.5.22",
     "uuid": "13.0.0",
     "yoga-wasm-web": "^0.3.3",
     "zod": "^4.2.0"

--- a/products/desktop/packages/agent/pnpm-lock.yaml
+++ b/products/desktop/packages/agent/pnpm-lock.yaml
@@ -95,11 +95,11 @@ importers:
         specifier: ^9.0.2
         version: 9.0.3
       minimatch:
-        specifier: ^10.0.3
-        version: 10.1.1
+        specifier: ^10.2.5
+        version: 10.2.5
       tar:
-        specifier: ^7.5.19
-        version: 7.5.21
+        specifier: ^7.5.22
+        version: 7.5.22
       uuid:
         specifier: 13.0.0
         version: 13.0.0
@@ -542,14 +542,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -1792,10 +1784,6 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -2128,8 +2116,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar@7.5.21:
-    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   thenify-all@1.6.0:
@@ -2893,12 +2881,6 @@ snapshots:
   '@inquirer/type@4.0.7(@types/node@24.10.1)':
     optionalDependencies:
       '@types/node': 24.10.1
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -4021,10 +4003,6 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  minimatch@10.1.1:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.1
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.8
@@ -4393,7 +4371,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar@7.5.21:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -850,10 +850,10 @@ importers:
         specifier: ^9.0.2
         version: 9.0.3
       minimatch:
-        specifier: ^10.0.3
-        version: 10.1.2
+        specifier: ^10.2.5
+        version: 10.2.5
       tar:
-        specifier: ^7.5.19
+        specifier: ^7.5.22
         version: 7.5.22
       uuid:
         specifier: 13.0.0
@@ -4190,14 +4190,6 @@ packages:
     resolution: {integrity: sha512-oDRQAst1noKp8uZ150dIJ5H8n70ZCkK5qptz+T/HDXx8dWIVwZWTeec1SXsoSUsVpofJlpQLTAdv7QU27K8i3w==}
     peerDependencies:
       inversify: ^7.6.1
-
-  '@isaacs/balanced-match@4.0.1':
-    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
-    engines: {node: 20 || >=22}
-
-  '@isaacs/brace-expansion@5.0.1':
-    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
-    engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -13009,10 +13001,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.1.2:
-    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -19133,12 +19121,6 @@ snapshots:
   '@inversifyjs/strongly-typed@2.2.0(inversify@7.11.0(reflect-metadata@0.2.2))':
     dependencies:
       inversify: 7.11.0(reflect-metadata@0.2.2)
-
-  '@isaacs/balanced-match@4.0.1': {}
-
-  '@isaacs/brace-expansion@5.0.1':
-    dependencies:
-      '@isaacs/balanced-match': 4.0.1
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -28850,10 +28832,6 @@ snapshots:
   mimic-response@3.1.0: {}
 
   min-indent@1.0.1: {}
-
-  minimatch@10.1.2:
-    dependencies:
-      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.2.5:
     dependencies:


### PR DESCRIPTION
## Problem

Ports **PostHog/code#4007**, closed after the desktop import with a pointer to recreate it here via the path mapping in [`products/desktop/MIGRATION.md`](../blob/master/products/desktop/MIGRATION.md).

Re-scanning the imported tree at HEAD, the two highest-severity deps from that PR are **still live** — `products/desktop/packages/agent` declares floors low enough that the lockfiles resolve *under* the published fixes:

| Dependency | Declared floor | Resolved | Advisories | Fixed in |
|---|---|---|---|---|
| `tar` | `^7.5.19` | **7.5.21** (agent publish lockfile) | GHSA-23hp-3jrh-7fpw (CVE-2026-59873, CVSS 9.2, gzip-bomb DoS) · GHSA-8x88-c5mf-7j5w (CVE-2026-59874, 8.7, infinite loop) | 7.5.22 |
| `minimatch` | `^10.0.3` | **10.1.1** (agent) / **10.1.2** (root) | GHSA-3ppc-4f35-3m26 (CVE-2026-26996, CVSS 8.7, ReDoS) | 10.2.5 |

`simple-git` (the third dep in #4007) is already pinned `^3.36.0` in `pnpm-workspace.yaml`, so it is excluded here.

MIGRATION.md notes the transitive tar/minimatch tail was left "for a dedicated dependency-hygiene sweep" — but because these are **direct** deps of `packages/agent` with loose floors, the resolutions above sit below the fixes, including in the **published `@posthog/agent` artifact** (`packages/agent/pnpm-lock.yaml` ships `tar@7.5.21` + `minimatch@10.1.1`).

## Changes

- `products/desktop/packages/agent/package.json` — `tar ^7.5.19 → ^7.5.22`, `minimatch ^10.0.3 → ^10.2.5`.
- `products/desktop/pnpm-lock.yaml` (root workspace) — direct `minimatch` `10.1.2 → 10.2.5`, `tar` floor tightened (already resolved `7.5.22`). Regenerated with `pnpm@10.23.0` (the `packageManager` pin); diff scoped to the two deps + the now-orphaned `minimatch@10.1.2` subtree.
- `products/desktop/packages/agent/pnpm-lock.yaml` (agent publish lockfile) — `tar 7.5.21 → 7.5.22`, `minimatch 10.1.1 → 10.2.5`. Regenerated via the temp-workspace recipe in MIGRATION.md's "Dependency CVEs" section so the published artifact carries the fix.

Manifests + lockfiles only; no source changes.

## How did you test this code?

Agent-authored — automated checks only. I did **not** run the desktop build or the agent test suite (no full desktop toolchain locally). What I actually ran:

- `pnpm install --frozen-lockfile --lockfile-only` (`pnpm@10.23.0`) against the regenerated **root** lockfile — passes (lockfile consistent with the bumped manifest).
- Same frozen check against the regenerated **agent publish** lockfile (temp workspace) — passes.
- Confirmed both lockfile diffs are scoped strictly to `tar`/`minimatch` and their orphaned subtrees, with no unrelated resolution drift.

The desktop CI suite (`Desktop Agent Release Verify`, typecheck, build-test) runs on this PR.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by an external security contributor ([Aeon](https://github.com/aeonframework) / @aeonframework) as a coordinated-disclosure port of PostHog/code#4007. No PostHog employee DRI; leaving unassigned for the owning team to triage.

Detected via [osv-scanner](https://google.github.io/osv-scanner/).
