### PR TITLE
fix(insights): drop the drill-down explanation from formula trend tooltips

### DIFF
--- a/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
+++ b/products/product_analytics/frontend/insights/shared/InsightSeriesTooltip.tsx
@@ -57,7 +57,7 @@ export interface InsightSeriesTooltipProps<Meta extends InsightSeriesMetaBase> {
     sortedByValue?: boolean
     /** Hide rows whose value is exactly 0 (e.g. absent lifecycle statuses). */
     hideZeroRows?: boolean
-    /** Override the default "click to view X" footer — e.g. to explain why drill-down is unavailable. */
+    /** Override the default "click to view X" footer, for charts whose click goes somewhere other than persons. */
     footerOverride?: React.ReactNode
 }
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -658,12 +658,12 @@ describe('TrendsLineChart', () => {
             },
         })
 
-        it('explains why drill-down is unavailable instead of opening the persons modal', async () => {
+        it('offers no click affordance and does not open the persons modal', async () => {
             renderInsight({ query: multiSeriesFormulaQuery })
 
             await chart.hoverTooltip(2)
 
-            expect(chart.getTooltip()?.textContent).toContain("Drill-down isn't available for formula insights")
+            expect(chart.getTooltip()?.textContent).not.toContain('Click to view')
             await chart.clickTooltipRow('Pageview')
             expect(personsModal.get()).not.toBeInTheDocument()
         })
@@ -677,9 +677,7 @@ describe('TrendsLineChart', () => {
             })
 
             await chart.hoverTooltip(2)
-            expect(chart.getTooltip()?.textContent).toContain(
-                "Drill-down isn't available for formula insights. Click to view the insight."
-            )
+            expect(chart.getTooltip()?.textContent).toContain('Click to view the insight')
 
             await chart.clickTooltipRow('Pageview')
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -137,8 +137,7 @@ export function TrendsLineChart({
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
     // The persons modal is intentionally unavailable for multi-series formulas (there's no
-    // single series of actors behind a computed ratio), so surface that instead of leaving
-    // the chart looking interactive with no explanation. On dashboard/card tiles a click
+    // single series of actors behind a computed ratio). On dashboard/card tiles a click
     // instead opens the underlying insight, since there's nowhere else for the click to go.
     const isFormulaDrillDownDisabled = !canHandleClick && isMultiSeriesFormula(formula)
     const canNavigateToInsight = embedded && !inSharedMode && isFormulaDrillDownDisabled && !!insight.short_id
@@ -151,11 +150,8 @@ export function TrendsLineChart({
         router.actions.push(urls.insightView(insight.short_id, insightProps.dashboardId))
     }, [insight.short_id, insightProps.dashboardId])
 
-    const noDrillDownFooter = isFormulaDrillDownDisabled
-        ? canNavigateToInsight
-            ? "Drill-down isn't available for formula insights. Click to view the insight."
-            : "Drill-down isn't available for formula insights"
-        : undefined
+    // The default footer offers persons, which isn't where this click goes.
+    const viewInsightFooter = canNavigateToInsight ? 'Click to view the insight' : undefined
 
     const clickDeps = useMemo(
         () => ({
@@ -220,7 +216,7 @@ export function TrendsLineChart({
                 groupTypeLabel: resolvedGroupTypeLabel,
                 formatCompareLabel: context?.formatCompareLabel,
                 onRowClick,
-                footerOverride: noDrillDownFooter,
+                footerOverride: viewInsightFooter,
             }
             return <InsightSeriesTooltip {...tooltipProps} />
         },
@@ -239,7 +235,7 @@ export function TrendsLineChart({
             canHandlePointInteraction,
             canHandleClick,
             navigateToInsight,
-            noDrillDownFooter,
+            viewInsightFooter,
             clickDeps,
         ]
     )


### PR DESCRIPTION
## Problem

Multi-series formula trend charts (ratios like "pageviews per active user") put an explanation in the tooltip footer: "Drill-down isn't available for formula insights." It tells people about a capability they weren't reaching for, in the one spot where the tooltip should be telling them what they *can* do. On a dashboard tile the string got longer still, appending "Click to view the insight."

Follow-up to #76517, which added the copy.

## Changes

- On the insight page and in shared views, formula charts now show no tooltip footer at all. There's no click to make, so there's nothing to say.
- On dashboard tiles the footer is just "Click to view the insight", which is the action that's actually available.
- The click behavior itself is unchanged: dashboard tiles still navigate to the underlying insight, shared views still do nothing.

The `footerOverride` prop on `InsightSeriesTooltip` stays. It's still needed, because the default footer offers persons and that isn't where this click goes.

## How did you test this code?

Updated the three existing cases in `TrendsLineChart.test.tsx` under "formula insights with drill-down disabled" to the new copy. The first now asserts the footer is absent rather than asserting the explanation text, which is the regression that would come back if the override leaked into the non-clickable path. No new tests: the behavior under test is the same, only the strings changed.

Ran that suite (3 passed) plus Oxfmt. `typescript:check` is clean for the touched files; the repo-wide run fails on pre-existing errors from the unbuilt nested quill workspace, unrelated to this change. I did not render the tooltip in a browser.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

N/A - no documented workflow or API changed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Sam asked where this tooltip copy came from, then decided it should go. I traced it to #76517 (merged the day before), which he'd approved, and cut the explanatory half of the string.

I offered two readings of "don't show any text if you can't click it" - drop the footer everywhere, or drop it only where there's no click and keep the plain action elsewhere - and went with the second when the question went unanswered, since it matches the "Click to view X" footer every other chart type uses.

Invoked `/writing-user-facing-copy`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
