### PR TITLE
fix(hogql): bind JSONExtract* keys as quoted JSONPaths for DuckDB

### DIFF
--- a/posthog/hogql/printer/duckdb.py
+++ b/posthog/hogql/printer/duckdb.py
@@ -18,6 +18,18 @@ _ELEMENT_TYPE_DEFAULTS: tuple[tuple[type, str], ...] = (
     (ast.StringType, "''"),
 )
 
+# JSONExtract*-family call name (lowercased) → (DuckDB extract function, cast type).
+# Cast types mirror the inherited Postgres handlers so both dialects return the same types.
+_JSON_PATH_CALL_FORMS: dict[str, tuple[str, str | None]] = {
+    "jsonextractstring": ("json_extract_string", None),
+    "jsonextractraw": ("json_extract", None),
+    "jsonextractarrayraw": ("json_extract", None),
+    "jsonextractint": ("json_extract_string", "INTEGER"),
+    "jsonextractuint": ("json_extract_string", "INTEGER"),
+    "jsonextractfloat": ("json_extract_string", "DOUBLE PRECISION"),
+    "jsonextractbool": ("json_extract_string", "BOOLEAN"),
+}
+
 
 class DuckDBPrinter(PostgresPrinter):
     """Prints a HogQL AST as DuckDB SQL.
@@ -70,6 +82,9 @@ class DuckDBPrinter(PostgresPrinter):
         return self._duckdb_function_handlers
 
     def visit_call(self, node: ast.Call) -> str:
+        json_path_rendered = self._maybe_visit_json_path_call(node)
+        if json_path_rendered is not None:
+            return json_path_rendered
         rendered = super().visit_call(node)
         return_type = node.type.return_type if isinstance(node.type, ast.CallType) else node.type
         if node.name.lower() in {"dateadd", "datetrunc", "date_trunc"} and isinstance(return_type, ast.DateType):
@@ -78,6 +93,36 @@ class DuckDBPrinter(PostgresPrinter):
             default = next((literal for t, literal in _ELEMENT_TYPE_DEFAULTS if isinstance(return_type, t)), None)
             if default is not None:
                 return f"COALESCE({rendered}, {default})"
+        return rendered
+
+    def _maybe_visit_json_path_call(self, node: ast.Call) -> str | None:
+        # DuckDB parses the key argument of json_extract* as a JSONPath, so the inherited
+        # Postgres rendering (key bound as a bare constant) fails to bind for `$`-prefixed
+        # keys — which is most PostHog properties. Fold constant keys into one quoted
+        # JSONPath (`$."k1"."k2"`) bound as a single value instead.
+        func_name = node.name.lower()
+        if func_name != "jsonhas" and func_name not in _JSON_PATH_CALL_FORMS:
+            return None
+        if len(node.args) < 2 or node.distinct or node.order_by:
+            return None
+        keys: list[str] = []
+        for key_arg in node.args[1:]:
+            if not (isinstance(key_arg, ast.Constant) and isinstance(key_arg.value, str)):
+                # Dynamic or positional keys can't be folded at compile time.
+                return None
+            keys.append(key_arg.value)
+
+        json_sql = self.visit(node.args[0])
+        (path_placeholder,) = self._json_property_args(keys)
+        if func_name == "jsonhas":
+            # json_extract returns JSON 'null' (not SQL NULL) for an existing null value,
+            # matching ClickHouse's JSONHas, which reports presence rather than non-nullness.
+            # The cast keeps the UInt8 return type HogQL resolves for it.
+            return f"CAST((json_extract({json_sql}, {path_placeholder}) IS NOT NULL) AS INTEGER)"
+        extract_fn, cast_type = _JSON_PATH_CALL_FORMS[func_name]
+        rendered = f"{extract_fn}({json_sql}, {path_placeholder})"
+        if cast_type is not None:
+            return f"CAST({rendered} AS {cast_type})"
         return rendered
 
     def _assert_with_ties_supported(self) -> None:

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -7990,9 +7990,9 @@ class TestDuckDBPrinter(SimpleTestCase):
             ("bitShiftLeft_uses_operator", "bitShiftLeft(1, 3)", "(1 << 3)"),
             ("bitShiftRight_uses_operator", "bitShiftRight(16, 2)", "(16 >> 2)"),
             (
-                "JSONHas_returns_integer_like_clickhouse",
-                "JSONHas(properties, 'key')",
-                "CAST((json_extract_path(events.properties, %(hogql_val_0)s) IS NOT NULL) AS INTEGER)",
+                "JSONHas_with_dynamic_key_returns_integer_like_clickhouse",
+                "JSONHas(properties, event)",
+                "CAST((json_extract_path(events.properties, events.event) IS NOT NULL) AS INTEGER)",
             ),
             (
                 "multiplyDecimal_casts_to_decimal",
@@ -8130,6 +8130,56 @@ class TestDuckDBPrinter(SimpleTestCase):
         context = HogQLContext(team_id=self.team_id, enable_select_queries=True)
         self._expr("properties['a\"b']", context=context)
         self.assertEqual(list(context.values.values()), ['$."a\\"b"'])
+
+    @parameterized.expand(
+        [
+            (
+                "JSONExtractString_binds_quoted_path",
+                "JSONExtractString(properties, '$survey_response_0a4a5226-1a46-49fd-9348-d01b3543589b')",
+                "json_extract_string(events.properties, %(hogql_val_0)s)",
+                '$."$survey_response_0a4a5226-1a46-49fd-9348-d01b3543589b"',
+            ),
+            (
+                "JSONExtractString_collapses_nested_keys",
+                "JSONExtractString(properties, 'a', '$browser')",
+                "json_extract_string(events.properties, %(hogql_val_0)s)",
+                '$."a"."$browser"',
+            ),
+            (
+                "JSONExtractRaw_binds_quoted_path",
+                "JSONExtractRaw(properties, '$feature/flag')",
+                "json_extract(events.properties, %(hogql_val_0)s)",
+                '$."$feature/flag"',
+            ),
+            (
+                "JSONExtractInt_casts_extracted_string",
+                "JSONExtractInt(properties, '$key')",
+                "CAST(json_extract_string(events.properties, %(hogql_val_0)s) AS INTEGER)",
+                '$."$key"',
+            ),
+            (
+                "JSONHas_binds_quoted_path",
+                "JSONHas(properties, '$key')",
+                "CAST((json_extract(events.properties, %(hogql_val_0)s) IS NOT NULL) AS INTEGER)",
+                '$."$key"',
+            ),
+        ]
+    )
+    def test_json_extract_call_with_constant_key_binds_jsonpath(
+        self, _name: str, expr: str, expected_sql: str, expected_path: str
+    ) -> None:
+        # DuckDB parses the key argument of json_extract* as a JSONPath, so a bare
+        # `$`-prefixed key (most PostHog properties) fails to bind with "JSON path error".
+        context = HogQLContext(team_id=self.team_id, enable_select_queries=True)
+        self.assertEqual(self._expr(expr, context=context), expected_sql)
+        self.assertEqual(list(context.values.values()), [expected_path])
+
+    def test_json_extract_call_with_dynamic_key_keeps_inherited_form(self) -> None:
+        # A non-constant key can't be folded into a bound JSONPath at compile time.
+        self.assertEqual(
+            self._expr("JSONExtractString(properties, event)"),
+            "json_extract_path_text(events.properties, events.event)",
+        )
 
     def test_repeated_property_access_reuses_one_placeholder(self):
         # DuckDB rejects `GROUP BY <expr>` when the same JSON path is bound to a different placeholder


### PR DESCRIPTION
## Problem

Duckgres shadow queries that call `JSONExtractString(properties, '$survey_response_...')` or similar fail at runtime with `Binder Error: JSON path error`. DuckDB parses the key argument of `json_extract*` as a JSONPath, and the inherited Postgres rendering binds the bare key, which fails for any `$`-prefixed key. Most PostHog properties (`$survey_response_*`, `$feature/*`, `$ai_*`) are `$`-prefixed.

Stacked on #78552.

## Changes

- The DuckDB printer folds constant string keys of `JSONExtract*` calls into one quoted JSONPath (`$."k1"."k2"`) bound as a single value, reusing the existing property-access machinery (same placeholder dedup, so GROUP BY reuse keeps working).
- Covered calls: `JSONExtractString`/`Raw`/`ArrayRaw`/`Int`/`UInt`/`Float`/`Bool` and `JSONHas`; result casts mirror the Postgres handlers.
- Dynamic (non-constant) keys keep the inherited rendering, since they can't be folded at compile time.

## How did you test this code?

- New parameterized `TestDuckDBPrinter` cases assert both the printed SQL and the bound JSONPath value, plus a dynamic-key fallback case. They catch the interception being dropped or the path quoting regressing.
- I reproduced the bare `$`-key binder error on DuckDB 1.5.2 locally and confirmed the quoted-path forms return correct values.
- Not run: duckgres integration against a live server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code in a Conductor workspace; second layer of the duckgres shadow parity stack.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decision: only constant keys are folded; dynamic keys deliberately keep the status-quo rendering rather than failing compile.
