### PR TITLE
fix(taxonomy): time out slow property definition list queries

### DIFF
--- a/posthog/api/test/test_property_definition.py
+++ b/posthog/api/test/test_property_definition.py
@@ -4,13 +4,19 @@ from typing import Any, Optional, Union, cast
 from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
 
+from django.db import OperationalError
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
 from rest_framework import status
 
 from posthog.models import ActivityLog, EventDefinition, EventProperty, Organization, PropertyDefinition, Team
-from posthog.taxonomy.property_definition_api import PropertyDefinitionQuerySerializer, PropertyDefinitionViewSet
+from posthog.taxonomy.property_definition_api import (
+    PropertyDefinitionQuerySerializer,
+    PropertyDefinitionViewSet,
+    QueryContext,
+    is_query_canceled,
+)
 
 
 def exclude_virtual_properties(results: list) -> list:
@@ -1035,6 +1041,56 @@ class TestPropertyDefinitionAPI(APIBaseTest):
         assert "$virt_traffic_type" in virtual_names
         assert "$virt_traffic_category" in virtual_names
         assert "$virt_bot_name" in virtual_names
+
+
+class TestPropertyDefinitionListStatementTimeout(APIBaseTest):
+    def test_cancelled_list_query_returns_a_retryable_503(self) -> None:
+        # Postgres cancels the statement, psycopg raises, and Django re-raises it as a bare
+        # OperationalError. Without the handler that renders as a 500, which the taxonomic filter
+        # shows as "no properties" rather than as a failure the user can retry.
+        slow_count_sql = "SELECT count(*) AS full_count FROM (SELECT pg_sleep(3)) s WHERE %(project_id)s IS NOT NULL"
+
+        with (
+            patch.object(QueryContext, "as_count_sql", return_value=slow_count_sql),
+            patch(
+                "posthog.taxonomy.property_definition_api.PROPERTY_DEFINITIONS_STATEMENT_TIMEOUT_MS",
+                250,
+            ),
+        ):
+            response = self.client.get(f"/api/projects/{self.team.pk}/property_definitions/")
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.json()["code"] == "property_definitions_timeout"
+
+
+class TestIsQueryCanceled(SimpleTestCase):
+    @staticmethod
+    def _wrapped_error(**attrs: str) -> OperationalError:
+        # Django surfaces the driver's error as its own OperationalError with the original attached
+        # as __cause__, which is where the SQLSTATE lives.
+        cause = Exception("canceling statement due to statement timeout")
+        for name, value in attrs.items():
+            setattr(cause, name, value)
+        error = OperationalError("canceling statement due to statement timeout")
+        error.__cause__ = cause
+        return error
+
+    @parameterized.expand(
+        [
+            ["psycopg3 exposes sqlstate", {"sqlstate": "57014"}, True],
+            ["psycopg2 exposes pgcode", {"pgcode": "57014"}, True],
+            ["a dropped connection is not a cancellation", {"sqlstate": "08006"}, False],
+            ["a driver error carrying no sqlstate", {}, False],
+        ]
+    )
+    def test_recognises_only_a_cancelled_statement(self, _name: str, attrs: dict[str, str], expected: bool) -> None:
+        assert is_query_canceled(self._wrapped_error(**attrs)) is expected
+
+    def test_recognises_the_code_on_the_error_itself(self) -> None:
+        error = OperationalError("canceling statement due to statement timeout")
+        error.sqlstate = "57014"  # type: ignore[attr-defined]
+
+        assert is_query_canceled(error) is True
 
 
 class TestPropertyDefinitionQuerySerializer(SimpleTestCase):

--- a/posthog/taxonomy/property_definition_api.py
+++ b/posthog/taxonomy/property_definition_api.py
@@ -3,15 +3,16 @@ import uuid
 import dataclasses
 from typing import Any, Optional, Self, Union, cast
 
-from django.db import connection, models
+from django.db import DEFAULT_DB_ALIAS, OperationalError, connections, models, router, transaction
 from django.db.models import Manager, QuerySet
 from django.db.models.functions import Coalesce
 from django.http import Http404
 from django.shortcuts import get_object_or_404
 
 from opentelemetry import trace
