### PR TITLE
fix(vercel): encode events pagination timestamps as ISO 8601

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/settings.py
@@ -18,6 +18,11 @@ class VercelEndpointConfig:
     # Query param that lower-bounds results by creation time (Unix ms). Only set where Vercel
     # documents a genuine server-side time filter — None means full refresh for this endpoint.
     since_param: Optional[str] = None
+    # Whether `since`/`until` must be sent as ISO 8601 UTC strings rather than raw Unix-ms
+    # integers. Vercel's OpenAPI spec types since/until as numbers (e.g. 1540095775941) for
+    # deployments, domains, aliases, and teams, but as strings (e.g. "2019-12-08T10:00:38.976Z")
+    # for events — sending events a raw ms integer gets rejected with a 400.
+    since_until_as_iso: bool = False
     # Team-owned resources require ?teamId=<id> on each request. Endpoints that list resources
     # visible to the token itself (e.g. /v2/teams) are not team-scoped.
     team_scoped: bool = True
@@ -91,6 +96,7 @@ VERCEL_ENDPOINTS: dict[str, VercelEndpointConfig] = {
         # time, so this is genuinely incremental rather than a client-side skip. `createdAt` is
         # immutable, making it both the incremental cursor and the pagination cursor.
         since_param="since",
+        since_until_as_iso=True,
         supports_incremental=True,
         supports_append=True,
         # Unlike the resource endpoints this one returns no `pagination` envelope, so pages are

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.vercel.ver
     _floor_to_day,
     _focus_charge_id,
     _iso8601_utc,
+    _ms_to_iso8601,
     _should_stop_desc,
     get_billing_rows,
     get_rows,
@@ -91,6 +92,22 @@ class TestBuildParams:
                 None,
                 None,
                 {"limit": PAGE_SIZE, "teamId": "team_1", "withPayload": "true"},
+            ),
+            # events' since/until must be ISO 8601 strings, not raw Unix-ms integers — Vercel's
+            # OpenAPI spec types them as strings and 400s a raw ms value (unlike deployments above,
+            # which documents since/until as numbers).
+            (
+                "events_since_and_until_as_iso",
+                "events",
+                None,
+                123,
+                456,
+                {
+                    "limit": PAGE_SIZE,
+                    "withPayload": "true",
+                    "since": "1970-01-01T00:00:00.123Z",
+                    "until": "1970-01-01T00:00:00.456Z",
+                },
             ),
         ]
     )
@@ -265,9 +282,10 @@ class TestGetRows:
 
         assert [r["id"] for r in rows] == ["e1", "e2", "e3"]
         assert "until=" not in calls[0]
-        # The oldest row on each page bounds the next, so page two asks for until=200, not 300.
-        assert "until=200" in calls[1]
-        assert "until=100" in calls[2]
+        # The oldest row on each page bounds the next, so page two asks for until=200, not 300 —
+        # encoded as the ISO string events requires, not the raw ms integer.
+        assert "until=1970-01-01T00%3A00%3A00.200Z" in calls[1]
+        assert "until=1970-01-01T00%3A00%3A00.100Z" in calls[2]
 
     def test_events_stop_when_a_whole_page_shares_one_timestamp(self, monkeypatch: Any) -> None:
         # The derived cursor can't advance past a page whose rows share a timestamp; the walk has
@@ -297,7 +315,7 @@ class TestGetRows:
         )
 
         assert [r["id"] for r in rows] == ["e1", "e2", "e3"]
-        assert "since=150" in calls[0]
+        assert "since=1970-01-01T00%3A00%3A00.150Z" in calls[0]
         assert len(calls) == 2
 
     def test_mid_page_yield_checkpoints_current_page_not_next(self, monkeypatch: Any) -> None:
@@ -378,6 +396,20 @@ class TestIso8601Utc:
     def test_formats_as_utc_z_with_millis(self) -> None:
         formatted = _iso8601_utc(datetime(2025, 1, 2, 3, 4, 5, tzinfo=UTC))
         assert formatted == "2025-01-02T03:04:05.000Z"
