### PR TITLE
fix(desktop/sessions): stop threads yanking readers back to the bottom

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -740,7 +740,7 @@ const ThreadRow = memo(function ThreadRow({
 });
 
 /**
- * Keeps the view pinned to the bottom from prompt submit until the user scrolls away.
+ * Keeps the view pinned to the bottom until the user scrolls away, re-arming on each prompt submit.
  *
  * The engine's own follow mode isn't enough on its own:
  * - It only re-engages within `scrollEdgeThreshold` of the exact bottom, so a submit from anywhere
@@ -751,10 +751,20 @@ const ThreadRow = memo(function ThreadRow({
  *   autoscrolling" and silently demote itself to `free-scrolling` mid-reply. While armed, any
  *   commit that leaves content below the fold re-issues `scrollToEnd` to recapture follow.
  *
- * User scroll intent (wheel, touch, pointer, keys — same signals the engine listens to) disarms
- * the pin; the next submit or the scroll-to-bottom button re-engages following.
+ * It arms on mount so a thread the reader is only watching — a cloud task streaming into a command
+ * center panel, with no prompt sent from here — still follows. User scroll intent (wheel, touch,
+ * pointer, keys — the same signals the engine listens to) disarms the pin for good, which is the
+ * half the engine gets wrong: it re-derives follow from scroll position and so overrules the
+ * gesture. The next submit or the scroll-to-bottom button re-engages following.
  */
-function ThreadAutoFollow({ items }: { items: ConversationItem[] }) {
+function ThreadAutoFollow({
+  items,
+  armedRef,
+}: {
+  items: ConversationItem[];
+  /** Owned by the body so the scroll-to-bottom button can re-arm the pin too. */
+  armedRef: RefObject<boolean>;
+}) {
   const { scrollToEnd } = useChatMessageScroller();
   const { end } = useChatMessageScrollerScrollable();
   const lastItem = items.at(-1);
@@ -764,7 +774,6 @@ function ThreadAutoFollow({ items }: { items: ConversationItem[] }) {
     [items],
   );
   const prevCountRef = useRef(userMessageCount);
-  const armedRef = useRef(false);
   const probeRef = useRef<HTMLSpanElement>(null);
 
   useLayoutEffect(() => {
@@ -774,7 +783,7 @@ function ThreadAutoFollow({ items }: { items: ConversationItem[] }) {
     if (lastItem?.type !== "user_message") return;
     armedRef.current = true;
     scrollToEnd({ behavior: "auto" });
-  }, [userMessageCount, lastItem, scrollToEnd]);
+  }, [userMessageCount, lastItem, scrollToEnd, armedRef]);
 
   useEffect(() => {
     const viewport = probeRef.current
@@ -793,14 +802,14 @@ function ThreadAutoFollow({ items }: { items: ConversationItem[] }) {
         viewport.removeEventListener(event, disarm);
       }
     };
-  }, []);
+  }, [armedRef]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-check on every streamed change — `end` alone doesn't re-notify while it stays true across commits.
   useEffect(() => {
     if (armedRef.current && end) {
       scrollToEnd({ behavior: "auto" });
     }
-  }, [items, end, scrollToEnd]);
+  }, [items, end, scrollToEnd, armedRef]);
 
   return <span ref={probeRef} className="hidden" aria-hidden="true" />;
 }
@@ -973,6 +982,8 @@ function ThreadScrollBody({
     }));
   }, [rows]);
 
+  const autoFollowArmedRef = useRef(true);
+
   // `group/thread` so the footer's hover-reveal (opacity-50 → 100 on group-hover) tracks the thread,
   // mirroring the legacy ConversationView container. `@container/thread` makes the thread's own
   // width the query basis for everything inside it — the panel is resizable and splittable, so the
@@ -983,7 +994,7 @@ function ThreadScrollBody({
       onPointerDownCapture={onUserInteract}
     >
       <MessageMinimap items={items} />
-      <ThreadAutoFollow items={items} />
+      <ThreadAutoFollow items={items} armedRef={autoFollowArmedRef} />
       <ThreadScrollStateRecorder stateRef={resumeStateRef} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent
@@ -1009,7 +1020,12 @@ function ThreadScrollBody({
           )}
         </ChatMessageScrollerContent>
       </ChatMessageScrollerViewport>
-      <ChatMessageScrollerButton />
+      {/* Re-arms the pin as well as scrolling: the button is the reader saying "follow again". */}
+      <ChatMessageScrollerButton
+        onClick={() => {
+          autoFollowArmedRef.current = true;
+        }}
+      />
     </ChatMessageScroller>
   );
 }
