### PR TITLE
feat(subscriptions): add delivery SLO dimensions

### DIFF
--- a/products/exports/backend/temporal/subscriptions/activities.py
+++ b/products/exports/backend/temporal/subscriptions/activities.py
@@ -313,6 +313,8 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
             team_id=team.id,
             distinct_id=str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id),
             target_type=subscription.target_type,
+            available_insight_count=resolved_insights.available_insight_count,
+            selected_insight_count=resolved_insights.selected_insight_count,
             status=ExportAssetPreparationStatus.NO_EXPORTABLE_INSIGHTS,
             failure_context=failure_context,
         )
@@ -382,6 +384,8 @@ async def create_export_assets(inputs: CreateExportAssetsInputs) -> CreateExport
         team_id=team.id,
         distinct_id=str(subscription.created_by.distinct_id) if subscription.created_by else str(team.id),
         target_type=subscription.target_type,
+        available_insight_count=resolved_insights.available_insight_count,
+        selected_insight_count=resolved_insights.selected_insight_count,
     )
 
 

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/activities.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/activities.py
@@ -223,6 +223,7 @@ async def generate_ai_subscription_report(inputs: GenerateAIReportInputs) -> Gen
             failed_step_count=failed_count,
             total_step_count=total_count,
             query_error_types=error_types,
+            target_type=subscription.target_type,
         )
 
     # Consent is gated once here, before any LLM cost — creation-time gates don't catch an
@@ -230,7 +231,9 @@ async def generate_ai_subscription_report(inputs: GenerateAIReportInputs) -> Gen
     if not subscription.team.organization.is_ai_data_processing_approved:
         LOGGER.warning("generate_ai_subscription_report.consent_revoked", subscription_id=subscription.id)
         aborted = await auto_disable_and_return(subscription, AI_CONSENT_REVOKED_DISABLE_REASON, [])
-        return GenerateAIReportResult(aborted=True, recipient_results=aborted.recipient_results)
+        return GenerateAIReportResult(
+            aborted=True, recipient_results=aborted.recipient_results, target_type=subscription.target_type
+        )
 
     # Gate on AI credits before any LLM cost — but only past the idempotency check above, so an
     # already-generated report (its tokens already spent) still ships. The interactive Max path
@@ -267,7 +270,7 @@ async def generate_ai_subscription_report(inputs: GenerateAIReportInputs) -> Gen
         )
         # skipped=True → the workflow records SKIPPED (not FAILED — the sub isn't broken) and skips
         # delivery; the sub stays enabled and advance_next_delivery_date recomputes from the reset.
-        return GenerateAIReportResult(skipped=True)
+        return GenerateAIReportResult(skipped=True, target_type=subscription.target_type)
 
     try:
         report_result = await build_ai_subscription_report(subscription)
@@ -293,7 +296,9 @@ async def generate_ai_subscription_report(inputs: GenerateAIReportInputs) -> Gen
             )
         ]
         aborted = await auto_disable_and_return(subscription, AI_PROMPT_INVALID_DISABLE_REASON, recipient_results)
-        return GenerateAIReportResult(aborted=True, recipient_results=aborted.recipient_results)
+        return GenerateAIReportResult(
+            aborted=True, recipient_results=aborted.recipient_results, target_type=subscription.target_type
+        )
 
     await _persist_ai_report(inputs.delivery_id, report_result, subscription.prompt)
     failed_count, total_count, error_types = _report_diagnostic_counts(report_result)
@@ -302,6 +307,7 @@ async def generate_ai_subscription_report(inputs: GenerateAIReportInputs) -> Gen
         failed_step_count=failed_count,
         total_step_count=total_count,
         query_error_types=error_types,
+        target_type=subscription.target_type,
     )
 
 