+
+
+class TestMsToIso8601:
+    @parameterized.expand(
+        [
+            ("whole_second", 1700000000000, "2023-11-14T22:13:20.000Z"),
+            # Millisecond digits must survive, not just the second — a truncated cursor would
+            # under-report `until` and re-request rows the previous page already yielded.
+            ("preserves_millis", 1699999999123, "2023-11-14T22:13:19.123Z"),
+            ("epoch", 0, "1970-01-01T00:00:00.000Z"),
+        ]
+    )
+    def test_ms_to_iso8601(self, _name: str, ms: int, expected: str) -> None:
+        assert _ms_to_iso8601(ms) == expected
 
 
 class TestFocusChargeId:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
@@ -69,6 +69,13 @@ def _get_headers(access_token: str) -> dict[str, str]:
     }
 
 
+def _ms_to_iso8601(ms: int) -> str:
+    """Convert a Unix-ms cursor value to the ISO 8601 UTC string format some Vercel endpoints
+    (e.g. events) expect for `since`/`until` — see `VercelEndpointConfig.since_until_as_iso`."""
+    seconds, millis = divmod(ms, 1000)
+    return datetime.fromtimestamp(seconds, tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.") + f"{millis:03d}Z"
+
+
 def _build_params(
     config: VercelEndpointConfig,
     team_id: str | None,
@@ -81,10 +88,10 @@ def _build_params(
         params["teamId"] = team_id
 
     if config.since_param and since_value is not None:
-        params[config.since_param] = since_value
+        params[config.since_param] = _ms_to_iso8601(since_value) if config.since_until_as_iso else since_value
 
     if until is not None:
-        params["until"] = until
+        params["until"] = _ms_to_iso8601(until) if config.since_until_as_iso else until
 
     return params
 


### PR DESCRIPTION
## Problem

Data warehouse imports of the Vercel `events` table fail every run with a 400 error and never recover, because the same rejected request gets retried indefinitely.

Vercel's `/v3/events` endpoint returned `400 Client Error: Bad Request` (error tracking: [issue](https://us.posthog.com/project/2/error_tracking/019fd2fb-b0cc-7932-9474-09483a074120)) for a request our pagination built with a valid team ID and token, so this isn't a credentials problem.

## Changes

- Vercel's OpenAPI spec types `since`/`until` as ISO 8601 strings (e.g. `2019-12-08T10:00:38.976Z`) for the events endpoint specifically, while deployments, domains, aliases, and teams all document them as raw Unix-ms numbers. Our pagination sent a raw ms integer to every endpoint, including events, which Vercel rejects with the 400 above.
- Add a `since_until_as_iso` flag to `VercelEndpointConfig`, set only for `events`, and encode the cursor as an ISO 8601 UTC string when it's set. Every other endpoint keeps sending raw integers.

## How did you test this code?

Added cases to `test_vercel.py`:
- `TestBuildParams` gained an `events_since_and_until_as_iso` case asserting ISO encoding, alongside the existing `deployments` case that still asserts raw-integer encoding is untouched.
- `TestMsToIso8601` covers the new conversion helper (whole seconds, millisecond precision, epoch).
- Updated `TestGetRows.test_events_pages_without_a_pagination_envelope` and `test_events_incremental_sends_since_and_stops_at_watermark`, which previously asserted the buggy raw-integer cursor in the request URL, to assert the ISO-encoded one instead.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/` (84 passed), `ruff check`/`ruff format --check`, and `uv run mypy --cache-fine-grained .` (repo-wide, clean).

Not run: a live call against Vercel's API, since I don't have credentials for the affected account — the fix is grounded in Vercel's published OpenAPI spec (`https://openapi.vercel.sh/`) rather than a live reproduction.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this only changes internal pagination encoding, not documented source behavior.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) triaged an error-tracking issue for the Vercel data-warehouse source, traced the 400 to the exact failing request, and cross-referenced Vercel's OpenAPI spec to find that events' `since`/`until` params are typed as ISO 8601 strings while every other endpoint on this source uses raw Unix-ms numbers. Invoked `/writing-tests` before touching the test file and `/writing-pr-descriptions` before writing this body. Searched for an existing human-authored fix (none found) and for prior bot-authored attempts (none found).