### PR TITLE
fix(data-warehouse): retry transient connection errors in Polar sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/polar/polar.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/polar/polar.py
@@ -3,7 +3,6 @@ from typing import Optional
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import requests
-from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -27,9 +26,10 @@ class PolarPermissionError(Exception):
 
 
 def _get_polar_session() -> requests.Session:
-    # Plain session with no retry adapter: errors fail fast so the caller
-    # can surface them immediately rather than silently retrying.
-    return make_tracked_session(retry=Retry(total=0))
+    # DEFAULT_RETRY backs off on 429/5xx and transient connection errors (honoring
+    # Retry-After), so a dropped connection mid-sync doesn't fail the whole activity.
+    # 401/403 aren't in its status_forcelist, so credential errors still surface immediately.
+    return make_tracked_session()
 
 
 def _build_url(endpoint: str, page: int) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/polar/test_polar_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/polar/test_polar_source.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import requests
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import DEFAULT_RETRY
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.polar import PolarSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.polar import polar as polar_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.polar.source import PolarSource
@@ -22,6 +23,14 @@ class _FakeResponse:
                 f"{self.status_code} Client Error: Unauthorized for url: https://api.polar.sh/v1/organizations/?limit=1",
                 response=self,  # type: ignore[arg-type]
             )
+
+
+class TestGetPolarSession:
+    def test_retries_transient_errors_instead_of_failing_the_sync_outright(self) -> None:
+        # A no-retry adapter previously made a single dropped connection or 5xx during
+        # pagination fail the whole sync activity instead of being absorbed here.
+        session = polar_module._get_polar_session()
+        assert session.adapters["https://"].max_retries is DEFAULT_RETRY
 
 
 class TestPolarValidateCredentials:


### PR DESCRIPTION
## Problem

A Polar data warehouse sync can fail outright on a single dropped connection or transient server error while paginating through Polar's API, even though the connection recovers moments later.

- The session Polar uses for both credential validation and the sync loop disabled the HTTP adapter's retry policy (`Retry(total=0)`).
- Error tracking caught one such failure: an SSL connection drop during a page fetch (issue [019fd356-43c7-75b3-ab00-54ca0d0fd4a8](https://us.posthog.com/project/2/error_tracking/019fd356-43c7-75b3-ab00-54ca0d0fd4a8)) failed the entire sync activity instead of being retried.

## Changes

- `_get_polar_session` now uses the shared `DEFAULT_RETRY` policy instead of `Retry(total=0)`, matching Paddle, the source Polar was modeled on.
- `DEFAULT_RETRY` backs off on connection errors and 429/5xx responses with retries. 401/403 aren't in its status forcelist, so credential errors still surface immediately for the existing non-retryable-error handling.

## How did you test this code?

- Added `TestGetPolarSession`, asserting the session's mounted adapter uses `DEFAULT_RETRY` — catches a regression if the retry policy reverts to a no-retry adapter.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/polar/test_polar_source.py` locally: both tests pass.
- Not run: a live sync against Polar's API, since this is a transient-network-condition fix that isn't practical to reproduce live.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — this changes internal retry behavior only, no user-facing or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a webhook-delivered error tracking alert for the Polar source.
- Skills invoked: `/writing-tests` before adding the test, `/writing-pr-descriptions` before writing this body.
- Investigated whether this was a user/upstream credential error (would extend `NonRetryableErrors`) versus a genuine transient infra error (should stay retryable) versus a fixable bug. Compared Polar's session setup against the Paddle source it was modeled on and against other sources in the same directory that intentionally disable adapter retries (all of which either own a custom retry loop or have an SSRF-related reason) — Polar had neither, and its no-retry choice predates this fix with no such justification.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*