### PR TITLE
fix(data-warehouse): vacuum with default retention and the guard on

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/maintenance.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/maintenance.py
@@ -75,9 +75,15 @@ class DeltaMaintenance:
         await self._logger.adebug("Vacuuming table...")
         # vacuum() commits a REMOVE of tombstoned files, so it's just as subject to delta-rs's
         # conflict checker as merge/optimize.compact — see execute_with_conflict_retry.
+        #
+        # Retention is deliberately left to the table's own `deletedFileRetentionDuration` (a week by
+        # default) with delta-rs's guard enforced. A shorter window with the guard disabled physically
+        # deletes files that a concurrent snapshot, an interleaved repartition swap, or a zombie
+        # activity attempt still references, which hollows the table out: the log keeps pointing at
+        # parquet files S3 404s on, and the only recovery is a full rebuild from source.
         vacuum_stats = await execute_with_conflict_retry(
             table,
-            lambda: table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False),
+            lambda: table.vacuum(dry_run=False),
             "vacuum_table",
             self._logger,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_maintenance.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_maintenance.py
@@ -242,6 +242,9 @@ class TestVacuum:
         await _make_maintenance(mock_delta)._vacuum(mock_delta)
 
         assert mock_delta.vacuum.call_count == 2
+        # No retention override: a sub-default window with enforcement off deletes files a concurrent
+        # snapshot or an interleaved repartition swap still references (the hollow-table failure).
+        assert mock_delta.vacuum.call_args.kwargs == {"dry_run": False}
         mock_delta.update_incremental.assert_called_once()
 
 


### PR DESCRIPTION
## Problem

- Every vacuum runs with `retention_hours=24` and `enforce_retention_duration=False`.
- That deletes files a concurrent snapshot, an interleaved repartition swap, or a zombie activity attempt still references.
- The delta log then points at parquet files S3 404s on: the hollow-table failure. The only recovery is a full rebuild from source.

## Changes

```diff
-            lambda: table.vacuum(retention_hours=24, enforce_retention_duration=False, dry_run=False),
+            lambda: table.vacuum(dry_run=False),
```

- Retention falls back to the table's own `deletedFileRetentionDuration`, a week by default, with delta-rs's guard enforced.

> [!NOTE]
> Trade-off: tombstoned files now live up to a week in S3 instead of a day. Extra storage is recoverable, a hollowed table is not.

- Re-applies the vacuum half of #75767, whose branch targets `delta_table_helper.py`, a file since split into `pipelines/core/delta/`.

## How did you test this code?

- Extended the existing `_vacuum` conflict-retry test to assert the call carries no retention override, so reintroducing the short window fails the suite.
- Ran `test_maintenance.py` locally: 33/33 pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Internal maintenance behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code authored this from a repartition-pipeline review session with @danielcarletti.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The detection half of #75767 (arming a revive when extraction hits a hollow table) is a separate follow-up. This PR removes the suspected cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
