### PR TITLE
chore(ci): add reusable container image metadata action

### DIFF
--- a/.github/actions/container-image-metadata/action.yml
+++ b/.github/actions/container-image-metadata/action.yml
@@ -1,0 +1,78 @@
+name: Container image metadata
+description: Generate consistent tags, labels, and OCI index annotations for a container image.
+
+inputs:
+    images:
+        required: true
+        description: 'Image repositories passed to docker/metadata-action.'
+    extra-tags:
+        required: false
+        default: ''
+        description: 'Additional docker/metadata-action tag specifications, one per line.'
+
+outputs:
+    tags:
+        description: 'Image tags for docker/build-push-action.'
+        value: ${{ steps.meta.outputs.tags }}
+    labels:
+        description: 'OCI labels for docker/build-push-action.'
+        value: ${{ steps.meta.outputs.labels }}
+    annotations:
+        description: 'OCI index annotations for docker/build-push-action.'
+        value: ${{ steps.meta.outputs.annotations }}
+    commit-subject:
+        description: 'First line of the commit message, limited to 160 characters.'
+        value: ${{ steps.commit.outputs.subject }}
+    commit-timestamp:
+        description: 'Committer timestamp in ISO 8601 UTC format.'
+        value: ${{ steps.commit.outputs.iso }}
+    commit-author:
+        description: 'Commit author.'
+        value: ${{ steps.commit.outputs.author }}
+    commit-committer:
+        description: 'Committer.'
+        value: ${{ steps.commit.outputs.committer }}
+
+runs:
+    using: composite
+    steps:
+        - name: Extract commit metadata
+          id: commit
+          shell: bash
+          env:
+              COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+              EVENT_AUTHOR: ${{ github.event.head_commit.author.username }}
+              EVENT_COMMITTER: ${{ github.event.head_commit.committer.username }}
+              LC_ALL: C.UTF-8
+          run: |
+              subject="$(printf '%s' "${COMMIT_MESSAGE}" | head -n 1)"
+              if [ -z "${subject}" ]; then
+                subject="$(git log -1 --format=%s)"
+              fi
+              if [ "${#subject}" -gt 160 ]; then
+                subject="${subject:0:157}..."
+              fi
+              author="${EVENT_AUTHOR:-$(git log -1 --format=%an)}"
+              committer="${EVENT_COMMITTER:-$(git log -1 --format=%cn)}"
+              {
+                echo "subject=${subject}"
+                echo "author=${author}"
+                echo "committer=${committer}"
+                echo "iso=$(TZ=UTC git show -s --date=format-local:%Y-%m-%dT%H:%M:%SZ --format=%cd HEAD)"
+              } >> "$GITHUB_OUTPUT"
+
+        - name: Generate container metadata
+          id: meta
+          uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+          env:
+              DOCKER_METADATA_ANNOTATIONS_LEVELS: index
+          with:
+              images: ${{ inputs.images }}
+              tags: |
+                  type=sha,prefix=sha-,format=long
+                  ${{ inputs.extra-tags }}
+              annotations: |
+                  com.posthog.image.author=${{ steps.commit.outputs.author }}
+                  com.posthog.image.committer=${{ steps.commit.outputs.committer }}
+                  com.posthog.image.message=${{ steps.commit.outputs.subject }}
+                  com.posthog.image.commit-timestamp=${{ steps.commit.outputs.iso }}


### PR DESCRIPTION
## Problem

Add a reusable action that generates consistent image tags and provenance metadata.

## Changes

- Generate an immutable `sha-<full commit SHA>` tag alongside optional caller-provided tags.
- Emit Docker labels and OCI index annotations from the same metadata source.
- Include commit author, committer, subject, and UTC timestamp annotations.
- Limit commit subjects to 160 characters and fall back to checked-out Git metadata when event metadata is unavailable.

## How did you test this code?

- Parsed the action YAML with `yq`.
- Ran ShellCheck against the composite action's Bash step.
- Ran `git diff --check`.
- Scanned the action for private repository and deployment-system terminology.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This adds a CI building block without changing a documented user workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented the action under direct human guidance. 
---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
