### PR TITLE
fix(error-tracking): paginate candidate selection

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -133,12 +133,14 @@ class ErrorTrackingQueryBuilder:
         date_from: datetime.datetime,
         date_to: datetime.datetime,
         candidate_limit: int,
+        candidate_offset: int = 0,
     ):
         self.query = query
         self.team = team
         self.date_from = date_from
         self.date_to = date_to
         self.candidate_limit = candidate_limit
+        self.candidate_offset = candidate_offset
         self.selected_fingerprints: list[int] | None = None
 
     def build_query(self) -> ast.SelectQuery:
@@ -235,7 +237,10 @@ class ErrorTrackingQueryBuilder:
             ),
             where=ast.And(exprs=outer_where_exprs) if outer_where_exprs else None,
             group_by=[ast.Field(chain=["id"])],
-            order_by=[ast.OrderExpr(expr=ast.Field(chain=[self.query.orderBy]), order=order_direction(self.query))],
+            order_by=[
+                ast.OrderExpr(expr=ast.Field(chain=[self.query.orderBy]), order=order_direction(self.query)),
+                ast.OrderExpr(expr=ast.Field(chain=["id"]), order="ASC"),
+            ],
         )
 
     def _build_inner_query(self) -> ast.SelectQuery:
@@ -296,8 +301,10 @@ class ErrorTrackingQueryBuilder:
                     expr=ast.Call(name="max", args=[ast.Field(chain=["ev", "last_seen_fp"])]),
                     order=order_direction(self.query),
                 ),
+                ast.OrderExpr(expr=ast.Field(chain=["fp_state", "issue_id"]), order="ASC"),
             ],
             limit=ast.Constant(value=self.candidate_limit),
+            offset=ast.Constant(value=self.candidate_offset),
         )
 
     def _inner_select_expressions(self) -> list[ast.Expr]:

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -60,7 +60,8 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             self.team,
             self.date_from,
             self.date_to,
-            candidate_limit=self.paginator.offset + self.paginator.limit + 1,
+            candidate_limit=self.paginator.limit + 1,
+            candidate_offset=self.paginator.offset,
         )
 
     def get_cache_payload(self) -> dict:
@@ -102,6 +103,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
 
     def _calculate(self):
         candidate_query = self._builder.build_candidate_query()
