### PR TITLE
fix(postgres): stop wrapping app-DB blips in an unrecognized exception type

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/exceptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/exceptions.py
@@ -18,18 +18,6 @@ class XminUnsupportedError(Exception):
     """
 
 
-class PostHogDatabaseConnectionError(Exception):
-    """Raised when loading sync metadata from PostHog's own database fails to connect.
-
-    This is a PostHog-side infrastructure blip (e.g. a transient DNS failure resolving our
-    database host), not a problem with the customer's Postgres. Its message intentionally
-    avoids the connection-error substrings in `PostgresSource.get_non_retryable_errors`: a
-    failure reaching our database stringifies the same as a customer misconfiguration (e.g.
-    "Name or service not known"), and must stay retryable rather than be misclassified as
-    non-retryable and stop a healthy sync.
-    """
-
-
 class ForeignServerUnreachableError(Exception):
     """Raised when a setup query touched a postgres_fdw foreign table whose foreign server failed.
 
@@ -38,7 +26,6 @@ class ForeignServerUnreachableError(Exception):
     e.g. "... failed: Connection refused". That English wording collides with the connect-time
     substrings in `PostgresSource.get_non_retryable_errors` (which target the *direct* connection to
     the customer's database), so a foreign server that's briefly down (failover, restart) would be
-    misclassified as a permanent misconfiguration and stop a healthy sync. The server-side sibling of
-    `PostHogDatabaseConnectionError`: its message intentionally avoids those substrings so a transient
-    foreign-server outage stays retryable.
+    misclassified as a permanent misconfiguration and stop a healthy sync. Its message intentionally
+    avoids those substrings so a transient foreign-server outage stays retryable.
     """

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -1,8 +1,6 @@
 import logging
 from typing import TYPE_CHECKING, Optional, cast
 
-from django.db import OperationalError as DjangoOperationalError
-
 import structlog
 from psycopg import OperationalError
 from psycopg.errors import SqlclientUnableToEstablishSqlconnection
@@ -1159,20 +1157,16 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.exceptions import (
             CDCHandledExternally,
             ForeignServerUnreachableError,
-            PostHogDatabaseConnectionError,
         )
 
         ssh_tunnel = self.make_ssh_tunnel_func(config, inputs.team_id)
 
-        # This reads sync metadata from PostHog's own database, not the customer's Postgres. A
-        # transient failure reaching our database here (e.g. a DNS blip resolving our host) raises
-        # the same "Name or service not known" wording a customer host misconfig would, which
-        # `get_non_retryable_errors` would misclassify as non-retryable and permanently stop a
-        # healthy sync. Re-raise as a retryable error whose message doesn't collide with those.
-        try:
-            schema = ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
-        except DjangoOperationalError as e:
-            raise PostHogDatabaseConnectionError("Failed to load sync metadata from PostHog's database") from e
+        # This reads sync metadata from PostHog's own database, not the customer's Postgres — a
+        # transient failure reaching it (e.g. a DNS blip resolving our host) is a plain Django
+        # `OperationalError`, which `_handle_import_error` already classifies as a self-recovering
+        # app-DB blip and keeps out of error tracking. Let it propagate as-is: wrapping it would only
+        # hide that type from the classifier and turn a benign retry into reported error-tracking noise.
+        schema = ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
         schema_metadata = schema.schema_metadata or {}
         source_schema = (
             schema_metadata.get("source_schema") if isinstance(schema_metadata.get("source_schema"), str) else None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -36,7 +36,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.exceptions import (
     ForeignServerUnreachableError,
-    PostHogDatabaseConnectionError,
     XminUnsupportedError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.partitioned_tables import (
@@ -275,14 +274,17 @@ class TestPostgresImplementationWiring:
 
 
 class TestPostgresSourceMetadataConnectionErrors:
-    def test_posthog_database_connection_failure_stays_retryable(self):
+    def test_posthog_database_connection_failure_propagates_unwrapped(self):
         # `source_for_pipeline` first reads sync metadata from PostHog's own database. A transient
-        # connection failure there (e.g. a DNS blip resolving our host) surfaces the same
-        # "Name or service not known" wording a customer host misconfig would, so it must be
-        # re-raised as PostHogDatabaseConnectionError to avoid being misclassified as non-retryable.
+        # connection failure there (e.g. a DNS blip resolving our host) must propagate as the same
+        # Django `OperationalError` it was raised as. `_handle_import_error` already classifies that
+        # type, regardless of message, as a self-recovering app-DB blip and keeps it out of error
+        # tracking — wrapping it in a source-specific exception type would hide it from that check
+        # and report it as a new bug on every occurrence instead.
         source = PostgresSource()
         config = MagicMock()
         inputs = MagicMock()
+        original_error = DjangoOperationalError("[Errno -2] Name or service not known")
 
         with (
             patch.object(PostgresSource, "make_ssh_tunnel_func", return_value=None),
@@ -290,16 +292,11 @@ class TestPostgresSourceMetadataConnectionErrors:
                 "products.warehouse_sources.backend.models.external_data_schema.ExternalDataSchema"
             ) as mock_schema_model,
         ):
-            mock_schema_model.objects.select_related.return_value.get.side_effect = DjangoOperationalError(
-                "[Errno -2] Name or service not known"
-            )
-            with pytest.raises(PostHogDatabaseConnectionError) as exc_info:
+            mock_schema_model.objects.select_related.return_value.get.side_effect = original_error
+            with pytest.raises(DjangoOperationalError) as exc_info:
                 source.source_for_pipeline(config, inputs)
 
-        non_retryable = source.get_non_retryable_errors()
-        error_msg = str(exc_info.value)
-        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
-        assert not is_non_retryable, f"A PostHog-side DB connection failure must stay retryable: {error_msg}"
+        assert exc_info.value is original_error
 
 
 class TestPostgresSourceForeignServerConnectionError:


### PR DESCRIPTION
## Problem

A Postgres sync that hits a transient blip reaching PostHog's own database gets reported to error tracking on every occurrence, even though the condition clears itself moments later.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd394-26ce-72a3-ab2d-f04f620ebc7b): `PostHogDatabaseConnectionError: Failed to load sync metadata from PostHog's database`.
- `source_for_pipeline` caught the underlying Django `OperationalError` and re-raised it as a custom `PostHogDatabaseConnectionError`, specifically so its message wouldn't collide with the connect-time substrings in `get_non_retryable_errors`.
- That wrapping backfires: `_handle_import_error` already classifies a raw `OperationalError`/`InterfaceError` as a self-recovering app-DB blip and keeps it out of error tracking, by type, before it ever reaches substring matching. Wrapping it into an unrecognized type hides it from that check, so it falls through to the generic handler, which logs it at exception level and reports it every time.
- The other SQL sources (ClickHouse, Redshift, HubSpot) don't wrap this same lookup at all — they already get the correct behavior for free.

## Changes

- `PostgresSource.source_for_pipeline` no longer catches and re-wraps the `OperationalError` from loading schema sync metadata; it now propagates unwrapped, like the other SQL sources.
- Removed the now-unused `PostHogDatabaseConnectionError` class.
- Temporal's retry behavior is unchanged: the activity still retries exactly as before, this only stops reporting an already-transient condition as an exception.

## How did you test this code?

- Updated `TestPostgresSourceMetadataConnectionErrors` to assert the original `OperationalError` instance propagates unwrapped from `source_for_pipeline`, guarding against the wrapping being reintroduced.
- Ran the updated test plus `TestPostgresSourceForeignServerConnectionError` and `TestPostgresImplementationWiring` locally: 4 passed.
- The existing `test_app_db_connection_error_reraised_as_non_reportable` in `test_import_data_sync.py` (parameterized over `OperationalError`/`InterfaceError`) already covers that `_handle_import_error` treats this type as non-reportable regardless of message, so no new test was needed there.
- `ruff check`/`ruff format --check` clean on the changed files, `uv run mypy --cache-fine-grained .` (repo-wide) reported no issues touching the changed files, `hogli ci:preflight --fix` reports 0 failures.
- Not run: the DB-backed suites in this same file (they require a live Postgres instance unavailable in this sandbox) — confirmed unrelated by inspection, since they don't touch `source_for_pipeline`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue. Confirmed the failure originates in this source's code (`source_for_pipeline` in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py`) and traced the call chain from `import_data_sync.py`'s `_handle_import_error` to find why the wrapped exception type escaped the "keep transient app-DB blips out of error tracking" classification that already exists for the raw Django exception types.

Checked for duplicates: searched open PRs (excluding the automation bot) by exception type, message text, and module path, and reviewed the data-warehouse maintainer's own open PRs — none address this wrapping.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*