### PR TITLE
feat(batch-exports): require an integration for new S3 exports

### DIFF
--- a/posthog/api/test/test_team_deletion.py
+++ b/posthog/api/test/test_team_deletion.py
@@ -11,6 +11,7 @@ from temporalio.service import RPCError
 
 from posthog.models import OrganizationMembership, Team
 from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.integration import Integration
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import describe_schedule
 from posthog.temporal.common.test_utils import start_test_worker
@@ -38,6 +39,16 @@ class TestTeamDeletionSideEffects(NonAtomicBaseTest):
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
         self.client.force_login(self.user)
+
+    def _create_aws_s3_integration(self, team: Team) -> Integration:
+        return Integration.objects.create(
+            team=team,
+            kind=Integration.IntegrationKind.AWS_S3,
+            integration_id="prod-aws",
+            config={"name": "prod-aws", "aws_account_id": "123456789012"},
+            sensitive_config={"aws_access_key_id": "abc123", "aws_secret_access_key": "secret"},
+            created_by=self.user,
+        )
 
     @freeze_time("2022-02-08")
     def test_delete_team_activity_log(self):
@@ -170,17 +181,17 @@ class TestTeamDeletionSideEffects(NonAtomicBaseTest):
 
     def test_delete_batch_exports(self):
         team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+        integration = self._create_aws_s3_integration(team)
 
         batch_export_data = {
             "name": "my-production-s3-bucket-destination",
             "destination": {
                 "type": "AwsS3",
+                "integration": integration.id,
                 "config": {
                     "bucket_name": "my-production-s3-bucket",
                     "region": "us-east-1",
                     "prefix": "posthog-events/",
-                    "aws_access_key_id": "abc123",
-                    "aws_secret_access_key": "secret",
                 },
             },
             "interval": "hour",
@@ -215,17 +226,17 @@ class TestTeamDeletionSideEffects(NonAtomicBaseTest):
     def test_delete_team_with_already_deleted_batch_export(self):
         """Team deletion should succeed even if batch exports were already soft-deleted."""
         team: Team = Team.objects.create_with_data(initiating_user=self.user, organization=self.organization)
+        integration = self._create_aws_s3_integration(team)
 
         batch_export_data = {
             "name": "my-production-s3-bucket-destination",
             "destination": {
                 "type": "AwsS3",
+                "integration": integration.id,
                 "config": {
                     "bucket_name": "my-production-s3-bucket",
                     "region": "us-east-1",
                     "prefix": "posthog-events/",
-                    "aws_access_key_id": "abc123",
-                    "aws_secret_access_key": "secret",
                 },
             },
             "interval": "hour",

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -50,6 +50,7 @@ from posthog.utils import relative_date_parse, str_to_bool
 from products.batch_exports.backend.api.destination_tests import get_destination_test
 from products.batch_exports.backend.models.batch_export import (
     BATCH_EXPORT_INTERVALS,
+    S3_CREATABLE_TYPES,
     S3_FAMILY_TYPES,
     TIMEZONES,
     BatchExport,
@@ -525,9 +526,8 @@ class AwsS3DestinationRequestSerializer(serializers.Serializer):
 
     type = serializers.ChoiceField(choices=["AwsS3"])
     integration_id = serializers.IntegerField(
-        required=False,
         help_text=(
-            "ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. "
+            "ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. "
             "Use the integrations-list MCP tool to find one."
         ),
     )
@@ -539,10 +539,9 @@ class S3CompatibleDestinationRequestSerializer(serializers.Serializer):
 
     type = serializers.ChoiceField(choices=["S3Compatible"])
     integration_id = serializers.IntegerField(
-        required=False,
         help_text=(
             "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. "
-            "Preferred over inline credentials. Use the integrations-list MCP tool to find one."
+            "Required when creating a batch export. Use the integrations-list MCP tool to find one."
         ),
     )
     config = S3CompatibleDestinationConfigSerializer()
@@ -582,11 +581,10 @@ class BatchExportDestinationRequestField(serializers.JSONField):
     """JSONField annotated with a polymorphic OpenAPI request schema.
 
     Only integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3,
-    S3Compatible, Snowflake) are exposed in the schema. integration_id is required for Databricks,
-    AzureBlob and BigQuery, and optional for the S3 family and Snowflake (inline credentials remain
-    supported for the time being). Existing Postgres, S3 and Snowflake exports created before
-    integrations keep their inline credentials. Runtime validation remains
-    `BatchExportDestinationSerializer.validate_destination`.
+    S3Compatible, Snowflake) are exposed in the schema. integration_id is required for every one of
+    those except Snowflake, where inline credentials remain supported for the time being. Existing
+    Postgres and Snowflake exports created before integrations keep their inline credentials.
+    Runtime validation remains `BatchExportDestinationSerializer.validate_destination`.
     """
 
     pass
@@ -688,8 +686,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text=(
             "ID of a team-scoped Integration providing credentials. Required when creating Databricks, "
-            "AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline "
-            "credentials remain supported); unused for other types."
+            "AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake "
+            "(inline credentials remain supported); unused for other types."
         ),
     )
 
@@ -729,7 +727,9 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
 
         # Some credential/connection fields are optional on the dataclass (integration-backed exports
         # resolve them at run time), so they must be required here only when no Integration is linked.
-        # TODO: remove this code once integrations for S3 and Snowflake are enforced
+        # For the S3 family this is only possible when updating an export that predates integrations:
+        # creating one without an Integration is rejected in `validate_destination`.
+        # TODO: remove this code once inline credentials are gone for S3 and integrations are enforced for Snowflake
         conditionally_required: set[str] = set()
         if attrs.get("integration") is None:
             if export_type in S3_FAMILY_TYPES:
@@ -1239,6 +1239,12 @@ class BatchExportSerializer(serializers.ModelSerializer):
                     "Cannot remove the integration from an S3 batch export that uses one. "
                     "Re-send its `integration` to keep it (or a different one to swap)."
                 )
+
+            # New S3 exports must use an Integration for credentials. Exports created before
+            # integrations existed keep their inline credentials, so only require it on create
+            # (`instance is None`); existing inline-credential exports stay valid when edited.
+            if integration is None and instance is None and destination_type in S3_CREATABLE_TYPES:
+                raise serializers.ValidationError(f"Integration is required for {destination_type} batch exports")
 
             # we already validate the required inputs in BatchExportDestinationSerializer::validate
             # so here we just ensure that the inputs are not empty

--- a/products/batch_exports/backend/tests/api/backfills/test_cancel.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_cancel.py
@@ -50,10 +50,11 @@ def wait_for_backfill_runs(backfill_id: str, timeout: int = 30) -> list[BatchExp
 
 
 @pytest.mark.django_db(transaction=True)
-def test_cancelling_a_batch_export_backfill(client: HttpClient, organization, team, user, temporal):
+def test_cancelling_a_batch_export_backfill(client: HttpClient, organization, team, user, aws_s3_integration, temporal):
     """Test cancelling a BatchExportBackfill."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/backfills/test_create.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_create.py
@@ -11,6 +11,7 @@ from rest_framework import status
 
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.models.integration import Integration
 from posthog.models.person.util import create_person
 from posthog.models.team import Team
 
@@ -27,6 +28,7 @@ pytestmark = [
 def _create_batch_export_ok(
     client: HttpClient,
     team: Team,
+    integration_id: int,
     model: str,
     interval: str = "hour",
     timezone: str = "UTC",
@@ -36,6 +38,7 @@ def _create_batch_export_ok(
     """Helper function to create a BatchExport."""
     destination_data = {
         "type": "AwsS3",
+        "integration": integration_id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -57,7 +60,9 @@ def _create_batch_export_ok(
 
 
 @pytest.mark.parametrize("model", ["events", "persons"])
-def test_batch_export_backfill_success(client: HttpClient, organization, team, user, temporal, model):
+def test_batch_export_backfill_success(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal, model
+):
     """Test a BatchExport can be backfilled.
 
     We should be able to create a Batch Export, then request that the Schedule
@@ -66,7 +71,7 @@ def test_batch_export_backfill_success(client: HttpClient, organization, team, u
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, model)
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, model)
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -88,7 +93,7 @@ def test_batch_export_backfill_success(client: HttpClient, organization, team, u
     ],
 )
 def test_batch_export_backfill_for_daily_schedule(
-    client: HttpClient, organization, team, user, temporal, timezone, offset_hour
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal, timezone, offset_hour
 ):
     """Test a BatchExport with a daily schedule can be backfilled.
 
@@ -97,7 +102,9 @@ def test_batch_export_backfill_for_daily_schedule(
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events", "day", timezone, None, offset_hour)
+    batch_export = _create_batch_export_ok(
+        client, team, aws_s3_integration.id, "events", "day", timezone, None, offset_hour
+    )
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -112,7 +119,7 @@ def test_batch_export_backfill_for_daily_schedule(
 
 
 def test_batch_export_backfill_for_daily_schedule_with_datetime_strings_fails(
-    client: HttpClient, organization, team, user, temporal
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
 ):
     """Test a BatchExport with a daily schedule fails if we pass datetime strings.
 
