### PR TITLE
fix(data-imports): stop non-retryable errors reaching error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -7,13 +7,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import botocore.exceptions
 from parameterized import parameterized
 
+from posthog.temporal.common.errors import NonReportableError
+
 from products.warehouse_sources.backend.temporal.data_imports import util as util_module
 from products.warehouse_sources.backend.temporal.data_imports.util import (
+    NonRetryableException,
     _is_transient_s3_connection_error,
     prepare_s3_files_for_querying,
 )
 
 _UTIL_MODULE = "products.warehouse_sources.backend.temporal.data_imports.util"
+
+
+def test_non_retryable_exception_is_non_reportable_error():
+    # Every NonRetryableException raise site (handle_non_retryable_error, custom-source config
+    # errors, CDC failure classification) already vetted the error as a known customer/upstream
+    # condition before raising it. Subclassing NonReportableError is what keeps that already-known
+    # condition out of error tracking; without it, the activity interceptor reports a fresh
+    # "bug" for every occurrence of an error a source already classified as non-retryable.
+    assert issubclass(NonRetryableException, NonReportableError)
 
 
 def _fake_s3(**kwargs):

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -12,6 +12,7 @@ from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions import capture_exception
 from posthog.settings.utils import get_from_env
+from posthog.temporal.common.errors import NonReportableError
 from posthog.utils import str_to_bool
 
 from products.data_warehouse.backend.facade.api import aget_s3_client
@@ -32,7 +33,13 @@ def _is_transient_s3_connection_error(error: BaseException) -> bool:
     return isinstance(error, _TRANSIENT_S3_CONNECTION_EXCEPTIONS)
 
 
-class NonRetryableException(Exception):
+class NonRetryableException(NonReportableError):
+    """Raised only for errors already classified as a permanent customer/upstream condition
+    (bad credentials, denied permissions, a deleted remote) via a source's
+    ``get_non_retryable_errors`` or an equivalent shared-code check, never for a fresh,
+    unclassified failure. Subclassing ``NonReportableError`` keeps that already-known condition
+    out of error tracking instead of reporting it as a new bug on every occurrence."""
+
     @property
     def cause(self) -> Optional[BaseException]:
         """Cause of the exception.


### PR DESCRIPTION
## Problem

- Error tracking captured a `NonRetryableException` from a MetaAds sync ([issue](https://us.posthog.com/project/2/error_tracking/019fd25a-46ce-76e1-9e8e-b3daa0a696ce)).
- The underlying cause was a Meta API 403 permission error, already correctly matched by `MetaAdsSource.get_non_retryable_errors`.
- `handle_non_retryable_error` only raises `NonRetryableException` after a source (or shared code) already classified the error as a permanent customer/upstream condition, never for a fresh, unclassified failure.
- `NonRetryableException` was a plain `Exception`, so the activity interceptor still reported it to error tracking as a new bug on every occurrence.

## Changes

- `NonRetryableException` now subclasses `NonReportableError`, the marker the interceptor already exempts from capture.
- This matches the existing pattern for other already-classified conditions: `RESTClientNonRetryableError`, `BillingLimitsWillBeReachedException`, `TransientObjectStoreError`.
- The exception's class name is unchanged, so Temporal's `non_retryable_error_types=["NonRetryableException", ...]` matching (which uses `type(exc).__name__`) is unaffected.

## How did you test this code?

- Added `test_non_retryable_exception_is_non_reportable_error`, mirroring the existing `test_billing_limit_exception_is_non_reportable_error` pattern; it fails on the prior base class.
- Ran `ruff check` and `ruff format --check` on the changed files.
- Ran `products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py` (14 passed).
- Could not finish the broader Django-DB-backed suite for this product in this session; the run stalled after Postgres came up. Filed via `hogli devex:feedback`.

## Docs update

No user-facing behavior changes; no docs update needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error tracking issue.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Investigated the stack trace and confirmed the Meta Ads permission-error message was already in `get_non_retryable_errors`, so the source-level classification needed no change.
- Traced why the exception still reached error tracking: `NonRetryableException` never subclassed `NonReportableError`, unlike every sibling "already-classified" exception type in the pipeline.
- Verified via Temporal's failure-converter source that class-name-based retry-policy matching is unaffected by the new base class.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
