### PR TITLE
chore(ci): restore python tool cache in ci-backend

### DIFF
--- a/.depot/actions/setup-python-cached/action.yml
+++ b/.depot/actions/setup-python-cached/action.yml
@@ -1,0 +1,65 @@
+# Depot mirror of .github/actions/setup-python-cached (same pattern as .depot/actions/pnpm-install).
+# Kept byte-for-byte equivalent to canonical. actions/cache routes to Depot Cache, so the shared
+# keys do not collide.
+name: Set up Python
+description: |
+    Wraps actions/setup-python with a pre-seeded tool cache
+    (`python-toolcache-<os>-<arch>-<version>`, master-gated save) so a hit turns
+    setup-python into a filesystem lookup: no GitHub API calls, no download.
+    Same pattern as the Node tool cache in pnpm-install.
+
+inputs:
+    python-version:
+        description: 'Python version to install. Only exact x.y.z pins engage the tool cache.'
+        required: true
+    token:
+        description: |
+            GitHub token for setup-python's version-manifest lookup and download on
+            a cache miss. Pass an app token at high-fanout call sites to keep those
+            API calls off the shared per-repo GITHUB_TOKEN core bucket.
+        required: false
+        default: ${{ github.token }}
+
+runs:
+    using: composite
+    steps:
+        - name: Resolve Python version
+          id: python-version
+          shell: bash
+          # An empty version (non-exact pin) skips the tool cache steps, so
+          # setup-python falls back to resolving the version itself. Only exact
+          # x.y.z pins are cacheable: the tool-cache directory is named after
+          # the resolved version, so a range spec would never match it.
+          env:
+              PYTHON_VERSION: ${{ inputs.python-version }}
+          run: |
+              version=$(tr -d 'v[:space:]' <<< "$PYTHON_VERSION")
+              [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || version=""
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+
+        # A tool-cache hit turns setup-python into a filesystem lookup. On a miss
+        # it fetches the version manifest from api.github.com (two rate-limited
+        # API calls per job) and downloads the tarball, on every Python job,
+        # because runner images don't ship the pinned version.
+        - name: Restore Python tool cache
+          id: python-toolcache
+          if: steps.python-version.outputs.version != ''
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/Python/${{ steps.python-version.outputs.version }}
+              key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.python-version.outputs.version }}
+
+        - name: Set up Python
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+          with:
+              python-version: ${{ inputs.python-version }}
+              token: ${{ inputs.token }}
+
+        # Save only on the default branch, for the same reasons as the pnpm
+        # store save in pnpm-install.
+        - name: Save Python tool cache
+          if: github.ref == 'refs/heads/master' && steps.python-version.outputs.version != '' && steps.python-toolcache.outputs.cache-hit != 'true'
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/Python/${{ steps.python-version.outputs.version }}
+              key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.python-version.outputs.version }}

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -9,8 +9,9 @@
 #
 # Intentional deltas vs canonical (everything else is kept apples-to-apples):
 # - runs-on: depot-* labels instead of ubuntu-latest
-# - action paths: ./.depot/actions/... instead of ./.github/actions/... (pnpm-install
-#   and setup-sqlx-cli are byte-equivalent mirrors of the canonical composites)
+# - action paths: ./.depot/actions/... instead of ./.github/actions/... (pnpm-install,
+#   setup-sqlx-cli, and setup-python-cached are byte-equivalent mirrors of the canonical
+#   composites)
 # - permissions: pull-requests:read (no comment/auto-commit side effects)
 # - Stripped side effects: artifact uploads, CI report section posters (canonical
 #   additionally skips these on trunk-merge/** branches to save GITHUB_TOKEN budget;
@@ -846,7 +847,7 @@ jobs:
                     with:
                         install-command: pnpm install --frozen-lockfile --filter=@posthog/root
                   - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    uses: ./.depot/actions/setup-python-cached
                     with:
                         python-version: 3.13.13
                         token: ${{ secrets.POSTHOG_BOT_PAT }}
@@ -961,7 +962,7 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.depot/actions/setup-python-cached
               with:
                   python-version: 3.13.13
             - name: Install uv
@@ -1023,7 +1024,7 @@ jobs:
                   owner: ${{ github.repository_owner }}
                   repositories: ${{ github.event.repository.name }}
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.depot/actions/setup-python-cached
               with:
                   python-version: 3.13.13
                   token: ${{ steps.app-token.outputs.token || github.token }}
