### PR TITLE
fix(warehouse): stop overlapping DuckLake registrations

### DIFF
--- a/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/temporal/ducklake_register_data_imports_workflow.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import re
 import json
+import time
 import uuid
 import typing
 import hashlib
 import datetime as dt
+import threading
 import contextlib
 import dataclasses
 from collections.abc import Iterator
+from contextvars import copy_context
 
 from django.conf import settings
 from django.db import close_old_connections
@@ -16,6 +19,7 @@ from django.db import close_old_connections
 import psycopg
 from psycopg import sql as psql
 from structlog.contextvars import bind_contextvars
+from structlog.types import FilteringBoundLogger
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ApplicationError
@@ -66,6 +70,11 @@ DATA_IMPORTS_GENERATIONS_PREFIX = "_imports"
 DUCKLAKE_REGISTER_STAGE_DURATION_METRIC = "ducklake_register_data_imports_stage_duration"
 S3_COPY_BATCH_SIZE = 16
 _SOURCE_JOB_STATE_PATCH_ID = "ducklake-register-source-job-state-2026-08"
+_NON_OVERLAPPING_REGISTRATION_PATCH_ID = "ducklake-register-non-overlapping-activity-2026-08"
+_ACTIVITY_DEADLINE_MARGIN = dt.timedelta(minutes=1)
+_DUCKGRES_INTERRUPT_POLL_INTERVAL_SECONDS = 0.5
+_DUCKGRES_INTERRUPT_TIMEOUT_SECONDS = 5.0
+_DUCKGRES_INTERRUPT_GRACE_SECONDS = 5.0
 
 
 def _register_source_job_update(
@@ -317,6 +326,7 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
     if not settings.TEST:
         close_old_connections()
 
+    activity_deadline = _activity_deadline()
     heartbeater = HeartbeaterSync(
         details=("ducklake_register_data_imports", inputs.metadata.source_schema_id),
         logger=logger,
@@ -336,7 +346,8 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
 
         try:
             with _connect_to_duckgres_for_team(inputs.team_id) as conn:
-                registered_rows = _register_prepared_parquet_files(inputs, conn, landing_paths)
+                with _interrupt_duckgres_on_activity_end(conn, logger, activity_deadline):
+                    registered_rows = _register_prepared_parquet_files(inputs, conn, landing_paths)
         except _StalePreparedGenerationError:
             get_ducklake_register_data_imports_stale_metric(
                 team_id=inputs.team_id, schema_id=schema_id, stage="publish"
@@ -474,6 +485,76 @@ def _prepared_generation_is_current(inputs: DuckLakeRegisterDataImportsActivityI
     return schema.table is not None and schema.table.queryable_folder == inputs.metadata.prepared_queryable_folder
 
 
+def _activity_deadline() -> float | None:
+    if not activity.in_activity():
+        return None
+    start_to_close_timeout = activity.info().start_to_close_timeout
+    if start_to_close_timeout is None:
+        return None
+    usable_budget = start_to_close_timeout - _ACTIVITY_DEADLINE_MARGIN
+    if usable_budget <= dt.timedelta():
+        return time.monotonic()
+    return time.monotonic() + usable_budget.total_seconds()
+
+
+def _interrupt_duckgres_connection(
+    conn: psycopg.Connection,
+    logger: FilteringBoundLogger,
+    stop_event: threading.Event,
+    reason: str,
+) -> None:
+    logger.warning("Interrupting Duckgres data import registration", reason=reason)
+    try:
+        conn.cancel_safe(timeout=_DUCKGRES_INTERRUPT_TIMEOUT_SECONDS)
+    except Exception as error:
+        logger.warning("Failed to cancel Duckgres data import registration", reason=reason, error=str(error))
+        try:
+            conn.close()
+        except Exception:
+            logger.exception("Failed to close interrupted Duckgres data import registration connection")
+        return
+
+    if stop_event.wait(_DUCKGRES_INTERRUPT_GRACE_SECONDS):
+        return
+    try:
+        conn.close()
+    except Exception:
+        logger.exception("Failed to close interrupted Duckgres data import registration connection")
+
+
+@contextlib.contextmanager
+def _interrupt_duckgres_on_activity_end(
+    conn: psycopg.Connection,
+    logger: FilteringBoundLogger,
+    deadline: float | None,
+) -> Iterator[None]:
+    if not activity.in_activity():
+        yield
+        return
+
+    stop_event = threading.Event()
+
+    def watch_activity() -> None:
+        while not stop_event.wait(_DUCKGRES_INTERRUPT_POLL_INTERVAL_SECONDS):
+            reason = None
+            if activity.is_cancelled():
+                reason = "cancelled"
+            elif deadline is not None and time.monotonic() >= deadline:
+                reason = "deadline"
+            if reason is not None:
+                _interrupt_duckgres_connection(conn, logger, stop_event, reason)
+                return
+
+    context = copy_context()
+    watcher = threading.Thread(target=context.run, args=(watch_activity,), daemon=True)
+    watcher.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        watcher.join()
+
+
 @contextlib.contextmanager
 def _connect_to_duckgres_for_team(team_id: int) -> Iterator[psycopg.Connection]:
     if is_dev_mode():
@@ -501,7 +582,11 @@ def _register_prepared_parquet_files(
     partition_columns = _hive_partition_columns(inputs.metadata.landing_uri, landing_paths)
 
     setup_duckgres_session(conn, extensions=("ducklake", "httpfs"))
-    with conn.transaction():
+    with _timed_transaction(
+        conn,
+        team_id=inputs.team_id,
+        schema_id=inputs.metadata.source_schema_id,
+    ):
         with _stage_timer(stage="register", team_id=inputs.team_id, schema_id=inputs.metadata.source_schema_id):
             conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(schema_name)))
             conn.execute(
@@ -587,6 +672,25 @@ def _register_prepared_parquet_files(
     return registered_count
 
 
+@contextlib.contextmanager
+def _timed_transaction(
+    conn: psycopg.Connection,
+    *,
+    team_id: int,
+    schema_id: str,
+) -> Iterator[None]:
+    transaction = conn.transaction()
+    transaction.__enter__()
+    try:
+        yield
+    except BaseException as error:
+        transaction.__exit__(type(error), error, error.__traceback__)
+        raise
+    else:
+        with _stage_timer(stage="commit", team_id=team_id, schema_id=schema_id):
+            transaction.__exit__(None, None, None)
+
+
 def _data_imports_shadow_table_name(inputs: DuckLakeRegisterDataImportsActivityInputs) -> str:
     schema_fragment = re.sub(r"[^A-Za-z0-9]", "", inputs.metadata.source_schema_id)[:8]
     job_fragment = re.sub(r"[^A-Za-z0-9]", "", inputs.job_id)[:8]
@@ -670,12 +774,13 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
                 job_id=inputs.job_id,
                 metadata=metadata,
             )
+            use_non_overlapping_activity = workflow.patched(_NON_OVERLAPPING_REGISTRATION_PATCH_ID)
             copy_applied = await workflow.execute_activity(
                 copy_and_register_ducklake_data_imports_activity,
                 activity_inputs,
                 start_to_close_timeout=dt.timedelta(minutes=30),
                 heartbeat_timeout=dt.timedelta(minutes=2),
-                retry_policy=RetryPolicy(maximum_attempts=2),
+                retry_policy=RetryPolicy(maximum_attempts=1 if use_non_overlapping_activity else 2),
             )
             if not copy_applied:
                 status = "stale"

--- a/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
+++ b/products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py
@@ -1,9 +1,11 @@
+import time
 import uuid
 import datetime as dt
+import threading
 import contextlib
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from parameterized import parameterized
 from temporalio.exceptions import ApplicationError
@@ -167,7 +169,21 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     conn.__enter__ = MagicMock(return_value=conn)
     conn.__exit__ = MagicMock(return_value=False)
     conn.transaction.return_value.__enter__ = MagicMock()
-    conn.transaction.return_value.__exit__ = MagicMock(return_value=False)
+    stage_events: list[str] = []
+
+    def record_transaction_exit(*args: object) -> bool:
+        stage_events.append("transaction:exit")
+        return False
+
+    conn.transaction.return_value.__exit__ = MagicMock(side_effect=record_transaction_exit)
+
+    @contextlib.contextmanager
+    def stage_timer(*, stage: str, team_id: int, schema_id: str):
+        stage_events.append(f"{stage}:start")
+        yield MagicMock()
+        stage_events.append(f"{stage}:end")
+
+    monkeypatch.setattr(registration_module, "_stage_timer", stage_timer)
 
     def execute(query: object) -> MagicMock:
         query_text = str(query)
@@ -229,6 +245,9 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     assert len(verification_indexes) == 2
     assert max(registration_indexes) < min(verification_indexes)
     assert max(verification_indexes) < drop_live_index < rename_index
+    assert stage_events.index("publish:end") < stage_events.index("commit:start")
+    assert stage_events.index("commit:start") < stage_events.index("transaction:exit")
+    assert stage_events.index("transaction:exit") < stage_events.index("commit:end")
     assert any("SET PARTITIONED BY" in query for query in executed)
     workload_metrics.files_getter.assert_called_once_with(team_id=1, schema_id="schema")
     workload_metrics.rows_getter.assert_called_once_with(team_id=1, schema_id="schema")
@@ -236,6 +255,32 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     workload_metrics.files.record.assert_called_once_with(2.0)
     workload_metrics.rows.record.assert_called_once_with(2.0)
     workload_metrics.bytes.record.assert_called_once_with(300.0)
+
+
+@pytest.mark.parametrize("trigger", ["cancelled", "deadline"])
+def test_duckgres_connection_is_interrupted_when_activity_ends(monkeypatch, trigger):
+    interrupted = threading.Event()
+    conn = MagicMock()
+    conn.cancel_safe.side_effect = lambda **kwargs: interrupted.set()
+    monkeypatch.setattr(registration_module.activity, "in_activity", lambda: True)
+    monkeypatch.setattr(registration_module.activity, "is_cancelled", lambda: trigger == "cancelled")
+    monkeypatch.setattr(registration_module, "_DUCKGRES_INTERRUPT_POLL_INTERVAL_SECONDS", 0.001)
+    deadline = time.monotonic() if trigger == "deadline" else None
+
+    with registration_module._interrupt_duckgres_on_activity_end(conn, MagicMock(), deadline):
+        assert interrupted.wait(timeout=1)
+
+    conn.cancel_safe.assert_called_once_with(timeout=registration_module._DUCKGRES_INTERRUPT_TIMEOUT_SECONDS)
+    conn.close.assert_not_called()
+
+
+def test_duckgres_connection_is_closed_when_cancellation_fails():
+    conn = MagicMock()
+    conn.cancel_safe.side_effect = RuntimeError("cancel failed")
+
+    registration_module._interrupt_duckgres_connection(conn, MagicMock(), threading.Event(), "deadline")
+
+    conn.close.assert_called_once_with()
 
 
 def test_copy_activity_does_not_touch_catalog_for_stale_generation(monkeypatch):
@@ -343,6 +388,12 @@ async def test_workflow_records_end_to_end_duration_after_gate(monkeypatch):
     metrics.duration.record.assert_called_once_with(432.0)
     metrics.last_success_getter.assert_called_once_with(**metric_identifiers)
     metrics.last_success.set.assert_called_once_with(finished_at.timestamp())
+    copy_call = next(
+        activity_call
+        for activity_call in execute_activity.await_args_list
+        if activity_call.args[0] is registration_module.copy_and_register_ducklake_data_imports_activity
+    )
+    assert copy_call.kwargs["retry_policy"].maximum_attempts == 1
     assert _recorded_source_job_statuses(execute_activity) == [
         registration_module.ManagedWarehouseSourceJobStatus.RUNNING,
         registration_module.ManagedWarehouseSourceJobStatus.COMPLETED,
@@ -366,7 +417,10 @@ async def test_workflow_skips_source_job_state_for_pre_patch_history(monkeypatch
 
     await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
 
-    patched.assert_called_once_with(registration_module._SOURCE_JOB_STATE_PATCH_ID)
+    assert patched.call_args_list == [
+        call(registration_module._SOURCE_JOB_STATE_PATCH_ID),
+        call(registration_module._NON_OVERLAPPING_REGISTRATION_PATCH_ID),
+    ]
     assert _recorded_source_job_statuses(execute_activity) == []
     metrics.finished_getter.assert_called_once_with(
         team_id=1,


### PR DESCRIPTION
## Problem

A long-running DuckLake registration can remain blocked while committing catalog metadata. Temporal previously retried the stateful activity automatically, which could leave two attempts modifying the same shadow table. The commit itself was also missing from stage-level timing, and a timed-out activity did not actively interrupt its Duckgres connection.

```mermaid
flowchart LR
    Start[Registration attempt] --> Work[Copy, register, verify, publish]
    Work --> Timeout[Activity timeout]
    Timeout --> Retry[Automatic retry]
    Work --> Zombie[Blocked connection continues]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Start phYellow;
    class Work phBlue;
    class Timeout,Retry,Zombie phRed;
```

## Changes

- Record transaction exit as an explicit `commit` stage.
- Monitor the activity deadline and cancellation state while Duckgres work is active. Send `cancel_safe()` and close the connection if it does not unwind.
- Disable automatic retries for new registration activity executions while preserving replay compatibility for existing workflow histories.

```mermaid
flowchart LR
    Start[Single registration attempt] --> Work[Copy, register, verify, publish]
    Work --> Commit[Timed commit stage]
    Deadline[Cancellation or local deadline] --> Cancel[Cancel Duckgres query]
    Cancel --> Close[Close if still blocked]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Start phYellow;
    class Work,Commit phBlue;
    class Deadline phGray;
    class Cancel,Close phRed;
```

## How did you test this code?

- `./bin/hogli test products/managed_warehouse/backend/tests/temporal/test_ducklake_register_data_imports_workflow.py -- -k "not registration_gate and not prepare_registration"` (15 passed)
- `uv run mypy --cache-fine-grained .` (17,652 source files, no issues)
- `./bin/hogli ci:preflight --fix` (passed)
- Commit hooks passed Python lint, formatting, and type checks.

The new tests catch regressions where commit timing stops covering transaction exit, cancellation or deadline handling stops interrupting Duckgres, or the activity becomes automatically retryable again. Five existing Django database setup cases could not run locally because the local ClickHouse coordination dependency was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update is needed because this changes internal workflow execution and observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated this change using the `/reviewing-distributed-systems`, `/writing-tests`, `/running-ci-preflight`, and `/signed-git-publish` skills. The change keeps existing workflow histories replay-compatible while applying the single-attempt policy to new executions. Performance changes to Parquet verification and DuckLake PostgreSQL metadata writes were intentionally left for focused follow-ups.