### PR TITLE
feat(data-modeling): classify transient duckgres shadow errors

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view_duckgres.py
@@ -3,8 +3,10 @@ import typing
 import datetime as dt
 import dataclasses
 
+import psycopg
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
@@ -38,6 +40,27 @@ from .utils import (
 LOGGER = get_logger(__name__)
 
 FEATURE_FLAG = "duckgres-data-modeling-shadow"
+
+TRANSIENT_DUCKGRES_ERROR_TYPE = "TransientDuckgresError"
+
+# Substrings of duckgres/control-plane infra failures. Matched case-insensitively
+# against the stringified exception; anything else is treated as a deterministic
+# query error that feeds node suspension.
+_TRANSIENT_ERROR_MARKERS = (
+    "connection",
+    "timeout",
+    "fatal:",
+    "control plane unreachable",
+    "resourceexhausted",
+    "catalog attachment",
+)
+
+
+def _is_transient_duckgres_error(error: BaseException) -> bool:
+    if isinstance(error, psycopg.OperationalError):
+        return True
+    message = str(error).lower()
+    return any(marker in message for marker in _TRANSIENT_ERROR_MARKERS)
 
 
 @dataclasses.dataclass
@@ -224,6 +247,17 @@ async def materialize_view_duckgres_activity(inputs: DuckgresShadowInputs) -> Du
         return shadow_result
     except Exception as e:
         duration = time.monotonic() - start_time
+        if _is_transient_duckgres_error(e):
+            await logger.awarning(
+                "Duckgres shadow materialization hit a transient error",
+                node_name=node.name,
+                error=str(e),
+                duration_seconds=round(duration, 2),
+            )
+            # Raise so Temporal retries. Infra failures must not finalize the job or
+            # count toward suspension; if every attempt fails, the workflow backstop
+            # marks the job FAILED and the finished metric records status "error".
+            raise ApplicationError(str(e), type=TRANSIENT_DUCKGRES_ERROR_TYPE) from e
         capture_exception(e, {"sql": sql, "inputs": inputs})
         await logger.awarning(
             "Duckgres shadow materialization failed",

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -166,8 +166,10 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     dangerously_execute_raw_sql=inputs.dangerously_execute_raw_sql,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=20),
+                # The activity only raises for transient duckgres errors (deterministic
+                # query failures return a result), so retries never repeat a doomed query.
                 retry_policy=temporalio.common.RetryPolicy(
-                    maximum_attempts=3 if inputs.duckgres_only else 1,
+                    maximum_attempts=3,
                     initial_interval=dt.timedelta(seconds=10),
                     maximum_interval=dt.timedelta(minutes=5),
                 ),

--- a/posthog/temporal/data_modeling/workflows/materialize_view.py
+++ b/posthog/temporal/data_modeling/workflows/materialize_view.py
@@ -166,6 +166,11 @@ class MaterializeViewWorkflow(PostHogWorkflow):
                     dangerously_execute_raw_sql=inputs.dangerously_execute_raw_sql,
                 ),
                 start_to_close_timeout=dt.timedelta(minutes=20),
