### PR TITLE
fix(data-warehouse): gate queued rewrites by their staging flag

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -48,6 +48,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.rep
     WAREHOUSE_AUTO_REPARTITION_FLAG,
     base_event_props,
     capture_repartition_event,
+    is_auto_coarsen_enabled,
     is_auto_repartition_enabled,
     maybe_flag_for_repartition,
     target_partition_bytes,
@@ -275,16 +276,26 @@ def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: Filterin
     # The flag has to stop a queued rewrite too, not only detection. Once a table is flagged, the
     # rewrite runs ahead of extraction on every sync, so a rewrite that can't finish delays the sync
     # by the full activity budget indefinitely; the flag is the only lever support has to release
-    # such a table, and it does nothing here if it only gates detection. Two exclusions: a staged
-    # swap must always be driven to completion because temp is the source of truth in that window
-    # and live may already be deleted, and an operator-staged rewrite ignores the rollout flag
-    # because they staged it knowing that syncing on the old layout is the worse option.
-    if not enabled and pending is not None and swap is None and pending.get("trigger_reason") != "admin":
-        logger.info(
-            f"repartition: queued rewrite skipped, controller disabled by feature flag schema_id={schema.id}",
-            schema_id=str(schema.id),
-        )
-        return
+    # such a table, and it does nothing here if it only gates detection. Each auto-staged trigger
+    # family answers to the flag that staged it, and any other reason fails open: operator-staged
+    # work (admin, coarsening nominations) was queued knowing that syncing on the old layout is the
+    # worse option, so it must never dead-end on a rollout flag. A staged swap is always driven to
+    # completion because temp is the source of truth in that window and live may already be deleted.
+    if pending is not None and swap is None:
+        reason = pending.get("trigger_reason")
+        if reason in ("proactive_threshold", "oom_history"):
+            release = not enabled
+        elif reason == "coarsening":
+            release = not is_auto_coarsen_enabled(schema)
+        else:
+            release = False
+        if release:
+            logger.info(
+                f"repartition: queued rewrite skipped, controller disabled by feature flag schema_id={schema.id}",
+                schema_id=str(schema.id),
+                trigger_reason=reason,
+            )
+            return
 
     # Fast no-op path: nothing queued and the gate says no on-disk measurement is needed (flag off, or
     # CDC). Return here — before fetching the job and reading the delta log — so the common healthy

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -239,16 +239,20 @@ class TestBudgetExhaustion:
 class TestFeatureFlagGate:
     @parameterized.expand(
         [
-            ("flag_off_releases_a_queued_rewrite", False, None, "proactive_threshold", False),
-            ("flag_off_still_finishes_a_staged_swap", False, {"state": "ready"}, "proactive_threshold", True),
-            ("flag_off_does_not_block_an_operator", False, None, "admin", True),
-            ("flag_on_rewrites_as_usual", True, None, "proactive_threshold", True),
+            ("flag_off_releases_a_queued_rewrite", False, True, None, "proactive_threshold", False),
+            ("flag_off_still_finishes_a_staged_swap", False, True, {"state": "ready"}, "proactive_threshold", True),
+            ("flag_off_does_not_block_an_operator", False, True, None, "admin", True),
+            ("flag_on_rewrites_as_usual", True, True, None, "proactive_threshold", True),
+            ("flag_off_does_not_release_a_nomination", False, False, None, "coarsening_requested", True),
+            ("coarsen_flag_off_releases_a_queued_coarsen", True, False, None, "coarsening", False),
+            ("repartition_flag_off_keeps_a_queued_coarsen", False, True, None, "coarsening", True),
         ]
     )
     @patch(f"{MODULE}.capture_repartition_event")
     @patch(f"{MODULE}.HeartbeaterSync")
     @patch(f"{MODULE}.repartition_table_in_place", new_callable=AsyncMock)
     @patch(f"{MODULE}.DeltaTableRef")
+    @patch(f"{MODULE}.is_auto_coarsen_enabled")
     @patch(f"{MODULE}.is_auto_repartition_enabled")
     @patch(f"{MODULE}.ExternalDataJob")
     @patch(f"{MODULE}.ExternalDataSchema")
@@ -256,18 +260,21 @@ class TestFeatureFlagGate:
         self,
         _name: str,
         enabled: bool,
+        coarsen_enabled: bool,
         swap: dict | None,
         trigger_reason: str,
         expect_rewrite: bool,
         mock_schema_model: MagicMock,
         _mock_job_model: MagicMock,
         mock_enabled: MagicMock,
+        mock_coarsen_enabled: MagicMock,
         _mock_helper_cls: MagicMock,
         mock_repartition: AsyncMock,
         _mock_heartbeater: MagicMock,
         _mock_capture_event: MagicMock,
     ) -> None:
         mock_enabled.return_value = enabled
+        mock_coarsen_enabled.return_value = coarsen_enabled
         schema = _schema(
             name="public.usages",
             s3_folder_name="usages",


### PR DESCRIPTION
## Problem

- #77769 added a gate that releases queued rewrites when the repartition rollout flag is off, with only `admin` targets exempt.
- #76349 landed after it with the `coarsening` and `coarsening_requested` trigger reasons.
- With the repartition flag off, the gate releases a queued coarsen rewrite on every sync. Auto-coarsen work never runs, and a failed nomination never retries.

## Changes

- Each auto-staged trigger family now answers to the flag that staged it: `proactive_threshold` and `oom_history` to the repartition flag, `coarsening` to the coarsen flag.
- Any other reason (`admin`, `coarsening_requested`, unknown) fails open, so operator-staged work never dead-ends on a rollout flag.
- A released target keeps `repartition_pending` set. Flipping the flag back on resumes it, as before.

## How did you test this code?

- Extended the existing gate matrix in `test_repartition_table.py` with 3 cases: a nomination retry runs with both flags off, a queued coarsen is released by the coarsen flag, and is kept when only the repartition flag is off. No existing test covered the coarsen trigger reasons.
- Ran the file locally: 19/19 pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal rollout-flag behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code authored this from a repartition-pipeline review session with @danielcarletti.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Considered extending the admin allowlist instead. Rejected it: every future operator-staged reason would repeat this bug, so unknown reasons fail open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
