### PR TITLE
feat(subscriptions): allow 10 dashboard insights

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -67,7 +67,7 @@ from products.product_analytics.backend.models.insight import Insight
 
 from ee.billing.quota_limiting import QuotaLimitingCaches, QuotaResource, is_team_limited
 from ee.tasks.subscriptions.auto_disable import validate_re_enable
-from ee.tasks.subscriptions.subscription_utils import MAX_DASHBOARD_INSIGHTS
+from ee.tasks.subscriptions.subscription_utils import MAX_INSIGHTS
 
 SUMMARY_QUOTA_CACHE_TTL_SECONDS = 60
 SUMMARY_CAP_HIT_DEDUPE_TTL_SECONDS = 600
@@ -671,9 +671,9 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         if dashboard_export_insights:
             selected_ids = set(dashboard_export_insights)
 
-            if len(selected_ids) > MAX_DASHBOARD_INSIGHTS:
+            if len(selected_ids) > MAX_INSIGHTS:
                 raise ValidationError(
-                    {"dashboard_export_insights": [f"Cannot select more than {MAX_DASHBOARD_INSIGHTS} insights."]}
+                    {"dashboard_export_insights": [f"Cannot select more than {MAX_INSIGHTS} insights."]}
                 )
 
             # Ensure all selected insights belong to the team

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -234,7 +234,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
     )
     dashboard_export_insights = DashboardExportInsightsField(
         required=False,
-        help_text="List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.",
+        help_text="List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.",
     )
     ai_prompt_config = AIPromptConfigSerializer(
         required=False,

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -41,7 +41,7 @@ from products.product_analytics.backend.models.insight import Insight
 from ee.api.test.base import APILicensedTest
 from ee.models.rbac.access_control import AccessControl
 from ee.tasks.subscriptions.slack_subscriptions import get_slack_integration_for_team
-from ee.tasks.subscriptions.subscription_utils import MAX_DASHBOARD_INSIGHTS
+from ee.tasks.subscriptions.subscription_utils import MAX_INSIGHTS
 
 
 class TestSubscriptionTemporal(APILicensedTest):
@@ -544,7 +544,7 @@ class TestSubscriptionTemporal(APILicensedTest):
 
     def test_dashboard_subscription_enforces_maximum_insights(self):
         insights = []
-        for _ in range(MAX_DASHBOARD_INSIGHTS + 1):
+        for _ in range(MAX_INSIGHTS + 1):
             insight = Insight.objects.create(
                 filters=Filter(data=self.insight_filter_dict).to_dict(),
                 team=self.team,
@@ -564,7 +564,7 @@ class TestSubscriptionTemporal(APILicensedTest):
         }
         response = self.client.post(
             f"/api/projects/{self.team.id}/subscriptions",
-            {**payload, "dashboard_export_insights": [i.id for i in insights[:MAX_DASHBOARD_INSIGHTS]]},
+            {**payload, "dashboard_export_insights": [i.id for i in insights[:MAX_INSIGHTS]]},
         )
         assert response.status_code == status.HTTP_201_CREATED
 
@@ -577,7 +577,7 @@ class TestSubscriptionTemporal(APILicensedTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "dashboard_export_insights"
-        assert f"Cannot select more than {MAX_DASHBOARD_INSIGHTS} insights" in response.json()["detail"]
+        assert f"Cannot select more than {MAX_INSIGHTS} insights" in response.json()["detail"]
 
     def test_cannot_create_dashboard_subscription_with_insights_from_other_dashboard(self):
         # Create an insight that belongs to a different dashboard

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -41,6 +41,7 @@ from products.product_analytics.backend.models.insight import Insight
 from ee.api.test.base import APILicensedTest
 from ee.models.rbac.access_control import AccessControl
 from ee.tasks.subscriptions.slack_subscriptions import get_slack_integration_for_team
+from ee.tasks.subscriptions.subscription_utils import MAX_DASHBOARD_INSIGHTS
 
 
 class TestSubscriptionTemporal(APILicensedTest):
@@ -541,9 +542,9 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "dashboard_export_insights"
 
-    def test_cannot_create_dashboard_subscription_with_too_many_insights(self):
+    def test_dashboard_subscription_enforces_maximum_insights(self):
         insights = []
-        for _ in range(7):
+        for _ in range(MAX_DASHBOARD_INSIGHTS + 1):
             insight = Insight.objects.create(
                 filters=Filter(data=self.insight_filter_dict).to_dict(),
                 team=self.team,
@@ -552,22 +553,31 @@ class TestSubscriptionTemporal(APILicensedTest):
             self.dashboard.tiles.create(insight=insight)
             insights.append(insight)
 
+        payload = {
+            "dashboard": self.dashboard.id,
+            "target_type": "email",
+            "target_value": "test@posthog.com",
+            "frequency": "weekly",
+            "interval": 1,
+            "start_date": "2022-01-01T00:00:00",
+            "title": "Dashboard Subscription",
+        }
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions",
+            {**payload, "dashboard_export_insights": [i.id for i in insights[:MAX_DASHBOARD_INSIGHTS]]},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
         response = self.client.post(
             f"/api/projects/{self.team.id}/subscriptions",
             {
-                "dashboard": self.dashboard.id,
+                **payload,
                 "dashboard_export_insights": [i.id for i in insights],  # exceeds limit
-                "target_type": "email",
-                "target_value": "test@posthog.com",
-                "frequency": "weekly",
-                "interval": 1,
-                "start_date": "2022-01-01T00:00:00",
-                "title": "Dashboard Subscription",
             },
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["attr"] == "dashboard_export_insights"
-        assert "Cannot select more than 6 insights" in response.json()["detail"]
+        assert f"Cannot select more than {MAX_DASHBOARD_INSIGHTS} insights" in response.json()["detail"]
 
     def test_cannot_create_dashboard_subscription_with_insights_from_other_dashboard(self):
         # Create an insight that belongs to a different dashboard

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -19,7 +19,7 @@ logger = structlog.get_logger(__name__)
 
 UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
 # Keep in sync with MAX_INSIGHTS in products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts.
-MAX_DASHBOARD_INSIGHTS = 6
+MAX_DASHBOARD_INSIGHTS = 10
 ASSET_GENERATION_FAILED_MESSAGE = "Failed to generate content"
 # Prometheus metrics for Temporal workers (web/worker pods)
 SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -18,7 +18,7 @@ from products.product_analytics.backend.models.insight import Insight
 logger = structlog.get_logger(__name__)
 
 UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
-# Keep in sync with MAX_INSIGHTS in products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts.
+# Keep in sync with MAX_DASHBOARD_INSIGHTS in products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts.
 MAX_DASHBOARD_INSIGHTS = 10
 ASSET_GENERATION_FAILED_MESSAGE = "Failed to generate content"
 # Prometheus metrics for Temporal workers (web/worker pods)

--- a/ee/tasks/subscriptions/subscription_utils.py
+++ b/ee/tasks/subscriptions/subscription_utils.py
@@ -18,8 +18,8 @@ from products.product_analytics.backend.models.insight import Insight
 logger = structlog.get_logger(__name__)
 
 UTM_TAGS_BASE = "utm_source=posthog&utm_campaign=subscription_report"
-# Keep in sync with MAX_DASHBOARD_INSIGHTS in products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts.
-MAX_DASHBOARD_INSIGHTS = 10
+# Keep in sync with MAX_INSIGHTS in products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts.
+MAX_INSIGHTS = 10
 ASSET_GENERATION_FAILED_MESSAGE = "Failed to generate content"
 # Prometheus metrics for Temporal workers (web/worker pods)
 SUBSCRIPTION_ASSET_GENERATION_TIMER = Histogram(
@@ -36,7 +36,7 @@ def _has_asset_failed(asset: ExportedAsset) -> bool:
 
 def generate_assets(
     resource: Union[Subscription, SharingConfiguration],
-    max_asset_count: int = MAX_DASHBOARD_INSIGHTS,
+    max_asset_count: int = MAX_INSIGHTS,
 ) -> tuple[list[Insight], list[ExportedAsset]]:
     with SUBSCRIPTION_ASSET_GENERATION_TIMER.labels(execution_path="celery").time():
         if resource.dashboard:

--- a/ee/tasks/test/subscriptions/test_subscriptions_utils.py
+++ b/ee/tasks/test/subscriptions/test_subscriptions_utils.py
@@ -7,7 +7,7 @@ from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.exports.backend.models.exported_asset import ExportedAsset
 from products.product_analytics.backend.models.insight import Insight
 
-from ee.tasks.subscriptions.subscription_utils import MAX_DASHBOARD_INSIGHTS, generate_assets
+from ee.tasks.subscriptions.subscription_utils import MAX_INSIGHTS, generate_assets
 from ee.tasks.test.subscriptions.subscriptions_test_factory import create_subscription
 
 
@@ -44,8 +44,8 @@ class TestSubscriptionsTasksUtils(APIBaseTest):
             insights, assets = generate_assets(subscription)
 
         assert len(insights) == len(self.tiles)
-        assert len(assets) == MAX_DASHBOARD_INSIGHTS
-        assert mock_export_task.si.call_count == MAX_DASHBOARD_INSIGHTS
+        assert len(assets) == MAX_INSIGHTS
+        assert mock_export_task.si.call_count == MAX_INSIGHTS
 
     def test_raises_if_missing_resource(self, _mock_export_task: MagicMock, _mock_group: MagicMock) -> None:
         subscription = create_subscription(team=self.team, created_by=self.user)

--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -52,7 +52,7 @@ from ee.tasks.subscriptions.auto_disable import (
 )
 from ee.tasks.subscriptions.email_subscriptions import send_email_subscription_report
 from ee.tasks.subscriptions.slack_subscriptions import send_slack_message_with_integration_async
-from ee.tasks.subscriptions.subscription_utils import MAX_DASHBOARD_INSIGHTS
+from ee.tasks.subscriptions.subscription_utils import MAX_INSIGHTS
 
 LOGGER = get_logger(__name__)
 
@@ -257,7 +257,7 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
         subscription_id=inputs.subscription_id,
     )
 
-    max_asset_count = inputs.max_asset_count if inputs.max_asset_count is not None else MAX_DASHBOARD_INSIGHTS
+    max_asset_count = inputs.max_asset_count if inputs.max_asset_count is not None else MAX_INSIGHTS
     if max_asset_count <= 0:
         raise ApplicationError(
             f"Dashboard insight export limit must be at least 1, received {max_asset_count} for subscription {inputs.subscription_id}",

--- a/products/subscriptions/frontend/components/Subscriptions/InsightSelector.test.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/InsightSelector.test.tsx
@@ -121,15 +121,15 @@ describe('InsightSelector', () => {
     })
 
     it('shows max limit message when at capacity', () => {
-        const sixInsightTiles = Array.from({ length: 6 }, (_, i) => ({
+        const maxInsightTiles = Array.from({ length: MAX_INSIGHTS }, (_, i) => ({
             id: i + 1,
             insight: { id: 100 + i, name: `Insight ${i}` } as any,
             layouts: { sm: { x: 0, y: i } } as any,
         }))
-        const selectedIds = sixInsightTiles.map((t) => t.insight.id)
+        const selectedIds = maxInsightTiles.map((t) => t.insight.id)
 
         renderInsightSelector({
-            tiles: sixInsightTiles as DashboardTile[],
+            tiles: maxInsightTiles as DashboardTile[],
             selectedInsightIds: selectedIds,
             onChange: jest.fn(),
         })

--- a/products/subscriptions/frontend/components/Subscriptions/InsightSelector.test.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/InsightSelector.test.tsx
@@ -8,7 +8,7 @@ import { initKeaTests } from '~/test/init'
 import { DashboardTile } from '~/types'
 
 import { InsightSelector } from './InsightSelector'
-import { MAX_INSIGHTS } from './insightSelectorLogic'
+import { MAX_DASHBOARD_INSIGHTS } from './insightSelectorLogic'
 
 function renderInsightSelector(props: {
     tiles: DashboardTile[]
@@ -64,7 +64,7 @@ describe('InsightSelector', () => {
             onChange: jest.fn(),
         })
 
-        expect(screen.getByText(`2 of ${MAX_INSIGHTS} insights selected`)).toBeInTheDocument()
+        expect(screen.getByText(`2 of ${MAX_DASHBOARD_INSIGHTS} insights selected`)).toBeInTheDocument()
     })
 
     it('calls onChange when selecting an insight', async () => {
@@ -121,7 +121,7 @@ describe('InsightSelector', () => {
     })
 
     it('shows max limit message when at capacity', () => {
-        const maxInsightTiles = Array.from({ length: MAX_INSIGHTS }, (_, i) => ({
+        const maxInsightTiles = Array.from({ length: MAX_DASHBOARD_INSIGHTS }, (_, i) => ({
             id: i + 1,
             insight: { id: 100 + i, name: `Insight ${i}` } as any,
             layouts: { sm: { x: 0, y: i } } as any,
@@ -134,7 +134,9 @@ describe('InsightSelector', () => {
             onChange: jest.fn(),
         })
 
-        expect(screen.getByText(`Maximum ${MAX_INSIGHTS} insights. Deselect one to add another.`)).toBeInTheDocument()
+        expect(
+            screen.getByText(`Maximum ${MAX_DASHBOARD_INSIGHTS} insights. Deselect one to add another.`)
+        ).toBeInTheDocument()
     })
 
     it('shows warning when none selected after user interaction', async () => {

--- a/products/subscriptions/frontend/components/Subscriptions/InsightSelector.test.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/InsightSelector.test.tsx
@@ -8,7 +8,7 @@ import { initKeaTests } from '~/test/init'
 import { DashboardTile } from '~/types'
 
 import { InsightSelector } from './InsightSelector'
-import { MAX_DASHBOARD_INSIGHTS } from './insightSelectorLogic'
+import { MAX_INSIGHTS } from './insightSelectorLogic'
 
 function renderInsightSelector(props: {
     tiles: DashboardTile[]
@@ -64,7 +64,7 @@ describe('InsightSelector', () => {
             onChange: jest.fn(),
         })
 
-        expect(screen.getByText(`2 of ${MAX_DASHBOARD_INSIGHTS} insights selected`)).toBeInTheDocument()
+        expect(screen.getByText(`2 of ${MAX_INSIGHTS} insights selected`)).toBeInTheDocument()
     })
 
     it('calls onChange when selecting an insight', async () => {
@@ -121,7 +121,7 @@ describe('InsightSelector', () => {
     })
 
     it('shows max limit message when at capacity', () => {
-        const maxInsightTiles = Array.from({ length: MAX_DASHBOARD_INSIGHTS }, (_, i) => ({
+        const maxInsightTiles = Array.from({ length: MAX_INSIGHTS }, (_, i) => ({
             id: i + 1,
             insight: { id: 100 + i, name: `Insight ${i}` } as any,
             layouts: { sm: { x: 0, y: i } } as any,
@@ -134,9 +134,7 @@ describe('InsightSelector', () => {
             onChange: jest.fn(),
         })
 
-        expect(
-            screen.getByText(`Maximum ${MAX_DASHBOARD_INSIGHTS} insights. Deselect one to add another.`)
-        ).toBeInTheDocument()
+        expect(screen.getByText(`Maximum ${MAX_INSIGHTS} insights. Deselect one to add another.`)).toBeInTheDocument()
     })
 
     it('shows warning when none selected after user interaction', async () => {

--- a/products/subscriptions/frontend/components/Subscriptions/InsightSelector.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/InsightSelector.tsx
@@ -6,7 +6,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 
 import { DashboardTile } from '~/types'
 
-import { MAX_DASHBOARD_INSIGHTS, insightSelectorLogic } from './insightSelectorLogic'
+import { MAX_INSIGHTS, insightSelectorLogic } from './insightSelectorLogic'
 
 interface InsightSelectorProps {
     tiles: DashboardTile[]
@@ -42,7 +42,7 @@ export function InsightSelector({
     useEffect(() => {
         // Auto-select the first N insights for new subscriptions (when nothing is selected yet)
         if (insightTiles.length > 0 && validSelectedIds.length === 0 && !userHasInteracted) {
-            const defaultSelection = insightTiles.slice(0, MAX_DASHBOARD_INSIGHTS).map((tile) => tile.insight!.id)
+            const defaultSelection = insightTiles.slice(0, MAX_INSIGHTS).map((tile) => tile.insight!.id)
             onChange(defaultSelection)
             onDefaultsApplied?.(defaultSelection)
         }
@@ -54,7 +54,7 @@ export function InsightSelector({
     }
 
     const selectedCount = validSelectedIds.length
-    const atMaxLimit = selectedCount >= MAX_DASHBOARD_INSIGHTS
+    const atMaxLimit = selectedCount >= MAX_INSIGHTS
 
     const toggleInsight = (insightId: number): void => {
         setUserHasInteracted()
@@ -70,7 +70,7 @@ export function InsightSelector({
         <div className="border rounded p-2 space-y-2">
             <div className="flex justify-between items-center text-sm">
                 <span className="font-medium">
-                    {selectedCount} of {MAX_DASHBOARD_INSIGHTS} insights selected
+                    {selectedCount} of {MAX_INSIGHTS} insights selected
                 </span>
                 {selectedCount === 0 && <span className="text-warning">Select at least one insight</span>}
             </div>
@@ -107,7 +107,7 @@ export function InsightSelector({
             </div>
             {atMaxLimit && (
                 <div className="text-xs text-secondary">
-                    Maximum {MAX_DASHBOARD_INSIGHTS} insights. Deselect one to add another.
+                    Maximum {MAX_INSIGHTS} insights. Deselect one to add another.
                 </div>
             )}
         </div>

--- a/products/subscriptions/frontend/components/Subscriptions/InsightSelector.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/InsightSelector.tsx
@@ -6,7 +6,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 
 import { DashboardTile } from '~/types'
 
-import { MAX_INSIGHTS, insightSelectorLogic } from './insightSelectorLogic'
+import { MAX_DASHBOARD_INSIGHTS, insightSelectorLogic } from './insightSelectorLogic'
 
 interface InsightSelectorProps {
     tiles: DashboardTile[]
@@ -42,7 +42,7 @@ export function InsightSelector({
     useEffect(() => {
         // Auto-select the first N insights for new subscriptions (when nothing is selected yet)
         if (insightTiles.length > 0 && validSelectedIds.length === 0 && !userHasInteracted) {
-            const defaultSelection = insightTiles.slice(0, MAX_INSIGHTS).map((tile) => tile.insight!.id)
+            const defaultSelection = insightTiles.slice(0, MAX_DASHBOARD_INSIGHTS).map((tile) => tile.insight!.id)
             onChange(defaultSelection)
             onDefaultsApplied?.(defaultSelection)
         }
@@ -54,7 +54,7 @@ export function InsightSelector({
     }
 
     const selectedCount = validSelectedIds.length
-    const atMaxLimit = selectedCount >= MAX_INSIGHTS
+    const atMaxLimit = selectedCount >= MAX_DASHBOARD_INSIGHTS
 
     const toggleInsight = (insightId: number): void => {
         setUserHasInteracted()
@@ -70,7 +70,7 @@ export function InsightSelector({
         <div className="border rounded p-2 space-y-2">
             <div className="flex justify-between items-center text-sm">
                 <span className="font-medium">
-                    {selectedCount} of {MAX_INSIGHTS} insights selected
+                    {selectedCount} of {MAX_DASHBOARD_INSIGHTS} insights selected
                 </span>
                 {selectedCount === 0 && <span className="text-warning">Select at least one insight</span>}
             </div>
@@ -107,7 +107,7 @@ export function InsightSelector({
             </div>
             {atMaxLimit && (
                 <div className="text-xs text-secondary">
-                    Maximum {MAX_INSIGHTS} insights. Deselect one to add another.
+                    Maximum {MAX_DASHBOARD_INSIGHTS} insights. Deselect one to add another.
                 </div>
             )}
         </div>

--- a/products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts
@@ -2,8 +2,8 @@ import { MakeLogicType, actions, kea, path, props, reducers, selectors } from 'k
 
 import { DashboardTile, InsightModel } from '~/types'
 
-// Keep in sync with MAX_DASHBOARD_INSIGHTS in ee/tasks/subscriptions/subscription_utils.py
-export const MAX_DASHBOARD_INSIGHTS = 10
+// Keep in sync with MAX_INSIGHTS in ee/tasks/subscriptions/subscription_utils.py
+export const MAX_INSIGHTS = 10
 
 export interface InsightSelectorLogicProps {
     tiles: DashboardTile[]

--- a/products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts
@@ -2,8 +2,8 @@ import { MakeLogicType, actions, kea, path, props, reducers, selectors } from 'k
 
 import { DashboardTile, InsightModel } from '~/types'
 
-// Keep in sync with DEFAULT_MAX_ASSET_COUNT in ee/tasks/subscriptions/subscription_utils.py
-export const MAX_INSIGHTS = 6
+// Keep in sync with MAX_DASHBOARD_INSIGHTS in ee/tasks/subscriptions/subscription_utils.py
+export const MAX_INSIGHTS = 10
 
 export interface InsightSelectorLogicProps {
     tiles: DashboardTile[]

--- a/products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/insightSelectorLogic.ts
@@ -3,7 +3,7 @@ import { MakeLogicType, actions, kea, path, props, reducers, selectors } from 'k
 import { DashboardTile, InsightModel } from '~/types'
 
 // Keep in sync with MAX_DASHBOARD_INSIGHTS in ee/tasks/subscriptions/subscription_utils.py
-export const MAX_INSIGHTS = 10
+export const MAX_DASHBOARD_INSIGHTS = 10
 
 export interface InsightSelectorLogicProps {
     tiles: DashboardTile[]

--- a/products/subscriptions/frontend/generated/api.schemas.ts
+++ b/products/subscriptions/frontend/generated/api.schemas.ts
@@ -194,7 +194,7 @@ export interface SubscriptionApi {
     readonly insight_short_id: string | null
     /** @nullable */
     readonly resource_name: string | null
-    /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6. */
+    /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10. */
     dashboard_export_insights?: number[]
     /**
      * Free-text prompt that drives the AI-generated report. Required when resource_type is 'ai_prompt'. Max 4000 characters.
@@ -342,7 +342,7 @@ export interface PatchedSubscriptionApi {
     readonly insight_short_id?: string | null
     /** @nullable */
     readonly resource_name?: string | null
-    /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6. */
+    /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10. */
     dashboard_export_insights?: number[]
     /**
      * Free-text prompt that drives the AI-generated report. Required when resource_type is 'ai_prompt'. Max 4000 characters.

--- a/products/subscriptions/frontend/generated/api.zod.ts
+++ b/products/subscriptions/frontend/generated/api.zod.ts
@@ -41,7 +41,7 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.'
+                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.'
             ),
         prompt: zod
             .string()
@@ -211,7 +211,7 @@ export const SubscriptionsUpdateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.'
+                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.'
             ),
         prompt: zod
             .string()
@@ -381,7 +381,7 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.'
+                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.'
             ),
         prompt: zod
             .string()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48316,7 +48316,7 @@ export namespace Schemas {
       readonly insight_short_id: string | null;
       /** @nullable */
       readonly resource_name: string | null;
-      /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6. */
+      /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10. */
       dashboard_export_insights?: number[];
       /**
          * Free-text prompt that drives the AI-generated report. Required when resource_type is 'ai_prompt'. Max 4000 characters.
@@ -56464,7 +56464,7 @@ export namespace Schemas {
       readonly insight_short_id?: string | null;
       /** @nullable */
       readonly resource_name?: string | null;
-      /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6. */
+      /** List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10. */
       dashboard_export_insights?: number[];
       /**
          * Free-text prompt that drives the AI-generated report. Required when resource_type is 'ai_prompt'. Max 4000 characters.

--- a/services/mcp/src/generated/subscriptions/api.ts
+++ b/services/mcp/src/generated/subscriptions/api.ts
@@ -76,7 +76,7 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.'
+                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.'
             ),
         prompt: zod
             .string()
@@ -259,7 +259,7 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
             .array(zod.number())
             .optional()
             .describe(
-                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.'
+                'List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.'
             ),
         prompt: zod
             .string()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-create.json
@@ -100,7 +100,7 @@
             "description": "Dashboard ID to subscribe to (mutually exclusive with insight on create)."
         },
         "dashboard_export_insights": {
-            "description": "List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.",
+            "description": "List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.",
             "items": {
                 "type": "number"
             },

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-partial-update.json
@@ -99,7 +99,7 @@
             "description": "Dashboard ID to subscribe to (mutually exclusive with insight on create)."
         },
         "dashboard_export_insights": {
-            "description": "List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 6.",
+            "description": "List of insight IDs from the dashboard to include. Required for dashboard subscriptions, max 10.",
             "items": {
                 "type": "number"
             },


### PR DESCRIPTION
## Problem

- Dashboard subscriptions currently stop users at six selected insights.
- The delivery workflow exports insights concurrently and supports a larger selection.

## Changes

Before: dashboard subscription → up to 6 insights
After: dashboard subscription → up to 10 insights

- Raise backend and frontend limits to 10.
- Update the API description and generated clients.
- Make limit tests derive their boundary from the shared constant.

## How did you test this code?

- Verified the backend rejects an 11-insight subscription.
- Verified the selector allows 10 insights and displays the capacity state.
- Ran all 13 InsightSelector tests.
- Regenerated OpenAPI clients.
- Ran Python and frontend formatting plus Python lint and type checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The generated API description now states the 10-insight limit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code.
- No repository skills were available or invoked.
- Kept backend and frontend constants aligned and updated generated API consumers.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