@@ -122,7 +129,7 @@ def test_batch_export_backfill_for_daily_schedule_with_datetime_strings_fails(
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events", "day")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events", "day")
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -148,7 +155,7 @@ def test_batch_export_backfill_for_daily_schedule_with_datetime_strings_fails(
     ],
 )
 def test_batch_export_backfill_for_weekly_schedule(
-    client: HttpClient, organization, team, user, temporal, timezone, offset_day, offset_hour
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal, timezone, offset_day, offset_hour
 ):
     """Test a BatchExport with a weekly schedule can be backfilled.
 
@@ -165,7 +172,9 @@ def test_batch_export_backfill_for_weekly_schedule(
         start_date = "2026-01-07"  # Wednesday
         end_date = "2026-01-14"  # Wednesday
 
-    batch_export = _create_batch_export_ok(client, team, "events", "week", timezone, offset_day, offset_hour)
+    batch_export = _create_batch_export_ok(
+        client, team, aws_s3_integration.id, "events", "week", timezone, offset_day, offset_hour
+    )
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -180,7 +189,7 @@ def test_batch_export_backfill_for_weekly_schedule(
 
 
 def test_batch_export_backfill_for_weekly_schedule_with_datetime_strings_fails(
-    client: HttpClient, organization, team, user, temporal
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
 ):
     """Test a BatchExport with a weekly schedule fails if we pass datetime strings.
 
