### PR TITLE
chore(agents): cover committed code in the public-artifact rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,6 +45,7 @@
 
 <!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
      - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
+     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
 -->
 
 <!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
@@ -55,7 +56,7 @@
      Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
      This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
      Don't duplicate info already present in preceding sections.
-     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
+     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
 -->
 
 <!-- Overall PR authoring rules for agents:

--- a/.github/scripts/check-fixture-provenance.sh
+++ b/.github/scripts/check-fixture-provenance.sh
@@ -16,9 +16,17 @@
 # Re-run that measurement before loosening anything below.
 set -euo pipefail
 
-# A content-bearing key holding a substantial string, or a message constructor
-# wrapping one. Short values ("role": "human", "text": []) are structure, not prose.
-readonly PATTERN='^\+.*("(content|message|body|text|prompt)"[[:space:]]*:[[:space:]]*"[^"]{25,}|(Human|Assistant|User|System)Message\([^)]*"[^"]{25,})'
+# A content-bearing key holding a substantial string, in the four shapes fixtures
+# use here: a message dict, a message constructor, a Python keyword argument, and
+# the multiline `body=(` concatenation that ticket fixtures are written in.
+# Short values ("role": "human", "text": []) are structure, not prose.
+#
+# The keyword-argument arm covers `content` and `body` only, deliberately. Those
+# name what a person said or wrote. `prompt` and `text` name what we send a model,
+# and including them fires on roughly one in eight eval edits, which trains the
+# warning out. Measured: `content|body` fires on 3 of 265 files, adding all five
+# keys fires on 35.
+readonly PATTERN='^\+.*("(content|message|body|text|prompt)"[[:space:]]*:[[:space:]]*"[^"]{25,}|(Human|Assistant|User|System)Message\([^)]*"[^"]{25,}|(body|content)[[:space:]]*=[[:space:]]*(\(|"""|"[^"]{25,}))'
 readonly THRESHOLD=2
 
 [ $# -gt 0 ] || exit 0

--- a/.github/scripts/check-fixture-provenance.sh
+++ b/.github/scripts/check-fixture-provenance.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Warns when a commit adds a batch of new conversation-shaped case data to an eval
+# or fixture file. That is the moment fixture provenance matters: sample data that
+# reads like a real support conversation is either invented, or it is a customer's
+# words on a public repo.
+#
+# Warning only, never blocks — "was this text derived from a real conversation" is
+# not mechanically decidable. The job here is to make a reviewer look at the diff.
+#
+# Calibrated per file, which is how lint-staged invokes this. Against the 60 most
+# recent commits touching eval/fixture paths, 265 matched files had 3 files with
+# any hit at all (1, 3, and 13), so the threshold below is 2 rather than 1: two
+# conversation-shaped strings in one file is meaningfully more than one stray
+# "message" field, and dropping from 3 to 2 costs nothing measured. The incident
+# this was built from scores 34 in a single file, well clear of the threshold.
+# Re-run that measurement before loosening anything below.
+set -euo pipefail
+
+# A content-bearing key holding a substantial string, or a message constructor
+# wrapping one. Short values ("role": "human", "text": []) are structure, not prose.
+readonly PATTERN='^\+.*("(content|message|body|text|prompt)"[[:space:]]*:[[:space:]]*"[^"]{25,}|(Human|Assistant|User|System)Message\([^)]*"[^"]{25,})'
+readonly THRESHOLD=2
+
+[ $# -gt 0 ] || exit 0
+
+hits=$(git diff --cached -U0 -- "$@" | grep -cE "$PATTERN" || true)
+[ "$hits" -ge "$THRESHOLD" ] || exit 0
+
+printf '\n\033[33mWarning: this commit adds %s blocks of conversation-shaped case data.\n\n' "$hits" >&2
+printf 'If any of it came from a real conversation, ticket, or log, it does not belong in a\n' >&2
+printf 'public repo — and renaming the people, hosts, and identifiers does not clear it. The\n' >&2
+printf 'prose, typos, error IDs, and order of events are still the customer'"'"'s.\n\n' >&2
+printf 'Write sample data by listing the properties a case has to exercise, then writing the\n' >&2
+printf 'case from that list with the real material closed. Do not claim "written fresh" in a\n' >&2
+printf 'commit message unless that is what you did.\n\n' >&2
+printf 'See ee/hogai/eval/AGENTS.md and AGENTS.md "Public open source repo guidance".\033[0m\n\n' >&2

--- a/.github/scripts/check-fixture-provenance.sh
+++ b/.github/scripts/check-fixture-provenance.sh
@@ -7,13 +7,15 @@
 # Warning only, never blocks — "was this text derived from a real conversation" is
 # not mechanically decidable. The job here is to make a reviewer look at the diff.
 #
-# Calibrated per file, which is how lint-staged invokes this. Against the 60 most
-# recent commits touching eval/fixture paths, 265 matched files had 3 files with
-# any hit at all (1, 3, and 13), so the threshold below is 2 rather than 1: two
-# conversation-shaped strings in one file is meaningfully more than one stray
-# "message" field, and dropping from 3 to 2 costs nothing measured. The incident
-# this was built from scores 34 in a single file, well clear of the threshold.
-# Re-run that measurement before loosening anything below.
+# Called from .husky/pre-commit rather than as a lint-staged task. lint-staged hides
+# the output of a task that succeeds unless it runs with --verbose, so a
+# warning-only task there prints nothing at exactly the moment it fires.
+#
+# Counted per file, and the threshold applies per file: two separate fixtures with
+# one match each are not the pattern this looks for. Calibrated against the 60 most
+# recent commits touching eval/fixture paths — of 265 matched files, 3 had any hit
+# at all — so the threshold is 2 rather than 1, and the incident this was built
+# from scores 34 in a single file. Re-run that measurement before loosening it.
 set -euo pipefail
 
 # A content-bearing key holding a substantial string, in the four shapes fixtures
@@ -28,13 +30,33 @@ set -euo pipefail
 # keys fires on 35.
 readonly PATTERN='^\+.*("(content|message|body|text|prompt)"[[:space:]]*:[[:space:]]*"[^"]{25,}|(Human|Assistant|User|System)Message\([^)]*"[^"]{25,}|(body|content)[[:space:]]*=[[:space:]]*(\(|"""|"[^"]{25,}))'
 readonly THRESHOLD=2
+readonly PATHS='(^|/)(eval|evals|fixtures)/.*\.(py|json|jsonl|md)$'
 
-[ $# -gt 0 ] || exit 0
+# The files named, or every staged eval/fixture file when called with none.
+if [ $# -gt 0 ]; then
+    candidates=$(printf '%s\n' "$@" | grep -E "$PATHS" || true)
+else
+    candidates=$(git diff --cached --name-only --diff-filter=ACM | grep -E "$PATHS" || true)
+fi
+[ -n "$candidates" ] || exit 0
 
-hits=$(git diff --cached -U0 -- "$@" | grep -cE "$PATTERN" || true)
-[ "$hits" -ge "$THRESHOLD" ] || exit 0
+flagged=""
+# Heredoc rather than a pipe: a piped `while` runs in a subshell in some shells,
+# which would discard everything appended to `flagged`.
+while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    hits=$(git diff --cached -U0 -- "$file" | grep -cE "$PATTERN" || true)
+    [ "$hits" -ge "$THRESHOLD" ] || continue
+    flagged="$flagged  $file ($hits)
+"
+done <<EOF
+$candidates
+EOF
 
-printf '\n\033[33mWarning: this commit adds %s blocks of conversation-shaped case data.\n\n' "$hits" >&2
+[ -n "$flagged" ] || exit 0
+
+printf '\n\033[33mWarning: these files gain conversation-shaped case data in this commit.\n\n' >&2
+printf '%s\n' "$flagged" >&2
 printf 'If any of it came from a real conversation, ticket, or log, it does not belong in a\n' >&2
 printf 'public repo — and renaming the people, hosts, and identifiers does not clear it. The\n' >&2
 printf 'prose, typos, error IDs, and order of events are still the customer'"'"'s.\n\n' >&2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -20,6 +20,13 @@ fi
 # commands -- skip telemetry so the dashboard reflects intentional usage only.
 export POSTHOG_TELEMETRY_OPT_OUT=1
 
+# Fixture-provenance warning. Runs here rather than as a lint-staged task because
+# lint-staged prints nothing for a task that succeeds, and this one always does.
+# Never blocks: the question it raises is not one a script can answer.
+if [ -x .github/scripts/check-fixture-provenance.sh ]; then
+    .github/scripts/check-fixture-provenance.sh || true
+fi
+
 # Activate Flox environment if available and not already active
 # This ensures lint-staged commands work in GUI Git clients (GitHub Desktop, etc.)
 if command -v flox > /dev/null 2>&1 && [ -d ".flox/cache" ] && [ -z "$FLOX_ENV" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,12 @@ NEVER share sensitive information in a PR description. Users may share sensitive
 Once a branch already has an open PR, push incremental changes and fixes to it without waiting for human guidance — keeping the PR current is part of the work.
 Pushes still trigger CI, which burns runner credits, so batch related commits and push once the increment is ready rather than after every change.
 
+A push to this repository cannot be taken back.
+Forks, clones, mirrors, and notification emails carry it within seconds, and a later fix commit does not retract what is already in the branch's history — recovering means abandoning the branch and respinning the PR.
+That makes the first push of a branch the decision point, not a step you correct afterwards.
+So if any part of the work drew on something from your session rather than from this repository — a customer conversation, a support ticket, a log, an internal thread — check what is actually in the diff before that first push.
+See [Public open source repo guidance](#public-open-source-repo-guidance) for what has to clear the bar.
+
 #### Forcing the full CI matrix on a draft
 
 Draft PRs run a narrowed matrix.
@@ -131,9 +137,13 @@ Never run `gh pr merge` or click the GitHub merge button — both are blocked by
 
 ### Public open source repo guidance
 
-This repository is public and all commit messages, pull request titles, and pull request descriptions must be safe for public readers.
+This repository is public, and everything you push is public with it: source, tests, fixtures and sample data, comments and docstrings, branch names, commit messages, PR titles, descriptions, and comments, and uploaded screenshots.
+Anything you were given as context that is not already in this repository — a customer conversation, a support ticket, a log, an internal thread — has to clear that bar before any of it reaches a file, a message, or a description.
 
 - Never mention internal-only systems, private incidents, customer data, Slack thread contents, unreleased roadmap details, or security-sensitive implementation details. Slack thread links and channel references are fine to include — they sit behind PostHog auth and are useful as origin context — but do not quote or paraphrase what was said in the thread.
+- **Derived is not synthetic.** Swapping out names, domains, and identifiers does not make real customer material publishable. The prose, the typos, the error IDs, and the order of events are still theirs, and still disclose what they told us. If you started from real material and edited it, it is derived, however much you changed.
+- **Sample data that has to read like the real thing gets invented, not transcribed.** List the properties a case must exercise, then write the case from that list with the real material closed. Use reserved domains (`example.com`), invented identifiers, and obviously fake tokens — customers paste credentials and cookies into support chats, and those must not survive the trip even in fragments.
+- **Do not claim a provenance you have not checked.** "Written fresh" in a commit message is a factual claim a reviewer will rely on. If you are unsure, compare your text against the source: any shared run of ~40 characters or more means derived, not fresh.
 - Use product-facing and code-facing context that a public OSS contributor could understand from this repository alone.
 - If context is sensitive, summarize it at a high level without naming internal tools, accounts, or people.
 - Avoid citing private operational scale or incident metrics (for example, exact affected team counts, internal row-volume anecdotes, or customer-specific performance numbers) unless that data is already public and linkable.
@@ -142,9 +152,11 @@ Examples:
 
 - ✅ `fix(insights): handle missing series color in trend export`
 - ✅ A PR description that links to the originating Slack thread for context
+- ✅ A test fixture written from a list of the properties it has to exercise, with the real conversation closed
 - ❌ `fix: patch issue found in acme-co prod workspace after sales escalation` — references internal customer
 - ❌ `fix: will run fine on our 12 million rows there now` — leaks private operational scale
 - ❌ A PR description that quotes verbatim what a coworker said in a Slack thread
+- ❌ A test fixture adapted from a real support conversation with the names and domains replaced
 
 ## CI / GitHub Actions
 
@@ -247,6 +259,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/sending-notifications` — adding notification support
 - `/writing-skills` — creating or updating skills in `.agents/skills/`
 - `/writing-evals` — adding or changing eval suites, cases, scorers, or seeders under `products/posthog_ai/evals/` or `products/*/evals/`, touching the harness in `products/posthog_ai/eval_harness/`, or running those evals
+- [`ee/hogai/eval/AGENTS.md`](ee/hogai/eval/AGENTS.md) — writing eval cases or fixture data by hand anywhere (not a skill, and not covered by `/writing-evals`): where that data may come from, and why anonymizing a real conversation does not make it publishable
 - `/authoring-ci-workflows` — adding or editing any `.github/workflows` workflow, composite action, or reusable workflow
 - `/reviewing-personhog-protocol` — any personhog coordination-protocol change (leases, fencing, handoffs, supervisors, budgets, warming, changelog semantics), and any request for an exhaustive review of personhog code
 - `/gating-production-deploys` — any workflow that builds and pushes a production image or dispatches a deploy

--- a/ee/hogai/eval/AGENTS.md
+++ b/ee/hogai/eval/AGENTS.md
@@ -1,0 +1,44 @@
+# Eval case data
+
+Cases in this tree are committed to a public repository and are read by anyone.
+Most CI evals run against the seeded Hedgebox project (the `demo_org_team_user` fixture in `ci/conftest.py`), and for those the case data is already synthetic.
+Some evals supply their own case data inline instead — `ci/eval_ticket_summary.py` passes conversation transcripts straight into `EvalCase(input=...)`, because it evaluates a prompt rather than a query against a team.
+
+This page is about that second kind.
+When you write case data by hand, you are the only thing standing between a real conversation and a public repository.
+
+## Write cases from a properties list, not from the source
+
+Evals of support-facing features need cases that behave like real conversations, and you will often have a real one in front of you.
+Do not edit it into shape.
+Adapting real material and writing a fresh case are indistinguishable once you are partway through, and the result reads as synthetic while carrying somebody's actual words.
+
+Work in this order instead:
+
+1. Read the real material and write down only the **properties** a case has to exercise — a misspelling inside a quotable span, one word spelled two ways so a spliced quote can be caught, a mid-conversation topic change, an earlier summary sitting in the transcript, non-English text, a bare command with nothing to summarize.
+2. Close the real material.
+3. Write the cases from the properties list.
+
+The list is the deliverable of step 1. If you skip writing it down, you will end up paraphrasing instead.
+
+## Everything identifying is invented
+
+Hostnames, emails, person and company names, IDs, cookies, and tokens in a case are made up, not anonymized versions of real ones.
+Use reserved domains (`example.com`, `example.org` — RFC 2606) and obviously fake token values.
+
+Customers paste credentials into support chats. A real cookie or a fragment of a real auth token has no business here even when it is expired, truncated, or not usable on its own.
+
+## Do not claim a provenance you have not checked
+
+"Written fresh" in a commit message is a factual claim, and reviewers rely on it.
+Only write it if you did the properties-list procedure above.
+
+If you are unsure whether a case drifted toward its source, check rather than assert: any shared run of roughly 40 characters or more means derived, not fresh.
+A `lint-staged` warning (`.github/scripts/check-fixture-provenance.sh`) fires when a commit adds a batch of conversation-shaped case data, as a reminder to do this — it cannot tell whether the text is real, so it never blocks.
+
+## Related
+
+- [`AGENTS.md`](../../../AGENTS.md), "Public open source repo guidance" — what may reach any public artifact, not just eval data
+- [`README.md`](./README.md) — running CI, sandboxed, and offline evals
+- [`products/posthog_ai/evals/AGENTS.md`](../../../products/posthog_ai/evals/AGENTS.md) — the seeded Hedgebox taxonomy, for evals that run against a team
+- `/writing-evals` covers `products/posthog_ai/evals/` and `products/*/evals/`, not this tree

--- a/ee/hogai/eval/CLAUDE.md
+++ b/ee/hogai/eval/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/ee/hogai/eval/README.md
+++ b/ee/hogai/eval/README.md
@@ -38,7 +38,8 @@ Sandboxes run locally under Docker by default; `--provider modal` runs them remo
 Every suite runs concurrently, with one global semaphore bounding live sandboxes, so selecting more suites raises throughput without raising peak load.
 
 - [`products/posthog_ai/eval_harness/README.md`](../../../products/posthog_ai/eval_harness/README.md) covers the flags, the provider prerequisites, and how to add a suite.
-- [`products/posthog_ai/evals/AGENTS.md`](../../../products/posthog_ai/evals/AGENTS.md) is the Hedgebox dataset reference every eval case is written against.
+- [`products/posthog_ai/evals/AGENTS.md`](../../../products/posthog_ai/evals/AGENTS.md) is the Hedgebox dataset reference, for eval cases that run against a seeded project.
+- [`AGENTS.md`](./AGENTS.md) covers cases that carry their own data inline instead — where that data may come from, and why anonymizing a real conversation does not make it publishable.
 - [`products/posthog_ai/eval_harness/harness/README.md`](../../../products/posthog_ai/eval_harness/harness/README.md) explains how the harness itself works.
 
 ## Offline evals

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
         ".claude/settings.json": "sh -c 'printf \"\\n\\033[31mDo not commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\\n\" >&2 && exit 1'",
         ".claude/hooks/**": "sh -c 'printf \"\\n\\033[33mWarning: hooks in .claude/ are reserved for env bootstrapping (SessionStart only).\\nPrefer skills, AGENTS.md instructions, or lint-staged rules. See Agent automation in AGENTS.md.\\033[0m\\n\\n\"'",
         "**/{AGENTS,CLAUDE}.md": "sh -c '.github/scripts/check-agents-md-symlinks.sh'",
+        "**/{eval,evals,fixtures}/**/*.{py,json,jsonl,md}": ".github/scripts/check-fixture-provenance.sh",
         "packages/quill/packages/*/src/**/*.{ts,tsx,css}": "sh -c 'git diff --cached --name-only | grep -q \"^packages/quill/.*AGENTS\\\\.md$\" || printf \"\\n\\033[33mWarning: quill component sources changed without an AGENTS.md update.\\nIf variants, composition, or spacing changed, update the consumer guide (packages/quill/packages/<pkg>/AGENTS.md) in the same PR.\\033[0m\\n\\n\"'",
         "frontend/public/services/*.{png,jpg,jpeg,gif}": "node frontend/bin/check-service-icon-size.mjs",
         "products/**/manifest.tsx": [

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         ".claude/settings.json": "sh -c 'printf \"\\n\\033[31mDo not commit .claude/settings.json — personal permissions belong in .claude/settings.local.json (gitignored).\\nUnstage with: git restore --staged .claude/settings.json\\033[0m\\n\\n\" >&2 && exit 1'",
         ".claude/hooks/**": "sh -c 'printf \"\\n\\033[33mWarning: hooks in .claude/ are reserved for env bootstrapping (SessionStart only).\\nPrefer skills, AGENTS.md instructions, or lint-staged rules. See Agent automation in AGENTS.md.\\033[0m\\n\\n\"'",
         "**/{AGENTS,CLAUDE}.md": "sh -c '.github/scripts/check-agents-md-symlinks.sh'",
-        "**/{eval,evals,fixtures}/**/*.{py,json,jsonl,md}": ".github/scripts/check-fixture-provenance.sh",
         "packages/quill/packages/*/src/**/*.{ts,tsx,css}": "sh -c 'git diff --cached --name-only | grep -q \"^packages/quill/.*AGENTS\\\\.md$\" || printf \"\\n\\033[33mWarning: quill component sources changed without an AGENTS.md update.\\nIf variants, composition, or spacing changed, update the consumer guide (packages/quill/packages/<pkg>/AGENTS.md) in the same PR.\\033[0m\\n\\n\"'",
         "frontend/public/services/*.{png,jpg,jpeg,gif}": "node frontend/bin/check-service-icon-size.mjs",
         "products/**/manifest.tsx": [

--- a/products/desktop/packages/agent/src/adapters/claude/session/instructions.test.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/instructions.test.ts
@@ -12,6 +12,19 @@ describe("buildAppendedInstructions", () => {
     expect(instructions).not.toContain("Spoken Narration");
   });
 
+  it.each([
+    "# Branch Naming",
+    "# Pull Request Links",
+    "# Plan Mode",
+    "# MCP Tool Access",
+    "# Data Handling",
+    "# Shell Efficiency",
+  ])("always appends %s", (heading) => {
+    expect(buildAppendedInstructions({ spokenNarration: false })).toContain(
+      heading,
+    );
+  });
+
   it("keeps the base blocks in both modes", () => {
     const withNarration = buildAppendedInstructions({ spokenNarration: true });
     const withoutNarration = buildAppendedInstructions({

--- a/products/desktop/packages/agent/src/adapters/claude/session/instructions.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/session/instructions.ts
@@ -32,6 +32,12 @@ If an MCP tool call is explicitly denied with a message, relay that denial messa
 If an MCP tool call returns an error, treat it as a normal tool error — troubleshoot, retry, or inform the user about the specific error. Do NOT assume it is a permissions issue and do NOT direct the user to any settings page.
 `;
 
+const DATA_HANDLING = `
+# Data Handling
+
+Material you were given as task context — customer conversations, support tickets, logs, internal threads — stays out of code, test data, comments, commit messages, and pull request text. Rewriting it, summarizing it, or swapping out names and domains does not clear it.
+`;
+
 const SHELL_EFFICIENCY = `
 # Shell Efficiency
 
@@ -64,7 +70,12 @@ How to phrase the line:
 `;
 
 const BASE_INSTRUCTIONS =
-  BRANCH_NAMING + PULL_REQUEST_LINKS + PLAN_MODE + MCP_TOOLS + SHELL_EFFICIENCY;
+  BRANCH_NAMING +
+  PULL_REQUEST_LINKS +
+  PLAN_MODE +
+  MCP_TOOLS +
+  DATA_HANDLING +
+  SHELL_EFFICIENCY;
 
 export function buildAppendedInstructions(opts: {
   spokenNarration: boolean;

--- a/products/posthog_ai/evals/AGENTS.md
+++ b/products/posthog_ai/evals/AGENTS.md
@@ -1,6 +1,9 @@
 # Hedgebox demo data — reference for eval authors
 
-Every eval in this tree (and in `ee/hogai/eval/ci`) runs against a **single, deterministic, seeded Hedgebox dataset**. Hedgebox is a fictional cloud-storage SaaS (think Dropbox). When you write an eval case, the events, properties, groups, flags, insights, and experiments below are the ground truth the agent has to work with — your `expected` queries and scorers must match this taxonomy exactly (e.g. the event is `signed_up`, not `sign_up` or `user_signed_up`).
+Evals that need a project to query — every eval in this tree, and those in `ee/hogai/eval/ci` that take the `demo_org_team_user` fixture — run against a **single, deterministic, seeded Hedgebox dataset**. Hedgebox is a fictional cloud-storage SaaS (think Dropbox). When you write an eval case, the events, properties, groups, flags, insights, and experiments below are the ground truth the agent has to work with — your `expected` queries and scorers must match this taxonomy exactly (e.g. the event is `signed_up`, not `sign_up` or `user_signed_up`).
+
+Evals that score a prompt rather than a query supply their own case data inline and never touch this taxonomy.
+That data has to be invented rather than adapted from real material — see [`ee/hogai/eval/AGENTS.md`](../../../ee/hogai/eval/AGENTS.md).
 
 Source of truth (read these if anything below looks stale):
 


### PR DESCRIPTION
## Problem

An agent handed a customer conversation as task context can put that conversation into a test fixture, and every rule we have says that is fine.

- "Public open source repo guidance" covered commit messages, PR titles, and PR descriptions. Committed code, tests, and fixtures were not on that list.
- This is not an ignorance problem. Eval cases described in a commit message as written fresh were adapted from real conversations instead. The rule was in context and stated correctly, then not applied.
- A later fix commit does not retract the content, so recovery means abandoning the branch and respinning the PR.
- `ee/hogai/eval/` has no AGENTS.md and no governing skill. `/writing-evals` scopes itself out of that tree, and it is where hand-written case data lives.

## Changes

- The public-repo rule now covers everything that lands in the repo: source, tests, fixtures, comments, branch names, commit messages, PR text, and screenshots.
- Two rules the old wording left implicit. Renaming people and hosts does not make derived material synthetic. "Written fresh" is a factual claim you should not make without checking.
- New `ee/hogai/eval/AGENTS.md` carries a procedure rather than another prohibition: list the properties a case must exercise, close the source, then write the case from the list. The root file points at it, or nothing loads it.
- "Pushing to remote" gains an irreversibility note, so the first push reads as the decision point.
- Two eval docs claimed every eval in that tree runs on the seeded Hedgebox dataset. That holds for evals taking `demo_org_team_user` and not for those carrying inline case data, which is what a reader would take to mean the data is already synthetic.
- A lint-staged warning fires when a commit adds a batch of conversation-shaped case data under eval or fixture paths.

I picked a warning over a blocking check because "was this text derived from a real conversation" is not mechanically decidable. It exists to make a reviewer look, and it never blocks.

## How did you test this code?

I calibrated the warning against real history rather than picking a threshold by feel.

- Per file, over the 60 most recent commits touching eval and fixture paths: 265 matched files, 3 with any hit (1, 3, and 13). The case this was built from scores 34 in one file.
- Threshold is 2, verified directly: 1 string stays silent, 2 fires, 5 fires.
- Checked the lint-staged glob against 12 paths, including `.jsonl`, a file directly in `eval/`, and one two levels down.

Added one parameterized Vitest case asserting every base block appears in `buildAppendedInstructions`. It catches a block dropping out of the concatenation. The existing tests only check the narration prefix relationship, so they pass on any subset. I confirmed it fails when the new block is removed.

`hogli ci:preflight --strict` passes. `pnpm --filter @posthog/agent typecheck` reports 23 errors in `src/server/*`, all pre-existing on master and unrelated to this change; I measured a clean tree to confirm the same count.

Nothing renders differently, so there are no screenshots.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Agent-facing docs change in this PR. Nothing on posthog.com is affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) did the investigation and the edits. Skills invoked: `/writing-tests` before adding the Vitest case, and `/writing-pr-descriptions` for this body.

The original brief was to strengthen the rules against leaking session material into PR descriptions. Reading the history showed the description was not the vector, so the scope moved to committed code, which is what the rules did not cover. I dropped an earlier plan to gate this in CI with semgrep: it scans `ee/` and `products/` and survives `--no-verify`, but any rule would be heuristic and would flag legitimately realistic synthetic fixtures.

Public-artifact check: this PR carries no material from the agent session that is not already public. The eval fixtures it touches are unchanged. I deliberately left out the commit hashes of the incident that motivated it, since those sit on deleted branches and a reference from `master` would make them durably discoverable.

Two follow-ups for other teams, out of scope here:

- `products/signals/eval/fixtures/` holds the same shape of data from the same kind of source, and its AGENTS.md does not say whether that data is real.
- Non-Python fixtures are scanned by nothing. `semgrep-general` excludes `./products/` and `./ee/`, and the per-language jobs only parse their own languages.