@@ -1091,7 +1092,7 @@ jobs:
                   nohup bin/ci-wait-for-docker launch --background --down \
                     </dev/null >"${RUNNER_TEMP:-/tmp}/compose-launch.log" 2>&1
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.depot/actions/setup-python-cached
               with:
                   python-version: 3.13.13
             - name: Install uv
@@ -1645,7 +1646,7 @@ jobs:
               run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
             - parallel:
                   - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    uses: ./.depot/actions/setup-python-cached
                     with:
                         python-version: ${{ matrix.python-version }}
                   - name: Install Rust

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1644,9 +1644,20 @@ jobs:
             - name: Add service hostnames to /etc/hosts
               shell: bash
               run: echo "127.0.0.1 db redis7 kafka clickhouse clickhouse-coordinator objectstorage seaweedfs temporal" | sudo tee -a /etc/hosts
+            # Tool cache steps inlined rather than the setup-python-cached composite:
+            # this job checks out the PR head ref, which cannot resolve a local
+            # action that only exists on master until the branch rebases. The
+            # restore sits before the parallel block so the tool cache is warm
+            # when setup-python starts.
+            - name: Restore Python tool cache
+              id: python-toolcache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
+                  key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
             - parallel:
                   - name: Set up Python
-                    uses: ./.depot/actions/setup-python-cached
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
                     with:
                         python-version: ${{ matrix.python-version }}
                   - name: Install Rust
@@ -1655,6 +1666,12 @@ jobs:
                     with:
                         toolchain: 1.91.1
                         components: cargo
+            - name: Save Python tool cache
+              if: github.ref == 'refs/heads/master' && steps.python-toolcache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
+                  key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
             - name: Install uv
               id: setup-uv-tests
               uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -10,8 +10,8 @@
 # Intentional deltas vs canonical (everything else is kept apples-to-apples):
 # - runs-on: depot-* labels instead of ubuntu-latest
 # - action paths: ./.depot/actions/... instead of ./.github/actions/... (pnpm-install,
-#   setup-sqlx-cli, and setup-python-cached are byte-equivalent mirrors of the canonical
-#   composites)
+#   setup-sqlx-cli, and setup-python-cached mirror the canonical composites; any
+#   deltas are documented in each mirror's header)
 # - permissions: pull-requests:read (no comment/auto-commit side effects)
 # - Stripped side effects: artifact uploads, CI report section posters (canonical
 #   additionally skips these on trunk-merge/** branches to save GITHUB_TOKEN budget;

--- a/.github/actions/setup-python-cached/action.yml
+++ b/.github/actions/setup-python-cached/action.yml
@@ -1,0 +1,62 @@
+name: Set up Python
+description: |
+    Wraps actions/setup-python with a pre-seeded tool cache
+    (`python-toolcache-<os>-<arch>-<version>`, master-gated save) so a hit turns
+    setup-python into a filesystem lookup: no GitHub API calls, no download.
+    Same pattern as the Node tool cache in pnpm-install.
+
+inputs:
+    python-version:
+        description: 'Python version to install. Only exact x.y.z pins engage the tool cache.'
+        required: true
+    token:
+        description: |
+            GitHub token for setup-python's version-manifest lookup and download on
+            a cache miss. Pass an app token at high-fanout call sites to keep those
+            API calls off the shared per-repo GITHUB_TOKEN core bucket.
+        required: false
+        default: ${{ github.token }}
+
+runs:
+    using: composite
+    steps:
+        - name: Resolve Python version
+          id: python-version
+          shell: bash
+          # An empty version (non-exact pin) skips the tool cache steps, so
+          # setup-python falls back to resolving the version itself. Only exact
+          # x.y.z pins are cacheable: the tool-cache directory is named after
+          # the resolved version, so a range spec would never match it.
+          env:
+              PYTHON_VERSION: ${{ inputs.python-version }}
+          run: |
+              version=$(tr -d 'v[:space:]' <<< "$PYTHON_VERSION")
+              [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || version=""
+              echo "version=$version" >> "$GITHUB_OUTPUT"
+
+        # A tool-cache hit turns setup-python into a filesystem lookup. On a miss
+        # it fetches the version manifest from api.github.com (two rate-limited
+        # API calls per job) and downloads the tarball, on every Python job,
+        # because runner images don't ship the pinned version.
+        - name: Restore Python tool cache
+          id: python-toolcache
+          if: steps.python-version.outputs.version != ''
+          uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/Python/${{ steps.python-version.outputs.version }}
+              key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.python-version.outputs.version }}
+
+        - name: Set up Python
+          uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+          with:
+              python-version: ${{ inputs.python-version }}
+              token: ${{ inputs.token }}
+
+        # Save only on the default branch, for the same reasons as the pnpm
+        # store save in pnpm-install.
+        - name: Save Python tool cache
+          if: github.ref == 'refs/heads/master' && steps.python-version.outputs.version != '' && steps.python-toolcache.outputs.cache-hit != 'true'
+          uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          with:
+              path: ${{ runner.tool_cache }}/Python/${{ steps.python-version.outputs.version }}
+              key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ steps.python-version.outputs.version }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2026,11 +2026,28 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}
                   skip-token-revoke: true
 
