### PR TITLE
fix(rust): stop rebuilding every crate when Cargo.lock changes

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -221,11 +221,13 @@ jobs:
                       f.write(f"matrix={json.dumps(matrix)}\n")
 
     build:
-        name: Build Rust services (depot-ubuntu-22.04-4)
+        name: Build Rust (${{ matrix.packages }})
+        strategy:
+            matrix: ${{ fromJSON(needs.affected.outputs.matrix) }}
         needs: [changes, affected]
         if: needs.changes.outputs.rust == 'true'
         runs-on: depot-ubuntu-22.04-4
-        timeout-minutes: 15
+        timeout-minutes: 20
         permissions:
             contents: read
 
@@ -279,16 +281,13 @@ jobs:
               env:
                   # Use system OpenSSL instead of vendored to avoid assembly build issue (2026-01-13)
                   OPENSSL_NO_VENDOR: '1'
-                  AFFECTED_CRATES: ${{ needs.affected.outputs.affected_crates }}
+                  SHARD_PACKAGES: ${{ matrix.packages }}
               run: |
-                  crates=$(echo "$AFFECTED_CRATES" | python3 -c "import json,sys; print(' '.join(f'-p {c}' for c in json.load(sys.stdin)))")
-                  if [ -z "$crates" ]; then
-                      echo "No affected crates — skipping build"
-                  else
-                      echo "Building affected crates: $crates"
-                      cargo build $crates --locked --release
-                      find target/release/ -maxdepth 1 -executable -type f -exec strip {} +
-                  fi
+                  crates=()
+                  for c in $SHARD_PACKAGES; do crates+=(-p "$c"); done
+                  echo "Building shard crates: ${crates[*]}"
+                  cargo build "${crates[@]}" --locked --release
+                  find target/release/ -maxdepth 1 -executable -type f -exec strip {} +
 
     test:
         name: Test Rust (${{ matrix.packages }})

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -3,28 +3,20 @@
 # Custom rules are processed before default rules. Default rules already handle:
 #   - .cargo/config, .cargo/config.toml → mark-changed = "all"
 #   - Cargo.toml (workspace root) → mark-changed = "all"
-#   - Cargo.lock → mark-changed = [] (ignored — we override below)
+#   - Cargo.lock → mark-changed = [] (ignored; the graph diff covers it)
 #   - README, LICENSE, .gitignore, etc. → mark-changed = []
 #
 # Paths are workspace-relative (strip the `rust/` repo prefix before passing).
 
 use-default-rules = true
 
-# Cargo.lock deliberately has no rule here — the default (mark-changed = [])
-# is correct. The determinator's own graph diff already covers it: whenever a
-# resolved dependency changes, `process_build_summaries` re-simulates each
-# workspace member's none/default/all feature sets against the old graph and
-# marks every dependent changed. A lockfile-only `cargo update` of a widely
-# used crate still fans out to all its dependents.
-#
-# A blanket mark-changed = "all" was tried here and reverted: it fired on every
-# lockfile touch, so adding one dev-dependency edge rebuilt all 68 crates and
-# blew the build job's timeout. Cargo.lock does not record features at all —
-# narrowing surfaces as a removed dependency edge, which the graph diff sees.
-#
-# The one case the graph diff cannot cover is when the old graph fails to
-# build, leaving nothing to diff against. compute_affected() handles that in
-# code by forcing rebuild-all, and that fallback is the real safety net.
+# Cargo.lock intentionally has no rule: the default (mark-changed = []) is
+# correct, because the determinator's graph diff already re-simulates each
+# member's feature sets and marks every dependent of a changed dependency.
+# Do not re-add mark-changed = "all" — it fires on every lockfile touch, so one
+# added dev-dependency rebuilds the whole workspace and blows the build timeout.
+# When the old graph is missing there is nothing to diff, and compute_affected()
+# forces rebuild-all in code instead.
 
 # Dockerfiles and CI image config — cross-cutting build changes.
 [[path-rule]]

--- a/rust/affected-services/determinator-rules.toml
+++ b/rust/affected-services/determinator-rules.toml
@@ -10,14 +10,21 @@
 
 use-default-rules = true
 
-# Cargo.lock: the determinator diffs resolved package graphs but does NOT
-# detect per-crate feature narrowing as a change — a crate whose enabled
-# feature set shrinks (or grows) only shows up in Cargo.lock, not in the
-# determinator's affected set. Force rebuild-all whenever Cargo.lock changes.
-# This overrides the default determinator rule (mark-changed = []).
-[[path-rule]]
-globs = ["Cargo.lock"]
-mark-changed = "all"
+# Cargo.lock deliberately has no rule here — the default (mark-changed = [])
+# is correct. The determinator's own graph diff already covers it: whenever a
+# resolved dependency changes, `process_build_summaries` re-simulates each
+# workspace member's none/default/all feature sets against the old graph and
+# marks every dependent changed. A lockfile-only `cargo update` of a widely
+# used crate still fans out to all its dependents.
+#
+# A blanket mark-changed = "all" was tried here and reverted: it fired on every
+# lockfile touch, so adding one dev-dependency edge rebuilt all 68 crates and
+# blew the build job's timeout. Cargo.lock does not record features at all —
+# narrowing surfaces as a removed dependency edge, which the graph diff sees.
+#
+# The one case the graph diff cannot cover is when the old graph fails to
+# build, leaving nothing to diff against. compute_affected() handles that in
+# code by forcing rebuild-all, and that fallback is the real safety net.
 
 # Dockerfiles and CI image config — cross-cutting build changes.
 [[path-rule]]

