### PR TITLE
feat(replay-vision): instrument alert/digest setup and delivery

### DIFF
--- a/products/replay_vision/README.md
+++ b/products/replay_vision/README.md
@@ -24,4 +24,21 @@ A sub-product of Session Replay. Users configure named **scanners** that PostHog
 - `backend/feature_flag.py` — `replay-vision` flag check + permission.
 - `backend/admin.py` — Django admin registrations.
 - `backend/temporal/vision_actions/` + `backend/api/vision_actions.py` — scheduled follow-up actions over observations (under active development).
+- `backend/telemetry.py` — shared property shaping for the vision-action lifecycle events below.
 - `frontend/` — kea-first scenes and logics for the scanner management UI.
+
+## Telemetry
+
+Product-usage events follow the `replay_vision_*` snake_case convention, and every event carries `organization_id` (plus `team_id` and, where one exists, `scanner_id`) as event properties, because org-level analyses join on them.
+
+**Setup events** fire from the API layer via `report_user_action`, so the web UI and MCP tools land in the same events with `source` telling them apart:
+
+- `replay_vision_scanner_created` / `_edited` / `_enabled` / `_disabled` / `_viewed` / `_deleted` — `api/scanners.py`.
+- `replay_vision_digest_created` / `_edited` / `_deleted` and `replay_vision_alert_created` / `_edited` / `_deleted` — `api/vision_actions.py`; digests are `mode=group_summary` actions, alerts are `mode=alert`.
+  Digest events carry the schedule (`rrule`, `timezone`); alert events carry the alert config (`alert_frequency`, `alert_metric`, …); both carry `destination_type`.
+  The scanner's built-in daily digest also reports `replay_vision_digest_created`, flagged `auto_provisioned: true` so setup-intent analyses can exclude it.
+
+**Delivery events** fire server-side from the Temporal engine via `posthoganalytics.capture` (landing in PostHog's internal project, cross-customer, with `region`/`environment`/`service` attached as super properties):
+
+- `replay_vision_scan_completed` — one per succeeded scan; `temporal/activities/observation_state.py`.
+- `replay_vision_digest_sent` / `replay_vision_alert_sent` — one per delivery target on every send, with `observation_count` and a `success` boolean (false when the CDP handoff raises); `temporal/vision_actions/activities.py`.

--- a/products/replay_vision/backend/api/scanners.py
+++ b/products/replay_vision/backend/api/scanners.py
@@ -84,6 +84,7 @@ from products.replay_vision.backend.quota import (
 from products.replay_vision.backend.scanner_config import scanner_config_error
 from products.replay_vision.backend.scanning import MAX_SESSIONS_PER_SCAN, run_inline_scan, scan_existing_scanner
 from products.replay_vision.backend.tag_suggestions import SuggestionError, suggest_classifier_tags
+from products.replay_vision.backend.telemetry import vision_action_lifecycle_properties
 from products.replay_vision.backend.temporal.constants import MAX_SESSION_ID_LENGTH
 
 # Date is set by the schedule at trigger time, not by the user — strip on save.
@@ -439,7 +440,18 @@ class ReplayScannerSerializer(UserAccessControlSerializerMixin, serializers.Mode
         # Every scanner starts with a built-in daily digest so the overview has a summary to show.
         # Flag-gated so teams without the actions feature don't accrue synthesis runs they can't see.
         if is_replay_vision_actions_enabled(user, team):
-            provision_scanner_digest(scanner, user)
+            digest = provision_scanner_digest(scanner, user)
+            if digest is not None:
+                # auto_provisioned marks this digest as a side effect of scanner creation rather than a
+                # user configuring one, so setup-intent analyses can exclude it while its later edits
+                # and deletes still reconcile against a created event.
+                report_user_action(
+                    user,
+                    "replay_vision_digest_created",
+                    {**vision_action_lifecycle_properties(digest, team), "auto_provisioned": True},
+                    team=team,
+                    request=self.context["request"],
+                )
         report_user_action(
             user,
             "replay_vision_scanner_created",

--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -27,6 +27,7 @@ from rest_framework.serializers import BaseSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.scoped_related_fields import TeamScopedPrimaryKeyRelatedField
 from posthog.api.shared import UserBasicSerializer
+from posthog.event_usage import report_user_action
 from posthog.models.integration import Integration
 from posthog.models.user import User
 
@@ -52,6 +53,7 @@ from products.replay_vision.backend.models.vision_action import (
 )
 from products.replay_vision.backend.rrule import validate_rrule, validate_timezone
 from products.replay_vision.backend.scanner_access import is_uuid, readable_scanner_ids
+from products.replay_vision.backend.telemetry import vision_action_lifecycle_properties, vision_action_noun
 from products.replay_vision.backend.temporal.scanners.monitor import MonitorVerdict
 
 logger = structlog.get_logger(__name__)
@@ -719,6 +721,15 @@ class VisionActionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         with transaction.atomic():
             action = serializer.save()
             provision_delivery(action, request=self.request, team=self.team)
+        # Reported after the atomic block so a provisioning rollback can't report a create that never
+        # committed. Web and MCP callers land here alike; `source` (from the request) tells them apart.
+        report_user_action(
+            cast(User, self.request.user),
+            f"replay_vision_{vision_action_noun(action)}_created",
+            {**vision_action_lifecycle_properties(action, self.team), "auto_provisioned": False},
+            team=self.team,
+            request=self.request,
+        )
 
     def perform_update(self, serializer: BaseSerializer) -> None:
         instance = cast(VisionAction, serializer.instance)
@@ -735,6 +746,8 @@ class VisionActionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         old_delivery = instance.delivery_config
         old_enabled = instance.enabled
         old_name = instance.name
+        # The UI PATCHes the whole form on save, so edits are detected by comparing values, not keys.
+        before = {field: getattr(instance, field) for field in serializer.validated_data}
         # Atomic so a re-provision failure rolls the action edit back too (parity with perform_create).
         with transaction.atomic():
             action = serializer.save()
@@ -743,10 +756,29 @@ class VisionActionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             # edits don't touch the destinations, so they must not churn them.
             if action.delivery_config != old_delivery or action.enabled != old_enabled or action.name != old_name:
                 provision_delivery(action, request=self.request, team=self.team)
+        changed_fields = sorted(field for field, value in before.items() if getattr(action, field) != value)
+        if changed_fields:
+            report_user_action(
+                cast(User, self.request.user),
+                f"replay_vision_{vision_action_noun(action)}_edited",
+                {**vision_action_lifecycle_properties(action, self.team), "edited_fields": changed_fields},
+                team=self.team,
+                request=self.request,
+            )
 
     def perform_destroy(self, instance: VisionAction) -> None:
+        # Snapshot the event name and lifecycle props before the row is deleted.
+        event = f"replay_vision_{vision_action_noun(instance)}_deleted"
+        properties = vision_action_lifecycle_properties(instance, self.team)
         archive_delivery(instance, team=self.team)
         super().perform_destroy(instance)
+        report_user_action(
+            cast(User, self.request.user),
+            event,
+            properties,
+            team=self.team,
+            request=self.request,
+        )
 
     @extend_schema(
         request=None,

--- a/products/replay_vision/backend/telemetry.py
+++ b/products/replay_vision/backend/telemetry.py
@@ -1,0 +1,57 @@
+"""Lifecycle telemetry for Replay Vision alerts and digests (VisionActions).
+
+Event names track the user-facing nouns rather than the model enum: `mode=alert` actions report as
+`replay_vision_alert_*`, everything else as `replay_vision_digest_*`. Every event carries
+`organization_id` as an event property because org-level analyses join on it. The helpers live here
+(not in api/vision_actions.py) so api/scanners.py can report the auto-provisioned scanner digest
+without importing another API module.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from products.replay_vision.backend.models.vision_action import ActionMode, VisionAction
+
+if TYPE_CHECKING:
+    from posthog.models import Team
+
+
+def vision_action_noun(action: VisionAction) -> str:
+    return "alert" if action.mode == ActionMode.ALERT else "digest"
+
+
+def vision_action_lifecycle_properties(action: VisionAction, team: "Team") -> dict[str, Any]:
+    """Config choices at save time, mirroring `_scanner_lifecycle_properties` in api/scanners.py.
+    Destination addresses (Slack channels, webhook URLs) stay out: they can carry customer data."""
+    delivery = action.delivery_config if isinstance(action.delivery_config, list) else []
+    destination_types = [target.get("type") for target in delivery if isinstance(target, dict)]
+    properties: dict[str, Any] = {
+        "vision_action_id": str(action.id),
+        "scanner_id": str(action.scanner_id) if action.scanner_id else None,
+        "mode": action.mode,
+        "enabled": action.enabled,
+        "is_scanner_digest": action.is_scanner_digest,
+        "destination_type": destination_types[0] if destination_types else None,
+        "destination_types": destination_types,
+        "team_id": team.id,
+        "organization_id": str(team.organization_id),
+    }
+    if action.mode == ActionMode.ALERT:
+        alert_config = action.alert_config if isinstance(action.alert_config, dict) else {}
+        properties.update(
+            {
+                "alert_frequency": alert_config.get("frequency"),
+                "alert_metric": alert_config.get("metric"),
+                "alert_threshold": alert_config.get("threshold"),
+                "alert_direction": alert_config.get("direction"),
+                "alert_window_days": alert_config.get("window_days"),
+            }
+        )
+    else:
+        trigger_config = action.trigger_config if isinstance(action.trigger_config, dict) else {}
+        properties.update(
+            {
+                "rrule": trigger_config.get("rrule"),
+                "timezone": trigger_config.get("timezone"),
+            }
+        )
+    return properties

--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -1,16 +1,18 @@
 """Supporting activities for the vision-action engine: per-scanner eligibility/claim, run lifecycle, and emit."""
 
 from datetime import UTC, datetime, timedelta
-from uuid import UUID
+from uuid import NAMESPACE_URL, UUID, uuid5
 
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 
 import structlog
+import posthoganalytics
 from temporalio import activity
 
 from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
+from posthog.models import Team
 from posthog.sync import database_sync_to_async
 
 from products.replay_vision.backend.models.replay_observation import ObservationStatus, ReplayObservation
@@ -207,33 +209,73 @@ def _emit(inputs: EmitActionReadyInputs) -> None:
     # internal_destination HogFunction filtered on vision_action_id delivers it. This is non-forgeable
     # with the public project token, and (unlike capture) it does NOT land in the analytics events
     # table — VisionActionRun is the durable history. `uuid=run.id` keeps the emit idempotent on retry.
-    produce_internal_event(
-        team_id=team.id,
-        event=InternalEventEvent(
-            event=_EVENT_NAME,
+    try:
+        produce_internal_event(
+            team_id=team.id,
+            event=InternalEventEvent(
+                event=_EVENT_NAME,
+                distinct_id=replay_vision_distinct_id(team.id),
+                uuid=str(run.id),
+                properties={
+                    "vision_action_id": str(action.id),
+                    "scanner_id": str(action.scanner_id) if action.scanner_id else None,
+                    "vision_action_run_id": str(run.id),
+                    "slack_text": output.get("slack", ""),
+                    # Pre-split section blocks so the full report renders as ONE Slack message; None (not
+                    # []) when absent so Slack falls back to slack_text rather than rejecting empty blocks.
+                    "slack_blocks": output.get("slack_blocks") or None,
+                    # Structured fields the webhook body references, so consumers get clean JSON rather than
+                    # the Slack-formatted text. The report is the canonical markdown, not the mrkdwn variant.
+                    "event_kind": event_kind,
+                    "is_recovery": is_recovery,
+                    "action_name": action.name,
+                    "scanner_name": action.scanner.name if action.scanner_id else None,
+                    "observation_count": run.observation_count,
+                    "report_markdown": run.synthesized_markdown,
+                    "run_url": _run_url(team.id, str(action.id), str(run.id)),
+                    "emitted_at": (run.scheduled_at or run.created_at).isoformat(),
+                },
+            ),
+        )
+    except Exception:
+        _capture_sent_telemetry(run, action, team, is_recovery=is_recovery, success=False)
+        raise
+    _capture_sent_telemetry(run, action, team, is_recovery=is_recovery, success=True)
+
+
+def _capture_sent_telemetry(
+    run: VisionActionRun, action: VisionAction, team: Team, *, is_recovery: bool, success: bool
+) -> None:
+    """Internal cross-customer telemetry mirroring `replay_vision_scan_completed`: one event per
+    delivery target, because the CDP handoff is a single produce but each configured destination is
+    a send. `region`/`environment`/`service` attach as posthoganalytics super properties."""
+    event = "replay_vision_alert_sent" if action.mode == ActionMode.ALERT else "replay_vision_digest_sent"
+    for index, target in enumerate(action.delivery_config):
+        posthoganalytics.capture(
             distinct_id=replay_vision_distinct_id(team.id),
-            uuid=str(run.id),
+            event=event,
+            # Deterministic uuid (dedup key) so an activity retry after a successful produce can't
+            # double-count a send. Failed attempts carry no uuid: each retry is a distinct attempt.
+            uuid=str(uuid5(NAMESPACE_URL, f"replay-vision-sent:{run.id}:{index}")) if success else None,
             properties={
                 "vision_action_id": str(action.id),
-                "scanner_id": str(action.scanner_id) if action.scanner_id else None,
                 "vision_action_run_id": str(run.id),
-                "slack_text": output.get("slack", ""),
-                # Pre-split section blocks so the full report renders as ONE Slack message; None (not
-                # []) when absent so Slack falls back to slack_text rather than rejecting empty blocks.
-                "slack_blocks": output.get("slack_blocks") or None,
-                # Structured fields the webhook body references, so consumers get clean JSON rather than
-                # the Slack-formatted text. The report is the canonical markdown, not the mrkdwn variant.
-                "event_kind": event_kind,
+                "scanner_id": str(action.scanner_id) if action.scanner_id else None,
                 "is_recovery": is_recovery,
-                "action_name": action.name,
-                "scanner_name": action.scanner.name if action.scanner_id else None,
+                "is_scanner_digest": action.is_scanner_digest,
+                "destination_type": target.get("type") if isinstance(target, dict) else None,
                 "observation_count": run.observation_count,
-                "report_markdown": run.synthesized_markdown,
-                "run_url": _run_url(team.id, str(action.id), str(run.id)),
-                "emitted_at": (run.scheduled_at or run.created_at).isoformat(),
+                "success": success,
+                "team_id": team.id,
+                "organization_id": str(team.organization_id),
             },
-        ),
-    )
+            # Mirrors posthog.event_usage.groups() without fetching the Organization row.
+            groups={
+                "instance": settings.SITE_URL,
+                "organization": str(team.organization_id),
+                "project": str(team.uuid),
+            },
+        )
 
 
 def _run_url(team_id: int, action_id: str, run_id: str) -> str:

--- a/products/replay_vision/backend/tests/test_api.py
+++ b/products/replay_vision/backend/tests/test_api.py
@@ -783,6 +783,21 @@ class TestScannerDigestProvisioning(_VisionAPITestCase):
         self.assertEqual(digest.created_by_id, self.user.id)
         self.assertTrue(digest.enabled)
 
+    def test_provisioned_digest_reports_auto_created(self) -> None:
+        # The built-in digest must stay distinguishable from a user configuring one, or setup-intent
+        # analyses would count every scanner creation as digest adoption.
+        with patch("products.replay_vision.backend.api.scanners.report_user_action") as report:
+            resp = self.client.post(self.scanners_url, data=self._CREATE_BODY, format="json")
+
+        self.assertEqual(resp.status_code, 201, resp.json())
+        events = [call.args[1] for call in report.call_args_list]
+        self.assertEqual(events, ["replay_vision_digest_created", "replay_vision_scanner_created"])
+        digest_properties = report.call_args_list[0].args[2]
+        self.assertTrue(digest_properties["auto_provisioned"])
+        self.assertTrue(digest_properties["is_scanner_digest"])
+        self.assertEqual(digest_properties["destination_type"], None)
+        self.assertEqual(digest_properties["organization_id"], str(self.team.organization_id))
+
     def test_no_digest_when_actions_flag_off(self) -> None:
         # Teams without the actions feature must not accrue billable synthesis runs they can't see.
         with patch(

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -321,14 +321,110 @@ class TestEngineActivities(BaseTest):
 
     def test_emit_noops_without_delivery(self) -> None:
         # No destinations configured → nothing to emit; the run row itself is the in-app artifact.
+        # No telemetry either: an in-app-only digest was not "sent" anywhere.
         action = _action(self.team)
         run = VisionActionRun(vision_action=action, team=self.team, idempotency_key="k2", output={"slack": "x"})
         run.save()
 
-        with patch.object(act, "produce_internal_event") as mock_emit:
+        with (
+            patch.object(act, "produce_internal_event") as mock_emit,
+            patch.object(act.posthoganalytics, "capture") as capture,
+        ):
             act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
 
         mock_emit.assert_not_called()
+        capture.assert_not_called()
+
+    def test_emit_captures_sent_telemetry_per_destination(self) -> None:
+        # Adoption dashboards count sends per destination and join on organization_id, and an
+        # activity retry after a successful produce must not double-count, so the uuid has to be
+        # deterministic per (run, target).
+        action = _action(
+            self.team,
+            delivery_config=[
+                {"type": "slack", "integration_id": 1, "channel": "#general"},
+                {"type": "webhook", "url": "https://example.com/hook"},
+            ],
+        )
+        run = VisionActionRun(
+            vision_action=action, team=self.team, idempotency_key="k", observation_count=3, output={"slack": "x"}
+        )
+        run.save()
+
+        with (
+            patch.object(act, "produce_internal_event"),
+            patch.object(act.posthoganalytics, "capture") as capture,
+        ):
+            act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
+            first_uuids = [call.kwargs["uuid"] for call in capture.call_args_list]
+            act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
+
+        self.assertEqual(capture.call_count, 4)
+        kwargs = capture.call_args_list[0].kwargs
+        self.assertEqual(kwargs["event"], "replay_vision_digest_sent")
+        self.assertEqual(kwargs["distinct_id"], f"replay-vision:{self.team.id}")
+        properties = kwargs["properties"]
+        self.assertEqual(properties["destination_type"], "slack")
+        self.assertEqual(properties["observation_count"], 3)
+        self.assertTrue(properties["success"])
+        self.assertEqual(properties["scanner_id"], str(action.scanner_id))
+        self.assertEqual(properties["team_id"], self.team.id)
+        self.assertEqual(properties["organization_id"], str(self.team.organization_id))
+        self.assertEqual(kwargs["groups"]["organization"], str(self.team.organization_id))
+        self.assertEqual(capture.call_args_list[1].kwargs["properties"]["destination_type"], "webhook")
+        self.assertEqual(len(set(first_uuids)), 2)
+        self.assertEqual([call.kwargs["uuid"] for call in capture.call_args_list[2:]], first_uuids)
+
+    @parameterized.expand(
+        [
+            ("fired", {}, False),
+            ("recovered", {"recovered": True}, True),
+        ]
+    )
+    def test_emit_captures_alert_sent(self, _label: str, extra_output: dict, expected_recovery: bool) -> None:
+        action = _action(
+            self.team,
+            mode="alert",
+            alert_config=EVERY_MATCH,
+            delivery_config=[{"type": "webhook", "url": "https://example.com/hook"}],
+        )
+        run = VisionActionRun(
+            vision_action=action,
+            team=self.team,
+            idempotency_key=f"k-{_label}",
+            output={"slack": "fired", **extra_output},
+        )
+        run.save()
+
+        with (
+            patch.object(act, "produce_internal_event"),
+            patch.object(act.posthoganalytics, "capture") as capture,
+        ):
+            act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
+
+        capture.assert_called_once()
+        self.assertEqual(capture.call_args.kwargs["event"], "replay_vision_alert_sent")
+        self.assertEqual(capture.call_args.kwargs["properties"]["is_recovery"], expected_recovery)
+
+    def test_emit_produce_failure_captures_failed_send(self) -> None:
+        # The failed attempt still surfaces in telemetry (success=false), and it must not carry the
+        # dedup uuid: a later successful retry is a distinct, countable send.
+        action = _action(self.team, delivery_config=[{"type": "slack", "integration_id": 1, "channel": "#c"}])
+        run = VisionActionRun(vision_action=action, team=self.team, idempotency_key="k", output={"slack": "x"})
+        run.save()
+
+        with (
+            patch.object(act, "produce_internal_event", side_effect=RuntimeError("kafka down")),
+            patch.object(act.posthoganalytics, "capture") as capture,
+        ):
+            with self.assertRaises(RuntimeError):
+                act._emit(EmitActionReadyInputs(run_id=run.id, team_id=self.team.id))
+
+        capture.assert_called_once()
+        kwargs = capture.call_args.kwargs
+        self.assertEqual(kwargs["event"], "replay_vision_digest_sent")
+        self.assertFalse(kwargs["properties"]["success"])
+        self.assertIsNone(kwargs["uuid"])
 
 
 # --- workflow orchestration (activities mocked at the temporalio.workflow boundary) ---

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -832,6 +832,109 @@ class TestVisionActionRunNow(_VisionActionAPITestCase):
         start_workflow.assert_not_called()
 
 
+class TestVisionActionLifecycleTelemetry(_VisionActionAPITestCase):
+    _ALERT_OVERRIDES: dict[str, Any] = {
+        "name": "rage-alert",
+        "mode": "alert",
+        "alert_config": {"frequency": "every_match", "metric": "count"},
+    }
+
+    def test_create_digest_reports_config_choices(self) -> None:
+        # Consumption dashboards join on organization_id and break down by destination_type, so a
+        # dropped property or a silent non-fire makes those reads a lie. Asserted at the capture
+        # boundary, where the source tag lands.
+        with patch("posthoganalytics.capture") as capture:
+            resp = self.client.post(self.actions_url, data=self._create_payload(), format="json")
+
+        self.assertEqual(resp.status_code, 201, resp.content)
+        created = [
+            call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_digest_created"
+        ]
+        self.assertEqual(len(created), 1)
+        properties = created[0].kwargs["properties"]
+        self.assertEqual(properties["vision_action_id"], resp.json()["id"])
+        self.assertEqual(properties["scanner_id"], str(self.scanner.id))
+        self.assertEqual(properties["mode"], "group_summary")
+        self.assertEqual(properties["destination_type"], "slack")
+        self.assertEqual(properties["rrule"], "FREQ=DAILY")
+        self.assertEqual(properties["timezone"], "UTC")
+        self.assertFalse(properties["auto_provisioned"])
+        self.assertEqual(properties["team_id"], self.team.id)
+        self.assertEqual(properties["organization_id"], str(self.team.organization_id))
+        self.assertEqual(properties["source"], "web")
+
+    def test_create_alert_reports_alert_config(self) -> None:
+        with patch("posthoganalytics.capture") as capture:
+            resp = self.client.post(self.actions_url, data=self._create_payload(**self._ALERT_OVERRIDES), format="json")
+
+        self.assertEqual(resp.status_code, 201, resp.content)
+        created = [call for call in capture.call_args_list if call.kwargs.get("event") == "replay_vision_alert_created"]
+        self.assertEqual(len(created), 1)
+        properties = created[0].kwargs["properties"]
+        self.assertEqual(properties["mode"], "alert")
+        self.assertEqual(properties["alert_frequency"], "every_match")
+        self.assertEqual(properties["alert_metric"], "count")
+        self.assertEqual(properties["organization_id"], str(self.team.organization_id))
+        self.assertNotIn("rrule", properties)
+
+    @parameterized.expand(
+        [
+            ("rename", {"name": "renamed"}, ["name"]),
+            ("toggle", {"enabled": False}, ["enabled"]),
+        ]
+    )
+    def test_edit_reports_only_actually_changed_fields(
+        self, _name: str, mutation: dict[str, Any], expected_fields: list[str]
+    ) -> None:
+        # The UI PATCHes the entire form on save, so submitted-but-unchanged fields must not be
+        # reported as edits.
+        create = self.client.post(self.actions_url, data=self._create_payload(), format="json")
+        self.assertEqual(create.status_code, 201, create.content)
+        with patch("products.replay_vision.backend.api.vision_actions.report_user_action") as report:
+            resp = self.client.patch(
+                f"{self.actions_url}{create.json()['id']}/",
+                data={**self._create_payload(), **mutation},
+                format="json",
+            )
+
+        self.assertEqual(resp.status_code, 200, resp.content)
+        report.assert_called_once()
+        self.assertEqual(report.call_args.args[1], "replay_vision_digest_edited")
+        self.assertEqual(report.call_args.args[2]["edited_fields"], expected_fields)
+
+    def test_full_body_save_with_no_changes_reports_nothing(self) -> None:
+        create = self.client.post(self.actions_url, data=self._create_payload(), format="json")
+        self.assertEqual(create.status_code, 201, create.content)
+        with patch("products.replay_vision.backend.api.vision_actions.report_user_action") as report:
+            resp = self.client.patch(
+                f"{self.actions_url}{create.json()['id']}/", data=self._create_payload(), format="json"
+            )
+
+        self.assertEqual(resp.status_code, 200, resp.content)
+        report.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("digest", {}, "replay_vision_digest_deleted"),
+            ("alert", _ALERT_OVERRIDES, "replay_vision_alert_deleted"),
+        ]
+    )
+    def test_delete_reports_props_snapshotted_before_removal(
+        self, _name: str, overrides: dict[str, Any], expected_event: str
+    ) -> None:
+        create = self.client.post(self.actions_url, data=self._create_payload(**overrides), format="json")
+        self.assertEqual(create.status_code, 201, create.content)
+        with patch("products.replay_vision.backend.api.vision_actions.report_user_action") as report:
+            resp = self.client.delete(f"{self.actions_url}{create.json()['id']}/")
+
+        self.assertEqual(resp.status_code, 204)
+        report.assert_called_once()
+        self.assertEqual(report.call_args.args[1], expected_event)
+        properties = report.call_args.args[2]
+        self.assertEqual(properties["vision_action_id"], create.json()["id"])
+        self.assertEqual(properties["organization_id"], str(self.team.organization_id))
+
+
 class TestDeliveryTargetSerializer(SimpleTestCase):
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

- Teams tracking Replay Vision adoption cannot see whether anyone configures or receives scanner alerts and digests: the "Digests and alerts" tab and its delivery path emit no analytics events.
- Scanner telemetry already exists (`replay_vision_scanner_created` and friends, `replay_vision_scan_completed`), so dashboards see scanners but alert/digest usage is invisible.

## Changes

- Setup now reports `replay_vision_alert_created` / `_edited` / `_deleted` and `replay_vision_digest_created` / `_edited` / `_deleted` from the VisionAction viewset hooks via `report_user_action`.
- One capture site covers the web UI and MCP tools, because both hit the same DRF endpoints; the `source` property tells them apart.
- Every event carries `organization_id` and `team_id`; digests add their schedule (`rrule`, `timezone`), alerts add their alert config, and both add `destination_type` (slack or webhook).
- The daily digest auto-created with each scanner reports `replay_vision_digest_created` flagged `auto_provisioned: true`, so setup-intent queries can exclude it while its later edits and deletes still reconcile against a created event.
- Delivery now reports `replay_vision_alert_sent` / `replay_vision_digest_sent` server-side, one event per delivery target, with `observation_count` and a `success` boolean (false when the CDP handoff raises).
- Delivery events use the module-level analytics client like `replay_vision_scan_completed`, so they aggregate cross-customer in the internal project and carry `region` / `environment` / `service` super properties.
- Deterministic event uuids dedupe Temporal activity retries, so a retried send cannot double-count.

Where the alert/digest code lives (previously undocumented): config is the `VisionAction` model, where digests are `mode=group_summary` and alerts are `mode=alert`, with CRUD in `products/replay_vision/backend/api/vision_actions.py`. Delivery is `_emit` in `backend/temporal/vision_actions/activities.py`, which produces a private `$replay_vision_action_ready` internal event that per-action CDP HogFunctions post to Slack or a webhook. The new README "Telemetry" section records the full event family; there was no taxonomy entry to extend, since `posthog/taxonomy/` only catalogs client-side events.

## How did you test this code?

- `TestVisionActionLifecycleTelemetry` (new, API level) catches a dropped property (especially `organization_id`), a silent non-fire, a wrong alert/digest noun, full-form PATCHes reporting unchanged fields as edits, and deletes reading the row after removal.
- The new auto-provision case in `TestScannerDigestProvisioning` catches the built-in digest losing its created event or its `auto_provisioned` flag.
- The new emit cases in `test_vision_action_engine.py` catch missing per-target fan-out, nondeterministic uuids (retry double-count), a missing `success=false` on produce failure, and telemetry firing for in-app-only digests with no destinations.
- Ran locally against the dockerized dev stack: the three touched suites (112 tests), ruff, mypy on the changed files, and `hogli ci:preflight --fix`, all clean. Not run: repo-wide mypy and the rest of CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- The product README gains a "Telemetry" section documenting the `replay_vision_*` event family; no `docs/` page covers these internal events.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Built with Claude Code (PostHog Code cloud task); the task asked to instrument the alert/digest config surface and delivery path with `replay_vision_*` events, matching whatever mechanism the code actually uses.
- Skills invoked: /improving-drf-endpoints, /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Decisions: events fire from the backend viewset rather than the frontend kea logics so MCP callers are covered by the same capture site; the auto-provisioned digest reports created with a flag rather than staying silent, keeping every VisionAction row's lifecycle reconstructible; sent events fire per delivery target (not per run) so `destination_type` stays a scalar and multi-destination actions count each send.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
