### PR TITLE
fix(data-warehouse): stop table registration failing when row count refresh times out

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_sync.py
@@ -16,6 +16,7 @@ import dlt.common.libs.pyarrow
 import dlt.extract.incremental
 import dlt.extract.incremental.transform
 from clickhouse_driver.errors import ServerException
+from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
@@ -133,6 +134,17 @@ async def set_initial_sync_complete(schema_id: str, team_id: int) -> None:
     await database_sync_to_async_pool(mark_initial_sync_complete)(schema_id=schema_id, team_id=team_id)
 
 
+def _refresh_cumulative_row_count(table: DataWarehouseTable, logger: FilteringBoundLogger, context: str) -> None:
+    # Counting the full S3 dataset can exceed both the chdb and ClickHouse-cluster timeouts on a
+    # large table (get_count() then raises). That's only a display stat, not the synced data itself
+    # (already written successfully by this point) — keep the previous row_count rather than let it
+    # fail the whole table registration.
+    try:
+        table.row_count = table.get_count()
+    except Exception:
+        logger.warning(f"Could not refresh cumulative row count for {context}, keeping previous value", exc_info=True)
+
+
 async def validate_schema_and_update_table(
     run_id: str,
     team_id: int,
@@ -209,7 +221,7 @@ async def validate_schema_and_update_table(
                 table.url_pattern = new_url_pattern
                 table.queryable_folder = queryable_folder
                 if external_data_schema.table_row_count_is_cumulative:
-                    table.row_count = table.get_count()
+                    _refresh_cumulative_row_count(table, logger, f"{_schema_name} ({_schema_id})")
                 else:
                     table.row_count = row_count
                 # get_count() above can retry against a degraded ClickHouse cluster for minutes, long
@@ -366,7 +378,7 @@ async def register_cdc_companion_table(
                 table.format = table_format
                 table.url_pattern = new_url_pattern
                 table.queryable_folder = queryable_folder
-                table.row_count = table.get_count()
+                _refresh_cumulative_row_count(table, logger, companion_table_name)
                 # Scope to the fields changed here so this out-of-transaction save doesn't rewrite
                 # `columns` with its pre-merge value before the column save below.
                 # get_count() above can retry against a degraded ClickHouse cluster for minutes, long

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/test_pipeline_sync.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers 
     resolve_table_and_folder_names,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import (
+    _refresh_cumulative_row_count,
     merge_columns,
     update_last_synced_at,
 )
@@ -85,6 +86,31 @@ class TestResolveTableAndFolderNames:
         source = ExternalDataSource(source_type=source_type, prefix="")
         names = resolve_table_and_folder_names(schema_name, None)
         assert build_table_name(source, names.table_storage_name) == expected
+
+
+class TestRefreshCumulativeRowCount:
+    def test_updates_row_count_on_success(self) -> None:
+        table = MagicMock(row_count=1)
+        table.get_count.return_value = 42
+
+        _refresh_cumulative_row_count(table, MagicMock(), "orders (schema-1)")
+
+        assert table.row_count == 42
+
+    def test_keeps_previous_row_count_when_get_count_fails(self) -> None:
+        # get_count() raises when both the chdb and ClickHouse-cluster reads of the S3 dataset
+        # time out on a large table. That's a display stat, not the synced data — it must not
+        # propagate and fail the whole table registration for an otherwise-successful sync.
+        table = MagicMock(row_count=7)
+        table.get_count.side_effect = Exception(
+            "Reading the files from your storage bucket took too long and the query was cancelled."
+        )
+        logger = MagicMock()
+
+        _refresh_cumulative_row_count(table, logger, "orders (schema-1)")
+
+        assert table.row_count == 7
+        logger.warning.assert_called_once()
 
 
 def _register_companion_sync(


### PR DESCRIPTION
## Problem

- [This error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd2ac-dbd8-7802-aceb-cf124d020f94) fired for a Stripe sync during table registration.
- Append/incremental/CDC schemas call `DataWarehouseTable.get_count()` to refresh the table's cumulative row count by re-scanning the full S3 dataset.
- On a large table, `get_count()` can exceed both the chdb subprocess timeout and the ClickHouse-cluster fallback's execution time, raising an exception.
- That exception propagates out of `validate_schema_and_update_table` / `register_cdc_companion_table`, failing the whole table registration step, even though the synced data had already landed successfully in S3/Delta.

## Changes

- Added `_refresh_cumulative_row_count()` in `pipeline_sync.py`: it calls `get_count()` and, on failure, logs a warning and leaves the table's previous `row_count` unchanged instead of raising.
- Both call sites (`validate_schema_and_update_table` and `register_cdc_companion_table`) now go through this helper.
- `get_count()` itself is unchanged; it still reports the underlying error via `capture_exception` internally.

## How did you test this code?

- Added `TestRefreshCumulativeRowCount` (`test_pipeline_sync.py`): one case asserts a successful count updates `row_count`, the other asserts a `get_count()` failure keeps the previous `row_count` and logs a warning instead of raising.
- Ran `test_pipeline_sync.py` locally (new tests pass; pre-existing `TestRegisterCDCCompanionTable` cases require a live Postgres not available in this environment).
- `ruff check` / `ruff format --check` clean, `uv run mypy --cache-fine-grained .` clean (repo-wide), `hogli ci:preflight --fix` reports 0 failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue. No duplicate found: searched open PRs (excluding the automation bot) by exception type, module path, and message text, and checked the data-warehouse maintainer's own open PRs — none touch this row-count refresh path.

Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*