### PR TITLE
chore(agents): debug CI failures that aren't test failures

### DIFF
--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -5,7 +5,7 @@ description: >
   and answers broad CI-health questions ("is CI red?", "is master green today?",
   "what's broken right now?"). Use when the user asks why CI is red, asks for the
   current CI or master status, or mentions a failing check, GitHub Actions run,
-  Depot runner, workflow, job, shard, flaky test, lint failure, typecheck
+  Depot runner, workflow, job, shard, merge queue kick, flaky test, lint failure, typecheck
   failure, snapshot diff, migration check, generated types drift, or skills
   build failure. Start with the `hogli ci:insights` digest (cross-run CI history
   from engineering analytics), then guides read-only inspection, failure
@@ -97,8 +97,9 @@ Caveats to carry into whatever you report:
 
 - Failure grouping is pytest-only. Jest, Playwright, and cargo failures appear
   only in the digest's grouped master-failures section, never as a row with a ref.
-- Every count is absolute, never a rate. Passing runs are not in this data, so
-  there is no denominator and no failure rate to quote.
+- Every count is absolute, never a rate. Passing runs are not in the test-level
+  data, so there is no denominator to quote. Job conclusions do record greens;
+  the base-rate section below is how to get a real rate from them.
 - A run's conclusion can lag until GitHub's `workflow_run` webhook settles it, so
   during a live incident confirm a specific run against `gh`.
 
@@ -120,15 +121,24 @@ Determine the target in this order:
 
 **A PR kicked from the merge queue is the exception: its own checks are the
 wrong target.** Trunk tests each queued PR on a `trunk-merge/pr-<n>/<uuid>`
-branch holding master plus every PR ahead of it in the queue. So:
+branch holding master plus every PR queued ahead of it whose impacted targets
+overlap its own. The lane script over-reports targets on purpose, so in
+practice that is most of the queue. So:
 
 - The failing run is on that branch, never on the PR's head SHA. Take it from
   the `Trunk Merge Queue` check run (`/merging-prs` step 4), not `gh pr checks`.
-- The PR's own checks can be green with the failing job **skipped**. Path
-  filters see only that PR's diff; the queue branch's diff is much wider. A
-  docs-only PR can be kicked by a job its own CI never ran.
+  The branch is ephemeral; the run and its logs stay on GitHub, and the
+  warehouse keeps its jobs under that `head_branch` (query 8 in the
+  `investigating-ci-failures` references).
+- The PR's own checks can be green with the failing job **skipped** or
+  narrowed. On the PR, path filters see only that diff and the Django suite runs
+  a selected subset; on the queue branch the diff is every carried PR's and the
+  full matrices always run. A docs-only PR can be kicked by a job its own CI
+  never ran.
 - The branch names one PR but carries many. A failure on it is not evidence
-  against that PR until you find the change that caused it.
+  against that PR until you find the change that caused it; the branch's other
+  merge commits are the first suspects.
+- In the digest this is the `blocking_merge_queue` state.
 
 Inspect read-only:
 
@@ -169,7 +179,8 @@ is a shortcut past log scanning: give it the run URL
 structured failing-test details — names, error messages, stdout/stderr — from
 the results CI uploaded to Trunk Flaky Tests, with quarantined known-flaky
 tests already filtered out. It only covers what ran and uploaded: for jobs
-that died before tests (build, setup, lint), stay with `gh run view --log`.
+that died before tests (build, setup, lint), use
+`engineering-analytics-run-failure-logs` or `gh run view --log`.
 Authenticate once via `/mcp` → `trunk` (browser OAuth); headless environments
 instead add an `Authorization: Bearer` header with a `TRUNK_API_TOKEN` org
 token to the server entry in `.mcp.json`. To dig into one test's flakiness
@@ -202,8 +213,9 @@ generic Playwright test failure.
 one run. A job that dies before its tests run leaves no test-level evidence: no
 `FAILED` line, so no fingerprint and no span, so it never appears as a row in
 `broken_tests` or in the flaky-tests tool. It is still visible as a job
-conclusion, which is what the digest's master-failures section and
-`engineering-analytics-run-failure-logs` read. Start there, not from a test.
+conclusion, which is what the digest's master-failures section groups by, and
+`engineering-analytics-run-failure-logs` still returns its failing lines because
+it reads by run, not by test. Start there, not from a test.
 
 Unlike the span-derived test reads, this one can give you a real rate: the
 warehouse records every job attempt, greens included, so the denominator is
