### PR TITLE
fix(postgres): stop CDC retrying an unreachable SSH gateway forever

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/errors.py
@@ -27,6 +27,7 @@ class CDCErrorCategory(enum.StrEnum):
     SSL_REQUIRED = "ssl_required"
     CONNECTION_FAILED = "connection_failed"
     HOST_UNREACHABLE = "host_unreachable"
+    SSH_TUNNEL_FAILED = "ssh_tunnel_failed"
     SLOT_MISSING = "slot_missing"
     SLOT_NOT_CONFIGURED = "slot_not_configured"
     PUBLICATION_MISSING = "publication_missing"
@@ -97,6 +98,13 @@ _CATEGORY_DEFAULTS: dict[CDCErrorCategory, tuple[str, bool]] = {
         "that the host and port are correct and reachable from the public internet (PostHog's IP "
         "addresses allowed through, and the host not resolving to a private or unreachable "
         "address), then re-enable change data capture.",
+        False,
+    ),
+    CDCErrorCategory.SSH_TUNNEL_FAILED: (
+        "Could not connect to your SSH tunnel — PostHog couldn't open a session to the SSH gateway. "
+        "Check that the SSH host and port point to a reachable SSH server (not the database port), "
+        "that the bastion is running, and that PostHog's IP addresses are allowed through its "
+        "firewall, then re-enable change data capture.",
         False,
     ),
     CDCErrorCategory.SLOT_MISSING: (

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/errors.py
@@ -12,6 +12,7 @@ import struct
 
 import psycopg
 import psycopg.errors
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import CDCErrorCategory
 
@@ -39,6 +40,13 @@ _HOST_UNREACHABLE_MARKERS = (
     "no route to host",
 )
 
+# sshtunnel raises BaseSSHTunnelForwarderError("Could not establish session to SSH gateway") when it
+# can't open a session to the bastion — the SSH host/port is wrong or unreachable, the bastion is
+# down, or its firewall blocks PostHog's IPs. Deterministic for the configured tunnel, so it's
+# non-retryable. Mirrors the non-retryable treatment on the batch path
+# (PostgresSource.get_non_retryable_errors's `_SSH_GATEWAY_SESSION_ERROR` entry).
+_SSH_GATEWAY_SESSION_ERROR_MARKER = "could not establish session to ssh gateway"
+
 
 def classify_postgres_cdc_error(exc: BaseException) -> CDCErrorCategory | None:
     """Classify a single Postgres exception into a ``CDCErrorCategory``.
@@ -49,6 +57,12 @@ def classify_postgres_cdc_error(exc: BaseException) -> CDCErrorCategory | None:
     # struct.error => the pgoutput binary stream couldn't be unpacked.
     if isinstance(exc, struct.error):
         return CDCErrorCategory.WAL_DECODE_ERROR
+
+    # sshtunnel's own exception, not a psycopg one — must be checked before the psycopg guard below.
+    if isinstance(exc, BaseSSHTunnelForwarderError):
+        if _SSH_GATEWAY_SESSION_ERROR_MARKER in str(exc).lower():
+            return CDCErrorCategory.SSH_TUNNEL_FAILED
+        return None
 
     # Guard all string-based checks: only psycopg exceptions carry these message patterns.
     # A non-psycopg exception whose message happens to contain e.g. "does not exist" would

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_errors.py
@@ -2,6 +2,7 @@ import struct
 
 import psycopg.errors
 from parameterized import parameterized
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import CDCErrorCategory
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.errors import (
@@ -73,6 +74,16 @@ class TestClassifyPostgresCDCError:
                 "wal_decode_struct_error",
                 struct.error("unpack requires a buffer of 4 bytes"),
                 CDCErrorCategory.WAL_DECODE_ERROR,
+            ),
+            (
+                "ssh_gateway_session_failure_is_non_retryable",
+                BaseSSHTunnelForwarderError("Could not establish session to SSH gateway"),
+                CDCErrorCategory.SSH_TUNNEL_FAILED,
+            ),
+            (
+                "unrecognized_ssh_tunnel_error_falls_back_to_unknown",
+                BaseSSHTunnelForwarderError("Some other sshtunnel failure"),
+                None,
             ),
             (
                 "unrelated_runtime_error",


### PR DESCRIPTION
## Problem

A change data capture (CDC) sync on a Postgres source behind an SSH tunnel fails identically on every scheduled tick when the SSH gateway can't be reached, instead of pausing with a clear, actionable error.

- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd3ba-47d7-7520-af3a-ac56ad6850b2): `BaseSSHTunnelForwarderError: Could not establish session to SSH gateway`, raised from `PgCDCStreamReader.connect`.
- `sshtunnel` raises this exact message when it can't open a session to the bastion: the SSH host or port is wrong, the bastion is down, or a firewall blocks PostHog's IPs. It's deterministic for the configured tunnel.
- The regular (non-CDC) Postgres sync path already classifies this message as non-retryable. The CDC extraction path uses a separate classifier (`classify_postgres_cdc_error`) that never checked for it, so it fell through to a generic `unknown`/retryable category.
- Because CDC's extraction workflow re-runs on a schedule, an unreachable gateway kept failing the same way on every tick instead of pausing the schedule with a friendly message.

## Changes

- Added a `SSH_TUNNEL_FAILED` category to the shared CDC error taxonomy (`cdc/errors.py`), non-retryable, with a friendly message mirroring the wording already used on the non-CDC path.
- `classify_postgres_cdc_error` now recognizes `BaseSSHTunnelForwarderError` carrying this message and maps it to the new category; any other `BaseSSHTunnelForwarderError` message still falls through to the generic classifier, so this doesn't widen non-retryable handling beyond the one deterministic case.

## How did you test this code?

- Added two cases to `TestClassifyPostgresCDCError`: the SSH gateway session failure classifies as `SSH_TUNNEL_FAILED`, and an unrelated `BaseSSHTunnelForwarderError` message still falls back to unclassified (guards against over-widening). Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_errors.py` (17 passed).
- Also ran the broader `cdc/tests` and `sources/postgres/cdc/tests` suites locally; all in-memory cases passed. The DB-backed cases in `test_extract_activity.py` errored on connecting to Postgres, unrelated to this change (no local Postgres available in this environment) — not run.
- Ran `ruff check`/`ruff format --check` and `mypy` on the changed files: clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, full stack trace, code variables) to confirm the failure genuinely originates in the Postgres CDC source's `connect()` path, then traced the classification gap between the batch-sync and CDC error-handling layers. No skills were invoked beyond `/writing-tests` and `/writing-pr-descriptions`. Searched for duplicate open PRs (human-authored, and the maintainer's own) before opening this one; found none addressing this issue.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*