--- a/products/exports/backend/temporal/subscriptions/test_delivery_activities.py
+++ b/products/exports/backend/temporal/subscriptions/test_delivery_activities.py
@@ -140,7 +140,7 @@ async def test_process_ai_subscription_picks_delivery_activity_from_patch(patch_
         if activity is validate_subscription_for_delivery:
             return None
         if activity is generate_ai_subscription_report:
-            return GenerateAIReportResult()
+            return GenerateAIReportResult(target_type="slack")
         if activity in (deliver_subscription, deliver_subscription_v2):
             picked = activity
             return DeliverSubscriptionResult()
@@ -156,8 +156,20 @@ async def test_process_ai_subscription_picks_delivery_activity_from_patch(patch_
         patch("temporalio.workflow.logger", MagicMock()),
     ):
         mock_info.return_value = MagicMock(workflow_id="wf-test-ai")
-        await ProcessAISubscriptionWorkflow().run(
-            TrackedSubscriptionInputs(subscription_id=1, team_id=1, distinct_id="u1")
+        inputs = TrackedSubscriptionInputs(
+            subscription_id=1,
+            team_id=1,
+            distinct_id="u1",
+            slo=SloConfig(
+                operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=1,
+                resource_id="1",
+                distinct_id="u1",
+            ),
         )
+        await ProcessAISubscriptionWorkflow().run(inputs)
 
     assert picked is (deliver_subscription_v2 if patch_active else deliver_subscription)
+    assert inputs.slo is not None
+    assert inputs.slo.completion_properties["target_type"] == "slack"

--- a/products/exports/backend/temporal/subscriptions/test_delivery_activities.py
+++ b/products/exports/backend/temporal/subscriptions/test_delivery_activities.py
@@ -88,7 +88,13 @@ async def test_process_subscription_picks_delivery_activity_from_patch(patch_act
         if activity is validate_subscription_for_delivery:
             return None
         if activity is create_export_assets:
-            return CreateExportAssetsResult(exported_asset_ids=[1], total_insight_count=3, target_type="email")
+            return CreateExportAssetsResult(
+                exported_asset_ids=[1],
+                total_insight_count=3,
+                target_type="email",
+                available_insight_count=5,
+                selected_insight_count=4,
+            )
         if activity is export_asset_activity:
             return ExportAssetResult(exported_asset_id=1, success=True)
         if activity is snapshot_subscription_insights:
@@ -125,8 +131,8 @@ async def test_process_subscription_picks_delivery_activity_from_patch(patch_act
     assert picked is (deliver_subscription_v2 if patch_active else deliver_subscription)
     assert inputs.slo is not None
     assert inputs.slo.completion_properties["target_type"] == "email"
-    assert inputs.slo.completion_properties["selected_insight_count"] == 1
-    assert inputs.slo.completion_properties["available_insight_count"] == 3
+    assert inputs.slo.completion_properties["selected_insight_count"] == 4
+    assert inputs.slo.completion_properties["available_insight_count"] == 5
 
 
 @pytest.mark.parametrize("patch_active", [True, False], ids=["patched_v2", "pre_patch_v1"])

--- a/products/exports/backend/temporal/subscriptions/test_delivery_activities.py
+++ b/products/exports/backend/temporal/subscriptions/test_delivery_activities.py
@@ -8,6 +8,7 @@ from temporalio.exceptions import ApplicationError
 from temporalio.testing import ActivityEnvironment
 
 from posthog.email import EmailDeliveryError
+from posthog.slo.types import SloArea, SloConfig, SloOperation
 from posthog.temporal.exports.activities import export_asset_activity
 from posthog.temporal.exports.types import ExportAssetResult
 
@@ -87,7 +88,7 @@ async def test_process_subscription_picks_delivery_activity_from_patch(patch_act
         if activity is validate_subscription_for_delivery:
             return None
         if activity is create_export_assets:
-            return CreateExportAssetsResult(exported_asset_ids=[1], total_insight_count=1)
+            return CreateExportAssetsResult(exported_asset_ids=[1], total_insight_count=3, target_type="email")
         if activity is export_asset_activity:
             return ExportAssetResult(exported_asset_id=1, success=True)
         if activity is snapshot_subscription_insights:
@@ -107,11 +108,25 @@ async def test_process_subscription_picks_delivery_activity_from_patch(patch_act
         patch("temporalio.workflow.logger", MagicMock()),
     ):
         mock_info.return_value = MagicMock(workflow_id="wf-test")
-        await ProcessSubscriptionWorkflow().run(
-            TrackedSubscriptionInputs(subscription_id=1, team_id=1, distinct_id="u1")
+        inputs = TrackedSubscriptionInputs(
+            subscription_id=1,
+            team_id=1,
+            distinct_id="u1",
+            slo=SloConfig(
+                operation=SloOperation.SUBSCRIPTION_DELIVERY,
+                area=SloArea.ANALYTIC_PLATFORM,
+                team_id=1,
+                resource_id="1",
+                distinct_id="u1",
+            ),
         )
+        await ProcessSubscriptionWorkflow().run(inputs)
 
     assert picked is (deliver_subscription_v2 if patch_active else deliver_subscription)
+    assert inputs.slo is not None
+    assert inputs.slo.completion_properties["target_type"] == "email"
+    assert inputs.slo.completion_properties["selected_insight_count"] == 1
+    assert inputs.slo.completion_properties["available_insight_count"] == 3
 
 
 @pytest.mark.parametrize("patch_active", [True, False], ids=["patched_v2", "pre_patch_v1"])

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -254,6 +254,7 @@ class GenerateAIReportResult:
     failed_step_count: int = 0
     total_step_count: int = 0
     query_error_types: list[str] = dataclasses.field(default_factory=list)
+    target_type: str = ""
 
     @property
     def all_queries_failed(self) -> bool:

--- a/products/exports/backend/temporal/subscriptions/types.py
+++ b/products/exports/backend/temporal/subscriptions/types.py
@@ -150,6 +150,8 @@ class CreateExportAssetsResult:
     team_id: int = 0
     distinct_id: str = ""
     target_type: str = ""
+    available_insight_count: int = 0
+    selected_insight_count: int = 0
     status: str = ExportAssetPreparationStatus.READY
     failure_context: NoExportableInsightsContext | None = None
 

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -145,6 +145,14 @@ class ScheduleAllSubscriptionsWorkflow(PostHogWorkflow):
                     team_id=sub.team_id,
                     resource_id=str(sub.subscription_id),
                     distinct_id=sub.distinct_id,
+                    start_properties={
+                        "resource_type": sub.resource_type,
+                        "trigger_type": SubscriptionTriggerType.SCHEDULED,
+                    },
+                    completion_properties={
+                        "resource_type": sub.resource_type,
+                        "trigger_type": SubscriptionTriggerType.SCHEDULED,
+                    },
                 ),
             )
             # AI-prompt subs run a dedicated workflow; distinct child-ID prefixes keep the
@@ -271,6 +279,14 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                     maximum_attempts=3,
                 ),
             )
+            if inputs.slo:
+                inputs.slo.completion_properties.update(
+                    {
+                        "target_type": prepare_result.target_type,
+                        "selected_insight_count": len(prepare_result.exported_asset_ids),
+                        "available_insight_count": prepare_result.total_insight_count,
+                    }
+                )
 
             if not prepare_result.exported_asset_ids:
                 if prepare_result.status == ExportAssetPreparationStatus.NO_EXPORTABLE_INSIGHTS:
@@ -686,6 +702,14 @@ class HandleSubscriptionValueChangeWorkflow(PostHogWorkflow):
                 team_id=inputs.team_id,
                 resource_id=str(inputs.subscription_id),
                 distinct_id=inputs.distinct_id,
+                start_properties={
+                    "resource_type": inputs.resource_type,
+                    "trigger_type": inputs.trigger_type,
+                },
+                completion_properties={
+                    "resource_type": inputs.resource_type,
+                    "trigger_type": inputs.trigger_type,
+                },
             ),
         )
         # Route AI-prompt subs (test delivery / target change) to the AI workflow, same

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -566,6 +566,8 @@ class ProcessAISubscriptionWorkflow(PostHogWorkflow):
                     maximum_attempts=3,
                 ),
             )
