### PR TITLE
fix(data-modeling): bind only shadow-ready models to DuckLake tables

### DIFF
--- a/products/managed_warehouse/backend/client.py
+++ b/products/managed_warehouse/backend/client.py
@@ -8,6 +8,7 @@ from psycopg import sql as psql
 from psycopg.conninfo import make_conninfo
 
 from products.managed_warehouse.backend.common import (
+    duckgres_data_modeling_table_name,
     get_duckgres_config_for_org,
     is_dev_mode,
     sanitize_ducklake_identifier,
@@ -225,7 +226,8 @@ def execute_ducklake_create_table(
     ``psycopg`` so the SELECT body is executed with safe parameter binding.
     """
     safe_schema = sanitize_ducklake_identifier(schema_name, default_prefix="shadow")
-    safe_table = sanitize_ducklake_identifier(table_name, default_prefix="model")
+    # Same resolver query binding uses, so a model always reads the table it wrote.
+    safe_table = duckgres_data_modeling_table_name(table_name)
     qualified = psql.Identifier(safe_schema, safe_table)
     conninfo = make_duckgres_conninfo(team_id, organization_id=organization_id)
     # capture previous table size before replacing — best-effort, don't block materialization

--- a/products/managed_warehouse/backend/common.py
+++ b/products/managed_warehouse/backend/common.py
@@ -562,6 +562,15 @@ def duckgres_data_modeling_schema(team_id: int) -> str:
     return f"{DATA_MODELING_DUCKGRES_SHADOW_SCHEMA_PREFIX}_{team_id}_models"
 
 
+def duckgres_data_modeling_table_name(normalized_name: str) -> str:
+    """Resolve the DuckLake table name of a shadow-materialized model.
+
+    Must match how ``execute_ducklake_create_table`` sanitizes the name it writes,
+    or query binding references a table the writer never created.
+    """
+    return sanitize_ducklake_identifier(normalized_name, default_prefix="model")
+
+
 TABLE_SUFFIX_MAX_LENGTH = 63
 # A schema name doubles as the suffix in `events_<suffix>` / `persons_<suffix>`, so it must
 # already be a safe SQL identifier — lowercase letters, numbers, and underscores. We validate

--- a/products/managed_warehouse/backend/common.py
+++ b/products/managed_warehouse/backend/common.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import re
+import hashlib
 import logging
 from datetime import date, datetime
 from typing import TYPE_CHECKING, TypedDict
@@ -493,6 +494,8 @@ def initialize_ducklake(config: dict[str, str] | None = None, *, alias: str = "d
 
 
 _IDENTIFIER_SANITIZE_RE = re.compile(r"[^0-9a-zA-Z]+")
+DUCKLAKE_IDENTIFIER_MAX_LENGTH = 63
+_TRUNCATED_NAME_DIGEST_LENGTH = 8
 
 
 def sanitize_ducklake_identifier(raw: str, *, default_prefix: str) -> str:
@@ -508,7 +511,7 @@ def sanitize_ducklake_identifier(raw: str, *, default_prefix: str) -> str:
         cleaned = default_prefix
     if cleaned[0].isdigit():
         cleaned = f"{default_prefix}_{cleaned}"
-    return cleaned[:63]
+    return cleaned[:DUCKLAKE_IDENTIFIER_MAX_LENGTH]
 
 
 def validate_duckgres_identifier(identifier: str) -> None:
@@ -565,10 +568,18 @@ def duckgres_data_modeling_schema(team_id: int) -> str:
 def duckgres_data_modeling_table_name(normalized_name: str) -> str:
     """Resolve the DuckLake table name of a shadow-materialized model.
 
-    Must match how ``execute_ducklake_create_table`` sanitizes the name it writes,
-    or query binding references a table the writer never created.
+    Both the shadow writer and query binding resolve names here, so a model always reads
+    the table it wrote. Names that fit the identifier limit are used verbatim; longer ones
+    keep a readable prefix plus a hash of the full name, because a bare truncation would
+    let two models whose names share a prefix collide onto a single table.
     """
-    return sanitize_ducklake_identifier(normalized_name, default_prefix="model")
+    sanitized = sanitize_ducklake_identifier(normalized_name, default_prefix="model")
+    if len(sanitized) < DUCKLAKE_IDENTIFIER_MAX_LENGTH:
+        return sanitized
+    # A result at the limit may or may not have lost characters, so disambiguate it too.
+    digest = hashlib.sha256(normalized_name.encode()).hexdigest()[:_TRUNCATED_NAME_DIGEST_LENGTH]
+    prefix = sanitized[: DUCKLAKE_IDENTIFIER_MAX_LENGTH - _TRUNCATED_NAME_DIGEST_LENGTH - 1].rstrip("_")
+    return f"{prefix}_{digest}"
 
 
 TABLE_SUFFIX_MAX_LENGTH = 63

--- a/products/managed_warehouse/backend/table_binding.py
+++ b/products/managed_warehouse/backend/table_binding.py
@@ -7,6 +7,7 @@ from products.managed_warehouse.backend.common import (
     duckgres_data_imports_schema,
     duckgres_data_imports_table_name,
     duckgres_data_modeling_schema,
+    duckgres_data_modeling_table_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -29,16 +30,37 @@ def bind_tables_to_ducklake(database: Any, team_id: int) -> None:
 
 
 def _bind_materialized_models(database: Any, team_id: int) -> None:
-    """Bind materialized data-modeling models to their DuckLake schema (``shadow_<team_id>_models``)."""
+    """Bind materialized data-modeling models to their DuckLake schema (``shadow_<team_id>_models``).
+
+    A model's DuckLake table only exists after at least one duckgres shadow run
+    completed (``CREATE OR REPLACE`` persists across later failures). Models without
+    one are inlined as their view definition instead, so a downstream model doesn't
+    fail with "Table ... does not exist" just because its upstream never shadowed.
+    """
     from posthog.hogql.database.direct_postgres_table import DirectPostgresTable
     from posthog.hogql.errors import ResolutionError
 
-    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+    from products.data_modeling.backend.facade.models import (
+        DataModelingJob,
+        DataModelingJobEngine,
+        DataModelingJobStatus,
+        DataWarehouseSavedQuery,
+    )
 
     schema_name = duckgres_data_modeling_schema(team_id)
-    materialized = DataWarehouseSavedQuery.objects.filter(
-        team_id=team_id, is_materialized=True, table__isnull=False
-    ).exclude(deleted=True)
+    materialized = list(
+        DataWarehouseSavedQuery.objects.filter(team_id=team_id, is_materialized=True, table__isnull=False).exclude(
+            deleted=True
+        )
+    )
+    shadowed_query_ids = set(
+        DataModelingJob.objects.filter(
+            team_id=team_id,
+            engine=DataModelingJobEngine.DUCKGRES,
+            status=DataModelingJobStatus.COMPLETED,
+            saved_query_id__in=[saved_query.id for saved_query in materialized],
+        ).values_list("saved_query_id", flat=True)
+    )
     for saved_query in materialized:
         try:
             node = database.get_table_node(saved_query.name.split("."))
@@ -48,11 +70,14 @@ def _bind_materialized_models(database: Any, team_id: int) -> None:
         existing = node.table
         if existing is None:
             continue
+        if saved_query.id not in shadowed_query_ids:
+            node.table = saved_query.hogql_definition(None)
+            continue
         node.table = DirectPostgresTable(
             name=saved_query.name,
             external_data_source_id="",
             postgres_schema=schema_name,
-            postgres_table_name=saved_query.normalized_name,
+            postgres_table_name=duckgres_data_modeling_table_name(saved_query.normalized_name),
             fields=existing.fields,
         )
 

--- a/products/managed_warehouse/backend/tests/test_client.py
+++ b/products/managed_warehouse/backend/tests/test_client.py
@@ -166,6 +166,23 @@ class TestDuckLakeModelRedirect:
         assert f"shadow_{team.pk}_models.{sanitized}" in postgres_sql
         assert f"shadow_{team.pk}_models.{saved_query.normalized_name}" not in postgres_sql
 
+    def test_long_model_names_sharing_a_prefix_get_distinct_tables(self) -> None:
+        from products.managed_warehouse.backend.common import (
+            DUCKLAKE_IDENTIFIER_MAX_LENGTH,
+            duckgres_data_modeling_table_name,
+        )
+
+        # Two models a user can both create, identical for the first 63 characters. Plain
+        # truncation would point them at one table, so materializing either would replace
+        # the other's rows.
+        shared_prefix = "a" * DUCKLAKE_IDENTIFIER_MAX_LENGTH
+        first = duckgres_data_modeling_table_name(f"{shared_prefix}_orders")
+        second = duckgres_data_modeling_table_name(f"{shared_prefix}_refunds")
+
+        assert first != second
+        assert len(first) <= DUCKLAKE_IDENTIFIER_MAX_LENGTH
+        assert len(second) <= DUCKLAKE_IDENTIFIER_MAX_LENGTH
+
     def test_source_table_resolves_to_ducklake_table_not_s3(self):
         from posthog.models import Organization, Team
 

--- a/products/managed_warehouse/backend/tests/test_client.py
+++ b/products/managed_warehouse/backend/tests/test_client.py
@@ -74,14 +74,11 @@ class TestCompileHogQLToDuckLakeSQL:
 
 
 class TestDuckLakeModelRedirect:
-    def test_materialized_model_resolves_to_ducklake_table_not_s3(self):
-        from posthog.models import Organization, Team
-
+    @staticmethod
+    def _create_materialized_model(team, name: str = "vitally_org"):
         from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
         from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
 
-        org = Organization.objects.create(name="ducklake-redirect")
-        team = Team.objects.create(organization=org)
         credential = DataWarehouseCredential.objects.create(team=team, access_key="key", access_secret="secret")
         source_table = DataWarehouseTable.objects.create(
             name="vitally_source",
@@ -91,15 +88,38 @@ class TestDuckLakeModelRedirect:
             url_pattern="https://bucket.s3.amazonaws.com/vitally/*.parquet",
             format="Parquet",
         )
-        DataWarehouseSavedQuery.objects.create(
+        return DataWarehouseSavedQuery.objects.create(
             team=team,
-            name="vitally_org",
+            name=name,
             query={"query": "SELECT org_id FROM vitally_source"},
             columns={"org_id": {"clickhouse": "String", "hogql": "StringDatabaseField"}},
             table=source_table,
             is_materialized=True,
             status=DataWarehouseSavedQuery.Status.COMPLETED,
         )
+
+    @staticmethod
+    def _create_completed_shadow_job(team, saved_query):
+        from products.data_modeling.backend.facade.models import (
+            DataModelingJob,
+            DataModelingJobEngine,
+            DataModelingJobStatus,
+        )
+
+        return DataModelingJob.objects.create(
+            team=team,
+            saved_query=saved_query,
+            engine=DataModelingJobEngine.DUCKGRES,
+            status=DataModelingJobStatus.COMPLETED,
+        )
+
+    def test_materialized_model_resolves_to_ducklake_table_not_s3(self):
+        from posthog.models import Organization, Team
+
+        org = Organization.objects.create(name="ducklake-redirect")
+        team = Team.objects.create(organization=org)
+        saved_query = self._create_materialized_model(team)
+        self._create_completed_shadow_job(team, saved_query)
 
         query = HogQLQuery(query="SELECT org_id FROM vitally_org")
         postgres_sql, _values, _hogql = compile_hogql_to_ducklake_sql(team.pk, query)
@@ -108,6 +128,43 @@ class TestDuckLakeModelRedirect:
         # ClickHouse s3() table function, which DuckDB cannot execute.
         assert "s3(" not in postgres_sql.lower()
         assert f"shadow_{team.pk}_models" in postgres_sql
+
+    def test_model_without_completed_shadow_job_inlines_its_definition(self):
+        from posthog.models import Organization, Team
+
+        org = Organization.objects.create(name="ducklake-unshadowed")
+        team = Team.objects.create(organization=org)
+        self._create_materialized_model(team)
+
+        query = HogQLQuery(query="SELECT org_id FROM vitally_org")
+        postgres_sql, _values, _hogql = compile_hogql_to_ducklake_sql(team.pk, query)
+
+        # No duckgres shadow run ever completed, so the DuckLake table does not exist.
+        # Binding it anyway would fail at runtime with "Table ... does not exist";
+        # the model's definition must be inlined as a subquery instead.
+        assert f"shadow_{team.pk}_models" not in postgres_sql
+        assert "vitally_source" in postgres_sql
+
+    def test_model_binding_matches_writer_name_sanitization(self):
+        from posthog.models import Organization, Team
+
+        from products.managed_warehouse.backend.common import duckgres_data_modeling_table_name
+
+        org = Organization.objects.create(name="ducklake-long-name")
+        team = Team.objects.create(organization=org)
+        long_name = "a_really_long_model_name_that_exceeds_the_sixty_three_character_identifier_limit"
+        saved_query = self._create_materialized_model(team, name=long_name)
+        self._create_completed_shadow_job(team, saved_query)
+
+        query = HogQLQuery(query=f"SELECT org_id FROM {long_name}")
+        postgres_sql, _values, _hogql = compile_hogql_to_ducklake_sql(team.pk, query)
+
+        # The writer truncates the DuckLake table name to 63 characters; binding the
+        # raw normalized name would reference a table the writer never created.
+        sanitized = duckgres_data_modeling_table_name(saved_query.normalized_name)
+        assert sanitized != saved_query.normalized_name
+        assert f"shadow_{team.pk}_models.{sanitized}" in postgres_sql
+        assert f"shadow_{team.pk}_models.{saved_query.normalized_name}" not in postgres_sql
 
     def test_source_table_resolves_to_ducklake_table_not_s3(self):
         from posthog.models import Organization, Team


### PR DESCRIPTION
## Problem

Duckgres shadow materializations of model-on-model queries fail with `Table with name <model> does not exist` when the upstream model's shadow never completed. The binder rewrites every ClickHouse-materialized model to its DuckLake table blindly, and shadow failures intentionally don't gate the DAG, so downstream models compile references to tables that were never created.

Separately, the writer sanitizes table names (63-char truncation, underscore stripping) while the binder used the raw normalized name, so long or underscore-prefixed model names bound to a table the writer never wrote. A broader fix for this shipped in #75290 and was reverted in #75857; this re-lands only the narrow data-modeling slice.

Stacked on #78566.

## Changes

- `_bind_materialized_models` binds a model to its DuckLake table only when a duckgres shadow job completed for it (`CREATE OR REPLACE` persists across later failures, so the table provably exists). Other models inline their view definition, the same path non-materialized models take.
- One shared `duckgres_data_modeling_table_name()` helper keeps writer sanitization and query binding in agreement.

> [!NOTE]
> After deploy, a model whose existing DuckLake table was written under a skewed name reads the new name and fails once; the next shadow run recreates the table under the shared name.

## How did you test this code?

- New tests: an un-shadowed materialized model inlines (no `shadow_<team>_models` reference), and a >63-char model name binds the same name the writer creates. Both catch the gate or the shared helper being removed.
- The existing redirect test now creates a completed shadow job, covering the bind-when-ready path.
- Not run: duckgres integration against a live server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Fourth layer of the duckgres shadow parity stack (Claude Code, Conductor workspace).
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decision: inline-fallback over hard DAG gating, so correctness never depends on shadow run history; the reverted #75290 was re-landed only for the data-modeling name helper, not its events/persons or v3-sink changes.