@@ -236,7 +248,7 @@ is unclear, read `.agents/skills/hogli/SKILL.md` and `hogli <command> --help`.
 | snapshot / visual   | Run the specific Playwright or Storybook workflow; read `playwright-test` if needed. |
 | migration / schema  | `hogli migrations:check`; run migrations only if the user agrees.                    |
 | codegen drift       | `hogli build:openapi`.                                                               |
-| infra / runner      | No local repro. Report and stop.                                                     |
+| infra / runner      | No local repro. Get the base rate (above), report, and stop.                         |
 | environment / setup | Reproduce the setup step only if cheap and relevant to changed files.                |
 | skills build        | `hogli lint:skills`; if that passes, `hogli build:skills`.                           |
 
@@ -277,4 +289,5 @@ Next action (needs your approval):
 ```
 
 If the classification is `infra / runner` or a shadow run, say so and stop;
-do not propose a code change.
+do not propose a code change. For `infra / runner`, include the base rate and
+whether a retry is warranted.

--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -118,6 +118,18 @@ Determine the target in this order:
    `gh pr view --json number,headRefName,statusCheckRollup`.
 3. If neither works, ask the user for a PR URL or run ID. Do not guess.
 
+**A PR kicked from the merge queue is the exception: its own checks are the
+wrong target.** Trunk tests each queued PR on a `trunk-merge/pr-<n>/<uuid>`
+branch holding master plus every PR ahead of it in the queue. So:
+
+- The failing run is on that branch, never on the PR's head SHA. Take it from
+  the `Trunk Merge Queue` check run (`/merging-prs` step 4), not `gh pr checks`.
+- The PR's own checks can be green with the failing job **skipped**. Path
+  filters see only that PR's diff; the queue branch's diff is much wider. A
+  docs-only PR can be kicked by a job its own CI never ran.
+- The branch names one PR but carries many. A failure on it is not evidence
+  against that PR until you find the change that caused it.
+
 Inspect read-only:
 
 ```bash
@@ -133,6 +145,12 @@ enough surrounding output:
 ```bash
 gh run view <run-id> --log --job <job-id>
 ```
+
+Given a run id, the `engineering-analytics-run-failure-logs` MCP tool returns
+every failed job's error region with original line numbers, already thinned.
+One call instead of a jobs listing plus a log download, and it works when the
+job died before any test ran. It is bounded by Logs retention, so fall back to
+`gh` for older runs.
 
 Extract these before classifying:
 
@@ -160,23 +178,46 @@ history, hand off to `fixing-flaky-tests`, which covers the `search-test` and
 
 ## Classification
 
