### PR TITLE
chore(deps): bump django to 5.2.17

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1796,16 +1796,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "5.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f8/ce120525ca78f12b07daf65786679c5d0b54a75285a8958d3ae55e39da35/django-5.2.17-py3-none-any.whl", hash = "sha256:f04fb3b36ee119e1af4fa1d397d5fd6cf12700f49321e84d4f4c642c5b1973db", size = 8315563, upload-time = "2026-08-04T15:03:59.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Nobody sees a difference, but PostHog runs Django 5.2.14, which carries four unpatched CVEs from the [August 4 security release](https://www.djangoproject.com/weblog/2026/aug/04/security-releases/).

- One has a live code path here: [CVE-2026-15920](https://docs.djangoproject.com/en/6.0/releases/5.2.17/), stored XSS from `URLField` values that the admin renders as links without checking the scheme.
- The other three do not. Two need the PostGIS backend, and `DATABASES["default"]["ENGINE"]` is `django.db.backends.postgresql_psycopg2`. The third needs `django.views.i18n.set_language`, which is not routed.

## Changes

- Bump the `uv.lock` pin from Django 5.2.14 to 5.2.17.
- `pyproject.toml` already allows this. The constraint is `django~=5.2.0`, so no source change is needed.
- The release has one backward incompatible change: spatial lookups now reject `dict` and non-geometry `str`. It cannot apply without a spatial backend.

Admin surfaces that reach the patched `display_for_field` sink: `cimd_metadata_url` in `OAuthApplicationAdmin.readonly_fields`, `url` in `MCPServerTemplateAdmin.list_display`, and every `URLField` on an admin-registered model for staff who hold view permission but not change permission.

> [!NOTE]
> No exploitable input exists today. Every write path into those fields is already scheme-constrained, by a DRF `URLValidator` for `Link.redirect_url` and by explicit `https://` checks for the OAuth fields. The bump closes the sink rather than a live hole.

## How did you test this code?

No new tests. A lockfile bump has no behavior of its own to assert, and the CI suites cover the framework upgrade.

I ran `uv lock --check`, which resolved cleanly. I did not run the backend test suites locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) assessed all four CVEs against master before writing this, which is where the reachability claims in Problem come from. Skills invoked: `/writing-pr-descriptions`.

`uv lock --upgrade-package django` also rewrote unrelated dependency markers on the nvidia, pywin32 and ptyprocess entries, a normalization from a newer local uv than the one that wrote the lock. I reverted those and applied only the three Django lines, so the diff stays at one dependency.

One follow-up this PR does not cover: two admin columns hand-roll their links with `format_html('<a href="{}">', obj.<url>)`, in `products/links/backend/admin.py` and `posthog/admin/admins/oauth_admin.py`. Django patched `display_for_field`, not custom display methods, so those two keep rendering whatever scheme they are given.