+                # Temporal raises timeouts outside the activity, so they skip the transient
+                # classification and the duckgres suspension path never sees them. Without a
+                # total cap, a query that always times out would hold a duckgres worker for
+                # three full attempts every scheduled run.
+                schedule_to_close_timeout=dt.timedelta(minutes=25),
                 # The activity only raises for transient duckgres errors (deterministic
                 # query failures return a result), so retries never repeat a doomed query.
                 retry_policy=temporalio.common.RetryPolicy(

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -10,6 +10,7 @@ import unittest.mock
 from django.conf import settings
 from django.test import override_settings
 
+import psycopg
 import pyarrow as pa
 import deltalake
 import pyarrow.parquet as pq
@@ -1168,6 +1169,85 @@ class _EmptyArrowClient:
                 return self.body
 
         yield _Response(body)
+
+
+class TestMaterializeViewDuckgresActivity:
+    @pytest.mark.parametrize(
+        "error,expected",
+        [
+            (psycopg.OperationalError("connection failed: server unreachable"), True),
+            (Exception("FATAL: failed to create session: acquire worker: spawn sized worker"), True),
+            (Exception("duckgres control plane unreachable reading team state for team 2"), True),
+            (Exception("Function 'argMax' is not supported in the DuckDB dialect."), False),
+            (Exception("Binder Error: JSON path error near 'survey_response'"), False),
+        ],
+    )
+    def test_is_transient_duckgres_error(self, error, expected):
+        from posthog.temporal.data_modeling.activities.materialize_view_duckgres import _is_transient_duckgres_error
+
+        assert _is_transient_duckgres_error(error) is expected
+
+    async def test_transient_error_raises_for_retry_without_finalizing_job(
+        self, activity_environment, ateam, anode, asaved_query, adag
+    ):
+        from temporalio.exceptions import ApplicationError
+
+        from posthog.temporal.data_modeling.activities.materialize_view_duckgres import (
+            TRANSIENT_DUCKGRES_ERROR_TYPE,
+            DuckgresShadowInputs,
+            materialize_view_duckgres_activity,
+        )
+        from posthog.temporal.data_modeling.activities.utils import is_node_suspended
+
+        job = await _make_job(
+            ateam, asaved_query, DataModelingJob.Status.RUNNING, engine=DataModelingJobEngine.DUCKGRES
+        )
+        inputs = DuckgresShadowInputs(team_id=ateam.pk, dag_id=str(adag.id), node_id=str(anode.id), job_id=str(job.id))
+        with (
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view_duckgres._compile_hogql_to_postgres_sql",
+                return_value=("SELECT 1", {}),
+            ),
+            unittest.mock.patch(
+                "products.managed_warehouse.backend.facade.client.execute_ducklake_create_table",
+                side_effect=psycopg.OperationalError("connection failed: worker spawn timeout"),
+            ),
+        ):
+            with pytest.raises(ApplicationError) as raised:
+                await activity_environment.run(materialize_view_duckgres_activity, inputs)
+
+        # Temporal retries the raise; the job and suspension state must be untouched
+        # so an infra blip never marks the model failed or benches it.
+        assert raised.value.type == TRANSIENT_DUCKGRES_ERROR_TYPE
+        await database_sync_to_async(job.refresh_from_db)()
+        assert job.status == DataModelingJob.Status.RUNNING
+        await database_sync_to_async(anode.refresh_from_db)()
+        assert is_node_suspended(anode, DataModelingJobEngine.DUCKGRES) is False
+        await database_sync_to_async(job.delete)()
+
+    async def test_query_error_finalizes_job_failed(self, activity_environment, ateam, anode, asaved_query, adag):
+        from posthog.hogql.errors import QueryError
+
+        from posthog.temporal.data_modeling.activities.materialize_view_duckgres import (
+            DuckgresShadowInputs,
+            materialize_view_duckgres_activity,
+        )
+
+        job = await _make_job(
+            ateam, asaved_query, DataModelingJob.Status.RUNNING, engine=DataModelingJobEngine.DUCKGRES
+        )
+        inputs = DuckgresShadowInputs(team_id=ateam.pk, dag_id=str(adag.id), node_id=str(anode.id), job_id=str(job.id))
+        with unittest.mock.patch(
+            "posthog.temporal.data_modeling.activities.materialize_view_duckgres._compile_hogql_to_postgres_sql",
+            side_effect=QueryError("Function 'argMax' is not supported in the DuckDB dialect."),
+        ):
+            result = await activity_environment.run(materialize_view_duckgres_activity, inputs)
+
+        assert result.error is not None
+        assert "argMax" in result.error
+        await database_sync_to_async(job.refresh_from_db)()
+        assert job.status == DataModelingJob.Status.FAILED
+        await database_sync_to_async(job.delete)()
 
 
 class TestHogqlTableEmptyResults:

