### PR TITLE
feat(replay-vision): rehydrate experiment targeting on edit and back-link scanners from the experiment

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
@@ -17,6 +17,7 @@ import {
 
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { pluralize } from 'lib/utils/strings'
 import { SessionRecordingsPlaylist } from 'scenes/session-recordings/playlist/SessionRecordingsPlaylist'
@@ -181,6 +182,7 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
         sessionBucketLoading,
         sessionBucketError,
         sessionBucketRequest,
+        experimentScanners,
     } = useValues(logic)
     const {
         setSelectedVariantKey,
@@ -254,22 +256,47 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
                     {EXPOSURE_FALLBACK_NOTICE}
                 </LemonBanner>
             )}
-            {scannerCrossSellEnabled && (
-                <LemonBanner
-                    type="info"
-                    className="mb-2"
-                    dismissKey="experiment-replay-vision-scanner-cross-sell"
-                    action={{
-                        children: 'Set up a scanner',
-                        to: scannerSetupUrl,
-                        onClick: () => scannerCrossSellClicked(),
-                        'data-attr': 'experiment-recordings-scanner-cross-sell',
-                    }}
-                >
-                    Replay vision can watch new recordings from this experiment for you. Scanners check each session and
-                    report what they find.
-                </LemonBanner>
-            )}
+            {scannerCrossSellEnabled &&
+                (experimentScanners.length > 0 ? (
+                    <LemonBanner
+                        type="info"
+                        className="mb-2"
+                        action={{
+                            children: 'Add another',
+                            to: scannerSetupUrl,
+                            onClick: () => scannerCrossSellClicked(),
+                            'data-attr': 'experiment-recordings-scanner-cross-sell',
+                        }}
+                    >
+                        <span data-attr="experiment-recordings-scanner-backlink">
+                            {experimentScanners.length === 1
+                                ? 'A scanner is'
+                                : `${experimentScanners.length} scanners are`}{' '}
+                            watching recordings from this experiment:{' '}
+                            {experimentScanners.map((scanner, index) => (
+                                <Fragment key={scanner.id}>
+                                    {index > 0 && ', '}
+                                    <Link to={urls.replayVision(scanner.id)}>{scanner.name}</Link>
+                                </Fragment>
+                            ))}
+                        </span>
+                    </LemonBanner>
+                ) : (
+                    <LemonBanner
+                        type="info"
+                        className="mb-2"
+                        dismissKey="experiment-replay-vision-scanner-cross-sell"
+                        action={{
+                            children: 'Set up a scanner',
+                            to: scannerSetupUrl,
+                            onClick: () => scannerCrossSellClicked(),
+                            'data-attr': 'experiment-recordings-scanner-cross-sell',
+                        }}
+                    >
+                        Replay vision can watch new recordings from this experiment for you. Scanners check each session
+                        and report what they find.
+                    </LemonBanner>
+                ))}
             <div className="mb-2 flex flex-wrap gap-2">
                 <LemonSegmentedButton
                     size="small"

--- a/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/experimentReplayTabLogic.ts
@@ -60,6 +60,8 @@ import type {
     ExperimentSessionEventDeltaResponseApi,
     ExperimentWatchCardApi,
 } from 'products/experiments/frontend/generated/api.schemas'
+import { visionScannersList } from 'products/replay_vision/frontend/generated/api'
+import type { ReplayScannerApi } from 'products/replay_vision/frontend/generated/api.schemas'
 
 import type { ExperimentIdType } from '../../../types'
 import type { ExperimentSavedMetric } from '../experimentLogic'
