### PR TITLE
fix(analytics): don't report org lifecycle events from the dev region

### DIFF
--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -19,10 +19,22 @@ from posthog.models.activity_logging.model_activity import is_impersonated_sessi
 from posthog.models.team import Team
 from posthog.settings import SITE_URL
 from posthog.synthetic_user import SyntheticUser
-from posthog.utils import get_instance_realm
+from posthog.utils import get_instance_realm, get_instance_region
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
+
+
+def reports_org_lifecycle() -> bool:
+    """
+    Whether this instance should report org lifecycle events (signup, deletion) to PostHog Cloud.
+
+    The hosted dev environment captures into the same production project as US and EU, and its
+    deploy smoke test signs up a throwaway user and organization on every run. Those accounts are
+    indistinguishable from real growth once they land, so they are not reported at all. Every other
+    kind of dev-env telemetry (exceptions, product usage) is unaffected.
+    """
+    return (get_instance_region() or "").upper() != "DEV"
 
 
 def report_user_signed_up(
@@ -42,7 +54,7 @@ def report_user_signed_up(
     Reports that a new user has joined. Only triggered when a new user is actually created (i.e. when an existing user
     joins a new organization, this event is **not** triggered; see `report_user_joined_organization`).
     """
-    if not user.distinct_id:
+    if not user.distinct_id or not reports_org_lifecycle():
         return
 
     props = {
@@ -511,7 +523,7 @@ def report_user_or_team_action(
 
 
 def report_organization_deleted(user: User, organization: Organization):
-    if not user.distinct_id:
+    if not user.distinct_id or not reports_org_lifecycle():
         return
     posthoganalytics.capture(
         distinct_id=user.distinct_id,
@@ -522,7 +534,7 @@ def report_organization_deleted(user: User, organization: Organization):
 
 
 def report_organization_deletion_initiated(user: User, organization: Organization):
-    if not user.distinct_id:
+    if not user.distinct_id or not reports_org_lifecycle():
         return
     posthoganalytics.capture(
         distinct_id=user.distinct_id,
@@ -537,7 +549,7 @@ def report_organization_deletion_completed(user_id: int, organization_id: str) -
     from posthog.ph_client import ph_scoped_capture
 
     user = UserModel.objects.filter(id=user_id).first()
-    if not user or not user.distinct_id:
+    if not user or not user.distinct_id or not reports_org_lifecycle():
         return
     with ph_scoped_capture() as capture_ph_event:
         capture_ph_event(

--- a/posthog/test/test_event_usage.py
+++ b/posthog/test/test_event_usage.py
@@ -4,6 +4,8 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 from rest_framework.test import APIRequestFactory
 
@@ -13,7 +15,11 @@ from posthog.event_usage import (
     get_event_source,
     get_mcp_properties,
     is_wizard_self_driving_program,
+    report_organization_deleted,
+    report_organization_deletion_initiated,
     report_user_action,
+    report_user_signed_up,
+    reports_org_lifecycle,
     sanitize_header_value,
 )
 
@@ -441,3 +447,39 @@ class TestSanitizeHeaderValue(BaseTest):
     )
     def test_sanitize_header_value(self, _name, input_value, expected):
         assert sanitize_header_value(input_value) == expected
+
+
+class TestReportsOrgLifecycle(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("us", "US", True),
+            ("eu", "EU", True),
+            ("dev", "DEV", False),
+            ("dev_lowercase", "dev", False),
+            ("self_hosted", None, True),
+        ]
+    )
+    def test_reports_org_lifecycle_by_region(self, _name, region, expected):
+        with self.settings(CLOUD_DEPLOYMENT=region):
+            assert reports_org_lifecycle() is expected
+
+
+class TestOrgLifecycleReporting(BaseTest):
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_signup_is_not_reported_from_the_dev_region(self, mock_capture):
+        with self.settings(CLOUD_DEPLOYMENT="DEV"):
+            report_user_signed_up(self.user, is_instance_first_user=True, is_organization_first_user=True)
+        mock_capture.assert_not_called()
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_signup_is_reported_from_a_production_region(self, mock_capture):
+        with self.settings(CLOUD_DEPLOYMENT="US"):
+            report_user_signed_up(self.user, is_instance_first_user=True, is_organization_first_user=True)
+        assert mock_capture.call_args.kwargs["event"] == "user signed up"
+
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_org_deletion_is_not_reported_from_the_dev_region(self, mock_capture):
+        with self.settings(CLOUD_DEPLOYMENT="DEV"):
+            report_organization_deleted(self.user, self.organization)
+            report_organization_deletion_initiated(self.user, self.organization)
+        mock_capture.assert_not_called()


### PR DESCRIPTION
## Problem

Anyone reading PostHog Cloud organization signup numbers sees inflated growth, because the hosted dev environment's throwaway accounts count as real signups.

- The dev environment captures into the same production project as US and EU. `posthog/apps.py` sets the production API key unconditionally, capture is only disabled for `TEST`, `DEBUG`, and E2E, and `is_cloud()` in `posthog/cloud_utils.py` includes `DEV`.
- Its deploy smoke test creates one new user and one new organization per run, several times an hour.
- Each run is a fresh org, so `is_organization_first_user` is true.
- `EMAIL_VERIFICATION_SKIP_FOR_DOMAINS` creates the smoke-test user already verified, so `is_email_verified` is true too.
- Every org signup metric in the project is affected, not one insight. The `region` super property is the only thing marking these events.

## Changes

- `reports_org_lifecycle()` returns false when the instance region is `DEV`.
- The signup and organization deletion reporters return early on it, so the dev environment emits no org lifecycle events.
- Other dev-environment telemetry still reports. Disabling capture wholesale in `apps.py` was the obvious alternative, but it would also drop exception and product-usage capture that people rely on.
- Self-hosted instances leave `CLOUD_DEPLOYMENT` unset and keep reporting.

> [!NOTE]
> This only stops new events. Already-captured history still needs a filter on the `region` property to be excluded from existing insights.

## How did you test this code?

- Added `TestReportsOrgLifecycle`, a no-DB `SimpleTestCase` over the region gate. It catches a regression where the check stops being case-insensitive, or starts reading an unset `CLOUD_DEPLOYMENT` as dev and silences signup reporting on every self-hosted instance. I ran it: 5 passed.
- Added three DB-backed cases asserting that `DEV` captures nothing and `US` still captures `user signed up`. They catch a reporter losing the guard. Not run — this sandbox has no Postgres, so CI is the first place they execute.
- `ruff format` and `ruff check` pass. I did not run `hogli ci:preflight` (no `node_modules` here) or mypy.
- No manual testing against a running instance.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) wrote this after tracing an anomaly in cloud signup numbers back to the dev environment's smoke test. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

Two decisions worth flagging for review. I gated on the instance region rather than on the smoke-test email domain, so a future dev-env job that signs up does not leak the same way. And I scoped the gate to org lifecycle events rather than all capture, which keeps the blast radius small but leaves other dev-env events flowing into the production project.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BMKTE4NG5/p1785963160981569)*
