### PR TITLE
fix(surveys): stop shipping draft and stopped surveys to SDKs

### DIFF
--- a/posthog/models/test/test_remote_config.py
+++ b/posthog/models/test/test_remote_config.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from decimal import Decimal
 from typing import Any
 
@@ -319,6 +320,27 @@ class TestRemoteConfigSurveys(_RemoteConfigBase):
 
         self.sync_remote_config()
         assert "survey_config" not in self.remote_config.config
+
+    def test_surveys_disabled_when_only_draft_and_stopped_surveys_exist(self):
+        Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Draft survey",
+            type="popover",
+            questions=[{"type": "open", "question": "What's a survey?"}],
+        )
+        Survey.objects.create(
+            team=self.team,
+            created_by=self.user,
+            name="Stopped survey",
+            type="popover",
+            questions=[{"type": "open", "question": "What's a hedgehog?"}],
+            start_date=timezone.now() - timedelta(days=2),
+            end_date=timezone.now() - timedelta(days=1),
+        )
+
+        self.sync_remote_config()
+        assert self.remote_config.config["surveys"] is False
 
     def test_includes_range_of_survey_types(self):
         survey_basic = Survey.objects.create(

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -3470,10 +3470,15 @@ def get_surveys_count(team: Team) -> int:
 
 
 def get_surveys_response(team: Team) -> dict[str, Any]:
+    # Every SDK discards surveys that aren't running before evaluating eligibility, so drafts and
+    # stopped surveys are payload every client downloads and throws away. The nullness check mirrors
+    # the SDKs' own `isSurveyRunning`; keeping it time-independent matters because this response is
+    # cached and only rebuilt when a survey is saved, so a comparison against `now` would go stale.
     surveys = SurveyAPISerializer(
         Survey.objects.db_manager(READ_DB_FOR_SURVEYS)
         .filter(team__project_id=team.project_id)
         .exclude(archived=True)
+        .filter(start_date__isnull=False, end_date__isnull=True)
         .select_related("linked_flag", "targeting_flag", "internal_targeting_flag")
         .prefetch_related("actions"),
         many=True,

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -457,6 +457,33 @@ class TestSurvey(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
         assert "base_language" in response.json() or "translation" in response.content.decode().lower()
 
+    @parameterized.expand(
+        [
+            ("running", {"start_date": datetime(2026, 1, 1, tzinfo=UTC)}, True),
+            ("draft", {}, False),
+            (
+                "stopped",
+                {"start_date": datetime(2026, 1, 1, tzinfo=UTC), "end_date": datetime(2026, 2, 1, tzinfo=UTC)},
+                False,
+            ),
+            ("archived", {"start_date": datetime(2026, 1, 1, tzinfo=UTC), "archived": True}, False),
+        ]
+    )
+    def test_sdk_payload_only_includes_running_surveys(
+        self, _name: str, lifecycle_fields: dict[str, Any], expected_in_payload: bool
+    ) -> None:
+        survey = Survey.objects.create(
+            team=self.team,
+            name="Lifecycle survey",
+            type="popover",
+            questions=[{"type": "open", "id": "q1", "question": "How are you?"}],
+            **lifecycle_fields,
+        )
+
+        payload_ids = {str(item["id"]) for item in get_surveys_response(self.team)["surveys"]}
+
+        assert (str(survey.id) in payload_ids) is expected_in_payload
+
     def test_sdk_payload_strips_non_runtime_question_fields(self) -> None:
         self.team.survey_config = {"appearance": {"backgroundColor": "black"}}
         self.team.save(update_fields=["survey_config"])
@@ -465,6 +492,7 @@ class TestSurvey(APIBaseTest):
             name="Q-level legacy",
             type="popover",
             base_language="en",
+            start_date=datetime(2026, 1, 1, tzinfo=UTC),
             questions=[
                 {
                     "id": "q1",


### PR DESCRIPTION
## Problem

- Every PostHog site downloads the definitions of surveys that can never show: drafts and stopped ones.
- The SDK survey payload includes every non-archived survey in the project.
- All five SDKs then drop anything without a `start_date`, or with an `end_date`, before evaluating eligibility.
- Projects that have run surveys for a while carry a long tail of stopped ones, so the wasted share grows over time.

## Changes

- `get_surveys_response` now returns only running surveys: `start_date` set and `end_date` unset.
- A project whose surveys are all drafts or stopped now gets `surveys: false`, so the web SDK skips loading the surveys extension entirely.
- The filter tests nullness rather than comparing against `now`. The response is cached and only rebuilt when a survey is saved, so a time-dependent filter would go stale between writes.
- This covers both delivery paths, since the remote config and the standalone surveys cache both call this one function. The Rust services serve the cached blob and run no survey SQL of their own.

> [!NOTE]
> `posthog.renderSurvey(id, selector)` renders any survey it can find by ID, skipping the running check. Calling it against a draft or stopped survey stops working, because those IDs are no longer in the payload.

The client-side checks stay as they are. Nothing depends on the server filter alone, so old SDK versions keep behaving the same way.

<details>
<summary>Where each SDK drops non-running surveys</summary>

| SDK | Check |
| --- | --- |
| Web | `isSurveyRunning`: `!!(survey.start_date && !survey.end_date)` |
| React Native | `getActiveMatchingSurveys`: `if (!survey.start_date \|\| survey.end_date) return false` |
| iOS | `PostHogSurvey.isActive`: `startDate != nil && endDate == nil` |
| Android | `PostHogSurveysIntegration`: `if (survey.startDate == null \|\| survey.endDate != null) return@filter false` |
| Flutter | Delegates to the native iOS and Android checks above |

</details>

## How did you test this code?

- Not run: this sandbox has no Postgres and no Django install, so I ran no Python tests. CI covers them.
- Verified: `ruff check` and `ruff format --check` pass on the three changed files.
- `test_sdk_payload_only_includes_running_surveys` in `test_survey.py` catches a regression that puts drafts or stopped surveys back in the SDK payload. No existing test covered any lifecycle state other than running.
- `test_surveys_disabled_when_only_draft_and_stopped_surveys_exist` in `test_remote_config.py` catches the case where a project with nothing running still tells the SDK to load its surveys code.
- I added `start_date` to the survey in `test_sdk_payload_strips_non_runtime_question_fields`, which relied on drafts appearing in the payload.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The lifecycle states are already documented as the SDK's own filter, and this moves that filter earlier.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (the PostHog Slack app, running Claude) made this change from a Slack thread asking to keep archived, draft, and stopped surveys out of the remote config payload. Archived surveys were already excluded.

Skills invoked: `/debugging-surveys`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions worth a reviewer's attention. I put the filter in `get_surveys_response` rather than in the remote config builder, so the standalone surveys cache that mobile SDKs read gets the same treatment. And I left `SurveyAPISerializer` untouched, because the feature flag detail endpoint reuses it to list surveys linked to a flag, where drafts should still appear.

One thing I did not change: a survey can be launched with an `end_date` in the future, and every SDK already treats any non-null `end_date` as stopped. This filter matches that existing behavior rather than fixing it. Worth a separate look.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1785956867729979?thread_ts=1785956867.729979&cid=C07QD3LT8U9)*
