### PR TITLE
fix(data-warehouse): stop billing-check network blips reporting noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.db.models import F, Q, Sum
 from django.db.utils import OperationalError
 
+import requests
 from dateutil import parser
 from redis import exceptions as redis_exceptions
 from structlog.types import FilteringBoundLogger
@@ -246,6 +247,12 @@ async def will_hit_billing_limit(team_id: int, source: "ExternalDataSource", log
         # Same rationale as above: a dropped Postgres connection while fetching billing
         # data is a transient infra blip, and the check already fails open.
         await logger.awarning(f"BillingLimits: Database error while checking billing limits, failing open: {e}")
+
+        return False
+    except requests.exceptions.RequestException as e:
+        # Same rationale as above: a network blip (e.g. a proxy timeout) reaching the
+        # billing service is a transient infra issue, and the check already fails open.
+        await logger.awarning(f"BillingLimits: Network error while checking billing limits, failing open: {e}")
 
         return False
     except Exception as e:

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
@@ -12,6 +12,7 @@ from unittest import mock
 from django.db.utils import OperationalError
 from django.test import override_settings
 
+import requests
 from asgiref.sync import sync_to_async
 from redis import exceptions as redis_exceptions
 from structlog.types import FilteringBoundLogger
@@ -236,6 +237,29 @@ class TestRowTracking(BaseTest):
             mock_get_billing.side_effect = OperationalError(
                 'connection failed: connection to server at "127.0.0.1", port 5432 failed: '
                 "server closed the connection unexpectedly"
+            )
+
+            assert await self._run(source, 10) is False
+
+        mock_capture_exception.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_row_tracking_fails_open_on_request_error_without_capturing_exception(self):
+        # A network blip (e.g. a proxy timeout) reaching the billing service is a transient
+        # infra issue, not a bug, and must fail open like any other billing-check error
+        # without being reported to error tracking.
+        source = await self._create_source()
+
+        with (
+            mock.patch("ee.billing.billing_manager.BillingManager.get_billing") as mock_get_billing,
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.row_tracking.capture_exception"
+            ) as mock_capture_exception,
+        ):
+            mock_get_billing.side_effect = requests.exceptions.ProxyError(
+                "HTTPSConnectionPool(host='billing.posthog.com', port=443): Max retries exceeded "
+                "with url: /api/billing (Caused by ProxyError('Cannot connect to proxy.', "
+                "OSError('Tunnel connection failed: 504 Gateway timeout')))"
             )
 
             assert await self._run(source, 10) is False


### PR DESCRIPTION
## Problem

A warehouse sync's row-limit check reports a proxy timeout reaching the billing service to error tracking, even though the check already tolerates the failure and lets the sync continue. This fired for both Postgres and BigQuery syncs, across full-refresh and incremental modes, confirming the bug is in the shared check, not a specific source. See [this error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd337-3fd7-7933-8906-ddec7b22faed).

## Changes

- `will_hit_billing_limit` already treats a dropped Redis or Postgres connection while fetching billing data as a transient infra blip: log a warning and fail open, without reporting to error tracking.
- A `requests` connection error (proxy timeout, connection reset, DNS blip) reaching the billing service fell through to the generic exception handler instead, which does report it.
- Add a `requests.exceptions.RequestException` handler with the same fail-open behavior, and no capture.

## How did you test this code?

Added `test_row_tracking_fails_open_on_request_error_without_capturing_exception`, mirroring the existing Redis/Postgres fail-open tests, asserting the billing check returns `False` and `capture_exception` is not called when the billing request raises `requests.exceptions.ProxyError`. Ran the full `test_row_tracking.py` suite locally (13 passed). Also ran `ruff check`/`ruff format --check` and a repo-wide `uv run mypy --cache-fine-grained .`, both clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue. Confirmed the stack trace, exception properties, and affected sources/sync types via the PostHog MCP error-tracking tools before diagging into the code.

No duplicate found: searched open PRs (excluding the automation bot) by exception type, module path, and message text, and checked the data-warehouse maintainer's own open PRs — none touch this billing-check path.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*