-| Signal in the log                                                        | Class               | First action                                                       |
-| ------------------------------------------------------------------------ | ------------------- | ------------------------------------------------------------------ |
-| `AssertionError`, test diff, `FAILED test_...` in a committed test file  | code regression     | reproduce with `hogli test <path>::<test>`                         |
-| Test failed here, passed on `master` or on rerun in the same PR          | flaky test          | confirm against `master` history; to fix, use `fixing-flaky-tests` |
-| `ruff`, `oxlint`, `stylelint`, `markdownlint`, `prettier` errors         | lint                | `hogli lint:python:fix` or `hogli format` on touched files         |
-| `mypy`, `pyright`, `tsc`, `typescript:check` errors                      | typecheck           | run the same checker locally, not the full suite                   |
-| Chromatic / Storybook / Playwright visual diff, snapshot mismatch        | snapshot / visual   | surface the diff URL; do NOT auto-accept snapshots                 |
-| `manage.py migrate` error, `migrations:check` failure, missing migration | migration / schema  | `hogli migrations:check` locally                                   |
-| OpenAPI schema diff, generated API types out of sync                     | codegen drift       | `hogli build:openapi`                                              |
-| `Cannot connect`, `ECONNREFUSED`, OOM, runner killed, setup step timeout | infra / runner      | treat as transient; report, do not fix                             |
-| `apt-get`, `uv sync`, `pnpm install`, docker pull, setup action failures | environment / setup | diff `.nvmrc`, `pyproject.toml`, `package.json`, Dockerfiles       |
-| `hogli lint:skills`, `hogli build:skills` failure                        | skills build        | run the same `hogli` command locally                               |
-| SDK compat check, `ci-survey-sdk-check`, cross-version failure           | SDK compatibility   | check SDK version matrix for the affected package                  |
+| Signal in the log                                                                                  | Class               | First action                                                       |
+| -------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------ |
+| `AssertionError`, test diff, `FAILED test_...` in a committed test file                            | code regression     | reproduce with `hogli test <path>::<test>`                         |
+| Test failed here, passed on `master` or on rerun in the same PR                                    | flaky test          | confirm against `master` history; to fix, use `fixing-flaky-tests` |
+| `ruff`, `oxlint`, `stylelint`, `markdownlint`, `prettier` errors                                   | lint                | `hogli lint:python:fix` or `hogli format` on touched files         |
+| `mypy`, `pyright`, `tsc`, `typescript:check` errors                                                | typecheck           | run the same checker locally, not the full suite                   |
+| Chromatic / Storybook / Playwright visual diff, snapshot mismatch                                  | snapshot / visual   | surface the diff URL; do NOT auto-accept snapshots                 |
+| `manage.py migrate` error, `migrations:check` failure, missing migration                           | migration / schema  | `hogli migrations:check` locally                                   |
+| OpenAPI schema diff, generated API types out of sync                                               | codegen drift       | `hogli build:openapi`                                              |
+| `Cannot connect`, `ECONNREFUSED`, `address already in use`, OOM, runner killed, setup step timeout | infra / runner      | get the base rate before calling it transient (below)              |
+| `apt-get`, `uv sync`, `pnpm install`, docker pull, setup action failures                           | environment / setup | diff `.nvmrc`, `pyproject.toml`, `package.json`, Dockerfiles       |
+| `hogli lint:skills`, `hogli build:skills` failure                                                  | skills build        | run the same `hogli` command locally                               |
+| SDK compat check, `ci-survey-sdk-check`, cross-version failure                                     | SDK compatibility   | check SDK version matrix for the affected package                  |
 
 If multiple signals match, choose the most specific class. For example, prefer
 codegen drift over lint, migration over typecheck, and snapshot / visual over a
 generic Playwright test failure.
+
+## Base rate for infra and setup failures
+
+"Transient" is a claim about how often the job fails, so do not assert it from
+one run. A job that dies before its tests run leaves no test-level evidence
+anywhere — no `FAILED` line, so nothing in the failure logs, the digest, or the
+flaky-tests tool. Job conclusions are the only substrate that sees it.
+
+Unlike the span-derived test reads, this one can give you a real rate: the
+warehouse records every job attempt, greens included, so the denominator is
+honest. Query 7 in
+`products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md`
+is copy-ready; that skill also owns the wider investigation and is worth reading
+directly, as it is a product skill and not invocable from this repo.
+
+Read the result as:
+
+- **Low percentage, recent hours mostly green** — transient. Report and move on;
+  for a queued PR, re-enqueueing is the next step, not a code change.
+- **Recent hours entirely red** — an outage, not a flake. Say so, and stop
+  telling people to retry.
+- **Steady over days** — a standing defect somebody owns. Worth a ticket even
+  though each occurrence looks like noise.
 
 ## Local reproduction
 

--- a/.agents/skills/debugging-ci-failures/SKILL.md
+++ b/.agents/skills/debugging-ci-failures/SKILL.md
@@ -199,9 +199,11 @@ generic Playwright test failure.
 ## Base rate for infra and setup failures
 
 "Transient" is a claim about how often the job fails, so do not assert it from
-one run. A job that dies before its tests run leaves no test-level evidence
-anywhere — no `FAILED` line, so nothing in the failure logs, the digest, or the
-flaky-tests tool. Job conclusions are the only substrate that sees it.
+one run. A job that dies before its tests run leaves no test-level evidence: no
+`FAILED` line, so no fingerprint and no span, so it never appears as a row in
+`broken_tests` or in the flaky-tests tool. It is still visible as a job
+conclusion, which is what the digest's master-failures section and
+`engineering-analytics-run-failure-logs` read. Start there, not from a test.
 
 Unlike the span-derived test reads, this one can give you a real rate: the
 warehouse records every job attempt, greens included, so the denominator is
