### PR TITLE
fix(errors): mark ambiguous-identifier query errors user-safe

### DIFF
--- a/posthog/errors.py
+++ b/posthog/errors.py
@@ -519,9 +519,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     203: ErrorCodeMeta("NO_FREE_CONNECTION", category=QueryErrorCategory.RATE_LIMITED),
     204: ErrorCodeMeta("CANNOT_FSYNC"),
     206: ErrorCodeMeta("ALIAS_REQUIRED"),
-    207: ErrorCodeMeta(
-        "AMBIGUOUS_IDENTIFIER", category=QueryErrorCategory.USER_ERROR
-    ),  # identifier resolves to multiple columns or aliases
+    207: ErrorCodeMeta("AMBIGUOUS_IDENTIFIER", user_safe=True),  # identifier resolves to multiple columns or aliases
     208: ErrorCodeMeta("EMPTY_NESTED_TABLE"),
     209: ErrorCodeMeta("SOCKET_TIMEOUT"),
     210: ErrorCodeMeta("NETWORK_ERROR"),
@@ -637,7 +635,7 @@ CLICKHOUSE_ERROR_CODE_LOOKUP: dict[int, ErrorCodeMeta] = {
     346: ErrorCodeMeta("CANNOT_CONVERT_CHARSET"),
     347: ErrorCodeMeta("CANNOT_LOAD_CONFIG"),
     349: ErrorCodeMeta("CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN", user_safe=True),
-    352: ErrorCodeMeta("AMBIGUOUS_COLUMN_NAME", category=QueryErrorCategory.USER_ERROR),
+    352: ErrorCodeMeta("AMBIGUOUS_COLUMN_NAME", user_safe=True),
     353: ErrorCodeMeta("INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE", user_safe=True),
     354: ErrorCodeMeta("ZLIB_INFLATE_FAILED"),
     355: ErrorCodeMeta("ZLIB_DEFLATE_FAILED"),

--- a/posthog/test/test_errors.py
+++ b/posthog/test/test_errors.py
@@ -1,0 +1,37 @@
+from clickhouse_driver.errors import ServerException
+from parameterized import parameterized
+
+from posthog.errors import (
+    ExposedCHQueryError,
+    InternalCHQueryError,
+    QueryErrorCategory,
+    look_up_clickhouse_error_code_meta,
+    wrap_clickhouse_query_error,
+)
+
+
+class TestWrapClickhouseQueryError:
+    @parameterized.expand(
+        [
+            # Ambiguous-identifier query errors are the user's malformed HogQL, not a server fault,
+            # so they must wrap as ExposedCHQueryError and stay out of error tracking.
+            (207, "AMBIGUOUS_IDENTIFIER"),
+            (352, "AMBIGUOUS_COLUMN_NAME"),
+        ]
+    )
+    def test_ambiguous_identifier_codes_wrap_as_exposed_error(self, code: int, name: str) -> None:
+        err = ServerException(f"DB::Exception: {name}", code=code)
+
+        wrapped = wrap_clickhouse_query_error(err)
+
+        assert isinstance(wrapped, ExposedCHQueryError)
+        assert look_up_clickhouse_error_code_meta(err).get_category() == QueryErrorCategory.USER_ERROR
+
+    def test_unmapped_internal_code_stays_internal(self) -> None:
+        # NETWORK_ERROR (210) is a genuine server-side fault and must not be exposed.
+        err = ServerException("DB::Exception: NETWORK_ERROR", code=210)
+
+        wrapped = wrap_clickhouse_query_error(err)
+
+        assert isinstance(wrapped, InternalCHQueryError)
+        assert not isinstance(wrapped, ExposedCHQueryError)


### PR DESCRIPTION
## Problem

- ClickHouse returns code 207 `AMBIGUOUS_IDENTIFIER` or 352 `AMBIGUOUS_COLUMN_NAME` when an identifier in a user's HogQL query resolves in multiple scopes.
- Both codes have `user_safe=False` in `posthog/errors.py`, so `wrap_clickhouse_query_error` wraps them as `InternalCHQueryError`.
- The user gets a generic 500, and the async query path reports the error to error tracking as a PostHog exception.
- These are the user's own malformed queries, and they create recurring triage noise.

## Changes

- Set `user_safe=True` on codes 207 and 352, so they wrap as `ExposedCHQueryError` and return a 400 with the ClickHouse message.
- Dropped the explicit `USER_ERROR` category: `get_category()` already returns `USER_ERROR` when `user_safe` is truthy.
- Revives #68473 (closed as stale); the original commit is cherry-picked and applies cleanly to current master.

> [!NOTE]
> Exposure review: sibling codes 47 `UNKNOWN_IDENTIFIER` and 60 `UNKNOWN_TABLE` are already `user_safe=True` on the same analyzer path, with the same message shape. `ExposedCHQueryError.__str__` strips the `DB::Exception` preamble and stack trace. This adds no new class of disclosure.

## How did you test this code?

- Added `posthog/test/test_errors.py`: codes 207 and 352 wrap as `ExposedCHQueryError` with category `USER_ERROR`. No existing test covered `wrap_clickhouse_query_error` for these codes, which previously wrapped as `InternalCHQueryError`.
- A negative control asserts code 210 `NETWORK_ERROR` still wraps as `InternalCHQueryError`, guarding against over-broad exposure.
- Ran the new tests locally (3 passed), plus ruff and repo-wide mypy.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Thiago asked to revive the agent-authored #68473 after a safety review; I (Claude Code) traced the exposure path (`wrap_clickhouse_query_error`, `execute_async`, the API catch sites) and confirmed the change matches the established pattern for the ~26 codes already marked `user_safe`.
- The original commit from #68473 is cherry-picked unchanged; I re-verified its tests and claims against current master.
- Skills invoked: /writing-tests, /writing-pr-descriptions.
