### PR TITLE
fix(hogql): expand expression fields for SQL dialects

### DIFF
--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -48,7 +48,7 @@ from posthog.hogql.constants import (
 )
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
-from posthog.hogql.database.models import DateDatabaseField, StringDatabaseField
+from posthog.hogql.database.models import DateDatabaseField, ExpressionField, StringDatabaseField
 from posthog.hogql.errors import ExposedHogQLError, ImpossibleASTError, QueryError
 from posthog.hogql.escape_sql import escape_clickhouse_identifier, escape_clickhouse_string
 from posthog.hogql.hogqlx import convert_tag_to_hx
@@ -8055,6 +8055,18 @@ class TestDuckDBPrinter(SimpleTestCase):
             self._select("SELECT event FROM events"),
             "SELECT events.event FROM events LIMIT 50000",
         )
+
+    @parameterized.expand([("plain", False), ("isolate_scope", True)])
+    def test_expression_field_expands(self, _name: str, isolate_scope: bool) -> None:
+        # Virtual fields (events.person_id, warehouse created_at shims) are ExpressionFields.
+        # If the resolver skips expanding them for SQL dialects, the printer hits the raw
+        # untyped expr and fails with "Field ... has no type".
+        context = HogQLContext(team_id=self.team_id, enable_select_queries=True)
+        context.database = Database()
+        context.database.get_table("events").fields["upper_event"] = ExpressionField(
+            name="upper_event", expr=parse_expr("upper(event)"), isolate_scope=isolate_scope
+        )
+        self.assertEqual(self._expr("upper_event", context=context), "upper(events.event)")
 
     def test_identifier_no_truncation(self):
         # PG would truncate a >63-char generated alias containing double underscores into a SHA-suffixed

--- a/posthog/hogql/resolver.py
+++ b/posthog/hogql/resolver.py
@@ -2342,8 +2342,9 @@ class Resolver(CloningVisitor):
         node.type = loop_type
 
         if isinstance(node.type, ast.ExpressionFieldType):
-            # only swap out expression fields in ClickHouse
-            if self.dialect == "clickhouse":
+            # Swap out expression fields for every executable dialect; only the HogQL
+            # dialect keeps the virtual field name, since it echoes the user's query.
+            if self.dialect != "hogql":
                 new_expr = clone_expr(node.type.expr)
                 new_node: ast.Expr = ast.Alias(alias=node.type.name, expr=new_expr, hidden=True)
 

--- a/products/managed_warehouse/backend/client.py
+++ b/products/managed_warehouse/backend/client.py
@@ -70,6 +70,8 @@ def compile_hogql_to_ducklake_sql(
     ``postgres_sql``; callers must pass it to ``cursor.execute(sql, values)`` or
     the query will fail with an unbound-placeholder error.
     """
+    from posthog.schema import HogQLQueryModifiers
+
     from posthog.hogql.context import HogQLContext
     from posthog.hogql.database.database import Database
     from posthog.hogql.parser import parse_select
@@ -77,6 +79,7 @@ def compile_hogql_to_ducklake_sql(
     from posthog.hogql.variables import replace_variables
 
     from posthog.models.team.team import Team
+    from posthog.schema_enums import PersonsOnEventsMode
 
     parsed = parse_select(query.query)
     if query.variables:
@@ -87,6 +90,11 @@ def compile_hogql_to_ducklake_sql(
     database = Database.create_for(
         team_id,
         user=user,
+        # DuckLake events ducklings carry the physical person_id column and no override
+        # tables, so person_id must read the column rather than expand a person join.
+        modifiers=HogQLQueryModifiers(
+            personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_NO_OVERRIDE_PROPERTIES_ON_EVENTS
+        ),
         bypass_warehouse_access_control=bypass_warehouse_access_control,
     )
     bind_tables_to_ducklake(database, team_id)

--- a/products/managed_warehouse/backend/tests/test_client.py
+++ b/products/managed_warehouse/backend/tests/test_client.py
@@ -58,6 +58,20 @@ class TestCompileHogQLToDuckLakeSQL:
         assert "purchase" in values.values()
         assert "variables" not in postgres_sql
 
+    def test_person_id_compiles_to_physical_column(self):
+        from posthog.models import Organization, Team
+
+        org = Organization.objects.create(name="ducklake-person-id")
+        team = Team.objects.create(organization=org)
+
+        query = HogQLQuery(query="SELECT person_id FROM events LIMIT 10")
+        postgres_sql, _values, _hogql = compile_hogql_to_ducklake_sql(team.pk, query)
+
+        # DuckLake events ducklings have a physical person_id column and no override or
+        # distinct-id tables, so the compile must not emit a person join.
+        assert "person_id" in postgres_sql
+        assert "person_distinct_id" not in postgres_sql
+
 
 class TestDuckLakeModelRedirect:
     def test_materialized_model_resolves_to_ducklake_table_not_s3(self):


### PR DESCRIPTION
## Problem

Duckgres shadow materializations of any model touching `events.person_id` or a warehouse virtual column fail at compile with `Field override.distinct_id has no type` or `Field __created has no type`. This was the second-largest deterministic failure class in the shadow rollout.

The resolver only expanded `ExpressionField`s (virtual columns like `person_id` and Stripe's `created_at`) for the ClickHouse dialect, so SQL dialects handed the printer a raw untyped expression.

Stacked on #78554.

## Changes

- The resolver expands `ExpressionField`s for every executable dialect; only the `hogql` echo dialect keeps the virtual field name.
- The ducklake compile pins `personsOnEventsMode` to `person_id_no_override_properties_on_events`. The events ducklings export a physical `person_id` column ([events_backfill_to_duckling.py](https://github.com/PostHog/posthog/blob/master/posthog/dags/events_backfill_to_duckling.py)) and DuckLake has no override tables, so `person_id` must read the column rather than expand a join that cannot execute there.

## How did you test this code?

- Parameterized printer cases (plain and `isolate_scope` expression fields) catch the resolver skipping expansion for SQL dialects again.
- A compile-level test asserts `SELECT person_id FROM events` emits no `person_distinct_id` join.
- Full `posthog/hogql/printer/test/`, `test_resolver.py`, and managed_warehouse client suites run locally; repo-wide mypy clean.
- Not run: duckgres integration against a live server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Third layer of the duckgres shadow parity stack (Claude Code, Conductor workspace).
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decision: the person_id strategy reads the physical duckling column instead of expanding the override join, because the overrides table does not exist in DuckLake.
