### PR TITLE
fix(slack_app): don't gate mentions on personal GitHub before classifying

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/repo_selection.py
+++ b/posthog/temporal/ai/slack_app/activities/repo_selection.py
@@ -32,10 +32,8 @@ def cascade_posthog_code_repository_activity(
 
     ``user_id`` defaults to ``None`` for backwards compatibility with the pre-2026-06
     call shape: if a worker drains an activity task that was scheduled by an older
-    workflow (recorded with two positional args), the call still binds. In that case
-    the activity short-circuits to ``no_repo`` since the pre-2026-06 workflow code on
-    the receiving end does not understand the ``needs_user_github`` outcome and would
-    drop into the discovery agent flow with an empty repo list anyway.
+    workflow (recorded with two positional args), the call still binds, and an
+    unidentifiable mentioner resolves no repos anyway.
     """
     from posthog.models.integration import Integration
 
@@ -48,7 +46,6 @@ def cascade_posthog_code_repository_activity(
         return PostHogCodeRepoCascadeOutcome(mode="no_repo", repository=None, reason="legacy_no_user_id")
 
     from products.slack_app.backend.api import _extract_explicit_repo, _get_full_repo_names
-    from products.slack_app.backend.feature_flags import is_slack_app_bot_prs_enabled
 
     integration = Integration.objects.select_related("team", "team__organization").get(
         id=inputs.integration_id,
@@ -58,13 +55,10 @@ def cascade_posthog_code_repository_activity(
     all_repos = _get_full_repo_names(integration, user_id=user_id)
 
     if not all_repos:
-        # With bot PRs off, a team install means a missing personal install is recoverable via the
-        # gate prompt; with bot PRs on, team repos are already folded into all_repos, so empty is no-op.
-        team_has_github = Integration.objects.filter(
-            team=integration.team, kind=Integration.IntegrationKind.GITHUB
-        ).exists()
-        if team_has_github and not is_slack_app_bot_prs_enabled(integration.team):
-            return PostHogCodeRepoCascadeOutcome(mode="needs_user_github", repository=None, reason="no_user_repos")
+        # No repos means no repo, whatever the team has installed. Deciding here that the user must
+        # connect a personal install would gate the mention before anyone has asked whether it is
+        # even about code; `no_repo` routes through the repo-need classifier first, so analytics and
+        # configuration asks get answered and only genuine coding asks reach the Connect-GitHub prompt.
         return PostHogCodeRepoCascadeOutcome(mode="no_repo", repository=None, reason="no_repos")
 
     if len(all_repos) == 1:

--- a/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
+++ b/posthog/temporal/ai/slack_app/posthog_code_slack_mention.py
@@ -215,11 +215,10 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
             if cascade.mode == "auto":
                 repository = cascade.repository
             elif cascade.mode == "no_repo":
-                # Cascade only emits `no_repo` when neither the team nor the
-                # mentioning user has any GitHub install. Classify first so
-                # non-coding asks ("how do I configure retention?") still
-                # answer with no repo; coding asks surface the connect-personal-
-                # GitHub prompt instead of silently no-op'ing.
+                # Cascade emits `no_repo` whenever the mentioning user resolves no
+                # repos. Classify first so non-coding asks ("how do I configure
+                # retention?") still answer with no repo; coding asks surface the
+                # connect-personal-GitHub prompt instead of silently no-op'ing.
                 repository = None
                 needs_repo = await _execute_posthog_code_activity(
                     classify_posthog_code_task_needs_repo_activity,
@@ -237,9 +236,11 @@ class PostHogCodeSlackMentionWorkflow(PostHogWorkflow):
                     if blocked:
                         return
             elif cascade.mode == "needs_user_github":
-                # Team has GitHub, but the mentioning user hasn't connected their
-                # personal install. Fire the gate so they get the Connect button
-                # instead of a silently no-repo task.
+                # Replay-only: the cascade no longer emits this mode, because gating on a
+                # missing personal install before classifying the ask walled analytics
+                # questions behind the Connect button. Kept so executions that recorded it
+                # before the change still replay against the same command sequence; drop it
+                # once the workflow history retention window has elapsed.
                 await _execute_posthog_code_activity(
                     block_posthog_code_task_if_no_personal_github_activity,
                     inputs,

--- a/posthog/temporal/ai/slack_app/types.py
+++ b/posthog/temporal/ai/slack_app/types.py
@@ -149,12 +149,11 @@ class PostHogCodeSlackMentionCommandWorkflowInputs:
 class PostHogCodeRepoCascadeOutcome:
     """Synchronous fast-path repo resolution before the discovery agent runs.
 
-    `auto` → use `repository` directly. `no_repo` → create a task with no repo
-    (e.g. team has no GitHub integration connected). `agent_needed` → there are
-    multiple candidates and no explicit mention. `needs_user_github` → the team
-    has a GitHub install but the mentioning user has not connected their personal
-    GitHub yet, so the workflow should fire the connect-GitHub prompt rather than
-    silently creating a no-repo task.
+    `auto` → use `repository` directly. `no_repo` → the mentioning user resolves no
+    repos, so the workflow classifies the ask and only gates on a personal GitHub
+    install when it actually needs code. `agent_needed` → there are multiple
+    candidates and no explicit mention. `needs_user_github` is no longer emitted and
+    survives only so workflow executions that recorded it still replay.
     """
 
     mode: Literal["auto", "no_repo", "agent_needed", "needs_user_github"]

--- a/posthog/temporal/tests/ai/test_cascade_bot_prs.py
+++ b/posthog/temporal/tests/ai/test_cascade_bot_prs.py
@@ -72,14 +72,26 @@ class TestCascadeBotPRs(TestCase):
         assert outcome.mode == expected_mode
         assert outcome.mode != "needs_user_github"
 
+    @parameterized.expand(
+        [
+            ("with_team_install", True),
+            ("without_team_install", False),
+        ]
+    )
     @patch("products.slack_app.backend.api.GitHubIntegration")
     @patch("products.slack_app.backend.api.posthoganalytics.feature_enabled", return_value=False)
-    def test_flag_off_with_team_install_blocks_on_user_github(self, _mock_feature_enabled, mock_team_github_class):
-        self._create_team_github_integration()
+    def test_flag_off_defers_gating_to_the_workflow_classifier(
+        self, _name, has_team_install, _mock_feature_enabled, mock_team_github_class
+    ):
+        # A team install must not turn an unresolved repo into a hard gate: `no_repo` sends the
+        # workflow through the repo-need classifier, so analytics asks get answered rather than
+        # walled behind the Connect-GitHub prompt.
+        if has_team_install:
+            self._create_team_github_integration()
 
         outcome = cascade_posthog_code_repository_activity(
             _make_inputs(self.slack_integration.id), "fix the thing", self.user.id
         )
 
-        assert outcome.mode == "needs_user_github"
+        assert outcome.mode == "no_repo"
         mock_team_github_class.assert_not_called()


### PR DESCRIPTION
## Problem

A Slack workspace member without a personal GitHub connection asks `@PostHog` a plain data question and gets "you haven't connected your personal GitHub" instead of an answer.

The trigger is the team connecting an org-level GitHub integration. Without one, the repo cascade returns `no_repo` and the workflow classifies the ask first, so analytics questions get answered. With one, it returns `needs_user_github`, which the workflow gates on outright — no classification.

Reported in [this thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785953930448739).

## Changes

- An empty repo list is now always `no_repo`, whatever the team has installed, so gating always runs behind the repo-need classifier. Coding asks still reach the Connect-GitHub prompt.
- Drops the team-install lookup and `slack-app-bot-prs` check that only fed the removed mode.

Changing the activity rather than the workflow keeps every `execute_activity` call identical, so no `workflow.patched()` marker is needed. The `needs_user_github` branch stays for executions that recorded it pre-deploy.

## How did you test this code?

Tested locally

`test_flag_off_defers_gating_to_the_workflow_classifier` is parameterized over team-install present/absent and pins the regression: a team install must not change the cascade outcome for a user with no personal repos. Nothing covered that, which is how this shipped.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Diagnosis came from production logs: the block event started firing for two workspaces within hours of each connecting a team GitHub integration, zero times for either in the week before.

First draft added the classifier call inside the `needs_user_github` branch behind a patch marker; the author redirected to fixing the cascade, which is smaller and avoids workflow versioning.

Separate decision, not touched here: `slack-app-bot-prs` doesn't exist as a flag in the project every region evaluates against, so `is_slack_app_bot_prs_enabled` has always returned False.