@@ -212,8 +214,9 @@ directly, as it is a product skill and not invocable from this repo.
 
 Read the result as:
 
-- **Low percentage, recent hours mostly green** — transient. Report and move on;
-  for a queued PR, re-enqueueing is the next step, not a code change.
+- **Low percentage, recent hours mostly green** — transient. Report and move on.
+  For a queued PR, recommend re-enqueueing rather than a code change; posting
+  `/trunk merge` yourself needs approval, per the Safety rules above.
 - **Recent hours entirely red** — an outage, not a flake. Say so, and stop
   telling people to retry.
 - **Steady over days** — a standing defect somebody owns. Worth a ticket even

--- a/.agents/skills/merging-prs/SKILL.md
+++ b/.agents/skills/merging-prs/SKILL.md
@@ -132,7 +132,7 @@ Optionally, Trunk's MCP server (`https://mcp.trunk.io/mcp`, OAuth or bearer toke
 > Filter by author (`.user.login == "trunk-io[bot]" and .user.type == "Bot"`; GitHub forbids `[` and `]` in human usernames, so that login isn't registrable by a person) and never use `gh pr view <n> --comments`, which flattens every author into one unattributed blob.
 
 - If the failure is clearly caused by this PR **and** the fix is obvious, fix it, push (the `ci:preflight` pre-push hook must pass — never `--no-verify`), wait for the PR's own checks to go green, and re-enqueue **once** with `/trunk merge`.
-- If the failure looks like a flake or an unrelated master breakage, say so and hand back — `/debugging-ci-failures` and `/fixing-flaky-tests` cover the diagnosis; don't re-enqueue on a hunch. Two things make this call wrong more often than it should: the queue branch carries every PR ahead of this one, so a failure on it is not this PR's by default; and this PR's own green checks are no evidence about a job that only ran in the queue. `/debugging-ci-failures` covers both, plus how to get a real failure rate for the job.
+- If the failure looks like a flake or an unrelated master breakage, say so and hand back — `/debugging-ci-failures` and `/fixing-flaky-tests` cover the diagnosis; don't re-enqueue on a hunch. Two traps: the queue branch carries every PR ahead of this one, so a failure on it is not this PR's by default, and this PR's own green checks say nothing about a job that only ran in the queue. `/debugging-ci-failures` covers both, plus how to get a real failure rate for the job.
 - Otherwise stop and report the failure and the workflow link. Don't repeatedly re-enqueue a red PR.
 
 ## 5. Cancel

--- a/.agents/skills/merging-prs/SKILL.md
+++ b/.agents/skills/merging-prs/SKILL.md
@@ -132,7 +132,7 @@ Optionally, Trunk's MCP server (`https://mcp.trunk.io/mcp`, OAuth or bearer toke
 > Filter by author (`.user.login == "trunk-io[bot]" and .user.type == "Bot"`; GitHub forbids `[` and `]` in human usernames, so that login isn't registrable by a person) and never use `gh pr view <n> --comments`, which flattens every author into one unattributed blob.
 
 - If the failure is clearly caused by this PR **and** the fix is obvious, fix it, push (the `ci:preflight` pre-push hook must pass — never `--no-verify`), wait for the PR's own checks to go green, and re-enqueue **once** with `/trunk merge`.
-- If the failure looks like a flake or an unrelated master breakage, say so and hand back — `/debugging-ci-failures` and `/fixing-flaky-tests` cover the diagnosis; don't re-enqueue on a hunch.
+- If the failure looks like a flake or an unrelated master breakage, say so and hand back — `/debugging-ci-failures` and `/fixing-flaky-tests` cover the diagnosis; don't re-enqueue on a hunch. Two things make this call wrong more often than it should: the queue branch carries every PR ahead of this one, so a failure on it is not this PR's by default; and this PR's own green checks are no evidence about a job that only ran in the queue. `/debugging-ci-failures` covers both, plus how to get a real failure rate for the job.
 - Otherwise stop and report the failure and the workflow link. Don't repeatedly re-enqueue a red PR.
 
 ## 5. Cancel

--- a/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
@@ -43,9 +43,11 @@ to pin a specific failure to a boundary and author.
 
 `blocking_merge_queue` is the one shape the manual table below does not cover, because it looks like
 a single-branch failure and is not. The merge queue runs the full suite on a gate branch
-(`trunk-merge/pr-<n>/…`) carrying the PR rebased onto trunk, so a failure there is on a commit that
-already passed the PR's own CI: a conflict with what landed in between, not that PR's own bug. Read
-it as "this stopped a merge", and diff the PR against trunk rather than reading the PR alone.
+(`trunk-merge/pr-<n>/…`) carrying master, the PR, and every PR queued ahead of it with overlapping
+impacted targets (in practice most of the queue), so a failure there is on a commit that already
+passed the PR's own CI: a conflict with what landed or queued in between, or a queue-mate's own
+break, not that PR's bug by default. Read it as "this stopped a merge", list what the gate branch
+ran (query 8), and diff it against trunk rather than reading the PR alone.
 
 ## The four failure shapes
 
@@ -55,7 +57,7 @@ falls out of three columns:
 | Shape                                   | Reading                         | Next step                                            |
 | --------------------------------------- | ------------------------------- | ---------------------------------------------------- |
 | 1 branch, any window                    | That PR's own problem           | Read its failure lines; done                         |
-| 1 `trunk-merge/pr-<n>/…` gate branch    | Conflict with what landed since | Diff the PR against trunk, not the PR alone          |
+| 1 `trunk-merge/pr-<n>/…` gate branch    | Queue-mate, or landed since     | Query 8, then diff the gate branch against trunk     |
 | Many branches, dense burst, hits master | Trunk break (master is/was red) | Boundary query → culprit (below)                     |
 | Many branches, sporadic over days/weeks | Flaky                           | Corroborate with `engineering-analytics-flaky-tests` |
 

--- a/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
@@ -64,13 +64,6 @@ fails every concurrently-running PR. A failure appearing on many unrelated branc
 window is the signature of a master-merge break, not of those PRs' code. Tell the asker explicitly
 when their PR is not at fault — that is usually the single most valuable sentence in the answer.
 
-**A branch named `trunk-merge/pr-<n>/<uuid>` is the exception to row 1.** It is a Trunk merge queue
-branch, holding master plus every PR ahead of `<n>` in the queue; a hundred commits from other people
-is normal. It reads as "1 branch, so PR `<n>`'s own problem" while being close to the opposite — the
-PR it is named after contributes the topmost commits, and the rest is other people's code. Attribute
-it as you would a trunk break, and re-check any `pr_only` verdict carrying this branch shape before
-repeating it. These branches are a fifth of recent job rows, not an edge case.
-
 ## Trunk break → culprit
 
 Run the boundary query (query 2): master-only job history for the failing job, ordered by

--- a/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
@@ -64,6 +64,13 @@ fails every concurrently-running PR. A failure appearing on many unrelated branc
 window is the signature of a master-merge break, not of those PRs' code. Tell the asker explicitly
 when their PR is not at fault — that is usually the single most valuable sentence in the answer.
 
+**A branch named `trunk-merge/pr-<n>/<uuid>` is the exception to row 1.** It is a Trunk merge queue
+branch, holding master plus every PR ahead of `<n>` in the queue; a hundred commits from other people
+is normal. It reads as "1 branch, so PR `<n>`'s own problem" while being close to the opposite — the
+PR it is named after contributes the topmost commits, and the rest is other people's code. Attribute
+it as you would a trunk break, and re-check any `pr_only` verdict carrying this branch shape before
+repeating it. These branches are a fifth of recent job rows, not an edge case.
+
 ## Trunk break → culprit
 
 Run the boundary query (query 2): master-only job history for the failing job, ordered by
@@ -99,6 +106,11 @@ threshold aren't recorded, so there is no honest denominator.
 - **Fingerprints are pytest-only (v1).** Jest / playwright / cargo failures appear in the raw
   failure logs but are not in `ci_failures`. For those, fall back to grouped triage via the
   `engineering-analytics-master-failures` / `engineering-analytics-ci-failure-logs` MCP tools.
+- **A job that failed before its tests ran is invisible to every test-level surface.** No `FAILED`
+  line means no fingerprint, no span, nothing for the flaky-tests tool to read — the failure is real
+  but the test-level answer is silence, not "fine". Setup, docker, and runner failures are only
+  visible as job conclusions (query 7), which is also the one surface here that yields an honest
+  rate, since it records greens.
 - **Freshness differs per source.** Logs stream in near-real-time; the warehouse jobs/runs tables
   arrive via webhook sync and can lag. During a live incident, start from `ci_failures` and check
   the warehouse's `max(created_at)` before trusting a boundary (query 5). A boundary computed
@@ -125,6 +137,7 @@ threshold aren't recorded, so there is no honest denominator.
 | "Why did MY PR's CI fail?"             | `engineering-analytics-ci-failure-logs` MCP tool (PR-scoped, grouped)  |
 | "Who broke master / when did X start?" | The two views, workflow above                                          |
 | "Is X flaky?"                          | Shape from `ci_failures` + the flaky-tests tool                        |
+| "Is this setup/infra failure common?"  | Job conclusions, query 7 (no test rows exist for it)                   |
 | "What's failing on master right now?"  | `engineering-analytics-master-failures` MCP tool (grouped triage feed) |
 | "Is CI slow / expensive / PRs stuck?"  | The `diagnosing-ci-and-merge-bottlenecks` skill                        |
 | "Save this as a dashboard/insight"     | The `turning-engineering-analytics-into-insights` skill                |

--- a/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
@@ -86,6 +86,11 @@ different problems sharing a test.
 
 ## Flaky → corroborate, don't guess
 
+**Read the sibling attempts before you say "flaky".** One run cannot separate a flake from a
+deterministic failure, and `ci_job_history` already carries every attempt's `conclusion` for the
+branch. If every run on a branch is red, there is no flake to find, and offering a re-run wastes a
+run: a retry changes none of the inputs.
+
 Sporadic shape alone is suggestive, not proof. The `engineering-analytics-flaky-tests` MCP tool reads per-test CI spans
 (rerun-pass signal — a test that failed then passed on retry in the same job) and is the stronger
 signal where it has coverage. Counts only, never rates: passing runs below the emitter's duration
@@ -104,6 +109,12 @@ threshold aren't recorded, so there is no honest denominator.
   but the test-level answer is silence, not "fine". Setup, docker, and runner failures are only
   visible as job conclusions (query 7), which is also the one surface here that yields an honest
   rate, since it records greens.
+- **Check `runs-on` before blaming a cache.** Jobs on `depot-*` runners resolve `actions/cache`
+  against Depot Cache, which the GitHub Actions cache API cannot see, so an empty result there is
+  not evidence of eviction. Read the job's own `Cache not found for input keys:` line for the keys
+  actually requested. Both steps stay green either way: `actions/cache/restore` succeeds on a miss,
+  and a failed `actions/cache/save` is only a warning, so a green producer job may have stored
+  nothing.
 - **Freshness differs per source.** Logs stream in near-real-time; the warehouse jobs/runs tables
   arrive via webhook sync and can lag. During a live incident, start from `ci_failures` and check
   the warehouse's `max(created_at)` before trusting a boundary (query 5). A boundary computed

--- a/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
@@ -140,25 +140,25 @@ a computed column and forces a full jobs scan. It's coarse (a whole-day, string 
 
 ## 7. Job failure rate (for failures with no test rows)
 
-For a job that failed _before_ its tests ran — docker setup, a runner port collision, a dependency
-install — there is no `FAILED` line, so `ci_failures` and the span-derived tools are all blind to it.
-Job conclusions are the only substrate that sees it, and unlike those tools they carry greens, so
-this is the one place a real rate is honest.
+A job that failed _before_ its tests ran (docker setup, a runner port collision, a dependency
+install) writes no `FAILED` line, so `ci_failures` and the span-derived tools are blind to it. Job
+conclusions are the only place it shows up, and they record greens too, so this is the one rate here
+with an honest denominator.
 
 ```sql
 SELECT
     countIf(conclusion = 'success') AS ok,
-    countIf(conclusion = 'failure') AS fail,
-    round(100.0 * countIf(conclusion = 'failure')
-          / nullIf(countIf(conclusion IN ('success', 'failure')), 0), 2) AS fail_pct
+    countIf(conclusion IN ('failure', 'timed_out')) AS fail,
+    round(100.0 * fail / nullIf(ok + fail, 0), 2) AS fail_pct
 FROM engineering_analytics_ci_job_history
 WHERE job_name = '<failing job name>'
   AND created_at >= now() - INTERVAL 7 DAY
   AND created_at_raw >= '<8 days ago, YYYY-MM-DD>'
 ```
 
-`cancelled` and `skipped` stay out of the denominator: neither reached a verdict, and both are
-common enough here (superseded pushes, path filters) to halve the rate if counted.
+`timed_out` counts as a failure, the same set every other rate in this product uses. `cancelled` and
+`skipped` are absent from `ok + fail` on purpose: neither reached a verdict, and both are common
+enough here (superseded pushes, path filters) to halve the rate if counted.
 
 A percentage alone can't tell an old flake from a live outage. Break the same window down by hour:
 
@@ -166,7 +166,7 @@ A percentage alone can't tell an old flake from a live outage. Break the same wi
 SELECT
     toStartOfHour(created_at) AS hour,
     countIf(conclusion = 'success') AS ok,
-    countIf(conclusion = 'failure') AS fail
+    countIf(conclusion IN ('failure', 'timed_out')) AS fail
 FROM engineering_analytics_ci_job_history
 WHERE job_name = '<failing job name>'
   AND created_at >= now() - INTERVAL 12 HOUR
@@ -175,8 +175,8 @@ GROUP BY hour
 ORDER BY hour DESC
 ```
 
-Reading: a low percentage with recent hours mostly green = transient, retry is reasonable. Recent
-hours entirely red = an outage; stop advising retries. Steady across days = a standing defect that
-looks like noise one run at a time.
+Reading: a low percentage with recent hours mostly green = transient, so recommend a retry rather
+than a code change. Recent hours entirely red = an outage; stop advising retries. Steady across days
+= a standing defect that looks like noise one run at a time.
 
 Both queries keep the `created_at_raw` string floor for the same pruning reason as query 6.

--- a/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
@@ -180,3 +180,21 @@ than a code change. Recent hours entirely red = an outage; stop advising retries
 = a standing defect that looks like noise one run at a time.
 
 Both queries keep the `created_at_raw` string floor for the same pruning reason as query 6.
+
+## 8. What the merge queue ran for a PR
+
+The `trunk-merge/pr-<n>/<uuid>` branch is ephemeral, but the jobs it ran stay in `ci_job_history`
+under that `head_branch`. One row per job attempt, failures first:
+
+```sql
+SELECT head_branch, run_id, workflow_name, job_name, conclusion, created_at
+FROM engineering_analytics_ci_job_history
+WHERE startsWith(head_branch, 'trunk-merge/pr-<n>/')
+  AND created_at >= now() - INTERVAL 7 DAY
+  AND created_at_raw >= '<8 days ago, YYYY-MM-DD>'
+ORDER BY conclusion IN ('failure', 'timed_out') DESC, created_at DESC
+```
+
+Each `<uuid>` is one queue attempt; a PR kicked twice has two. The failing `job_name` feeds query 7.
+The PRs the branch carried are readable off its head: `gh api repos/<owner>/<repo>/compare/master...<head_sha>`
+lists merge commits titled `Merging <sha> into trunk-temp/pr-<m>/…`, one `<m>` per queue-mate.

--- a/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
@@ -137,3 +137,46 @@ the job still red = a different failure holds the job red — don't attribute it
 The `created_at_raw` floor lets the warehouse scan prune — the parsed `created_at` filter alone hits
 a computed column and forces a full jobs scan. It's coarse (a whole-day, string floor a day below the
 7-day window), so keep the precise `created_at` bound too.
+
+## 7. Job failure rate (for failures with no test rows)
+
+For a job that failed _before_ its tests ran — docker setup, a runner port collision, a dependency
+install — there is no `FAILED` line, so `ci_failures` and the span-derived tools are all blind to it.
+Job conclusions are the only substrate that sees it, and unlike those tools they carry greens, so
+this is the one place a real rate is honest.
+
+```sql
+SELECT
+    countIf(conclusion = 'success') AS ok,
+    countIf(conclusion = 'failure') AS fail,
+    round(100.0 * countIf(conclusion = 'failure')
+          / nullIf(countIf(conclusion IN ('success', 'failure')), 0), 2) AS fail_pct
+FROM engineering_analytics_ci_job_history
+WHERE job_name = '<failing job name>'
+  AND created_at >= now() - INTERVAL 7 DAY
+  AND created_at_raw >= '<8 days ago, YYYY-MM-DD>'
+```
+
+`cancelled` and `skipped` stay out of the denominator: neither reached a verdict, and both are
+common enough here (superseded pushes, path filters) to halve the rate if counted.
+
+A percentage alone can't tell an old flake from a live outage. Break the same window down by hour:
+
+```sql
+SELECT
+    toStartOfHour(created_at) AS hour,
+    countIf(conclusion = 'success') AS ok,
+    countIf(conclusion = 'failure') AS fail
+FROM engineering_analytics_ci_job_history
+WHERE job_name = '<failing job name>'
+  AND created_at >= now() - INTERVAL 12 HOUR
+  AND created_at_raw >= '<yesterday, YYYY-MM-DD>'
+GROUP BY hour
+ORDER BY hour DESC
+```
+
+Reading: a low percentage with recent hours mostly green = transient, retry is reasonable. Recent
+hours entirely red = an outage; stop advising retries. Steady across days = a standing defect that
+looks like noise one run at a time.
+
+Both queries keep the `created_at_raw` string floor for the same pruning reason as query 6.

--- a/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/references/investigation-queries.md
@@ -151,10 +151,16 @@ SELECT
     countIf(conclusion IN ('failure', 'timed_out')) AS fail,
     round(100.0 * fail / nullIf(ok + fail, 0), 2) AS fail_pct
 FROM engineering_analytics_ci_job_history
-WHERE job_name = '<failing job name>'
+WHERE repo_name = '<repo>'
+  AND workflow_name = '<failing workflow name>'
+  AND job_name = '<failing job name>'
   AND created_at >= now() - INTERVAL 7 DAY
   AND created_at_raw >= '<8 days ago, YYYY-MM-DD>'
 ```
+
+Scope by repository and workflow as well as job: the view unions every connected repository, and job
+names repeat across workflows (`Desktop Tests Pass` fails under two), so a job-only filter pools
+unrelated attempts into the denominator.
 
 `timed_out` counts as a failure, the same set every other rate in this product uses. `cancelled` and
 `skipped` are absent from `ok + fail` on purpose: neither reached a verdict, and both are common
@@ -168,7 +174,9 @@ SELECT
     countIf(conclusion = 'success') AS ok,
     countIf(conclusion IN ('failure', 'timed_out')) AS fail
 FROM engineering_analytics_ci_job_history
-WHERE job_name = '<failing job name>'
+WHERE repo_name = '<repo>'
+  AND workflow_name = '<failing workflow name>'
+  AND job_name = '<failing job name>'
   AND created_at >= now() - INTERVAL 12 HOUR
   AND created_at_raw >= '<yesterday, YYYY-MM-DD>'
 GROUP BY hour


### PR DESCRIPTION
## Problem

- A PR kicked from the merge queue keeps green checks of its own, so an agent triaging it calls "flake" from one run.
- A job that dies before its tests run writes no `FAILED` line. `ci_failures`, the `ci:insights` digest, and the flaky-tests tool stay silent.
- No skill said either thing.

## Changes

- `debugging-ci-failures`: the target for a kicked PR is its `trunk-merge/pr-<n>/<uuid>` run, which carries master plus the PRs queued ahead and always runs the full matrices. New base-rate section for infra and setup failures.
- `investigating-ci-failures`: the gate-branch shape now names queue-mates; caveats for pre-test failures and Depot Cache.
- `investigation-queries.md`: query 7 (job failure rate, hourly split) and query 8 (what the queue ran for a PR).
- `merging-prs`: one line naming both traps where the flake call is made.

## How did you test this code?

- Queries 7 and 8 ran against the warehouse in project 2 via MCP (not linked).
- Queue-branch claim checked on a live `trunk-merge/pr-78609/…` branch: merges from ten other PRs.
- `hogli lint:skills` passes. Docs only.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal agent skills.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code wrote this; the gap is one it fell into on a live queue kick.
- Rebased onto master after [point hogli ci:insights at engineering analytics](https://github.com/PostHog/posthog/pull/77581) merged; no longer stacked.
- Skills invoked: `/writing-pr-descriptions`.
