### PR TITLE
fix(data-imports): treat Northpass empty-collection 404s as empty pages

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/northpass_lms.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/northpass_lms.py
@@ -116,7 +116,10 @@ def _top_level_source(
 ) -> Resource:
     rest_config: RESTAPIConfig = {
         "client": _client_config(api_key),
-        "resource_defaults": {},
+        # A collection with no rows 404s instead of returning `data: []` (seen on
+        # /learning-paths); retrying can't produce rows, so treat it like the empty-body
+        # case above and let the resource yield nothing rather than failing the sync.
+        "resource_defaults": {"endpoint": {"response_actions": [{"status_code": 404, "action": "ignore"}]}},
         "resources": [
             {
                 "name": endpoint,
@@ -170,7 +173,10 @@ def _fan_out_source(
 
     rest_config: RESTAPIConfig = {
         "client": _client_config(api_key),
-        "resource_defaults": {},
+        # Same "empty collection 404s instead of `data: []`" case as the top-level source: the
+        # parent enumeration below inherits this so an account with no parent rows fans out over
+        # zero parents instead of failing the sync outright.
+        "resource_defaults": {"endpoint": {"response_actions": [{"status_code": 404, "action": "ignore"}]}},
         "resources": [
             {
                 "name": parent_name,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/northpass_lms/tests/test_northpass_lms.py
@@ -184,6 +184,18 @@ class TestTopLevelPagination:
         assert off_host_url not in sent
         assert sent == [COURSES_P1]
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_treats_404_on_first_page_as_empty_collection(self, mock_make_session):
+        # An account with no rows in a collection 404s instead of returning `data: []` (seen on
+        # /learning-paths). This must not fail the sync -- it's the same "no data" outcome as an
+        # empty body, not a retryable or fatal error.
+        pages = {COURSES_P1: _resp({"errors": []}, status=404)}
+        _wire(mock_make_session, pages)
+
+        rows = _rows("courses", _make_manager())
+
+        assert rows == []
+
 
 class TestFanOut:
     def _parent_and_children(self) -> dict[str, Any]:
@@ -257,6 +269,17 @@ class TestFanOut:
 
         with pytest.raises(requests.HTTPError):
             _rows("course_enrollments", _make_manager())
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_treats_404_on_parent_enumeration_as_empty(self, mock_make_session):
+        # The parent list itself (not a per-parent child page) 404s when the account has no
+        # parent rows. Fanning out over zero parents must yield zero rows, not crash the sync.
+        pages = {"https://api.northpass.com/v2/courses?limit=100": _resp({"errors": []}, status=404)}
+        _wire(mock_make_session, pages)
+
+        rows = _rows("course_enrollments", _make_manager())
+
+        assert rows == []
 
 
 class TestNorthpassSource:


### PR DESCRIPTION
## Problem

- NorthpassLMS `learning_paths` and `learning_path_enrollments` syncs fail with `HTTPError: 404 Client Error: Not Found for url: .../learning-paths` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd2b5-ef94-7c20-bb62-cc210025fe5d)).
- Northpass returns 404 for a collection with no rows, instead of `{"data": []}`.
- The same 404 hits the standalone `learning_paths` schema and the fan-out parent enumeration behind `learning_path_enrollments`, since both list the same `/learning-paths` collection.
- Retrying can't turn a 404 into rows, so the sync fails outright instead of syncing zero rows.

## Changes

- Add `response_actions: [{"status_code": 404, "action": "ignore"}]` as a resource default on both the top-level and fan-out-parent REST configs in `northpass_lms.py`.
- A 404 on any Northpass collection page now ends pagination as an empty page.
- This matches the existing per-endpoint pattern already used for `learning_path_enrollments`'s child fetch (a parent deleted mid-fanout) and the framework's `tvmaze` source (a 404 signals the end of an index).

## How did you test this code?

- Added `test_treats_404_on_first_page_as_empty_collection` (`TestTopLevelPagination`), covering the standalone schema case.
- Added `test_treats_404_on_parent_enumeration_as_empty` (`TestFanOut`), covering the fan-out parent enumeration case.
- Ran the full `northpass_lms` test suite (43 passed) and `ruff check` / `ruff format --check` on the touched files.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via Claude Code using the PostHog MCP error-tracking tools to pull the issue's stack trace, sampled events, and `warehouse_sources_*` properties, which scoped the failure to the `learning_path_enrollments` schema and, via a follow-up SQL query, the standalone `learning_paths` schema too. Traced the call path from the activity down into the shared REST client, then into `northpass_lms.py`'s resource configs. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

Found a related open human-authored PR, [#78441](https://github.com/PostHog/posthog/pull/78441), which classifies any unclassified REST-source 404 as non-retryable at the shared activity handler. That fixes a different failure mode (a permanently broken endpoint retried to the activity's max) and would still leave this sync failing rather than succeeding with zero rows, so it doesn't cover this bug; the two changes are complementary.