### PR TITLE
fix(mysql): recognize Vitess-wrapped unknown-column errors as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -271,11 +271,13 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # longer exists in the source table — almost always the configured incremental field
             # after the column was renamed or dropped (schema drift). The streaming query reissues
             # the same WHERE/ORDER BY on every attempt, so it fails identically forever; the COUNT(*)
-            # probe already swallows this same error expecting it to be classified here. Match on the
-            # locale-independent error code (the column name and clause are volatile, and the message
-            # text is translated on non-English servers) so it catches both the raw pymysql string and
-            # the Temporal-wrapped `OperationalError: (1054, ...)` form.
-            '(1054, "Unknown column': "A column referenced during sync no longer exists in your source table (MySQL error 1054). This usually means a column was renamed or dropped — if it's the table's incremental field, update it to a column that exists (or switch to a full re-sync), then resync.",
+            # probe already swallows this same error expecting it to be classified here. Match on
+            # "Unknown column" alone (not anchored to a `(1054, "` prefix) so it also catches Vitess/
+            # PlanetScale's vtgate, which re-wraps the same 1054 error with its own gRPC preamble —
+            # e.g. `(1054, 'unknown: target: ...: vttablet: rpc error: code = NotFound desc = Unknown
+            # column ... (errno 1054) ...')` — where the message text sits well after `(1054, ` and
+            # behind a single quote rather than the double quote pymysql itself uses.
+            "Unknown column": "A column referenced during sync no longer exists in your source table (MySQL error 1054). This usually means a column was renamed or dropped — if it's the table's incremental field, update it to a column that exists (or switch to a full re-sync), then resync.",
             # MySQL/MariaDB error 1130 (ER_HOST_NOT_PRIVILEGED): the server has no grant permitting
             # PostHog's connecting host, so the handshake is rejected before any credentials are
             # checked. Only a DB admin can fix this server-side (GRANT for the host, or allow our

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1895,6 +1895,17 @@ class TestMySQLSourceNonRetryableErrors:
             "OperationalError: (1054, \"Unknown column 'favoritor_id' in 'where clause'\")",
             # Other clause variants share the same 1054 code and "Unknown column" prefix.
             "OperationalError: (1054, \"Unknown column 'deleted_at' in 'order clause'\")",
+            # Vitess/PlanetScale's vtgate re-wraps the same 1054 error with its own gRPC preamble,
+            # so "Unknown column" sits well after `(1054, ` and behind a single quote rather than
+            # pymysql's own double quote — this shape doesn't share a contiguous `(1054, "` prefix
+            # with the raw pymysql form above.
+            str(
+                pymysql.err.OperationalError(
+                    1054,
+                    "unknown: target: ks.-.primary: vttablet: rpc error: code = NotFound desc = "
+                    "Unknown column 'team_id' in 'field list' (errno 1054) (sqlstate 42S22)",
+                )
+            ),
         ],
     )
     def test_unknown_column_is_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

A MySQL/Vitess-backed sync retries forever when a column referenced in the sync query no longer exists in the source table, instead of stopping with an actionable message.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fd2dd-5181-7de2-a3bd-1302a41c5b68

## Changes

- MySQL error 1054 (unknown column) is already classified as non-retryable, but the match required `Unknown column` to sit directly after `(1054, "` in the message.
- Vitess/PlanetScale's vtgate re-wraps the same 1054 error with its own gRPC diagnostic preamble, so the text lands well past that prefix and behind a single quote instead of pymysql's double quote. The existing pattern never matched it, so the sync kept retrying an error that fails identically every time.
- Widened the match to the stable substring `Unknown column` alone, which both the raw pymysql form and the Vitess-wrapped form contain.

## How did you test this code?

Extended `test_unknown_column_is_non_retryable` with the Vitess-wrapped message shape (gRPC preamble before "Unknown column", single-quoted). This is the regression that fell through before this change; verified it now passes along with the rest of the file's non-retryable-error tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the `mysql` data-warehouse source (Claude Code). Confirmed the stack trace originates in `MySQLImplementation._stream_with_optional_force_index` (mysql.py), read the source and existing `get_non_retryable_errors` classification, and traced why the existing 1054 pattern doesn't match Vitess's wrapped rendering of the same error. Searched open PRs (human and bot) for a duplicate fix; found none.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.