### PR TITLE
fix(bigquery): stop retrying a query that exceeds the on-demand pricing ratio

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -698,6 +698,12 @@ def _get_primary_keys_for_table(table: bigquery.Table, client: bigquery.Client) 
 # stay in lockstep if BigQuery ever adjusts the phrasing.
 BIGQUERY_RESOURCES_EXCEEDED_ERROR = "Resources exceeded during query execution"
 
+# Stable wording BigQuery puts in a `billingTierLimitExceeded` query failure's message, raised as a
+# 400 BadRequest from `jobs.getQueryResults` when a query's CPU-second usage relative to bytes
+# billed exceeds the ratio the on-demand pricing model allows. Shared with
+# `BigQuerySource.get_non_retryable_errors` so the two stay in lockstep.
+BIGQUERY_ON_DEMAND_RATIO_EXCEEDED_ERROR = "exceeds the ratio supported by the on-demand pricing model"
+
 
 def _is_bigquery_resource_exceeded(error: BadRequest) -> bool:
     """True for BigQuery's `resourcesExceeded` query failures.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -17,6 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.b
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
     BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_INVALID_KEY_FILE_ERROR,
+    BIGQUERY_ON_DEMAND_RATIO_EXCEEDED_ERROR,
     BIGQUERY_RESOURCES_EXCEEDED_ERROR,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryImplementation,
@@ -260,6 +261,18 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # source view. Matched on BigQuery's stable wording, not the volatile peak-usage percentage
             # or job id.
             BIGQUERY_RESOURCES_EXCEEDED_ERROR: "BigQuery couldn't run a query for this source because it exceeded the memory allowed for a single query. This is usually caused by heavy sorts or analytic (window) functions over a large table or view. Retrying won't help — please reduce how much data you're syncing (for example add row filters or an incremental field), or simplify the source view, then re-enable the source.",
+            # Raised as a 400 BadRequest from `jobs.getQueryResults` (reason `billingTierLimitExceeded`)
+            # when a query's CPU-second usage relative to the bytes it billed exceeds the ratio the
+            # on-demand pricing model allows, e.g. "Query exceeded resource limits. This query used
+            # <N> CPU seconds but would charge only <M> Analysis bytes. This exceeds the ratio
+            # supported by the on-demand pricing model.". We copy incremental / view / row-filtered
+            # reads into a temp table before reading them (`_run_destination_query_with_job_retry` in
+            # `bigquery.py`), and a CPU-heavy source view or query shape carries this ratio into that
+            # copy. It's a deterministic property of the customer's query shape and billing tier —
+            # retrying the identical query always fails identically, so it just spams error tracking.
+            # BigQuery itself tells the user to move to capacity-based pricing or reduce the workload.
+            # Matched on BigQuery's stable wording, not the volatile CPU-second/byte counts or job id.
+            BIGQUERY_ON_DEMAND_RATIO_EXCEEDED_ERROR: "BigQuery couldn't run a query for this source because it used too many CPU seconds relative to the data it billed, which exceeds the ratio the on-demand pricing model allows. Retrying won't help — please move this workload to a capacity-based pricing model, or reduce how much data you're syncing (for example add row filters or an incremental field, or simplify the source view), then re-enable the source.",
             # Raised as a 400 BadRequest from `jobs.getQueryResults` (the poll `_run_destination_query_
             # with_job_retry` / `_query_result_with_job_retry` in `bigquery.py` do while awaiting a query
             # job) when the job's result set holds a NaN in a column typed NUMERIC/BIGNUMERIC — that type

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1866,6 +1866,28 @@ def test_bigquery_resources_exceeded_is_non_retryable():
     assert all(non_retryable_errors[key] is not None for key in matching)
 
 
+def test_bigquery_on_demand_ratio_exceeded_is_non_retryable():
+    """A query whose CPU-second usage relative to billed bytes exceeds the on-demand pricing
+    model's ratio fails deterministically for the same query shape and billing tier, so retrying
+    the identical temp-table copy in `_run_destination_query_with_job_retry` always fails — it must
+    be recognised as non-retryable rather than retried on every attempt."""
+    error_msg = str(
+        BadRequest(
+            "GET https://bigquery.googleapis.com/bigquery/v2/projects/<redacted>/queries/<redacted>"
+            "?maxResults=0&location=us-central1&prettyPrint=false: Query exceeded resource limits. "
+            "This query used 553474 CPU seconds but would charge only 1031M Analysis bytes. This "
+            "exceeds the ratio supported by the on-demand pricing model, which does not have this "
+            "limit. 553474 CPU seconds were used, and this query must use less than 263900 CPU seconds."
+        )
+    )
+
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in error_msg]
+
+    assert matching, "on-demand pricing ratio failure should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
 def test_bigquery_source_declares_v2_as_default():
     # The core of this PR: v2 is a supported version and the default for new sources, while the
     # legacy label stays supported so existing pins keep resolving. Guards a revert of the default


### PR DESCRIPTION
## Problem

A BigQuery source's sync kept retrying a query forever after Google rejected it for exceeding the on-demand pricing model's CPU-to-billed-bytes ratio, instead of surfacing an actionable message. Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fd392-50fe-7621-9272-a83a845759f6

## Changes

- Add BigQuery's `exceeds the ratio supported by the on-demand pricing model` wording to `BigQuerySource.get_non_retryable_errors`, matched on the stable phrase rather than the volatile CPU-second/byte counts or job id.
- This is a deterministic property of the query shape and billing tier: retrying the same query fails identically every time, and BigQuery itself tells the user to move to capacity-based pricing or reduce the workload.
- Mirrors the existing `resourcesExceeded` (`BIGQUERY_RESOURCES_EXCEEDED_ERROR`) handling in the same file for a query that fails for a different, related reason.

## How did you test this code?

Added `test_bigquery_on_demand_ratio_exceeded_is_non_retryable`, mirroring `test_bigquery_resources_exceeded_is_non_retryable` — asserts the new error message is recognized as non-retryable. Ran the full `test_source.py` suite (42 passed) and repo-wide `mypy` (clean).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this classifier's message list.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) triaged an error-tracking webhook for a BigQuery `BadRequest` and confirmed the stack trace originates in `_run_destination_query_with_job_retry` in this source's code. Classified it as a user/upstream billing-tier limit rather than a code bug, since the message tells the customer to change pricing tier or reduce the workload. Invoked `/writing-tests` before adding the test and `/writing-pr-descriptions` before writing this body. Searched open PRs (human-authored and bot-authored) for duplicates; found none addressing this specific error.