### PR TITLE
chore(ci): publish OCI index metadata

### DIFF
--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -48,7 +48,7 @@ outputs:
         value: ${{ steps.meta.outputs.labels }}
     annotations:
         description: 'Docker metadata annotations'
-        value: ${{ steps.meta.outputs.annotations }}
+        value: ${{ steps.annotations.outputs.value }}
     ecr-registry:
         description: 'ECR registry URL'
         value: ${{ steps.aws-ecr.outputs.registry }}
@@ -148,8 +148,24 @@ runs:
                   type=sha,format=long
                   type=raw,value=${{ github.sha }}
                   type=raw,value=latest,enable={{is_default_branch}}
-              annotations: |
-                  com.posthog.image.author=${{ steps.commit.outputs.author }}
-                  com.posthog.image.committer=${{ steps.commit.outputs.committer }}
-                  com.posthog.image.message=${{ steps.commit.outputs.subject }}
-                  com.posthog.image.commit-timestamp=${{ steps.commit.outputs.timestamp }}
+
+        - name: Add commit annotations
+          id: annotations
+          shell: bash
+          env:
+              AUTHOR: ${{ steps.commit.outputs.author }}
+              COMMITTER: ${{ steps.commit.outputs.committer }}
+              MESSAGE: ${{ steps.commit.outputs.subject }}
+              METADATA_ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
+              TIMESTAMP: ${{ steps.commit.outputs.timestamp }}
+          run: |
+              set -euo pipefail
+              {
+                echo "value<<ANNOTATIONS_EOF"
+                printf '%s\n' "$METADATA_ANNOTATIONS"
+                printf 'index:com.posthog.image.author=%s\n' "$AUTHOR"
+                printf 'index:com.posthog.image.committer=%s\n' "$COMMITTER"
+                printf 'index:com.posthog.image.message=%s\n' "$MESSAGE"
+                printf 'index:com.posthog.image.commit-timestamp=%s\n' "$TIMESTAMP"
+                echo "ANNOTATIONS_EOF"
+              } >> "$GITHUB_OUTPUT"

--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -46,6 +46,9 @@ outputs:
     labels:
         description: 'Docker metadata labels'
         value: ${{ steps.meta.outputs.labels }}
+    annotations:
+        description: 'Docker metadata annotations'
+        value: ${{ steps.meta.outputs.annotations }}
     ecr-registry:
         description: 'ECR registry URL'
         value: ${{ steps.aws-ecr.outputs.registry }}
@@ -109,14 +112,44 @@ runs:
               PUSH_TO_GHCR: ${{ inputs.push-to-ghcr }}
               PUSH_TO_ECR: ${{ inputs.push-to-ecr }}
 
+        - name: Extract commit metadata
+          id: commit
+          shell: bash
+          env:
+              EVENT_AUTHOR: ${{ github.event.head_commit.author.username }}
+              EVENT_COMMITTER: ${{ github.event.head_commit.committer.username }}
+              LC_ALL: C.UTF-8
+          run: |
+              set -euo pipefail
+              subject="$(git log -1 --format=%s)"
+              author="${EVENT_AUTHOR:-$(git log -1 --format=%an)}"
+              committer="${EVENT_COMMITTER:-$(git log -1 --format=%cn)}"
+              timestamp="$(TZ=UTC git show -s --date=format-local:%Y-%m-%dT%H:%M:%SZ --format=%cd HEAD)"
+              if [ "${#subject}" -gt 160 ]; then
+                subject="${subject:0:157}..."
+              fi
+              {
+                echo "subject=${subject}"
+                echo "author=${author}"
+                echo "committer=${committer}"
+                echo "timestamp=${timestamp}"
+              } >> "$GITHUB_OUTPUT"
+
         - name: Docker meta
           id: meta
           uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+          env:
+              DOCKER_METADATA_ANNOTATIONS_LEVELS: index
           with:
               images: ${{ steps.images.outputs.list }}
               tags: |
                   type=ref,event=pr
                   type=ref,event=branch
-                  type=sha
+                  type=sha,format=long
                   type=raw,value=${{ github.sha }}
                   type=raw,value=latest,enable={{is_default_branch}}
+              annotations: |
+                  com.posthog.image.author=${{ steps.commit.outputs.author }}
+                  com.posthog.image.committer=${{ steps.commit.outputs.committer }}
+                  com.posthog.image.message=${{ steps.commit.outputs.subject }}
+                  com.posthog.image.commit-timestamp=${{ steps.commit.outputs.timestamp }}

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -75,8 +75,8 @@ jobs:
             # Idempotency preflight. If this commit's image is already in ECR (a manual
             # re-run, or an earlier attempt that pushed to ECR before failing on another
             # registry) do NOT rebuild: a rebuild yields a new digest and would overwrite
-            # the immutable sha-<short>/<full-sha> tags. We reconcile from the existing
-            # digest instead (see "Reconcile tags from existing image" below). Uses
+            # the immutable full-SHA tags. We reconcile from the existing digest instead
+            # (see "Reconcile tags from existing image" below). Uses
             # batch-get-image because the ECR publish role has ecr:BatchGetImage but not
             # ecr:DescribeImages. A genuine miss exits 0 (a `None` result); a throttle,
             # credential, or network error exits non-zero and must fail the step — we can't
@@ -115,6 +115,7 @@ jobs:
                   push: true
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: |
                       COMMIT_HASH=${{ github.sha }}
@@ -183,6 +184,7 @@ jobs:
                   push: true
                   tags: ${{ steps.docker-meta.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
+                  annotations: ${{ steps.docker-meta.outputs.annotations }}
                   platforms: linux/arm64,linux/amd64
                   build-args: |
                       COMMIT_HASH=${{ github.sha }}


### PR DESCRIPTION
## Problem

Commit metadata on the `posthog-cloud` OCI index is unavailable because the build only writes image-config labels. Index-level annotations make revision and commit context available without inspecting architecture-specific manifests.

## Changes

- Publish standard `org.opencontainers.image.*` metadata and `com.posthog.image.*` commit metadata as OCI index annotations on both build attempts.
- Preserve GitHub author and committer logins from push events, with checked-out Git metadata as a fallback; source the commit subject and UTC timestamp from Git.
- Append commit-derived annotations as literal data after metadata generation so commit text cannot be interpreted as Handlebars templates.
- Preserve PR, branch, bare full-commit, and default-branch `latest` tags across every configured registry.
- Replace the short `sha-` tag with `sha-<full commit SHA>` for downstream artifact discovery while retaining the existing bare full-SHA tag.
- Keep the implementation in the existing `docker-meta` action so all image workflows retain one metadata and tag policy.
- Leave existing images unchanged; index annotations begin with the first image built after this change.

Post-merge verification after the next `master` build:

- [ ] Check the resulting OCI index in the target registry.
- [ ] Confirm standard OCI metadata and the four commit metadata annotations are present.

## How did you test this code?

- Ran `actionlint -ignore SC2086 .github/workflows/container-images-cd.yml`.
- Parsed both changed YAML files with `yq`.
- Ran ShellCheck against the commit-metadata extraction step.
- Executed the extraction step against the checked-out commit and confirmed all four values were non-empty.
- Verified annotation values containing `{{#if}}`, `$HOME`, and `$(false)` remain literal and do not fail or execute.
- Ran `git diff --check` and the repository formatting hooks.
- Audited all nine `docker-meta` callers, including checkout ordering and sparse-checkout contents.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This updates build metadata without changing a documented user workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code prepared the workflow change under direct human guidance.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
