### PR TITLE
fix(mcp): stop union coercion mangling property filter values

### DIFF
--- a/services/mcp/scripts/lib/json-schema-to-zod.ts
+++ b/services/mcp/scripts/lib/json-schema-to-zod.ts
@@ -105,7 +105,7 @@ export function getEntryVarName(entryDefName: string): string {
 // Core conversion
 // ------------------------------------------------------------------
 
-function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
+function schemaToZod(schema: JsonSchema, ctx: ConvertContext, opts?: { strictPrimitives?: boolean }): string {
     // $ref
     if (schema.$ref) {
         const refName = schema.$ref.replace('#/definitions/', '')
@@ -141,7 +141,13 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
         if (variants.length === 1) {
             return schemaToZod(variants[0]!, ctx)
         }
-        const members = variants.map((v) => schemaToZod(v, ctx)).join(', ')
+        // Union members must be strict: zod tries branches in order and a coercing
+        // branch is greedy — z.coerce.boolean() accepts every input (Boolean(x)
+        // never throws) and z.coerce.number() turns null into 0, so any array/null
+        // branch after them is unreachable and inputs get silently mangled
+        // (e.g. a `["host.com"]` filter value became `true`). Coercion is for
+        // lone primitive fields, where there is no other branch to fall through to.
+        const members = variants.map((v) => schemaToZod(v, ctx, { strictPrimitives: true })).join(', ')
         return `z.union([${members}])`
     }
 
@@ -159,10 +165,12 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
     if (Array.isArray(schema.type)) {
         const types = schema.type.filter((t) => t !== 'null')
         const hasNull = schema.type.includes('null')
+        // Multi-type arrays are unions too, so their primitives must be strict
+        // for the same branch-ordering reason as anyOf above.
         const base =
             types.length === 1
-                ? primitiveToZod(types[0]!)
-                : `z.union([${types.map((t) => primitiveToZod(t)).join(', ')}])`
+                ? primitiveToZod(types[0]!, opts?.strictPrimitives)
+                : `z.union([${types.map((t) => primitiveToZod(t, true)).join(', ')}])`
         return hasNull ? `${base}.nullable()` : base
     }
 
@@ -186,12 +194,12 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
 
     // integer special ref — use coerce for MCP client compatibility (some clients send numbers as strings)
     if (schema.type === 'integer') {
-        return applyNumericConstraints('z.coerce.number().int()', schema)
+        return applyNumericConstraints(primitiveToZod('integer', opts?.strictPrimitives), schema)
     }
 
     // primitives
     if (schema.type) {
-        const base = primitiveToZod(schema.type as string)
+        const base = primitiveToZod(schema.type as string, opts?.strictPrimitives)
         if (schema.type === 'integer' || schema.type === 'number') {
             return applyNumericConstraints(base, schema)
         }
@@ -214,17 +222,21 @@ function applyNumericConstraints(expr: string, schema: JsonSchema): string {
     return out
 }
 
-/** Use z.coerce for numbers/booleans — some MCP clients send primitives as strings */
-function primitiveToZod(type: string): string {
+/**
+ * Use z.coerce for numbers/booleans — some MCP clients send primitives as strings.
+ * `strict` disables coercion for primitives that sit inside a union, where a
+ * coercing branch would greedily swallow inputs meant for later branches.
+ */
+function primitiveToZod(type: string, strict = false): string {
     switch (type) {
         case 'string':
             return 'z.string()'
         case 'number':
-            return 'z.coerce.number()'
+            return strict ? 'z.number()' : 'z.coerce.number()'
         case 'integer':
-            return 'z.coerce.number().int()'
+            return strict ? 'z.number().int()' : 'z.coerce.number().int()'
         case 'boolean':
-            return 'z.coerce.boolean()'
+            return strict ? 'z.boolean()' : 'z.coerce.boolean()'
         case 'null':
             return 'z.null()'
         default:

--- a/services/mcp/src/tools/generated/ai_observability.ts
+++ b/services/mcp/src/tools/generated/ai_observability.ts
@@ -2135,7 +2135,7 @@ const AssistantFlagPropertyFilter = z.object({
         )
         .default('flag'),
     value: z
-        .union([z.coerce.boolean(), z.string()])
+        .union([z.boolean(), z.string()])
         .describe('`true`/`false` for boolean flags, or a variant name string for multivariate flags.'),
 })
 

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -298,7 +298,7 @@ const PropertyOperator = z.enum([
     'not_icontains_multi',
 ])
 
-const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
+const PropertyFilterBaseValue = z.union([z.string(), z.number(), z.boolean()])
 
 const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
 
@@ -390,7 +390,7 @@ const LogEntryPropertyFilter = z.object({
 
 const GroupPropertyFilter = z.object({
     group_key_names: z.record(z.string(), z.string()).optional(),
-    group_type_index: z.union([z.coerce.number().int(), z.null()]).optional(),
+    group_type_index: z.union([z.number().int(), z.null()]).optional(),
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
@@ -414,7 +414,7 @@ const FlagPropertyFilter = z.object({
         .describe('Only flag_evaluates_to operator is allowed for flag dependencies')
         .default('flag_evaluates_to'),
     type: z.literal('flag').describe('Feature flag dependency').default('flag'),
-    value: z.union([z.coerce.boolean(), z.string()]).describe('The value can be true, false, or a variant name'),
+    value: z.union([z.boolean(), z.string()]).describe('The value can be true, false, or a variant name'),
 })
 
 const HogQLPropertyFilter = z.object({

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -324,7 +324,7 @@ const AssistantFlagPropertyFilter = z.object({
         )
         .default('flag'),
     value: z
-        .union([z.coerce.boolean(), z.string()])
+        .union([z.boolean(), z.string()])
         .describe('`true`/`false` for boolean flags, or a variant name string for multivariate flags.'),
 })
 

--- a/services/mcp/src/tools/generated/replay.ts
+++ b/services/mcp/src/tools/generated/replay.ts
@@ -513,7 +513,7 @@ const AssistantFlagPropertyFilter = z.object({
         )
         .default('flag'),
     value: z
-        .union([z.coerce.boolean(), z.string()])
+        .union([z.boolean(), z.string()])
         .describe('`true`/`false` for boolean flags, or a variant name string for multivariate flags.'),
 })
 

--- a/services/mcp/src/tools/generated/web_analytics.ts
+++ b/services/mcp/src/tools/generated/web_analytics.ts
@@ -356,7 +356,7 @@ const PropertyOperator = z.enum([
     'not_icontains_multi',
 ])
 
-const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
+const PropertyFilterBaseValue = z.union([z.string(), z.number(), z.boolean()])
 
 const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
 

--- a/services/mcp/tests/unit/json-schema-to-zod.test.ts
+++ b/services/mcp/tests/unit/json-schema-to-zod.test.ts
@@ -51,3 +51,58 @@ describe('generateZodFromSchemaRef — array constraints', () => {
         expect(out).not.toMatch(/\.max\(/)
     })
 })
+
+describe('generateZodFromSchemaRef — union primitive strictness', () => {
+    // Coercing branches inside a union are greedy (z.coerce.boolean() accepts any
+    // input, z.coerce.number() turns null into 0), which made later array/null
+    // branches unreachable: a `["host.com"]` property-filter value parsed as `true`
+    // and a feature-flag variant string parsed as `true`. Union members must be strict.
+    it.each([
+        {
+            label: 'anyOf of primitives',
+            schema: {
+                anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }],
+            },
+            expected: 'z.union([z.string(), z.number(), z.boolean()])',
+        },
+        {
+            label: 'anyOf with array and null branches',
+            schema: {
+                anyOf: [
+                    { anyOf: [{ type: 'string' }, { type: 'number' }] },
+                    { type: 'array', items: { type: 'string' } },
+                    { type: 'null' },
+                ],
+            },
+            expected: 'z.union([z.union([z.string(), z.number()]), z.array(z.string()), z.null()])',
+        },
+        {
+            label: 'multi-type array',
+            schema: { type: ['string', 'boolean'] },
+            expected: 'z.union([z.string(), z.boolean()])',
+        },
+    ])('emits strict primitives for $label', ({ schema, expected }) => {
+        const root = { definitions: { Subject: { type: 'object', properties: { value: schema } } } }
+
+        const out = generateZodFromSchemaRef(root, 'Subject')
+
+        expect(out).toContain(expected)
+        expect(out).not.toContain('z.coerce')
+    })
+
+    it('keeps coercion on lone primitive fields', () => {
+        const root = {
+            definitions: {
+                Subject: {
+                    type: 'object',
+                    properties: { count: { type: 'number' }, flag: { type: 'boolean' } },
+                },
+            },
+        }
+
+        const out = generateZodFromSchemaRef(root, 'Subject')
+
+        expect(out).toContain('z.coerce.number()')
+        expect(out).toContain('z.coerce.boolean()')
+    })
+})


### PR DESCRIPTION
## Problem

Agents filtering any MCP query wrapper by an array value get a broken or silently wrong query. `query-web-vitals` alone failed 1,146 times in 14 days across every harness, 97% of its errors.

- The generated property-filter value schema is `z.union([z.string(), z.coerce.number(), z.coerce.boolean()])`, tried in order.
- `z.coerce.boolean()` accepts every input, so `["host.com"]` parses as `true` and the array branch after it never runs.
- The backend coerces `true` to `1.0`, and ClickHouse rejects `mat_$host = 1.0` with `NO_COMMON_TYPE` ([sample failing queries](https://us.posthog.com/project/2/insights/new#q=%7B%22kind%22%3A%22InsightVizNode%22%2C%22source%22%3A%7B%22dateRange%22%3A%7B%22date_from%22%3A%22-14d%22%7D%2C%22kind%22%3A%22MCPToolFailuresQuery%22%2C%22toolName%22%3A%22query-web-vitals%22%7D%7D)).
- On numeric properties the same mangling returns wrong data instead of an error.
- `z.coerce.number()` turns `null` into `0`, so the `z.null()` branch is dead too.
- Feature-flag value unions had the same shape, so a variant name like `"control"` always parsed as `true` in ai_observability, replay, and query-wrapper tools.

## Changes

- Union members (anyOf/oneOf and multi-type arrays) now emit strict primitives: `z.number()`, `z.boolean()`, never `z.coerce`.
- Lone primitive fields keep coercion, which exists for clients that send numbers as strings.
- Coercion inside these unions was already useless: every union also has a `z.string()` branch that catches string inputs first.
- Regenerated the five affected tool files.

> [!NOTE]
> Two behavior changes reviewers should weigh, beyond the bug fix:
>
> - Flag-based property filters (replay, ai_observability, query wrappers) never worked for multivariate flags: every variant name coerced to `true`. After this merge those filters start returning correct results, which reads as a data change to anyone comparing filtered numbers over time.
> - `group_type_index` (`number | null`) loses string tolerance: `"0"` was coerced to `0`, now it fails validation with an explicit error. If stringly-number clients show up in validation errors post-merge, the follow-up is to order `z.null()`/array branches before `z.coerce.number()` instead of stripping coercion; `z.coerce.boolean()` stays banned from unions since it accepts every input.

## How did you test this code?

- New parameterized generator tests: union primitives are strict, array/null branches are reachable, lone fields keep coercion. They catch a reintroduction of greedy coercion branches.
- Full MCP unit suite (2,456) and typecheck pass.
- Reproduced the production failure before the fix by calling `query-web-vitals` with `value: ["us.posthog.com"]` against project 2; it returned the exact `NO_COMMON_TYPE` error from the failing queries.
- Not re-run against a live MCP server after the fix; the generated schema now routes arrays to the array branch, verified in the generated code and unit tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code) traced a steady 18-22% error rate on `query-web-vitals` (flat for 14+ days) to this generator bug: pulled the failure buckets from MCP analytics, extracted the executed query JSON from `system.query_log` (every failure carried `value: 1`), reproduced with an array-valued filter, and found the greedy coercion branches in `json-schema-to-zod.ts`. Skills invoked: `/writing-tests`-gated test additions, `/writing-pr-descriptions`.

