### PR TITLE
fix(bigquery): recognize a renamed/dropped column as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -281,6 +281,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # user must fix the view or table definition. Matched on BigQuery's stable wording, not
             # the volatile column name or [row:col] location.
             "is ambiguous": "BigQuery couldn't run a query for this source because a column name in the table or view being synced is ambiguous. This usually happens when a view joins tables that share a column name, or two columns differ only by letter case. Retrying won't help — please update the view or table definition to remove the naming conflict (for example by aliasing the duplicate column), then reconnect the source.",
+            # Raised as a 400 BadRequest (reason `invalidQuery`) when a query we build references a
+            # column that no longer exists on the table, e.g. "Unrecognized name: ingested_at at
+            # [1:37]". We only reference columns the customer configured — the incremental field, an
+            # enabled column, or a row filter — so this means that column was renamed or dropped from
+            # the source table after the source (or its incremental field) was set up. It's a
+            # deterministic mismatch between our stored config and the customer's live schema: the
+            # same query fails identically on every retry. The user must update the source's column
+            # selection or incremental field to match the table's current schema. Matched on
+            # BigQuery's stable wording, not the volatile column name or [row:col] location.
+            "Unrecognized name:": "BigQuery couldn't run a query for this source because it referenced a column that no longer exists on the table — usually the configured incremental field, or a column selected for syncing, was renamed or removed. Retrying won't help — please update the source's column selection or incremental field to match the table's current schema, then reconnect the source.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -756,6 +756,27 @@ def test_bigquery_ambiguous_column_is_non_retryable(observed_error):
 
 
 @pytest.mark.parametrize(
+    "observed_error",
+    [
+        # Incremental field (or an enabled column) renamed/dropped from the source table.
+        "400 Unrecognized name: ingested_at at [1:37]; reason: invalidQuery, location: query, "
+        "message: Unrecognized name: ingested_at at [1:37]\n\nLocation: europe-north1\nJob ID: "
+        "f50c015b-4295-4b95-a361-2503e9c936f7\n",
+        # Different column name and location — the match must not rely on either.
+        "400 Unrecognized name: legacy_status at [2:10]; reason: invalidQuery, location: query, "
+        "message: Unrecognized name: legacy_status at [2:10]",
+    ],
+)
+def test_bigquery_unrecognized_column_name_is_non_retryable(observed_error):
+    """A column referenced by our query (the incremental field, an enabled column, or a row
+    filter) that was renamed or dropped from the source table makes every retry fail identically."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in observed_error]
+    assert matching, "Unrecognized column name error should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
     "transient_error",
     [
         # A token refresh that failed for a transient reason must stay retryable.


### PR DESCRIPTION
## Problem

A BigQuery sync using an incremental field, an enabled column, or a row filter on a column that gets renamed or dropped from the source table fails and keeps retrying forever, generating repeated error-tracking noise instead of an actionable stop.

BigQuery raises this as a `BadRequest` (reason `invalidQuery`), e.g. "Unrecognized name: ingested_at at [1:37]" — see [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd3cf-1211-7a33-9d90-c2bb051b5900). The stack traces into `bigquery.py`'s `get_rows` → `_run_destination_query_with_job_retry`, which copies the incremental query into a temp table before reading it.

## Changes

- Add BigQuery's stable "Unrecognized name:" wording to `BigQuerySource.get_non_retryable_errors`, mirroring the existing "is ambiguous" entry for the same class of query-shape error (a deterministic mismatch between the source's stored config and the table's live schema — retrying the same query always fails identically).
- The column name and `[row:col]` location in the raw message are volatile, so the match is on BigQuery's stable prefix only, not the specific column.

## How did you test this code?

Added 2 parameterized cases to `test_bigquery_unrecognized_column_name_is_non_retryable` in `test_source.py`, mirroring the existing ambiguous-column test — guards that this error is classified non-retryable regardless of the specific column name or `[row:col]` location. Ran the full `test_source.py` suite (163 passed) and `ruff check`/`ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing config or workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue delivered by webhook. Used Claude Code with the PostHog MCP's error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue and pull the full stack trace, then read `bigquery.py`/`source.py`/`projection.py` to trace the failing query back to a user-configured column (incremental field / enabled column / row filter) no longer present on the live table. No repo skills matched this narrow fix beyond `/writing-tests` and `/writing-pr-descriptions`, both invoked before writing the test and this body.