### PR TITLE
fix(signals): deterministic signal document id

### DIFF
--- a/products/engineering_analytics/backend/logic/signals/detectors.py
+++ b/products/engineering_analytics/backend/logic/signals/detectors.py
@@ -60,20 +60,18 @@ DURATION_MIN_PCT_INCREASE = 0.2
 DURATION_MIN_ABS_INCREASE_SECONDS = 60.0
 
 
-# A sharded job reports as one GitHub job per shard, labeled `(i/N)`. The label is not always a
-# suffix: a product-test job renders as `Product tests (<product> (i/N), events schema <mode>)`,
-# which carries the label mid-name, so matching only at the end of the string would leave every
-# sharded product-test job splitting per shard.
+# A sharded job reports one GitHub job per shard, labeled `(i/N)`. turbo-discover.js builds the
+# label into the matrix group and ci-backend.yml wraps the group mid-name for product tests, so
+# the match cannot be anchored to the end of the string.
 SHARD_LABEL_RE = re.compile(r"\s*\(\d+/\d+\)")
 
 
 def _base_job_name(job_name: str) -> str:
     """The job name with its shard label removed.
 
-    The flaky thing is the job, not the shard that happened to hold the offending test: shards are a
-    sizing detail, and the shard count itself moves between runs, so a raw-name key splits one flaky
-    job across a signal per shard (each separately gated by min_flaky_runs) and mints fresh keys the
-    day the count changes. Falls back to the raw name if stripping would leave nothing.
+    The flaky thing is the job, not the shard, and the shard count moves between runs, so a
+    raw-name key splits one flaky job into a signal per shard, each gated separately by
+    min_flaky_runs. Falls back to the raw name if stripping would leave nothing.
     """
     return SHARD_LABEL_RE.sub("", job_name) or job_name
 

--- a/products/engineering_analytics/backend/logic/signals/detectors.py
+++ b/products/engineering_analytics/backend/logic/signals/detectors.py
@@ -63,7 +63,7 @@ DURATION_MIN_ABS_INCREASE_SECONDS = 60.0
 # A sharded job reports one GitHub job per shard, labeled `(i/N)`. turbo-discover.js builds the
 # label into the matrix group and ci-backend.yml wraps the group mid-name for product tests, so
 # the match cannot be anchored to the end of the string.
-SHARD_LABEL_RE = re.compile(r"\s*\(\d+/\d+\)")
+SHARD_LABEL_RE = re.compile(r"\s*\((\d+)/\d+\)")
 
 
 def _base_job_name(job_name: str) -> str:
