### PR TITLE
fix(ci): hold product manifests to the lanes that read them

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -109,7 +109,9 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..')
 // lane that runs Python, `javascript` every lane that runs TypeScript or
 // JavaScript, `rust` every crate. A domain never names less than the file can
 // break; it only stops asserting a radius the file does not have, which is what
-// keeps a frontend lint rule from serializing against Rust.
+// keeps a frontend lint rule from serializing against Rust. `product-surface`
+// is the one domain named for its readers rather than for a language, because
+// the files it covers have a small enumerable set of them.
 //
 // Entries are matched in order and the first match wins, so a narrower entry
 // has to precede the tree it sits in. A `null` domain is an explicit
@@ -118,6 +120,12 @@ const UNIVERSAL = 'universal'
 const PYTHON = 'python'
 const JAVASCRIPT = 'javascript'
 const RUST = 'rust'
+
+// The product manifests and the artifacts generated from them. Not a toolchain
+// domain: it names the two lane families that read that data rather than a
+// language, and it exists because `universal` was claiming lanes no reader of
+// those files can reach.
+const PRODUCT_SURFACE = 'product-surface'
 
 // Resolved per file from the rule's own `languages:` declaration rather than
 // from its path, so it cannot be expressed as a static domain here.
@@ -209,10 +217,21 @@ const TRIPWIRE_RULES = [
     // schema.json generates posthog/schema.py, and both sides are committed.
     ['frontend/src/queries/schema.json', UNIVERSAL],
     ['posthog/schema.py', UNIVERSAL],
-    // products.json is loaded at runtime by posthog/products.py and generated
-    // from every product's manifest.
-    ['frontend/src/products.json', UNIVERSAL],
-    ['products/*/manifest.tsx', UNIVERSAL],
+    // A manifest publishes its product's urls, routes, and tree items into
+    // globals any other product's frontend can reference, and build-products.mjs
+    // compiles every manifest into products.json, which posthog/products.py
+    // loads at runtime and user_product_list.py keys off the `path` values of.
+    // So both sides of the fe/py split can hold a reference to what one manifest
+    // renames, and both claim their full lane family here.
+    //
+    // Outside those two the only reader is services/mcp, which the lane function
+    // names. Nothing under rust/ or nodejs/ reads products.json or globs the
+    // manifests, so `universal` was asserting a radius these files do not have.
+    // The generated products.tsx and productScenes.tsx are deliberately absent:
+    // they have no Python reader, and the frontend rule below already gives them
+    // the frontend lanes.
+    ['frontend/src/products.json', PRODUCT_SURFACE],
+    ['products/*/manifest.tsx', PRODUCT_SURFACE],
     // Generates the frontend API types from the backend serializers, so a
     // change lands on both sides of the fe/py split at once.
     ['tools/openapi-codegen/**', UNIVERSAL],
@@ -1073,6 +1092,26 @@ function addJavaScriptLanes(targets, context) {
     return true
 }
 
+// Both lane families in full, plus the MCP pair. The frontend half cannot be
+// narrowed to the product that owns the manifest: every manifest's urls and
+// tree items are merged into one global object, so any product's frontend can
+// reference what another's manifest declares.
+//
+// services/mcp/scripts reads the manifests directly — lint-tool-names.ts walks
+// products/*/manifest.tsx for the routes the generated app-url manifest cannot
+// carry — so svc:mcp is a reader like any other, and ci-cli.yml builds the CLI
+// from those same sources.
+function addProductSurfaceLanes(targets, context) {
+    addPythonLanes(targets, context)
+    targets.add('fe:core')
+    for (const product of context.products) {
+        targets.add(feProduct(product))
+    }
+    targets.add('svc:mcp')
+    targets.add('cli')
+    return true
+}
+
 function addRustLanes(targets, context) {
     if (!context.rustGraph) {
         return false
@@ -1087,6 +1126,7 @@ const TRIPWIRE_DOMAIN_LANES = new Map([
     [PYTHON, addPythonLanes],
     [JAVASCRIPT, addJavaScriptLanes],
     [RUST, addRustLanes],
+    [PRODUCT_SURFACE, addProductSurfaceLanes],
 ])
 
 // Returns false when the file's domain is universal, which is the caller's cue

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -1101,10 +1101,16 @@ function addJavaScriptLanes(targets, context) {
 // products/*/manifest.tsx for the routes the generated app-url manifest cannot
 // carry — so svc:mcp is a reader like any other, and ci-cli.yml builds the CLI
 // from those same sources.
+//
+// The Python half is spelled out rather than delegated to addPythonLanes, which
+// also claims the independent tools/ lanes. Those exist because the Python
+// toolchain spans tools/, and no tool in that list loads products.json or globs
+// the manifests.
 function addProductSurfaceLanes(targets, context) {
-    addPythonLanes(targets, context)
+    targets.add('py:core')
     targets.add('fe:core')
     for (const product of context.products) {
+        targets.add(pyProduct(product))
         targets.add(feProduct(product))
     }
     targets.add('svc:mcp')

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -196,6 +196,12 @@ test('a product manifest claims the frontend and python lanes together', () => {
     for (const target of ['node:ingestion', 'svc:oauth-proxy', 'rust:crate:shared']) {
         assert.equal(manifest.includes(target), false, target)
     }
+    // The independent tools/ lanes ride along with any other Python tripwire,
+    // and none of those tools reads a manifest or products.json.
+    assert.equal(
+        manifest.some((target) => target.startsWith('tools:')),
+        false
+    )
 })
 
 // The manifest is the file a person edits, and it already claims both families.

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -110,7 +110,6 @@ test('a universal tripwire claims every known target', () => {
         'proto/events.proto',
         'frontend/src/queries/schema.json',
         'posthog/schema.py',
-        'products/alpha/manifest.tsx',
         'bin/start',
         '.test_durations',
         // Trees that steer what every suite runs or what it runs against: the
@@ -172,6 +171,41 @@ test('a language-scoped tripwire claims only that language', () => {
 
     const rust = computeTargets(['.github/workflows/ci-rust.yml'], CONTEXT)
     assert.deepEqual(rust, ['rust:crate:consumer', 'rust:crate:shared', 'rust:crate:unrelated'])
+})
+
+// A manifest is the one input both sides read: the frontend merges every
+// manifest's urls and tree items into globals any product can reference, and
+// products.json is generated from all of them for posthog/products.py. So it
+// takes both lane families in full and stops there — no rust crate, service, or
+// nodejs suite reads either file.
+test('a product manifest claims the frontend and python lanes together', () => {
+    const manifest = computeTargets(['products/alpha/manifest.tsx'], CONTEXT)
+    assert.deepEqual(computeTargets(['frontend/src/products.json'], CONTEXT), manifest)
+
+    for (const target of ['fe:core', 'fe:product:beta', 'py:core', 'py:product:beta']) {
+        assert.equal(manifest.includes(target), true, target)
+    }
+    // The frontend half cannot narrow to alpha: beta's frontend can reference
+    // what alpha's manifest declares, through the merged urls object.
+    assert.equal(manifest.includes('fe:product:alpha'), true)
+    // services/mcp/scripts walks the manifests for the routes its tool-name lint
+    // checks against, so it is a reader and keeps its lane.
+    assert.equal(manifest.includes('svc:mcp'), true)
+    assert.equal(manifest.includes('cli'), true)
+    assert.notDeepEqual(manifest, EVERYTHING)
+    for (const target of ['node:ingestion', 'svc:oauth-proxy', 'rust:crate:shared']) {
+        assert.equal(manifest.includes(target), false, target)
+    }
+})
+
+// The manifest is the file a person edits, and it already claims both families.
+// These are compiled from it and carry no Python reader, so the frontend rule's
+// radius is the honest one.
+test('the generated frontend product artifacts claim only the frontend lanes', () => {
+    const generated = computeTargets(['frontend/src/products.tsx', 'frontend/src/productScenes.tsx'], CONTEXT)
+    assert.equal(generated.includes('fe:core'), true)
+    assert.equal(generated.includes('fe:product:alpha'), true)
+    assert.equal(generated.includes('py:core'), false)
 })
 
 // A workflow decides which suites run, so the suite it defines is the radius.


### PR DESCRIPTION
## Problem

- `products/*/manifest.tsx` and `frontend/src/products.json` were universal tripwires in the merge queue lane rules.
- A universal tripwire claims every lane in the repo, so the PR serializes against every other PR in the queue.
- 91 commits touched a product manifest in the last 60 days.
- `universal` means the blast radius is unknown. These two files have a short, enumerable reader list.

## Changes

I (actually Claude) added a `PRODUCT_SURFACE` tripwire domain and applied it to both files. It claims the lane families below instead of the universal set.

| Reader | Lanes it needs |
| --- | --- |
| The frontend merges every manifest's urls and tree items into shared globals | `fe:core` and every `fe:product:*` |
| `posthog/products.py` loads products.json at runtime, and `user_product_list.py` keys off its `path` values | `py:core` and every `py:product:*` |
| `services/mcp/scripts/lint-tool-names.ts` walks the manifests for routes | `svc:mcp` |
| `ci-cli.yml` builds the CLI from the services/mcp sources | `cli` |

- A manifest change now claims 170 of 258 targets.
- It drops the rust crates, `node:ingestion`, the non-MCP services, the independent `tools:*` lanes, and the standalone trees.
- The generated `products.tsx` and `productScenes.tsx` keep the existing frontend rule. No Python reader loads them.

> [!NOTE]
> The frontend half cannot narrow to the product that owns the manifest. Every manifest's urls merge into one global object, so any product's frontend can reference another product's declarations.

## How did you test this code?

- I ran `node --test` on both script suites. 74 tests pass.
- I ran the script against this checkout. A manifest path yields 170 targets: 84 frontend, 84 python, `svc:mcp`, `cli`.
- `hogli ci:preflight --strict` reports no failures.
- I did not exercise the merge queue itself.

New tests and the regression each one catches:

- `a product manifest claims the frontend and python lanes together` catches a radius that drops `svc:mcp`. No existing test covered the MCP scripts as manifest readers.
- `the generated frontend product artifacts claim only the frontend lanes` catches those artifacts picking up python lanes no reader can reach.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The lane rules document themselves in the script.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 5) wrote this under my direction. The work started from a question about why any change under `frontend/` claims every frontend lane in the merge queue.
- Skills invoked: `/writing-pr-descriptions`.
- I first scoped a different fix: making the generated `products.tsx`, `productScenes.tsx`, and `products.json` inert. That buys nothing, because `products/*/manifest.tsx` was independently universal.
- A first pass built the Python half by calling `addPythonLanes`, which also claims the independent `tools:*` lanes. Review caught it. Those lanes exist because the Python toolchain spans `tools/`, and no tool there reads a manifest or products.json.
- A first pass dropped `svc:mcp` from the radius. A grep for a literal `products/.*manifest` string missed `services/mcp/scripts/lint-tool-names.ts`, which builds the path with `path.join`. Dropping that lane would let a manifest route rename and an MCP tool-name change merge in parallel.