+            if inputs.slo:
+                inputs.slo.completion_properties["target_type"] = generate_result.target_type
             if generate_result.aborted:
                 # Consent revoked or prompt invalid — generation already auto-disabled.
                 delivery_recipient_results = _to_recipient_dicts(generate_result.recipient_results)

--- a/products/exports/backend/temporal/subscriptions/workflows.py
+++ b/products/exports/backend/temporal/subscriptions/workflows.py
@@ -283,8 +283,8 @@ class ProcessSubscriptionWorkflow(PostHogWorkflow):
                 inputs.slo.completion_properties.update(
                     {
                         "target_type": prepare_result.target_type,
-                        "selected_insight_count": len(prepare_result.exported_asset_ids),
-                        "available_insight_count": prepare_result.total_insight_count,
+                        "selected_insight_count": prepare_result.selected_insight_count,
+                        "available_insight_count": prepare_result.available_insight_count,
                     }
                 )
 


### PR DESCRIPTION
## Problem

- Subscription delivery SLO events cannot be segmented by subscription type, trigger, destination, or configured insight count.
- This makes regressions from larger dashboard subscriptions difficult to isolate.

## Changes

- Add resource and trigger dimensions to SLO start and completion events.
- Add destination, selected insight count, and available insight count to completion events.
- Keep subscription IDs out of Temporal metric labels.

## How did you test this code?

- Verified scheduled and immediate delivery paths populate the new properties.
- Verified destination and insight-count completion properties for both delivery activity paths.
- Ran the focused subscription delivery tests: 6 passed.
- Ran Python lint and type checks through the commit hooks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No user-facing documentation change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code.
- No repository skills were available or invoked.
- Used low-cardinality SLO properties and retained the existing subscription resource identifier.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
