### PR TITLE
fix(web-analytics): cap warmer runs at 6h via dagster run monitoring

### DIFF
--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1172,6 +1172,14 @@ def report_warming_plan_op(context: dagster.OpExecutionContext, queries: list[di
     tags={
         "owner": JobOwners.TEAM_WEB_ANALYTICS.value,
         "dagster/web_analytics_cache_warming": "web_analytics_cache_warming",
+        # Run-level backstop, enforced by Dagster run monitoring. The in-op
+        # guards (stall windows, pass deadline) only bound executing shard
+        # code; a run can also zombie at the orchestration layer — steps dying
+        # to infra and idling between retries — while mutual exclusion skips
+        # every scheduled tick. Sized above the worst legitimate case (3h shard
+        # deadline + retry + step scheduling), far below the days a zombie
+        # otherwise holds the slot.
+        "dagster/max_runtime": 6 * 3600,
         # The agent default is 2 CPUs / 8Gi (charts: argocd/dagster/values). The
         # sharded pass runs one subprocess per shard, each compiling HogQL on its
         # own core, so the run pod needs CPU for the shards and memory for that


### PR DESCRIPTION
## Problem

The warming job's in-op guards (stall windows from #75551, the 3h pass deadline from #77743) only bound *executing* shard code. A run can also zombie at the orchestration layer: shard steps killed by infra (a ClickHouse replica dying mid-pass), the run idling between step retries, or steps stuck queued. Two incidents in three days blocked every scheduled tick this way - one for 50 hours, one for 3 - because the job's mutual exclusion skips ticks while any run is active, and nothing bounds a run's total age.

## Changes

Add `dagster/max_runtime: 6h` to `web_analytics_cache_warming_job`, so Dagster's run monitoring terminates any run older than 6 hours regardless of what layer it's stuck in. Sized above the worst legitimate case (a full-cold recovery pass: 3h shard deadline + one retry + step scheduling overhead), far below the days a zombie otherwise holds the slot.

> [!NOTE]
> This relies on run monitoring being enabled in the Dagster instance config (`run_monitoring.enabled` in the deployment values). If it is off, the tag is inert - worth confirming at review.

## How did you test this code?

`hogli test products/web_analytics/dags/tests/test_cache_warming.py` - 84/84 pass. No new test: a job tag enforced by Dagster's own run monitoring, not by our code paths.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude-authored follow-up to the Aug 2-4 (crawling shard, 50h) and Aug 5 (orchestration-layer zombie after a replica death, 3h) warmer incidents, both diagnosed in-session; Lucas terminated both runs manually. This closes the class the in-op guards can't reach.