### PR TITLE
fix(desktop): paginate the space repository picker

### DIFF
--- a/products/desktop/packages/core/src/integrations/repositories.test.ts
+++ b/products/desktop/packages/core/src/integrations/repositories.test.ts
@@ -3,8 +3,10 @@ import {
   buildTeamRepositoryOptions,
   buildUserRepositoryOptions,
   combineGithubRepositories,
-  combineRepositoryPicker,
   combineUserGithubRepositories,
+  computeNextRepositoryPickerOffsets,
+  computeRepositoryNextOffset,
+  flattenRepositoryPickerPages,
   getIntegrationIdForRepo,
   isEmptyRepositoryMap,
   isRepoInIntegration,
@@ -143,24 +145,63 @@ describe("combineUserGithubRepositories", () => {
   });
 });
 
-describe("combineRepositoryPicker", () => {
-  it("merges pages, derives hasMore/isRefreshing/isPending", () => {
-    const combined = combineRepositoryPicker<UserRepositoryIntegrationRef>([
+describe("repository picker pages", () => {
+  it("appends pages and maps repositories to their integrations", () => {
+    const firstRef = { userIntegrationId: "u1", installationId: "i1" };
+    const secondRef = { userIntegrationId: "u2", installationId: "i2" };
+    const combined = flattenRepositoryPickerPages([
       {
-        data: {
-          ref: { userIntegrationId: "u1", installationId: "i1" },
-          repositories: ["a/x"],
-          hasMore: true,
-        },
-        isPending: false,
-        isError: false,
-        isRefetching: true,
+        integrations: [
+          {
+            key: "i1",
+            ref: firstRef,
+            repositories: ["a/x"],
+            hasMore: true,
+            nextOffset: 1,
+          },
+        ],
+      },
+      {
+        integrations: [
+          {
+            key: "i1",
+            ref: firstRef,
+            repositories: ["a/y"],
+            hasMore: false,
+          },
+          {
+            key: "i2",
+            ref: secondRef,
+            repositories: ["b/x"],
+            hasMore: true,
+            nextOffset: 51,
+          },
+        ],
       },
     ]);
 
-    expect(Object.keys(combined.repositoryMap)).toEqual(["a/x"]);
+    expect(combined.repositoryMap).toEqual({
+      "a/x": firstRef,
+      "a/y": firstRef,
+      "b/x": secondRef,
+    });
     expect(combined.hasMore).toBe(true);
-    expect(combined.isRefreshing).toBe(true);
+    expect(
+      computeNextRepositoryPickerOffsets({
+        integrations: [
+          {
+            key: "i2",
+            ref: secondRef,
+            repositories: ["b/x"],
+            hasMore: true,
+            nextOffset: 51,
+          },
+        ],
+      }),
+    ).toEqual({ i2: 51 });
+    expect(
+      computeRepositoryNextOffset(50, { repositories: [], hasMore: true }),
+    ).toBeUndefined();
   });
 });
 

--- a/products/desktop/packages/core/src/integrations/repositories.ts
+++ b/products/desktop/packages/core/src/integrations/repositories.ts
@@ -218,41 +218,64 @@ export interface RepositoryPageResult<TRef> {
 
 export interface CombinedRepositoryPicker<TRef> {
   repositoryMap: Record<string, TRef>;
-  isPending: boolean;
-  isRefreshing: boolean;
   hasMore: boolean;
 }
 
-export function combineRepositoryPicker<TRef>(
-  results: ReadonlyArray<RepositoryQueryResult<RepositoryPageResult<TRef>>>,
+export interface RepositoryPickerPage<TRef> {
+  integrations: ReadonlyArray<
+    RepositoryPageResult<TRef> & {
+      key: string;
+      nextOffset?: number;
+    }
+  >;
+}
+
+export const REPOSITORY_PICKER_PAGE_SIZE = 50;
+export type RepositoryPickerOffsets = Record<string, number>;
+
+export function computeRepositoryNextOffset(
+  offset: number,
+  page: Pick<RepositoryPageResult<unknown>, "repositories" | "hasMore">,
+): number | undefined {
+  const resultCount = page.repositories?.length ?? 0;
+  return page.hasMore && resultCount > 0 ? offset + resultCount : undefined;
+}
+
+export function flattenRepositoryPickerPages<TRef>(
+  pages: ReadonlyArray<RepositoryPickerPage<TRef>> | undefined,
 ): CombinedRepositoryPicker<TRef> {
   const map: Record<string, TRef> = {};
-  let pending = false;
-  let refreshing = false;
-  let hasMoreResults = false;
-
-  for (const result of results) {
-    if (result.isPending) pending = true;
-    if (result.isRefetching) refreshing = true;
-    if (!result.data) continue;
-
-    if (result.data.hasMore) {
-      hasMoreResults = true;
-    }
-
-    for (const repo of result.data.repositories ?? []) {
-      if (!(repo in map)) {
-        map[repo] = result.data.ref;
+  for (const page of pages ?? []) {
+    for (const integration of page.integrations) {
+      for (const repository of integration.repositories ?? []) {
+        if (!(repository in map)) {
+          map[repository] = integration.ref;
+        }
       }
     }
   }
 
   return {
     repositoryMap: map,
-    isPending: pending,
-    isRefreshing: refreshing,
-    hasMore: hasMoreResults,
+    hasMore:
+      pages
+        ?.at(-1)
+        ?.integrations.some(
+          (integration) => integration.nextOffset !== undefined,
+        ) ?? false,
   };
+}
+
+export function computeNextRepositoryPickerOffsets<TRef>(
+  lastPage: RepositoryPickerPage<TRef>,
+): RepositoryPickerOffsets | undefined {
+  const offsets: RepositoryPickerOffsets = {};
+  for (const integration of lastPage.integrations) {
+    if (integration.nextOffset !== undefined) {
+      offsets[integration.key] = integration.nextOffset;
+    }
+  }
+  return Object.keys(offsets).length > 0 ? offsets : undefined;
 }
 
 export function normalizeRepoKey(repoKey: string | null | undefined): string {

--- a/products/desktop/packages/core/src/integrations/repositoryKeys.ts
+++ b/products/desktop/packages/core/src/integrations/repositoryKeys.ts
@@ -11,6 +11,17 @@ export const integrationKeys = {
       search,
       limit,
     ] as const,
+  repositoryPickerPages: (
+    integrationIds: ReadonlyArray<number>,
+    search?: string,
+  ) =>
+    [
+      ...integrationKeys.all,
+      "repository-picker",
+      "pages",
+      integrationIds,
+      search,
+    ] as const,
   branches: (integrationId?: number, repo?: string | null, search?: string) =>
     [...integrationKeys.all, "branches", integrationId, repo, search] as const,
 };
@@ -31,6 +42,17 @@ export const userGithubIntegrationKeys = {
       installationId,
       search,
       limit,
+    ] as const,
+  repositoryPickerPages: (
+    installationIds: ReadonlyArray<string>,
+    search?: string,
+  ) =>
+    [
+      ...userGithubIntegrationKeys.all,
+      "repository-picker",
+      "pages",
+      installationIds,
+      search,
     ] as const,
   branches: (installationId?: string, repo?: string | null, search?: string) =>
     [

--- a/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
@@ -3,25 +3,16 @@ import {
   Button,
   Chip,
   ChipClose,
-  Input,
-  ItemContent,
-  ItemMedia,
-  ItemMenuItem,
-  ItemTitle,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Spinner,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@posthog/quill";
-import { useRepositoryIntegration } from "@posthog/ui/features/integrations/useIntegrations";
+import { GitHubRepoPicker } from "@posthog/ui/features/folder-picker/GitHubRepoPicker";
+import { useIntegrationSelectors } from "@posthog/ui/features/integrations/store";
+import { useGithubRepositories } from "@posthog/ui/features/integrations/useIntegrations";
 import { useState } from "react";
 
 export const MAX_REPOSITORIES = 10;
-
-const REPO_SEARCH_THRESHOLD = 10;
 
 function RepoChip({
   repository,
@@ -48,84 +39,52 @@ function RepoChip({
 }
 
 function AddRepositoryPopover({
-  available,
+  selected,
+  integrationId,
   onAdd,
   label,
 }: {
-  available: string[];
-  onAdd: (repository: string) => void;
+  selected: string[];
+  integrationId: number | null;
+  onAdd: (repository: string, integrationId: number) => void;
   label: string;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
-
-  const showSearch = available.length > REPO_SEARCH_THRESHOLD;
-  const trimmed = query.trim().toLowerCase();
-  const filtered = trimmed
-    ? available.filter((repository) =>
-        repository.toLowerCase().includes(trimmed),
-      )
-    : available;
+  const {
+    repositories,
+    getIntegrationIdForRepo,
+    isPending,
+    hasMore,
+    loadMore,
+  } = useGithubRepositories(query, true, integrationId);
+  const available = repositories.filter(
+    (repository) => !selected.includes(repository),
+  );
 
   return (
-    <Popover
+    <GitHubRepoPicker
+      value={null}
+      repositories={available}
+      isLoading={isPending}
+      placeholder={label}
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
         if (!next) setQuery("");
       }}
-    >
-      <PopoverTrigger
-        render={
-          <Button variant="outline" size="sm">
-            <GithubLogoIcon size={14} />
-            {label}
-          </Button>
-        }
-      />
-      <PopoverContent
-        align="start"
-        sideOffset={6}
-        className="flex max-h-72 w-64 flex-col p-0"
-      >
-        {showSearch ? (
-          <div className="shrink-0 border-gray-5 border-b p-1.5">
-            <Input
-              autoFocus
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search repositories…"
-              className="h-7"
-            />
-          </div>
-        ) : null}
-        <div className="min-h-0 flex-1 overflow-y-auto p-1">
-          {filtered.length === 0 ? (
-            <div className="px-2 py-1.5 text-[13px] text-gray-10">
-              No repositories found
-            </div>
-          ) : (
-            filtered.map((repository) => (
-              <ItemMenuItem
-                key={repository}
-                size="xs"
-                onClick={() => {
-                  onAdd(repository);
-                  setOpen(false);
-                }}
-              >
-                <ItemMedia variant="icon">
-                  <GithubLogoIcon size={14} />
-                </ItemMedia>
-                <ItemContent variant="menuItem">
-                  <ItemTitle className="truncate">{repository}</ItemTitle>
-                </ItemContent>
-              </ItemMenuItem>
-            ))
-          )}
-        </div>
-      </PopoverContent>
-    </Popover>
+      searchQuery={query}
+      onSearchQueryChange={setQuery}
+      hasMore={hasMore}
+      onLoadMore={loadMore}
+      onChange={(repository) => {
+        if (!repository) return;
+        const repositoryIntegrationId = getIntegrationIdForRepo(repository);
+        if (repositoryIntegrationId == null) return;
+        onAdd(repository, repositoryIntegrationId);
+        setOpen(false);
+      }}
+    />
   );
 }
 
@@ -142,28 +101,16 @@ export function RepositoriesField({
   onChange,
   disabled = false,
 }: RepositoriesFieldProps) {
-  const {
-    repositories,
-    getIntegrationIdForRepo,
-    isLoadingRepos,
-    hasGithubIntegration,
-  } = useRepositoryIntegration();
+  const { hasGithubIntegration } = useIntegrationSelectors();
 
   const atLimit = selected.length >= MAX_REPOSITORIES;
-  const available = repositories.filter((repository) => {
-    const repositoryIntegration = getIntegrationIdForRepo(repository);
-    return (
-      !selected.includes(repository) &&
-      repositoryIntegration != null &&
-      (integrationId === null || repositoryIntegration === integrationId)
-    );
-  });
 
-  const addRepository = (repository: string) => {
+  const addRepository = (
+    repository: string,
+    repositoryIntegrationId: number,
+  ) => {
     if (disabled || selected.includes(repository)) return;
-    const repositoryIntegration = getIntegrationIdForRepo(repository);
-    if (repositoryIntegration == null) return;
-    onChange([...selected, repository], repositoryIntegration);
+    onChange([...selected, repository], repositoryIntegrationId);
   };
 
   const removeRepository = (repository: string) => {
@@ -172,16 +119,11 @@ export function RepositoriesField({
     onChange(next, next.length === 0 ? null : integrationId);
   };
 
-  const isLoadingList = isLoadingRepos && available.length === 0;
   const addDisabledReason = !hasGithubIntegration
     ? "Connect GitHub in settings to add repositories"
     : atLimit
       ? `You can add up to ${MAX_REPOSITORIES} repositories`
-      : available.length === 0
-        ? selected.length > 0
-          ? "All accessible repositories are already added"
-          : "No repositories available"
-        : null;
+      : null;
 
   return (
     <div className="flex min-h-7 w-fit max-w-full flex-wrap items-center gap-2">
@@ -199,11 +141,6 @@ export function RepositoriesField({
           <GithubLogoIcon size={14} />
           Add repository
         </Button>
-      ) : isLoadingList && hasGithubIntegration ? (
-        <Button variant="outline" size="sm" disabled>
-          <Spinner className="size-3.5" />
-          Loading repositories…
-        </Button>
       ) : addDisabledReason ? (
         <Tooltip>
           <TooltipTrigger
@@ -220,7 +157,8 @@ export function RepositoriesField({
         </Tooltip>
       ) : (
         <AddRepositoryPopover
-          available={available}
+          selected={selected}
+          integrationId={integrationId}
           onAdd={addRepository}
           label={selected.length > 0 ? "Add…" : "Add repository…"}
         />

--- a/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/RepositoriesField.tsx
@@ -55,6 +55,7 @@ function AddRepositoryPopover({
     repositories,
     getIntegrationIdForRepo,
     isPending,
+    isFetchingMore,
     hasMore,
     loadMore,
   } = useGithubRepositories(query, true, integrationId);
@@ -67,6 +68,7 @@ function AddRepositoryPopover({
       value={null}
       repositories={available}
       isLoading={isPending}
+      isLoadingMore={isFetchingMore}
       placeholder={label}
       open={open}
       onOpenChange={(next) => {

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -61,7 +61,11 @@ describe("GitHubRepoPicker", () => {
       onLoadMore: vi.fn(),
     };
     const { container, rerender } = render(
-      <GitHubRepoPicker {...props} repositories={firstPage} isLoadingMore />,
+      <GitHubRepoPicker
+        {...props}
+        repositories={firstPage}
+        isLoadingMore={false}
+      />,
     );
     const list = container.ownerDocument.querySelector(
       "[data-slot='combobox-list']",
@@ -69,7 +73,15 @@ describe("GitHubRepoPicker", () => {
     if (!(list instanceof HTMLElement)) {
       throw new Error("Expected the repository results list to render");
     }
-    list.scrollTop = 240;
+    Object.defineProperties(list, {
+      clientHeight: { value: 360 },
+      scrollHeight: { value: 600 },
+      scrollTop: { value: 240, writable: true },
+    });
+    fireEvent.scroll(list);
+    rerender(
+      <GitHubRepoPicker {...props} repositories={firstPage} isLoadingMore />,
+    );
 
     expect(screen.getByText("posthog/repository-0")).toBeInTheDocument();
     expect(screen.queryByText("Loading more")).not.toBeInTheDocument();
@@ -78,6 +90,8 @@ describe("GitHubRepoPicker", () => {
 
     expect(screen.getByText("Loading more")).toBeInTheDocument();
     expect(list.scrollTop).toBe(240);
+
+    list.scrollTop = 0;
 
     rerender(
       <GitHubRepoPicker

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { GitHubRepoPicker } from "./GitHubRepoPicker";
+
+describe("GitHubRepoPicker", () => {
+  it("loads the next page once when the results reach the scroll end", () => {
+    const onLoadMore = vi.fn();
+    const { container } = render(
+      <GitHubRepoPicker
+        value={null}
+        onChange={vi.fn()}
+        repositories={Array.from(
+          { length: 50 },
+          (_, index) => `posthog/repository-${index}`,
+        )}
+        isLoading={false}
+        open
+        onOpenChange={vi.fn()}
+        searchQuery=""
+        onSearchQueryChange={vi.fn()}
+        hasMore
+        onLoadMore={onLoadMore}
+      />,
+    );
+    const list = container.ownerDocument.querySelector(
+      "[data-slot='combobox-list']",
+    );
+    if (!list) {
+      throw new Error("Expected the repository results list to render");
+    }
+    Object.defineProperties(list, {
+      clientHeight: { value: 240 },
+      scrollHeight: { value: 600 },
+      scrollTop: { value: 360, writable: true },
+    });
+
+    fireEvent.scroll(list);
+    fireEvent.scroll(list);
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -1,9 +1,11 @@
-import { fireEvent, render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { GitHubRepoPicker } from "./GitHubRepoPicker";
 
 describe("GitHubRepoPicker", () => {
+  afterEach(() => vi.useRealTimers());
+
   it("loads the next page once when the results reach the scroll end", () => {
     const onLoadMore = vi.fn();
     const { container } = render(
@@ -39,5 +41,61 @@ describe("GitHubRepoPicker", () => {
     fireEvent.scroll(list);
 
     expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the current page in place while the next page loads", () => {
+    vi.useFakeTimers();
+    const firstPage = Array.from(
+      { length: 50 },
+      (_, index) => `posthog/repository-${index}`,
+    );
+    const props = {
+      value: null,
+      onChange: vi.fn(),
+      isLoading: false,
+      open: true,
+      onOpenChange: vi.fn(),
+      searchQuery: "",
+      onSearchQueryChange: vi.fn(),
+      hasMore: true,
+      onLoadMore: vi.fn(),
+    };
+    const { container, rerender } = render(
+      <GitHubRepoPicker {...props} repositories={firstPage} isLoadingMore />,
+    );
+    const list = container.ownerDocument.querySelector(
+      "[data-slot='combobox-list']",
+    );
+    if (!(list instanceof HTMLElement)) {
+      throw new Error("Expected the repository results list to render");
+    }
+    list.scrollTop = 240;
+
+    expect(screen.getByText("posthog/repository-0")).toBeInTheDocument();
+    expect(screen.queryByText("Loading more")).not.toBeInTheDocument();
+
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(screen.getByText("Loading more")).toBeInTheDocument();
+    expect(list.scrollTop).toBe(240);
+
+    rerender(
+      <GitHubRepoPicker
+        {...props}
+        repositories={[
+          ...firstPage,
+          ...Array.from(
+            { length: 50 },
+            (_, index) => `posthog/repository-${index + 50}`,
+          ),
+        ]}
+        isLoadingMore={false}
+      />,
+    );
+
+    expect(screen.getByText("posthog/repository-0")).toBeInTheDocument();
+    expect(screen.getByText("posthog/repository-99")).toBeInTheDocument();
+    expect(screen.queryByText("Loading more")).not.toBeInTheDocument();
+    expect(list.scrollTop).toBe(240);
   });
 });

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -64,6 +64,7 @@ describe("GitHubRepoPicker", () => {
     rerender(
       <GitHubRepoPicker
         {...pickerProps}
+        repositories={[]}
         isLoading
         isLoadingMore={false}
         onLoadMore={onLoadMore}

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -64,9 +64,7 @@ describe("GitHubRepoPicker", () => {
     rerender(
       <GitHubRepoPicker
         {...pickerProps}
-        repositories={[]}
-        isLoading
-        isLoadingMore={false}
+        isLoadingMore
         onLoadMore={onLoadMore}
       />,
     );

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -47,13 +47,9 @@ describe("GitHubRepoPicker", () => {
 
   it("keeps results visible and delays the load more spinner", () => {
     vi.useFakeTimers();
+    const onLoadMore = vi.fn();
     const { rerender } = render(
-      <GitHubRepoPicker
-        {...pickerProps}
-        isLoading
-        isLoadingMore
-        onLoadMore={vi.fn()}
-      />,
+      <GitHubRepoPicker {...pickerProps} onLoadMore={onLoadMore} />,
     );
     const loadMoreButton = screen
       .getByText("Load more repositories")
@@ -61,6 +57,18 @@ describe("GitHubRepoPicker", () => {
     if (!loadMoreButton) {
       throw new Error("Expected the load more button to render");
     }
+
+    fireEvent.click(loadMoreButton);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <GitHubRepoPicker
+        {...pickerProps}
+        isLoading
+        isLoadingMore={false}
+        onLoadMore={onLoadMore}
+      />,
+    );
 
     expect(screen.getByText("posthog/repository-0")).toBeInTheDocument();
     expect(screen.queryByText("Loading repositories")).not.toBeInTheDocument();
@@ -81,8 +89,9 @@ describe("GitHubRepoPicker", () => {
             (_, index) => `posthog/repository-${index + 50}`,
           ),
         ]}
+        isLoading={false}
         isLoadingMore={false}
-        onLoadMore={vi.fn()}
+        onLoadMore={onLoadMore}
       />,
     );
 

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.test.tsx
@@ -3,27 +3,33 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { GitHubRepoPicker } from "./GitHubRepoPicker";
 
-describe("GitHubRepoPicker", () => {
-  afterEach(() => vi.useRealTimers());
+const repositories = Array.from(
+  { length: 50 },
+  (_, index) => `posthog/repository-${index}`,
+);
 
-  it("loads the next page once when the results reach the scroll end", () => {
+const pickerProps = {
+  value: null,
+  onChange: vi.fn(),
+  repositories,
+  isLoading: false,
+  open: true,
+  onOpenChange: vi.fn(),
+  searchQuery: "",
+  onSearchQueryChange: vi.fn(),
+  hasMore: true,
+};
+
+describe("GitHubRepoPicker", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("loads the next page only when the load more button is clicked", () => {
     const onLoadMore = vi.fn();
     const { container } = render(
-      <GitHubRepoPicker
-        value={null}
-        onChange={vi.fn()}
-        repositories={Array.from(
-          { length: 50 },
-          (_, index) => `posthog/repository-${index}`,
-        )}
-        isLoading={false}
-        open
-        onOpenChange={vi.fn()}
-        searchQuery=""
-        onSearchQueryChange={vi.fn()}
-        hasMore
-        onLoadMore={onLoadMore}
-      />,
+      <GitHubRepoPicker {...pickerProps} onLoadMore={onLoadMore} />,
     );
     const list = container.ownerDocument.querySelector(
       "[data-slot='combobox-list']",
@@ -31,85 +37,56 @@ describe("GitHubRepoPicker", () => {
     if (!list) {
       throw new Error("Expected the repository results list to render");
     }
-    Object.defineProperties(list, {
-      clientHeight: { value: 240 },
-      scrollHeight: { value: 600 },
-      scrollTop: { value: 360, writable: true },
-    });
 
     fireEvent.scroll(list);
-    fireEvent.scroll(list);
+    expect(onLoadMore).not.toHaveBeenCalled();
 
+    fireEvent.click(screen.getByText("Load more repositories"));
     expect(onLoadMore).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps the current page in place while the next page loads", () => {
+  it("keeps results visible and delays the load more spinner", () => {
     vi.useFakeTimers();
-    const firstPage = Array.from(
-      { length: 50 },
-      (_, index) => `posthog/repository-${index}`,
-    );
-    const props = {
-      value: null,
-      onChange: vi.fn(),
-      isLoading: false,
-      open: true,
-      onOpenChange: vi.fn(),
-      searchQuery: "",
-      onSearchQueryChange: vi.fn(),
-      hasMore: true,
-      onLoadMore: vi.fn(),
-    };
-    const { container, rerender } = render(
+    const { rerender } = render(
       <GitHubRepoPicker
-        {...props}
-        repositories={firstPage}
-        isLoadingMore={false}
+        {...pickerProps}
+        isLoading
+        isLoadingMore
+        onLoadMore={vi.fn()}
       />,
     );
-    const list = container.ownerDocument.querySelector(
-      "[data-slot='combobox-list']",
-    );
-    if (!(list instanceof HTMLElement)) {
-      throw new Error("Expected the repository results list to render");
+    const loadMoreButton = screen
+      .getByText("Load more repositories")
+      .closest("button");
+    if (!loadMoreButton) {
+      throw new Error("Expected the load more button to render");
     }
-    Object.defineProperties(list, {
-      clientHeight: { value: 360 },
-      scrollHeight: { value: 600 },
-      scrollTop: { value: 240, writable: true },
-    });
-    fireEvent.scroll(list);
-    rerender(
-      <GitHubRepoPicker {...props} repositories={firstPage} isLoadingMore />,
-    );
 
     expect(screen.getByText("posthog/repository-0")).toBeInTheDocument();
-    expect(screen.queryByText("Loading more")).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading repositories")).not.toBeInTheDocument();
+    expect(loadMoreButton).toHaveAttribute("aria-disabled", "true");
+    expect(loadMoreButton).not.toHaveAttribute("data-loading");
 
     act(() => vi.advanceTimersByTime(200));
 
-    expect(screen.getByText("Loading more")).toBeInTheDocument();
-    expect(list.scrollTop).toBe(240);
-
-    list.scrollTop = 0;
+    expect(loadMoreButton).toHaveAttribute("data-loading", "true");
 
     rerender(
       <GitHubRepoPicker
-        {...props}
+        {...pickerProps}
         repositories={[
-          ...firstPage,
+          ...repositories,
           ...Array.from(
             { length: 50 },
             (_, index) => `posthog/repository-${index + 50}`,
           ),
         ]}
         isLoadingMore={false}
+        onLoadMore={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("posthog/repository-0")).toBeInTheDocument();
     expect(screen.getByText("posthog/repository-99")).toBeInTheDocument();
-    expect(screen.queryByText("Loading more")).not.toBeInTheDocument();
-    expect(list.scrollTop).toBe(240);
+    expect(loadMoreButton).not.toHaveAttribute("data-loading");
   });
 });

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -1,4 +1,8 @@
-import { ArrowClockwise, GithubLogo } from "@phosphor-icons/react";
+import {
+  ArrowClockwise,
+  GithubLogo,
+  MagnifyingGlass,
+} from "@phosphor-icons/react";
 import {
   Button,
   Combobox,
@@ -7,8 +11,9 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  ComboboxListFooter,
   ComboboxTrigger,
+  InputGroupAddon,
+  InputGroupButton,
 } from "@posthog/quill";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { defaultFilter } from "cmdk";
@@ -61,6 +66,7 @@ export function GitHubRepoPicker({
   const buttonSize = size === "2" ? "lg" : "sm";
   const buttonTextClass = size === "2" ? "text-[13px]" : "";
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const loadMoreRequestKeyRef = useRef<string | null>(null);
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [uncontrolledSearchQuery, setUncontrolledSearchQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(COMBOBOX_INITIAL_LIMIT);
@@ -93,6 +99,22 @@ export function GitHubRepoPicker({
       onChange(onlyRepo);
     }
   }, [onlyRepo, value, onChange]);
+
+  const loadMoreAtScrollEnd = () => {
+    const requestKey = remoteMode
+      ? `${trimmedSearchQuery}:${repositories.length}`
+      : `${trimmedSearchQuery}:${visibleLimit}`;
+    if (!hasMore || isLoading || loadMoreRequestKeyRef.current === requestKey)
+      return;
+    loadMoreRequestKeyRef.current = requestKey;
+
+    if (remoteMode) {
+      onLoadMore?.();
+      return;
+    }
+
+    setVisibleLimit((currentLimit) => currentLimit + COMBOBOX_INITIAL_LIMIT);
+  };
 
   if (isLoading && !showInlineLoadingState) {
     return (
@@ -194,70 +216,22 @@ export function GitHubRepoPicker({
         anchor={anchor ?? triggerRef}
         side="bottom"
         sideOffset={6}
-        className="min-w-[280px]"
+        className="flex h-80 w-80 flex-col"
       >
         {showSearchInput ? (
-          <div className="flex min-w-0 items-center gap-1 pe-2">
-            <div className="min-w-0 flex-1">
-              <ComboboxInput placeholder="Search repositories..." />
-            </div>
+          <ComboboxInput
+            placeholder="Search repositories..."
+            showTrigger={false}
+          >
+            <InputGroupAddon align="inline-start">
+              <MagnifyingGlass size={14} />
+            </InputGroupAddon>
             {onRefresh ? (
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={disabled || isRefreshing}
-                aria-label="Refresh repositories"
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  onRefresh();
-                }}
-              >
-                <ArrowClockwise
-                  size={14}
-                  className={isRefreshing ? "animate-spin" : undefined}
-                />
-              </Button>
-            ) : null}
-          </div>
-        ) : null}
-        <ComboboxEmpty>
-          {showInlineLoadingState
-            ? "Loading repositories..."
-            : "No repositories found."}
-        </ComboboxEmpty>
-        <ComboboxList>
-          {(repo: string) => (
-            <ComboboxItem key={repo} value={repo}>
-              {repo}
-            </ComboboxItem>
-          )}
-        </ComboboxList>
-
-        {(hasMore ||
-          (remoteMode
-            ? repositories.length > COMBOBOX_INITIAL_LIMIT
-            : filteredRepositoryCount > COMBOBOX_INITIAL_LIMIT)) && (
-          <ComboboxListFooter>
-            <div className="px-2 pb-2">
-              <div className="px-1 pb-2 text-center text-muted-foreground text-xs">
-                {remoteMode
-                  ? trimmedSearchQuery
-                    ? `Showing ${repositories.length}${hasMore ? "+" : ""} matches`
-                    : `Showing ${repositories.length}${hasMore ? "+" : ""} repositories`
-                  : trimmedSearchQuery
-                    ? `Showing ${Math.min(visibleLimit, filteredRepositoryCount)} of ${filteredRepositoryCount} matches`
-                    : `Showing ${Math.min(visibleLimit, repositories.length)} of ${repositories.length}`}
-              </div>
-              {hasMore ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full justify-center"
+              <InputGroupAddon align="inline-end">
+                <InputGroupButton
+                  size="icon-xs"
+                  disabled={disabled || isRefreshing}
+                  aria-label="Refresh repositories"
                   onMouseDown={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
@@ -265,22 +239,38 @@ export function GitHubRepoPicker({
                   onClick={(event) => {
                     event.preventDefault();
                     event.stopPropagation();
-                    if (remoteMode) {
-                      onLoadMore?.();
-                      return;
-                    }
-
-                    setVisibleLimit(
-                      (currentLimit) => currentLimit + COMBOBOX_INITIAL_LIMIT,
-                    );
+                    onRefresh();
                   }}
                 >
-                  Load more
-                </Button>
-              ) : null}
-            </div>
-          </ComboboxListFooter>
-        )}
+                  <ArrowClockwise
+                    size={14}
+                    className={isRefreshing ? "animate-spin" : undefined}
+                  />
+                </InputGroupButton>
+              </InputGroupAddon>
+            ) : null}
+          </ComboboxInput>
+        ) : null}
+        <ComboboxEmpty>
+          {showInlineLoadingState
+            ? "Loading repositories..."
+            : "No repositories found."}
+        </ComboboxEmpty>
+        <ComboboxList
+          className="flex-1"
+          onScroll={(event) => {
+            const list = event.currentTarget;
+            if (list.scrollHeight - list.scrollTop - list.clientHeight <= 32) {
+              loadMoreAtScrollEnd();
+            }
+          }}
+        >
+          {(repo: string) => (
+            <ComboboxItem key={repo} value={repo}>
+              {repo}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
       </ComboboxContent>
     </Combobox>
   );

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -14,6 +14,8 @@ import {
   ComboboxTrigger,
   InputGroupAddon,
   InputGroupButton,
+  Spinner,
+  Text,
 } from "@posthog/quill";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { defaultFilter } from "cmdk";
@@ -251,10 +253,23 @@ export function GitHubRepoPicker({
             ) : null}
           </ComboboxInput>
         ) : null}
-        <ComboboxEmpty>
-          {showInlineLoadingState
-            ? "Loading repositories..."
-            : "No repositories found."}
+        <ComboboxEmpty
+          className={
+            showInlineLoadingState
+              ? "flex-1 flex-col items-center justify-center gap-2"
+              : undefined
+          }
+        >
+          {showInlineLoadingState ? (
+            <>
+              <Spinner className="size-4" />
+              <Text size="sm" variant="muted">
+                Loading repositories
+              </Text>
+            </>
+          ) : (
+            "No repositories found."
+          )}
         </ComboboxEmpty>
         <ComboboxList
           className="flex-1"

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -19,18 +19,10 @@ import {
 } from "@posthog/quill";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { defaultFilter } from "cmdk";
-import {
-  type RefObject,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 
 const COMBOBOX_INITIAL_LIMIT = 50;
 const LOAD_MORE_INDICATOR_DELAY_MS = 200;
-const LOAD_MORE_SENTINEL = "\0loading-more";
 
 function useDelayedVisibility(visible: boolean, delay: number): boolean {
   const [delayedVisible, setDelayedVisible] = useState(false);
@@ -95,10 +87,6 @@ export function GitHubRepoPicker({
   const buttonSize = size === "2" ? "lg" : "sm";
   const buttonTextClass = size === "2" ? "text-[13px]" : "";
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
-  const loadMoreRequestKeyRef = useRef<string | null>(null);
-  const preservePaginationScrollRef = useRef(false);
-  const paginationScrollTopRef = useRef(0);
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [uncontrolledSearchQuery, setUncontrolledSearchQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(COMBOBOX_INITIAL_LIMIT);
@@ -109,7 +97,8 @@ export function GitHubRepoPicker({
     onSearchQueryChange !== undefined ||
     controlledHasMore !== undefined ||
     onLoadMore !== undefined;
-  const showInlineLoadingState = remoteMode && open && isLoading;
+  const showInlineLoadingState =
+    remoteMode && open && isLoading && !isLoadingMore;
   const onlyRepo =
     !remoteMode && repositories.length === 1 ? repositories[0] : null;
   const trimmedSearchQuery = searchQuery.trim();
@@ -129,9 +118,6 @@ export function GitHubRepoPicker({
     isLoadingMore,
     LOAD_MORE_INDICATOR_DELAY_MS,
   );
-  const items = showLoadingMore
-    ? [...repositories, LOAD_MORE_SENTINEL]
-    : repositories;
 
   useEffect(() => {
     if (onlyRepo && value !== onlyRepo) {
@@ -139,28 +125,8 @@ export function GitHubRepoPicker({
     }
   }, [onlyRepo, value, onChange]);
 
-  useLayoutEffect(() => {
-    if (!preservePaginationScrollRef.current || !listRef.current) return;
-
-    if (repositories.length === 0) {
-      preservePaginationScrollRef.current = false;
-      return;
-    }
-    listRef.current.scrollTop = paginationScrollTopRef.current;
-    if (!isLoadingMore && !showLoadingMore) {
-      preservePaginationScrollRef.current = false;
-    }
-  }, [isLoadingMore, repositories.length, showLoadingMore]);
-
-  const loadMoreAtScrollEnd = () => {
-    const requestKey = remoteMode
-      ? `${trimmedSearchQuery}:${repositories.length}`
-      : `${trimmedSearchQuery}:${visibleLimit}`;
-    if (!hasMore || isLoading || loadMoreRequestKeyRef.current === requestKey)
-      return;
-    loadMoreRequestKeyRef.current = requestKey;
-    preservePaginationScrollRef.current = true;
-    paginationScrollTopRef.current = listRef.current?.scrollTop ?? 0;
+  const loadMore = () => {
+    if (!hasMore || isLoading || isLoadingMore) return;
 
     if (remoteMode) {
       onLoadMore?.();
@@ -170,7 +136,7 @@ export function GitHubRepoPicker({
     setVisibleLimit((currentLimit) => currentLimit + COMBOBOX_INITIAL_LIMIT);
   };
 
-  if (isLoading && !showInlineLoadingState) {
+  if (isLoading && !isLoadingMore && !showInlineLoadingState) {
     return (
       <Button
         variant="outline"
@@ -227,7 +193,7 @@ export function GitHubRepoPicker({
 
   return (
     <Combobox
-      items={items}
+      items={repositories}
       filter={remoteMode ? null : undefined}
       limit={remoteMode ? undefined : visibleLimit}
       value={value}
@@ -239,7 +205,6 @@ export function GitHubRepoPicker({
         setUncontrolledOpen(nextOpen);
         onOpenChange?.(nextOpen);
         if (!nextOpen) {
-          preservePaginationScrollRef.current = false;
           setUncontrolledSearchQuery("");
           onSearchQueryChange?.("");
           setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -247,7 +212,6 @@ export function GitHubRepoPicker({
       }}
       inputValue={searchQuery}
       onInputValueChange={(nextSearchQuery) => {
-        preservePaginationScrollRef.current = false;
         setUncontrolledSearchQuery(nextSearchQuery);
         onSearchQueryChange?.(nextSearchQuery);
         setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -326,37 +290,27 @@ export function GitHubRepoPicker({
             "No repositories found."
           )}
         </ComboboxEmpty>
-        <ComboboxList
-          ref={listRef}
-          className="flex-1"
-          onScroll={(event) => {
-            const list = event.currentTarget;
-            if (preservePaginationScrollRef.current) {
-              paginationScrollTopRef.current = list.scrollTop;
-            }
-            if (list.scrollHeight - list.scrollTop - list.clientHeight <= 32) {
-              loadMoreAtScrollEnd();
-            }
-          }}
-        >
-          {(repo: string) =>
-            repo === LOAD_MORE_SENTINEL ? (
-              <output
-                key={repo}
-                className="flex h-9 items-center justify-center gap-2 px-3"
-              >
-                <Spinner className="size-3.5" />
-                <Text size="xs" variant="muted">
-                  Loading more
-                </Text>
-              </output>
-            ) : (
-              <ComboboxItem key={repo} value={repo}>
-                {repo}
-              </ComboboxItem>
-            )
-          }
+        <ComboboxList className="flex-1">
+          {(repo: string) => (
+            <ComboboxItem key={repo} value={repo}>
+              {repo}
+            </ComboboxItem>
+          )}
         </ComboboxList>
+        {hasMore ? (
+          <div className="shrink-0 border-t p-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              disabled={isLoadingMore}
+              loading={showLoadingMore}
+              onClick={loadMore}
+            >
+              Load more repositories
+            </Button>
+          </div>
+        ) : null}
       </ComboboxContent>
     </Combobox>
   );

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -90,10 +90,6 @@ export function GitHubRepoPicker({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [uncontrolledSearchQuery, setUncontrolledSearchQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(COMBOBOX_INITIAL_LIMIT);
-  const [paginationSnapshot, setPaginationSnapshot] = useState<string[] | null>(
-    null,
-  );
-  const paginationWasLoadingRef = useRef(false);
   const open = controlledOpen ?? uncontrolledOpen;
   const searchQuery = controlledSearchQuery ?? uncontrolledSearchQuery;
   const remoteMode =
@@ -101,10 +97,7 @@ export function GitHubRepoPicker({
     onSearchQueryChange !== undefined ||
     controlledHasMore !== undefined ||
     onLoadMore !== undefined;
-  const effectiveIsLoadingMore = isLoadingMore || paginationSnapshot !== null;
-  const displayedRepositories = paginationSnapshot
-    ? Array.from(new Set([...paginationSnapshot, ...repositories]))
-    : repositories;
+  const effectiveIsLoadingMore = isLoadingMore;
   const showInlineLoadingState =
     remoteMode && open && isLoading && !effectiveIsLoadingMore;
   const onlyRepo =
@@ -128,30 +121,6 @@ export function GitHubRepoPicker({
   );
 
   useEffect(() => {
-    if (!paginationSnapshot) return;
-
-    if (isLoading || isLoadingMore) {
-      paginationWasLoadingRef.current = true;
-      return;
-    }
-
-    if (
-      paginationWasLoadingRef.current ||
-      repositories.length !== paginationSnapshot.length ||
-      !hasMore
-    ) {
-      paginationWasLoadingRef.current = false;
-      setPaginationSnapshot(null);
-    }
-  }, [
-    hasMore,
-    isLoading,
-    isLoadingMore,
-    paginationSnapshot,
-    repositories.length,
-  ]);
-
-  useEffect(() => {
     if (onlyRepo && value !== onlyRepo) {
       onChange(onlyRepo);
     }
@@ -161,8 +130,6 @@ export function GitHubRepoPicker({
     if (!hasMore || isLoading || effectiveIsLoadingMore) return;
 
     if (remoteMode) {
-      paginationWasLoadingRef.current = false;
-      setPaginationSnapshot(repositories);
       onLoadMore?.();
       return;
     }
@@ -227,7 +194,7 @@ export function GitHubRepoPicker({
 
   return (
     <Combobox
-      items={displayedRepositories}
+      items={repositories}
       filter={remoteMode ? null : undefined}
       limit={remoteMode ? undefined : visibleLimit}
       value={value}
@@ -239,8 +206,6 @@ export function GitHubRepoPicker({
         setUncontrolledOpen(nextOpen);
         onOpenChange?.(nextOpen);
         if (!nextOpen) {
-          setPaginationSnapshot(null);
-          paginationWasLoadingRef.current = false;
           setUncontrolledSearchQuery("");
           onSearchQueryChange?.("");
           setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -248,8 +213,6 @@ export function GitHubRepoPicker({
       }}
       inputValue={searchQuery}
       onInputValueChange={(nextSearchQuery) => {
-        setPaginationSnapshot(null);
-        paginationWasLoadingRef.current = false;
         setUncontrolledSearchQuery(nextSearchQuery);
         onSearchQueryChange?.(nextSearchQuery);
         setVisibleLimit(COMBOBOX_INITIAL_LIMIT);

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -90,10 +90,10 @@ export function GitHubRepoPicker({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [uncontrolledSearchQuery, setUncontrolledSearchQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(COMBOBOX_INITIAL_LIMIT);
-  const [paginationPending, setPaginationPending] = useState(false);
-  const paginationStartCountRef = useRef(0);
+  const [paginationSnapshot, setPaginationSnapshot] = useState<string[] | null>(
+    null,
+  );
   const paginationWasLoadingRef = useRef(false);
-  const paginationRepositoriesRef = useRef<string[]>([]);
   const open = controlledOpen ?? uncontrolledOpen;
   const searchQuery = controlledSearchQuery ?? uncontrolledSearchQuery;
   const remoteMode =
@@ -101,14 +101,9 @@ export function GitHubRepoPicker({
     onSearchQueryChange !== undefined ||
     controlledHasMore !== undefined ||
     onLoadMore !== undefined;
-  const effectiveIsLoadingMore = isLoadingMore || paginationPending;
-  if (paginationPending && repositories.length > 0) {
-    paginationRepositoriesRef.current = Array.from(
-      new Set([...paginationRepositoriesRef.current, ...repositories]),
-    );
-  }
-  const displayedRepositories = paginationPending
-    ? paginationRepositoriesRef.current
+  const effectiveIsLoadingMore = isLoadingMore || paginationSnapshot !== null;
+  const displayedRepositories = paginationSnapshot
+    ? Array.from(new Set([...paginationSnapshot, ...repositories]))
     : repositories;
   const showInlineLoadingState =
     remoteMode && open && isLoading && !effectiveIsLoadingMore;
@@ -133,7 +128,7 @@ export function GitHubRepoPicker({
   );
 
   useEffect(() => {
-    if (!paginationPending) return;
+    if (!paginationSnapshot) return;
 
     if (isLoading || isLoadingMore) {
       paginationWasLoadingRef.current = true;
@@ -142,17 +137,17 @@ export function GitHubRepoPicker({
 
     if (
       paginationWasLoadingRef.current ||
-      repositories.length !== paginationStartCountRef.current ||
+      repositories.length !== paginationSnapshot.length ||
       !hasMore
     ) {
       paginationWasLoadingRef.current = false;
-      setPaginationPending(false);
+      setPaginationSnapshot(null);
     }
   }, [
     hasMore,
     isLoading,
     isLoadingMore,
-    paginationPending,
+    paginationSnapshot,
     repositories.length,
   ]);
 
@@ -166,10 +161,8 @@ export function GitHubRepoPicker({
     if (!hasMore || isLoading || effectiveIsLoadingMore) return;
 
     if (remoteMode) {
-      paginationStartCountRef.current = repositories.length;
       paginationWasLoadingRef.current = false;
-      paginationRepositoriesRef.current = repositories;
-      setPaginationPending(true);
+      setPaginationSnapshot(repositories);
       onLoadMore?.();
       return;
     }
@@ -246,7 +239,7 @@ export function GitHubRepoPicker({
         setUncontrolledOpen(nextOpen);
         onOpenChange?.(nextOpen);
         if (!nextOpen) {
-          setPaginationPending(false);
+          setPaginationSnapshot(null);
           paginationWasLoadingRef.current = false;
           setUncontrolledSearchQuery("");
           onSearchQueryChange?.("");
@@ -255,7 +248,7 @@ export function GitHubRepoPicker({
       }}
       inputValue={searchQuery}
       onInputValueChange={(nextSearchQuery) => {
-        setPaginationPending(false);
+        setPaginationSnapshot(null);
         paginationWasLoadingRef.current = false;
         setUncontrolledSearchQuery(nextSearchQuery);
         onSearchQueryChange?.(nextSearchQuery);

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -90,6 +90,9 @@ export function GitHubRepoPicker({
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [uncontrolledSearchQuery, setUncontrolledSearchQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(COMBOBOX_INITIAL_LIMIT);
+  const [paginationPending, setPaginationPending] = useState(false);
+  const paginationStartCountRef = useRef(0);
+  const paginationWasLoadingRef = useRef(false);
   const open = controlledOpen ?? uncontrolledOpen;
   const searchQuery = controlledSearchQuery ?? uncontrolledSearchQuery;
   const remoteMode =
@@ -97,8 +100,9 @@ export function GitHubRepoPicker({
     onSearchQueryChange !== undefined ||
     controlledHasMore !== undefined ||
     onLoadMore !== undefined;
+  const effectiveIsLoadingMore = isLoadingMore || paginationPending;
   const showInlineLoadingState =
-    remoteMode && open && isLoading && !isLoadingMore;
+    remoteMode && open && isLoading && !effectiveIsLoadingMore;
   const onlyRepo =
     !remoteMode && repositories.length === 1 ? repositories[0] : null;
   const trimmedSearchQuery = searchQuery.trim();
@@ -115,9 +119,33 @@ export function GitHubRepoPicker({
   }, [repositories, trimmedSearchQuery]);
   const hasMore = controlledHasMore ?? filteredRepositoryCount > visibleLimit;
   const showLoadingMore = useDelayedVisibility(
-    isLoadingMore,
+    effectiveIsLoadingMore,
     LOAD_MORE_INDICATOR_DELAY_MS,
   );
+
+  useEffect(() => {
+    if (!paginationPending) return;
+
+    if (isLoading || isLoadingMore) {
+      paginationWasLoadingRef.current = true;
+      return;
+    }
+
+    if (
+      paginationWasLoadingRef.current ||
+      repositories.length !== paginationStartCountRef.current ||
+      !hasMore
+    ) {
+      paginationWasLoadingRef.current = false;
+      setPaginationPending(false);
+    }
+  }, [
+    hasMore,
+    isLoading,
+    isLoadingMore,
+    paginationPending,
+    repositories.length,
+  ]);
 
   useEffect(() => {
     if (onlyRepo && value !== onlyRepo) {
@@ -126,9 +154,12 @@ export function GitHubRepoPicker({
   }, [onlyRepo, value, onChange]);
 
   const loadMore = () => {
-    if (!hasMore || isLoading || isLoadingMore) return;
+    if (!hasMore || isLoading || effectiveIsLoadingMore) return;
 
     if (remoteMode) {
+      paginationStartCountRef.current = repositories.length;
+      paginationWasLoadingRef.current = false;
+      setPaginationPending(true);
       onLoadMore?.();
       return;
     }
@@ -136,7 +167,7 @@ export function GitHubRepoPicker({
     setVisibleLimit((currentLimit) => currentLimit + COMBOBOX_INITIAL_LIMIT);
   };
 
-  if (isLoading && !isLoadingMore && !showInlineLoadingState) {
+  if (isLoading && !effectiveIsLoadingMore && !showInlineLoadingState) {
     return (
       <Button
         variant="outline"
@@ -205,6 +236,8 @@ export function GitHubRepoPicker({
         setUncontrolledOpen(nextOpen);
         onOpenChange?.(nextOpen);
         if (!nextOpen) {
+          setPaginationPending(false);
+          paginationWasLoadingRef.current = false;
           setUncontrolledSearchQuery("");
           onSearchQueryChange?.("");
           setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -212,6 +245,8 @@ export function GitHubRepoPicker({
       }}
       inputValue={searchQuery}
       onInputValueChange={(nextSearchQuery) => {
+        setPaginationPending(false);
+        paginationWasLoadingRef.current = false;
         setUncontrolledSearchQuery(nextSearchQuery);
         onSearchQueryChange?.(nextSearchQuery);
         setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -303,7 +338,7 @@ export function GitHubRepoPicker({
               variant="outline"
               size="sm"
               className="w-full"
-              disabled={isLoadingMore}
+              disabled={effectiveIsLoadingMore}
               loading={showLoadingMore}
               onClick={loadMore}
             >

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -22,12 +22,31 @@ import { defaultFilter } from "cmdk";
 import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 
 const COMBOBOX_INITIAL_LIMIT = 50;
+const LOAD_MORE_INDICATOR_DELAY_MS = 200;
+const LOAD_MORE_SENTINEL = "\0loading-more";
+
+function useDelayedVisibility(visible: boolean, delay: number): boolean {
+  const [delayedVisible, setDelayedVisible] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      setDelayedVisible(false);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setDelayedVisible(true), delay);
+    return () => window.clearTimeout(timeout);
+  }, [delay, visible]);
+
+  return delayedVisible;
+}
 
 interface GitHubRepoPickerProps {
   value: string | null;
   onChange: (repo: string | null) => void;
   repositories: string[];
   isLoading: boolean;
+  isLoadingMore?: boolean;
   placeholder?: string;
   size?: "1" | "2";
   disabled?: boolean;
@@ -50,6 +69,7 @@ export function GitHubRepoPicker({
   onChange,
   repositories,
   isLoading,
+  isLoadingMore = false,
   placeholder = "Select repository...",
   size = "1",
   disabled = false,
@@ -95,6 +115,13 @@ export function GitHubRepoPicker({
     );
   }, [repositories, trimmedSearchQuery]);
   const hasMore = controlledHasMore ?? filteredRepositoryCount > visibleLimit;
+  const showLoadingMore = useDelayedVisibility(
+    isLoadingMore,
+    LOAD_MORE_INDICATOR_DELAY_MS,
+  );
+  const items = showLoadingMore
+    ? [...repositories, LOAD_MORE_SENTINEL]
+    : repositories;
 
   useEffect(() => {
     if (onlyRepo && value !== onlyRepo) {
@@ -175,8 +202,9 @@ export function GitHubRepoPicker({
 
   return (
     <Combobox
-      items={repositories}
-      limit={visibleLimit}
+      items={items}
+      filter={remoteMode ? null : undefined}
+      limit={remoteMode ? undefined : visibleLimit}
       value={value}
       onValueChange={(v) => {
         onChange(v ? (v as string) : null);
@@ -280,11 +308,23 @@ export function GitHubRepoPicker({
             }
           }}
         >
-          {(repo: string) => (
-            <ComboboxItem key={repo} value={repo}>
-              {repo}
-            </ComboboxItem>
-          )}
+          {(repo: string) =>
+            repo === LOAD_MORE_SENTINEL ? (
+              <output
+                key={repo}
+                className="flex h-9 items-center justify-center gap-2 px-3"
+              >
+                <Spinner className="size-3.5" />
+                <Text size="xs" variant="muted">
+                  Loading more
+                </Text>
+              </output>
+            ) : (
+              <ComboboxItem key={repo} value={repo}>
+                {repo}
+              </ComboboxItem>
+            )
+          }
         </ComboboxList>
       </ComboboxContent>
     </Combobox>

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -93,6 +93,7 @@ export function GitHubRepoPicker({
   const [paginationPending, setPaginationPending] = useState(false);
   const paginationStartCountRef = useRef(0);
   const paginationWasLoadingRef = useRef(false);
+  const paginationRepositoriesRef = useRef<string[]>([]);
   const open = controlledOpen ?? uncontrolledOpen;
   const searchQuery = controlledSearchQuery ?? uncontrolledSearchQuery;
   const remoteMode =
@@ -101,6 +102,14 @@ export function GitHubRepoPicker({
     controlledHasMore !== undefined ||
     onLoadMore !== undefined;
   const effectiveIsLoadingMore = isLoadingMore || paginationPending;
+  if (paginationPending && repositories.length > 0) {
+    paginationRepositoriesRef.current = Array.from(
+      new Set([...paginationRepositoriesRef.current, ...repositories]),
+    );
+  }
+  const displayedRepositories = paginationPending
+    ? paginationRepositoriesRef.current
+    : repositories;
   const showInlineLoadingState =
     remoteMode && open && isLoading && !effectiveIsLoadingMore;
   const onlyRepo =
@@ -159,6 +168,7 @@ export function GitHubRepoPicker({
     if (remoteMode) {
       paginationStartCountRef.current = repositories.length;
       paginationWasLoadingRef.current = false;
+      paginationRepositoriesRef.current = repositories;
       setPaginationPending(true);
       onLoadMore?.();
       return;
@@ -224,7 +234,7 @@ export function GitHubRepoPicker({
 
   return (
     <Combobox
-      items={repositories}
+      items={displayedRepositories}
       filter={remoteMode ? null : undefined}
       limit={remoteMode ? undefined : visibleLimit}
       value={value}

--- a/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
+++ b/products/desktop/packages/ui/src/features/folder-picker/GitHubRepoPicker.tsx
@@ -19,7 +19,14 @@ import {
 } from "@posthog/quill";
 import { Tooltip } from "@posthog/ui/primitives/Tooltip";
 import { defaultFilter } from "cmdk";
-import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type RefObject,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 const COMBOBOX_INITIAL_LIMIT = 50;
 const LOAD_MORE_INDICATOR_DELAY_MS = 200;
@@ -88,7 +95,10 @@ export function GitHubRepoPicker({
   const buttonSize = size === "2" ? "lg" : "sm";
   const buttonTextClass = size === "2" ? "text-[13px]" : "";
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const loadMoreRequestKeyRef = useRef<string | null>(null);
+  const preservePaginationScrollRef = useRef(false);
+  const paginationScrollTopRef = useRef(0);
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [uncontrolledSearchQuery, setUncontrolledSearchQuery] = useState("");
   const [visibleLimit, setVisibleLimit] = useState(COMBOBOX_INITIAL_LIMIT);
@@ -129,6 +139,19 @@ export function GitHubRepoPicker({
     }
   }, [onlyRepo, value, onChange]);
 
+  useLayoutEffect(() => {
+    if (!preservePaginationScrollRef.current || !listRef.current) return;
+
+    if (repositories.length === 0) {
+      preservePaginationScrollRef.current = false;
+      return;
+    }
+    listRef.current.scrollTop = paginationScrollTopRef.current;
+    if (!isLoadingMore && !showLoadingMore) {
+      preservePaginationScrollRef.current = false;
+    }
+  }, [isLoadingMore, repositories.length, showLoadingMore]);
+
   const loadMoreAtScrollEnd = () => {
     const requestKey = remoteMode
       ? `${trimmedSearchQuery}:${repositories.length}`
@@ -136,6 +159,8 @@ export function GitHubRepoPicker({
     if (!hasMore || isLoading || loadMoreRequestKeyRef.current === requestKey)
       return;
     loadMoreRequestKeyRef.current = requestKey;
+    preservePaginationScrollRef.current = true;
+    paginationScrollTopRef.current = listRef.current?.scrollTop ?? 0;
 
     if (remoteMode) {
       onLoadMore?.();
@@ -214,6 +239,7 @@ export function GitHubRepoPicker({
         setUncontrolledOpen(nextOpen);
         onOpenChange?.(nextOpen);
         if (!nextOpen) {
+          preservePaginationScrollRef.current = false;
           setUncontrolledSearchQuery("");
           onSearchQueryChange?.("");
           setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -221,6 +247,7 @@ export function GitHubRepoPicker({
       }}
       inputValue={searchQuery}
       onInputValueChange={(nextSearchQuery) => {
+        preservePaginationScrollRef.current = false;
         setUncontrolledSearchQuery(nextSearchQuery);
         onSearchQueryChange?.(nextSearchQuery);
         setVisibleLimit(COMBOBOX_INITIAL_LIMIT);
@@ -300,9 +327,13 @@ export function GitHubRepoPicker({
           )}
         </ComboboxEmpty>
         <ComboboxList
+          ref={listRef}
           className="flex-1"
           onScroll={(event) => {
             const list = event.currentTarget;
+            if (preservePaginationScrollRef.current) {
+              paginationScrollTopRef.current = list.scrollTop;
+            }
             if (list.scrollHeight - list.scrollTop - list.clientHeight <= 32) {
               loadMoreAtScrollEnd();
             }

--- a/products/desktop/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DataSourceSetup.tsx
@@ -91,6 +91,7 @@ function GitHubSetup({ onComplete, onCancel }: SetupFormProps) {
   const {
     repositories: visibleRepositories,
     isPending: visibleRepositoriesLoading,
+    isFetchingMore: visibleRepositoriesFetchingMore,
     hasMore: visibleRepositoriesHasMore,
     loadMore: loadMoreVisibleRepositories,
   } = useGithubRepositories(repoPickerSearchQuery, isRepoPickerOpen);
@@ -234,6 +235,7 @@ function GitHubSetup({ onComplete, onCancel }: SetupFormProps) {
           isLoading={
             isLoadingRepos || (isRepoPickerOpen && visibleRepositoriesLoading)
           }
+          isLoadingMore={visibleRepositoriesFetchingMore}
           isRefreshing={isRefreshingRepos}
           onRefresh={handleRefreshRepositories}
           open={isRepoPickerOpen}

--- a/products/desktop/packages/ui/src/features/integrations/useCloudRepoPicker.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useCloudRepoPicker.ts
@@ -17,6 +17,7 @@ export function useCloudRepoPicker() {
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,
+    isFetchingMore: cloudRepositoriesFetchingMore,
     hasMore,
     loadMore,
   } = useUserGithubRepositories(searchQuery, isOpen);
@@ -40,6 +41,7 @@ export function useCloudRepoPicker() {
   return {
     repositories: isOpen ? visibleCloudRepositories : repositories,
     isLoading: isLoadingRepos || (isOpen && cloudRepositoriesLoading),
+    isLoadingMore: isOpen && cloudRepositoriesFetchingMore,
     isRefreshing: isRefreshingRepos,
     onRefresh: handleRefresh,
     open: isOpen,

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -46,6 +46,7 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -143,6 +144,43 @@ function useAllUserGithubRepositories(
 
 const REPOSITORIES_PAGE_SIZE = 50;
 
+function useRetainedRepositoryPickerResult<TRef>(
+  paginationKey: string,
+  result: ReturnType<typeof combineRepositoryPicker<TRef>>,
+  isPaginating: boolean,
+): ReturnType<typeof combineRepositoryPicker<TRef>> {
+  const retainedResultRef = useRef({
+    paginationKey,
+    repositoryMap: result.repositoryMap,
+    hasMore: result.hasMore,
+  });
+
+  if (retainedResultRef.current.paginationKey !== paginationKey) {
+    retainedResultRef.current = {
+      paginationKey,
+      repositoryMap: result.repositoryMap,
+      hasMore: result.hasMore,
+    };
+  } else if (!isPaginating) {
+    retainedResultRef.current.repositoryMap = result.repositoryMap;
+    retainedResultRef.current.hasMore = result.hasMore;
+  } else if (Object.keys(result.repositoryMap).length > 0) {
+    retainedResultRef.current.repositoryMap = {
+      ...retainedResultRef.current.repositoryMap,
+      ...result.repositoryMap,
+    };
+    retainedResultRef.current.hasMore = result.hasMore;
+  }
+
+  if (!isPaginating) return result;
+
+  return {
+    ...result,
+    repositoryMap: retainedResultRef.current.repositoryMap,
+    hasMore: retainedResultRef.current.hasMore,
+  };
+}
+
 function useRepositoryPickerLimit(resetKey: string) {
   const [request, setRequest] = useState({
     key: resetKey,
@@ -184,7 +222,7 @@ export function useGithubRepositories(
   const queryEnabled =
     enabled && !!client && matchingGithubIntegrations.length > 0;
 
-  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
+  const queryResult = useQueries({
     queries: matchingGithubIntegrations.map((integration) => ({
       queryKey: integrationKeys.repositoryPicker(
         integration.id,
@@ -210,6 +248,13 @@ export function useGithubRepositories(
     })),
     combine: combineRepositoryPicker<number>,
   });
+
+  const { repositoryMap, isPending, isRefreshing, hasMore } =
+    useRetainedRepositoryPickerResult(
+      paginationKey,
+      queryResult,
+      requestedLimit > REPOSITORIES_PAGE_SIZE,
+    );
 
   const isFetchingMore =
     requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);
@@ -241,7 +286,7 @@ export function useUserGithubRepositories(
   const { requestedLimit, loadMore } = useRepositoryPickerLimit(paginationKey);
   const queryEnabled = enabled && !!client && githubIntegrations.length > 0;
 
-  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
+  const queryResult = useQueries({
     queries: githubIntegrations.map((integration) => ({
       queryKey: userGithubIntegrationKeys.repositoryPicker(
         integration.installation_id,
@@ -273,6 +318,13 @@ export function useUserGithubRepositories(
     })),
     combine: combineRepositoryPicker<UserRepositoryIntegrationRef>,
   });
+
+  const { repositoryMap, isPending, isRefreshing, hasMore } =
+    useRetainedRepositoryPickerResult(
+      paginationKey,
+      queryResult,
+      requestedLimit > REPOSITORIES_PAGE_SIZE,
+    );
 
   const isFetchingMore =
     requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -46,7 +46,6 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 
@@ -144,43 +143,6 @@ function useAllUserGithubRepositories(
 
 const REPOSITORIES_PAGE_SIZE = 50;
 
-function useRetainedRepositoryPickerResult<TRef>(
-  paginationKey: string,
-  result: ReturnType<typeof combineRepositoryPicker<TRef>>,
-  isPaginating: boolean,
-): ReturnType<typeof combineRepositoryPicker<TRef>> {
-  const retainedResultRef = useRef({
-    paginationKey,
-    repositoryMap: result.repositoryMap,
-    hasMore: result.hasMore,
-  });
-
-  if (retainedResultRef.current.paginationKey !== paginationKey) {
-    retainedResultRef.current = {
-      paginationKey,
-      repositoryMap: result.repositoryMap,
-      hasMore: result.hasMore,
-    };
-  } else if (!isPaginating) {
-    retainedResultRef.current.repositoryMap = result.repositoryMap;
-    retainedResultRef.current.hasMore = result.hasMore;
-  } else if (Object.keys(result.repositoryMap).length > 0) {
-    retainedResultRef.current.repositoryMap = {
-      ...retainedResultRef.current.repositoryMap,
-      ...result.repositoryMap,
-    };
-    retainedResultRef.current.hasMore = result.hasMore;
-  }
-
-  if (!isPaginating) return result;
-
-  return {
-    ...result,
-    repositoryMap: retainedResultRef.current.repositoryMap,
-    hasMore: retainedResultRef.current.hasMore,
-  };
-}
-
 function useRepositoryPickerLimit(resetKey: string) {
   const [request, setRequest] = useState({
     key: resetKey,
@@ -206,6 +168,7 @@ export function useGithubRepositories(
   integrationId?: number | null,
 ) {
   const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
   const { githubIntegrations } = useIntegrationSelectors();
   const matchingGithubIntegrations = useMemo(
     () =>
@@ -222,12 +185,11 @@ export function useGithubRepositories(
   const queryEnabled =
     enabled && !!client && matchingGithubIntegrations.length > 0;
 
-  const queryResult = useQueries({
+  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
     queries: matchingGithubIntegrations.map((integration) => ({
       queryKey: integrationKeys.repositoryPicker(
         integration.id,
         deferredSearch,
-        requestedLimit,
       ),
       queryFn: async () => {
         if (!client) throw new Error("Not authenticated");
@@ -243,18 +205,32 @@ export function useGithubRepositories(
       },
       enabled: queryEnabled,
       staleTime: 5 * 60 * 1000,
-      placeholderData: (prev: unknown) => prev,
       meta: AUTH_SCOPED_QUERY_META,
     })),
     combine: combineRepositoryPicker<number>,
   });
 
-  const { repositoryMap, isPending, isRefreshing, hasMore } =
-    useRetainedRepositoryPickerResult(
-      paginationKey,
-      queryResult,
-      requestedLimit > REPOSITORIES_PAGE_SIZE,
+  useEffect(() => {
+    if (!queryEnabled || requestedLimit === REPOSITORIES_PAGE_SIZE) return;
+
+    void Promise.all(
+      matchingGithubIntegrations.map((integration) =>
+        queryClient.refetchQueries({
+          queryKey: integrationKeys.repositoryPicker(
+            integration.id,
+            deferredSearch,
+          ),
+          exact: true,
+        }),
+      ),
     );
+  }, [
+    deferredSearch,
+    matchingGithubIntegrations,
+    queryClient,
+    queryEnabled,
+    requestedLimit,
+  ]);
 
   const isFetchingMore =
     requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);
@@ -280,18 +256,18 @@ export function useUserGithubRepositories(
   enabled: boolean = true,
 ) {
   const client = useOptionalAuthenticatedClient();
+  const queryClient = useQueryClient();
   const { data: githubIntegrations = [] } = useUserGithubIntegrations();
   const deferredSearch = useDeferredValue(search?.trim() ?? "");
   const paginationKey = `${githubIntegrations.map((integration) => integration.installation_id).join(",")}:${deferredSearch}`;
   const { requestedLimit, loadMore } = useRepositoryPickerLimit(paginationKey);
   const queryEnabled = enabled && !!client && githubIntegrations.length > 0;
 
-  const queryResult = useQueries({
+  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
     queries: githubIntegrations.map((integration) => ({
       queryKey: userGithubIntegrationKeys.repositoryPicker(
         integration.installation_id,
         deferredSearch,
-        requestedLimit,
       ),
       queryFn: async () => {
         if (!client) throw new Error("Not authenticated");
@@ -313,18 +289,32 @@ export function useUserGithubRepositories(
       },
       enabled: queryEnabled,
       staleTime: 5 * 60 * 1000,
-      placeholderData: (prev: unknown) => prev,
       meta: AUTH_SCOPED_QUERY_META,
     })),
     combine: combineRepositoryPicker<UserRepositoryIntegrationRef>,
   });
 
-  const { repositoryMap, isPending, isRefreshing, hasMore } =
-    useRetainedRepositoryPickerResult(
-      paginationKey,
-      queryResult,
-      requestedLimit > REPOSITORIES_PAGE_SIZE,
+  useEffect(() => {
+    if (!queryEnabled || requestedLimit === REPOSITORIES_PAGE_SIZE) return;
+
+    void Promise.all(
+      githubIntegrations.map((integration) =>
+        queryClient.refetchQueries({
+          queryKey: userGithubIntegrationKeys.repositoryPicker(
+            integration.installation_id,
+            deferredSearch,
+          ),
+          exact: true,
+        }),
+      ),
     );
+  }, [
+    deferredSearch,
+    githubIntegrations,
+    queryClient,
+    queryEnabled,
+    requestedLimit,
+  ]);
 
   const isFetchingMore =
     requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -8,12 +8,17 @@ import {
 import { REPOSITORIES_SERVICE } from "@posthog/core/integrations/identifiers";
 import {
   combineGithubRepositories,
-  combineRepositoryPicker,
   combineUserGithubRepositories,
+  computeNextRepositoryPickerOffsets,
+  computeRepositoryNextOffset,
+  flattenRepositoryPickerPages,
   getIntegrationIdForRepo,
   getRepoEntry,
   isEmptyRepositoryMap,
   isRepoInIntegration,
+  REPOSITORY_PICKER_PAGE_SIZE,
+  type RepositoryPickerOffsets,
+  type RepositoryPickerPage,
   resolveEffectiveUserRepositoryMap,
   resolveUserRepositoryCacheAction,
   type UserRepositoryIntegrationRef,
@@ -141,34 +146,12 @@ function useAllUserGithubRepositories(
   });
 }
 
-const REPOSITORIES_PAGE_SIZE = 50;
-
-function useRepositoryPickerLimit(resetKey: string) {
-  const [request, setRequest] = useState({
-    key: resetKey,
-    limit: REPOSITORIES_PAGE_SIZE,
-  });
-  const requestedLimit =
-    request.key === resetKey ? request.limit : REPOSITORIES_PAGE_SIZE;
-  const loadMore = useCallback(() => {
-    setRequest((current) => ({
-      key: resetKey,
-      limit:
-        (current.key === resetKey ? current.limit : REPOSITORIES_PAGE_SIZE) +
-        REPOSITORIES_PAGE_SIZE,
-    }));
-  }, [resetKey]);
-
-  return { requestedLimit, loadMore };
-}
-
 export function useGithubRepositories(
   search?: string,
   enabled: boolean = true,
   integrationId?: number | null,
 ) {
   const client = useOptionalAuthenticatedClient();
-  const queryClient = useQueryClient();
   const { githubIntegrations } = useIntegrationSelectors();
   const matchingGithubIntegrations = useMemo(
     () =>
@@ -180,60 +163,59 @@ export function useGithubRepositories(
     [githubIntegrations, integrationId],
   );
   const deferredSearch = useDeferredValue(search?.trim() ?? "");
-  const paginationKey = `${matchingGithubIntegrations.map((integration) => integration.id).join(",")}:${deferredSearch}`;
-  const { requestedLimit, loadMore } = useRepositoryPickerLimit(paginationKey);
+  const integrationIds = matchingGithubIntegrations.map(
+    (integration) => integration.id,
+  );
   const queryEnabled =
     enabled && !!client && matchingGithubIntegrations.length > 0;
 
-  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
-    queries: matchingGithubIntegrations.map((integration) => ({
-      queryKey: integrationKeys.repositoryPicker(
-        integration.id,
-        deferredSearch,
+  const query = useAuthenticatedInfiniteQuery<
+    RepositoryPickerPage<number>,
+    RepositoryPickerOffsets
+  >(
+    integrationKeys.repositoryPickerPages(integrationIds, deferredSearch),
+    async (authenticatedClient, offsets) => ({
+      integrations: await Promise.all(
+        matchingGithubIntegrations
+          .filter(
+            (integration) => offsets[String(integration.id)] !== undefined,
+          )
+          .map(async (integration) => {
+            const offset = offsets[String(integration.id)] ?? 0;
+            const page = await authenticatedClient.getGithubRepositoriesPage(
+              integration.id,
+              offset,
+              REPOSITORY_PICKER_PAGE_SIZE,
+              deferredSearch,
+            );
+            return {
+              key: String(integration.id),
+              ref: integration.id,
+              ...page,
+              nextOffset: computeRepositoryNextOffset(offset, page),
+            };
+          }),
       ),
-      queryFn: async () => {
-        if (!client) throw new Error("Not authenticated");
-
-        const page = await client.getGithubRepositoriesPage(
-          integration.id,
-          0,
-          requestedLimit,
-          deferredSearch,
-        );
-
-        return { ref: integration.id, ...page };
-      },
+    }),
+    {
       enabled: queryEnabled,
-      staleTime: 5 * 60 * 1000,
-      meta: AUTH_SCOPED_QUERY_META,
-    })),
-    combine: combineRepositoryPicker<number>,
-  });
-
-  useEffect(() => {
-    if (!queryEnabled || requestedLimit === REPOSITORIES_PAGE_SIZE) return;
-
-    void Promise.all(
-      matchingGithubIntegrations.map((integration) =>
-        queryClient.refetchQueries({
-          queryKey: integrationKeys.repositoryPicker(
-            integration.id,
-            deferredSearch,
-          ),
-          exact: true,
-        }),
+      initialPageParam: Object.fromEntries(
+        integrationIds.map((id) => [String(id), 0]),
       ),
-    );
-  }, [
-    deferredSearch,
-    matchingGithubIntegrations,
-    queryClient,
-    queryEnabled,
-    requestedLimit,
-  ]);
+      getNextPageParam: computeNextRepositoryPickerOffsets,
+      staleTime: 5 * 60 * 1000,
+    },
+  );
 
-  const isFetchingMore =
-    requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);
+  const { repositoryMap, hasMore } = useMemo(
+    () => flattenRepositoryPickerPages(query.data?.pages),
+    [query.data?.pages],
+  );
+
+  const loadMore = useCallback(() => {
+    if (!query.hasNextPage || query.isFetching) return;
+    void query.fetchNextPage();
+  }, [query.fetchNextPage, query.hasNextPage, query.isFetching]);
 
   const getIntegrationIdForRepository = useCallback(
     (repoKey: string) => getIntegrationIdForRepo(repositoryMap, repoKey),
@@ -243,9 +225,11 @@ export function useGithubRepositories(
   return {
     repositories: Object.keys(repositoryMap),
     getIntegrationIdForRepo: getIntegrationIdForRepository,
-    isPending: queryEnabled ? isPending && !isFetchingMore : false,
-    isFetchingMore: queryEnabled ? isFetchingMore : false,
-    isRefreshing: queryEnabled ? isRefreshing : false,
+    isPending: queryEnabled ? query.isPending : false,
+    isFetchingMore: query.isFetchingNextPage,
+    isRefreshing: queryEnabled
+      ? query.isRefetching && !query.isFetchingNextPage
+      : false,
     hasMore,
     loadMore,
   };
@@ -256,74 +240,75 @@ export function useUserGithubRepositories(
   enabled: boolean = true,
 ) {
   const client = useOptionalAuthenticatedClient();
-  const queryClient = useQueryClient();
   const { data: githubIntegrations = [] } = useUserGithubIntegrations();
   const deferredSearch = useDeferredValue(search?.trim() ?? "");
-  const paginationKey = `${githubIntegrations.map((integration) => integration.installation_id).join(",")}:${deferredSearch}`;
-  const { requestedLimit, loadMore } = useRepositoryPickerLimit(paginationKey);
+  const installationIds = githubIntegrations.map(
+    (integration) => integration.installation_id,
+  );
   const queryEnabled = enabled && !!client && githubIntegrations.length > 0;
 
-  const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
-    queries: githubIntegrations.map((integration) => ({
-      queryKey: userGithubIntegrationKeys.repositoryPicker(
-        integration.installation_id,
-        deferredSearch,
+  const query = useAuthenticatedInfiniteQuery<
+    RepositoryPickerPage<UserRepositoryIntegrationRef>,
+    RepositoryPickerOffsets
+  >(
+    userGithubIntegrationKeys.repositoryPickerPages(
+      installationIds,
+      deferredSearch,
+    ),
+    async (authenticatedClient, offsets) => ({
+      integrations: await Promise.all(
+        githubIntegrations
+          .filter(
+            (integration) => offsets[integration.installation_id] !== undefined,
+          )
+          .map(async (integration) => {
+            const offset = offsets[integration.installation_id] ?? 0;
+            const page =
+              await authenticatedClient.getGithubUserRepositoriesPage(
+                integration.installation_id,
+                offset,
+                REPOSITORY_PICKER_PAGE_SIZE,
+                deferredSearch,
+              );
+            return {
+              key: integration.installation_id,
+              ref: {
+                userIntegrationId: integration.id,
+                installationId: integration.installation_id,
+              },
+              ...page,
+              nextOffset: computeRepositoryNextOffset(offset, page),
+            };
+          }),
       ),
-      queryFn: async () => {
-        if (!client) throw new Error("Not authenticated");
-
-        const page = await client.getGithubUserRepositoriesPage(
-          integration.installation_id,
-          0,
-          requestedLimit,
-          deferredSearch,
-        );
-
-        return {
-          ref: {
-            userIntegrationId: integration.id,
-            installationId: integration.installation_id,
-          },
-          ...page,
-        };
-      },
+    }),
+    {
       enabled: queryEnabled,
-      staleTime: 5 * 60 * 1000,
-      meta: AUTH_SCOPED_QUERY_META,
-    })),
-    combine: combineRepositoryPicker<UserRepositoryIntegrationRef>,
-  });
-
-  useEffect(() => {
-    if (!queryEnabled || requestedLimit === REPOSITORIES_PAGE_SIZE) return;
-
-    void Promise.all(
-      githubIntegrations.map((integration) =>
-        queryClient.refetchQueries({
-          queryKey: userGithubIntegrationKeys.repositoryPicker(
-            integration.installation_id,
-            deferredSearch,
-          ),
-          exact: true,
-        }),
+      initialPageParam: Object.fromEntries(
+        installationIds.map((id) => [id, 0]),
       ),
-    );
-  }, [
-    deferredSearch,
-    githubIntegrations,
-    queryClient,
-    queryEnabled,
-    requestedLimit,
-  ]);
+      getNextPageParam: computeNextRepositoryPickerOffsets,
+      staleTime: 5 * 60 * 1000,
+    },
+  );
 
-  const isFetchingMore =
-    requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);
+  const { repositoryMap, hasMore } = useMemo(
+    () => flattenRepositoryPickerPages(query.data?.pages),
+    [query.data?.pages],
+  );
+
+  const loadMore = useCallback(() => {
+    if (!query.hasNextPage || query.isFetching) return;
+    void query.fetchNextPage();
+  }, [query.fetchNextPage, query.hasNextPage, query.isFetching]);
 
   return {
     repositories: Object.keys(repositoryMap),
-    isPending: queryEnabled ? isPending && !isFetchingMore : false,
-    isFetchingMore: queryEnabled ? isFetchingMore : false,
-    isRefreshing: queryEnabled ? isRefreshing : false,
+    isPending: queryEnabled ? query.isPending : false,
+    isFetchingMore: query.isFetchingNextPage,
+    isRefreshing: queryEnabled
+      ? query.isRefetching && !query.isFetchingNextPage
+      : false,
     hasMore,
     loadMore,
   };

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -146,19 +146,30 @@ const REPOSITORIES_PAGE_SIZE = 50;
 export function useGithubRepositories(
   search?: string,
   enabled: boolean = true,
+  integrationId?: number | null,
 ) {
   const client = useOptionalAuthenticatedClient();
   const { githubIntegrations } = useIntegrationSelectors();
+  const matchingGithubIntegrations = useMemo(
+    () =>
+      integrationId == null
+        ? githubIntegrations
+        : githubIntegrations.filter(
+            (integration) => integration.id === integrationId,
+          ),
+    [githubIntegrations, integrationId],
+  );
   const deferredSearch = useDeferredValue(search?.trim() ?? "");
   const [requestedLimit, setRequestedLimit] = useState(REPOSITORIES_PAGE_SIZE);
-  const queryEnabled = enabled && !!client && githubIntegrations.length > 0;
+  const queryEnabled =
+    enabled && !!client && matchingGithubIntegrations.length > 0;
 
   useEffect(() => {
     setRequestedLimit(REPOSITORIES_PAGE_SIZE);
   }, []);
 
   const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
-    queries: githubIntegrations.map((integration) => ({
+    queries: matchingGithubIntegrations.map((integration) => ({
       queryKey: integrationKeys.repositoryPicker(
         integration.id,
         deferredSearch,
@@ -188,8 +199,14 @@ export function useGithubRepositories(
     setRequestedLimit((currentLimit) => currentLimit + REPOSITORIES_PAGE_SIZE);
   }, []);
 
+  const getIntegrationIdForRepository = useCallback(
+    (repoKey: string) => getIntegrationIdForRepo(repositoryMap, repoKey),
+    [repositoryMap],
+  );
+
   return {
     repositories: Object.keys(repositoryMap),
+    getIntegrationIdForRepo: getIntegrationIdForRepository,
     isPending: queryEnabled ? isPending : false,
     isRefreshing: queryEnabled ? isRefreshing : false,
     hasMore,

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -143,6 +143,25 @@ function useAllUserGithubRepositories(
 
 const REPOSITORIES_PAGE_SIZE = 50;
 
+function useRepositoryPickerLimit(resetKey: string) {
+  const [request, setRequest] = useState({
+    key: resetKey,
+    limit: REPOSITORIES_PAGE_SIZE,
+  });
+  const requestedLimit =
+    request.key === resetKey ? request.limit : REPOSITORIES_PAGE_SIZE;
+  const loadMore = useCallback(() => {
+    setRequest((current) => ({
+      key: resetKey,
+      limit:
+        (current.key === resetKey ? current.limit : REPOSITORIES_PAGE_SIZE) +
+        REPOSITORIES_PAGE_SIZE,
+    }));
+  }, [resetKey]);
+
+  return { requestedLimit, loadMore };
+}
+
 export function useGithubRepositories(
   search?: string,
   enabled: boolean = true,
@@ -160,13 +179,10 @@ export function useGithubRepositories(
     [githubIntegrations, integrationId],
   );
   const deferredSearch = useDeferredValue(search?.trim() ?? "");
-  const [requestedLimit, setRequestedLimit] = useState(REPOSITORIES_PAGE_SIZE);
+  const paginationKey = `${matchingGithubIntegrations.map((integration) => integration.id).join(",")}:${deferredSearch}`;
+  const { requestedLimit, loadMore } = useRepositoryPickerLimit(paginationKey);
   const queryEnabled =
     enabled && !!client && matchingGithubIntegrations.length > 0;
-
-  useEffect(() => {
-    setRequestedLimit(REPOSITORIES_PAGE_SIZE);
-  }, []);
 
   const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
     queries: matchingGithubIntegrations.map((integration) => ({
@@ -195,9 +211,8 @@ export function useGithubRepositories(
     combine: combineRepositoryPicker<number>,
   });
 
-  const loadMore = useCallback(() => {
-    setRequestedLimit((currentLimit) => currentLimit + REPOSITORIES_PAGE_SIZE);
-  }, []);
+  const isFetchingMore =
+    requestedLimit > REPOSITORIES_PAGE_SIZE && isRefreshing;
 
   const getIntegrationIdForRepository = useCallback(
     (repoKey: string) => getIntegrationIdForRepo(repositoryMap, repoKey),
@@ -207,7 +222,8 @@ export function useGithubRepositories(
   return {
     repositories: Object.keys(repositoryMap),
     getIntegrationIdForRepo: getIntegrationIdForRepository,
-    isPending: queryEnabled ? isPending : false,
+    isPending: queryEnabled ? isPending && !isFetchingMore : false,
+    isFetchingMore: queryEnabled ? isFetchingMore : false,
     isRefreshing: queryEnabled ? isRefreshing : false,
     hasMore,
     loadMore,
@@ -221,12 +237,9 @@ export function useUserGithubRepositories(
   const client = useOptionalAuthenticatedClient();
   const { data: githubIntegrations = [] } = useUserGithubIntegrations();
   const deferredSearch = useDeferredValue(search?.trim() ?? "");
-  const [requestedLimit, setRequestedLimit] = useState(REPOSITORIES_PAGE_SIZE);
+  const paginationKey = `${githubIntegrations.map((integration) => integration.installation_id).join(",")}:${deferredSearch}`;
+  const { requestedLimit, loadMore } = useRepositoryPickerLimit(paginationKey);
   const queryEnabled = enabled && !!client && githubIntegrations.length > 0;
-
-  useEffect(() => {
-    setRequestedLimit(REPOSITORIES_PAGE_SIZE);
-  }, []);
 
   const { repositoryMap, isPending, isRefreshing, hasMore } = useQueries({
     queries: githubIntegrations.map((integration) => ({
@@ -255,18 +268,19 @@ export function useUserGithubRepositories(
       },
       enabled: queryEnabled,
       staleTime: 5 * 60 * 1000,
+      placeholderData: (prev: unknown) => prev,
       meta: AUTH_SCOPED_QUERY_META,
     })),
     combine: combineRepositoryPicker<UserRepositoryIntegrationRef>,
   });
 
-  const loadMore = useCallback(() => {
-    setRequestedLimit((currentLimit) => currentLimit + REPOSITORIES_PAGE_SIZE);
-  }, []);
+  const isFetchingMore =
+    requestedLimit > REPOSITORIES_PAGE_SIZE && isRefreshing;
 
   return {
     repositories: Object.keys(repositoryMap),
-    isPending: queryEnabled ? isPending : false,
+    isPending: queryEnabled ? isPending && !isFetchingMore : false,
+    isFetchingMore: queryEnabled ? isFetchingMore : false,
     isRefreshing: queryEnabled ? isRefreshing : false,
     hasMore,
     loadMore,

--- a/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
+++ b/products/desktop/packages/ui/src/features/integrations/useIntegrations.ts
@@ -212,7 +212,7 @@ export function useGithubRepositories(
   });
 
   const isFetchingMore =
-    requestedLimit > REPOSITORIES_PAGE_SIZE && isRefreshing;
+    requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);
 
   const getIntegrationIdForRepository = useCallback(
     (repoKey: string) => getIntegrationIdForRepo(repositoryMap, repoKey),
@@ -275,7 +275,7 @@ export function useUserGithubRepositories(
   });
 
   const isFetchingMore =
-    requestedLimit > REPOSITORIES_PAGE_SIZE && isRefreshing;
+    requestedLimit > REPOSITORIES_PAGE_SIZE && (isPending || isRefreshing);
 
   return {
     repositories: Object.keys(repositoryMap),

--- a/products/desktop/packages/ui/src/features/settings/sections/AutostartBaseBranchesSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/AutostartBaseBranchesSettings.tsx
@@ -103,6 +103,7 @@ export function AutostartBaseBranchesSettings({
                 isLoading={
                   isLoadingRepos || (isRepoPickerOpen && repoPage.isPending)
                 }
+                isLoadingMore={repoPage.isFetchingMore}
                 isRefreshing={isRefreshingRepos}
                 onRefresh={refreshRepositories}
                 open={isRepoPickerOpen}

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -460,6 +460,7 @@ export function TaskInput({
   const {
     repositories: visibleCloudRepositories,
     isPending: cloudRepositoriesLoading,
+    isFetchingMore: cloudRepositoriesFetchingMore,
     hasMore: cloudRepositoriesHasMore,
     loadMore: loadMoreCloudRepositories,
   } = useUserGithubRepositories(cloudRepoSearchQuery, isCloudRepoPickerOpen);
@@ -1279,6 +1280,7 @@ export function TaskInput({
                           isLoadingRepos ||
                           (isCloudRepoPickerOpen && cloudRepositoriesLoading)
                         }
+                        isLoadingMore={cloudRepositoriesFetchingMore}
                         isRefreshing={isRefreshingRepos}
                         onRefresh={handleRefreshRepositories}
                         open={isCloudRepoPickerOpen}


### PR DESCRIPTION
## Problem

People configuring a Space wait for every accessible GitHub repository before the repository picker becomes usable.

Pagination could also replace the current results with the full loader.

## Changes

- The shared repository picker loads an initial page and searches all accessible repositories on the server.
- The popover uses a stable 320px viewport with a dedicated search header.
- Search has no selector chevron, and refresh sits inside the search field.
- A full-width footer button loads each additional page explicitly.
- Pagination preserves current rows while the next page loads.
- The button shows a spinner only when pagination takes longer than 200ms.
- The full-panel loader appears only for initial loads and searches.
- Repository choices stay scoped to the selected GitHub integration.
- Screenshots are not included because this state requires authenticated repository data.

## How did you test this code?

- Added component tests that verify scrolling does not paginate and clicking the footer does.
- The pagination test verifies retained rows, the delayed button spinner, and results beyond the first 50 rows.
- Ran the full @posthog/ui test suite.
- Ran the desktop workspace build, @posthog/ui TypeScript check, and Biome lint.
- Did not manually test with an authenticated GitHub integration.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. The shared picker behavior is self-contained.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change with the posthog-desktop, writing-tests, writing-user-facing-copy, and writing-pr-descriptions skills.

The design follows Quill and Base UI’s input-inside-popup pattern while preserving keyboard and screen-reader behavior.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*