@@ -190,7 +199,7 @@ def test_batch_export_backfill_for_weekly_schedule_with_datetime_strings_fails(
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events", "week", "UTC", 0, 0)
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events", "week", "UTC", 0, 0)
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -208,7 +217,7 @@ def test_batch_export_backfill_for_weekly_schedule_with_datetime_strings_fails(
 
 
 def test_batch_export_backfill_for_weekly_schedule_fails_if_day_of_week_is_incorrect(
-    client: HttpClient, organization, team, user, temporal
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
 ):
     """Test a BatchExport with a weekly schedule fails if we pass a date that is not on the correct day of the week.
 
@@ -218,7 +227,7 @@ def test_batch_export_backfill_for_weekly_schedule_fails_if_day_of_week_is_incor
     client.force_login(user)
 
     # use an offset day of 1, so we run weekly on Monday
-    batch_export = _create_batch_export_ok(client, team, "events", "week", "UTC", 1, None)
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events", "week", "UTC", 1, None)
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -235,12 +244,14 @@ def test_batch_export_backfill_for_weekly_schedule_fails_if_day_of_week_is_incor
     )
 
 
-def test_batch_export_backfill_with_non_isoformatted_dates(client: HttpClient, organization, team, user, temporal):
+def test_batch_export_backfill_with_non_isoformatted_dates(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
+):
     """Test a BatchExport backfill fails if we pass malformed dates."""
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
 
     batch_export_id = batch_export["id"]
 
@@ -251,13 +262,15 @@ def test_batch_export_backfill_with_non_isoformatted_dates(client: HttpClient, o
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_batch_export_backfill_with_end_at_in_the_future(client: HttpClient, organization, team, user, temporal):
+def test_batch_export_backfill_with_end_at_in_the_future(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
+):
     """Test a BatchExport backfill fails if we pass malformed dates."""
 
     test_time = dt.datetime.now(dt.UTC)
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
 
     batch_export_id = batch_export["id"]
 
@@ -273,11 +286,13 @@ def test_batch_export_backfill_with_end_at_in_the_future(client: HttpClient, org
         assert "is in the future" in response.json()["detail"]
 
 
-def test_batch_export_backfill_with_naive_bounds(client: HttpClient, organization, team, user, temporal):
+def test_batch_export_backfill_with_naive_bounds(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
+):
     """Test a BatchExport backfill fails if we naive dates."""
 
     client.force_login(user)
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
 
     batch_export_id = batch_export["id"]
 
@@ -288,12 +303,14 @@ def test_batch_export_backfill_with_naive_bounds(client: HttpClient, organizatio
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_batch_export_backfill_with_start_at_after_end_at(client: HttpClient, organization, team, user, temporal):
+def test_batch_export_backfill_with_start_at_after_end_at(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
+):
     """Test a BatchExport backfill fails if start_at is after end_at."""
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -315,13 +332,15 @@ def test_batch_export_backfill_with_start_at_after_end_at(client: HttpClient, or
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
 
-def test_cannot_trigger_backfill_for_another_organization(client: HttpClient, temporal, organization, team, user):
+def test_cannot_trigger_backfill_for_another_organization(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     other_organization = create_organization("Other Org")
     create_team(other_organization)
     other_user = create_user("other-test@user.com", "Other Test User", other_organization)
 
     client.force_login(user)
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
 
     batch_export_id = batch_export["id"]
 
@@ -337,14 +356,14 @@ def test_cannot_trigger_backfill_for_another_organization(client: HttpClient, te
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_backfill_is_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
+def test_backfill_is_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     from posthog.api.test.test_team import create_team
 
     other_team = create_team(organization)
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -358,7 +377,9 @@ def test_backfill_is_partitioned_by_team_id(client: HttpClient, temporal, organi
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.json()
 
 
-def test_batch_export_backfill_created_in_timezone(client: HttpClient, temporal, organization, user, team):
+def test_batch_export_backfill_created_in_timezone(
+    client: HttpClient, temporal, organization, user, team, aws_s3_integration
+):
     """Test creating a BatchExportBackfill sets the right ID in UTC timezone.
 
     PostgreSQL stores datetime values in their UTC representation, converting the input
@@ -373,7 +394,7 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient, temporal,
 
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
     batch_export_id = batch_export["id"]
 
     response = backfill_batch_export(
@@ -391,12 +412,12 @@ def test_batch_export_backfill_created_in_timezone(client: HttpClient, temporal,
 
 
 def test_batch_export_earliest_backfill_rejected_without_feature_flag(
-    client: HttpClient, organization, team, user, temporal
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
 ):
     """Test that earliest backfill (start_at=None) is rejected when feature flag is disabled."""
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "persons")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "persons")
     batch_export_id = batch_export["id"]
 
     with patch("products.batch_exports.backend.api.batch_export.posthoganalytics.feature_enabled", return_value=False):
@@ -412,11 +433,13 @@ def test_batch_export_earliest_backfill_rejected_without_feature_flag(
 
 
 @override_settings(BATCH_EXPORT_MAX_CONCURRENT_BACKFILLS_PER_TEAM=2)
-def test_backfill_rejected_when_team_at_concurrent_limit(client: HttpClient, organization, team, user, temporal):
+def test_backfill_rejected_when_team_at_concurrent_limit(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
+):
     """Test backfill creation is rejected with 429 when team is at the concurrent limit."""
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
     batch_export_id = batch_export["id"]
     batch_export_obj = BatchExport.objects.get(id=batch_export_id)
 
@@ -442,11 +465,13 @@ def test_backfill_rejected_when_team_at_concurrent_limit(client: HttpClient, org
 
 
 @override_settings(BATCH_EXPORT_MAX_CONCURRENT_BACKFILLS_PER_TEAM=2)
-def test_backfill_allowed_when_team_below_concurrent_limit(client: HttpClient, organization, team, user, temporal):
+def test_backfill_allowed_when_team_below_concurrent_limit(
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
+):
     """Test backfill creation succeeds when team has fewer running backfills than the limit."""
     client.force_login(user)
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
     batch_export_id = batch_export["id"]
     batch_export_obj = BatchExport.objects.get(id=batch_export_id)
 
@@ -480,17 +505,26 @@ def test_backfill_allowed_when_team_below_concurrent_limit(client: HttpClient, o
 
 @override_settings(BATCH_EXPORT_MAX_CONCURRENT_BACKFILLS_PER_TEAM=2)
 def test_other_teams_backfills_do_not_count_toward_concurrent_limit(
-    client: HttpClient, organization, team, user, temporal
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
 ):
     """Test that running backfills from other teams don't count toward this team's limit."""
     client.force_login(user)
 
     other_team = create_team(organization)
+    # Integrations are team-scoped, so the other team's export needs its own.
+    other_team_integration = Integration.objects.create(
+        team=other_team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
 
-    batch_export = _create_batch_export_ok(client, team, "events")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "events")
     batch_export_id = batch_export["id"]
 
-    other_batch_export = _create_batch_export_ok(client, other_team, "events")
+    other_batch_export = _create_batch_export_ok(client, other_team, other_team_integration.id, "events")
     other_batch_export_obj = BatchExport.objects.get(id=other_batch_export["id"])
 
     for _ in range(5):
@@ -513,7 +547,7 @@ def test_other_teams_backfills_do_not_count_toward_concurrent_limit(
 
 
 def test_batch_export_earliest_backfill_allowed_with_feature_flag(
-    client: HttpClient, organization, team, user, temporal
+    client: HttpClient, organization, team, user, aws_s3_integration, temporal
 ):
     """Test that earliest backfill (start_at=None) is allowed when feature flag is enabled."""
     client.force_login(user)
@@ -526,7 +560,7 @@ def test_batch_export_earliest_backfill_allowed_with_feature_flag(
         timestamp=dt.datetime(2021, 1, 1, 0, 0, 0, tzinfo=dt.UTC),
     )
 
-    batch_export = _create_batch_export_ok(client, team, "persons")
+    batch_export = _create_batch_export_ok(client, team, aws_s3_integration.id, "persons")
     batch_export_id = batch_export["id"]
 
     with patch("products.batch_exports.backend.api.batch_export.posthoganalytics.feature_enabled", return_value=True):

--- a/products/batch_exports/backend/tests/api/conftest.py
+++ b/products/batch_exports/backend/tests/api/conftest.py
@@ -12,6 +12,7 @@ from temporalio.client import (
 )
 from temporalio.service import RPCError
 
+from posthog.models.integration import Integration
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.codec import EncryptionCodec
 
@@ -90,6 +91,30 @@ def team(organization):
 @pytest.fixture
 def user(organization):
     return create_user("test@user.com", "Test User", organization)
+
+
+@pytest.fixture
+def aws_s3_integration(team, user):
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def s3_compatible_integration(team, user):
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.S3_COMPATIBLE,
+        integration_id="my-r2",
+        config={"name": "my-r2", "endpoint_url": "https://account.r2.cloudflarestorage.com"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
 
 
 def assert_is_daily_schedule(schedule: ScheduleDescription, expected_hour: int):

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -36,7 +36,7 @@ pytestmark = [
 
 
 def test_create_batch_export_with_interval_schedule(
-    client: HttpClient, temporal, encryption_codec, organization, team, user
+    client: HttpClient, temporal, encryption_codec, organization, team, user, s3_compatible_integration
 ):
     """Test creating a BatchExport.
 
@@ -59,7 +59,7 @@ def test_create_batch_export_with_interval_schedule(
             "endpoint_url": "https://localhost:9000",
             "use_virtual_style_addressing": True,
         },
-        "integration": None,
+        "integration": s3_compatible_integration.id,
     }
 
     batch_export_data: dict[str, t.Any] = {
@@ -185,7 +185,7 @@ def test_create_batch_export_with_different_intervals_timezones_and_interval_off
     offset. We check the upcoming runs to confirm these look correct based on this information.
     """
 
-    destination_data = {
+    destination_data: dict[str, t.Any] = {
         "type": "AwsS3",
         "config": {
             "bucket_name": "my-production-s3-bucket",
@@ -211,6 +211,16 @@ def test_create_batch_export_with_different_intervals_timezones_and_interval_off
     # create a team with a timezone different to the one we are testing to ensure this has no effect on the batch export
     team = create_team(organization, timezone="Asia/Seoul")
     user = create_user("test@user.com", "Test User", organization)
+    # Integrations are team-scoped, so this test's own team needs its own.
+    integration = Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+    destination_data["integration"] = integration.id
     client.force_login(user)
 
     # ensure high-frequency-batch-exports feature flag is enabled
@@ -413,10 +423,11 @@ def test_cannot_create_batch_export_with_integration_from_another_team(
 
 
 def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(
-    client: HttpClient, temporal, organization, team, user
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
 ):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -470,7 +481,7 @@ FROM events
 
 
 def test_create_batch_export_with_custom_schema(
-    client: HttpClient, temporal, encryption_codec, organization, team, user
+    client: HttpClient, temporal, encryption_codec, organization, team, user, aws_s3_integration
 ):
     """Test creating a BatchExport with a custom schema expressed as a HogQL Query.
 
@@ -482,6 +493,7 @@ def test_create_batch_export_with_custom_schema(
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -579,12 +591,13 @@ def test_create_batch_export_with_custom_schema(
     ],
 )
 def test_create_batch_export_fails_with_invalid_query(
-    client: HttpClient, invalid_query, expected_error_message, temporal, organization, team, user
+    client: HttpClient, invalid_query, expected_error_message, temporal, organization, team, user, aws_s3_integration
 ):
     """Test creating a BatchExport should fail with an invalid query."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -734,6 +747,7 @@ def test_creating_batch_export_with_filters(
     organization,
     team,
     user,
+    aws_s3_integration,
     filters,
     expected_status,
     expected_error,
@@ -742,6 +756,7 @@ def test_creating_batch_export_with_filters(
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": _S3_FILTER_TEST_CONFIG,
     }
 

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -8,8 +8,6 @@ from django.test.client import Client as HttpClient
 from rest_framework import status
 from temporalio.client import ScheduleActionStartWorkflow
 
-from posthog.models.integration import Integration
-
 from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES
 from products.batch_exports.backend.tests.api.conftest import describe_schedule
 from products.batch_exports.backend.tests.api.operations import create_batch_export
@@ -29,12 +27,12 @@ _S3_FAMILY_BASE_CONFIG = {
 
 
 @pytest.mark.parametrize(
-    "destination_type,extra_config,expected_persisted_type",
+    "destination_type,integration_fixture,extra_config,expected_persisted_type",
     [
         # Refined AwsS3 (with AWS-only encryption field)
-        ("AwsS3", {"encryption": "AES256"}, "AwsS3"),
-        # Refined S3Compatible (endpoint_url is required)
-        ("S3Compatible", {"endpoint_url": "https://localhost:9000"}, "S3Compatible"),
+        ("AwsS3", "aws_s3_integration", {"encryption": "AES256"}, "AwsS3"),
+        # Refined S3Compatible (accepts an inline endpoint_url alongside the integration's)
+        ("S3Compatible", "s3_compatible_integration", {"endpoint_url": "https://localhost:9000"}, "S3Compatible"),
     ],
 )
 def test_create_s3_family_batch_export(
@@ -44,10 +42,13 @@ def test_create_s3_family_batch_export(
     team,
     user,
     destination_type,
+    integration_fixture,
     extra_config,
     expected_persisted_type,
+    request,
 ):
     """Posting a creatable S3-family destination type creates a batch export and persists with the expected type."""
+    integration = request.getfixturevalue(integration_fixture)
     client.force_login(user)
     response = create_batch_export(
         client,
@@ -58,11 +59,35 @@ def test_create_s3_family_batch_export(
             "destination": {
                 "type": destination_type,
                 "config": {**_S3_FAMILY_BASE_CONFIG, **extra_config},
+                "integration": integration.id,
             },
         },
     )
     assert response.status_code == status.HTTP_201_CREATED, response.json()
     assert response.json()["destination"]["type"] == expected_persisted_type
+
+
+@pytest.mark.parametrize("destination_type", sorted(S3_CREATABLE_TYPES))
+def test_create_s3_family_batch_export_requires_an_integration(
+    client: HttpClient, temporal, organization, team, user, destination_type
+):
+    """Inline credentials are no longer enough to create an S3-family export: an Integration is required."""
+    client.force_login(user)
+    config = {**_S3_FAMILY_BASE_CONFIG}
+    if destination_type == "S3Compatible":
+        config["endpoint_url"] = "https://localhost:9000"
+
+    response = create_batch_export(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {"type": destination_type, "config": config},
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == f"Integration is required for {destination_type} batch exports"
 
 
 def test_create_legacy_s3_type_is_rejected(client: HttpClient, temporal, organization, team, user):
@@ -83,19 +108,25 @@ def test_create_legacy_s3_type_is_rejected(client: HttpClient, temporal, organiz
     assert "S3Compatible" in response.json()["detail"]
 
 
-@pytest.mark.parametrize("destination_type", sorted(S3_CREATABLE_TYPES))
+@pytest.mark.parametrize(
+    "destination_type,integration_fixture",
+    [
+        ("AwsS3", "aws_s3_integration"),
+        ("S3Compatible", "s3_compatible_integration"),
+    ],
+)
 def test_create_s3_family_batch_export_validates_empty_inputs(
-    client: HttpClient, temporal, organization, team, user, destination_type
+    client: HttpClient, temporal, organization, team, user, destination_type, integration_fixture, request
 ):
-    """Empty required string inputs are rejected for every S3-family destination."""
+    """Empty required string inputs are rejected for every S3-family destination.
+
+    Credentials come from the integration, so the bucket/region/prefix inputs are the ones
+    that can still arrive empty.
+    """
+    integration = request.getfixturevalue(integration_fixture)
     client.force_login(user)
-    config = {
-        **_S3_FAMILY_BASE_CONFIG,
-        "aws_access_key_id": "",
-        "aws_secret_access_key": "",
-    }
+    config = {**_S3_FAMILY_BASE_CONFIG, "bucket_name": "", "region": ""}
     if destination_type == "S3Compatible":
-        # S3Compatible additionally requires `endpoint_url` to be present.
         config["endpoint_url"] = "https://localhost:9000"
 
     response = create_batch_export(
@@ -104,11 +135,11 @@ def test_create_s3_family_batch_export_validates_empty_inputs(
         {
             "name": "my-export",
             "interval": "hour",
-            "destination": {"type": destination_type, "config": config},
+            "destination": {"type": destination_type, "config": config, "integration": integration.id},
         },
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"
+    assert response.json()["detail"] == "The following inputs are empty: ['bucket_name', 'region']"
 
 
 @pytest.mark.parametrize(
@@ -217,18 +248,25 @@ def test_create_s3_family_batch_export_rejects_inapplicable_fields(
     ],
 )
 def test_create_s3_batch_export_validates_file_format_and_compression(
-    client: HttpClient, file_format, compression, expected_error_message, temporal, organization, team, user
+    client: HttpClient,
+    file_format,
+    compression,
+    expected_error_message,
+    temporal,
+    organization,
+    team,
+    user,
+    aws_s3_integration,
 ):
     """Test creating a BatchExport with S3 destination validates file format and compression."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-s3-bucket",
             "region": "us-east-1",
             "prefix": "posthog-events/",
-            "aws_access_key_id": "abc123",
-            "aws_secret_access_key": "secret",
             "file_format": file_format,
             "compression": compression,
         },
@@ -272,7 +310,7 @@ def test_create_s3_batch_export_validates_file_format_and_compression(
     ],
 )
 def test_creating_s3_family_batch_export_fails_if_using_invalid_endpoint_url(
-    client: HttpClient, temporal, organization, team, user, destination_type, endpoint_url
+    client: HttpClient, temporal, organization, team, user, destination_type, endpoint_url, s3_compatible_integration
 ):
     """Test that creating an S3 batch export fails if passing an internal IP as endpoint URL.
 
@@ -286,7 +324,7 @@ def test_creating_s3_family_batch_export_fails_if_using_invalid_endpoint_url(
             "use_virtual_style_addressing": True,
             "endpoint_url": endpoint_url,
         },
-        "integration": None,
+        "integration": s3_compatible_integration.id,
     }
 
     batch_export_data: dict[str, t.Any] = {
@@ -305,30 +343,6 @@ def test_creating_s3_family_batch_export_fails_if_using_invalid_endpoint_url(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert f"Invalid endpoint_url: '{endpoint_url}'" in response.json()["detail"]
-
-
-@pytest.fixture
-def aws_s3_integration(team, user):
-    return Integration.objects.create(
-        team=team,
-        kind=Integration.IntegrationKind.AWS_S3,
-        integration_id="prod-aws",
-        config={"name": "prod-aws", "aws_account_id": "123456789012"},
-        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
-        created_by=user,
-    )
-
-
-@pytest.fixture
-def s3_compatible_integration(team, user):
-    return Integration.objects.create(
-        team=team,
-        kind=Integration.IntegrationKind.S3_COMPATIBLE,
-        integration_id="my-r2",
-        config={"name": "my-r2", "endpoint_url": "https://account.r2.cloudflarestorage.com"},
-        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
-        created_by=user,
-    )
 
 
 @pytest.mark.parametrize(

--- a/products/batch_exports/backend/tests/api/test_delete.py
+++ b/products/batch_exports/backend/tests/api/test_delete.py
@@ -31,10 +31,11 @@ pytestmark = [
 ]
 
 
-def test_delete_batch_export(client: HttpClient, temporal, organization, team, user):
+def test_delete_batch_export(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     """Test deleting a BatchExport."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -89,10 +90,13 @@ async def wait_for_workflow_in_status(
 
 
 @pytest.mark.django_db(transaction=True)
-def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal, organization, team, user):
+def test_delete_batch_export_cancels_backfills(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """Test deleting a BatchExport cancels ongoing BatchExportBackfill."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -147,9 +151,12 @@ def test_delete_batch_export_cancels_backfills(client: HttpClient, temporal, org
         describe_schedule(temporal, batch_export_id)
 
 
-def test_cannot_delete_export_of_other_organizations(client: HttpClient, temporal, organization, team, user):
+def test_cannot_delete_export_of_other_organizations(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -182,9 +189,10 @@ def test_cannot_delete_export_of_other_organizations(client: HttpClient, tempora
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
+def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -215,10 +223,13 @@ def test_deletes_are_partitioned_by_team_id(client: HttpClient, temporal, organi
 
 
 @pytest.mark.django_db(transaction=True)
-def test_delete_batch_export_even_without_underlying_schedule(client: HttpClient, temporal, organization, team, user):
+def test_delete_batch_export_even_without_underlying_schedule(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """Test deleting a BatchExport completes even if underlying Schedule was already deleted."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_get.py
+++ b/products/batch_exports/backend/tests/api/test_get.py
@@ -6,6 +6,7 @@ from rest_framework import status
 
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.models.integration import Integration
 
 from products.batch_exports.backend.models.batch_export import BatchExport, BatchExportDestination
 from products.batch_exports.backend.tests.api.fixtures import create_organization
@@ -28,10 +29,20 @@ pytestmark = [
     ],
 )
 def test_can_get_exports_for_your_organizations(
-    client: HttpClient, temporal, organization, team, user, interval, timezone, offset_day, offset_hour
+    client: HttpClient,
+    temporal,
+    organization,
+    team,
+    user,
+    aws_s3_integration,
+    interval,
+    timezone,
+    offset_day,
+    offset_hour,
 ):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -85,9 +96,12 @@ def test_can_get_exports_for_your_organizations(
     }
 
 
-def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal, organization, team, user):
+def test_cannot_get_exports_for_other_organizations(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -118,13 +132,16 @@ def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, organization, team, user):
+def test_batch_exports_are_partitioned_by_team(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """
     You shouldn't be able to fetch a BatchExport by id, via a team that it
     doesn't belong to.
     """
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -141,6 +158,15 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
     }
 
     another_team = create_team(organization)
+    # Integrations are team-scoped, so the other team's export needs its own.
+    another_team_integration = Integration.objects.create(
+        team=another_team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
 
     client.force_login(user)
     batch_export = create_batch_export_ok(
@@ -156,7 +182,7 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
     batch_export = create_batch_export_ok(
         client,
         another_team.pk,
-        batch_export_data,
+        {**batch_export_data, "destination": {**destination_data, "integration": another_team_integration.id}},
     )
 
     response = get_batch_export(client, team.pk, batch_export["id"])

--- a/products/batch_exports/backend/tests/api/test_list.py
+++ b/products/batch_exports/backend/tests/api/test_list.py
@@ -19,7 +19,7 @@ pytestmark = [
 ]
 
 
-def test_list_batch_exports(client: HttpClient, organization, team, user):
+def test_list_batch_exports(client: HttpClient, organization, team, user, aws_s3_integration):
     """
     Should be able to list batch exports.
     """
@@ -27,6 +27,7 @@ def test_list_batch_exports(client: HttpClient, organization, team, user):
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -58,7 +59,9 @@ def test_list_batch_exports(client: HttpClient, organization, team, user):
     assert len(response["results"]) == 0
 
 
-def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient, organization, team, user):
+def test_cannot_list_batch_exports_for_other_organizations(
+    client: HttpClient, organization, team, user, aws_s3_integration
+):
     """
     Should not be able to list batch exports for other teams.
     """
@@ -68,6 +71,7 @@ def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient, o
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -96,7 +100,7 @@ def test_cannot_list_batch_exports_for_other_organizations(client: HttpClient, o
     assert len(response["results"]) == 0
 
 
-def test_list_is_partitioned_by_team(client: HttpClient, organization, team, user):
+def test_list_is_partitioned_by_team(client: HttpClient, organization, team, user, aws_s3_integration):
     """
     Should be able to list batch exports for a specific team.
     """
@@ -104,6 +108,7 @@ def test_list_is_partitioned_by_team(client: HttpClient, organization, team, use
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -153,7 +158,9 @@ def enable_backfilling_workflows(team):
         )
 
 
-def test_list_filters_workflows_destination(client: HttpClient, organization, team, user, enable_backfilling_workflows):
+def test_list_filters_workflows_destination(
+    client: HttpClient, organization, team, user, aws_s3_integration, enable_backfilling_workflows
+):
     """
     Workflows should be filtered out from the list.
     """
@@ -161,6 +168,7 @@ def test_list_filters_workflows_destination(client: HttpClient, organization, te
 
     s3_destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_pause.py
+++ b/products/batch_exports/backend/tests/api/test_pause.py
@@ -25,11 +25,12 @@ pytestmark = [
 ]
 
 
-def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organization, team, user):
+def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     """Test pausing and unpausing a BatchExport."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -75,10 +76,11 @@ def test_pause_and_unpause_batch_export(client: HttpClient, temporal, organizati
 
 
 def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
-    client: HttpClient, temporal, organization, team, user
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
 ):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -139,9 +141,12 @@ def test_cannot_pause_and_unpause_batch_exports_of_other_organizations(
     assert schedule_desc.schedule.state.paused is True
 
 
-def test_pause_and_unpause_are_partitioned_by_team_id(client: HttpClient, temporal, organization, team, user):
+def test_pause_and_unpause_are_partitioned_by_team_id(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -194,11 +199,14 @@ def test_pause_and_unpause_are_partitioned_by_team_id(client: HttpClient, tempor
     assert schedule_desc.schedule.state.paused is True
 
 
-def test_pause_batch_export_that_is_already_paused(client: HttpClient, temporal, organization, team, user):
+def test_pause_batch_export_that_is_already_paused(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """Test pausing a BatchExport that is already paused doesn't actually do anything."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -243,11 +251,14 @@ def test_pause_batch_export_that_is_already_paused(client: HttpClient, temporal,
     assert last_updated_at == data["last_updated_at"]
 
 
-def test_unpause_batch_export_that_is_already_unpaused(client: HttpClient, temporal, organization, team, user):
+def test_unpause_batch_export_that_is_already_unpaused(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """Test unpausing a BatchExport that is already unpaused doesn't actually do anything."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -283,11 +294,12 @@ def test_unpause_batch_export_that_is_already_unpaused(client: HttpClient, tempo
     assert last_updated_at == data["last_updated_at"]
 
 
-def test_pause_non_existent_batch_export(client: HttpClient, temporal, organization, team, user):
+def test_pause_non_existent_batch_export(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     """Test pausing a BatchExport that doesn't exist."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -321,11 +333,12 @@ def test_pause_non_existent_batch_export(client: HttpClient, temporal, organizat
     assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organization, team, user):
+def test_unpause_can_trigger_a_backfill(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     """Test unpausing a BatchExport can trigger a backfill."""
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_runs.py
+++ b/products/batch_exports/backend/tests/api/test_runs.py
@@ -9,6 +9,8 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
+from posthog.models.integration import Integration
+
 from products.batch_exports.backend.models.batch_export import BatchExportRun
 from products.batch_exports.backend.tests.api.fixtures import (
     create_batch_export,
@@ -35,9 +37,12 @@ pytestmark = [
 ]
 
 
-def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal, organization, team, user):
+def test_can_get_export_runs_for_your_organizations(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -64,9 +69,12 @@ def test_can_get_export_runs_for_your_organizations(client: HttpClient, temporal
     assert response.status_code == status.HTTP_200_OK, response.json()
 
 
-def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal, organization, team, user):
+def test_cannot_get_exports_for_other_organizations(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -96,13 +104,16 @@ def test_cannot_get_exports_for_other_organizations(client: HttpClient, temporal
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
 
 
-def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, organization, team, user):
+def test_batch_exports_are_partitioned_by_team(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """
     You shouldn't be able to fetch a BatchExport by id, via a team that it
     doesn't belong to.
     """
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -119,6 +130,15 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
     }
 
     another_team = create_team(organization)
+    # Integrations are team-scoped, so the other team's export needs its own.
+    another_team_integration = Integration.objects.create(
+        team=another_team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
     client.force_login(user)
     batch_export = create_batch_export_ok(
         client,
@@ -133,7 +153,7 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
     batch_export = create_batch_export_ok(
         client,
         another_team.pk,
-        batch_export_data,
+        {**batch_export_data, "destination": {**destination_data, "integration": another_team_integration.id}},
     )
 
     response = get_batch_export(client, team.pk, batch_export["id"])
@@ -141,10 +161,11 @@ def test_batch_exports_are_partitioned_by_team(client: HttpClient, temporal, org
 
 
 @pytest.mark.django_db(transaction=True)
-def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organization, team, user):
+def test_cancelling_a_batch_export_run(client: HttpClient, temporal, organization, team, user, aws_s3_integration):
     """Test cancelling a BatchExportRun."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_test.py
+++ b/products/batch_exports/backend/tests/api/test_test.py
@@ -95,11 +95,32 @@ async def delete_all_from_s3(object_storage_client, bucket_name: str, key_prefix
                 await object_storage_client.delete_object(Bucket=bucket_name, Key=obj["Key"])
 
 
+@pytest.fixture
+def object_storage_integration(team, user):
+    """An s3-compatible Integration pointing at the local object storage used by these tests.
+
+    The shared `s3_compatible_integration` fixture points at a fake provider, and its endpoint and
+    credentials would override the inline ones when running a destination test step.
+    """
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.S3_COMPATIBLE,
+        integration_id="local-object-storage",
+        config={"name": "local-object-storage", "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT},
+        sensitive_config={
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+        created_by=user,
+    )
+
+
 def test_can_run_s3_test_step_for_new_destination(
-    client: HttpClient, bucket_name, object_storage_client, organization, team, user
+    client: HttpClient, bucket_name, object_storage_client, organization, team, user, object_storage_integration
 ):
     destination_data = {
         "type": "S3Compatible",
+        "integration": object_storage_integration.id,
         "config": {
             "bucket_name": bucket_name,
             "region": "us-east-1",
@@ -133,10 +154,18 @@ def test_can_run_s3_test_step_for_new_destination(
 
 
 def test_can_run_s3_test_step_for_destination(
-    client: HttpClient, bucket_name, object_storage_client, temporal, organization, team, user
+    client: HttpClient,
+    bucket_name,
+    object_storage_client,
+    temporal,
+    organization,
+    team,
+    user,
+    object_storage_integration,
 ):
     destination_data = {
         "type": "S3Compatible",
+        "integration": object_storage_integration.id,
         "config": {
             "bucket_name": bucket_name,
             "region": "us-east-1",
@@ -175,7 +204,9 @@ def test_can_run_s3_test_step_for_destination(
     assert destination_test["result"]["message"] is None
 
 
-def test_run_test_step_rejects_destination_type_change(client: HttpClient, temporal, organization, team, user):
+def test_run_test_step_rejects_destination_type_change(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     """A test step must not be able to change the destination type of an existing export.
 
     Otherwise a caller could, for example, switch an "AwsS3" export (no `endpoint_url`) to the
@@ -185,6 +216,7 @@ def test_run_test_step_rejects_destination_type_change(client: HttpClient, tempo
 
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -338,7 +370,14 @@ def test_can_run_snowflake_test_step_for_partial_config(
 
 
 def test_can_run_s3_test_step_with_additional_fields(
-    client: HttpClient, bucket_name, object_storage_client, temporal, organization, team, user
+    client: HttpClient,
+    bucket_name,
+    object_storage_client,
+    temporal,
+    organization,
+    team,
+    user,
+    object_storage_integration,
 ):
     """Test we can run test steps successfully even with additional configuration fields.
 
@@ -349,6 +388,7 @@ def test_can_run_s3_test_step_with_additional_fields(
 
     destination_data = {
         "type": "S3Compatible",
+        "integration": object_storage_integration.id,
         "config": {
             "bucket_name": bucket_name,
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_update.py
+++ b/products/batch_exports/backend/tests/api/test_update.py
@@ -48,9 +48,10 @@ def bigquery_integration(team, user):
     )
 
 
-def test_can_put_config(client: HttpClient, temporal, encryption_codec, organization, team, user):
+def test_can_put_config(client: HttpClient, temporal, encryption_codec, organization, team, user, aws_s3_integration):
     destination_data: dict[str, t.Any] = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -122,12 +123,15 @@ def test_can_put_config(client: HttpClient, temporal, encryption_codec, organiza
 
 
 @pytest.mark.parametrize("interval", ["hour", "day"])
-def test_can_patch_config(client: HttpClient, interval, temporal, encryption_codec, organization, team, user):
+def test_can_patch_config(
+    client: HttpClient, interval, temporal, encryption_codec, organization, team, user, aws_s3_integration
+):
     timezone = "Europe/Berlin"
     # use offset of 1 hour for daily exports and None for hourly exports (these don't support offsets)
     offset_hour = None if interval == "hour" else 1
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -163,6 +167,7 @@ def test_can_patch_config(client: HttpClient, interval, temporal, encryption_cod
     # credentials. The existing values should be preserved.
     new_destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-new-production-s3-bucket",
             "region": "us-east-1",
@@ -408,6 +413,7 @@ def test_can_patch_schedule_configuration(
     organization,
     team,
     user,
+    aws_s3_integration,
     initial_state,
     patch_data,
     expected_state,
@@ -421,6 +427,7 @@ def test_can_patch_schedule_configuration(
     """
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -569,11 +576,13 @@ def test_patch_rejects_destination_type_change(
     organization,
     team,
     user,
+    aws_s3_integration,
     bigquery_integration,
 ):
     """Assert PATCH cannot change the destination type — callers must delete and recreate."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -621,10 +630,12 @@ def test_put_rejects_destination_type_change(
     organization,
     team,
     user,
+    aws_s3_integration,
 ):
     """Assert PUT cannot change the destination type either — same restriction as PATCH."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -665,10 +676,13 @@ def test_put_rejects_destination_type_change(
     assert refreshed["destination"]["config"]["bucket_name"] == "my-production-s3-bucket"
 
 
-def test_can_patch_hogql_query(client: HttpClient, temporal, encryption_codec, organization, team, user):
+def test_can_patch_hogql_query(
+    client: HttpClient, temporal, encryption_codec, organization, team, user, aws_s3_integration
+):
     """Test we can patch a schema with a HogQL query."""
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",
@@ -755,9 +769,12 @@ def test_can_patch_hogql_query(client: HttpClient, temporal, encryption_codec, o
     }
 
 
-def test_patch_returns_error_on_unsupported_hogql_query(client: HttpClient, temporal, organization, team, user):
+def test_patch_returns_error_on_unsupported_hogql_query(
+    client: HttpClient, temporal, organization, team, user, aws_s3_integration
+):
     destination_data = {
         "type": "AwsS3",
+        "integration": aws_s3_integration.id,
         "config": {
             "bucket_name": "my-production-s3-bucket",
             "region": "us-east-1",

--- a/products/batch_exports/backend/tests/api/test_update_s3.py
+++ b/products/batch_exports/backend/tests/api/test_update_s3.py
@@ -6,7 +6,7 @@ from rest_framework import status
 
 from posthog.models.integration import Integration
 
-from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES, BatchExportDestination
+from products.batch_exports.backend.models.batch_export import BatchExportDestination
 from products.batch_exports.backend.tests.api.fixtures import create_batch_export as create_batch_export_orm
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok, patch_batch_export
 
@@ -34,38 +34,6 @@ def _assert_empty_inputs_rejected(client: HttpClient, team_id: int, batch_export
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json()["detail"] == "The following inputs are empty: ['aws_access_key_id', 'aws_secret_access_key']"
-
-
-@pytest.mark.parametrize("destination_type", sorted(S3_CREATABLE_TYPES))
-def test_updating_s3_family_batch_export_validates_empty_inputs(
-    client: HttpClient, temporal, organization, team, user, destination_type
-):
-    """Empty required string inputs are rejected when patching every creatable S3-family destination."""
-    initial_config = {
-        "bucket_name": "my-s3-bucket",
-        "region": "us-east-1",
-        "prefix": "events/",
-        "aws_access_key_id": "abc123",
-        "aws_secret_access_key": "secret",
-        "file_format": "JSONLines",
-        "compression": "gzip",
-    }
-    if destination_type == "S3Compatible":
-        # S3Compatible additionally requires `endpoint_url` to be present.
-        initial_config["endpoint_url"] = "https://localhost:9000"
-
-    client.force_login(user)
-    batch_export = create_batch_export_ok(
-        client,
-        team.pk,
-        {
-            "name": "my-s3-bucket",
-            "destination": {"type": destination_type, "config": initial_config},
-            "interval": "hour",
-        },
-    )
-
-    _assert_empty_inputs_rejected(client, team.pk, batch_export["id"], destination_type)
 
 
 def test_updating_legacy_s3_batch_export_validates_empty_inputs(client: HttpClient, temporal, organization, team, user):

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -377,7 +377,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.
+     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.
      * @nullable
      */
     integration_id?: number | null
@@ -1274,8 +1274,8 @@ export const AwsS3DestinationRequestApiType = {
  */
 export interface AwsS3DestinationRequestApi {
     type: AwsS3DestinationRequestApiType
-    /** ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
-    integration_id?: number
+    /** ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+    integration_id: number
     config: AwsS3DestinationConfigApi
 }
 
@@ -1291,8 +1291,8 @@ export const S3CompatibleDestinationRequestApiType = {
  */
 export interface S3CompatibleDestinationRequestApi {
     type: S3CompatibleDestinationRequestApiType
-    /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
-    integration_id?: number
+    /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+    integration_id: number
     config: S3CompatibleDestinationConfigApi
 }
 

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -186,9 +186,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         type: zod.enum(['AwsS3']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -243,9 +242,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         type: zod.enum(['S3Compatible']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -790,9 +788,8 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['AwsS3']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -847,9 +844,8 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['S3Compatible']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1149,9 +1145,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['AwsS3']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1206,9 +1201,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['S3Compatible']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -1616,7 +1610,7 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
@@ -1972,7 +1966,7 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
@@ -2319,7 +2313,7 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
@@ -2679,7 +2673,7 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(

--- a/products/batch_exports/mcp/tools.yaml
+++ b/products/batch_exports/mcp/tools.yaml
@@ -24,8 +24,8 @@ tools:
             BigQuery, Postgres, AwsS3, S3Compatible and Snowflake destinations. All of those except Snowflake require a
             team-scoped Integration for credentials (use integrations-list to find one). Other destination types are
             permitted by the API but typically must be created via the PostHog UI because their credentials are stored
-            in the destination config. Always specify the model field (events, persons, or sessions) —
-            omitting it defaults to events but the field should be set explicitly.
+            in the destination config. Always specify the model field (events, persons, or sessions) — omitting it
+            defaults to events but the field should be set explicitly.
         exclude_params:
             - id
             - team_id

--- a/products/batch_exports/mcp/tools.yaml
+++ b/products/batch_exports/mcp/tools.yaml
@@ -20,10 +20,11 @@ tools:
             idempotent: false
         title: Create batch export
         description: >
-            Create a new batch export. Typed destination config schemas are available for Databricks and AzureBlob
-            destinations — both require a team-scoped Integration (use integrations-list to find one). Other destination
-            types are permitted by the API but typically must be created via the PostHog UI because their credentials
-            are stored in the destination config. Always specify the model field (events, persons, or sessions) —
+            Create a new batch export. Typed destination config schemas are available for Databricks, AzureBlob,
+            BigQuery, Postgres, AwsS3, S3Compatible and Snowflake destinations. All of those except Snowflake require a
+            team-scoped Integration for credentials (use integrations-list to find one). Other destination types are
+            permitted by the API but typically must be created via the PostHog UI because their credentials are stored
+            in the destination config. Always specify the model field (events, persons, or sessions) —
             omitting it defaults to events but the field should be set explicitly.
         exclude_params:
             - id

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -822,7 +822,7 @@
         }
     },
     "batch-export-create": {
-        "description": "Create a new batch export. Typed destination config schemas are available for Databricks and AzureBlob destinations — both require a team-scoped Integration (use integrations-list to find one). Other destination types are permitted by the API but typically must be created via the PostHog UI because their credentials are stored in the destination config. Always specify the model field (events, persons, or sessions) — omitting it defaults to events but the field should be set explicitly.",
+        "description": "Create a new batch export. Typed destination config schemas are available for Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible and Snowflake destinations. All of those except Snowflake require a team-scoped Integration for credentials (use integrations-list to find one). Other destination types are permitted by the API but typically must be created via the PostHog UI because their credentials are stored in the destination config. Always specify the model field (events, persons, or sessions) — omitting it defaults to events but the field should be set explicitly.",
         "category": "Data pipelines",
         "feature": "batch_exports",
         "summary": "Create batch export",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -837,7 +837,7 @@
         }
     },
     "batch-export-create": {
-        "description": "Create a new batch export. Typed destination config schemas are available for Databricks and AzureBlob destinations — both require a team-scoped Integration (use integrations-list to find one). Other destination types are permitted by the API but typically must be created via the PostHog UI because their credentials are stored in the destination config. Always specify the model field (events, persons, or sessions) — omitting it defaults to events but the field should be set explicitly.",
+        "description": "Create a new batch export. Typed destination config schemas are available for Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible and Snowflake destinations. All of those except Snowflake require a team-scoped Integration for credentials (use integrations-list to find one). Other destination types are permitted by the API but typically must be created via the PostHog UI because their credentials are stored in the destination config. Always specify the model field (events, persons, or sessions) — omitting it defaults to events but the field should be set explicitly.",
         "category": "Data pipelines",
         "feature": "batch_exports",
         "summary": "Create batch export",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9869,8 +9869,8 @@ export namespace Schemas {
      */
     export interface AwsS3DestinationRequest {
       type: AwsS3DestinationRequestType;
-      /** ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
-      integration_id?: number;
+      /** ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+      integration_id: number;
       config: AwsS3DestinationConfig;
     }
 
@@ -10722,7 +10722,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3, S3Compatible and Snowflake (inline credentials remain supported); unused for other types.
+         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, Postgres, AwsS3, and S3Compatible destinations; optional for Snowflake (inline credentials remain supported); unused for other types.
          * @nullable
          */
       integration_id?: number | null;
@@ -11686,8 +11686,8 @@ export namespace Schemas {
      */
     export interface S3CompatibleDestinationRequest {
       type: S3CompatibleDestinationRequestType;
-      /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
-      integration_id?: number;
+      /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one. */
+      integration_id: number;
       config: S3CompatibleDestinationConfig;
     }
 

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -202,9 +202,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         type: zod.enum(['AwsS3']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -258,9 +257,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                         type: zod.enum(['S3Compatible']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -562,9 +560,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['AwsS3']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({
@@ -618,9 +615,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                         type: zod.enum(['S3Compatible']),
                         integration_id: zod
                             .number()
-                            .optional()
                             .describe(
-                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.'
                             ),
                         config: zod
                             .object({

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -265,7 +265,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -273,7 +273,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type", "config"],
+                    "required": ["type", "integration_id", "config"],
                     "type": "object"
                 },
                 {
@@ -334,7 +334,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -342,7 +342,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type", "config"],
+                    "required": ["type", "integration_id", "config"],
                     "type": "object"
                 },
                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -264,7 +264,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -272,7 +272,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type", "config"],
+                    "required": ["type", "integration_id", "config"],
                     "type": "object"
                 },
                 {
@@ -333,7 +333,7 @@
                             "type": "object"
                         },
                         "integration_id": {
-                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Required when creating a batch export. Use the integrations-list MCP tool to find one.",
                             "type": "number"
                         },
                         "type": {
@@ -341,7 +341,7 @@
                             "type": "string"
                         }
                     },
-                    "required": ["type", "config"],
+                    "required": ["type", "integration_id", "config"],
                     "type": "object"
                 },
                 {


### PR DESCRIPTION
## Problem

S3 batch exports moved to the Integration model; until now we still support creating exports without an integration but we now want to enforce this

## Changes

- New `AwsS3` and `S3Compatible` destinations require a team-scoped Integration.
- Exports that predate integrations keep their inline credentials and stay editable. Though, in practice these are being migrated to use integrations, and so will be phased out very soon.
- Once we totally remove the 'S3' destination, we can enforce integrations everywhere for S3; this will be done in a follow-up PR.
- Most of the changes here are related to tests: a lot needed to be updated to use Integrations now that these are required for S3.


## How did you test this code?

Claude ran the the batch exports API suite: 266 passed, 67 skipped.

## Automatic notifications

- [x] Publish to changelog?

Worth mentioning that all new S3 batch exports require an integration going forward.

## Docs update

Not at this point. We already mention integrations in the S3 docs. Once the migration is 100% complete we can update the docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this with PostHog Code (Claude Opus 4.8 and Opus 5) as the follow-up to the S3 integration data migration, which I ran across both regions first. Claude scoped the change before writing it, and I approved the scope.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`, `/create-pr`.