+from prometheus_client import Counter
 from rest_framework import mixins, request, response, serializers, status, viewsets
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import APIException, ValidationError
 from rest_framework.pagination import LimitOffsetPagination
 
 from posthog.api.documentation import extend_schema
@@ -39,6 +40,51 @@ EXCLUDED_EVENT_CORE_PROPERTIES = [
     prop for prop in CORE_FILTER_DEFINITIONS_BY_GROUP["event_properties"].keys() if not prop.startswith("$")
 ]
 
+PROPERTY_DEFINITION_TYPES = ["event", "person", "group", "session"]
+
+# Listing runs two raw queries (a count, then a page fetch) that take seconds on projects with
+# very many property definitions. The app database sets no statement_timeout, so a slow one keeps
+# consuming database CPU for the full request until the gateway gives up at 120s, long after the
+# client stopped waiting for it. Bounding each statement well below that ceiling sheds the load
+# instead of queueing it, and returns a 503 the caller can retry or report.
+PROPERTY_DEFINITIONS_STATEMENT_TIMEOUT_MS = 25_000
+
+# Postgres reports a statement cancelled by statement_timeout as SQLSTATE 57014. psycopg2 exposes
+# it as `pgcode` and psycopg3 as `sqlstate`, and Django re-raises either as its own
+# OperationalError, so both attribute names have to be checked on the error and on its cause.
+QUERY_CANCELED_SQLSTATE = "57014"
+
+PROPERTY_DEFINITIONS_TIMED_OUT_COUNTER = Counter(
+    "property_definitions_list_timed_out_total",
+    "Property definition list requests cancelled by the statement timeout.",
+    labelnames=["property_type"],
+)
+
+
+class PropertyDefinitionsTimedOut(APIException):
+    # The taxonomic filter renders a failed list the same way as an empty one, so a generic 5xx here
+    # reads to the user as "this project has no properties". A stable code lets the client tell a
+    # timed-out list apart from any other server error and offer a retry instead.
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_code = "property_definitions_timeout"
+    default_detail = "Loading properties took too long. Try a narrower search, or try again in a moment."
+
+
+def read_db_alias() -> str:
+    # The page fetch is an ORM RawQuerySet, so it follows the read router (see ReplicaRouter's
+    # opt-in list). The count query and the statement timeout have to land on that same connection
+    # or they describe a different session than the one doing the work.
+    return router.db_for_read(PropertyDefinition) or DEFAULT_DB_ALIAS
+
+
+def is_query_canceled(error: BaseException) -> bool:
+    for exc in (error, error.__cause__):
+        if exc is None:
+            continue
+        if (getattr(exc, "sqlstate", None) or getattr(exc, "pgcode", None)) == QUERY_CANCELED_SQLSTATE:
+            return True
+    return False
+
 
 class SeenTogetherQuerySerializer(serializers.Serializer):
     event_names: serializers.ListField = serializers.ListField(child=serializers.CharField(), required=True)
@@ -53,7 +99,7 @@ class PropertyDefinitionQuerySerializer(serializers.Serializer):
     )
 
     type = serializers.ChoiceField(
-        choices=["event", "person", "group", "session"],
+        choices=PROPERTY_DEFINITION_TYPES,
         help_text="What property definitions to return",
         default="event",
     )