--- a/rust/affected-services/tests/integration.rs
+++ b/rust/affected-services/tests/integration.rs
@@ -378,6 +378,7 @@ fn two_graph_lockfile_alone_does_not_rebuild_all() {
         "a lockfile change with an old graph to diff against must not force rebuild-all — the determinator's summary diff decides what is affected"
     );
     assert!(result.crates.is_empty());
+    assert!(result.images.is_empty());
 }
 
 #[test]

--- a/rust/affected-services/tests/integration.rs
+++ b/rust/affected-services/tests/integration.rs
@@ -369,16 +369,15 @@ fn old_graph_no_changed_files_produces_empty() {
 }
 
 #[test]
-fn two_graph_lockfile_triggers_rebuild_all() {
+fn two_graph_lockfile_alone_does_not_rebuild_all() {
     let (graph, images) = load_test_fixtures();
     let result =
         compute_affected(&["rust/Cargo.lock".into()], Some(&graph), &graph, &images).unwrap();
     assert!(
-        result.rebuild_all,
-        "Cargo.lock change should force rebuild-all even with two graphs (feature narrowing is invisible to the determinator)"
+        !result.rebuild_all,
+        "a lockfile change with an old graph to diff against must not force rebuild-all — the determinator's summary diff decides what is affected"
     );
-    let workspace_count = graph.workspace().iter().count();
-    assert_eq!(result.crates.len(), workspace_count);
+    assert!(result.crates.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Any Rust PR that edits `rust/Cargo.lock` builds all 68 workspace crates and times out, however small the edit.
Three propdefs PRs are stuck on this: #77926, #77929, #77942.

- `rust/affected-services/determinator-rules.toml` marks every crate changed on any `Cargo.lock` edit.
- The `build` job then runs one unsharded `cargo build --release` over all 68 crates.
- The job hits its 15 minute limit. GitHub reports a job timeout as `cancelled`, so it does not read as a timeout.
- #77926 and #77942 both died at 15m16s. Every test shard passed on both.

The diffs that trigger this are one lockfile line each. #77926 adds `+ "rdkafka"` inside the `property-defs-rs` dependency list.

## Changes

**Drop the `Cargo.lock` path rule.**
The determinator already covers lockfile changes on its own.
Its `process_build_summaries` re-simulates each member's none, default and all feature sets against the old graph, then marks every dependent changed.

**Shard the `build` job** on the matrix the `affected` job already computes for `test`.
The matrix collapses to one shard when few crates change, so the common case gains no runners.
This is what keeps a genuine 68-crate rebuild inside the timeout.

I kept the fallback in `compute_affected()` that forces rebuild-all when the old graph fails to build.
Nothing can diff against a missing graph, so that path stays the real safety net.

The rule came from #61907, whose own Cargo.toml change was `# no-op: trigger rebuild`.
It was incident response rather than a scoped rule.
Its stated reason was feature narrowing hiding in the lockfile, but Cargo.lock records no features at all.
Narrowing surfaces there as a removed dependency edge, which the graph diff sees.

> [!NOTE]
> `SCCACHE_WEBDAV_KEY_PREFIX` is keyed on the Cargo.lock hash, so a lockfile PR also gets a cold compile cache.
> `Lint Rust services` shows the cost. It builds the full workspace every run, so the workload is constant:
>
> | Lint run | Cargo.lock state | Duration |
> | --- | --- | --- |
> | This PR | unchanged, reuses master's cache | 4m09s |
> | #77929 | changed, warmed by #77926's retries | 8m21s |
> | #77926 | changed, first to touch it | 14m31s |
>
> Lint shares the 15 minute limit, so #77926 sat 29 seconds under its own timeout.
> Lint does not read `affected`, so neither change in this PR helps it.
> It needs a restore-keys fallback to master's prefix, which is a separate PR.

## How did you test this code?

I (actually Claude) built `affected-services` from this branch and ran it against the real base-ref diffs of both blocked PRs.

| Input | Before | After |
| --- | --- | --- |
| #77926, one dev-dependency edge | 68 crates, 28 images | 1 crate, 1 image |
| #77942, one removed edge | 68 crates, 28 images | 1 crate, 1 image |
| `cargo update -p serde_json`, lockfile only | 68 crates | 59 crates |

The third row is the safety check.
A version bump with no Cargo.toml change still reaches every transitive dependent, so real dependency changes keep fanning out.

`cargo test -p affected-services` passes, 22 tests.
I inverted `two_graph_lockfile_triggers_rebuild_all`, which asserted the behavior this PR removes.
It now catches the reverse regression: a lockfile change with an old graph available must not escalate to rebuild-all.
`single_graph_lockfile_triggers_rebuild_all` stays and guards the fallback.

I did not run the sharded `build` job. CI on this PR is the first exercise of that matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Georges-Antoine brought the three blocked PRs and asked me to check the diagnosis before any filter change landed.

Skills invoked: `/authoring-ci-workflows`, `/writing-pr-descriptions`.

The starting theory was that the crate filter needed widening. Reading the rule showed the opposite: it is deliberate, with a documented rationale, so I tested that rationale instead of patching around it. Building the determinator locally and running it against the real diffs settled it, and the `serde_json` counterfactual is what made removal safe rather than plausible.

I traced the failure to the `build` job rather than the tests, which the `cancelled` status had been hiding. That is why this PR shards `build` as well: without it, the next genuine full rebuild hits the same wall.
