### PR TITLE
revert: fix(error-tracking): avoid person override join in issue queries (#78301)

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_builder.py
@@ -294,9 +294,9 @@ class ErrorTrackingQueryBuilder:
                     ),
                 )
             )
-            # Resolving person_id adds a full person-distinct-id override join before
-            # aggregation. event_person_id avoids that join and is already nullable for
-            # personless events, where distinct_id remains the fallback.
+            # Same HLL tradeoff as `sessions`. Input semantics preserved
+            # (resolved person_id with distinct_id fallback) so the user
+            # population is unchanged — only the counting algorithm changed.
             exprs.append(
                 ast.Alias(
                     alias="users_state",
@@ -310,9 +310,7 @@ class ErrorTrackingQueryBuilder:
                                         ast.Call(
                                             name="nullIf",
                                             args=[
-                                                ast.Call(
-                                                    name="toString", args=[ast.Field(chain=["e", "event_person_id"])]
-                                                ),
+                                                ast.Call(name="toString", args=[ast.Field(chain=["e", "person_id"])]),
                                                 ast.Constant(value="00000000-0000-0000-0000-000000000000"),
                                             ],
                                         ),

--- a/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
+++ b/products/error_tracking/backend/hogql_queries/test/__snapshots__/test_error_tracking_query_runner.ambr
@@ -23,12 +23,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -86,12 +93,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -636,12 +650,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -858,12 +879,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
+            least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2018-01-11 12:11:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN
@@ -1054,7 +1082,7 @@
             least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1134,7 +1162,7 @@
             least(0, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 1)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
      LEFT OUTER JOIN
        (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -1214,8 +1242,15 @@
             least(3, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 4)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
      WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
@@ -1274,12 +1309,19 @@
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_functions', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS function_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_sources', -1), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS source_state,
             argMaxState(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$lib'), ''), 'null'), '^"|"$', ''), toTimeZone(e.timestamp, 'UTC')) AS library_state,
-            least(2, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 3)))) AS bin_idx,
+            least(2, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toTimeZone(e.timestamp, 'UTC')), greatest(1, intDiv(dateDiff('seconds', toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC'), toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')), 3)))) AS bin_idx,
             count() AS occ,
             uniqState(nullIf(e.`$session_id`, '')) AS sessions_state,
-            uniqState(coalesce(nullIf(toString(e.person_id), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
+            uniqState(coalesce(nullIf(toString(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id)), '00000000-0000-0000-0000-000000000000'), e.distinct_id)) AS users_state
      FROM events AS e
-     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('2020-01-10 00:00:00.000000', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+     WHERE and(equals(e.team_id, 99999), equals(e.event, '$exception'), isNotNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, '$exception_fingerprint'), ''), 'null'), '^"|"$', '')), greaterOrEquals(e.timestamp, toDateTime(toDateTime64('explicit_redacted_timestamp', 6, 'UTC'), 'UTC')), lessOrEquals(e.timestamp, toDateTime(toDateTime64('today', 6, 'UTC'), 'UTC')))
      GROUP BY fp_hash,
               bin_idx) AS ev
   INNER JOIN

--- a/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/test/test_error_tracking_query_runner.py
@@ -129,12 +129,6 @@ class TestErrorTrackingQueryRunner(ClickhouseTestMixin, NonAtomicBaseTestKeepIde
         self.assertIn("JSONExtractString(e.properties, '$exception_fingerprint')", response["hogql"])
         self.assertNotIn("mat_$exception_fingerprint", response["hogql"])
 
-    def test_user_aggregation_does_not_resolve_person_overrides(self):
-        response = self._calculate(withAggregations=True)
-
-        self.assertIn("e.event_person_id", response["hogql"])
-        self.assertNotIn("person_distinct_id_overrides", response["hogql"])
-
     def setUp(self):
         super().setUp()
 


### PR DESCRIPTION
## Problem

Reverts #78301 (avoid person override join in issue queries) — it's causing issues in error tracking issue queries.

## Changes

Clean revert of 23b8ce0a96716273f13c0fc8e2d08e46c6332f80; restores the person override join in the error tracking query builder along with the previous test expectations and snapshots.

## How did you test this code?

Mechanical revert applied cleanly; no commits since the original merge touch this surface. Relying on CI for the error tracking query runner tests.
