### PR TITLE
feat(desktop): add archive task shortcut

### DIFF
--- a/products/desktop/packages/core/src/sidebar/taskRunning.ts
+++ b/products/desktop/packages/core/src/sidebar/taskRunning.ts
@@ -5,7 +5,9 @@ import type { TaskData } from "./sidebarData.types";
 // trustworthy for cloud runs; local runs stay "in_progress" forever (nothing
 // writes a terminal status when the agent goes idle), so a local run counts as
 // running only while a prompt is in flight (isGenerating).
-export function isTaskActivelyRunning(task: TaskData): boolean {
+export function isTaskActivelyRunning(
+  task: Pick<TaskData, "isGenerating" | "taskRunEnvironment" | "taskRunStatus">,
+): boolean {
   if (task.isGenerating) return true;
   return (
     task.taskRunEnvironment === "cloud" &&

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.test.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.test.ts
@@ -47,6 +47,17 @@ describe("getShortcutsByCategory", () => {
 });
 
 describe("SHORTCUTS", () => {
+  it("registers the task detail archive shortcut", () => {
+    expect(SHORTCUTS.ARCHIVE_TASK).toBe("mod+shift+a");
+    expect(KEYBOARD_SHORTCUTS).toContainEqual(
+      expect.objectContaining({
+        id: "archive-task",
+        keys: SHORTCUTS.ARCHIVE_TASK,
+        context: "Task detail",
+      }),
+    );
+  });
+
   // The Electron View menu binds CmdOrCtrl+0 to "Actual Size" in the main
   // process, which a renderer preventDefault can't reliably beat.
   it("leaves mod+0 to the host's reset-zoom accelerator", () => {

--- a/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
+++ b/products/desktop/packages/ui/src/features/command/keyboard-shortcuts.ts
@@ -16,6 +16,7 @@ export const SHORTCUTS = {
   TOGGLE_REVIEW_PANEL: "mod+shift+b",
   PREV_TASK: "mod+shift+[,ctrl+shift+tab",
   NEXT_TASK: "mod+shift+],ctrl+tab",
+  ARCHIVE_TASK: "mod+shift+a",
   CLOSE_TAB: "mod+w",
   SWITCH_TAB: "ctrl+1,ctrl+2,ctrl+3,ctrl+4,ctrl+5,ctrl+6,ctrl+7,ctrl+8,ctrl+9",
   SWITCH_TASK: "mod+1,mod+2,mod+3,mod+4,mod+5,mod+6,mod+7,mod+8,mod+9",
@@ -156,6 +157,13 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     description: "Next task",
     category: "navigation",
     alternateKeys: "ctrl+tab",
+  },
+  {
+    id: "archive-task",
+    keys: SHORTCUTS.ARCHIVE_TASK,
+    description: "Archive current task",
+    category: "navigation",
+    context: "Task detail",
   },
   {
     id: "space-up",

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -1,10 +1,13 @@
+import { isTaskActivelyRunning } from "@posthog/core/sidebar/taskRunning";
 import type { Task } from "@posthog/shared/domain-types";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys, useHotkeysContext } from "react-hotkeys-hook";
 import { useBlurOnEscape } from "../../../hooks/useBlurOnEscape";
 import { useSetHeaderContent } from "../../../hooks/useSetHeaderContent";
+import { toast } from "../../../primitives/toast";
 import { logger } from "../../../shell/logger";
+import { useArchiveTask } from "../../archive/useArchiveTask";
 import { ChannelBreadcrumb } from "../../canvas/components/ChannelBreadcrumb";
 import { CopyThreadLinkButton } from "../../canvas/components/CopyThreadLinkButton";
 import {
@@ -13,12 +16,16 @@ import {
 } from "../../code-review/components/LazyReviewPages";
 import { useReviewNavigationStore } from "../../code-review/reviewNavigationStore";
 import { useFileSearchStore } from "../../command/fileSearchStore";
+import { SHORTCUTS } from "../../command/keyboard-shortcuts";
 import { useRepoFileWatcher } from "../../file-watcher/useRepoFileWatcher";
 import { clearGitReviewQueries } from "../../git-interaction/gitCacheKeys";
 import { PanelLayout } from "../../panels/components/PanelLayout";
 import { PiSessionView } from "../../pi-sessions/PiSessionView";
 import { MIN_CHAT_WIDTH } from "../../sessions/constants";
+import { useArchivingTasksStore } from "../../sidebar/archivingTasksStore";
+import { ArchiveRunningTaskDialog } from "../../sidebar/components/ArchiveRunningTaskDialog";
 import { useCwd } from "../../sidebar/useCwd";
+import { useSidebarSessionMap } from "../../sidebar/useSidebarSessionMap";
 import { useRenameTask } from "../../tasks/useTaskMutations";
 import { useWorkspace } from "../../workspace/useWorkspace";
 import { useWorkspaceEvents } from "../../workspace/useWorkspaceEvents";
@@ -49,6 +56,7 @@ export function TaskDetail({
 }: TaskDetailProps) {
   const taskId = initialTask.id;
   const { task } = useTaskData({ taskId, initialTask });
+  const taskSession = useSidebarSessionMap().get(taskId);
   const runtime = task.runtime === "pi" ? "pi" : "acp";
   const selectedTaskRunId = task.latest_run?.id;
 
@@ -57,6 +65,48 @@ export function TaskDetail({
   const openFilePicker = useFileSearchStore((state) => state.openPicker);
 
   const { enableScope, disableScope } = useHotkeysContext();
+  const { archiveTask } = useArchiveTask({
+    navigateSpace: channelId ? "website" : "code",
+  });
+  const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
+
+  const runArchive = useCallback(async () => {
+    const store = useArchivingTasksStore.getState();
+    if (store.isArchiving(taskId)) return;
+
+    store.startArchiving(taskId);
+    try {
+      await archiveTask({ taskId });
+    } catch (error) {
+      log.error("Failed to archive task", error);
+      toast.error("Failed to archive task");
+      throw error;
+    } finally {
+      useArchivingTasksStore.getState().stopArchiving(taskId);
+    }
+  }, [archiveTask, taskId]);
+
+  useHotkeys(
+    SHORTCUTS.ARCHIVE_TASK,
+    (event) => {
+      event.preventDefault();
+      if (useArchivingTasksStore.getState().isArchiving(taskId)) return;
+      if (
+        isTaskActivelyRunning({
+          isGenerating: taskSession?.isPromptPending ?? false,
+          taskRunEnvironment: task.latest_run?.environment,
+          taskRunStatus:
+            taskSession?.cloudStatus ?? task.latest_run?.status ?? undefined,
+        })
+      ) {
+        setShowArchiveConfirm(true);
+        return;
+      }
+      void runArchive().catch(() => undefined);
+    },
+    { scopes: ["taskDetail"] },
+    [task, taskId, taskSession, runArchive],
+  );
 
   useEffect(() => {
     enableScope("taskDetail");
@@ -282,6 +332,16 @@ export function TaskDetail({
           </Box>
         )}
       </Flex>
+      <ArchiveRunningTaskDialog
+        open={showArchiveConfirm}
+        taskTitle={task.title}
+        stopsCloudSandbox={task.latest_run?.environment === "cloud"}
+        onConfirm={async () => {
+          await runArchive();
+          setShowArchiveConfirm(false);
+        }}
+        onCancel={() => setShowArchiveConfirm(false)}
+      />
     </Box>
   );
 }

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -1,8 +1,12 @@
+import { PI_SESSION_CONTROLLER } from "@posthog/core/pi-runtime/identifiers";
+import type { PiSessionController } from "@posthog/core/pi-runtime/piSessionController";
 import { isTaskActivelyRunning } from "@posthog/core/sidebar/taskRunning";
+import { useService } from "@posthog/di/react";
 import type { Task } from "@posthog/shared/domain-types";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys, useHotkeysContext } from "react-hotkeys-hook";
+import { useStore } from "zustand";
 import { useBlurOnEscape } from "../../../hooks/useBlurOnEscape";
 import { useSetHeaderContent } from "../../../hooks/useSetHeaderContent";
 import { toast } from "../../../primitives/toast";
@@ -57,6 +61,13 @@ export function TaskDetail({
   const taskId = initialTask.id;
   const { task } = useTaskData({ taskId, initialTask });
   const taskSession = useSidebarSessionMap().get(taskId);
+  const piSessionController = useService<PiSessionController>(
+    PI_SESSION_CONTROLLER,
+  );
+  const isPiGenerating = useStore(
+    piSessionController.store,
+    (state) => state.sessions[taskId]?.status?.isStreaming ?? false,
+  );
   const runtime = task.runtime === "pi" ? "pi" : "acp";
   const selectedTaskRunId = task.latest_run?.id;
 
@@ -93,7 +104,10 @@ export function TaskDetail({
       if (useArchivingTasksStore.getState().isArchiving(taskId)) return;
       if (
         isTaskActivelyRunning({
-          isGenerating: taskSession?.isPromptPending ?? false,
+          isGenerating:
+            runtime === "pi"
+              ? isPiGenerating
+              : (taskSession?.isPromptPending ?? false),
           taskRunEnvironment: task.latest_run?.environment,
           taskRunStatus:
             taskSession?.cloudStatus ?? task.latest_run?.status ?? undefined,
@@ -105,7 +119,7 @@ export function TaskDetail({
       void runArchive().catch(() => undefined);
     },
     { scopes: ["taskDetail"] },
-    [task, taskId, taskSession, runArchive],
+    [task, taskId, taskSession, runtime, isPiGenerating, runArchive],
   );
 
   useEffect(() => {

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -351,8 +351,11 @@ export function TaskDetail({
         taskTitle={task.title}
         stopsCloudSandbox={task.latest_run?.environment === "cloud"}
         onConfirm={async () => {
-          await runArchive();
-          setShowArchiveConfirm(false);
+          try {
+            await runArchive();
+          } finally {
+            setShowArchiveConfirm(false);
+          }
         }}
         onCancel={() => setShowArchiveConfirm(false)}
       />


### PR DESCRIPTION
## Problem

- Archiving the focused task requires leaving the keyboard flow and using the task menu.

## Changes

```text
Before: Focused task -> open task menu -> Archive
After:  Focused task -> Cmd/Ctrl + Shift + A -> Archive
                         |
                         +-> Running task -> confirmation
```

- Adds the shortcut to Keyboard Combos.
- Supports ACP and Pi tasks.
- Preserves Code and Website navigation context.
- Prevents duplicate archive requests and keeps Undo behavior.

<img width="1620" height="1392" alt="CleanShot 2026-08-05 at 11 17 45@2x" src="https://github.com/user-attachments/assets/8dd3a965-3555-4039-8480-2c7a43cc18f1" />

https://github.com/user-attachments/assets/72a60839-41a4-438f-ac1d-0ce45f282d69



## How did you test this code?

- 24 focused tests passed for shortcut registration, archive state, and running-task detection.
- Local macOS ARM build completed successfully.
- Full typecheck remains blocked by existing React type conflicts in `ChannelFeedView.tsx` and `ChatThread.tsx`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No docs update required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code using Codex and parallel QA reviewers.
- No repository skill was invoked. `/qa-team` was unavailable, so equivalent logic, test, and UX reviews ran in parallel.
- QA moved shortcut ownership to task detail to cover both runtimes and reuse running-task confirmation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
