### PR TITLE
feat(tasks): add cloud task terminal relay

### DIFF
--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -80,6 +80,7 @@ from products.tasks.backend.facade.agent_proxy import (
     agent_proxy_callback,
     agent_proxy_port_forward_exchange_ticket,
     agent_proxy_port_forward_resolve,
+    agent_proxy_terminal_resolve,
 )
 from products.user_interviews.backend.presentation.webhooks import (
     start_call as user_interviews_start_call,
@@ -573,6 +574,10 @@ urlpatterns = [
     path(
         "internal/tasks/port-forward/exchange-ticket/",
         csrf_exempt(agent_proxy_port_forward_exchange_ticket),
+    ),
+    path(
+        "internal/tasks/terminal/resolve/",
+        csrf_exempt(agent_proxy_terminal_resolve),
     ),
     # Internal SQLV2 run result callback (auth: signed callback token)
     path(

--- a/products/desktop/packages/agent/package.json
+++ b/products/desktop/packages/agent/package.json
@@ -186,6 +186,7 @@
     "jsonwebtoken": "^9.0.2",
     "minimatch": "^10.0.3",
     "@modelcontextprotocol/sdk": "1.29.0",
+    "node-pty": "1.1.0",
     "tar": "^7.5.19",
     "uuid": "13.0.0",
     "yoga-wasm-web": "^0.3.3",

--- a/products/desktop/packages/agent/src/server/agent-server.ts
+++ b/products/desktop/packages/agent/src/server/agent-server.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { access, cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { platform } from "node:os";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { pathToFileURL } from "node:url";
 import type {
@@ -28,6 +29,7 @@ import {
 } from "@posthog/shared";
 import { unzipSync } from "fflate";
 import { type Context, Hono } from "hono";
+import * as pty from "node-pty";
 import { z } from "zod";
 import packageJson from "../../package.json" with { type: "json" };
 import { POSTHOG_METHODS, POSTHOG_NOTIFICATIONS } from "../acp-extensions";
@@ -374,6 +376,7 @@ const PORT_FORWARD_HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 const MAX_PORT_FORWARD_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
+const TERMINAL_RING_BUFFER_LINES = 500;
 
 function buildLoopbackPortForwardUrl(requestUrl: string, port: number): string {
   const incoming = new URL(requestUrl);
@@ -464,6 +467,215 @@ async function readBoundedPortForwardRequestBody(
   return body.buffer;
 }
 
+interface TerminalSubscriber {
+  send: (event: TerminalStreamEvent) => void;
+}
+
+type TerminalStreamEvent =
+  | { type: "output"; terminalId: string; data: string }
+  | { type: "exit"; terminalId: string; exitCode: number };
+
+interface TerminalSession {
+  pty: pty.IPty;
+  subscribers: Set<TerminalSubscriber>;
+  ring: TerminalStreamEvent[];
+  disposables: pty.IDisposable[];
+  exitCode: number | null;
+}
+
+function defaultTerminalShell(): string {
+  if (platform() === "win32") {
+    return process.env.COMSPEC || "cmd.exe";
+  }
+  return process.env.SHELL || "/bin/bash";
+}
+
+function defaultTerminalShellArgs(shell: string): string[] {
+  if (platform() === "win32") {
+    const lower = shell.toLowerCase();
+    return lower.includes("powershell") || lower.includes("pwsh")
+      ? ["-NoLogo"]
+      : [];
+  }
+  return ["-l"];
+}
+
+function buildTerminalEnv(): Record<string, string> {
+  return { ...process.env, TERM: "xterm-256color" } as Record<string, string>;
+}
+
+function resolveTerminalCwd(
+  repositoryPath: string,
+  requestedCwd?: unknown,
+): string {
+  if (
+    typeof requestedCwd !== "string" ||
+    !requestedCwd ||
+    !isAbsolute(requestedCwd)
+  ) {
+    return repositoryPath;
+  }
+  const relativePath = relative(repositoryPath, requestedCwd);
+  if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+    return repositoryPath;
+  }
+  return requestedCwd;
+}
+
+class AgentTerminalManager {
+  private sessions = new Map<string, TerminalSession>();
+
+  constructor(
+    private readonly repositoryPath: string,
+    private readonly logger: Logger,
+  ) {}
+
+  create(
+    terminalId: string,
+    options: { cwd?: unknown; cols?: unknown; rows?: unknown } = {},
+  ): void {
+    if (this.sessions.has(terminalId)) {
+      return;
+    }
+
+    const shell = defaultTerminalShell();
+    const cols =
+      typeof options.cols === "number" && Number.isInteger(options.cols)
+        ? Math.max(20, Math.min(options.cols, 400))
+        : 80;
+    const rows =
+      typeof options.rows === "number" && Number.isInteger(options.rows)
+        ? Math.max(5, Math.min(options.rows, 200))
+        : 24;
+    const cwd = resolveTerminalCwd(this.repositoryPath, options.cwd);
+    const ptyProcess = pty.spawn(shell, defaultTerminalShellArgs(shell), {
+      name: "xterm-256color",
+      cols,
+      rows,
+      cwd,
+      env: buildTerminalEnv(),
+      encoding: "utf8",
+    });
+
+    const session: TerminalSession = {
+      pty: ptyProcess,
+      subscribers: new Set(),
+      ring: [],
+      disposables: [],
+      exitCode: null,
+    };
+
+    const push = (event: TerminalStreamEvent): void => {
+      session.ring.push(event);
+      if (session.ring.length > TERMINAL_RING_BUFFER_LINES) {
+        session.ring.shift();
+      }
+      for (const subscriber of session.subscribers) {
+        subscriber.send(event);
+      }
+    };
+
+    session.disposables.push(
+      ptyProcess.onData((data: string) => {
+        push({ type: "output", terminalId, data });
+      }),
+    );
+    session.disposables.push(
+      ptyProcess.onExit(({ exitCode }) => {
+        session.exitCode = exitCode;
+        push({ type: "exit", terminalId, exitCode });
+        for (const disposable of session.disposables) {
+          disposable.dispose();
+        }
+        session.disposables = [];
+      }),
+    );
+
+    this.sessions.set(terminalId, session);
+    this.logger.debug("Terminal session created", { terminalId, cwd });
+  }
+
+  write(terminalId: string, data: string): boolean {
+    const session = this.sessions.get(terminalId);
+    if (!session || session.exitCode !== null) {
+      return false;
+    }
+    session.pty.write(data);
+    return true;
+  }
+
+  resize(terminalId: string, cols: number, rows: number): boolean {
+    const session = this.sessions.get(terminalId);
+    if (!session || session.exitCode !== null) {
+      return false;
+    }
+    session.pty.resize(
+      Math.max(20, Math.min(cols, 400)),
+      Math.max(5, Math.min(rows, 200)),
+    );
+    return true;
+  }
+
+  destroy(terminalId: string): boolean {
+    const session = this.sessions.get(terminalId);
+    if (!session) {
+      return false;
+    }
+    for (const disposable of session.disposables) {
+      disposable.dispose();
+    }
+    session.pty.kill();
+    this.sessions.delete(terminalId);
+    return true;
+  }
+
+  stream(terminalId: string): Response {
+    const session = this.sessions.get(terminalId);
+    if (!session) {
+      return new Response(JSON.stringify({ error: "Terminal not found" }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    let subscriber: TerminalSubscriber | null = null;
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        let streamClosed = false;
+        const send = (event: TerminalStreamEvent): void => {
+          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+          if (event.type === "exit" && subscriber) {
+            session.subscribers.delete(subscriber);
+            controller.close();
+            streamClosed = true;
+          }
+        };
+        subscriber = { send };
+        for (const event of session.ring) {
+          send(event);
+        }
+        if (!streamClosed) {
+          session.subscribers.add(subscriber);
+        }
+      },
+      cancel: () => {
+        if (subscriber) {
+          session.subscribers.delete(subscriber);
+        }
+      },
+    });
+
+    return new Response(body, {
+      headers: {
+        "Content-Type": "application/x-ndjson",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  }
+}
+
 export class AgentServer {
   private config: AgentServerConfig;
   private sessionReadyBootMs?: number;
@@ -534,6 +746,7 @@ export class AgentServer {
   private readonly posthogExecPermissionRegex: RegExp;
   private readonly posthogExecPermissionRegexSource: string;
   private mcpRelayServer: McpRelayServer | null = null;
+  private terminalManager: AgentTerminalManager;
 
   /**
    * Start loopback relay endpoints for the run's designated desktop-only MCP
@@ -601,6 +814,10 @@ export class AgentServer {
       this.posthogExecPermissionRegexSource,
     );
     this.logger = new Logger({ debug: true, prefix: "[AgentServer]" });
+    this.terminalManager = new AgentTerminalManager(
+      config.repositoryPath ?? process.cwd(),
+      this.logger.child("Terminal"),
+    );
     this.posthogAPI = new PostHogAPIClient({
       apiUrl: config.apiUrl,
       projectId: config.projectId,
@@ -945,6 +1162,106 @@ export class AgentServer {
 
     app.all("/ports/:port", handlePortForward);
     app.all("/ports/:port/*", handlePortForward);
+
+    const authenticateTerminalRequest = (c: Context): Response | null => {
+      try {
+        this.authenticateRequest(c.req.header.bind(c.req));
+        return null;
+      } catch (error) {
+        return c.json(
+          {
+            error:
+              error instanceof JwtValidationError
+                ? error.message
+                : "Invalid token",
+          },
+          401,
+        );
+      }
+    };
+
+    app.post("/terminals/:terminalId", async (c) => {
+      const authError = authenticateTerminalRequest(c);
+      if (authError) {
+        return authError;
+      }
+      const { terminalId } = c.req.param() as { terminalId: string };
+      const body = await c.req.json().catch(() => ({}));
+      this.terminalManager.create(
+        terminalId,
+        typeof body === "object" && body !== null ? body : {},
+      );
+      return c.json({ terminalId, status: "active" });
+    });
+
+    app.get("/terminals/:terminalId/stream", (c) => {
+      const authError = authenticateTerminalRequest(c);
+      if (authError) {
+        return authError;
+      }
+      const { terminalId } = c.req.param() as { terminalId: string };
+      return this.terminalManager.stream(terminalId);
+    });
+
+    app.post("/terminals/:terminalId/input", async (c) => {
+      const authError = authenticateTerminalRequest(c);
+      if (authError) {
+        return authError;
+      }
+      const { terminalId } = c.req.param() as { terminalId: string };
+      const body = await c.req.json().catch(() => null);
+      const data =
+        typeof body === "object" &&
+        body !== null &&
+        typeof body.data === "string"
+          ? body.data
+          : null;
+      if (data === null) {
+        return c.json({ error: "Invalid input" }, 400);
+      }
+      if (!this.terminalManager.write(terminalId, data)) {
+        return c.json({ error: "Terminal not found" }, 404);
+      }
+      return c.json({ ok: true });
+    });
+
+    app.post("/terminals/:terminalId/resize", async (c) => {
+      const authError = authenticateTerminalRequest(c);
+      if (authError) {
+        return authError;
+      }
+      const { terminalId } = c.req.param() as { terminalId: string };
+      const body = await c.req.json().catch(() => null);
+      const cols =
+        typeof body === "object" &&
+        body !== null &&
+        typeof body.cols === "number"
+          ? body.cols
+          : null;
+      const rows =
+        typeof body === "object" &&
+        body !== null &&
+        typeof body.rows === "number"
+          ? body.rows
+          : null;
+      if (!Number.isInteger(cols) || !Number.isInteger(rows)) {
+        return c.json({ error: "Invalid terminal size" }, 400);
+      }
+      if (!this.terminalManager.resize(terminalId, cols, rows)) {
+        return c.json({ error: "Terminal not found" }, 404);
+      }
+      return c.json({ ok: true });
+    });
+
+    app.delete("/terminals/:terminalId", (c) => {
+      const authError = authenticateTerminalRequest(c);
+      if (authError) {
+        return authError;
+      }
+      const { terminalId } = c.req.param() as { terminalId: string };
+      this.terminalManager.destroy(terminalId);
+      return c.json({ ok: true });
+    });
 
     app.notFound((c) => {
       return c.json({ error: "Not found" }, 404);

--- a/products/desktop/pnpm-lock.yaml
+++ b/products/desktop/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
       minimatch:
         specifier: ^10.0.3
         version: 10.1.2
+      node-pty:
+        specifier: 1.1.0
+        version: 1.1.0(patch_hash=4dfdf785f5ac51a03f5d6032371cebe89036381acd403621f250a896245647c5)
       tar:
         specifier: ^7.5.19
         version: 7.5.22

--- a/products/tasks/backend/agent_proxy_callback.py
+++ b/products/tasks/backend/agent_proxy_callback.py
@@ -18,6 +18,8 @@ from products.tasks.backend.presentation.serializers import (
     TaskRunPortForwardResolveResponseSerializer,
     TaskRunPortForwardTicketExchangeRequestSerializer,
     TaskRunPortForwardTicketExchangeResponseSerializer,
+    TaskRunTerminalResolveRequestSerializer,
+    TaskRunTerminalResolveResponseSerializer,
 )
 from products.tasks.backend.push_dispatcher import notify_task_run_turn_completed
 
@@ -219,3 +221,36 @@ def agent_proxy_port_forward_exchange_ticket(request) -> JsonResponse:
     if token is None:
         return JsonResponse({"error": "Ticket not found"}, status=404)
     return JsonResponse(TaskRunPortForwardTicketExchangeResponseSerializer({"token": token}).data)
+
+
+@extend_schema(
+    tags=["task-runs"],
+    request=TaskRunTerminalResolveRequestSerializer,
+    responses={
+        200: OpenApiResponse(response=TaskRunTerminalResolveResponseSerializer, description="Sandbox connection"),
+        400: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid request body"),
+        403: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Invalid agent-proxy secret"),
+        404: OpenApiResponse(response=TaskRunErrorResponseSerializer, description="Terminal not found or inactive"),
+    },
+    summary="Resolve task-run terminal",
+    description="Internal endpoint called by agent-proxy to resolve a valid terminal token into sandbox details.",
+)
+def agent_proxy_terminal_resolve(request) -> JsonResponse:
+    if request.method != "POST":
+        return JsonResponse({"error": "Method not allowed"}, status=405)
+    if secret_response := _validate_agent_proxy_secret(request):
+        return secret_response
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON body"}, status=400)
+
+    serializer = TaskRunTerminalResolveRequestSerializer(data=body)
+    if not serializer.is_valid():
+        return JsonResponse({"error": "Invalid request body", "detail": serializer.errors}, status=400)
+
+    resolved = tasks_facade.resolve_task_run_terminal(serializer.validated_data["token"])
+    if resolved is None:
+        return JsonResponse({"error": "Terminal not found"}, status=404)
+    return JsonResponse(TaskRunTerminalResolveResponseSerializer(resolved).data)

--- a/products/tasks/backend/facade/agent_proxy.py
+++ b/products/tasks/backend/facade/agent_proxy.py
@@ -9,6 +9,12 @@ from products.tasks.backend.agent_proxy_callback import (
     agent_proxy_callback,
     agent_proxy_port_forward_exchange_ticket,
     agent_proxy_port_forward_resolve,
+    agent_proxy_terminal_resolve,
 )
 
-__all__ = ["agent_proxy_callback", "agent_proxy_port_forward_exchange_ticket", "agent_proxy_port_forward_resolve"]
+__all__ = [
+    "agent_proxy_callback",
+    "agent_proxy_port_forward_exchange_ticket",
+    "agent_proxy_port_forward_resolve",
+    "agent_proxy_terminal_resolve",
+]

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -152,6 +152,7 @@ __all__ = [
     "create_task_run_living_artifact",
     "create_task_run_port_forward",
     "create_task_run_port_forward_token",
+    "create_task_run_terminal_token",
     "create_task_run_stream_read_token",
     "resolve_stream_base_url",
     "claim_and_fail_stale_run",
@@ -217,6 +218,7 @@ __all__ = [
     "redispatch_task_run",
     "relay_task_run_message",
     "resolve_task_run_port_forward",
+    "resolve_task_run_terminal",
     "resolve_slack_thread_context",
     "resume_task_run_in_cloud",
     "run_task",
@@ -326,6 +328,16 @@ def _task_run_port_forward_preview_url(port_forward: TaskRunPortForward, *, tick
     if ticket:
         return urlunsplit((parsed.scheme, netloc, "/auth/", urlencode({"ticket": ticket}), ""))
     return urlunsplit((parsed.scheme, netloc, "/", "", ""))
+
+
+def _task_run_terminal_url(run: TaskRun, *, terminal_id: str) -> str | None:
+    base_url = settings.TASKS_AGENT_PROXY_PUBLIC_URL
+    if not base_url:
+        return None
+    parsed = urlsplit(base_url)
+    if not parsed.scheme or not parsed.netloc or parsed.username or parsed.password:
+        return None
+    return urlunsplit((parsed.scheme, parsed.netloc, f"/v1/runs/{run.id}/terminals/{terminal_id}", "", ""))
 
 
 def _task_run_port_forward_to_dto(
@@ -2279,6 +2291,87 @@ def resolve_task_run_port_forward(token: str) -> contracts.TaskRunPortForwardRes
         team_id=run.team_id,
         forward_id=port_forward.id,
         port=port_forward.port,
+        sandbox_url=sandbox_url,
+        sandbox_connect_token=(run.state or {}).get("sandbox_connect_token"),
+        connection_token=_create_connection_token(run, user_id=payload.user_id, distinct_id=payload.distinct_id),
+    )
+
+
+def create_task_run_terminal_token(
+    run_id: str | UUID,
+    task_id: str | UUID,
+    team_id: int,
+    *,
+    user_id: int,
+    distinct_id: str,
+    terminal_id: str | None = None,
+) -> contracts.TaskRunTerminalTokenDTO | None:
+    run = _get_visible_run(run_id, task_id, team_id)
+    if run is None:
+        return None
+    if _validate_port_forward_target(run, 1):
+        return None
+
+    resolved_terminal_id = terminal_id or f"term-{secrets.token_urlsafe(18)}"
+
+    from products.tasks.backend.logic.services.connection_token import (  # noqa: PLC0415
+        create_task_terminal_token as _create,
+    )
+
+    token = _create(
+        run,
+        terminal_id=resolved_terminal_id,
+        user_id=user_id,
+        distinct_id=distinct_id,
+    )
+    return contracts.TaskRunTerminalTokenDTO(
+        terminal_id=resolved_terminal_id,
+        token=token,
+        terminal_url=_task_run_terminal_url(run, terminal_id=resolved_terminal_id),
+    )
+
+
+def resolve_task_run_terminal(token: str) -> contracts.TaskRunTerminalResolveDTO | None:
+    """Resolve a terminal token into sandbox connection details for the agent-proxy."""
+    from products.tasks.backend.logic.services.connection_token import (  # noqa: PLC0415
+        create_sandbox_connection_token as _create_connection_token,
+        validate_task_terminal_token,
+    )
+
+    try:
+        payload = validate_task_terminal_token(token)
+    except Exception:
+        return None
+    try:
+        run_id = UUID(payload.run_id)
+        task_id = UUID(payload.task_id)
+    except ValueError:
+        return None
+
+    run = (
+        TaskRun.objects.filter(
+            id=run_id,
+            task_id=task_id,
+            team_id=payload.team_id,
+        )
+        .select_related("task")
+        .first()
+    )
+    if run is None:
+        return None
+    if _validate_port_forward_target(run, 1) is not None:
+        return None
+
+    sandbox_url = (run.state or {}).get("sandbox_url")
+    if _validate_port_forward_sandbox_url(sandbox_url) is not None:
+        return None
+    assert isinstance(sandbox_url, str)
+
+    return contracts.TaskRunTerminalResolveDTO(
+        run_id=run.id,
+        task_id=run.task_id,
+        team_id=run.team_id,
+        terminal_id=payload.terminal_id,
         sandbox_url=sandbox_url,
         sandbox_connect_token=(run.state or {}).get("sandbox_connect_token"),
         connection_token=_create_connection_token(run, user_id=payload.user_id, distinct_id=payload.distinct_id),

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -134,6 +134,24 @@ class TaskRunPortForwardResolveDTO:
 
 
 @dataclass(frozen=True)
+class TaskRunTerminalTokenDTO:
+    terminal_id: str
+    token: str
+    terminal_url: str | None = None
+
+
+@dataclass(frozen=True)
+class TaskRunTerminalResolveDTO:
+    run_id: UUID
+    task_id: UUID
+    team_id: int
+    terminal_id: str
+    sandbox_url: str
+    connection_token: str
+    sandbox_connect_token: str | None = None
+
+
+@dataclass(frozen=True)
 class WizardPrReadyEmailContextDTO:
     """Everything ``send_wizard_pr_ready_email`` needs to read off a task run's PR-ready state."""
 

--- a/products/tasks/backend/logic/services/connection_token.py
+++ b/products/tasks/backend/logic/services/connection_token.py
@@ -35,6 +35,9 @@ STREAM_READ_TOKEN_TTL = timedelta(minutes=15)
 TASK_PORT_FORWARD_AUDIENCE = "posthog:task_port_forward"
 TASK_PORT_FORWARD_TOKEN_TTL = timedelta(hours=1)
 
+TASK_TERMINAL_AUDIENCE = "posthog:task_terminal"
+TASK_TERMINAL_TOKEN_TTL = timedelta(hours=1)
+
 
 @dataclass(frozen=True)
 class SandboxEventIngestTokenPayload:
@@ -65,6 +68,16 @@ class TaskPortForwardTokenPayload:
     team_id: int
     forward_id: str
     port: int
+    user_id: int
+    distinct_id: str
+
+
+@dataclass(frozen=True)
+class TaskTerminalTokenPayload:
+    run_id: str
+    task_id: str
+    team_id: int
+    terminal_id: str
     user_id: int
     distinct_id: str
 
@@ -338,6 +351,23 @@ def create_task_port_forward_token(
     )
 
 
+def create_task_terminal_token(
+    task_run: TaskRun,
+    *,
+    terminal_id: str,
+    user_id: int,
+    distinct_id: str,
+    ttl: timedelta = TASK_TERMINAL_TOKEN_TTL,
+) -> str:
+    """Create a short-lived JWT that authorizes one terminal attached to a task sandbox."""
+    return _encode_run_scoped_token(
+        task_run,
+        TASK_TERMINAL_AUDIENCE,
+        ttl,
+        {"terminal_id": terminal_id, "user_id": user_id, "distinct_id": distinct_id},
+    )
+
+
 def validate_stream_read_token(token: str) -> StreamReadTokenPayload:
     payload = _decode_sandbox_token(token, STREAM_READ_AUDIENCE)
 
@@ -379,6 +409,36 @@ def validate_task_port_forward_token(token: str) -> TaskPortForwardTokenPayload:
         team_id=team_id,
         forward_id=forward_id,
         port=port,
+        user_id=user_id,
+        distinct_id=distinct_id,
+    )
+
+
+def validate_task_terminal_token(token: str) -> TaskTerminalTokenPayload:
+    payload = _decode_sandbox_token(token, TASK_TERMINAL_AUDIENCE)
+
+    run_id = payload.get("run_id")
+    task_id = payload.get("task_id")
+    team_id = payload.get("team_id")
+    terminal_id = payload.get("terminal_id")
+    user_id = payload.get("user_id")
+    distinct_id = payload.get("distinct_id")
+
+    if (
+        not isinstance(run_id, str)
+        or not isinstance(task_id, str)
+        or type(team_id) is not int
+        or not isinstance(terminal_id, str)
+        or type(user_id) is not int
+        or not isinstance(distinct_id, str)
+    ):
+        raise jwt.InvalidTokenError("Task terminal token has invalid claims")
+
+    return TaskTerminalTokenPayload(
+        run_id=run_id,
+        task_id=task_id,
+        team_id=team_id,
+        terminal_id=terminal_id,
         user_id=user_id,
         distinct_id=distinct_id,
     )

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -38,6 +38,8 @@ from products.tasks.backend.facade.contracts import (
     TaskRunDetailDTO,
     TaskRunPortForwardDTO,
     TaskRunPortForwardResolveDTO,
+    TaskRunTerminalResolveDTO,
+    TaskRunTerminalTokenDTO,
     TaskSummaryDTO,
     TaskThreadMessageDTO,
     TaskUserBasicInfo,
@@ -1941,6 +1943,28 @@ class TaskRunPortForwardTicketExchangeResponseSerializer(serializers.Serializer)
 class TaskRunPortForwardResolveResponseSerializer(DataclassSerializer):
     class Meta:
         dataclass = TaskRunPortForwardResolveDTO
+
+
+class TaskRunTerminalTokenRequestSerializer(serializers.Serializer):
+    terminal_id = serializers.RegexField(
+        regex=r"^[A-Za-z0-9_.:-]{1,120}$",
+        required=False,
+        help_text="Optional caller-chosen terminal session id. A new id is generated when omitted.",
+    )
+
+
+class TaskRunTerminalTokenResponseSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = TaskRunTerminalTokenDTO
+
+
+class TaskRunTerminalResolveRequestSerializer(serializers.Serializer):
+    token = serializers.CharField()
+
+
+class TaskRunTerminalResolveResponseSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = TaskRunTerminalResolveDTO
 
 
 MAX_IMPORTED_MCP_SERVERS = 20

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -134,6 +134,8 @@ from products.tasks.backend.presentation.serializers import (
     TaskRunSessionLogsQuerySerializer,
     TaskRunSetOutputRequestSerializer,
     TaskRunStartRequestSerializer,
+    TaskRunTerminalTokenRequestSerializer,
+    TaskRunTerminalTokenResponseSerializer,
     TaskRunUpdateSerializer,
     TaskSerializer,
     TaskSessionResponseSerializer,
@@ -1847,6 +1849,35 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if stopped is None:
             raise NotFound()
         return Response(TaskRunPortForwardSerializer(stopped).data)
+
+    @validated_request(
+        request_serializer=TaskRunTerminalTokenRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=TaskRunTerminalTokenResponseSerializer, description="Terminal token"),
+            404: OpenApiResponse(description="Task run not found or sandbox inactive"),
+        },
+        summary="Get task run terminal token",
+        description="Generate a short-lived token for opening an interactive terminal in a live cloud task sandbox.",
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="terminal_token",
+        required_scopes=["task:write"],
+    )
+    def terminal_token(self, request, pk=None, **kwargs):
+        task_id = self._ensure_task_accessible()
+        token = tasks_facade.create_task_run_terminal_token(
+            pk,
+            task_id,
+            self.team_id,
+            user_id=request.user.id,
+            distinct_id=request.user.distinct_id,
+            terminal_id=request.validated_data.get("terminal_id"),
+        )
+        if token is None:
+            raise NotFound()
+        return Response(TaskRunTerminalTokenResponseSerializer(token).data)
 
     @validated_request(
         request_serializer=TaskRunCommandRequestSerializer,

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -4899,6 +4899,76 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(data["sandbox_connect_token"], "connect-token")
         self.assertIn("connection_token", data)
 
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @override_settings(SANDBOX_JWT_PUBLIC_KEY=None)
+    def test_terminal_token_returns_proxy_url(self):
+        reset_sandbox_jwt_key_cache()
+        task, run = self._create_run_for_origin(Task.OriginProduct.USER_CREATED)
+        run.state = {"sandbox_url": "https://sandbox.modal.run"}
+        run.save(update_fields=["state"])
+
+        with self.settings(TASKS_AGENT_PROXY_PUBLIC_URL="https://agent-proxy.example.com"):
+            response = self.client.post(
+                f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/terminal_token/",
+                {"terminal_id": "term-local-1"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["terminal_id"], "term-local-1")
+        self.assertEqual(
+            data["terminal_url"], f"https://agent-proxy.example.com/v1/runs/{run.id}/terminals/term-local-1"
+        )
+        self.assertIn("token", data)
+
+        public_key = get_sandbox_jwt_public_key()
+        decoded = jwt.decode(
+            data["token"],
+            public_key,
+            audience="posthog:task_terminal",
+            algorithms=["RS256"],
+        )
+        self.assertEqual(decoded["run_id"], str(run.id))
+        self.assertEqual(decoded["terminal_id"], "term-local-1")
+        self.assertEqual(decoded["user_id"], self.user.id)
+
+    @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
+    @override_settings(SANDBOX_JWT_PUBLIC_KEY=None)
+    def test_internal_terminal_resolve_returns_sandbox_connection(self):
+        reset_sandbox_jwt_key_cache()
+        task, run = self._create_run_for_origin(Task.OriginProduct.USER_CREATED)
+        run.state = {"sandbox_url": "https://sandbox.modal.run", "sandbox_connect_token": "connect-token"}
+        run.save(update_fields=["state"])
+        distinct_id = self.user.distinct_id
+        if distinct_id is None:
+            raise AssertionError("Expected test user to have a distinct_id")
+        token_dto = tasks_facade.create_task_run_terminal_token(
+            run.id,
+            task.id,
+            self.team.id,
+            terminal_id="term-local-1",
+            user_id=self.user.id,
+            distinct_id=distinct_id,
+        )
+        if token_dto is None:
+            raise AssertionError("Expected terminal token")
+
+        with self.settings(DEBUG=True, AGENT_PROXY_CALLBACK_SECRET=""):
+            response = self.client.post(
+                "/internal/tasks/terminal/resolve/",
+                {"token": token_dto.token},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["run_id"], str(run.id))
+        self.assertEqual(data["terminal_id"], "term-local-1")
+        self.assertEqual(data["sandbox_url"], "https://sandbox.modal.run")
+        self.assertEqual(data["sandbox_connect_token"], "connect-token")
+        self.assertIn("connection_token", data)
+
     def test_list_runs_with_malformed_task_id_returns_404(self):
         # A non-UUID task id in the URL must 404, not 500 through the UUIDField filter.
         response = self.client.get("/api/projects/@current/tasks/not-a-uuid/runs/")
@@ -8643,6 +8713,7 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             ("task:read", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/connection_token/", False),
             ("task:read", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/ports/", True),
             ("task:read", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/ports/", False),
+            ("task:read", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/terminal_token/", False),
             ("task:read", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/living_artifacts/", True),
             (
                 "task:read",
@@ -8680,6 +8751,7 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             ("task:write", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/start/", True),
             ("task:write", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/ports/", True),
             ("task:write", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/ports/", True),
+            ("task:write", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/terminal_token/", True),
             (
                 "task:write",
                 "GET",
@@ -8720,6 +8792,7 @@ class TestTasksAPIPermissions(BaseTaskAPITest):
             ("*", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/start/", True),
             ("*", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/ports/", True),
             ("*", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/ports/", True),
+            ("*", "POST", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/terminal_token/", True),
             ("*", "GET", f"/api/projects/@current/tasks/{{task_id}}/runs/{{run_id}}/living_artifacts/", True),
             (
                 "*",

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3176,6 +3176,21 @@ export interface TaskSessionSyncResponseApi {
     content_sha256: string
 }
 
+export interface TaskRunTerminalTokenRequestApi {
+    /**
+     * Optional caller-chosen terminal session id. A new id is generated when omitted.
+     * @pattern ^[A-Za-z0-9_.:-]{1,120}$
+     */
+    terminal_id?: string
+}
+
+export interface TaskRunTerminalTokenDTOApi {
+    terminal_id: string
+    token: string
+    /** @nullable */
+    terminal_url?: string | null
+}
+
 /**
  * * `slack_message` - slack_message
  * * `slack_canvas` - slack_canvas

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -108,6 +108,8 @@ import type {
     TaskRunRelayMessageRequestApi,
     TaskRunRelayMessageResponseApi,
     TaskRunStartRequestApi,
+    TaskRunTerminalTokenDTOApi,
+    TaskRunTerminalTokenRequestApi,
     TaskSessionResponseApi,
     TaskSessionSyncResponseApi,
     TaskStagedArtifactsFinalizeUploadRequestApi,
@@ -2082,6 +2084,29 @@ export const tasksRunsTaskSessionSyncCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/octet-stream', ...options?.headers },
         body: tasksRunsTaskSessionSyncCreateBody,
+    })
+}
+
+export const getTasksRunsTerminalTokenCreateUrl = (projectId: string, taskId: string, id: string) => {
+    return `/api/projects/${projectId}/tasks/${taskId}/runs/${id}/terminal_token/`
+}
+
+/**
+ * Generate a short-lived token for opening an interactive terminal in a live cloud task sandbox.
+ * @summary Get task run terminal token
+ */
+export const tasksRunsTerminalTokenCreate = async (
+    projectId: string,
+    taskId: string,
+    id: string,
+    taskRunTerminalTokenRequestApi?: TaskRunTerminalTokenRequestApi,
+    options?: RequestInit
+): Promise<TaskRunTerminalTokenDTOApi> => {
+    return apiMutator<TaskRunTerminalTokenDTOApi>(getTasksRunsTerminalTokenCreateUrl(projectId, taskId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(taskRunTerminalTokenRequestApi),
     })
 }
 

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -2825,6 +2825,20 @@ export const TasksRunsStartCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Generate a short-lived token for opening an interactive terminal in a live cloud task sandbox.
+ * @summary Get task run terminal token
+ */
+export const tasksRunsTerminalTokenCreateBodyTerminalIdRegExp = new RegExp('^[A-Za-z0-9_.:-]{1,120}$')
+
+export const TasksRunsTerminalTokenCreateBody = /* @__PURE__ */ zod.object({
+    terminal_id: zod
+        .string()
+        .regex(tasksRunsTerminalTokenCreateBodyTerminalIdRegExp)
+        .optional()
+        .describe('Optional caller-chosen terminal session id. A new id is generated when omitted.'),
+})
+
+/**
  * Create a stable, editable artifact handle from direct markdown/text content or an existing run artifact. Slack adapters deliver into the mapped Slack thread; document artifacts use external connector storage when available.
  * @summary Create a living artifact for a task run
  */

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -580,6 +580,9 @@ tools:
     tasks-runs-task-session-sync-create:
         operation: tasks_runs_task_session_sync_create
         enabled: false
+    tasks-runs-terminal-token-create:
+        operation: tasks_runs_terminal_token_create
+        enabled: false
     tasks-slack-thread-context-retrieve:
         operation: tasks_slack_thread_context_retrieve
         enabled: false

--- a/services/agent-proxy/src/hono/app.ts
+++ b/services/agent-proxy/src/hono/app.ts
@@ -19,11 +19,11 @@ import { stream } from 'hono/streaming'
 import type { Redis } from 'ioredis'
 
 import type { Config } from '../lib/config.js'
-import { validateStreamReadToken, validateTaskPortForwardToken } from '../lib/jwt.js'
+import { validateStreamReadToken, validateTaskPortForwardToken, validateTaskTerminalToken } from '../lib/jwt.js'
 import { logger, type RequestLogger } from '../lib/logging.js'
 import { getStreamKey } from '../lib/redis-stream.js'
 import { StreamCapacity } from '../lib/stream-capacity.js'
-import type { StreamReadTokenPayload, TaskPortForwardTokenPayload } from '../lib/types.js'
+import type { StreamReadTokenPayload, TaskPortForwardTokenPayload, TaskTerminalTokenPayload } from '../lib/types.js'
 import { handleIngest } from './ingest-handler.js'
 import { observeStreamConnectionRejected } from './metrics.js'
 import { corsHeaders, corsPreflightHandler, httpMetrics, requestLog, securityHeaders } from './middleware.js'
@@ -291,6 +291,78 @@ export function createApp(redis: Redis, config: Config, publicKeys: CryptoKey[])
         return handlePortForward(c, forwardId, 'path')
     })
 
+    const handleTerminal = async (c: HonoCtx, suffix: TerminalProxySuffix): Promise<Response> => {
+        const token = extractStreamReadToken(c)
+        if (token === null) {
+            return c.json({ error: 'Missing terminal token' }, 401)
+        }
+
+        let claims: TaskTerminalTokenPayload
+        try {
+            claims = await validateTaskTerminalToken(token, publicKeys)
+        } catch (err: unknown) {
+            const code = err instanceof Error ? err.constructor.name : 'UnknownError'
+            return c.json({ error: 'Invalid terminal token', code }, 401)
+        }
+
+        const { run, terminalId } = c.req.param() as { run: string; terminalId: string }
+        if (claims.runId !== run || claims.terminalId !== terminalId) {
+            return c.json({ error: 'Token does not match terminal' }, 403)
+        }
+
+        const method = c.req.method.toUpperCase()
+        let requestBody: ArrayBuffer | undefined
+        if (method !== 'GET' && method !== 'HEAD') {
+            const body = await readBoundedRequestBody(c.req.raw)
+            if (body === null) {
+                return c.json({ error: 'Terminal request body is too large' }, 413)
+            }
+            requestBody = body
+        }
+
+        const resolved = await resolveTerminal(config, token)
+        if (resolved === null) {
+            return c.json({ error: 'Terminal is not available' }, 404)
+        }
+        if (resolved.terminal_id !== claims.terminalId || resolved.run_id !== claims.runId) {
+            return c.json({ error: 'Resolved terminal does not match token' }, 403)
+        }
+
+        const upstreamUrl = buildSandboxTerminalUrl(terminalId, suffix, resolved, config)
+        if (upstreamUrl === null) {
+            return c.json({ error: 'Terminal target is not available' }, 502)
+        }
+
+        const headers = filteredProxyHeaders(c.req.raw.headers)
+        headers.set('Authorization', `Bearer ${resolved.connection_token}`)
+        const init: RequestInit = { method, headers, redirect: 'manual' }
+        if (requestBody !== undefined) {
+            init.body = requestBody
+        }
+
+        try {
+            const upstream = await fetch(upstreamUrl, init)
+            return new Response(upstream.body, {
+                status: upstream.status,
+                statusText: upstream.statusText,
+                headers: filteredTerminalResponseHeaders(upstream.headers),
+            })
+        } catch (err) {
+            logger.warn('terminal:upstream_unreachable', {
+                terminalId,
+                run: claims.runId,
+                error: err instanceof Error ? err.message : String(err),
+            })
+            return c.json({ error: 'Terminal target is not reachable' }, 502)
+        }
+    }
+
+    app.post('/v1/runs/:run/terminals/:terminalId', (c) => handleTerminal(c, ''))
+    app.get('/v1/runs/:run/terminals/:terminalId/stream', (c) => handleTerminal(c, '/stream'))
+    app.post('/v1/runs/:run/terminals/:terminalId/input', (c) => handleTerminal(c, '/input'))
+    app.post('/v1/runs/:run/terminals/:terminalId/resize', (c) => handleTerminal(c, '/resize'))
+    app.delete('/v1/runs/:run/terminals/:terminalId', (c) => handleTerminal(c, ''))
+
     // -- Catch-all 404 --
     app.all('*', (c) => {
         const forwardId = previewForwardIdFromHost(c, config)
@@ -368,6 +440,18 @@ interface ResolvedPortForward {
 }
 
 type PortForwardMode = 'host' | 'path'
+
+interface ResolvedTerminal {
+    run_id: string
+    task_id: string
+    team_id: number
+    terminal_id: string
+    sandbox_url: string
+    connection_token: string
+    sandbox_connect_token?: string | null
+}
+
+type TerminalProxySuffix = '' | '/stream' | '/input' | '/resize'
 
 function isSamePreviewOriginRequest(c: HonoCtx, config: Config): boolean {
     const expectedOrigin = previewOriginFromHost(c, config)
@@ -557,6 +641,26 @@ async function resolvePortForward(config: Config, token: string): Promise<Resolv
     return (await response.json()) as ResolvedPortForward
 }
 
+async function resolveTerminal(config: Config, token: string): Promise<ResolvedTerminal | null> {
+    if (!config.djangoCallbackBaseUrl) {
+        logger.warn('terminal:resolve_unconfigured')
+        return null
+    }
+    const response = await fetch(`${config.djangoCallbackBaseUrl}/internal/tasks/terminal/resolve/`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Agent-Proxy-Secret': config.agentProxyCallbackSecret,
+        },
+        body: JSON.stringify({ token }),
+    })
+    if (!response.ok) {
+        logger.warn('terminal:resolve_failed', { status: response.status })
+        return null
+    }
+    return (await response.json()) as ResolvedTerminal
+}
+
 function buildSandboxPortUrl(
     requestUrl: string,
     forwardId: string,
@@ -581,6 +685,24 @@ function buildSandboxPortUrl(
     incoming.searchParams.forEach((value, key) => {
         target.searchParams.append(key, value)
     })
+    if (resolved.sandbox_connect_token) {
+        target.searchParams.set('_modal_connect_token', resolved.sandbox_connect_token)
+    }
+    return target.toString()
+}
+
+function buildSandboxTerminalUrl(
+    terminalId: string,
+    suffix: TerminalProxySuffix,
+    resolved: ResolvedTerminal,
+    config: Config
+): string | null {
+    const sandboxBaseUrl = parseAllowedSandboxUrl(resolved.sandbox_url, config)
+    if (sandboxBaseUrl === null) {
+        logger.warn('terminal:invalid_sandbox_url', { terminalId, run: resolved.run_id })
+        return null
+    }
+    const target = new URL(`/terminals/${encodeURIComponent(terminalId)}${suffix}`, sandboxBaseUrl)
     if (resolved.sandbox_connect_token) {
         target.searchParams.set('_modal_connect_token', resolved.sandbox_connect_token)
     }
@@ -658,6 +780,18 @@ function filteredResponseHeaders(
         }
         if (normalized === 'location') {
             headers.set(key, rewritePortForwardLocation(value, forwardId, resolved, mode))
+            return
+        }
+        headers.set(key, value)
+    })
+    return headers
+}
+
+function filteredTerminalResponseHeaders(input: Headers): Headers {
+    const headers = new Headers()
+    input.forEach((value, key) => {
+        const normalized = key.toLowerCase()
+        if (HOP_BY_HOP_HEADERS.has(normalized) || normalized === 'service-worker-allowed') {
             return
         }
         headers.set(key, value)

--- a/services/agent-proxy/src/lib/constants.ts
+++ b/services/agent-proxy/src/lib/constants.ts
@@ -76,7 +76,7 @@ export const MAX_REQUEST_BYTES = 5_000_000
 export const MAX_EVENTS_PER_REQUEST = 1_000
 
 // CORS headers (must match the Python ASGI middleware values exactly)
-export const CORS_ALLOW_METHODS = 'GET, POST, OPTIONS'
+export const CORS_ALLOW_METHODS = 'GET, POST, DELETE, OPTIONS'
 export const CORS_ALLOW_HEADERS =
     'authorization, last-event-id, content-type, accept, x-csrftoken, x-posthog-distinct-id, x-posthog-session-id'
 export const CORS_MAX_AGE = '600'
@@ -85,6 +85,7 @@ export const CORS_MAX_AGE = '600'
 export const STREAM_READ_AUDIENCE = 'posthog:stream_read'
 export const SANDBOX_EVENT_INGEST_AUDIENCE = 'posthog:sandbox_event_ingest'
 export const TASK_PORT_FORWARD_AUDIENCE = 'posthog:task_port_forward'
+export const TASK_TERMINAL_AUDIENCE = 'posthog:task_terminal'
 
 // SSE event names (keepalive and terminal events carry a named "event:" line;
 // normal stream events do not — they carry only "id:" and "data:").

--- a/services/agent-proxy/src/lib/jwt.ts
+++ b/services/agent-proxy/src/lib/jwt.ts
@@ -15,8 +15,18 @@
 
 import { errors, importSPKI, jwtVerify, type JWTPayload } from 'jose'
 
-import { SANDBOX_EVENT_INGEST_AUDIENCE, STREAM_READ_AUDIENCE, TASK_PORT_FORWARD_AUDIENCE } from './constants.js'
-import type { SandboxEventIngestTokenPayload, StreamReadTokenPayload, TaskPortForwardTokenPayload } from './types.js'
+import {
+    SANDBOX_EVENT_INGEST_AUDIENCE,
+    STREAM_READ_AUDIENCE,
+    TASK_PORT_FORWARD_AUDIENCE,
+    TASK_TERMINAL_AUDIENCE,
+} from './constants.js'
+import type {
+    SandboxEventIngestTokenPayload,
+    StreamReadTokenPayload,
+    TaskPortForwardTokenPayload,
+    TaskTerminalTokenPayload,
+} from './types.js'
 
 // ---------------------------------------------------------------------------
 // Public key loading
@@ -135,4 +145,23 @@ export async function validateTaskPortForwardToken(
     }
 
     return { ...base, forwardId, port: port as number, userId: userId as number }
+}
+
+export async function validateTaskTerminalToken(
+    token: string,
+    publicKeys: CryptoKey[]
+): Promise<TaskTerminalTokenPayload> {
+    const payload = await verifyWithKeys(token, publicKeys, TASK_TERMINAL_AUDIENCE)
+    const base = assertStreamClaims(payload as Record<string, unknown>)
+    const terminalId = payload['terminal_id']
+    const userId = payload['user_id']
+
+    if (typeof terminalId !== 'string') {
+        throw new Error('Token has invalid claim: terminal_id must be a string')
+    }
+    if (!Number.isInteger(userId)) {
+        throw new Error('Token has invalid claim: user_id must be an integer')
+    }
+
+    return { ...base, terminalId, userId: userId as number }
 }

--- a/services/agent-proxy/src/lib/types.ts
+++ b/services/agent-proxy/src/lib/types.ts
@@ -112,6 +112,15 @@ export interface TaskPortForwardTokenPayload {
     userId: number
 }
 
+// Claims extracted from a posthog:task_terminal JWT.
+export interface TaskTerminalTokenPayload {
+    runId: string
+    taskId: string
+    teamId: number
+    terminalId: string
+    userId: number
+}
+
 // ---------------------------------------------------------------------------
 // SSE stream connection outcome (matches Python StreamConnectionOutcome values)
 // ---------------------------------------------------------------------------

--- a/services/agent-proxy/tests/hono/app.test.ts
+++ b/services/agent-proxy/tests/hono/app.test.ts
@@ -8,14 +8,16 @@ vi.mock('@/lib/jwt.js', () => ({
     validateSandboxEventIngestToken: vi.fn(),
     validateStreamReadToken: vi.fn(),
     validateTaskPortForwardToken: vi.fn(),
+    validateTaskTerminalToken: vi.fn(),
     loadPublicKeys: vi.fn(),
 }))
 
 import { createApp } from '@/hono/app.js'
-import { validateSandboxEventIngestToken, validateTaskPortForwardToken } from '@/lib/jwt.js'
+import { validateSandboxEventIngestToken, validateTaskPortForwardToken, validateTaskTerminalToken } from '@/lib/jwt.js'
 
 const mockValidate = vi.mocked(validateSandboxEventIngestToken)
 const mockValidatePortForward = vi.mocked(validateTaskPortForwardToken)
+const mockValidateTerminal = vi.mocked(validateTaskTerminalToken)
 
 function makeConfig(overrides?: Partial<Config>): Config {
     return {
@@ -46,6 +48,13 @@ describe('app onError', () => {
             teamId: 42,
             forwardId: 'forward-123',
             port: 8000,
+            userId: 7,
+        })
+        mockValidateTerminal.mockResolvedValue({
+            runId: 'run-123',
+            taskId: 'task-abc',
+            teamId: 42,
+            terminalId: 'term-123',
             userId: 7,
         })
     })
@@ -490,5 +499,76 @@ describe('app onError', () => {
 
         expect(res.status).toBe(404)
         expect(await res.json()).toEqual({ error: 'Not found' })
+    })
+
+    it('resolves and proxies a terminal input request to the sandbox agent server', async () => {
+        const redis = {} as unknown as Redis
+        const { app } = createApp(
+            redis,
+            makeConfig({ djangoCallbackBaseUrl: 'http://django', agentProxyCallbackSecret: 'secret' }),
+            []
+        )
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValueOnce(
+                Response.json({
+                    run_id: 'run-123',
+                    task_id: 'task-abc',
+                    team_id: 42,
+                    terminal_id: 'term-123',
+                    sandbox_url: 'https://sandbox.modal.run',
+                    sandbox_connect_token: 'connect-token',
+                    connection_token: 'connection-token',
+                })
+            )
+            .mockResolvedValueOnce(Response.json({ ok: true }))
+
+        const res = await app.request('/v1/runs/run-123/terminals/term-123/input', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer terminal-token', 'Content-Type': 'application/json' },
+            body: JSON.stringify({ data: 'ls\n' }),
+        })
+
+        expect(res.status).toBe(200)
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            1,
+            'http://django/internal/tasks/terminal/resolve/',
+            expect.objectContaining({
+                body: JSON.stringify({ token: 'terminal-token' }),
+            })
+        )
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            'https://sandbox.modal.run/terminals/term-123/input?_modal_connect_token=connect-token',
+            expect.objectContaining({
+                method: 'POST',
+                headers: expect.any(Headers),
+            })
+        )
+        const upstreamInit = fetchMock.mock.calls[1]?.[1]
+        expect(upstreamInit).not.toBeUndefined()
+        expect((upstreamInit?.headers as Headers).get('Authorization')).toBe('Bearer connection-token')
+        fetchMock.mockRestore()
+    })
+
+    it('rejects a terminal token that does not match the URL terminal id', async () => {
+        mockValidateTerminal.mockResolvedValueOnce({
+            runId: 'run-123',
+            taskId: 'task-abc',
+            teamId: 42,
+            terminalId: 'different-term',
+            userId: 7,
+        })
+        const redis = {} as unknown as Redis
+        const { app } = createApp(redis, makeConfig(), [])
+
+        const res = await app.request('/v1/runs/run-123/terminals/term-123/input', {
+            method: 'POST',
+            headers: { Authorization: 'Bearer terminal-token' },
+            body: JSON.stringify({ data: 'ls\n' }),
+        })
+
+        expect(res.status).toBe(403)
+        expect(await res.json()).toEqual({ error: 'Token does not match terminal' })
     })
 })

--- a/services/agent-proxy/tests/lib/jwt.test.ts
+++ b/services/agent-proxy/tests/lib/jwt.test.ts
@@ -6,12 +6,18 @@
 import { SignJWT, exportSPKI, generateKeyPair } from 'jose'
 import { describe, it, expect, beforeAll } from 'vitest'
 
-import { SANDBOX_EVENT_INGEST_AUDIENCE, STREAM_READ_AUDIENCE, TASK_PORT_FORWARD_AUDIENCE } from '@/lib/constants.js'
+import {
+    SANDBOX_EVENT_INGEST_AUDIENCE,
+    STREAM_READ_AUDIENCE,
+    TASK_PORT_FORWARD_AUDIENCE,
+    TASK_TERMINAL_AUDIENCE,
+} from '@/lib/constants.js'
 import {
     loadPublicKeys,
     validateSandboxEventIngestToken,
     validateStreamReadToken,
     validateTaskPortForwardToken,
+    validateTaskTerminalToken,
 } from '@/lib/jwt.js'
 
 // ---------------------------------------------------------------------------
@@ -65,6 +71,7 @@ interface TokenOptions {
     forwardId?: string
     port?: unknown
     userId?: unknown
+    terminalId?: string
 }
 
 async function signToken(opts: TokenOptions = {}): Promise<string> {
@@ -79,6 +86,7 @@ async function signToken(opts: TokenOptions = {}): Promise<string> {
         forwardId,
         port,
         userId,
+        terminalId,
     } = opts
 
     const claims: Record<string, unknown> = { run_id: runId, task_id: taskId, team_id: teamId }
@@ -90,6 +98,9 @@ async function signToken(opts: TokenOptions = {}): Promise<string> {
     }
     if (userId !== undefined) {
         claims.user_id = userId
+    }
+    if (terminalId !== undefined) {
+        claims.terminal_id = terminalId
     }
 
     const builder = new SignJWT(claims).setProtectedHeader({
@@ -214,6 +225,37 @@ describe('jwt', () => {
 
             await expect(validateTaskPortForwardToken(token, keys.publicKeys)).rejects.toThrow(
                 'forward_id must be a string'
+            )
+        })
+    })
+
+    describe('validateTaskTerminalToken', () => {
+        it('verifies a valid task_terminal token', async () => {
+            const token = await signToken({
+                audience: TASK_TERMINAL_AUDIENCE,
+                terminalId: 'term-123',
+                userId: 7,
+            })
+
+            const payload = await validateTaskTerminalToken(token, keys.publicKeys)
+
+            expect(payload).toEqual({
+                runId: 'run-abc-123',
+                taskId: 'task-abc-123',
+                teamId: 42,
+                terminalId: 'term-123',
+                userId: 7,
+            })
+        })
+
+        it('rejects a terminal token missing the terminal id', async () => {
+            const token = await signToken({
+                audience: TASK_TERMINAL_AUDIENCE,
+                userId: 7,
+            })
+
+            await expect(validateTaskTerminalToken(token, keys.publicKeys)).rejects.toThrow(
+                'terminal_id must be a string'
             )
         })
     })

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -73128,6 +73128,21 @@ export namespace Schemas {
       pending_user_artifact_ids?: string[];
     }
 
+    export interface TaskRunTerminalTokenDTO {
+      terminal_id: string;
+      token: string;
+      /** @nullable */
+      terminal_url?: string | null;
+    }
+
+    export interface TaskRunTerminalTokenRequest {
+      /**
+         * Optional caller-chosen terminal session id. A new id is generated when omitted.
+         * @pattern ^[A-Za-z0-9_.:-]{1,120}$
+         */
+      terminal_id?: string;
+    }
+
     export interface TaskSessionResponse {
       /** Task session identifier */
       id: string;


### PR DESCRIPTION
## Problem

Cloud tasks can now expose preview ports, but debugging still requires the agent to run every command. This adds the backend and proxy plumbing needed for an authenticated terminal attached to the task sandbox.

Refs #78011

## Changes

- Add a task terminal JWT capability and run-scoped token/resolve APIs.
- Relay terminal create, stream, input, resize, and close requests through agent-proxy.
- Add a PTY manager in the sandbox agent server with repository-scoped cwd handling and a bounded output buffer.

## How did you test this code?

- `pnpm --filter @posthog/agent-proxy lint`
- `pnpm --filter @posthog/agent-proxy typecheck`
- `pnpm --filter @posthog/agent-proxy test -- --runInBand`
- `cd products/desktop && npx @biomejs/biome@2.2.4 check packages/agent/src/server/agent-server.ts packages/agent/package.json`
- `uv run ruff check ...` on touched task backend files
- `uv run mypy ...` on touched task backend files

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update yet. This is backend/proxy/sandbox plumbing, not a user-facing Desktop UI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this as a stacked follow-up to [#76825](https://github.com/PostHog/posthog/pull/76825). No repo-provided skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