@@ -174,6 +176,8 @@ export interface experimentReplayTabLogicValues {
     bucketSessionIds: string[] | undefined
     effectiveMetricUuids: string[]
     effectiveVariantKey: string | null
+    experimentScanners: ReplayScannerApi[]
+    experimentScannersLoading: boolean
     exposureUnlinkable: boolean
     loadedRecordings: ExperimentReplayRecording[]
     loadedRecordingsById: Map<string, ExperimentReplayRecording>
@@ -255,6 +259,21 @@ export interface experimentReplayTabLogicActions {
     setDefaultTab: (tab: SessionRecordingSidebarTab) => {
         tab: SessionRecordingSidebarTab
     } // playerSidebarLogic
+    loadExperimentScanners: () => any
+    loadExperimentScannersFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadExperimentScannersSuccess: (
+        experimentScanners: ReplayScannerApi[],
+        payload?: any
+    ) => {
+        experimentScanners: ReplayScannerApi[]
+        payload?: any
+    }
     loadSeenTogetherFailure: (
         error: string,
         errorObject?: any
@@ -458,6 +477,20 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
         scannerCrossSellClicked: true,
     }),
     loaders(({ values, props, actions }) => ({
+        experimentScanners: [
+            [] as ReplayScannerApi[],
+            {
+                loadExperimentScanners: async () => {
+                    if (!values.featureFlags[FEATURE_FLAGS.VISION_ENTRYPOINT_EXPERIMENTS]) {
+                        return []
+                    }
+                    const response = await visionScannersList(String(values.currentProjectId), {
+                        experiment_id: String(props.experiment.id),
+                    })
+                    return (response.results ?? []) as ReplayScannerApi[]
+                },
+            },
+        ],
         sessionBucket: [
             null as ExperimentSessionBucket | null,
             {
@@ -1097,6 +1130,8 @@ export const experimentReplayTabLogic = kea<experimentReplayTabLogicType>([
         if (values.sessionBucketRequest) {
             actions.loadSessionBucket()
         }
+
+        actions.loadExperimentScanners()
 
         // The linkability check is shared with the metrics tab, so it can already have settled —
         // loaded, or failed with no reload coming — before this tab is opened, in which case no

--- a/products/replay_vision/frontend/replay_scanners/experimentTargeting.ts
+++ b/products/replay_vision/frontend/replay_scanners/experimentTargeting.ts
@@ -19,6 +19,7 @@ import {
     UniversalFiltersGroupValue,
 } from '~/types'
 
+import type { ScannerExperimentTargetingApi } from '../generated/api.schemas'
 import type { ReplayScanner } from './types'
 
 /**
@@ -272,11 +273,21 @@ export function experimentScannerName(baseName: string, experimentName: string):
     return name.slice(0, 255)
 }
 
+/** The persisted projection of the wizard's experiment context, stored on the scanner. */
+export function experimentTargetingFromContext(context: ExperimentScannerContext): ScannerExperimentTargetingApi {
+    return {
+        experiment_id: context.experiment.id as number,
+        variant_keys: context.variantKeys,
+        use_exposure_fallback: context.useExposureFallback,
+    }
+}
+
 /** Applies the experiment context to a fresh (or freshly templated) scanner: targeted query, scoped name. */
 export function prefillScannerForExperiment(scanner: ReplayScanner, context: ExperimentScannerContext): ReplayScanner {
     return {
         ...scanner,
         name: experimentScannerName(scanner.name, context.experiment.name),
         query: buildExperimentScannerQuery(context.experiment, context.variantKeys, context.useExposureFallback),
+        experiment_targeting: experimentTargetingFromContext(context),
     }
 }

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.experiment.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.experiment.test.ts
@@ -46,8 +46,9 @@ describe('replayScannerLogic experiment targeting', () => {
         logic?.unmount()
     })
 
-    it('remove clears the context and strips the managed exposure filter from the query', async () => {
+    it('remove clears the context, the persisted experiment_targeting, and the managed exposure filter', async () => {
         expect(logic.values.scanner.query?.events).toHaveLength(1)
+        expect(logic.values.scanner.experiment_targeting).toMatchObject({ experiment_id: 9 })
 
         await expectLogic(logic, () => logic.actions.removeExperimentTargeting()).toDispatchActions([
             'removeExperimentTargeting',
@@ -55,14 +56,51 @@ describe('replayScannerLogic experiment targeting', () => {
         ])
 
         expect(logic.values.experimentContext).toBeNull()
+        expect(logic.values.scanner.experiment_targeting).toBeNull()
         expect(logic.values.scanner.query?.events).toEqual([])
         expect(logic.values.scanner.query?.properties).toEqual([])
     })
 
-    it('variant changes recompile the exposure filter in the stored query', async () => {
+    it('variant changes recompile the exposure filter and the persisted experiment_targeting', async () => {
         await expectLogic(logic, () => logic.actions.setExperimentVariantKeys(['control']))
         const exposureEvent = logic.values.scanner.query?.events?.[0] as { properties: { value: unknown }[] }
         expect(exposureEvent.properties[0]).toMatchObject({ value: ['control'] })
+        expect(logic.values.scanner.experiment_targeting).toMatchObject({ variant_keys: ['control'] })
+    })
+
+    it('editing a saved scanner with a experiment_targeting rehydrates the targeting card', async () => {
+        useMocks({
+            get: {
+                '/api/projects/:team/vision/scanners/saved-1/': {
+                    ...newScanner(null),
+                    id: 'saved-1',
+                    name: 'Saved scanner',
+                    experiment_targeting: {
+                        experiment_id: 9,
+                        variant_keys: ['test'],
+                        use_exposure_fallback: false,
+                    },
+                },
+                '/api/projects/:team/vision/scanners/:id/observations/': { results: [] },
+                '/api/projects/:team/vision/scanners/:id/observations/stats/': {
+                    status_counts: { total: 0, succeeded: 0, failed: 0, ineligible: 0, in_flight: 0 },
+                    coverage: { recent_sessions: 0, total_sessions: 0, recent_days: 14 },
+                    available_tags: [],
+                },
+                '/api/projects/:team/experiments/9/': experiment,
+            },
+        })
+        const savedLogic = replayScannerLogic({ id: 'saved-1' })
+        savedLogic.mount()
+        try {
+            await expectLogic(savedLogic).toDispatchActions(['loadScannerSuccess', 'setExperimentContext'])
+            expect(savedLogic.values.experimentContext).toMatchObject({
+                variantKeys: ['test'],
+                experiment: { id: 9 },
+            })
+        } finally {
+            savedLogic.unmount()
+        }
     })
 
     it('query prefill matches the compiled experiment query', () => {

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -66,6 +66,7 @@ import {
 import { clampDurationFilter, durationFilterError } from './durationBounds'
 import {
     ExperimentScannerContext,
+    experimentTargetingFromContext,
     parseExperimentScannerParams,
     prefillScannerForExperiment,
     reconcileVariantKeys,
@@ -1508,6 +1509,22 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     // The API never carries the UI-only toggle; materialize it so clearing a loaded limit
                     // still blocks the save instead of silently saving as unlimited.
                     actions.loadScannerSuccess({ ...scanner, credit_limit_enabled: scanner.credit_limit != null })
+                    // Rebuild the experiment targeting card from the persisted context. Fail-soft:
+                    // a deleted or unreadable experiment just leaves the raw filter editor, which
+                    // still shows the scanner's real query.
+                    const targeting = scanner.experiment_targeting
+                    if (targeting?.experiment_id) {
+                        try {
+                            const experiment = await api.experiments.get(targeting.experiment_id)
+                            actions.setExperimentContext({
+                                experiment,
+                                variantKeys: targeting.variant_keys ?? [],
+                                useExposureFallback: targeting.use_exposure_fallback ?? false,
+                            })
+                        } catch {
+                            // Deliberately silent: the scanner loaded fine, only the friendly editor degrades.
+                        }
+                    }
                 } catch (error: any) {
                     lemonToast.error(`Failed to load scanner${error.detail ? `: ${error.detail}` : ''}`)
                     actions.loadScannerFailure()
@@ -1540,6 +1557,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                         'query',
                         replaceExperimentExposureFilter(values.scanner?.query ?? null, context)
                     )
+                    actions.setScannerValue('experiment_targeting', experimentTargetingFromContext(context))
                 } catch (error: any) {
                     lemonToast.error(`Couldn't load the experiment${error?.detail ? `: ${error.detail}` : ''}`)
                 }
@@ -1557,6 +1575,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     'query',
                     removeManagedExposureFromQuery(values.scanner?.query ?? null, context.experiment)
                 )
+                actions.setScannerValue('experiment_targeting', null)
                 actions.detachExperimentContext()
             },
 
@@ -1571,6 +1590,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                     'query',
                     replaceExperimentExposureFilter(values.scanner?.query ?? null, context)
                 )
+                actions.setScannerValue('experiment_targeting', experimentTargetingFromContext(context))
             },
 
             // Changing type keeps the rest of the form: it spreads `current`, so an experiment

--- a/products/replay_vision/frontend/replay_scanners/scannerTemplates.ts
+++ b/products/replay_vision/frontend/replay_scanners/scannerTemplates.ts
@@ -127,6 +127,7 @@ export function newScanner(templateKey?: string | null): ScannerFormValues {
         sampling_rate: 1,
         sampling_mode: 'comprehensive' as const,
         query: { kind: NodeKind.RecordingsQuery },
+        experiment_targeting: null,
         provider: DEFAULT_PROVIDER,
         model: DEFAULT_MODEL,
         emits_signals: false,


### PR DESCRIPTION
## Problem

Stacked on #78071 and consuming the `experiment_targeting` field from #78514. Two gaps close here: the experiment link on a scanner died at save time (re-editing showed raw filters instead of the variant selector), and the experiment Recordings tab had no way to show which scanners were already watching it.

## Changes

- The wizard persists `experiment_targeting` alongside the compiled query: written on prefill and on cold attach, kept in sync on variant changes, nulled by Remove.
- Editing a saved scanner rehydrates the experiment targeting card from `experiment_targeting` (fetches the experiment, restores the variant multiselect). Fail-soft: if the experiment is deleted or unreadable, the editor degrades to raw filters with no error, since the scanner's query is intact.
- The experiment Recordings tab loads the scanners created to watch it (via the `experiment_id` list filter) and shows "N scanners are watching recordings from this experiment" with a link per scanner and an "Add another" action. The dismissible cross-sell banner shows only when there are none. Both remain behind `vision-entrypoint-experiments`.

### Screenshots

The back-link banner once a scanner targets the experiment (created through the real API in local dev):

![Back-link banner listing the scanner watching this experiment](https://raw.githubusercontent.com/PostHog/pr-assets/86ec9c7e5cf986f121b18871735536084e1baed5/2026/08/3c2d0065-8660-45fd-990b-f672e721d70c.png)

Re-editing that saved scanner rehydrates the targeting card from `experiment_targeting`:

![Rehydrated targeting card when editing a saved scanner](https://raw.githubusercontent.com/PostHog/pr-assets/86ec9c7e5cf986f121b18871735536084e1baed5/2026/08/3167572a-e290-43d6-86f2-b1c26bef0a17.png)

## How did you test this code?

Jest logic tests (extended `replayScannerLogic.experiment.test.ts`): rehydration mounts a saved scanner with a `experiment_targeting` and asserts the targeting card state is rebuilt (catches the round-trip breaking, which was this PR's reason to exist); remove now also asserts the persisted context nulls, and variant changes assert it stays in sync (catches drift between the query and the stored context). All 345 tests across the affected suites pass; typecheck and lint clean. I did not browser-test the banner swap.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Follows when the entry points are unflagged, with the rest of the stack.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) directed by Kim Dugan. Skills invoked: /writing-tests, /writing-user-facing-copy, /writing-code-comments. Decision: the back-link banner is not dismissible (it's status, not a promo) while the cross-sell banner keeps its dismissKey; scanner discovery uses the persisted context rather than client-side flag-key matching so it survives users editing filters.



