### PR TITLE
fix(warehouse): document the settings.modules.READ scope the credential probe requires

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/source.py
@@ -59,7 +59,7 @@ class ZohoCRMSource(ResumableSource[ZohoCRMSourceConfig, ZohoCRMResumeConfig]):
             # variant too, or the same credential rejection retries the whole activity budget.
             "400 Client Error:  for url: https://accounts.zoho": "Zoho CRM rejected your OAuth credentials. Check that the client ID, client secret, and refresh token all belong to the same self client.",
             "401 Client Error: Unauthorized for url": "Your Zoho CRM access token is invalid or expired. Reconnect the source to issue a new one.",
-            "403 Client Error: Forbidden for url": "Your Zoho CRM token is missing a scope for this module. Re-authorize with the ZohoCRM.modules.ALL and ZohoCRM.settings.fields.READ scopes.",
+            "403 Client Error: Forbidden for url": "Your Zoho CRM token is missing a scope for this module. Re-authorize with the ZohoCRM.modules.ALL, ZohoCRM.settings.fields.READ, and ZohoCRM.settings.modules.READ scopes.",
         }
 
     @property
@@ -72,7 +72,7 @@ class ZohoCRMSource(ResumableSource[ZohoCRMSourceConfig, ZohoCRMResumeConfig]):
             releaseStatus=ReleaseStatus.ALPHA,
             caption="""Connect your Zoho CRM account to pull leads, contacts, deals, and your other modules into the PostHog Data warehouse.
 
-In the [Zoho API console](https://api-console.zoho.com), create a **Self Client** and generate a refresh token for the scopes `ZohoCRM.modules.ALL` and `ZohoCRM.settings.fields.READ`. Paste the client ID, client secret, and refresh token below, then pick the data center your Zoho account lives in.""",
+In the [Zoho API console](https://api-console.zoho.com), create a **Self Client** and generate a refresh token for the scopes `ZohoCRM.modules.ALL`, `ZohoCRM.settings.fields.READ`, and `ZohoCRM.settings.modules.READ`. Paste the client ID, client secret, and refresh token below, then pick the data center your Zoho account lives in.""",
             iconPath="/static/services/zoho_crm.png",
             docsUrl="https://posthog.com/docs/cdp/sources/zoho-crm",
             fields=cast(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm_source.py
@@ -90,6 +90,28 @@ class TestZohoCRMSource:
         assert self.source.default_version == "v8"
         assert self.source.api_docs_url.startswith("https://")
 
+    def test_source_config_documents_scopes_the_requests_require(self) -> None:
+        # `settings.modules.READ` is the easy one to drop, because nothing in the sync path uses it:
+        # it exists only so `validate_credentials` can probe /settings/modules. Zoho answers that
+        # probe with a 401 OAUTH_SCOPE_MISMATCH when the scope is missing, and the blanket
+        # `except Exception` in `validate_credentials` flattens it to "Invalid Zoho CRM credentials"
+        # — so leaving it out of the caption fails every setup that followed the caption exactly.
+        # The caption is also the docs page: posthog.com builds /docs/cdp/sources/zoho-crm from it
+        # via /api/public_source_configs, so this string is the only place the scopes are published.
+        required_scopes = [
+            "ZohoCRM.modules.ALL",
+            "ZohoCRM.settings.fields.READ",
+            "ZohoCRM.settings.modules.READ",
+        ]
+        caption = self.source.get_source_config.caption
+        forbidden_message = self.source.get_non_retryable_errors()["403 Client Error: Forbidden for url"]
+
+        assert caption is not None
+        assert forbidden_message is not None
+        for scope in required_scopes:
+            assert scope in caption
+            assert scope in forbidden_message
+
     @pytest.mark.parametrize(
         "observed_error",
         [


### PR DESCRIPTION
## Problem

Creating a Zoho CRM source failed with **"Invalid credentials" even when the credentials were correct** — for anyone who followed our setup instructions exactly.

`validate_credentials` probes `GET /crm/v8/settings/modules`. Per [Zoho's v8 Modules API docs](https://www.zoho.com/crm/developer/docs/api/v8/modules-api.html), that endpoint requires `ZohoCRM.settings.modules.READ` (or the catch-all `ZohoCRM.settings.ALL`). But the setup caption only asked for `ZohoCRM.modules.ALL` and `ZohoCRM.settings.fields.READ`.

So the probe came back **401 `OAUTH_SCOPE_MISMATCH`** → `raise_for_status()` → the blanket `except Exception: return False, None` in `validate_credentials` → the literal string `"Invalid Zoho CRM credentials"`.

The failure was also completely opaque: the exception is swallowed, so there was **no log line, no error-tracking event, and no source row** to debug from.

A detail that made this especially confusing to diagnose: **token minting is scope-independent**, so the same refresh token exchanges successfully in Postman. The failure is the follow-up API call, which Postman never makes.

## Fix

Add `ZohoCRM.settings.modules.READ` to the setup caption, and keep the 403 guidance in `get_non_retryable_errors` in sync. These two strings are the only places in the codebase where the Zoho scopes are written down.

Used the narrow `ZohoCRM.settings.modules.READ` rather than `ZohoCRM.settings.ALL` — the latter would collapse the list to two scopes but grants write access to org settings the connector never needs.

| Scope | Used by |
|---|---|
| `ZohoCRM.modules.ALL` | record reads, `/crm/{v}/{module}` |
| `ZohoCRM.settings.fields.READ` | field metadata for table columns, `/settings/fields` |
| `ZohoCRM.settings.modules.READ` | the `validate_credentials` probe, `/settings/modules` |

## This is also the docs fix

There is **no** `zoho-crm.md` in the posthog.com repo (verified against the full master tree — zero files with "zoho" in the path). The page at `/docs/cdp/sources/zoho-crm` is generated from this caption:

`get_source_config` → `build_source_configs()` → public `GET /api/public_source_configs` → posthog.com `fetchDataWarehouseSources()` (`gatsby/sourceNodes.ts`) → `DataWarehouseSource.tsx`, which renders `{caption && <ReactMarkdown>{caption}</ReactMarkdown>}`.

⚠️ So **no posthog.com PR is needed**, but the public docs page only updates after this ships to production and posthog.com rebuilds — not instantly on merge.

## Testing

`flox activate -- uv run --no-sync pytest .../zoho_crm/tests/ -q` → **108 passed**, including a new `test_source_config_documents_scopes_the_requests_require` modeled on the existing precedent in `plain/tests/test_plain_source.py`. It asserts all three scopes appear in both the caption and the 403 message, so they can't drift apart again.

`test_public_source_configs.py` needs a running Postgres and wasn't run locally; leaving it to CI.

## Known issues left for follow-up

Found while diagnosing, deliberately out of scope to keep this diff minimal:

1. **Validation failures are silent.** The blanket `except Exception: return False, None` discards the reason with no logging or `capture_exception` — this is why there was nothing to check in the logs. Worth parsing Zoho's stable JSON `code` and logging it (pattern: `databricks/source.py`).
2. **The 403 key can never match a scope error.** Zoho returns **401** for `OAUTH_SCOPE_MISMATCH`, so at sync time a scope problem matches the 401 key instead and misreports as "access token is invalid or expired."
3. **Wasted token exchange.** `get()` re-mints and retries on any 401, including scope errors that re-minting can never fix.
4. **The probe tests a scope the pipeline never uses.** Nothing outside `validate_credentials` calls `/settings/modules`; the sync only uses `/settings/fields` and `/crm/{v}/{module}`. Switching the probe to `/settings/fields` would let us drop this scope request entirely — a cleaner fix, deferred as a behaviour change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*