### PR TITLE
fix(data-imports): stop cloudflare audit_logs sync failing on deep pagination

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/settings.py
@@ -229,6 +229,12 @@ CLOUDFLARE_ENDPOINTS: dict[str, CloudflareEndpointConfig] = {
         # match SourceResponse's ascending sort mode.
         params={"direction": "asc"},
         incremental_param="since",
+        # This list has no `result_info.total_pages`, so the paginator only learns it has
+        # reached the end from a short page; when an account's true count is an exact
+        # multiple of PAGE_SIZE, the page right past the end gets a 400 rather than an
+        # empty list. Treat it like the end of the list — the next sync's `since` picks up
+        # where this one stopped.
+        extra_skip_status_codes=(400,),
     ),
     "billing_usage": CloudflareEndpointConfig(
         name="billing_usage",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
@@ -369,6 +369,29 @@ class TestAccountFanout:
 
         assert [(r["ts"], r["_account_id"]) for r in rows] == [(1, "a2")]
 
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_audit_logs_stops_on_400_past_a_full_last_page(self, MockSession) -> None:
+        # audit_logs has no result_info.total_pages, so a "short page" is the only way the
+        # paginator learns it has reached the end. When an account's true count is an exact
+        # multiple of PAGE_SIZE, the page right past the end is requested anyway, and
+        # Cloudflare answers it with a 400 instead of an empty list. The rows already fetched
+        # must survive rather than the whole sync failing.
+        session = MockSession.return_value
+        full_page = [{"id": str(i)} for i in range(PAGE_SIZE)]
+        _wire(
+            session,
+            [
+                _response([{"id": "a1"}], total_pages=1),
+                _response(full_page),
+                _error_response(400),
+            ],
+        )
+
+        rows = _rows(cloudflare_source("token", "audit_logs", team_id=1, job_id="j"))
+
+        assert len(rows) == PAGE_SIZE
+        assert {r["_account_id"] for r in rows} == {"a1"}
+
 
 class TestSinglePageEndpoints:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

A Cloudflare `audit_logs` sync fails outright once an account has accumulated
an exact multiple of 50 pending audit log entries since its last successful
sync, surfaced by an [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd3aa-d452-7111-a1fb-a83f5e535f04) (`HTTPError: 400 Client Error: Bad Request` for the audit_logs URL).

## Changes

- The `audit_logs` endpoint's response carries no `result_info.total_pages`, so the paginator only learns it reached the end from a short page.
- When the true row count is an exact multiple of the page size, the last real page is full, so the paginator requests one page past the end.
- Cloudflare answers that page with a 400 instead of an empty list, and today that fails the whole sync instead of ending it gracefully.
- Add `400` to `audit_logs`'s `extra_skip_status_codes`, so this page is treated as the end of the list — the same pattern already used for `billing_usage` and `custom_certificates`, which get a 400 instead of an empty list under similar conditions.
- The next scheduled sync picks up from the `since` watermark where this one stopped, so no rows are lost.

## How did you test this code?

Added a test to `test_cloudflare_client.py` simulating a full last page followed by a 400 on the next page: asserts the already-fetched rows are still synced instead of the whole stream erroring. Ran the full `test_cloudflare_client.py` suite (132 tests) locally, all passing.

Not run: an end-to-end Temporal sync against live Cloudflare, since this requires credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for a Cloudflare data warehouse sync failure. Used PostHog's error-tracking MCP tools to pull the full stack trace and a representative event, then read the shared REST pagination framework (`products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/`) and the Cloudflare source config to find the root cause: a page-number pagination edge case that only this endpoint's lack of `total_pages` metadata exposes. Confirmed via Cloudflare's public API docs that `audit_logs` responses omit `result_info` entirely, unlike other v4 list endpoints. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.