### PR TITLE
fix(data-warehouse): keep a staged swap when repartition gives up

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -527,14 +527,24 @@ def _handle_failure(
     )
 
     if attempts >= MAX_REPARTITION_ATTEMPTS:
-        props["final"] = True
-        schema.clear_repartition_pending()
-        schema.clear_repartition_swap()
-        # Engage the cooldown as well, or the give-up never takes effect: the trigger that queued
-        # this rewrite (the largest partition is over budget) is just as true on the next sync and
-        # the layout is unchanged, so detection re-flags the table immediately with `attempts` back
-        # at 0 and the three attempts start over. The cooldown re-evaluates at most daily instead.
-        schema.stamp_last_repartition_at()
+        if (schema.repartition_swap or {}).get("state") == "ready":
+            # Never drop a staged swap from a failure path: once the marker is recorded, the swap
+            # may already have purged live, which makes temp the only complete copy of the table.
+            # Clearing the marker here would strand that temp for the next rebuild's sweep to
+            # delete, and the following sync would bootstrap an empty table over the lost data. So
+            # keep the markers and let every later sync retry the swap from temp: wasted compute is
+            # recoverable, the table is not.
+            props["swap_kept"] = True
+            schema.set_repartition_pending({**pending, "attempts": attempts})
+        else:
+            props["final"] = True
+            schema.clear_repartition_pending()
+            schema.clear_repartition_swap()
+            # Engage the cooldown as well, or the give-up never takes effect: the trigger that queued
+            # this rewrite (the largest partition is over budget) is just as true on the next sync and
+            # the layout is unchanged, so detection re-flags the table immediately with `attempts` back
+            # at 0 and the three attempts start over. The cooldown re-evaluates at most daily instead.
+            schema.stamp_last_repartition_at()
     else:
         updated = {**pending, "attempts": attempts}
         schema.set_repartition_pending(updated)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -236,6 +236,50 @@ class TestBudgetExhaustion:
             schema.stamp_last_repartition_at.assert_not_called()
 
 
+class TestGiveUpWithStagedSwap:
+    @patch(f"{MODULE}.capture_exception")
+    @patch(f"{MODULE}.capture_repartition_event")
+    @patch(f"{MODULE}.HeartbeaterSync")
+    @patch(f"{MODULE}.repartition_table_in_place", new_callable=AsyncMock)
+    @patch(f"{MODULE}.DeltaTableRef")
+    @patch(f"{MODULE}.is_auto_repartition_enabled", return_value=True)
+    @patch(f"{MODULE}.ExternalDataJob")
+    @patch(f"{MODULE}.ExternalDataSchema")
+    def test_final_failure_with_a_staged_swap_keeps_the_markers(
+        self,
+        mock_schema_model: MagicMock,
+        _mock_job_model: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_helper_cls: MagicMock,
+        mock_repartition: AsyncMock,
+        _mock_heartbeater: MagicMock,
+        _mock_capture_event: MagicMock,
+        _mock_capture_exception: MagicMock,
+    ) -> None:
+        schema = _schema(
+            name="public.usages",
+            s3_folder_name="usages",
+            pending={**PENDING_TARGET, "attempts": 2},
+            swap={
+                "state": "ready",
+                "temp_uri": "s3://bucket/usages__repartitioned_ab",
+                "live_uri": "s3://bucket/usages",
+            },
+        )
+        mock_schema_model.objects.select_related.return_value.get.return_value = schema
+        mock_repartition.side_effect = ValueError("temp row count 10 != live row count 12")
+
+        _maybe_repartition_table(
+            RepartitionActivityInputs(team_id=TEAM_ID, schema_id=SCHEMA_ID, job_id=JOB_ID, source_id=SOURCE_ID),
+            MagicMock(),
+        )
+
+        schema.clear_repartition_swap.assert_not_called()
+        schema.clear_repartition_pending.assert_not_called()
+        schema.stamp_last_repartition_at.assert_not_called()
+        assert schema.set_repartition_pending.call_args.args[0]["attempts"] == 3
+
+
 class TestFeatureFlagGate:
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- A third hard repartition failure while a swap is staged deletes the table's data.
- Once `repartition_swap` is `ready`, the swap may already have purged live, so temp holds the only complete copy.
- The give-up path in `_handle_failure` cleared the swap marker unconditionally.
- The next rebuild's temp sweep then deletes the orphaned temp, and the next sync bootstraps an empty table over the data.

## Changes

- Give-up keeps `repartition_pending` and `repartition_swap` whenever a ready swap is staged, and keeps counting failed attempts.
- Every later sync retries the swap from temp. Wasted compute is recoverable, the table is not.
- The failure event carries `swap_kept: true` on this path instead of `final: true`.
- Give-up without a staged swap behaves as before: clear both markers, stamp the cooldown.

## How did you test this code?

- New test: third hard failure with a ready swap staged asserts both markers survive and attempts still increment. No existing test covered give-up with a staged swap.
- Ran the file locally: 17/17 pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal failure-path behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code authored this from a repartition-pipeline review session with @danielcarletti.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Considered completing the swap from the failure handler instead. Rejected it: the handler runs inside an except path with unknown S3 state, and the existing per-sync resume already drives a staged swap to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
