### PR TITLE
fix(tiktok_ads): surface app/token mismatch as a reconnect prompt

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/source.py
@@ -40,6 +40,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads
     tiktok_ads_source,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.utils import (
+    TIKTOK_APP_TOKEN_MISMATCH_MESSAGE,
     TIKTOK_AUTH_ERROR_CODES,
     TIKTOK_NON_RETRYABLE_ERROR_PREFIX,
     TIKTOK_TRANSIENT_ERROR_CODES,
@@ -153,7 +154,9 @@ class TikTokAdsSource(ResumableSource[TikTokAdsSourceConfig, TikTokAdsResumeConf
             # Transient and TikTok/network-side: map to the same actionable "try again" message.
             raise IntegrationAccountListingError(TIKTOK_TRANSIENT_ERROR_MESSAGE) from e
         except TikTokAdsAPIError as e:
-            if e.api_code in TIKTOK_AUTH_ERROR_CODES:
+            if e.api_code in TIKTOK_AUTH_ERROR_CODES or (
+                e.api_code == 40000 and TIKTOK_APP_TOKEN_MISMATCH_MESSAGE in str(e)
+            ):
                 raise IntegrationAccountListingError(
                     "TikTok rejected the credentials for this integration. Please reconnect your TikTok Ads "
                     "integration and make sure the connected account can access your advertiser accounts."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_source.py
@@ -29,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.source import TikTokAdsSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.utils import (
     TIKTOK_TRANSIENT_ERROR_MESSAGE,
+    TikTokAdsAPIError,
     TikTokAdsPaginator,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType, IncrementalFieldType
@@ -136,6 +137,44 @@ class TestTikTokAdsSource:
                 self.source.get_oauth_accounts(self.integration_id, self.team_id)
 
         assert str(exc_info.value) == TIKTOK_TRANSIENT_ERROR_MESSAGE
+
+    @parameterized.expand(
+        [
+            ("invalid_access_token", 40105, "Invalid access_token"),
+            ("no_advertiser_permission", 40110, "No permission to access this advertiser"),
+            (
+                "app_token_mismatch",
+                40000,
+                "The app_id is inconsistent with the token's app information. Please retry after correcting it.",
+            ),
+        ]
+    )
+    def test_get_oauth_accounts_maps_auth_errors_to_reconnect_message(self, name, api_code, message):
+        """Auth-rejection responses — including the app/token mismatch TikTok returns under the
+        generic 40000 code — must surface as an actionable reconnect message, not escape as a bug."""
+        _MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.source"
+        error = TikTokAdsAPIError(message, api_code=api_code)
+        with (
+            patch.object(self.source, "get_oauth_integration", return_value=self.mock_integration),
+            patch(f"{_MODULE}.list_advertisers", side_effect=error),
+        ):
+            with pytest.raises(IntegrationAccountListingError) as exc_info:
+                self.source.get_oauth_accounts(self.integration_id, self.team_id)
+
+        assert "reconnect your TikTok Ads integration" in str(exc_info.value)
+
+    def test_get_oauth_accounts_does_not_treat_other_40000_errors_as_auth(self):
+        """Code 40000 is a generic params-error bucket with many unrelated messages — only the
+        specific app/token mismatch text should map to the reconnect message; anything else must
+        keep surfacing as a bug so real request-construction errors aren't hidden."""
+        _MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.tiktok_ads.source"
+        error = TikTokAdsAPIError("Invalid parameter: advertiser_id", api_code=40000)
+        with (
+            patch.object(self.source, "get_oauth_integration", return_value=self.mock_integration),
+            patch(f"{_MODULE}.list_advertisers", side_effect=error),
+        ):
+            with pytest.raises(TikTokAdsAPIError):
+                self.source.get_oauth_accounts(self.integration_id, self.team_id)
 
     def test_get_source_config(self):
         """Test source configuration generation."""

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -27,6 +27,12 @@ logger = structlog.get_logger(__name__)
 # missing permission). Note 40100 is NOT one of them — it means "requests made too frequently".
 TIKTOK_AUTH_ERROR_CODES = {40105, 40110}
 
+# Code 40000 is TikTok's generic "params error" bucket and covers many unrelated messages, so it
+# can't be treated as auth-only by code alone. This specific message means the access token was
+# minted under a different TikTok app than the one currently configured — reconnecting to mint a
+# fresh token under the current app is the only fix; retrying with the same token cannot succeed.
+TIKTOK_APP_TOKEN_MISMATCH_MESSAGE = "app_id is inconsistent with the token's app information"
+
 # Throttling (400xx) and TikTok-side outages (5xxxx/60001) also arrive as HTTP 200 + a body `code`,
 # so no HTTP-level retry ever fires on them. Neither is our bug and neither is fixed by reconnecting:
 # the caller just has to try again shortly.


### PR DESCRIPTION
## Problem

Listing TikTok Ads advertiser accounts crashes with an unhandled error when the connected access token was issued under a different TikTok app than the one currently configured. TikTok reports this via its generic client-error code (40000) with a message naming the app/token mismatch, so it fell through the existing auth-error handling and surfaced as a bug instead of the same actionable "reconnect your integration" message other auth failures already get.

Confirmed in production error tracking: [issue 019fd3ac-31c2-76a1-81c0-bee819e58cff](https://us.posthog.com/project/2/error_tracking/019fd3ac-31c2-76a1-81c0-bee819e58cff), raised from `list_advertisers` in this source's own code.

## Changes

- `get_oauth_accounts` now also recognizes TikTok's app/token mismatch message and maps it to the existing reconnect message, alongside the already-handled 40105/40110 auth codes.
- The match is on the specific message text, not the 40000 code alone, because that code is TikTok's generic "params error" bucket and also covers unrelated request errors that should keep surfacing as bugs.

## How did you test this code?

Added 4 cases to `test_tiktok_ads_source.py`:
- 3 parameterized cases confirm the existing auth codes (40105, 40110) and the new app/token mismatch message all map to the reconnect message — this is the regression the error-tracking issue caught, and no existing test exercised this mapping.
- 1 case confirms an unrelated message under the same 40000 code still surfaces as a bug, guarding against over-broadly treating that code as auth-only.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/` (169 passed) and `uv run mypy --cache-fine-grained .` (clean) locally. Not run: a live call against TikTok's API, since this only touches error-mapping logic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing workflow or API changed, only an internal error message mapping.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking webhook for this source. Read the stack trace and confirmed it originates in `tiktok_ads/utils.py`'s `list_advertisers`, called only from the interactive `get_oauth_accounts` path (not the Temporal sync pipeline), so the fix belongs in that method's exception handling rather than in `get_non_retryable_errors`. Invoked `/writing-tests` before adding test cases and `/writing-pr-descriptions` before writing this body. Searched open PRs (human-authored and bot-authored) for an existing fix; found none.