@@ -124,16 +124,19 @@ def detect_flaky_checks(
 
     findings: list[CISignalFinding] = []
     for (repo_owner, repo_name, workflow_name, job_name), rows in sorted(by_job.items()):
-        flaky_count = len(rows)
+        # One run recovering on several shards is one flaky run: counting rows would let a single
+        # bad run clear min_flaky_runs on its own.
+        flaky_count = len({row.run_id for row in rows})
         if flaky_count < min_flaky_runs:
             continue
         repo = f"{repo_owner}/{repo_name}"
         # The flaky thing is the job, not any one rerun: one worked example plus a count.
         latest = max(rows, key=lambda row: row.run_id)
         # Which shard holds the offending test is still evidence, so keep it on the worked example
-        # even though it's out of the key.
-        shard_names = {row.job_name for row in rows}
-        shard_note = f", spread over {len(shard_names)} shards of the job" if len(shard_names) > 1 else ""
+        # even though it's out of the key. Distinct indices, not names: `(1/4)` and `(1/6)` are the
+        # same shard slot under a drifted count.
+        shard_indices = {match.group(1) for row in rows if (match := SHARD_LABEL_RE.search(row.job_name))}
+        shard_note = f", spread over {len(shard_indices)} shards of the job" if len(shard_indices) > 1 else ""
         latest_shard = f" (shard '{latest.job_name}')" if latest.job_name != job_name else ""
         findings.append(
             CISignalFinding(

--- a/products/engineering_analytics/backend/logic/signals/detectors.py
+++ b/products/engineering_analytics/backend/logic/signals/detectors.py
@@ -157,7 +157,9 @@ def detect_flaky_checks(
                     repo_owner=repo_owner,
                     repo_name=repo_name,
                     workflow_name=workflow_name,
-                    job_name=job_name,
+                    # The worked example's real job name, not the shard-stripped key: downstream
+                    # investigation queries filter warehouse rows on the rendered name.
+                    job_name=latest.job_name,
                     run_id=latest.run_id,
                     head_sha=latest.head_sha,
                     failed_attempt=latest.failed_attempt,

--- a/products/engineering_analytics/backend/logic/signals/detectors.py
+++ b/products/engineering_analytics/backend/logic/signals/detectors.py
@@ -4,6 +4,7 @@ They compose the ``logic/queries/`` read modules instead of authoring SQL, so de
 MCP read surface can never disagree (SPEC §7). Thresholds are overridable arguments.
 """
 
+import re
 import hashlib
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
@@ -59,8 +60,26 @@ DURATION_MIN_PCT_INCREASE = 0.2
 DURATION_MIN_ABS_INCREASE_SECONDS = 60.0
 
 
+# A sharded job reports as one GitHub job per shard, labeled `(i/N)`. The label is not always a
+# suffix: a product-test job renders as `Product tests (<product> (i/N), events schema <mode>)`,
+# which carries the label mid-name, so matching only at the end of the string would leave every
+# sharded product-test job splitting per shard.
+SHARD_LABEL_RE = re.compile(r"\s*\(\d+/\d+\)")
+
+
+def _base_job_name(job_name: str) -> str:
+    """The job name with its shard label removed.
+
+    The flaky thing is the job, not the shard that happened to hold the offending test: shards are a
+    sizing detail, and the shard count itself moves between runs, so a raw-name key splits one flaky
+    job across a signal per shard (each separately gated by min_flaky_runs) and mints fresh keys the
+    day the count changes. Falls back to the raw name if stripping would leave nothing.
+    """
+    return SHARD_LABEL_RE.sub("", job_name) or job_name
+
+
 def _job_key(row: FlakyJobRun) -> tuple[str, str, str, str]:
-    return (row.repo_owner, row.repo_name, row.workflow_name, row.job_name)
+    return (row.repo_owner, row.repo_name, row.workflow_name, _base_job_name(row.job_name))
 
 
 def _observation_week(now: datetime) -> str:
@@ -113,6 +132,11 @@ def detect_flaky_checks(
         repo = f"{repo_owner}/{repo_name}"
         # The flaky thing is the job, not any one rerun: one worked example plus a count.
         latest = max(rows, key=lambda row: row.run_id)
+        # Which shard holds the offending test is still evidence, so keep it on the worked example
+        # even though it's out of the key.
+        shard_names = {row.job_name for row in rows}
+        shard_note = f", spread over {len(shard_names)} shards of the job" if len(shard_names) > 1 else ""
+        latest_shard = f" (shard '{latest.job_name}')" if latest.job_name != job_name else ""
         findings.append(
             CISignalFinding(
                 source_type=SOURCE_TYPE_FLAKY_CHECK,
@@ -123,8 +147,9 @@ def detect_flaky_checks(
                     # Grouping titles a split report from the first line, so keep ids out of it.
                     f"CI job '{job_name}' in workflow '{workflow_name}' is flaky on {repo}\n"
                     f"It failed and then passed on a rerun of the same commit {flaky_count} time(s) in the "
-                    f"last {window_days}d. Most recent: run {latest.run_id} for commit {latest.head_sha} "
-                    f"failed on attempt {latest.failed_attempt} and passed on attempt {latest.passed_attempt}."
+                    f"last {window_days}d{shard_note}. Most recent: run {latest.run_id} for commit "
+                    f"{latest.head_sha}{latest_shard} failed on attempt {latest.failed_attempt} and passed on "
+                    f"attempt {latest.passed_attempt}."
                 ),
                 weight=SIGNAL_WEIGHT,
                 extra=EngineeringAnalyticsCIFlakyCheckSignalExtra(

--- a/products/engineering_analytics/backend/tests/test_ci_signals.py
+++ b/products/engineering_analytics/backend/tests/test_ci_signals.py
@@ -671,6 +671,48 @@ class TestCISignalDetectors(ClickhouseTestMixin, BaseTest):
         assert findings[0].extra["run_id"] == 3
         _assert_emittable(findings[0])
 
+    def test_flaky_check_groups_a_sharded_job_under_one_signal(self) -> None:
+        # A sharded job reports per shard, and the shard count moves between runs, so keying on the raw
+        # name splits one flaky job into a signal per shard name, each separately gated by
+        # min_flaky_runs, so a job that recovered 3 times reports nothing at all. These are the real
+        # rendered names: the shard label sits mid-name, so a key that only strips a trailing label
+        # still splits this job.
+        now = datetime.now(UTC).replace(tzinfo=None)
+        shards = [
+            "Product tests (warehouse-sources (1/4), events schema legacy)",
+            "Product tests (warehouse-sources (1/5), events schema legacy)",
+            "Product tests (warehouse-sources (1/6), events schema legacy)",
+        ]
+        rows = []
+        jobs = []
+        for run_id, shard in enumerate(shards, start=1):
+            rows.append(
+                _run_row(run_id, "CI", f"shaS{run_id}", "success", now - timedelta(hours=run_id), 60, run_attempt=2)
+            )
+            jobs.append(
+                _job_row(
+                    run_id * 10, run_id, shard, f"shaS{run_id}", "failure", now - timedelta(hours=run_id), run_attempt=1
+                )
+            )
+            jobs.append(
+                _job_row(
+                    run_id * 10 + 1,
+                    run_id,
+                    shard,
+                    f"shaS{run_id}",
+                    "success",
+                    now - timedelta(hours=run_id),
+                    run_attempt=2,
+                )
+            )
+        findings = detect_flaky_checks(self._curated_over_runs(rows, jobs), min_flaky_runs=3)
+        assert len(findings) == 1
+        assert findings[0].extra["job_name"] == "Product tests (warehouse-sources, events schema legacy)"
+        assert findings[0].extra["flaky_count"] == 3
+        # The shard the worked example came from is evidence, so it survives outside the key.
+        assert "Product tests (warehouse-sources (1/6), events schema legacy)" in findings[0].description
+        _assert_emittable(findings[0])
+
     @parameterized.expand(
         [
             # A `* Pass` gate fails only because a job it gates failed, so counting it emits a second

--- a/products/engineering_analytics/backend/tests/test_ci_signals.py
+++ b/products/engineering_analytics/backend/tests/test_ci_signals.py
@@ -708,7 +708,21 @@ class TestCISignalDetectors(ClickhouseTestMixin, BaseTest):
         assert findings[0].extra["flaky_count"] == 3
         # The shard the worked example came from is evidence, so it survives outside the key.
         assert "Product tests (warehouse-sources (1/6), events schema legacy)" in findings[0].description
+        # `(1/4)`..`(1/6)` are all shard slot 1, so no multi-shard spread is claimed.
+        assert "spread over" not in findings[0].description
         _assert_emittable(findings[0])
+
+    def test_flaky_check_counts_runs_not_shard_recoveries(self) -> None:
+        # One run recovering on three shards is one flaky run: counting query rows would let a
+        # single bad run clear min_flaky_runs on its own.
+        now = datetime.now(UTC).replace(tzinfo=None)
+        rows = [_run_row(1, "CI", "shaQ", "success", now - timedelta(hours=1), 60, run_attempt=2)]
+        jobs = []
+        for index in range(1, 4):
+            shard = f"Product tests (warehouse-sources ({index}/6), events schema legacy)"
+            jobs.append(_job_row(index * 10, 1, shard, "shaQ", "failure", now - timedelta(hours=1), run_attempt=1))
+            jobs.append(_job_row(index * 10 + 1, 1, shard, "shaQ", "success", now - timedelta(hours=1), run_attempt=2))
+        assert detect_flaky_checks(self._curated_over_runs(rows, jobs), min_flaky_runs=3) == []
 
     @parameterized.expand(
         [

--- a/products/engineering_analytics/backend/tests/test_ci_signals.py
+++ b/products/engineering_analytics/backend/tests/test_ci_signals.py
@@ -672,11 +672,8 @@ class TestCISignalDetectors(ClickhouseTestMixin, BaseTest):
         _assert_emittable(findings[0])
 
     def test_flaky_check_groups_a_sharded_job_under_one_signal(self) -> None:
-        # A sharded job reports per shard, and the shard count moves between runs, so keying on the raw
-        # name splits one flaky job into a signal per shard name, each separately gated by
-        # min_flaky_runs, so a job that recovered 3 times reports nothing at all. These are the real
-        # rendered names: the shard label sits mid-name, so a key that only strips a trailing label
-        # still splits this job.
+        # Real rendered names with the shard label mid-name: an end-anchored match still splits
+        # this job, and per-shard keys each miss min_flaky_runs, so 3 recoveries report nothing.
         now = datetime.now(UTC).replace(tzinfo=None)
         shards = [
             "Product tests (warehouse-sources (1/4), events schema legacy)",

--- a/products/engineering_analytics/backend/tests/test_ci_signals.py
+++ b/products/engineering_analytics/backend/tests/test_ci_signals.py
@@ -704,7 +704,10 @@ class TestCISignalDetectors(ClickhouseTestMixin, BaseTest):
             )
         findings = detect_flaky_checks(self._curated_over_runs(rows, jobs), min_flaky_runs=3)
         assert len(findings) == 1
-        assert findings[0].extra["job_name"] == "Product tests (warehouse-sources, events schema legacy)"
+        # The key and description group on the base name; extra keeps the worked example's real
+        # job name so investigation queries on the warehouse still match.
+        assert "CI job 'Product tests (warehouse-sources, events schema legacy)'" in findings[0].description
+        assert findings[0].extra["job_name"] == "Product tests (warehouse-sources (1/6), events schema legacy)"
         assert findings[0].extra["flaky_count"] == 3
         # The shard the worked example came from is evidence, so it survives outside the key.
         assert "Product tests (warehouse-sources (1/6), events schema legacy)" in findings[0].description

--- a/products/signals/backend/temporal/grouping.py
+++ b/products/signals/backend/temporal/grouping.py
@@ -1,6 +1,5 @@
 import os
 import json
-import uuid
 import asyncio
 from collections import defaultdict
 from dataclasses import asdict, dataclass
@@ -74,6 +73,7 @@ from products.signals.backend.temporal.types import (
     SignalTypeExample,
     SpecificityMetadata,
     TeamSignalGroupingInput,
+    signal_document_id,
 )
 
 logger = structlog.get_logger(__name__)
@@ -1234,7 +1234,7 @@ async def _process_signal_batch(
         emitted_signals = _par.emitted_signals
 
     for i, signal in enumerate(batch if not _use_parallel_sequential else []):
-        signal_id = str(uuid.uuid4())
+        signal_id = signal_document_id(signal)
         try:
             # Augment CH candidates with earlier-in-batch signals
             augmented_results = _augment_candidates_with_batch(

--- a/products/signals/backend/temporal/parallel_grouping.py
+++ b/products/signals/backend/temporal/parallel_grouping.py
@@ -1,4 +1,3 @@
-import uuid
 import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
@@ -37,6 +36,7 @@ from products.signals.backend.temporal.types import (
     SignalCandidate,
     SignalReportSummaryWorkflowInputs,
     SpecificityMetadata,
+    signal_document_id,
 )
 
 logger = structlog.get_logger(__name__)
@@ -326,7 +326,7 @@ async def _process_parallel_batch(
     coroutines = []
     for idx in batch_indices:
         signal = batch[idx]
-        signal_id = str(uuid.uuid4())
+        signal_id = signal_document_id(signal)
 
         # Augment CH candidates with all previously processed signals (from earlier batches)
         augmented_results = _augment_candidates_with_batch(

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -38,20 +38,16 @@ class EmitSignalInputs:
 def signal_document_id(signal: EmitSignalInputs) -> str:
     """The ClickHouse `document_id` to emit a signal under.
 
-    Every signal read groups on `document_id`, so a random id per emission made a re-processed signal
-    undedupable: a grouping-workflow replay or retry re-emitted a condition already reported and it
-    landed in the inbox a second time. Deriving the id from the signal instead makes that write
-    idempotent — the replay lands on the row it already wrote.
+    Every signal read groups on `document_id`, so a random id per emission turned a grouping-workflow
+    replay or retry into a permanent inbox duplicate. A deterministic id lands the replay on the row
+    it already wrote.
 
-    Keyed on the source record (`SignalEmissionRecord`'s unique tuple) *plus the description*, not the
-    tuple alone. Several sources reuse one `source_id` across genuinely distinct occurrences — an
-    error-tracking issue reopening twice, a log alert firing again after resolving — and those carry
-    different evidence in their text. Keying on the tuple alone would silently overwrite the earlier
-    occurrence; including the content narrows the collapse to what is actually a duplicate.
+    Keyed on `SignalEmissionRecord`'s unique tuple plus the description, because sources like log
+    alerts and error tracking reuse one `source_id` across genuinely distinct occurrences that differ
+    only in their evidence text; the tuple alone would overwrite the earlier occurrence.
 
-    Components are percent-encoded before joining so `(source_type="a|b", source_id="c")` can't
-    collide with `(source_type="a", source_id="b|c")`. A blank `source_id` identifies nothing, so
-    those keep a random id rather than leaning on the description alone.
+    Components are percent-encoded before joining so a delimiter inside one component cannot forge
+    another tuple. A blank `source_id` identifies nothing, so those keep a random id.
     """
     if not signal.source_id:
         return str(uuid.uuid4())

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -38,9 +38,9 @@ class EmitSignalInputs:
 def signal_document_id(signal: EmitSignalInputs) -> str:
     """The ClickHouse `document_id` to emit a signal under.
 
-    Every signal read groups on `document_id`, so a random id per emission turned a grouping-workflow
-    replay or retry into a permanent inbox duplicate. A deterministic id lands the replay on the row
-    it already wrote.
+    Every signal read groups on `document_id`, so a random id per emission makes each grouping-workflow
+    replay or retry a permanent inbox duplicate. A deterministic id lands a re-processed emission on
+    the row it already wrote.
 
     Keyed on `SignalEmissionRecord`'s unique tuple plus the description, because sources like log
     alerts and error tracking reuse one `source_id` across genuinely distinct occurrences that differ

--- a/products/signals/backend/temporal/types.py
+++ b/products/signals/backend/temporal/types.py
@@ -1,7 +1,9 @@
 import os
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Optional
+from urllib.parse import quote
 
 # Above this many assigned signals, an already-researched (READY/RESOLVED) report stops
 # re-researching on new signals; signals are still assigned. See assign_and_emit_signal_activity.
@@ -31,6 +33,39 @@ class EmitSignalInputs:
     # the Temporal/S3 JSON round-trip. Surfaced to the research agent as authoritative direction when
     # present; not required by any source.
     remediation: Optional[dict] = None
+
+
+def signal_document_id(signal: EmitSignalInputs) -> str:
+    """The ClickHouse `document_id` to emit a signal under.
+
+    Every signal read groups on `document_id`, so a random id per emission made a re-processed signal
+    undedupable: a grouping-workflow replay or retry re-emitted a condition already reported and it
+    landed in the inbox a second time. Deriving the id from the signal instead makes that write
+    idempotent — the replay lands on the row it already wrote.
+
+    Keyed on the source record (`SignalEmissionRecord`'s unique tuple) *plus the description*, not the
+    tuple alone. Several sources reuse one `source_id` across genuinely distinct occurrences — an
+    error-tracking issue reopening twice, a log alert firing again after resolving — and those carry
+    different evidence in their text. Keying on the tuple alone would silently overwrite the earlier
+    occurrence; including the content narrows the collapse to what is actually a duplicate.
+
+    Components are percent-encoded before joining so `(source_type="a|b", source_id="c")` can't
+    collide with `(source_type="a", source_id="b|c")`. A blank `source_id` identifies nothing, so
+    those keep a random id rather than leaning on the description alone.
+    """
+    if not signal.source_id:
+        return str(uuid.uuid4())
+    key = "|".join(
+        quote(part, safe="")
+        for part in (
+            str(signal.team_id),
+            signal.source_product,
+            signal.source_type,
+            signal.source_id,
+            signal.description,
+        )
+    )
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"posthog:signals:signal:{key}"))
 
 
 @dataclass

--- a/products/signals/backend/test/test_signal_document_id.py
+++ b/products/signals/backend/test/test_signal_document_id.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 from parameterized import parameterized
 
 from products.signals.backend.temporal.types import EmitSignalInputs, signal_document_id
 
 
-def _signal(**overrides) -> EmitSignalInputs:
+def _signal(**overrides: Any) -> EmitSignalInputs:
     return EmitSignalInputs(
         **{
             "team_id": 2,
@@ -17,11 +19,11 @@ def _signal(**overrides) -> EmitSignalInputs:
 
 
 class TestSignalDocumentId:
-    def test_reprocessing_one_signal_reuses_its_document(self):
-        # A random id here made every grouping replay a second inbox item.
+    def test_reprocessing_one_signal_reuses_its_document(self) -> None:
+        # A random id here makes every grouping replay a second inbox item.
         assert signal_document_id(_signal()) == signal_document_id(_signal())
 
-    def test_weight_alone_does_not_fork_the_document(self):
+    def test_weight_alone_does_not_fork_the_document(self) -> None:
         # Weight is scoring, not identity: the pipeline may rescore the same emission.
         assert signal_document_id(_signal(weight=1.0)) == signal_document_id(_signal())
 
@@ -36,18 +38,18 @@ class TestSignalDocumentId:
             ("description", {"description": "CI job 'warehouse-sources' recovered on a rerun again"}),
         ]
     )
-    def test_distinct_signals_get_distinct_documents(self, _name, overrides):
+    def test_distinct_signals_get_distinct_documents(self, _name: str, overrides: dict[str, Any]) -> None:
         assert signal_document_id(_signal(**overrides)) != signal_document_id(_signal())
 
     @parameterized.expand([("colon", ":"), ("pipe", "|")])
-    def test_a_delimiter_inside_a_component_cannot_forge_another_tuple(self, _name, delimiter):
+    def test_a_delimiter_inside_a_component_cannot_forge_another_tuple(self, _name: str, delimiter: str) -> None:
         # Every delimiter candidate is legal inside source_type and source_id, so a plain join lets
         # (type="a:b", id="c") and (type="a", id="b:c") share a document and overwrite each other.
         left = _signal(source_type=f"a{delimiter}b", source_id="c")
         right = _signal(source_type="a", source_id=f"b{delimiter}c")
         assert signal_document_id(left) != signal_document_id(right)
 
-    def test_blank_source_id_stays_unique_per_emission(self):
+    def test_blank_source_id_stays_unique_per_emission(self) -> None:
         # A blank source_id identifies nothing, so keying on it would collapse every such signal in a
         # team onto one document.
         assert signal_document_id(_signal(source_id="")) != signal_document_id(_signal(source_id=""))

--- a/products/signals/backend/test/test_signal_document_id.py
+++ b/products/signals/backend/test/test_signal_document_id.py
@@ -1,0 +1,55 @@
+from parameterized import parameterized
+
+from products.signals.backend.temporal.types import EmitSignalInputs, signal_document_id
+
+
+def _signal(**overrides) -> EmitSignalInputs:
+    return EmitSignalInputs(
+        **{
+            "team_id": 2,
+            "source_product": "engineering_analytics",
+            "source_type": "ci_flaky_check",
+            "source_id": "PostHog/posthog:CI:warehouse-sources:2026-07-20:flaky",
+            "description": "CI job 'warehouse-sources' in workflow 'CI' is flaky",
+            **overrides,
+        }
+    )
+
+
+class TestSignalDocumentId:
+    def test_reprocessing_one_signal_reuses_its_document(self):
+        # document_id is what every signal read groups on. A random id per emission made a replayed or
+        # retried emission a second inbox item for a condition already reported.
+        assert signal_document_id(_signal()) == signal_document_id(_signal())
+
+    def test_weight_alone_does_not_fork_the_document(self):
+        # Weight is scoring, not identity — the pipeline may rescore the same emission.
+        assert signal_document_id(_signal(weight=1.0)) == signal_document_id(_signal())
+
+    @parameterized.expand(
+        [
+            ("team", {"team_id": 3}),
+            ("source_product", {"source_product": "error_tracking"}),
+            ("source_type", {"source_type": "ci_broken_default_branch"}),
+            ("source_id", {"source_id": "PostHog/posthog:CI:storybook:2026-07-20:flaky"}),
+            # Sources like error tracking (issue reopened) and log alerts (alert re-fired) reuse one
+            # source_id across genuinely distinct occurrences, differing only in their evidence text.
+            # Keying on the tuple alone would silently overwrite the earlier occurrence.
+            ("description", {"description": "CI job 'warehouse-sources' recovered on a rerun again"}),
+        ]
+    )
+    def test_distinct_signals_get_distinct_documents(self, _name, overrides):
+        assert signal_document_id(_signal(**overrides)) != signal_document_id(_signal())
+
+    @parameterized.expand([("colon", ":"), ("pipe", "|")])
+    def test_a_delimiter_inside_a_component_cannot_forge_another_tuple(self, _name, delimiter):
+        # Every delimiter candidate is legal inside source_type and source_id, so a plain join lets
+        # (type="a:b", id="c") and (type="a", id="b:c") share a document and overwrite each other.
+        left = _signal(source_type=f"a{delimiter}b", source_id="c")
+        right = _signal(source_type="a", source_id=f"b{delimiter}c")
+        assert signal_document_id(left) != signal_document_id(right)
+
+    def test_blank_source_id_stays_unique_per_emission(self):
+        # A blank source_id identifies nothing, so keying on it would collapse every such signal in a
+        # team onto one document.
+        assert signal_document_id(_signal(source_id="")) != signal_document_id(_signal(source_id=""))

--- a/products/signals/backend/test/test_signal_document_id.py
+++ b/products/signals/backend/test/test_signal_document_id.py
@@ -18,12 +18,11 @@ def _signal(**overrides) -> EmitSignalInputs:
 
 class TestSignalDocumentId:
     def test_reprocessing_one_signal_reuses_its_document(self):
-        # document_id is what every signal read groups on. A random id per emission made a replayed or
-        # retried emission a second inbox item for a condition already reported.
+        # A random id here made every grouping replay a second inbox item.
         assert signal_document_id(_signal()) == signal_document_id(_signal())
 
     def test_weight_alone_does_not_fork_the_document(self):
-        # Weight is scoring, not identity — the pipeline may rescore the same emission.
+        # Weight is scoring, not identity: the pipeline may rescore the same emission.
         assert signal_document_id(_signal(weight=1.0)) == signal_document_id(_signal())
 
     @parameterized.expand(
@@ -32,9 +31,8 @@ class TestSignalDocumentId:
             ("source_product", {"source_product": "error_tracking"}),
             ("source_type", {"source_type": "ci_broken_default_branch"}),
             ("source_id", {"source_id": "PostHog/posthog:CI:storybook:2026-07-20:flaky"}),
-            # Sources like error tracking (issue reopened) and log alerts (alert re-fired) reuse one
-            # source_id across genuinely distinct occurrences, differing only in their evidence text.
-            # Keying on the tuple alone would silently overwrite the earlier occurrence.
+            # Error tracking and log alerts reuse one source_id across distinct occurrences that
+            # differ only in their evidence text, so the description must fork the document.
             ("description", {"description": "CI job 'warehouse-sources' recovered on a rerun again"}),
         ]
     )


### PR DESCRIPTION
## Problem

- Grouping mints `uuid.uuid4()` per emission and writes it as the ClickHouse `document_id`.
- Every signal read groups on `document_id`, so a replayed emission lands as a permanent inbox duplicate.
- Last 30 days: 489 signals stored under 2+ documents with identical content, 531 extra inbox items, across 11 source types (19 `ci_flaky_check`).
- 2026-07-28 incident: 3 `ci_flaky_check` source_ids each emitted exactly once (emission telemetry `started=1, emitted=1`), each stored under 2 `document_id`s.

## Changes

- `signal_document_id()` derives a uuid5 from (team, source_product, source_type, source_id, description). Both grouping paths use it.
- The description is part of the key: log alerts (`{alert_id}:{action}`) and error tracking (`issue_id`) reuse one `source_id` across real occurrences.
- A blank `source_id` keeps a random id.

> [!WARNING]
> A five-lens review found three interactions that need a signals-team design call before merge:
> - Grouping's OPTIMISTIC wait passes no `inserted_at` (grouping.py:1388), so a reused id can hit a stale recently-seen entry and skip the wait. Interacts with #68885.
> - A byte-identical recurrence reuses the old document's id, and the `argMax` read re-points its `report_id`, stranding the prior report's evidence. Interacts with #71981. The deleted-report path (grouping.py:717) can retract a live document the same way.
> - Two identical signals in one batch share one id, making the ClickHouse wait's `count(DISTINCT document_id)` unsatisfiable, which stalls up to 1h on a store miss.
> `workflow.uuid4()` is the narrower alternative: it fixes replay non-determinism but not buffer re-delivery. The deterministic key fixes both, at the cost of the interactions above.

## How did you test this code?

- `test_signal_document_id.py`: 10 passed. Covers replay reuse, per-component forking, delimiter forgery, blank `source_id`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude) extracted the signals-owned slice of #74419; the devex detector fix sits below in #78417.
- Duplicate counts come from grouping signal documents on (source_id, content hash) and counting distinct `document_id`.
- Skills: /stacking-prs, /writing-pr-descriptions, /simplify, /code-review, /writing-code-comments.
