### PR TITLE
chore(docs): note the commit signing requirement in developing-locally

### DIFF
--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -62,6 +62,10 @@ This is the recommended option for most developers.
 
 ### Prerequisites
 
+**GitHub access.**
+Before your first push, set up an [SSH key and commit signing](https://posthog.com/handbook/engineering/security#github) using Secretive or 1Password.
+Signing is required: an org-wide ruleset rejects unsigned commits in every PostHog repository, so an unsigned push fails with `GH013: Commits must have verified signatures`.
+
 #### macOS
 
 1. Install Xcode Command Line Tools if you haven't already: `xcode-select --install`.


### PR DESCRIPTION
## Problem

A new engineer following "Developing locally" gets all the way to their first push, then fails with `GH013: Commits must have verified signatures` and no explanation.

- Commit signing is now enforced across every repository in the org by a GitHub ruleset.
- The page never mentions git identity, SSH keys, or signing.
- Its prerequisites cover Xcode Command Line Tools, Homebrew, and OrbStack, and it clones over HTTPS.

## Changes

- Add a GitHub access prerequisite before the macOS and Ubuntu split, so it applies to both.
- Link to the handbook's `#github` section, which covers SSH keys and signing together.
- Name the `GH013` error, so someone who already hit it can search their way here.

The link is an absolute `posthog.com` URL because this page renders from a different repo than the one it points at.

## How did you test this code?

Docs-only, no code path to exercise. I confirmed the `#github` anchor resolves to the `## GitHub` heading in `contents/handbook/engineering/security.md`.

Not run: the site build, which lives in the posthog.com repo.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

This is the docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this after auditing every workflow in the org for unsigned commits and fixing them, which is what surfaced the gap here. Skills invoked: `/writing-pr-descriptions`.

The companion PR is [posthog.com#19282](https://github.com/PostHog/posthog.com/pull/19282), which states the enforcement policy, documents how workflows sign commits through the GitHub API, and fixes the SDK release page. This PR only adds the prerequisite; everything else lives there.
