### PR TITLE
fix(data-imports): promote numeric types when unifying v3 batch schemas

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/test_writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/test_writer.py
@@ -1,5 +1,6 @@
 import json
 import errno
+from datetime import UTC, datetime
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -7,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pyarrow as pa
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer import (
+    S3BatchWriter,
     _write_parquet_to_s3,
     build_schema_dict,
 )
@@ -75,3 +77,32 @@ class TestBuildSchemaDict:
         schema = pa.schema([pa.field("id", pa.int64())])
 
         assert build_schema_dict(schema)["fields"][0]["metadata"] is None
+
+
+class TestSchemaAccumulation:
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer._write_parquet_to_s3"
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer.ensure_bucket")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer.get_s3_client")
+    def test_accumulated_schema_promotes_int_to_double_across_batches(
+        self, mock_get_s3_client, _mock_ensure_bucket, _mock_write
+    ) -> None:
+        # Two batches of the same column can infer different numeric types within one run (whole
+        # values -> int64, later fractional values -> double). Unifying them must widen to double
+        # rather than raising ArrowTypeError, which would crash the whole extraction.
+        mock_get_s3_client.return_value.info.return_value = {"Size": 1}
+
+        job = MagicMock()
+        job.team_id = 1
+        job.created_at = datetime(2026, 8, 5, tzinfo=UTC)
+        job.workflow_run_id = "run-1"
+
+        writer = S3BatchWriter(MagicMock(), job, schema_id="schema-1", run_uuid="run-1")
+
+        writer.write_batch(pa.table({"consumed_quantity": pa.array([1, 2], type=pa.int64())}), 0)
+        writer.write_batch(pa.table({"consumed_quantity": pa.array([1.5, 2.5], type=pa.float64())}), 1)
+
+        schema = writer.get_schema()
+        assert schema is not None
+        assert schema.field("consumed_quantity").type == pa.float64()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
@@ -142,7 +142,10 @@ class S3BatchWriter:
         if self._schema is None:
             self._schema = pa_table.schema
         else:
-            self._schema = pa.unify_schemas([self._schema, pa_table.schema])
+            # Batches infer their own types, so one run's column can land int64 in an early batch and
+            # double in a later one (whole vs fractional values). Permissive promotion widens to the
+            # common type instead of raising ArrowTypeError; the default only unifies identical types.
+            self._schema = pa.unify_schemas([self._schema, pa_table.schema], promote_options="permissive")
 
         self._logger.debug(
             f"Batch {batch_index} written successfully",


### PR DESCRIPTION
## Problem

- A Vercel sync failed in shared v3 pipeline code with `ArrowTypeError: Unable to merge: Field consumed_quantity has incompatible types: double vs int64`.
- Error tracking: [issue 019fd29e](https://us.posthog.com/project/2/error_tracking/019fd29e-e1bf-7e93-baf5-fea020b4d7c3).
- V3 extraction infers each batch's Arrow types independently. One batch reads a numeric column as `int64` (whole values), a later batch reads it as `double` (fractional values).
- `S3BatchWriter.write_batch` accumulates the run schema with `pa.unify_schemas` in the default strict mode, which rejects that pair and crashes the whole extraction activity before any data loads.

## Changes

- Pass `promote_options="permissive"` to `pa.unify_schemas` so the merge widens `int64` and `double` to `double` instead of raising.
- The accumulated schema is descriptive metadata written to `schema.json`. The load stage casts each parquet part toward the Delta table on its own, so a widened metadata schema is correct and does not change stored data.
- Matches the existing `pa.concat_tables(..., promote_options="permissive")` in `sources/common/webhook_s3.py`.

## How did you test this code?

- Added `TestSchemaAccumulation` in `pipeline_v3/s3/test_writer.py`: two batches, `int64` then `double`, asserting the accumulated schema promotes to `double`. Without the fix it fails with the exact production `ArrowTypeError`; with the fix it passes.
- `pytest pipeline_v3/s3/test_writer.py` — 6 passed. `ruff check` and `ruff format --check` clean.
- Not run: no manual sync against a real source, no S3-backed run.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs describe this failure mode.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue by Claude Code (Opus 4.8). Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Related work on the same numeric-widening theme, for reconciliation at review time:

- [#75819](https://github.com/PostHog/posthog/pull/75819) (bot-authored, unassigned) fixes the same extraction-side crash more broadly with `unify_schemas_with_text_fallback` plus per-batch reconciliation and telemetry. This PR is the minimal, targeted fix for the reported numeric case.
- [#78201](https://github.com/PostHog/posthog/pull/78201) widens stored Delta columns at the load stage. Different code path; it runs after extraction and does not touch this writer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