+        result_paginator = self.paginator
         if candidate_query is not None:
             with self.timings.measure("error_tracking_candidate_query_hogql_execute"):
                 candidate_result = execute_hogql_query(
@@ -118,9 +120,16 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             self._builder.selected_fingerprints = [
                 fingerprint for row in candidate_result.results for fingerprint in row[0]
             ]
+            # The candidate query already applied the requested offset. The
+            # enrichment query therefore paginates only within that window.
+            result_paginator = HogQLHasMorePaginator(
+                limit=self.paginator.limit,
+                offset=0,
+                limit_context=LimitContext.QUERY,
+            )
 
         with self.timings.measure("error_tracking_query_hogql_execute"):
-            query_result = self.paginator.execute_hogql_query(
+            query_result = result_paginator.execute_hogql_query(
                 query=self._builder.build_query(),
                 team=self.team,
                 query_type="ErrorTrackingQuery",
@@ -140,7 +149,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
             timings=query_result.timings,
             hogql=query_result.hogql,
             modifiers=self.modifiers,
-            **self.paginator.response_params(),
+            **{**result_paginator.response_params(), "offset": self.paginator.offset},
         )
 
     # Aggregation queries return only event uuids for first/last event (reading the

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -17,19 +17,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_correctly_counts_persons.1
@@ -86,7 +87,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -240,19 +242,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_empty_search_query.1
@@ -309,7 +312,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -433,19 +437,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.1
@@ -485,7 +490,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -519,19 +525,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.3
@@ -571,7 +578,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -605,19 +613,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.5
@@ -657,7 +666,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -691,19 +701,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_group_key_filter.7
@@ -743,7 +754,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -794,19 +806,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_hogql_filters.1
@@ -863,7 +876,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -942,19 +956,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_issue_grouping.1
@@ -1011,7 +1026,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, '01936e7f-d7ff-7314-b2d4-7627981e34f0'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1045,19 +1061,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_only_returns_exception_events.1
@@ -1097,7 +1114,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1131,19 +1149,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_ordering.1
@@ -1183,7 +1202,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1236,7 +1256,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY first_seen ASC
+  ORDER BY first_seen ASC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1306,7 +1327,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY occurrences DESC
+  ORDER BY occurrences DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1347,19 +1369,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_person_id_filter.1
@@ -1406,7 +1429,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1457,19 +1481,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_person_properties.1
@@ -1526,7 +1551,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1577,19 +1603,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_query.1
@@ -1656,7 +1683,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1707,19 +1735,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_search_query_with_multiple_search_items.1
@@ -1786,7 +1815,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1820,19 +1850,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, 'e9ac529f-ac1c-4a96-bd3a-102334368d64'), 0))
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_volume_aggregation_advanced.1
@@ -1889,7 +1920,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE and(isNotNull(fp_state.issue_id), ifNull(equals(fp_state.issue_id, 'e9ac529f-ac1c-4a96-bd3a-102334368d64'), 0))
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,
@@ -1923,19 +1955,20 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY fp_state.issue_id
-  ORDER BY max(ev.last_seen_fp) DESC
-  LIMIT 101 SETTINGS readonly=2,
-                     max_execution_time=60,
-                     allow_experimental_object_type=1,
-                     max_ast_elements=4000000,
-                     max_expanded_ast_elements=4000000,
-                     max_bytes_before_external_group_by=0,
-                     transform_null_in=1,
-                     optimize_min_equality_disjunction_chain_length=4294967295,
-                     optimize_rewrite_aggregate_function_with_if=0,
-                     optimize_min_inequality_conjunction_chain_length=4294967295,
-                     allow_experimental_join_condition=1,
-                     use_hive_partitioning=0
+  ORDER BY max(ev.last_seen_fp) DESC, fp_state.issue_id ASC
+  LIMIT 101
+  OFFSET 0 SETTINGS readonly=2,
+                    max_execution_time=60,
+                    allow_experimental_object_type=1,
+                    max_ast_elements=4000000,
+                    max_expanded_ast_elements=4000000,
+                    max_bytes_before_external_group_by=0,
+                    transform_null_in=1,
+                    optimize_min_equality_disjunction_chain_length=4294967295,
+                    optimize_rewrite_aggregate_function_with_if=0,
+                    optimize_min_inequality_conjunction_chain_length=4294967295,
+                    allow_experimental_join_condition=1,
+                    use_hive_partitioning=0
   '''
 # ---
 # name: TestErrorTrackingQueryRunner.test_volume_aggregation_simple.1
@@ -1992,7 +2025,8 @@
      HAVING equals(argMax(error_tracking_fingerprint_issue_state.is_deleted, error_tracking_fingerprint_issue_state.version), 0) SETTINGS optimize_aggregation_in_order=1) AS fp_state ON equals(ev.fp_hash, fp_state.fp_hash)
   WHERE isNotNull(fp_state.issue_id)
   GROUP BY id
-  ORDER BY last_seen DESC
+  ORDER BY last_seen DESC,
+           id ASC
   LIMIT 101
   OFFSET 0 SETTINGS readonly=2,
                     max_execution_time=60,

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -32,6 +32,8 @@ from posthog.schema import (
     PropertyOperator,
 )
 
+from posthog.hogql import ast
+
 from posthog.clickhouse.client import sync_execute
 from posthog.models.utils import uuid7
 
@@ -557,10 +559,35 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         self.assertEqual([r["id"] for r in results], [self.issue_id_one, self.issue_id_two, self.issue_id_three])
 
     @freeze_time("2022-01-10T12:11:00")
-    def test_last_seen_candidate_selection_covers_requested_page(self):
+    def test_last_seen_candidate_selection_applies_offset_before_enrichment(self):
         response = self._calculate(orderBy="last_seen", limit=1, offset=1)
 
         self.assertEqual(response["results"][0]["id"], self.issue_id_two)
+        self.assertEqual(response["offset"], 1)
+        self.assertTrue(response["hasMore"])
+
+    def test_last_seen_candidate_selection_uses_stable_issue_id_tiebreaker(self):
+        builder = ErrorTrackingQueryBuilder(
+            query=ErrorTrackingQuery(
+                kind="ErrorTrackingQuery",
+                dateRange=DateRange(date_from="-7d"),
+                orderBy="last_seen",
+                volumeResolution=1,
+            ),
+            team=self.team,
+            date_from=datetime(2022, 1, 3, tzinfo=UTC),
+            date_to=datetime(2022, 1, 10, tzinfo=UTC),
+            candidate_limit=11,
+            candidate_offset=20,
+        )
+
+        candidate_query = builder.build_candidate_query()
+
+        assert candidate_query is not None
+        self.assertEqual(candidate_query.limit, ast.Constant(value=11))
+        self.assertEqual(candidate_query.offset, ast.Constant(value=20))
+        self.assertEqual(candidate_query.order_by[-1].expr, ast.Field(chain=["fp_state", "issue_id"]))
+        self.assertEqual(candidate_query.order_by[-1].order, "ASC")
 
     @freeze_time("2022-01-10T12:11:00")
     def test_status(self):


### PR DESCRIPTION
## Problem

Candidate selection currently reads every issue before the requested page, so enrichment is bounded but deep-page candidate work still grows with the offset.

## Changes

Apply `OFFSET` and `LIMIT + 1` directly to candidate selection, then enrich that bounded window from offset zero. Add `issue_id` as a deterministic tie-breaker for equal `last_seen` values.

## How did you test this code?

- Added regressions for direct candidate offsets, response metadata, `hasMore`, and deterministic tie-breaking.
- The two focused pagination tests pass.
- Ruff and mypy pass.
- The full query-runner suite reached 40/41; the remaining test was blocked by local ClickHouse file-descriptor exhaustion, not an assertion failure.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented this as a stacked follow-up to candidate preselection. Direct pagination was chosen to keep enrichment work constant for deep pages; both phases share the same stable secondary ordering.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*