### PR TITLE
fix(signals): raise the per-team enabled-scout cap to 250

### DIFF
--- a/products/signals/backend/scout_harness/limits.py
+++ b/products/signals/backend/scout_harness/limits.py
@@ -56,4 +56,4 @@ AUTO_PAUSE_PROBE_INTERVAL_S = 24 * 60 * 60
 # spend, not a routine limit (the canonical fleet is ~16 scouts). Enforced at the write
 # surfaces (config create/update) and in auto-registration, which falls back to registering
 # new scouts disabled once the team is at the cap.
-MAX_ENABLED_SCOUTS_PER_TEAM = 100
+MAX_ENABLED_SCOUTS_PER_TEAM = 250


### PR DESCRIPTION
## Problem

- A team that authors many custom scouts hits the 100 enabled-scout cap and cannot enable a new scout without disabling an old one.
- The cap (`MAX_ENABLED_SCOUTS_PER_TEAM`) is a hard code constant, unlike the run-rate caps, which are tunable per team through the `signals-scout` flag payload.

## Changes

- Raise `MAX_ENABLED_SCOUTS_PER_TEAM` from 100 to 250.
- Actual spend stays bounded by the unchanged per-tick and per-day run budgets, so the cap remains a backstop, not the cost control.

> [!NOTE]
> A follow-up PR will make this cap resolvable through the flag payload (`team_configs` → `default_team_config` → constant), like the run caps.

## How did you test this code?

- No new tests: every existing cap test patches the constant (to 1), so none depend on the value.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no doc references the cap value.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code session: hit the cap while enabling a new internal measurement scout; Andy chose a quick constant bump now with the flag-tunable resolution as a follow-up.
- Skills invoked: /writing-pr-descriptions, /writing-tests (gate concluded no new tests needed), /improving-drf-endpoints (loaded while scoping the follow-up; no DRF surface touched here).
