### PR TITLE
fix(onboarding): resolve step ids against the flow, not the key list

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -383,6 +383,16 @@ describe('onboardingLogic — flow composition', () => {
             expect(logic.values.currentFlowStep?.id).toBe('invite_teammates:conversations')
         })
 
+        it('self-corrects link_data when the flow will never carry it', async () => {
+            // `link_data` is gated on the product keys alone, which are set before the step is,
+            // so for a primary that never gets it there is nothing to wait for.
+            logic.actions.setProductKey(ProductKey.WEB_ANALYTICS)
+            logic.actions.setStepId(OnboardingStepKey.LINK_DATA)
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('')
+            expect(logic.values.currentFlowStep?.id).toBe('install:web_analytics')
+        })
+
         it('holds a shared trailing step open until it is appended', async () => {
             // `plans` joins the flow only once billing loads, which it has not here.
             // Self-correcting it would lose the request before the flow settles.

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -372,6 +372,25 @@ describe('onboardingLogic — flow composition', () => {
             expect(logic.values.stepId).toBe('')
             expect(logic.values.currentFlowStep?.id).toBe('install:web_analytics')
         })
+
+        it('self-corrects a valid step key the flow has no step for', async () => {
+            // Product selection always routes to ?step=install, but Support's flow has no
+            // install step, so a key being valid is not reason enough to keep waiting on it.
+            logic.actions.setProductKey(ProductKey.CONVERSATIONS)
+            logic.actions.setStepId(OnboardingStepKey.INSTALL)
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('')
+            expect(logic.values.currentFlowStep?.id).toBe('invite_teammates:conversations')
+        })
+
+        it('holds a shared trailing step open until it is appended', async () => {
+            // `plans` joins the flow only once billing loads, which it has not here.
+            // Self-correcting it would lose the request before the flow settles.
+            logic.actions.setProductKey(ProductKey.WEB_ANALYTICS)
+            logic.actions.setStepId(OnboardingStepKey.PLANS)
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe(OnboardingStepKey.PLANS)
+        })
     })
 
     describe('navigation', () => {

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -37,7 +37,7 @@ import type {
 } from '../../../types'
 import { onboardingEventUsageLogic } from '../onboardingEventUsageLogic'
 import { arraysEqual, parseProductsParam, stepKeyToTitle } from './onboardingFlowUtils'
-import { appendSharedTrailingSteps } from './sharedSteps'
+import { appendSharedTrailingSteps, mayBeAppendedLater } from './sharedSteps'
 import { onboardingProviderRegistry } from './stepProviderRegistry'
 import { type OnboardingFlowContext, type OnboardingStepDescriptor } from './types'
 
@@ -913,19 +913,17 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // `currentFlowStep` returns null and the host shows a spinner forever.
             // Reconcile by falling through to flow[0].
             //
-            // Important: only self-correct when the stepId is genuinely unknown — NOT when
-            // it's a valid OnboardingStepKey that simply hasn't been emitted into the flow
-            // yet. Steps like `plans` are appended async (after billing loads) by
-            // `appendSharedTrailingSteps`; self-correcting too eagerly here would clobber
-            // the URL before the flow settles, leaving the user on `flow[0]` even after
-            // billing arrives.
-            // A `?` or `&` means query params fused into the step value (a mangled URL) — never
-            // treat that as a valid namespaced id, or self-correction skips it and the host
-            // spins forever waiting for a step that can't resolve.
-            const isKnownStepKey = (id: string): boolean =>
-                !/[?&]/.test(id) &&
-                (Object.values(OnboardingStepKey).includes(id as OnboardingStepKey) || id.includes(':'))
-            if (stepId && values.flow.length > 0 && !isKnownStepKey(stepId)) {
+            // Important: hold the URL open for a step that hasn't been emitted into the flow
+            // yet. Only `appendSharedTrailingSteps` adds steps late (after billing and org data
+            // load), so `mayBeAppendedLater` is the whole set worth waiting on; self-correcting
+            // those too eagerly would clobber the URL before the flow settles, leaving the user
+            // on `flow[0]` even after billing arrives.
+            //
+            // Every other key has to resolve against the flow it was built for. Treating a valid
+            // key as reason enough to wait strands any product whose flow lacks that step — a
+            // product with no install step still routes to `?step=install` on selection, and the
+            // host then spins forever on a step that is never coming.
+            if (stepId && values.flow.length > 0 && !mayBeAppendedLater(stepId)) {
                 const exact = values.flow.find((step) => step.id === stepId)
                 const loose = exact ? null : values.flow.find((step) => step.stepKey === stepId)
                 if (!exact && !loose) {
@@ -1023,17 +1021,14 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // through urlToAction and re-dispatches setStepId(bogus), looping
             // indefinitely. Stripping unresolvable stepIds here keeps the URL
             // self-consistent with the reducer state.
-            // Mirror the `setStepId` listener's `isKnownStepKey` heuristic. Billing-gated
-            // steps (plans, invite_teammates, link_data) are appended async after billing
-            // loads, so they may not be in `flow` when the URL push lands. Stripping them
-            // from the URL would re-fire `setStepId('')` and permanently lose the request.
-            const isKnownStepKey =
-                !/[?&]/.test(stepId) &&
-                (Object.values(OnboardingStepKey).includes(stepId as OnboardingStepKey) || stepId.includes(':'))
+            // Mirror the `setStepId` listener's hold-open rule. The shared trailing steps are
+            // appended async after billing and org data load, so they may not be in `flow` when
+            // the URL push lands. Stripping them would re-fire `setStepId('')` and permanently
+            // lose the request.
             const stepResolves =
                 !stepId ||
                 values.flow.length === 0 ||
-                isKnownStepKey ||
+                mayBeAppendedLater(stepId) ||
                 !!values.flow.find((s) => s.id === stepId || s.stepKey === stepId)
             // The first tuple element must be a bare pathname: kea-router joins the tuple by
             // string concatenation (`path + '?' + search`), so a query embedded here would get a

--- a/frontend/src/scenes/onboarding/legacy/sharedSteps.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sharedSteps.tsx
@@ -8,6 +8,30 @@ import { OnboardingAIReports } from './notifications/OnboardingAIReports'
 import { OnboardingInviteTeammates } from './OnboardingInviteTeammates'
 import { OnboardingFlowContext, OnboardingStepDescriptor } from './types'
 
+// The only step keys that join a flow after it first renders, since each is gated on data that
+// loads asynchronously (billing, organization). Keep in sync with the pushes below.
+const ASYNC_TRAILING_STEP_KEYS = new Set<string>([
+    OnboardingStepKey.LINK_DATA,
+    OnboardingStepKey.PLANS,
+    OnboardingStepKey.INVITE_TEAMMATES,
+    OnboardingStepKey.AI_REPORTS,
+])
+
+/**
+ * Whether a stepId could still be appended to the flow, so an unresolved URL targeting it is
+ * worth holding open rather than self-correcting. Any other key either resolves against the
+ * flow it was built for or never will.
+ */
+export function mayBeAppendedLater(stepId: string): boolean {
+    // A `?` or `&` means query params fused into the step value, which is a mangled URL rather
+    // than a step anything is waiting on.
+    if (/[?&]/.test(stepId)) {
+        return false
+    }
+    const [stepKey] = stepId.split(':')
+    return ASYNC_TRAILING_STEP_KEYS.has(stepKey)
+}
+
 export function appendSharedTrailingSteps(
     steps: OnboardingStepDescriptor[],
     ctx: OnboardingFlowContext,

--- a/frontend/src/scenes/onboarding/legacy/sharedSteps.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sharedSteps.tsx
@@ -8,10 +8,12 @@ import { OnboardingAIReports } from './notifications/OnboardingAIReports'
 import { OnboardingInviteTeammates } from './OnboardingInviteTeammates'
 import { OnboardingFlowContext, OnboardingStepDescriptor } from './types'
 
-// The only step keys that join a flow after it first renders, since each is gated on data that
-// loads asynchronously (billing, organization). Keep in sync with the pushes below.
+// The only step keys that join a flow after it first renders. Each is gated on data that arrives
+// asynchronously (billing, organization, feature flags), so a URL targeting one has to be held
+// open until that data settles. `link_data` is deliberately absent: it is gated on the primary and
+// secondary product keys alone, both of which are set from the URL before the step is, so it is
+// either in the flow immediately or never. Keep in sync with the pushes below.
 const ASYNC_TRAILING_STEP_KEYS = new Set<string>([
-    OnboardingStepKey.LINK_DATA,
     OnboardingStepKey.PLANS,
     OnboardingStepKey.INVITE_TEAMMATES,
     OnboardingStepKey.AI_REPORTS,


### PR DESCRIPTION
## Problem

Picking Support as your only product during onboarding leaves you on a spinner that never resolves, so you can't finish setup or reach the Support product at all.

- Product selection always routes to `?step=install`, but Support's flow has no install step.
- The URL self-correction that exists for exactly this case never fires. It treats any valid `OnboardingStepKey` as a step that might still be appended, and `install` is valid.
- Clicking Support in the sidebar then returns you to onboarding, because onboarding never completed. That's the loop.

Not specific to Support: any product whose flow lacks the step the URL asks for hits the same dead end.

## Changes

- `mayBeAppendedLater` replaces the valid-key heuristic. It matches only the trailing steps gated on async data: `plans`, `invite_teammates`, `ai_reports`.
- An unresolvable step now self-corrects to `flow[0]` unless it names one of those.
- `link_data` is deliberately not deferred. It is gated on the product keys alone, which are set from the URL before the step id, so it is in the flow immediately or never.
- That list sits next to `appendSharedTrailingSteps`, so it can't drift from the pushes it describes.
- Mangled step values, where query params fuse into the step, self-correct exactly as before.

Deliberately narrow: this fixes the spinner only. Enabling Support when it's picked alongside another product is separate behavior and is untouched here. A previous attempt at both, [#72936](https://github.com/PostHog/posthog/pull/72936), was closed as larger than the problem warranted.

Origin thread: [#team-growth](https://posthog.slack.com/archives/C08S2L0S5MZ/p1784745492567649).

## How did you test this code?

Verified in a browser against a local dev instance, before and after the change.

- **Before:** `/project/2/onboarding/conversations?step=install` renders the onboarding chrome and then a permanent spinner where the step should be. Reproduces the reported symptom.
- **After:** the same URL drops the unresolvable `?step=install` and renders the Invite teammates step with a working Finish button. The page title becomes `Invite teammates • Support • PostHog`.
- **Hold-open path:** `?step=plans` is still retained rather than stripped, since `plans` only joins the flow once billing loads.

Automated:

- `frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts` and the rest of `src/scenes/onboarding` pass locally.
- I confirmed the new self-correction test fails when the old guard is restored, so it locks in this fix rather than passing vacuously.

Two new tests, each aimed at a regression nothing else covers:

- **valid step key with no matching step self-corrects** — the bug this PR fixes. Reverting the guard turns it red.
- **shared trailing step is held open until appended** — the behavior the old conservative guard existed to protect. Catches an over-correction that would drop `plans` before billing loads.

Not included: before/after screenshots. `hogli pr:upload-image` returned HTTP 409 on both files, so they aren't embedded here.

Not checked: `typescript:check` reports pre-existing errors in this worktree from an unbuilt nested quill workspace. None are in the changed files, and none are introduced here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code (Opus 5), directed by @MattBro after triaging a support ticket where a user hit this loop repeatedly and never completed onboarding. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`, `/pr-ready`.

The scope call is the main thing worth a reviewer's attention. Review feedback on the earlier attempt was that it should be simpler, so this one changes the resolution rule and nothing else.

One case is knowingly left open: if a flow is genuinely empty, with no billing product and a user who cannot invite teammates, both this guard and the URL writer still hold and the host would spin. An org creator is always an admin, so `invite_teammates` is always present for the signup path this affects. Worth a follow-up rather than widening this diff.