+            # Tool cache steps inlined rather than the setup-python-cached composite:
+            # this job checks out the PR head ref, which cannot resolve a local
+            # action that only exists on master until the branch rebases.
+            - name: Restore Python tool cache
+              id: python-toolcache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ runner.tool_cache }}/Python/3.13.13
+                  key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-3.13.13
+
             - name: Set up Python
-              uses: ./.github/actions/setup-python-cached
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
+
+            - name: Save Python tool cache
+              if: github.ref == 'refs/heads/master' && steps.python-toolcache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ runner.tool_cache }}/Python/3.13.13
+                  key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-3.13.13
 
             - name: Install uv
               id: setup-uv
@@ -2588,9 +2605,21 @@ jobs:
                   private-key: ${{ secrets.GH_APP_POSTHOG_DEVEX_GENERAL_PRIVATE_KEY }}
                   skip-token-revoke: true
 
+            # Tool cache steps inlined rather than the setup-python-cached composite:
+            # this job checks out the PR head ref, which cannot resolve a local
+            # action that only exists on master until the branch rebases. The
+            # restore sits before the parallel block so the tool cache is warm
+            # when setup-python starts.
+            - name: Restore Python tool cache
+              id: python-toolcache
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
+                  key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
+
             - parallel:
                   - name: Set up Python
-                    uses: ./.github/actions/setup-python-cached
+                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
                     with:
                         python-version: ${{ matrix.python-version }}
                         token: ${{ steps.setup-gh-token.outputs.token || github.token }}
@@ -2601,6 +2630,13 @@ jobs:
                     with:
                         toolchain: 1.91.1
                         components: cargo
+
+            - name: Save Python tool cache
+              if: github.ref == 'refs/heads/master' && steps.python-toolcache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: ${{ runner.tool_cache }}/Python/${{ matrix.python-version }}
+                  key: python-toolcache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
 
             - name: Install uv
               id: setup-uv-tests

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -849,7 +849,7 @@ jobs:
                         token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
                   - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    uses: ./.github/actions/setup-python-cached
                     with:
                         python-version: 3.13.13
                         token: ${{ steps.setup-gh-token.outputs.token || github.token }}
@@ -1152,7 +1152,7 @@ jobs:
                   skip-token-revoke: true
 
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.github/actions/setup-python-cached
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
@@ -1285,7 +1285,7 @@ jobs:
                   repositories: ${{ github.event.repository.name }}
 
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.github/actions/setup-python-cached
               with:
                   python-version: 3.13.13
                   # Reuse the app token already minted above instead of a second mint.
@@ -1383,7 +1383,7 @@ jobs:
                   skip-token-revoke: true
 
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.github/actions/setup-python-cached
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
@@ -2027,7 +2027,7 @@ jobs:
                   skip-token-revoke: true
 
             - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              uses: ./.github/actions/setup-python-cached
               with:
                   python-version: 3.13.13
                   token: ${{ steps.setup-gh-token.outputs.token || github.token }}
@@ -2590,7 +2590,7 @@ jobs:
 
             - parallel:
                   - name: Set up Python
-                    uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+                    uses: ./.github/actions/setup-python-cached
                     with:
                         python-version: ${{ matrix.python-version }}
                         token: ${{ steps.setup-gh-token.outputs.token || github.token }}

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1284,8 +1284,11 @@ jobs:
                   owner: ${{ github.repository_owner }}
                   repositories: ${{ github.event.repository.name }}
 
+            # Plain setup-python: this PR-only job runs on ubuntu-latest, whose cache
+            # store no master job ever saves the python tool cache to, so the
+            # setup-python-cached restore would miss on every run.
             - name: Set up Python