@@ -722,7 +768,7 @@ class PropertyDefinitionViewSet(
             span.set_attribute("joins_event_property", query_context.should_join_event_property)
 
             with tracer.start_as_current_span("property_definitions_count_query") as count_span:
-                with connection.cursor() as cursor:
+                with connections[read_db_alias()].cursor() as cursor:
                     cursor.execute(query_context.as_count_sql(), query_context.params)
                     full_count = cursor.fetchone()[0]
                 count_span.set_attribute("full_count", full_count)
@@ -796,9 +842,29 @@ class PropertyDefinitionViewSet(
 
     @extend_schema(parameters=[PropertyDefinitionQuerySerializer])
     def list(self, request, *args, **kwargs):
-        response = super().list(request, *args, **kwargs)
-
         event_type = request.query_params.get("type", "event")
+
+        # Both raw queries and the serialization that reads their rows have to sit inside this
+        # transaction, because SET LOCAL only lasts until it commits and the page fetch is a lazy
+        # RawQuerySet that the paginator does not evaluate until super().list() serializes it.
+        alias = read_db_alias()
+        try:
+            with transaction.atomic(using=alias):
+                with connections[alias].cursor() as cursor:
+                    cursor.execute(
+                        "SET LOCAL statement_timeout = %s",
+                        [PROPERTY_DEFINITIONS_STATEMENT_TIMEOUT_MS],
+                    )
+                response = super().list(request, *args, **kwargs)
+        except OperationalError as error:
+            if not is_query_canceled(error):
+                raise
+            # `event_type` is raw query input, so clamp it to the known set rather than letting a
+            # caller mint unbounded Prometheus label values.
+            PROPERTY_DEFINITIONS_TIMED_OUT_COUNTER.labels(
+                property_type=event_type if event_type in PROPERTY_DEFINITION_TYPES else "unknown"
+            ).inc()
+            raise PropertyDefinitionsTimedOut from error
 
         # Inject virtual event/person/group properties to the end of the results
         if event_type in ["event", "person", "group"]:


### PR DESCRIPTION
## Problem

- Opening a property filter on a project with very many property definitions can hang for two minutes, then fail with a gateway timeout, and the dropdown shows "No results" as if the project had no properties.
- Listing property definitions runs a count query and a page fetch that take seconds on those projects.
- The app database sets no `statement_timeout`, so a slow query keeps consuming database CPU for the full 120 seconds, long after the client stopped waiting for the response.

## Changes

- `GET /api/projects/:id/property_definitions` now caps each of its statements at 25 seconds.
- A cancelled statement returns 503 with the code `property_definitions_timeout`, instead of a 500 or a gateway 504.
- The new counter `property_definitions_list_timed_out_total` labels timeouts by property type.
- The count query now runs on the routed read connection, which the page fetch already used.

Why `SET LOCAL` inside a transaction rather than a global `statement_timeout`: this endpoint is the slow one, and a database-wide limit would also cut off migrations, exports, and every other query. `SET LOCAL` needs the transaction because it lasts only until commit, and the page fetch is a lazy `RawQuerySet` that the paginator evaluates during serialization, inside `super().list()`.

The two connections had to converge for the timeout to hold. The page fetch is an ORM `RawQuerySet` and follows `ReplicaRouter`, while the count query named the default connection directly. Today both resolve to `default`, so this changes nothing in production. It stops the timeout from silently covering only half the work if `PropertyDefinition` is ever added to `READ_REPLICA_OPT_IN`.

> [!NOTE]
> A request that used to succeed after more than 25 seconds now fails instead. That is the intent: the client has usually gone away by then, and the query keeps a database core busy until it finishes.

The 503 is not declared in the OpenAPI schema. Passing `responses=` to `@extend_schema` replaces drf-spectacular's inferred paginated 200, so adding it means regenerating the frontend types for a response the client only needs to recognize as a failure. Happy to do it in a follow-up if a reviewer wants the error typed.

## How did you test this code?

- `test_cancelled_list_query_returns_a_retryable_503` drives a real cancellation through the endpoint with a 250 ms timeout and a sleeping count query. It guards the wiring: without the handler, Django raises a bare `OperationalError` and the endpoint 500s.
- `TestIsQueryCanceled` pins SQLSTATE 57014 detection across psycopg2's `pgcode` and psycopg3's `sqlstate`, on the error and on its `__cause__`. A driver upgrade that moves the attribute would otherwise turn every timeout back into a 500 with no test failing.
- Not checked: I ran nothing against production, and I did not exercise a real 25-second timeout on a large project. The 250 ms test timeout stands in for it.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow or setting changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Cursor's Opus 5 agent) wrote this at Eli's direction, after investigating gateway timeouts reported against this endpoint. The investigation first checked whether two `property-defs-rs` writer changes that merged the same morning were involved. They were not: write volume to `posthog_propertydefinition` dropped sharply at that deploy, and these read queries have been among the slowest on the database for far longer than the reports.

One planned change was dropped. The plan included skipping the `DISTINCT posthog_eventproperty` subquery for the count query, on the theory that the count never reads a column from it. `EXPLAIN` showed the Postgres 15 planner already eliminates that join, so the change would have added code for no gain.

Skills invoked: `/writing-pr-descriptions`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy` (for the 503 detail message).

A companion PR handles the client side, so a failed list renders as a retryable error rather than as an empty one.