@@ -1348,11 +1364,12 @@ function ChatThreadRenderer({
             // engine's own follow would fight it, so it only auto-scrolls when non-virtualized.
             autoScroll={!virtualized}
             defaultScrollPosition="end"
-            // Default is 8px: with the thread's bottom padding you're rarely that close, so
-            // auto-follow ("following-bottom") would disengage on any stray trackpad wheel and
-            // never re-engage. Within this band the engine recaptures follow on the next content
-            // change; deliberate upward flicks travel past it and stay free-scrolling.
-            scrollEdgeThreshold={100}
+            // `scrollEdgeThreshold` is left at the engine's tight default on purpose. The engine
+            // re-enters "following-bottom" on *every* scroll event taken within the band, which
+            // overrides the free-scrolling its own wheel handler just set — so a wide band traps a
+            // reader scrolling up out of the bottom, and streamed content yanks them back each
+            // frame. `ThreadAutoFollow` is what keeps the thread pinned across the band's width;
+            // unlike the engine it only lets go on a real gesture.
             scrollPreviousItemPeek={SCROLL_PREVIOUS_ITEM_PEEK}
           >
             {virtualized ? (

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -68,8 +68,13 @@ import {
   completedTurnTimestamp,
   countFlatRows,
   type FlatThreadRow,
+  FOLLOWING_END,
   flattenTurnRows,
+  nextThreadFollowState,
   SCROLL_PREVIOUS_ITEM_PEEK,
+  SCROLL_UP_KEYS,
+  sampleThreadScroll,
+  type ThreadFollowState,
   type ThreadItem,
   type ThreadScrollResume,
   type TurnRow,
@@ -752,18 +757,18 @@ const ThreadRow = memo(function ThreadRow({
  *   commit that leaves content below the fold re-issues `scrollToEnd` to recapture follow.
  *
  * It arms on mount so a thread the reader is only watching — a cloud task streaming into a command
- * center panel, with no prompt sent from here — still follows. User scroll intent (wheel, touch,
- * pointer, keys — the same signals the engine listens to) disarms the pin for good, which is the
- * half the engine gets wrong: it re-derives follow from scroll position and so overrules the
- * gesture. The next submit or the scroll-to-bottom button re-engages following.
+ * center panel, with no prompt sent from here — still follows. Scrolling upward disarms it, which
+ * is the half the engine gets wrong: the engine re-derives follow from scroll position and so
+ * overrules the gesture. Scrolling back down to the end re-arms it, a submit or the
+ * scroll-to-bottom button re-arms it from anywhere.
  */
 function ThreadAutoFollow({
   items,
-  armedRef,
+  followRef,
 }: {
   items: ConversationItem[];
   /** Owned by the body so the scroll-to-bottom button can re-arm the pin too. */
-  armedRef: RefObject<boolean>;
+  followRef: RefObject<ThreadFollowState>;
 }) {
   const { scrollToEnd } = useChatMessageScroller();
   const { end } = useChatMessageScrollerScrollable();
@@ -781,35 +786,55 @@ function ThreadAutoFollow({
     prevCountRef.current = userMessageCount;
     if (previous === 0 || userMessageCount <= previous) return;
     if (lastItem?.type !== "user_message") return;
-    armedRef.current = true;
+    followRef.current = FOLLOWING_END;
     scrollToEnd({ behavior: "auto" });
-  }, [userMessageCount, lastItem, scrollToEnd, armedRef]);
+  }, [userMessageCount, lastItem, scrollToEnd, followRef]);
 
   useEffect(() => {
     const viewport = probeRef.current
       ?.closest('[data-slot="chat-message-scroller"]')
       ?.querySelector('[data-slot="chat-message-scroller-viewport"]');
-    if (!viewport) return;
-    const disarm = () => {
-      armedRef.current = false;
+    if (!(viewport instanceof HTMLElement)) return;
+
+    // An upward gesture too small to register as a direction change below still means the reader
+    // is reading, not following.
+    const leaveEnd = () => {
+      if (followRef.current.leftEnd || viewport.scrollTop <= 0) return;
+      followRef.current = { following: false, leftEnd: true };
     };
-    const events = ["wheel", "touchmove", "pointerdown", "keydown"] as const;
-    for (const event of events) {
-      viewport.addEventListener(event, disarm, { passive: true });
-    }
+    const onWheel = (event: Event) => {
+      if ((event as WheelEvent).deltaY < 0) leaveEnd();
+    };
+    const onKeyDown = (event: Event) => {
+      if (SCROLL_UP_KEYS.has((event as KeyboardEvent).key)) leaveEnd();
+    };
+    // Direction, not position: the reader who scrolls back to the bottom while the agent keeps
+    // appending never lands on the exact end, so following has to resume from the gesture.
+    let lastScrollTop = viewport.scrollTop;
+    const onScroll = () => {
+      const sample = sampleThreadScroll(viewport, lastScrollTop);
+      lastScrollTop = viewport.scrollTop;
+      followRef.current = nextThreadFollowState(followRef.current, sample);
+    };
+
+    viewport.addEventListener("wheel", onWheel, { passive: true });
+    viewport.addEventListener("touchmove", leaveEnd, { passive: true });
+    viewport.addEventListener("keydown", onKeyDown, { passive: true });
+    viewport.addEventListener("scroll", onScroll, { passive: true });
     return () => {
-      for (const event of events) {
-        viewport.removeEventListener(event, disarm);
-      }
+      viewport.removeEventListener("wheel", onWheel);
+      viewport.removeEventListener("touchmove", leaveEnd);
+      viewport.removeEventListener("keydown", onKeyDown);
+      viewport.removeEventListener("scroll", onScroll);
     };
-  }, [armedRef]);
+  }, [followRef]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-check on every streamed change — `end` alone doesn't re-notify while it stays true across commits.
   useEffect(() => {
-    if (armedRef.current && end) {
+    if (followRef.current.following && end) {
       scrollToEnd({ behavior: "auto" });
     }
-  }, [items, end, scrollToEnd, armedRef]);
+  }, [items, end, scrollToEnd, followRef]);
 
   return <span ref={probeRef} className="hidden" aria-hidden="true" />;
 }
@@ -982,7 +1007,7 @@ function ThreadScrollBody({
     }));
   }, [rows]);
 
-  const autoFollowArmedRef = useRef(true);
+  const autoFollowRef = useRef<ThreadFollowState>(FOLLOWING_END);
 
   // `group/thread` so the footer's hover-reveal (opacity-50 → 100 on group-hover) tracks the thread,
   // mirroring the legacy ConversationView container. `@container/thread` makes the thread's own
@@ -994,7 +1019,7 @@ function ThreadScrollBody({
       onPointerDownCapture={onUserInteract}
     >
       <MessageMinimap items={items} />
-      <ThreadAutoFollow items={items} armedRef={autoFollowArmedRef} />
+      <ThreadAutoFollow items={items} followRef={autoFollowRef} />
       <ThreadScrollStateRecorder stateRef={resumeStateRef} />
       <ChatMessageScrollerViewport>
         <ChatMessageScrollerContent
@@ -1023,7 +1048,7 @@ function ThreadScrollBody({
       {/* Re-arms the pin as well as scrolling: the button is the reader saying "follow again". */}
       <ChatMessageScrollerButton
         onClick={() => {
-          autoFollowArmedRef.current = true;
+          autoFollowRef.current = FOLLOWING_END;
         }}
       />
     </ChatMessageScroller>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -9,10 +9,14 @@ import { MessageMinimap } from "@posthog/ui/features/sessions/components/chat-th
 import {
   computeStickyAnchor,
   type FlatThreadRow,
+  FOLLOWING_END,
   nextThreadFollowState,
   SCROLL_PREVIOUS_ITEM_PEEK,
+  SCROLL_UP_KEYS,
   type StickyAnchorEntry,
   type StickyAnchorState,
+  sampleThreadScroll,
+  THREAD_AT_END_THRESHOLD,
   type ThreadFollowState,
   type ThreadScrollResume,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
@@ -39,22 +43,8 @@ import {
 // tuning these rows share (same item mix, same measure-then-settle churn).
 const ESTIMATED_ROW_SIZE = 80;
 const OVERSCAN = 12;
-/**
- * Tolerance for calling the viewport "at the end". Generous because rows are estimated until they
- * mount, so a fresh append reads short by more than a few pixels. It is only a measurement
- * allowance: an upward gesture takes the reader out of following regardless of where they are
- * inside it (see {@link nextThreadFollowState}).
- */
-const AT_BOTTOM_THRESHOLD = 100;
-/** Slack for sub-pixel scroll positions when deciding the viewport is hard against the bottom. */
-const AT_EXACT_END_EPSILON = 1;
-// A real upward drift, not a 1-frame measure transient: the DOM bottom sits this far below the
-// viewport. Well above any single append's measure gap.
-const FAR_DRIFT_THRESHOLD = 400;
 /** Top of the virtual coordinate space — stands in for the non-virtualized content's `py-4`. */
 const PADDING_START = 16;
-/** Keys that move the viewport upward, so pressing them reads as leaving the end. */
-const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
 /** Frames a programmatic scroll keeps re-issuing while rows around the target still measure. */
 const SETTLE_AT_END_ATTEMPTS = 12;
 const SETTLE_TO_INDEX_ATTEMPTS = 8;
@@ -105,10 +95,7 @@ function useSettleControls(
 ) {
   // Starts following; the mount-position effect below flips it if the handoff state says the reader
   // was parked above the fold.
-  const followRef = useRef<ThreadFollowState>({
-    following: true,
-    leftEnd: false,
-  });
+  const followRef = useRef<ThreadFollowState>(FOLLOWING_END);
   const settleRafRef = useRef<number | null>(null);
 
   const cancelSettle = useCallback(() => {
@@ -120,12 +107,12 @@ function useSettleControls(
 
   const settleAtEnd = useCallback(() => {
     cancelSettle();
-    followRef.current = { following: true, leftEnd: false };
+    followRef.current = FOLLOWING_END;
     let attempts = 0;
     const step = () => {
       virtualizer.scrollToEnd();
       if (
-        virtualizer.isAtEnd(AT_BOTTOM_THRESHOLD) ||
+        virtualizer.isAtEnd(THREAD_AT_END_THRESHOLD) ||
         ++attempts > SETTLE_AT_END_ATTEMPTS
       ) {
         settleRafRef.current = null;
@@ -168,9 +155,9 @@ function useSettleControls(
   );
 
   /**
-   * An upward gesture: leave following until the reader is back against the bottom. Ignored when
-   * there is nothing above to reach — a stray wheel over a thread that fits the viewport would
-   * otherwise kill following with no scroll event left to undo it.
+   * An upward gesture: leave following until the reader scrolls back down into the end tolerance.
+   * Ignored when there is nothing above to reach — a stray wheel over a thread that fits the
+   * viewport would otherwise kill following with no scroll event left to undo it.
    */
   const leaveEnd = useCallback(() => {
     if (followRef.current.leftEnd) return;
@@ -345,7 +332,7 @@ export function VirtualThreadScrollBody({
     overscan: OVERSCAN,
     anchorTo: "end",
     followOnAppend: true,
-    scrollEndThreshold: AT_BOTTOM_THRESHOLD,
+    scrollEndThreshold: THREAD_AT_END_THRESHOLD,
     paddingStart: PADDING_START,
     paddingEnd: footerHeight,
     getItemKey: (index) => flatRows[index]?.key ?? index,
@@ -410,24 +397,13 @@ export function VirtualThreadScrollBody({
 
   const handleScroll = useCallback(() => {
     const el = viewportRef.current;
-    const scrollTop = el?.scrollTop ?? 0;
-    // Tolerate sub-pixel jitter; only a real upward move counts as leaving end.
-    const scrolledUp = scrollTop < lastScrollTopRef.current - 1;
-    lastScrollTopRef.current = scrollTop;
-
-    const distanceFromEnd = el
-      ? el.scrollHeight - el.clientHeight - scrollTop
-      : 0;
-    followRef.current = nextThreadFollowState(followRef.current, {
-      atEnd: virtualizer.isAtEnd(AT_BOTTOM_THRESHOLD),
-      atExactEnd: distanceFromEnd <= AT_EXACT_END_EPSILON,
-      scrolledUp,
-      // Genuine far drift (not a 1-frame measure transient): the DOM bottom sits well below the
-      // viewport, so follow can't get silently stuck mid-thread.
-      farFromEnd: distanceFromEnd > FAR_DRIFT_THRESHOLD,
-    });
+    if (el) {
+      const sample = sampleThreadScroll(el, lastScrollTopRef.current);
+      lastScrollTopRef.current = el.scrollTop;
+      followRef.current = nextThreadFollowState(followRef.current, sample);
+    }
     scheduleStickyRecompute();
-  }, [virtualizer, scheduleStickyRecompute, followRef]);
+  }, [scheduleStickyRecompute, followRef]);
 
   useFollowBottom({
     virtualizer,
@@ -453,9 +429,9 @@ export function VirtualThreadScrollBody({
         <ChatMessageScrollerViewport
           ref={viewportRef}
           onScroll={handleScroll}
-          // Reading upward is intent, not geometry. Without these the scroll event the gesture
-          // produces still measures "at the end" for the first AT_BOTTOM_THRESHOLD pixels, so a
-          // slow scroll out of the bottom would be undone by the next streamed chunk.
+          // Reading upward is intent, not geometry: these catch a gesture too small to register as
+          // a direction change in the scroll handler, which would otherwise still measure "at the
+          // end" and let the next streamed chunk undo it.
           onWheelCapture={(event: ReactWheelEvent) => {
             if (event.deltaY < 0) leaveEnd();
           }}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/VirtualThreadScrollBody.tsx
@@ -9,9 +9,11 @@ import { MessageMinimap } from "@posthog/ui/features/sessions/components/chat-th
 import {
   computeStickyAnchor,
   type FlatThreadRow,
+  nextThreadFollowState,
   SCROLL_PREVIOUS_ITEM_PEEK,
   type StickyAnchorEntry,
   type StickyAnchorState,
+  type ThreadFollowState,
   type ThreadScrollResume,
 } from "@posthog/ui/features/sessions/components/chat-thread/threadVirtualization";
 import {
@@ -20,8 +22,10 @@ import {
 } from "@posthog/ui/features/sessions/constants";
 import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
 import {
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
+  type WheelEvent as ReactWheelEvent,
   type RefObject,
   useCallback,
   useEffect,
@@ -35,13 +39,22 @@ import {
 // tuning these rows share (same item mix, same measure-then-settle churn).
 const ESTIMATED_ROW_SIZE = 80;
 const OVERSCAN = 12;
-/** Matches the Provider's `scrollEdgeThreshold` so "at bottom" agrees between engine and windowing. */
+/**
+ * Tolerance for calling the viewport "at the end". Generous because rows are estimated until they
+ * mount, so a fresh append reads short by more than a few pixels. It is only a measurement
+ * allowance: an upward gesture takes the reader out of following regardless of where they are
+ * inside it (see {@link nextThreadFollowState}).
+ */
 const AT_BOTTOM_THRESHOLD = 100;
+/** Slack for sub-pixel scroll positions when deciding the viewport is hard against the bottom. */
+const AT_EXACT_END_EPSILON = 1;
 // A real upward drift, not a 1-frame measure transient: the DOM bottom sits this far below the
 // viewport. Well above any single append's measure gap.
 const FAR_DRIFT_THRESHOLD = 400;
 /** Top of the virtual coordinate space — stands in for the non-virtualized content's `py-4`. */
 const PADDING_START = 16;
+/** Keys that move the viewport upward, so pressing them reads as leaving the end. */
+const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
 /** Frames a programmatic scroll keeps re-issuing while rows around the target still measure. */
 const SETTLE_AT_END_ATTEMPTS = 12;
 const SETTLE_TO_INDEX_ATTEMPTS = 8;
@@ -84,15 +97,18 @@ function useReservedFooterHeight(
 /**
  * Programmatic scrolls that survive measurement drift. Rows are estimated until they mount, so a
  * single `scrollToEnd`/`scrollToIndex` lands short; both helpers re-issue across frames until the
- * target offset stops moving. `isAtBottomRef` is the follow flag the rest of the body reads.
+ * target offset stops moving. `followRef` is the follow state the rest of the body reads.
  */
 function useSettleControls(
   virtualizer: ThreadVirtualizer,
   viewportRef: RefObject<HTMLDivElement | null>,
 ) {
-  // Starts true; the mount-position effect below flips it if the handoff state says the reader was
-  // parked above the fold.
-  const isAtBottomRef = useRef(true);
+  // Starts following; the mount-position effect below flips it if the handoff state says the reader
+  // was parked above the fold.
+  const followRef = useRef<ThreadFollowState>({
+    following: true,
+    leftEnd: false,
+  });
   const settleRafRef = useRef<number | null>(null);
 
   const cancelSettle = useCallback(() => {
@@ -104,7 +120,7 @@ function useSettleControls(
 
   const settleAtEnd = useCallback(() => {
     cancelSettle();
-    isAtBottomRef.current = true;
+    followRef.current = { following: true, leftEnd: false };
     let attempts = 0;
     const step = () => {
       virtualizer.scrollToEnd();
@@ -123,7 +139,9 @@ function useSettleControls(
   const settleToIndex = useCallback(
     (index: number) => {
       cancelSettle();
-      isAtBottomRef.current = false;
+      // A jump is the reader choosing a spot in the thread; streamed content must not pull them off
+      // it, even when the target happens to sit inside the at-end tolerance.
+      followRef.current = { following: false, leftEnd: true };
       virtualizer.scrollToIndex(index, { align: "start" });
       let attempts = 0;
       const step = () => {
@@ -149,9 +167,20 @@ function useSettleControls(
     [virtualizer, viewportRef, cancelSettle],
   );
 
+  /**
+   * An upward gesture: leave following until the reader is back against the bottom. Ignored when
+   * there is nothing above to reach — a stray wheel over a thread that fits the viewport would
+   * otherwise kill following with no scroll event left to undo it.
+   */
+  const leaveEnd = useCallback(() => {
+    if (followRef.current.leftEnd) return;
+    if ((viewportRef.current?.scrollTop ?? 0) <= 0) return;
+    followRef.current = { following: false, leftEnd: true };
+  }, [viewportRef]);
+
   useEffect(() => cancelSettle, [cancelSettle]);
 
-  return { isAtBottomRef, settleAtEnd, settleToIndex };
+  return { followRef, leaveEnd, settleAtEnd, settleToIndex };
 }
 
 /**
@@ -226,20 +255,20 @@ function useFollowBottom({
   virtualizer,
   totalSize,
   items,
-  isAtBottomRef,
+  followRef,
   settleAtEnd,
 }: {
   virtualizer: ThreadVirtualizer;
   totalSize: number;
   items: ConversationItem[];
-  isAtBottomRef: RefObject<boolean>;
+  followRef: RefObject<ThreadFollowState>;
   settleAtEnd: () => void;
 }) {
   // biome-ignore lint/correctness/useExhaustiveDependencies: totalSize is the trigger, not a body dependency
   useLayoutEffect(() => {
-    if (!isAtBottomRef.current) return;
+    if (!followRef.current.following) return;
     virtualizer.scrollToEnd();
-  }, [totalSize, virtualizer, isAtBottomRef]);
+  }, [totalSize, virtualizer, followRef]);
 
   const lastItem = items.at(-1);
   const userMessageCount = useMemo(
@@ -258,12 +287,12 @@ function useFollowBottom({
 
   useEffect(() => {
     const handleVisibilityChange = () => {
-      if (!document.hidden && isAtBottomRef.current) settleAtEnd();
+      if (!document.hidden && followRef.current.following) settleAtEnd();
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () =>
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-  }, [settleAtEnd, isAtBottomRef]);
+  }, [settleAtEnd, followRef]);
 }
 
 /**
@@ -322,7 +351,7 @@ export function VirtualThreadScrollBody({
     getItemKey: (index) => flatRows[index]?.key ?? index,
   });
 
-  const { isAtBottomRef, settleAtEnd, settleToIndex } = useSettleControls(
+  const { followRef, leaveEnd, settleAtEnd, settleToIndex } = useSettleControls(
     virtualizer,
     viewportRef,
   );
@@ -386,28 +415,25 @@ export function VirtualThreadScrollBody({
     const scrolledUp = scrollTop < lastScrollTopRef.current - 1;
     lastScrollTopRef.current = scrollTop;
 
-    const atEnd = virtualizer.isAtEnd(AT_BOTTOM_THRESHOLD);
-    // Genuine far drift (not a 1-frame measure transient): the DOM bottom sits well below the
-    // viewport, so follow can't get silently stuck mid-thread.
-    const farFromEnd = el
-      ? el.scrollHeight - el.clientHeight - scrollTop > FAR_DRIFT_THRESHOLD
-      : false;
-    // Hysteresis: each append measures taller than the estimate, so for one frame isAtEnd reads
-    // false before followOnAppend/anchorTo re-pin. Re-arm at the end; only clear on a real upward
-    // scroll or a genuine drift.
-    if (atEnd) {
-      isAtBottomRef.current = true;
-    } else if (scrolledUp || farFromEnd) {
-      isAtBottomRef.current = false;
-    }
+    const distanceFromEnd = el
+      ? el.scrollHeight - el.clientHeight - scrollTop
+      : 0;
+    followRef.current = nextThreadFollowState(followRef.current, {
+      atEnd: virtualizer.isAtEnd(AT_BOTTOM_THRESHOLD),
+      atExactEnd: distanceFromEnd <= AT_EXACT_END_EPSILON,
+      scrolledUp,
+      // Genuine far drift (not a 1-frame measure transient): the DOM bottom sits well below the
+      // viewport, so follow can't get silently stuck mid-thread.
+      farFromEnd: distanceFromEnd > FAR_DRIFT_THRESHOLD,
+    });
     scheduleStickyRecompute();
-  }, [virtualizer, scheduleStickyRecompute, isAtBottomRef]);
+  }, [virtualizer, scheduleStickyRecompute, followRef]);
 
   useFollowBottom({
     virtualizer,
     totalSize,
     items,
-    isAtBottomRef,
+    followRef,
     settleAtEnd,
   });
 
@@ -424,7 +450,20 @@ export function VirtualThreadScrollBody({
           onJump={jumpToMessage}
           anchorId={stickyState.anchorId}
         />
-        <ChatMessageScrollerViewport ref={viewportRef} onScroll={handleScroll}>
+        <ChatMessageScrollerViewport
+          ref={viewportRef}
+          onScroll={handleScroll}
+          // Reading upward is intent, not geometry. Without these the scroll event the gesture
+          // produces still measures "at the end" for the first AT_BOTTOM_THRESHOLD pixels, so a
+          // slow scroll out of the bottom would be undone by the next streamed chunk.
+          onWheelCapture={(event: ReactWheelEvent) => {
+            if (event.deltaY < 0) leaveEnd();
+          }}
+          onTouchMoveCapture={leaveEnd}
+          onKeyDownCapture={(event: ReactKeyboardEvent) => {
+            if (SCROLL_UP_KEYS.has(event.key)) leaveEnd();
+          }}
+        >
           {/* `block` overrides the content's flex+gap layout — spacing moves into the rows
               (pb-4) and the virtual paddings, so translateY offsets are the whole layout. */}
           <ChatMessageScrollerContent

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -6,7 +6,9 @@ import {
   computeStickyAnchor,
   countFlatRows,
   flattenTurnRows,
+  nextThreadFollowState,
   type StickyAnchorEntry,
+  type ThreadScrollSample,
   type TurnRow,
 } from "./threadVirtualization";
 
@@ -177,6 +179,59 @@ describe("countFlatRows", () => {
 
   it("is zero for an empty thread", () => {
     expect(countFlatRows([])).toBe(0);
+  });
+});
+
+describe("nextThreadFollowState", () => {
+  const sample = (
+    over: Partial<ThreadScrollSample> = {},
+  ): ThreadScrollSample => ({
+    atEnd: false,
+    atExactEnd: false,
+    scrolledUp: false,
+    farFromEnd: false,
+    ...over,
+  });
+
+  it.each([
+    [
+      "holds following while an append measures short of the end",
+      { following: true, leftEnd: false },
+      sample(),
+      { following: true, leftEnd: false },
+    ],
+    [
+      "drops following once the reader scrolls up past the tolerance",
+      { following: true, leftEnd: false },
+      sample({ scrolledUp: true }),
+      { following: false, leftEnd: false },
+    ],
+    [
+      "drops following when the end has drifted far below the fold",
+      { following: true, leftEnd: false },
+      sample({ farFromEnd: true }),
+      { following: false, leftEnd: false },
+    ],
+    [
+      "re-arms inside the tolerance when the reader never left the end",
+      { following: false, leftEnd: false },
+      sample({ atEnd: true }),
+      { following: true, leftEnd: false },
+    ],
+    [
+      "stays off inside the tolerance after an upward gesture",
+      { following: false, leftEnd: true },
+      sample({ atEnd: true }),
+      { following: false, leftEnd: true },
+    ],
+    [
+      "resumes once the reader is back against the bottom",
+      { following: false, leftEnd: true },
+      sample({ atEnd: true, atExactEnd: true }),
+      { following: true, leftEnd: false },
+    ],
+  ])("%s", (_name, state, event, expected) => {
+    expect(nextThreadFollowState(state, event)).toEqual(expected);
   });
 });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.test.ts
@@ -8,6 +8,7 @@ import {
   flattenTurnRows,
   nextThreadFollowState,
   type StickyAnchorEntry,
+  sampleThreadScroll,
   type ThreadScrollSample,
   type TurnRow,
 } from "./threadVirtualization";
@@ -189,6 +190,7 @@ describe("nextThreadFollowState", () => {
     atEnd: false,
     atExactEnd: false,
     scrolledUp: false,
+    scrolledDown: false,
     farFromEnd: false,
     ...over,
   });
@@ -219,9 +221,21 @@ describe("nextThreadFollowState", () => {
       { following: true, leftEnd: false },
     ],
     [
-      "stays off inside the tolerance after an upward gesture",
+      "stays off when streamed content grows past a reader parked inside the tolerance",
       { following: false, leftEnd: true },
       sample({ atEnd: true }),
+      { following: false, leftEnd: true },
+    ],
+    [
+      "resumes when the reader scrolls back down into the tolerance",
+      { following: false, leftEnd: true },
+      sample({ atEnd: true, scrolledDown: true }),
+      { following: true, leftEnd: false },
+    ],
+    [
+      "ignores a downward scroll that stops short of the tolerance",
+      { following: false, leftEnd: true },
+      sample({ scrolledDown: true }),
       { following: false, leftEnd: true },
     ],
     [
@@ -230,8 +244,54 @@ describe("nextThreadFollowState", () => {
       sample({ atEnd: true, atExactEnd: true }),
       { following: true, leftEnd: false },
     ],
+    [
+      "drops following on an upward scroll that stays inside the tolerance",
+      { following: true, leftEnd: false },
+      sample({ atEnd: true, scrolledUp: true }),
+      { following: false, leftEnd: false },
+    ],
   ])("%s", (_name, state, event, expected) => {
     expect(nextThreadFollowState(state, event)).toEqual(expected);
+  });
+});
+
+describe("sampleThreadScroll", () => {
+  // Scroll range is 0..1500.
+  const viewport = (scrollTop: number) => ({
+    scrollTop,
+    scrollHeight: 2000,
+    clientHeight: 500,
+  });
+
+  it.each([
+    [
+      "a downward move that stops just short of the bottom",
+      1450,
+      1400,
+      { atEnd: true, atExactEnd: false, scrolledDown: true },
+    ],
+    [
+      "a downward move that stops outside the tolerance",
+      1300,
+      1200,
+      { atEnd: false, atExactEnd: false, scrolledDown: true },
+    ],
+    [
+      "sub-pixel drift, which is neither direction",
+      900,
+      900.5,
+      { atEnd: false, atExactEnd: false, scrolledDown: false },
+    ],
+    [
+      "the true bottom",
+      1500,
+      1450,
+      { atEnd: true, atExactEnd: true, scrolledDown: true },
+    ],
+  ])("measures %s", (_name, scrollTop, previous, expected) => {
+    expect(sampleThreadScroll(viewport(scrollTop), previous)).toMatchObject(
+      expected,
+    );
   });
 });
 

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -149,6 +149,44 @@ export function countFlatRows(rows: TurnRow[]): number {
   return count;
 }
 
+/** Whether the windowed body re-pins to the bottom as content arrives. */
+export interface ThreadFollowState {
+  following: boolean;
+  /**
+   * The reader deliberately moved off the end. Cleared only by a return to the true bottom or an
+   * explicit scroll-to-bottom — not by the at-end tolerance below, which would otherwise re-arm
+   * following on the very scroll event the gesture produced and drag the reader back down on the
+   * next streamed chunk.
+   */
+  leftEnd: boolean;
+}
+
+/** A scroll event's geometry, as the windowed body measures it. */
+export interface ThreadScrollSample {
+  /** Inside the at-end tolerance — a little above the bottom still counts, to absorb measure drift. */
+  atEnd: boolean;
+  /** Hard against the bottom, the only geometry that re-arms following once the reader left it. */
+  atExactEnd: boolean;
+  /** The viewport moved upward since the previous sample. */
+  scrolledUp: boolean;
+  /** Far enough below the fold that following is stuck mid-thread rather than measuring. */
+  farFromEnd: boolean;
+}
+
+/** Fold one scroll sample into the follow state. */
+export function nextThreadFollowState(
+  state: ThreadFollowState,
+  sample: ThreadScrollSample,
+): ThreadFollowState {
+  if (sample.atExactEnd) return { following: true, leftEnd: false };
+  if (state.leftEnd) return state;
+  if (sample.atEnd) return { following: true, leftEnd: false };
+  if (sample.scrolledUp || sample.farFromEnd) {
+    return { following: false, leftEnd: false };
+  }
+  return state;
+}
+
 /** A user-message row's measured extent in the scroll space, in row order. */
 export interface StickyAnchorEntry {
   id: string;

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/threadVirtualization.ts
@@ -149,28 +149,70 @@ export function countFlatRows(rows: TurnRow[]): number {
   return count;
 }
 
-/** Whether the windowed body re-pins to the bottom as content arrives. */
+/**
+ * Tolerance for calling the viewport "at the end". Generous because rows are estimated until they
+ * mount and streamed content keeps appending, so the reader who has just scrolled down as far as
+ * the wheel takes them is routinely tens of pixels short of the true bottom.
+ */
+export const THREAD_AT_END_THRESHOLD = 100;
+/** Slack for sub-pixel scroll positions when deciding the viewport is hard against the bottom. */
+export const THREAD_AT_EXACT_END_EPSILON = 1;
+/** Movement below this is measurement noise, not a direction the reader chose. */
+export const THREAD_SCROLL_DIRECTION_EPSILON = 1;
+/**
+ * A real upward drift, not a 1-frame measure transient: the DOM bottom sits this far below the
+ * viewport. Well above any single append's measure gap.
+ */
+export const THREAD_FAR_DRIFT_THRESHOLD = 400;
+
+/** Keys that move the viewport upward, so pressing them reads as leaving the end. */
+export const SCROLL_UP_KEYS = new Set(["ArrowUp", "PageUp", "Home"]);
+
+/** Whether a thread body re-pins to the bottom as content arrives. */
 export interface ThreadFollowState {
   following: boolean;
   /**
-   * The reader deliberately moved off the end. Cleared only by a return to the true bottom or an
-   * explicit scroll-to-bottom — not by the at-end tolerance below, which would otherwise re-arm
-   * following on the very scroll event the gesture produced and drag the reader back down on the
-   * next streamed chunk.
+   * The reader deliberately moved off the end. Held until they move back down into the end
+   * tolerance, so streamed content that keeps growing under them never re-arms following on its
+   * own — the reader's own downward gesture is what asks for it back.
    */
   leftEnd: boolean;
 }
 
-/** A scroll event's geometry, as the windowed body measures it. */
+/** The follow state a thread starts in, and the one an explicit scroll-to-bottom restores. */
+export const FOLLOWING_END: ThreadFollowState = {
+  following: true,
+  leftEnd: false,
+};
+
+/** A scroll event's geometry, as a thread body measures it. */
 export interface ThreadScrollSample {
   /** Inside the at-end tolerance — a little above the bottom still counts, to absorb measure drift. */
   atEnd: boolean;
-  /** Hard against the bottom, the only geometry that re-arms following once the reader left it. */
+  /** Hard against the bottom, which always means following. */
   atExactEnd: boolean;
   /** The viewport moved upward since the previous sample. */
   scrolledUp: boolean;
+  /** The viewport moved downward since the previous sample. */
+  scrolledDown: boolean;
   /** Far enough below the fold that following is stuck mid-thread rather than measuring. */
   farFromEnd: boolean;
+}
+
+/** Measure one scroll position against the previous one. */
+export function sampleThreadScroll(
+  el: { scrollTop: number; scrollHeight: number; clientHeight: number },
+  previousScrollTop: number,
+): ThreadScrollSample {
+  const distanceFromEnd = el.scrollHeight - el.clientHeight - el.scrollTop;
+  const delta = el.scrollTop - previousScrollTop;
+  return {
+    atEnd: distanceFromEnd <= THREAD_AT_END_THRESHOLD,
+    atExactEnd: distanceFromEnd <= THREAD_AT_EXACT_END_EPSILON,
+    scrolledUp: delta < -THREAD_SCROLL_DIRECTION_EPSILON,
+    scrolledDown: delta > THREAD_SCROLL_DIRECTION_EPSILON,
+    farFromEnd: distanceFromEnd > THREAD_FAR_DRIFT_THRESHOLD,
+  };
 }
 
 /** Fold one scroll sample into the follow state. */
@@ -178,12 +220,17 @@ export function nextThreadFollowState(
   state: ThreadFollowState,
   sample: ThreadScrollSample,
 ): ThreadFollowState {
-  if (sample.atExactEnd) return { following: true, leftEnd: false };
-  if (state.leftEnd) return state;
-  if (sample.atEnd) return { following: true, leftEnd: false };
-  if (sample.scrolledUp || sample.farFromEnd) {
-    return { following: false, leftEnd: false };
+  if (sample.atExactEnd) return FOLLOWING_END;
+  // An upward move is intent even inside the tolerance, so a short gesture off the bottom isn't
+  // undone by the scroll event it produced.
+  if (sample.scrolledUp) return { following: false, leftEnd: state.leftEnd };
+  if (state.leftEnd) {
+    // Scrolling back down into the tolerance is the reader asking to follow again. Geometry alone
+    // must not do it: streamed appends push the bottom away without the reader moving.
+    return sample.atEnd && sample.scrolledDown ? FOLLOWING_END : state;
   }
+  if (sample.atEnd) return FOLLOWING_END;
+  if (sample.farFromEnd) return { following: false, leftEnd: false };
   return state;
 }
 


### PR DESCRIPTION
## Problem

Scrolling up in a live thread snaps the view back to the bottom and jitters, so a reader cannot read an earlier turn while the agent streams. It is worst in command center panels, where the panel is short.

- Both thread bodies read "within 100px of the bottom" as proof the reader wants to follow.
- Both re-derive that on every scroll event, so a gesture shorter than 100px is undone a tick later.
- Streamed text grows the thread every frame, so the undo repeats. That is the jitter.
- The windowed body never observed wheel or touch at all. The list it replaced dropped follow on `deltaY < 0`.

## Changes

<img width="1894" height="750" alt="2026-08-06 10 42 34" src="https://github.com/user-attachments/assets/fd2aac97-bfee-4445-99ff-82aba50e4eec" />


- An upward gesture now outranks geometry: following stays off until the reader is back at the bottom, presses scroll to bottom, or submits a prompt.
- `nextThreadFollowState` holds that rule as a pure function in `threadVirtualization.ts`.
- The windowed viewport listens for wheel, touch, and the PageUp, ArrowUp and Home keys.
- The plain body drops its widened `scrollEdgeThreshold`. Quill's engine re-enters `following-bottom` on any scroll taken inside the band, which overrides the free-scrolling its own wheel handler just set. A wide band cannot be made to respect a gesture.
- `ThreadAutoFollow` keeps the pin instead. It arms on mount, so a cloud task streaming into a panel you never prompted from still follows.
- The scroll-to-bottom button re-arms that pin.

No screenshot: a still frame looks identical. The change is in how the thread behaves while content arrives.

> [!NOTE]
> `products/desktop/` is a port of PostHog/code at a pinned SHA, so this is lost on the next resync unless it is upstreamed or recorded as intentional drift. The engine half is arguably a quill bug worth reporting there too.

## How did you test this code?

- Added six parameterized cases for `nextThreadFollowState`. The one that catches this bug: after an upward gesture, a sample still inside the at-end tolerance must not re-arm following.
- I (actually Claude) ran the desktop `pnpm typecheck` and the `packages/ui` sessions suite locally.
- Not done: I never launched the Electron app or reproduced the scroll by hand, so the fix is unverified against a real streaming thread. It is worth a manual pass in the command center before merge.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) investigated a report that the new thread UX hijacks scrolling, and wrote the fix in Claude Code. Skills invoked: `posthog-desktop`, `writing-tests`, `writing-pr-descriptions`.

I read the shipped `@posthog/quill@0.3.0-beta.24` bundle to confirm the engine re-derives its follow mode from scroll position on every scroll event. That is what makes the widened band unfixable from the outside, and it decided the `scrollEdgeThreshold` change.

My first idea was to restore only the wheel handler the legacy list had. That does not hold, because the scroll event the gesture produces re-arms following one tick later, so the state had to become sticky.

https://claude.ai/code/session_015EbqyiijcHqfP13S3KXDHh