-              uses: ./.github/actions/setup-python-cached
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.13.13
                   # Reuse the app token already minted above instead of a second mint.


### PR DESCRIPTION
## Problem

- #77740 one layer down does this for Node; Python misses the same way: every job logs `Version 3.13.13 was not found in the local cache`, then two rate-limited api.github.com calls, a tarball download, and a pip upgrade from PyPI.
- ci-backend is the hottest setup-python surface: 71 of 88 jobs on a full matrix run it.

## Changes

- New `setup-python-cached` composite: restore `$RUNNER_TOOL_CACHE/Python/<version>` (key: os/arch/version) before setup-python, master-gated save. Same steps as the Node layer.
- 7 call sites use the composite. The `django` and `check-openapi-types` jobs get the same steps inlined: they check out the PR head ref, which cannot resolve a local action that only exists on master until the branch rebases.
- `validate-product-yamls` keeps plain setup-python: it is the only ubuntu-latest site and runs only on PRs, so its cache store never gets a master save and a restore would miss forever.
- Per-site token wiring unchanged.
- Non-exact version specs skip the cache steps and keep today's behavior.
- Review note: on Depot runners the entry lands in Depot Cache, same trust level as the existing pnpm store cache there (exact-match key, no `restore-keys`, so strictly narrower than the pnpm prefix match). The master-only save gate is workflow text, so on Depot Cache it is a convention, not a boundary.

### Per-job effect

| | today (miss, every job) | on a hit (after first master save) |
|---|---|---|
| setup-python step | ~14s (live master Django job) | ~1-3s est. (entry unpopulated until merge) |
| api.github.com calls | 2 | 0 |
| downloads | ~40 MB python tarball + pip upgrade from PyPI | none |
| cache entry | n/a | 97 MB, one per os/arch/version |
| Depot Cache storage | n/a | ~0.1 GB, ~$0.02/month at $0.20/GB-month (GitHub store free) |

### Evidence

| claim | verification |
|---|---|
| a hit makes zero network calls | setup-python v6.2.0 source: `tc.find('Python', ...)` runs before any manifest fetch; offline container restore of the saved entry logs `Successfully set up CPython (3.13.13)` and the restored python and pip work |
| a miss makes 2 api.github.com calls plus PyPI traffic | CONNECT-logging proxy around the pinned dist in a clean ubuntu 24.04 container: 2x `api.github.com`, tarball from release assets, pip upgrade via pypi.org and files.pythonhosted.org |
| a restore needs no path fixup | actions/python-versions builders bake the `/opt/hostedtoolcache` prefix at build time, and setup.sh writes only inside `Python/<version>/`, including the `x64.complete` marker |
| every job misses today | [master Django tests job](https://github.com/PostHog/posthog/actions/runs/30962627994/job/92170121986): `Version 3.13.13 was not found in the local cache` |
| env exports still run on hits | setup-python exports `pythonLocation`, PATH, and `LD_LIBRARY_PATH` after the tool-cache find, on hit and miss alike |
| unrebased PRs keep working | per-job audit: every remaining composite site checks out the default merge ref (which always contains the new action) before the composite runs; the two head-ref jobs carry the steps inline, so their workflow text is self-contained |
| the inline steps run clean on real runners | [Validate OpenAPI types job on this PR](https://github.com/PostHog/posthog/actions/runs/31031308114/job/92392580687): restore success on miss, setup-python success, save skipped on the PR ref |
| three independent adversarial reviews found no behavior-breaking bug | diff red-team, Actions-semantics red-team, and history/conventions lenses; their two real findings (the dead ubuntu-latest call site, the mirror header wording) are fixed in this PR |

## How did you test this code?

- `bin/hogli lint:workflows` 7/7 across 124 workflows; no new actionlint findings vs base.
- Container run of the pinned setup-python v6.2.0: a logging proxy shows the miss makes exactly 2 api.github.com calls; the saved `Python/3.13.13` entry restored into a network-disabled container sets up successfully, with working `python` and `pip`.
- Not runnable end to end locally: the first master run after merge populates the cache; until then restores miss and behavior is unchanged.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5). Skills: `/stacking-prs`, `/authoring-ci-workflows`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Chose one shared composite over inline cache steps at 11 call sites; exact-version key with no `restore-keys`.
- Verified from the actions/python-versions builders that installs write only inside the cached directory and bake the `/opt/hostedtoolcache` prefix, so a restore needs no path fixup.

