### PR TITLE
fix(mysql): stop retrying a deleted or sleeping PlanetScale branch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -320,6 +320,14 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # the sync path classifies and in the " ".join(e.args) form validate_credentials builds
             # (the formatted "codec can't encode character" text is reconstructed in neither).
             "ordinal not in range(256)": "One of your connection details contains an invisible or unsupported character (for example a zero-width space pasted in from another app). Retype the affected field — host, database, user, or password — by hand instead of pasting it, then re-enable the sync.",
+            # Vitess/PlanetScale vtgate error 1105 (ER_UNKNOWN_ERROR) raised when the target
+            # keyspace ("branch" in PlanetScale) has been deleted or put to sleep. Unlike the other
+            # transient 1105 payloads mysql.py already retries in-process (`code = Unavailable`,
+            # `reparent operation in progress`), a sleeping branch never wakes on its own — PlanetScale
+            # only wakes it from the dashboard or once a billing issue is resolved — and a deleted
+            # branch never comes back, so every retry fails identically. Match the stable phrase,
+            # excluding the volatile branch id that follows it.
+            "branch is missing or sleeping": "The PlanetScale (or Vitess) branch this source connects to has been deleted or put to sleep. Wake it from the PlanetScale dashboard (or resolve any billing issue), or point this source at a database that exists, then resync.",
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2062,6 +2062,20 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form the import/sync path classifies.
+            str(pymysql.err.OperationalError(1105, "not_found: branch is missing or sleeping: aaaaaaaaaaaa")),
+            # Temporal-wrapped str(e.cause) form — different branch id, same stable phrase.
+            "OperationalError: (1105, 'not_found: branch is missing or sleeping: bbbbbbbbbbbb')",
+        ],
+    )
+    def test_planetscale_branch_sleeping_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"PlanetScale sleeping/missing branch error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",


### PR DESCRIPTION
## Problem

A MySQL/MariaDB source backed by a PlanetScale (or other Vitess) database retries forever once its target branch has been deleted or put to sleep for inactivity.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fd2e4-a8bd-7953-9d55-314006013452

## Changes

- PlanetScale surfaces this as MySQL error 1105 with the message `not_found: branch is missing or sleeping: <id>`. It wasn't in `MySQLSource.get_non_retryable_errors`, so the sync treated it as a fresh, retryable failure on every attempt.
- A sleeping branch never wakes on its own — PlanetScale only wakes it from its dashboard or once a billing issue is resolved — and a deleted branch never comes back, so retrying just repeats the same failure forever.
- Added the stable phrase `branch is missing or sleeping` to `get_non_retryable_errors`, excluding the volatile branch id that follows it, with a message telling the user to wake the branch or point the source at a database that exists.
- This is a different 1105 payload than the transient ones `mysql.py` already retries in-process (`code = Unavailable`, `reparent operation in progress`), which self-heal within seconds and stay untouched.

## How did you test this code?

Added `test_planetscale_branch_sleeping_is_non_retryable` to `TestMySQLSourceNonRetryableErrors`, covering both the raw pymysql error shape and the Temporal-wrapped form. This is the regression that would let the error slip back to retrying forever.

Ran the full `TestMySQLSourceNonRetryableErrors` suite locally (51 cases) and repo-wide `mypy` — both clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this only changes internal retry classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for the `mysql` data-warehouse source (Claude Code). Confirmed the stack trace originates in `MySQLSource._connect_with_transient_retry` (mysql.py), then researched PlanetScale's branch-sleeping behavior to confirm it requires manual intervention rather than resolving on retry. Searched open PRs (human and bot) for a duplicate fix; found none — a related PR (#78474) fixes a different 1054 unknown-column error on the same source.

Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.