### PR TITLE
fix(hubspot): treat OAuth token rate limit as retryable, not tracked

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -142,6 +142,12 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             "Hubspot search malformed JSON response (retryable)",
             "Hubspot v4 associations error (retryable): status=",
             "Hubspot v4 associations malformed JSON response (retryable)",
+            # auth.hubspot_refresh_access_token also retries in-process (5 attempts, Retry-After
+            # aware) before re-raising HubspotRetryableError with HubSpot's own 429 body verbatim
+            # (no code-added prefix, unlike the fetch-loop errors above). Match HubSpot's stable,
+            # documented rate-limit wording so this self-recovering condition doesn't get tracked
+            # as noise once Temporal's activity retry picks it back up.
+            "You have reached your rate limit.",
         }
 
     # TODO: clean up hubspot job inputs to not have two auth config options

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -313,6 +313,8 @@ def test_missing_token_error_is_non_retryable(error_msg: str) -> None:
         "url=https://api.hubapi.com/crm/v4/associations/contacts/deals/batch/read",
         "Hubspot v4 associations malformed JSON response (retryable): "
         "url=https://api.hubapi.com/crm/v4/associations/contacts/deals/batch/read",
+        # auth.hubspot_refresh_access_token, exhausted after tenacity's 5 in-process attempts
+        "You have reached your rate limit.",
     ],
 )
 def test_transient_http_error_is_retryable(error_msg: str) -> None:


### PR DESCRIPTION
## Problem

HubSpot imports show up in error tracking when the OAuth token refresh hits HubSpot's rate limit, even though the sync recovers on its own once the limit clears.

- The token refresh helper (`auth.hubspot_refresh_access_token`) already retries in-process (5 attempts, honoring `Retry-After`) before re-raising `HubspotRetryableError` with HubSpot's own 429 body.
- That message never matched `HubspotSource.get_retryable_errors()`, so Temporal's outer activity retry recovered the sync, but the error was still logged as a tracked exception instead of a benign warning.

## Changes

- Add HubSpot's stable rate-limit wording, `"You have reached your rate limit."`, to `get_retryable_errors()`.
- Unlike the other entries in that set, this one has no code-added prefix (no `status=`/URL), because `auth.py` re-raises HubSpot's raw message rather than building its own — the comment explains why.

## How did you test this code?

- Extended the existing `test_transient_http_error_is_retryable` in `test_source_routing.py` with the rate-limit message, closing the gap where only the CRM/search/associations fetch-loop retryable messages were covered.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py` locally: 144 passed.
- `ruff check` / `ruff format --check` clean on both changed files.
- Not run: a live HubSpot 429 against the real API (no test credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was produced autonomously in response to a HubSpot error tracking issue showing `HubspotRetryableError: You have reached your rate limit.` originating in `products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/auth.py`.

- Tool: Claude Code.
- Skills invoked: `/writing-tests` (gate for the added test case), `/writing-pr-descriptions` (this body).
- Investigated the full stack trace and confirmed the exception originates in this source's own code, then traced why it wasn't recognized as retryable despite already being self-recovering.
- Searched for existing open PRs (human-authored and the maintainer's own) covering this error; found none.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*