### PR TITLE
fix(data-imports): stop retrying a 404 from a REST-based source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -8,6 +8,7 @@ from typing import Any, NoReturn, Optional
 from django.db import InterfaceError, OperationalError
 from django.db.models import Prefetch
 
+from requests.exceptions import HTTPError
 from structlog.contextvars import bind_contextvars
 from structlog.typing import FilteringBoundLogger
 from temporalio import activity
@@ -387,6 +388,16 @@ async def _handle_import_error(
     # contract by type so every REST-based source stops immediately, rather than depending on each
     # source listing the message in get_non_retryable_errors.
     if isinstance(error, RESTClientNonRetryableError):
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
+
+    # A 404 from the shared REST engine's fallback `raise_for_status()` path means the configured
+    # endpoint/resource doesn't exist — every retry replays the identical request against the same
+    # dead URL. Unlike 401 (a token needing refresh, which the REST engine's own retry re-mints) or
+    # 429/5xx (already RESTClientRetryableError), there's no self-recovering path for a 404, so
+    # classify it here rather than depending on each REST-based source listing it.
+    if isinstance(error, HTTPError) and error.response is not None and error.response.status_code == 404:
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -10,6 +10,7 @@ from unittest import mock
 from django.db import InterfaceError, OperationalError
 
 from parameterized import parameterized
+from requests.exceptions import HTTPError
 
 from posthog.temporal.common.errors import NonReportableError
 
@@ -227,6 +228,68 @@ async def test_rest_client_non_retryable_error_routes_through_handler_without_so
     assert handle_mock.await_args is not None
     assert handle_mock.await_args.args[5] is error
     logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_404_routes_through_handler_without_source_opt_in():
+    # A 404 from the shared REST engine's fallback raise_for_status() path means the configured
+    # endpoint/resource doesn't exist — every retry hits the identical dead URL. It must be honored
+    # by status code even when the source's get_non_retryable_errors doesn't list the message, so
+    # any REST-based source stops instead of retrying to the activity max and minting error-tracking
+    # noise on every attempt.
+    error = HTTPError(
+        "404 Client Error: Not Found for url: https://api.example.com/export", response=mock.MagicMock(status_code=404)
+    )
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
+    assert handle_mock.await_args.args[5] is error
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_401_is_reraised_for_activity_retry():
+    # A 401 can mean an access token expired mid-run — the REST engine's own auth layer re-mints
+    # the token on the next attempt, so this must stay retryable rather than being swept into the
+    # same non-retryable bucket as a 404 (which has no self-recovering path).
+    error = HTTPError(
+        "401 Client Error: Unauthorized for url: https://api.example.com/export",
+        response=mock.MagicMock(status_code=401),
+    )
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        with pytest.raises(HTTPError):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_not_awaited()
+    logger.aexception.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A recurring `Custom` source sync kept failing with an `HTTPError: 404 Client Error: Not Found` for a configured export endpoint ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd2a7-4c25-7700-90db-4e1b5549419d)).

- The shared REST engine's fallback `raise_for_status()` path let a 404 escape as a raw, unclassified `HTTPError`.
- Temporal retried the whole activity to its full budget on every sync.
- Error tracking got a fresh report on every attempt.
- A 404 here means the configured endpoint or resource doesn't exist; retrying replays the identical request.

## Changes

- Classify an `HTTPError` with status 404 as non-retryable in `_handle_import_error`, the shared activity error handler.
- This follows the same pattern already used for `RESTClientNonRetryableError` and other cross-source conditions.
- A 401 is left untouched and retryable, since the REST engine's own auth layer can re-mint an expired token on the next attempt.
- Scoped to the shared handler so every REST-based source benefits, not just `Custom`.

## How did you test this code?

- Added `test_http_404_routes_through_handler_without_source_opt_in`, confirming a 404 routes through `handle_non_retryable_error` even when the source doesn't list it.
- Added `test_http_401_is_reraised_for_activity_retry`, locking in that a 401 still re-raises for Temporal's normal retry (guards the OAuth token-refresh path).
- Ran the full `test_import_data_sync.py` suite (18 passed, 1 pre-existing DB-dependent failure unrelated to this change).
- `ruff check`, `ruff format --check`, and `mypy --cache-fine-grained .` repo-wide (17772 files, no issues).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via Claude Code, using the PostHog MCP error-tracking tools to pull the issue's stack trace and sampled events, then traced the call path from the activity wrapper down into the shared REST client (`rest_client.py`). No repo skills were invoked beyond `/writing-tests` and `/writing-pr-descriptions`.

Considered wrapping the 404 as `RESTClientNonRetryableError` inside `rest_client.py` itself, but that would have changed the type raised by the client's existing fallback path and broken an existing test asserting `HTTPError` there. Classifying by status code in the shared activity handler instead keeps that contract intact while still covering every REST-based source.

Checked for duplicate PRs first: two open bot PRs (#78410, #78391) touch adjacent non-retryable-error plumbing but address a different concern (keeping already-classified errors out of error tracking during retries), not this classification gap.