### PR TITLE
fix(hogql): print tuples as named structs for DuckDB

### DIFF
--- a/posthog/hogql/printer/duckdb_functions.py
+++ b/posthog/hogql/printer/duckdb_functions.py
@@ -26,7 +26,6 @@ DUCKDB_FUNCTION_RENAMES: dict[str, str] = {
     "argMax": "arg_max",
     "argMin": "arg_min",
     "dateTrunc": "date_trunc",
-    "tuple": "row",
     "range": "range",
     # ClickHouse's JSON_VALUE takes a real JSONPath argument, which DuckDB's
     # json_extract_string accepts directly.
@@ -60,7 +59,18 @@ def _handle_group_uniq_array_if(args: list[str]) -> str:
     return f"list(DISTINCT {args[0]}) FILTER (WHERE {args[1]})"
 
 
+def _handle_tuple(args: list[str]) -> str:
+    # DuckDB cannot CREATE TABLE from an unnamed struct (row(...)), which is exactly
+    # what shadow materialization does with every query result, so name the fields.
+    fields = ", ".join(f"f{index + 1} := {arg}" for index, arg in enumerate(args))
+    return f"struct_pack({fields})"
+
+
 def _handle_tuple_element(args: list[str]) -> str:
+    # struct_extract rejects integer keys on named structs; struct_extract_at is
+    # 1-based like ClickHouse's tupleElement and works on both.
+    if args[1].isdigit():
+        return f"struct_extract_at({args[0]}, {args[1]})"
     return f"struct_extract({args[0]}, {args[1]})"
 
 
@@ -117,6 +127,7 @@ DUCKDB_FUNCTION_HANDLERS: dict[str, Callable[[list[str]], str]] = {
     "dateAdd": _handle_date_add,
     "groupUniqArray": _handle_group_uniq_array,
     "groupUniqArrayIf": _handle_group_uniq_array_if,
+    "tuple": _handle_tuple,
     "tupleElement": _handle_tuple_element,
     "multiply": _handle_multiply,
     "not": _handle_not,

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -7926,7 +7926,6 @@ class TestDuckDBPrinter(SimpleTestCase):
                 "dateTrunc('day', timestamp)",
                 "date_trunc(%(hogql_val_0)s, events.timestamp)",
             ),
-            ("tuple_renames_to_row", "tuple(event, 1)", "row(events.event, 1)"),
             ("range_is_allowed", "range(3)", "range(3)"),
             (
                 "JSON_VALUE_renames_to_json_extract_string",
@@ -7977,9 +7976,14 @@ class TestDuckDBPrinter(SimpleTestCase):
                 "list(DISTINCT events.event) FILTER (WHERE (events.event = %(hogql_val_0)s))",
             ),
             (
-                "tupleElement_uses_struct_extract",
+                "tuple_uses_named_struct_pack",
+                "tuple(event, 1)",
+                "struct_pack(f1 := events.event, f2 := 1)",
+            ),
+            (
+                "tupleElement_with_index_uses_struct_extract_at",
                 "tupleElement(tuple(1, event), 2)",
-                "struct_extract(row(1, events.event), 2)",
+                "struct_extract_at(struct_pack(f1 := 1, f2 := events.event), 2)",
             ),
             ("multiply_uses_operator", "multiply(2, 3)", "(2 * 3)"),
             ("not_uses_operator", ast.Call(name="NOT", args=[ast.Constant(value=True)]), "(NOT true)"),


### PR DESCRIPTION
## Problem

Duckgres shadow materializations of any query selecting a tuple fail. DuckDB cannot `CREATE TABLE` from an unnamed struct, so the `tuple` → `row(...)` mapping from #77879 fails with `A table cannot be created from an unnamed struct` (or `Duplicate child name "" found in column "element"` inside lists) - and shadow materialization wraps every query in `CREATE OR REPLACE TABLE ... AS`.

Stacked on #78568.

## Changes

- `tuple(a, b)` prints `struct_pack(f1 := a, f2 := b)`, which DuckDB can materialize.
- `tupleElement` with a numeric index prints `struct_extract_at`, which is 1-based like ClickHouse and accepts named structs (`struct_extract` rejects integer keys on them). String keys keep `struct_extract`.

## How did you test this code?

- Updated parameterized printer cases pin both forms; they catch a regression back to `row(...)` or `struct_extract` with integer keys.
- Both failure modes and both fixes verified against DuckDB 1.5.2 locally, including `CREATE TABLE AS` over a list of structs.
- Not run: duckgres integration against a live server.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Sixth layer of the duckgres shadow parity stack (Claude Code, Conductor workspace).
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Found while verifying the planned "Duplicate child name" fix: the bare `row()` create failure is broader than the list case the production error suggested.
