### PR TITLE
fix(canvas): restore edit composer after generation

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/FreeformCanvasView.tsx
@@ -26,6 +26,7 @@ import {
 } from "@posthog/quill";
 import { CANVAS_COMPONENT_PATH } from "@posthog/shared";
 import {
+  activeCanvasGenerationTaskId,
   isCanvasGenerating,
   isCanvasGenerationRunning,
 } from "@posthog/ui/features/canvas/freeform/canvasGenerationStatus";
@@ -714,7 +715,10 @@ export function FreeformCanvasView({
               overflow:hidden) so the embedded run's session — and its activity
               heartbeat — stays alive and chat scroll survives a minimize. */}
           <CanvasSidePanel
-            effectiveTaskId={effectiveTaskId}
+            effectiveTaskId={activeCanvasGenerationTaskId(
+              effectiveTaskId,
+              isGenerating,
+            )}
             onMinimize={() => {
               setCollapsed(true);
               setGeneratingPanelDismissed(true);

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.test.ts
@@ -2,6 +2,7 @@ import type { AgentSession } from "@posthog/shared";
 import type { TaskRun, TaskRunStatus } from "@posthog/shared/domain-types";
 import { describe, expect, it } from "vitest";
 import {
+  activeCanvasGenerationTaskId,
   hasCanvasGenerationStarted,
   isCanvasGenerating,
   isCanvasGenerationRunning,
@@ -29,6 +30,14 @@ const session = (
   status: AgentSession["status"],
   cloudStatus?: TaskRunStatus,
 ): Session => ({ status, cloudStatus, isPromptPending: false });
+
+describe("activeCanvasGenerationTaskId", () => {
+  it("returns the task only while its generation turn is active", () => {
+    expect(activeCanvasGenerationTaskId("t1", true)).toBe("t1");
+    expect(activeCanvasGenerationTaskId("t1", false)).toBeNull();
+    expect(activeCanvasGenerationTaskId(null, true)).toBeNull();
+  });
+});
 
 describe("isCanvasGenerationRunning", () => {
   it("is not running when there is no generation task", () => {

--- a/products/desktop/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
+++ b/products/desktop/packages/ui/src/features/canvas/freeform/canvasGenerationStatus.ts
@@ -96,6 +96,16 @@ export function isCanvasGenerating({
   return session?.status === "connecting" || session?.isPromptPending === true;
 }
 
+// The side panel only owns the live generation conversation. Once that turn
+// settles it must return to the edit composer, even if the canvas record keeps
+// the task association around for status/history polling.
+export function activeCanvasGenerationTaskId(
+  taskId: string | null,
+  isGenerating: boolean,
+): string | null {
+  return isGenerating ? taskId : null;
+}
+
 // Whether there's concrete evidence the generation run has actually started, as
 // opposed to merely having been created. The completion-toast watcher arms on
 // this so the brief gap between creating the task and its live session


### PR DESCRIPTION
## Problem

After a canvas generation settles, its retained task association keeps the completed Chat panel mounted. “Ask agent to fix” then targets an unmounted edit composer and silently does nothing.

**Why:** Runtime and build repair actions need a usable composer after generation finishes.

## Changes

Return the canvas side panel to Edit mode once generation is no longer active, while preserving the task association for polling and history.

## How did you test this code?

- `canvasGenerationStatus.test.ts`: 40 tests passed, including the completed-generation panel regression.
- Biome checks passed for all three changed files.
- Full UI typecheck was not completed because sparse-checkout dependencies were not built.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. No repository or public skills were invoked; the requested PR-writing skill was unavailable. Kept the retained task ID for lifecycle polling and limited the change to side-panel presentation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*