--- a/products/data_modeling/backend/management/commands/resume_duckgres_suspensions.py
+++ b/products/data_modeling/backend/management/commands/resume_duckgres_suspensions.py
@@ -1,0 +1,31 @@
+from django.core.management.base import BaseCommand
+
+from products.data_modeling.backend.logic.node_suspension import resume_nodes
+from products.data_modeling.backend.models.data_modeling_job import DataModelingJobEngine
+from products.data_modeling.backend.models.node import Node
+
+RESUMED_BY = "resume_duckgres_suspensions"
+
+
+class Command(BaseCommand):
+    help = (
+        "Clear duckgres-engine node suspensions so shadow materializations retry. "
+        "Run after a duckgres compatibility fix deploys; suspensions for other engines are untouched."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--team-id", type=int, default=None, help="Limit to one team (default: all teams)")
+        parser.add_argument("--dry-run", action="store_true", help="Only report how many nodes would be resumed")
+
+    def handle(self, *args, **options):
+        suspended_nodes = Node.objects.filter(
+            properties__system__suspended__has_key=DataModelingJobEngine.DUCKGRES.value
+        )
+        if options["team_id"] is not None:
+            suspended_nodes = suspended_nodes.filter(team_id=options["team_id"])
+        count = suspended_nodes.count()
+        if options["dry_run"]:
+            self.stdout.write(f"Would resume {count} duckgres-suspended nodes")
+            return
+        resumed = resume_nodes(suspended_nodes.iterator(), by=RESUMED_BY, engine=DataModelingJobEngine.DUCKGRES.value)
+        self.stdout.write(f"Resumed {resumed} of {count} duckgres-suspended nodes")

--- a/products/data_modeling/backend/tests/test_resume_duckgres_suspensions.py
+++ b/products/data_modeling/backend/tests/test_resume_duckgres_suspensions.py
@@ -1,0 +1,66 @@
+from io import StringIO
+
+import pytest
+
+from django.core.management import call_command
+
+from posthog.models import Organization, Team
+
+from products.data_modeling.backend.logic.node_suspension import is_node_suspended, mark_node_suspended
+from products.data_modeling.backend.models.dag import DAG
+from products.data_modeling.backend.models.data_modeling_job import DataModelingJobEngine
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_modeling.backend.models.node import Node, NodeType
+
+pytestmark = pytest.mark.django_db
+
+COMMAND = "resume_duckgres_suspensions"
+
+
+def _suspended_node(team: Team, *, engines: list[str]) -> Node:
+    dag = DAG.objects.create(team=team, name=f"dag-{team.pk}")
+    saved_query = DataWarehouseSavedQuery.objects.create(
+        team=team, name=f"model_{team.pk}", query={"query": "SELECT 1"}
+    )
+    node = Node.objects.create(
+        team=team, dag=dag, saved_query=saved_query, name=f"model-{team.pk}", type=NodeType.MAT_VIEW
+    )
+    for engine in engines:
+        mark_node_suspended(node, engine=engine, reason="boom", job_id="job-1")
+    node.save(update_fields=["properties"])
+    return node
+
+
+def _team() -> Team:
+    return Team.objects.create(organization=Organization.objects.create(name="org"), name="t")
+
+
+def test_resumes_duckgres_but_keeps_other_engines() -> None:
+    team = _team()
+    node = _suspended_node(team, engines=[DataModelingJobEngine.DUCKGRES.value, DataModelingJobEngine.CLICKHOUSE.value])
+
+    out = StringIO()
+    call_command(COMMAND, stdout=out)
+
+    node.refresh_from_db()
+    assert is_node_suspended(node, DataModelingJobEngine.DUCKGRES.value) is False
+    assert is_node_suspended(node, DataModelingJobEngine.CLICKHOUSE.value) is True
+    assert "Resumed 1 of 1" in out.getvalue()
+
+
+def test_team_scope_and_dry_run_leave_other_teams_suspended() -> None:
+    target_team, other_team = _team(), _team()
+    target_node = _suspended_node(target_team, engines=[DataModelingJobEngine.DUCKGRES.value])
+    other_node = _suspended_node(other_team, engines=[DataModelingJobEngine.DUCKGRES.value])
+
+    dry_out = StringIO()
+    call_command(COMMAND, "--dry-run", stdout=dry_out)
+    target_node.refresh_from_db()
+    assert is_node_suspended(target_node, DataModelingJobEngine.DUCKGRES.value) is True
+    assert "Would resume 2" in dry_out.getvalue()
+
+    call_command(COMMAND, "--team-id", str(target_team.pk), stdout=StringIO())
+    target_node.refresh_from_db()
+    other_node.refresh_from_db()
+    assert is_node_suspended(target_node, DataModelingJobEngine.DUCKGRES.value) is False
+    assert is_node_suspended(other_node, DataModelingJobEngine.DUCKGRES.value) is True


### PR DESCRIPTION
## Problem

Duckgres infra blips (worker spawn timeouts, concurrent-worker exhaustion, control-plane outages) count toward the 5-strike duckgres node suspension exactly like real dialect bugs, so healthy models get benched by transient failures. There is also no way to un-suspend nodes in bulk after a compatibility fix ships - suspensions clear only on a successful run, a query edit, or per-node API calls.

Stacked on #78569.

## Changes

- The shadow activity classifies errors: transient duckgres/control-plane failures raise for Temporal retry (3 attempts, was 1) instead of finalizing the job. Deterministic query failures keep the current path and remain the only suspension trigger.
- The split lands on the existing metric: transient exhaustion surfaces as `duckgres_shadow_materialization_finished{status="error"}`, deterministic failures stay `status="failed"` - so the Grafana alert can page on infra separately from query-parity work.
- New `resume_duckgres_suspensions` management command clears duckgres-engine suspensions (per team or globally, with `--dry-run`), leaving other engines untouched. Run it after each parity fix deploys.

> [!NOTE]
> Jobs FAILED by the workflow backstop after exhausted transient retries still count in the 5-strike window read from job rows. Distinguishing them fully needs an error-class column; the resume command recovers any mis-suspension.

## How did you test this code?

- Parameterized classification tests over real production error shapes catch a marker regression re-benching nodes on infra errors.
- Activity tests: a transient error raises the retryable type without finalizing the job or suspending; a query error still finalizes the job FAILED.
- Command tests: duckgres cleared while clickhouse suspension stays; team scoping and dry-run leave other teams untouched.
- Not run: a live Temporal worker retry cycle; the retry policy is an activity-options change, which does not alter recorded workflow commands.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Final layer of the duckgres shadow parity stack (Claude Code, Conductor workspace).
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions; retry-policy change checked against .claude/rules/temporal-workflow-versioning.md (options change, no new workflow commands).
- Decision: transient errors raise instead of returning results so the existing status labels separate infra from query bugs without a new metric label or schema migration.
