### PR TITLE
fix(postgres): stop reporting exhausted connection-limit retries as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -43,6 +43,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.c
     drop_slot_and_publication,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import (
+    _CONNECTION_LIMIT_ERROR_SUBSTRINGS,
     _SSH_HANDSHAKE_EOF_ERROR,
     XMIN_AS_INCREMENTAL_FIELD_ERROR,
     PostgresImplementation,
@@ -774,7 +775,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         # offset-chunking reconnect also retries in-process (`_SERVER_STARTING_UP_ERROR_SUBSTRINGS`
         # in postgres.py) — this is the same whole-activity-retry fallback for when that budget is
         # exhausted (e.g. a longer maintenance window).
-        return {"terminating connection due to", "the database system is shutting down"}
+        #
+        # `_CONNECTION_LIMIT_ERROR_SUBSTRINGS` (e.g. "remaining connection slots are reserved") is a
+        # connect-time capacity refusal already retried in-process by `_connect_with_dropped_retry` /
+        # `_is_dropped_or_connection_limit`. A slot frees the moment another connection closes, so a
+        # sustained shortage that outlasts that budget is still transient — the same
+        # reaches-here-only-after-internal-retries-exhaust case as the two entries above.
+        return {
+            "terminating connection due to",
+            "the database system is shutting down",
+            *_CONNECTION_LIMIT_ERROR_SUBSTRINGS,
+        }
 
     def reconcile_schema_metadata(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1238,6 +1238,30 @@ class TestPostgresSourceRetryableErrors:
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Server-shutting-down error should not be non-retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # SQLSTATE 53300: the source (or a pooler in front of it) refuses a new connection
+            # because only the superuser-reserved slots remain. `_connect_with_dropped_retry`
+            # already retries this in-process on the read/sync connect path; this is the
+            # whole-activity-retry fallback for when a sustained shortage outlasts that budget.
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+            "FATAL:  remaining connection slots are reserved for roles with the SUPERUSER attribute",
+            "sorry, too many clients already",
+            "too many connections for role",
+        ],
+    )
+    def test_connection_limit_is_classified_retryable(self, source, error_msg):
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg.lower() for pattern in retryable)
+        assert is_retryable, f"Connection-limit error should be classified retryable: {error_msg}"
+
+    def test_connection_limit_is_not_also_non_retryable(self, source):
+        error_msg = "remaining connection slots are reserved for roles with the SUPERUSER attribute"
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Connection-limit error should not be non-retryable: {error_msg}"
+
 
 def _raise_eof() -> None:
     # Indirection so the `yield` below stays reachable under mypy's warn_unreachable — at runtime


### PR DESCRIPTION
## Problem

A Postgres sync that hits a source or pooler connection-slot limit gets reported to error tracking on every occurrence, even though the condition clears itself moments later.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd308-47ba-7f01-b39b-db44d3aab40b): `OperationalError: ... FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute`.
- `_connect_with_dropped_retry` already retries this in-process (`_is_connection_limit_error` in `postgres.py`), reconnecting once a slot frees up.
- Once that retry budget is exhausted, the error reaches `_handle_import_error`, which only recognized two other transient substrings ("terminating connection due to", "the database system is shutting down") as retryable. Everything else gets logged at exception level and captured, even when Temporal is about to retry the whole activity anyway.

## Changes

- `PostgresSource.get_retryable_errors()` now also matches the connection-limit substrings already defined in `_CONNECTION_LIMIT_ERROR_SUBSTRINGS` (superuser-reserved slots, "too many clients already", "too many connections for role").
- No change to `get_non_retryable_errors()` or to Temporal's retry policy: the activity still retries exactly as before, this only stops reporting an already-transient condition as an exception.

## How did you test this code?

- Added `TestPostgresSourceRetryableErrors.test_connection_limit_is_classified_retryable` (parameterized over the three connection-limit message shapes) and `test_connection_limit_is_not_also_non_retryable`, mirroring the existing tests for the sibling "terminating connection"/"shutting down" cases. Guards against this connection-limit message class being misclassified again.
- Ran the full `TestPostgresSourceRetryableErrors` class locally: 10 passed.
- `ruff check`/`ruff format --check` clean, `uv run mypy --cache-fine-grained .` clean (repo-wide), `hogli ci:preflight --fix` reports 0 failures.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue. Confirmed the failure originates in this source's code (stack trace runs through `postgres.py`'s connect path) and traced the full call chain via the sampled event's stack trace to `get_rows` → `_connect_with_dropped_retry` → `_connect_with_options_fallback`, showing the connect call already had in-process retry before escaping to `_handle_import_error`.

Checked for duplicates: searched open PRs (excluding the automation bot) by exception type, module path, and message text, and reviewed the data-warehouse maintainer's own open PRs (including [#78410](https://github.com/PostHog/posthog/pull/78410), which addresses a different reporting path) — none touch `get_retryable_errors` or this connection-limit condition.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*