### PR TITLE
fix(data-imports): suppress error tracking noise for confirmed non-retryable errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -12,6 +12,7 @@ from temporalio import activity
 from posthog.exceptions_capture import capture_exception
 from posthog.redis import get_async_client
 from posthog.sync import database_sync_to_async_pool
+from posthog.temporal.common.errors import NonReportableError
 from posthog.utils import get_machine_id
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.load import get_incremental_field_value
@@ -207,7 +208,11 @@ async def handle_non_retryable_error(
             await logger.adebug(
                 f"Non-retryable error attempt {attempts}/{NON_RETRYABLE_ERROR_RETRY_LIMIT}, retrying. error={error_msg}"
             )
-            raise error
+            # Already matched a known, non-actionable customer/upstream error - re-raising it
+            # unwrapped here would report it to error tracking on every confirmation attempt.
+            # Wrapping in NonReportableError keeps Temporal's normal retry (it isn't in any
+            # activity's non_retryable_error_types) while suppressing that noise.
+            raise NonReportableError(error_msg) from error
 
     await logger.adebug(f"Non-retryable error after {attempts} runs, giving up. error={error_msg}")
     raise NonRetryableException() from error

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -1,4 +1,5 @@
 import uuid
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -8,12 +9,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
 
+from posthog.temporal.common.errors import NonReportableError
+
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.oom_event import ExternalDataSchemaOOMEvent
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
+    NON_RETRYABLE_ERROR_RETRY_LIMIT,
     handle_corrupted_delta_log,
+    handle_non_retryable_error,
     handle_reset_or_full_refresh,
     persist_primary_keys,
     report_heartbeat_timeout,
@@ -384,6 +389,56 @@ class TestHandleCorruptedDeltaLog:
         assert ph.capture.call_args.kwargs["event"] == "warehouse_delta_revived"
         assert ph.capture.call_args.kwargs["properties"]["outcome"] == "salvaged"
         assert ph.capture.call_args.kwargs["properties"]["made_non_billable"] is False
+
+
+class TestHandleNonRetryableError:
+    @staticmethod
+    def _redis_returning(incr_value: int):
+        @asynccontextmanager
+        async def _ctx():
+            redis_client = MagicMock()
+            redis_client.incr = AsyncMock(return_value=incr_value)
+            redis_client.expire = AsyncMock()
+            yield redis_client
+
+        return _ctx
+
+    def test_confirmation_attempt_does_not_reraise_bare_error(self):
+        # A classified non-retryable error (e.g. Meta Ads' "ads_read permission" 403) still gets
+        # a few confirmation retries before giving up. Re-raising the bare original exception here
+        # reports it to error tracking on every one of those attempts via
+        # `_PostHogClientActivityInboundInterceptor` — flooding error tracking with an issue for a
+        # cause that's already known and non-actionable. It must come back wrapped as
+        # NonReportableError instead, which that interceptor already exempts from capture.
+        original_error = Exception("Meta API request failed: 403 - permission denied")
+        logger = MagicMock(adebug=AsyncMock())
+
+        with patch(f"{_EXTRACT_MODULE}._get_redis", side_effect=self._redis_returning(1)):
+            with pytest.raises(NonReportableError) as exc_info:
+                async_to_sync(handle_non_retryable_error)(
+                    1, "source-1", "run-1", str(original_error), logger, original_error
+                )
+
+        assert not isinstance(exc_info.value, NonRetryableException)
+        assert exc_info.value.__cause__ is original_error
+
+    def test_gives_up_with_non_reportable_exception_after_retry_limit(self):
+        # Once the retry budget is exhausted, the same known error must still not surface as a
+        # fresh error-tracking issue - NonRetryableException has to stay a NonReportableError.
+        original_error = Exception("Meta API request failed: 403 - permission denied")
+        logger = MagicMock(adebug=AsyncMock())
+
+        with patch(
+            f"{_EXTRACT_MODULE}._get_redis",
+            side_effect=self._redis_returning(NON_RETRYABLE_ERROR_RETRY_LIMIT + 1),
+        ):
+            with pytest.raises(NonRetryableException) as exc_info:
+                async_to_sync(handle_non_retryable_error)(
+                    1, "source-1", "run-1", str(original_error), logger, original_error
+                )
+
+        assert isinstance(exc_info.value, NonReportableError)
+        assert exc_info.value.__cause__ is original_error
 
 
 # transaction=True: the webhook-first branch clears the reset flag via update_sync_type_config_keys,

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -12,6 +12,7 @@ from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions import capture_exception
 from posthog.settings.utils import get_from_env
+from posthog.temporal.common.errors import NonReportableError
 from posthog.utils import str_to_bool
 
 from products.data_warehouse.backend.facade.api import aget_s3_client
@@ -32,7 +33,14 @@ def _is_transient_s3_connection_error(error: BaseException) -> bool:
     return isinstance(error, _TRANSIENT_S3_CONNECTION_EXCEPTIONS)
 
 
-class NonRetryableException(Exception):
+class NonRetryableException(NonReportableError):
+    """A non-retryable classification is always reached after matching a known,
+    non-actionable customer/upstream error (see ``get_non_retryable_errors``), so it must
+    never surface as a fresh error-tracking issue - inheriting ``NonReportableError`` keeps
+    the activity interceptor from reporting it. Temporal's own retry policies still key off
+    this exact class name, e.g. ``non_retryable_error_types=["NonRetryableException", ...]``.
+    """
+
     @property
     def cause(self) -> Optional[BaseException]:
         """Cause of the exception.


### PR DESCRIPTION
## Problem

- Error tracking captured a MetaAds sync 403 permission error as a fresh issue multiple times within seconds ([issue](https://us.posthog.com/project/2/error_tracking/019fd25a-23e1-74b0-919b-807b9360a59d)).
- The error was already matched by `MetaAdsSource.get_non_retryable_errors`, which correctly disabled the sync and showed the user a friendly message.
- `handle_non_retryable_error` still re-raises the bare original exception during its confirmation-retry attempts (before giving up permanently), and the activity interceptor reports any bare exception to error tracking.
- `NonRetryableException`, raised on the final give-up, was a plain `Exception`, so that path was reported too.

## Changes

- `handle_non_retryable_error`'s confirmation-retry branch now raises `NonReportableError` instead of the bare original exception. `NonReportableError` is already exempt from error tracking capture and isn't in any activity's `non_retryable_error_types`, so Temporal's own retry is unaffected.
- `NonRetryableException` now subclasses `NonReportableError` too, so the final give-up exception is also exempt. Its class name is unchanged, so Temporal's `non_retryable_error_types=["NonRetryableException", ...]` matching still works.

An earlier PR, [#78391](https://github.com/PostHog/posthog/pull/78391), already made the `NonRetryableException` base-class change but not the confirmation-retry fix, which is the larger source of the noise (it fires on every early attempt, not only the final one). This PR includes both changes so it stands on its own; whichever PR merges first leaves a no-op diff on the shared file for the other.

## How did you test this code?

- Added two tests in `test_extract.py` covering `handle_non_retryable_error`'s confirmation-retry and give-up paths, asserting both raise a `NonReportableError`-derived exception with the original error preserved as `__cause__`.
- Ran `ruff check` and `ruff format` on the changed files.
- Ran `uv run mypy --cache-fine-grained .` repo-wide: no issues.
- Ran `test_extract.py`: all cases not requiring a local ClickHouse instance pass, including the new ones.

## Docs update

No user-facing behavior change; no docs update needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a PostHog error tracking issue delivered by webhook.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the stack trace through `handle_non_retryable_error` and confirmed the Meta Ads permission error was already classified as non-retryable, so the bug was in shared pipeline code reporting already-classified errors to error tracking, not in the source's classification.
- Checked Temporal's `non_retryable_error_types` usage across the data-imports activities to confirm neither change alters retry behavior.
- Found the related, partial fix in #78391 while checking for duplicates and scoped this PR to complete it rather than skip or fully duplicate it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*