### PR TITLE
fix(error-tracking): preselect recent issue candidates

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -126,11 +126,20 @@ class ErrorTrackingQueryBuilder:
       mixed-OR semantics across the events/issue boundary.
     """
 
-    def __init__(self, query: ErrorTrackingQuery, team: Team, date_from: datetime.datetime, date_to: datetime.datetime):
+    def __init__(
+        self,
+        query: ErrorTrackingQuery,
+        team: Team,
+        date_from: datetime.datetime,
+        date_to: datetime.datetime,
+        candidate_limit: int,
+    ):
         self.query = query
         self.team = team
         self.date_from = date_from
         self.date_to = date_to
+        self.candidate_limit = candidate_limit
+        self.selected_fingerprints: list[int] | None = None
 
     def build_query(self) -> ast.SelectQuery:
         if self._needs_legacy_shape():
@@ -240,6 +249,55 @@ class ErrorTrackingQueryBuilder:
             select_from=ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e"),
             where=ast.And(exprs=self._inner_where_exprs()),
             group_by=group_by,
+        )
+
+    def build_candidate_query(self) -> ast.SelectQuery | None:
+        if self.query.orderBy != "last_seen" or self._needs_legacy_shape():
+            return None
+
+        event_candidates = ast.SelectQuery(
+            select=[
+                ast.Alias(alias="fp_hash", expr=_fingerprint_hash_expr()),
+                ast.Alias(alias="last_seen_fp", expr=ast.Call(name="max", args=[ast.Field(chain=["timestamp"])])),
+            ],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"]), alias="e"),
+            where=ast.And(exprs=self._inner_where_exprs()),
+            group_by=[ast.Field(chain=["fp_hash"])],
+        )
+        outer_where_exprs = self._outer_where_exprs()
+        return ast.SelectQuery(
+            select=[
+                ast.Alias(
+                    alias="fp_hashes",
+                    expr=ast.Call(name="groupArray", args=[ast.Field(chain=["ev", "fp_hash"])]),
+                ),
+            ],
+            select_from=ast.JoinExpr(
+                table=event_candidates,
+                alias="ev",
+                next_join=ast.JoinExpr(
+                    table=ast.Field(chain=["posthog", "error_tracking_fingerprint_issue_state"]),
+                    alias="fp_state",
+                    join_type="INNER JOIN",
+                    constraint=ast.JoinConstraint(
+                        expr=ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=["ev", "fp_hash"]),
+                            right=ast.Field(chain=["fp_state", "fp_hash"]),
+                        ),
+                        constraint_type="ON",
+                    ),
+                ),
+            ),
+            where=ast.And(exprs=outer_where_exprs) if outer_where_exprs else None,
+            group_by=[ast.Field(chain=["fp_state", "issue_id"])],
+            order_by=[
+                ast.OrderExpr(
+                    expr=ast.Call(name="max", args=[ast.Field(chain=["ev", "last_seen_fp"])]),
+                    order=order_direction(self.query),
+                ),
+            ],
+            limit=ast.Constant(value=self.candidate_limit),
         )
 
     def _inner_select_expressions(self) -> list[ast.Expr]:
@@ -416,6 +474,17 @@ class ErrorTrackingQueryBuilder:
             user_filter = self._filter_value_to_ast(self.query.filterGroup.values[0])
             if user_filter is not None:
                 exprs.append(user_filter)
+
+        if self.selected_fingerprints is not None:
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.In,
+                    left=_fingerprint_hash_expr(),
+                    right=ast.Tuple(exprs=[ast.Constant(value=value) for value in self.selected_fingerprints]),
+                )
+                if self.selected_fingerprints
+                else ast.Constant(value=False)
+            )
 
         return exprs
 

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -133,12 +133,14 @@ class ErrorTrackingQueryBuilder:
         date_from: datetime.datetime,
         date_to: datetime.datetime,
         candidate_limit: int,
+        candidate_offset: int = 0,
     ):
         self.query = query
         self.team = team
         self.date_from = date_from
         self.date_to = date_to
         self.candidate_limit = candidate_limit
+        self.candidate_offset = candidate_offset
         self.selected_fingerprints: list[int] | None = None
 
     def build_query(self) -> ast.SelectQuery:
@@ -235,7 +237,10 @@ class ErrorTrackingQueryBuilder:
             ),
             where=ast.And(exprs=outer_where_exprs) if outer_where_exprs else None,
             group_by=[ast.Field(chain=["id"])],
-            order_by=[ast.OrderExpr(expr=ast.Field(chain=[self.query.orderBy]), order=order_direction(self.query))],
+            order_by=[
+                ast.OrderExpr(expr=ast.Field(chain=[self.query.orderBy]), order=order_direction(self.query)),
+                ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC"),
+            ],
         )
 
     def _build_inner_query(self) -> ast.SelectQuery:
@@ -296,8 +301,10 @@ class ErrorTrackingQueryBuilder:
                     expr=ast.Call(name="max", args=[ast.Field(chain=["ev", "last_seen_fp"])]),
                     order=order_direction(self.query),
                 ),
+                ast.OrderExpr(expr=ast.Field(chain=["fp_state", "issue_id"]), order="ASC"),
             ],
             limit=ast.Constant(value=self.candidate_limit),
+            offset=ast.Constant(value=self.candidate_offset),
         )
 
     def _inner_select_expressions(self) -> list[ast.Expr]:

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -55,7 +55,13 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
 
     @cached_property
     def _builder(self) -> ErrorTrackingQueryBuilder:
-        return ErrorTrackingQueryBuilder(self.query, self.team, self.date_from, self.date_to)
+        return ErrorTrackingQueryBuilder(
+            self.query,
+            self.team,
+            self.date_from,
+            self.date_to,
+            candidate_limit=self.paginator.offset + self.paginator.limit + 1,
+        )
 
     def get_cache_payload(self) -> dict:
         payload = super().get_cache_payload()
@@ -95,6 +101,24 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
         return ctx
 
     def _calculate(self):
+        candidate_query = self._builder.build_candidate_query()
+        if candidate_query is not None:
+            with self.timings.measure("error_tracking_candidate_query_hogql_execute"):
+                candidate_result = execute_hogql_query(
+                    query=candidate_query,
+                    team=self.team,
+                    query_type="ErrorTrackingCandidateQuery",
+                    timings=self.timings,
+                    modifiers=self.modifiers,
+                    limit_context=self.limit_context,
+                    filters=self._builder.hogql_filters(),
+                    user=self.user,
+                    context=self._hogql_context(),
+                )
+            self._builder.selected_fingerprints = [
+                fingerprint for row in candidate_result.results for fingerprint in row[0]
+            ]
+
         with self.timings.measure("error_tracking_query_hogql_execute"):
             query_result = self.paginator.execute_hogql_query(
                 query=self._builder.build_query(),

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -60,7 +60,8 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             self.team,
             self.date_from,
             self.date_to,
-            candidate_limit=self.paginator.offset + self.paginator.limit + 1,
+            candidate_limit=self.paginator.limit + 1,
+            candidate_offset=self.paginator.offset,
         )
 
     def get_cache_payload(self) -> dict:
@@ -102,6 +103,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
 
     def _calculate(self):
         candidate_query = self._builder.build_candidate_query()
+        result_paginator = self.paginator
         if candidate_query is not None:
             with self.timings.measure("error_tracking_candidate_query_hogql_execute"):
                 candidate_result = execute_hogql_query(
@@ -118,9 +120,16 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             self._builder.selected_fingerprints = [
                 fingerprint for row in candidate_result.results for fingerprint in row[0]
             ]
+            # The candidate query already applied the requested offset. The
+            # enrichment query therefore paginates only within that window.
+            result_paginator = HogQLHasMorePaginator(
+                limit=self.paginator.limit,
+                offset=0,
+                limit_context=LimitContext.QUERY,
+            )
 
         with self.timings.measure("error_tracking_query_hogql_execute"):
-            query_result = self.paginator.execute_hogql_query(
+            query_result = result_paginator.execute_hogql_query(
                 query=self._builder.build_query(),
                 team=self.team,
                 query_type="ErrorTrackingQuery",
@@ -140,7 +149,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             timings=query_result.timings,
             hogql=query_result.hogql,
             modifiers=self.modifiers,
-            **self.paginator.response_params(),
+            **{**result_paginator.response_params(), "offset": self.paginator.offset},
         )
 
     # Aggregation queries return only event uuids for first/last event (reading the

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -1,6 +1,39 @@
 # serializer version: 1
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_persons
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_correctly_counts_persons.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -23,12 +56,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -64,6 +104,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_session_ids
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_correctly_counts_session_ids.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -86,12 +159,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -126,6 +206,56 @@
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_empty_search_query
+  '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), and(or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('probs')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('probs')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('probs')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('probs')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('probs')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('probs')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('not')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('not')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('not')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('not')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('not')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('not')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('found')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('found')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('found')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('found')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('found')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('found')), 0), 0))))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_empty_search_query.1
   '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
@@ -162,7 +292,7 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), and(or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('probs')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('probs')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('probs')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('probs')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('probs')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('probs')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('not')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('not')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('not')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('not')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('not')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('not')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('found')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('found')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('found')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('found')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('found')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('found')), 0), 0))))
+     WHERE 0
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -287,55 +417,35 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter
   '''
-  SELECT fp_state.issue_id AS id,
-         any(fp_state.issue_status) AS status,
-         any(fp_state.issue_name) AS name,
-         any(fp_state.issue_description) AS description,
-         any(fp_state.assigned_user_id) AS assignee_user_id,
-         any(fp_state.assigned_role_id) AS assignee_role_id,
-         min(fp_state.first_seen) AS first_seen,
-         max(ev.last_seen_fp) AS last_seen,
-         argMaxMerge(ev.function_state) AS function,
-         argMaxMerge(ev.source_state) AS source,
-         argMaxMerge(ev.library_state) AS library
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
   FROM
     (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
-            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp,
-            argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
-            argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
-            argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
      FROM events AS e
      WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:acme'))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
-            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id,
-            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_status), error_tracking_fingerprint_issue_state.version), 1)) AS issue_status,
-            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_name), error_tracking_fingerprint_issue_state.version), 1)) AS issue_name,
-            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_description), error_tracking_fingerprint_issue_state.version), 1)) AS issue_description,
-            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.assigned_user_id), error_tracking_fingerprint_issue_state.version), 1)) AS assigned_user_id,
-            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.assigned_role_id), error_tracking_fingerprint_issue_state.version), 1)) AS assigned_role_id,
-            toNullable(tupleElement(argMax(tuple(toTimeZone(error_tracking_fingerprint_issue_state.first_seen, 'UTC')), error_tracking_fingerprint_issue_state.version), 1)) AS first_seen
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
      FROM error_tracking_fingerprint_issue_state
      WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
      GROUP BY fp_hash
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
-  GROUP BY id
-  ORDER BY last_seen DESC
-  LIMIT 101
-  OFFSET 0 SETTINGS readonly=2,
-                    max_execution_time=60,
-                    allow_experimental_object_type=1,
-                    max_ast_elements=4000000,
-                    max_expanded_ast_elements=4000000,
-                    max_bytes_before_external_group_by=0,
-                    transform_null_in=1,
-                    optimize_min_equality_disjunction_chain_length=4294967295,
-                    optimize_rewrite_aggregate_function_with_if=0,
-                    optimize_min_inequality_conjunction_chain_length=4294967295,
-                    allow_experimental_join_condition=1,
-                    use_hive_partitioning=0
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.1
@@ -358,7 +468,7 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:widgets'))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:acme'), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(13834093324050175082)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -393,6 +503,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.2
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:widgets'))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.3
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -411,7 +554,7 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_1`, 'project:alpha'))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'org:widgets'), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(15366427982652043542)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -444,7 +587,40 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestErrorTrackingQueryRunner.test_group_key_filter.3
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.4
+  '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_1`, 'project:alpha'))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.5
   '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
@@ -464,7 +640,93 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
      FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_1`, 'project:alpha'), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(1152126499224129183)))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_status), error_tracking_fingerprint_issue_state.version), 1)) AS issue_status,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_name), error_tracking_fingerprint_issue_state.version), 1)) AS issue_name,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_description), error_tracking_fingerprint_issue_state.version), 1)) AS issue_description,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.assigned_user_id), error_tracking_fingerprint_issue_state.version), 1)) AS assigned_user_id,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.assigned_role_id), error_tracking_fingerprint_issue_state.version), 1)) AS assigned_role_id,
+            toNullable(tupleElement(argMax(tuple(toTimeZone(error_tracking_fingerprint_issue_state.first_seen, 'UTC')), error_tracking_fingerprint_issue_state.version), 1)) AS first_seen
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY id
+  ORDER BY last_seen DESC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.6
+  '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
      WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(e.`$group_0`, 'nonexistent'))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_group_key_filter.7
+  '''
+  SELECT fp_state.issue_id AS id,
+         any(fp_state.issue_status) AS status,
+         any(fp_state.issue_name) AS name,
+         any(fp_state.issue_description) AS description,
+         any(fp_state.assigned_user_id) AS assignee_user_id,
+         any(fp_state.assigned_role_id) AS assignee_role_id,
+         min(fp_state.first_seen) AS first_seen,
+         max(ev.last_seen_fp) AS last_seen,
+         argMaxMerge(ev.function_state) AS function,
+         argMaxMerge(ev.source_state) AS source,
+         argMaxMerge(ev.library_state) AS library
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp,
+            argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
+            argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
+            argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
+     FROM events AS e
+     WHERE 0
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -498,6 +760,56 @@
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_hogql_filters
+  '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), ifNull(equals(e__person.properties___email, 'email@posthog.com'), 0))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_hogql_filters.1
   '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
@@ -534,7 +846,7 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), ifNull(equals(e__person.properties___email, 'email@posthog.com'), 0))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), ifNull(equals(e__person.properties___email, 'email@posthog.com'), 0), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(2310519210687506206, 636546878523031622)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -614,6 +926,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_issue_grouping
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_issue_grouping.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -636,12 +981,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -677,6 +1029,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_only_returns_exception_events
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2016-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_only_returns_exception_events.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -695,7 +1080,7 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2016-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2016-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(2310519210687506206, 9260275362171164701, 636546878523031622)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -730,6 +1115,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_ordering
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_ordering.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -748,7 +1166,7 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(2310519210687506206, 9260275362171164701, 636546878523031622)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -781,7 +1199,7 @@
                     use_hive_partitioning=0
   '''
 # ---
-# name: TestErrorTrackingQueryRunner.test_ordering.1
+# name: TestErrorTrackingQueryRunner.test_ordering.2
   '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
@@ -858,12 +1276,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -899,6 +1324,46 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_person_id_filter
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), '00000000-0000-4000-8000-000000000002'))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_person_id_filter.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -924,7 +1389,7 @@
         WHERE equals(person_distinct_id_overrides.team_id, 99999)
         GROUP BY person_distinct_id_overrides.distinct_id
         HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), '00000000-0000-4000-8000-000000000002'))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), '00000000-0000-4000-8000-000000000002'), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(9122167362312657284)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -959,6 +1424,56 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_person_properties
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('david@posthog.com')), 0), 0)))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_search_person_properties.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -994,7 +1509,7 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('david@posthog.com')), 0), 0)))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('david@posthog.com')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('david@posthog.com')), 0), 0)), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(8570543476623758977)))
      GROUP BY fp_hash) AS ev
   INNER JOIN
     (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
@@ -1029,6 +1544,56 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_query
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('databasenot')), 0), 0)))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_search_query.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -1054,7 +1619,7 @@
             least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1073,7 +1638,7 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('databasenot')), 0), 0)))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('databasenot')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('databasenot')), 0), 0)), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(8570543476623758977, 11579807306593773267)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -1109,6 +1674,56 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_query_with_multiple_search_items
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     LEFT JOIN
+       (SELECT person.id AS id,
+               replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'email'), ''), 'null'), '^"|"$', '') AS properties___email
+        FROM person
+        WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                      (SELECT person.id AS id, max(person.version) AS version
+                                                       FROM person
+                                                       WHERE equals(person.team_id, 99999)
+                                                       GROUP BY person.id
+                                                       HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), and(or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('databasenotfoundX')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('clickhouse/client/execute.py')), 0), 0))))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_search_query_with_multiple_search_items.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -1134,7 +1749,7 @@
             least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1153,7 +1768,7 @@
                                                        WHERE equals(person.team_id, 99999)
                                                        GROUP BY person.id
                                                        HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), and(or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('databasenotfoundX')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('clickhouse/client/execute.py')), 0), 0))))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), ifNull(notILike(toString(e__person.properties___email), '%@posthog.com%'), 1), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), and(or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('databasenotfoundX')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('databasenotfoundX')), 0), 0)), or(ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_types`, ''), 'null')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(nullIf(nullIf(e.`mat_$exception_values`, ''), 'null')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'email'), ''), 'null'), '^"|"$', '')), lower('clickhouse/client/execute.py')), 0), 0), ifNull(greater(position(lower(e__person.properties___email), lower('clickhouse/client/execute.py')), 0), 0))), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(8570543476623758977)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -1189,6 +1804,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_volume_aggregation_advanced
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, 'e9ac529f-ac1c-4a96-bd3a-102334368d64'), 0))
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_volume_aggregation_advanced.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -1214,9 +1862,16 @@
             least(3, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 4)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(4986565558883927947)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -1252,6 +1907,39 @@
 # ---
 # name: TestErrorTrackingQueryRunner.test_volume_aggregation_simple
   '''
+  SELECT groupArray(ev.fp_hash) AS fp_hashes
+  FROM
+    (SELECT cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')) AS fp_hash,
+            max(toTimeZone(e.timestamp, 'UTC')) AS last_seen_fp
+     FROM events AS e
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     GROUP BY fp_hash) AS ev
+  INNER JOIN
+    (SELECT cityHash64(error_tracking_fingerprint_issue_state.fingerprint) AS fp_hash,
+            toNullable(tupleElement(argMax(tuple(error_tracking_fingerprint_issue_state.issue_id), error_tracking_fingerprint_issue_state.version), 1)) AS issue_id
+     FROM error_tracking_fingerprint_issue_state
+     WHERE equals(error_tracking_fingerprint_issue_state.team_id, 99999)
+     GROUP BY fp_hash
+     HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
+  WHERE isNotNull(fp_state.issue_id)
+  GROUP BY fp_state.issue_id
+  ORDER BY max(ev.last_seen_fp) DESC
+  LIMIT 101 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestErrorTrackingQueryRunner.test_volume_aggregation_simple.1
+  '''
   SELECT fp_state.issue_id AS id,
          any(fp_state.issue_status) AS status,
          any(fp_state.issue_name) AS name,
@@ -1274,12 +1962,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(2, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 3)))) AS bin_idx,
+            least(2, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 3)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(2310519210687506206, 9260275362171164701, 636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -57,19 +57,12 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -122,19 +115,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_session_ids.1
@@ -161,19 +155,12 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -191,7 +178,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -996,19 +984,12 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -1297,19 +1278,12 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -1646,7 +1620,7 @@
             least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1778,7 +1752,7 @@
             least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1893,15 +1867,8 @@
             least(3, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 4)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
      WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(4986565558883927947)))
      GROUP BY fp_hash,
               bin_idx) AS ev
@@ -1995,19 +1962,12 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(2, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 3)))) AS bin_idx,
+            least(2, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 3)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     LEFT OUTER JOIN
-       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-               person_distinct_id_overrides.distinct_id AS distinct_id
-        FROM person_distinct_id_overrides
-        WHERE equals(person_distinct_id_overrides.team_id, 99999)
-        GROUP BY person_distinct_id_overrides.distinct_id
-        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(2310519210687506206, 9260275362171164701, 636546878523031622)))
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), in(cityHash64(JSONExtractString(e.properties, '$exception_fingerprint')), tuple(2310519210687506206, 9260275362171164701, 636546878523031622)))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -17,19 +17,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_persons.1
@@ -86,7 +87,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -240,19 +242,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_empty_search_query.1
@@ -309,7 +312,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -433,19 +437,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.1
@@ -485,7 +490,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -519,19 +525,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.3
@@ -571,7 +578,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -605,19 +613,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.5
@@ -657,7 +666,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -691,19 +701,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.7
@@ -743,7 +754,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -794,19 +806,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_hogql_filters.1
@@ -863,7 +876,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -942,19 +956,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_issue_grouping.1
@@ -1011,7 +1026,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1045,19 +1061,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_only_returns_exception_events.1
@@ -1097,7 +1114,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1131,19 +1149,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_ordering.1
@@ -1183,7 +1202,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1236,7 +1256,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY first_seen ASC
+  ORDER BY first_seen ASC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1306,7 +1327,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY occurrences DESC
+  ORDER BY occurrences DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1347,19 +1369,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_person_id_filter.1
@@ -1406,7 +1429,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1457,19 +1481,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_person_properties.1
@@ -1526,7 +1551,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1577,19 +1603,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_query.1
@@ -1656,7 +1683,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1707,19 +1735,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_query_with_multiple_search_items.1
@@ -1786,7 +1815,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1820,19 +1850,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, 'e9ac529f-ac1c-4a96-bd3a-102334368d64'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_volume_aggregation_advanced.1
@@ -1889,7 +1920,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, 'e9ac529f-ac1c-4a96-bd3a-102334368d64'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1923,19 +1955,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_volume_aggregation_simple.1
@@ -1992,7 +2025,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -32,6 +32,8 @@ from posthog.schema import (
     PropertyOperator,
 )
 
+from posthog.hogql import ast
+
 from posthog.clickhouse.client import sync_execute
 from posthog.models.utils import uuid7
 
@@ -563,10 +565,35 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         self.assertEqual([r["id"] for r in results], [self.issue_id_one, self.issue_id_two, self.issue_id_three])
 
     @freeze_time("2022-01-10T12:11:00")
-    def test_last_seen_candidate_selection_covers_requested_page(self):
+    def test_last_seen_candidate_selection_applies_offset_before_enrichment(self):
         response = self._calculate(orderBy="last_seen", limit=1, offset=1)
 
         self.assertEqual(response["results"][0]["id"], self.issue_id_two)
+        self.assertEqual(response["offset"], 1)
+        self.assertTrue(response["hasMore"])
+
+    def test_last_seen_candidate_selection_uses_stable_issue_id_tiebreaker(self):
+        builder = ErrorTrackingQueryBuilder(
+            query=ErrorTrackingQuery(
+                kind="ErrorTrackingQuery",
+                dateRange=DateRange(date_from="-7d"),
+                orderBy="last_seen",
+                volumeResolution=1,
+            ),
+            team=self.team,
+            date_from=datetime(2022, 1, 3, tzinfo=UTC),
+            date_to=datetime(2022, 1, 10, tzinfo=UTC),
+            candidate_limit=11,
+            candidate_offset=20,
+        )
+
+        candidate_query = builder.build_candidate_query()
+
+        assert candidate_query is not None
+        self.assertEqual(candidate_query.limit, ast.Constant(value=11))
+        self.assertEqual(candidate_query.offset, ast.Constant(value=20))
+        self.assertEqual(candidate_query.order_by[-1].expr, ast.Field(chain=["fp_state", "issue_id"]))
+        self.assertEqual(candidate_query.order_by[-1].order, "ASC")
 
     @freeze_time("2022-01-10T12:11:00")
     def test_status(self):

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -196,6 +196,8 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         personId=None,
         groupKey=None,
         groupTypeIndex=None,
+        limit=None,
+        offset=None,
     ):
         return (
             ErrorTrackingQueryRunner(
@@ -219,6 +221,8 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
                     personId=personId,
                     groupKey=groupKey,
                     groupTypeIndex=groupTypeIndex,
+                    limit=limit,
+                    offset=offset,
                 ),
             )
             .calculate()
@@ -559,6 +563,12 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         self.assertEqual([r["id"] for r in results], [self.issue_id_one, self.issue_id_two, self.issue_id_three])
 
     @freeze_time("2022-01-10T12:11:00")
+    def test_last_seen_candidate_selection_covers_requested_page(self):
+        response = self._calculate(orderBy="last_seen", limit=1, offset=1)
+
+        self.assertEqual(response["results"][0]["id"], self.issue_id_two)
+
+    @freeze_time("2022-01-10T12:11:00")
     def test_status(self):
         resolved_issue = ErrorTrackingIssue.objects.get(id=self.issue_id_one)
         resolved_issue.status = ErrorTrackingIssue.Status.RESOLVED
@@ -754,6 +764,7 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
             team=self.team,
             date_from=datetime(2022, 1, 3, tzinfo=UTC),
             date_to=datetime(2022, 1, 10, tzinfo=UTC),
+            candidate_limit=101,
         )
         user_filter_expr = builder._user_filter_expr()
         assert user_filter_expr is not None


### PR DESCRIPTION
## Problem

The error-tracking list aggregates expensive issue state across every matching fingerprint before applying pagination, causing broad queries to exceed their execution limit.

## Changes

For last-seen ordering, run a lightweight candidate query with the requested offset and `limit + 1`, then perform the full aggregation only for that bounded fingerprint window. An `issue_id` tie-breaker keeps equal timestamps stable. Other ordering modes and legacy mixed filters retain the existing path.

A representative comparison showed roughly 40% lower wall time for the two-phase approach. Direct candidate pagination further bounds enrichment work on deep pages.

## How did you test this code?

- Ran the original 40 error-tracking query-runner tests successfully.
- Added regressions for direct candidate offsets, response metadata, `hasMore`, deterministic tie-breaking, and legacy-filter fallback.
- The new focused pagination tests pass.
- Ruff, mypy, and `hogli ci:preflight --fix` pass.
- A later full-suite rerun was limited by local ClickHouse file-descriptor exhaustion rather than an assertion failure.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented this with the `/writing-tests`, `/writing-code-comments`, and `/writing-pr-descriptions` skills. A nested subquery approach was rejected after benchmarking; separate executions allow ClickHouse to constrain the expensive phase with constants.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*