### PR TITLE
fix(taxonomic-filter): show a retryable error when a list fetch fails

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2532,6 +2532,10 @@ snapshots:
         hash: v1.k794b7964.422ddb7aef488b7df5fb0a27715994aed79448f280b62f4e786e08f755c88b3c.kny9iJ5G5fwjTNqF1xKveHzAT06hjte-CATByxBVFaM
     filters-taxonomic-filter--events-premium--light:
         hash: v1.k794b7964.81a78bc8ee376be4d5515ddcab000082de15195a6ea1e700546a2346d4cb17f3.BZBvpIZWaczTKJuEBUyigcG45af_A0jgpe10HbXQ9rQ
+    filters-taxonomic-filter--failed-fetch-offers-retry--dark:
+        hash: v1.k794b7964.dbbfe19dede7bc642e918f48fb4f80151c48e2ccbbcb62617157e6df3c4d533d.C8yxDgBe0uM24bqwnL0r4iJczX5vS93okDcE1Ceqsos
+    filters-taxonomic-filter--failed-fetch-offers-retry--light:
+        hash: v1.k794b7964.a7baf4370142ad9d63f131c07b9485638e88a08d8dec67196e85f1b098a7c48d.KNaiZbsQDpXQXNeJ04WDLW_9pdwkXpIH0HyEajxI86I
     filters-taxonomic-filter--mcp-tool-call-context-leads-with-mcp-properties--dark:
         hash: v1.k794b7964.13fd306591ab8aa983b98d475f2fa5566c4fdc3f8cf86d634d98c884c326a779.ZS2ZfxmIjJjZY9VD_0Ueclr1mbmK_5qkuHbny_eV2B4
     filters-taxonomic-filter--mcp-tool-call-context-leads-with-mcp-properties--light:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3803,13 +3803,13 @@ const api = {
         async list(params: GroupListParams): Promise<CountedPaginatedResponse<Group>> {
             return await new ApiRequest().groups().withQueryString(toParams(params, true)).get()
         },
-        async listClickhouse(params: GroupListParams): Promise<GroupsQueryResponse> {
+        async listClickhouse(params: GroupListParams, options?: ApiMethodOptions): Promise<GroupsQueryResponse> {
             const groupsQuery: GroupsQuery = {
                 kind: NodeKind.GroupsQuery,
                 ...params,
             }
 
-            return await new ApiRequest().query().create({ data: { query: groupsQuery } })
+            return await new ApiRequest().query().create({ ...options, data: { query: groupsQuery } })
         },
         async create(data: CreateGroupParams): Promise<Group> {
             return await new ApiRequest().groups().create({ data })

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -6,7 +6,7 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { CSSProperties, useEffect, useState } from 'react'
 import { List, useListRef } from 'react-window'
 
-import { IconArchive, IconCheck, IconPin, IconPinFilled, IconPlus, IconSearch } from '@posthog/icons'
+import { IconArchive, IconCheck, IconPin, IconPinFilled, IconPlus, IconSearch, IconWarning } from '@posthog/icons'
 import { LemonButton, LemonDivider, LemonTag } from '@posthog/lemon-ui'
 
 import { AutoSizer } from 'lib/components/AutoSizer'
@@ -824,6 +824,26 @@ function InfiniteListEmptyState(): JSX.Element {
     )
 }
 
+function InfiniteListErrorState(): JSX.Element {
+    const { retryRemoteItems } = useActions(infiniteListLogic)
+
+    return (
+        <div className="no-infinite-results flex flex-col gap-y-1 items-center">
+            <IconWarning className="text-5xl text-tertiary" />
+            <span className="text-center">Couldn't load results</span>
+            <LemonButton
+                type="secondary"
+                size="xsmall"
+                data-attr="taxonomic-retry-remote-items"
+                onClick={retryRemoteItems}
+            >
+                Try again
+            </LemonButton>
+            <span className="text-center text-secondary italic">If it keeps happening, contact support.</span>
+        </div>
+    )
+}
+
 export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: InfiniteListProps): JSX.Element {
     const {
         mouseInteractionsEnabled,
@@ -852,6 +872,7 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         showPopover,
         showNonCapturedEventOption,
         showEmptyState,
+        showErrorState,
         showLoadingState,
         isSuggestedFilters,
         isActiveTab,
@@ -878,12 +899,14 @@ export function InfiniteList({ popupAnchorElement, definitionPopoverRenderer }: 
         <div
             className={cn(
                 'taxonomic-infinite-list',
-                showEmptyState && 'empty-infinite-list',
+                (showEmptyState || showErrorState) && 'empty-infinite-list',
                 'h-full',
                 isSuggestedFilters && 'empty-infinite-list--start'
             )}
         >
-            {showEmptyState ? (
+            {showErrorState ? (
+                <InfiniteListErrorState />
+            ) : showEmptyState ? (
                 <InfiniteListEmptyState />
             ) : showLoadingState ? (
                 <div className="flex items-center justify-center h-full">

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.stories.tsx
@@ -603,6 +603,42 @@ export const RenamedSeriesSelectedPill: Story = {
     },
 }
 
+export const FailedFetchOffersRetry: Story = {
+    render: (args) => {
+        useMountedLogic(actionsModel)
+        const { setSearchQuery } = useActions(
+            taxonomicFilterLogic({ ...args, taxonomicFilterLogicKey: args.taxonomicFilterLogicKey as string })
+        )
+
+        useOnMountEffect(() => setSearchQuery('user_signed_up'))
+
+        return (
+            <div className="w-fit border rounded p-2 bg-surface-primary">
+                <TaxonomicFilter {...args} />
+            </div>
+        )
+    },
+    args: {
+        taxonomicFilterLogicKey: 'events-failed-fetch',
+        taxonomicGroupTypes: [TaxonomicFilterGroupType.Events],
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/projects/:team_id/event_definitions': () => [500, { detail: 'server error' }],
+            },
+        }),
+    ],
+    parameters: {
+        testOptions: { waitForSelector: '[data-attr="taxonomic-retry-remote-items"]' },
+        docs: {
+            description: {
+                story: 'When the search request fails, the list says so and offers a retry, rather than showing the same "No results" as a genuine empty search.',
+            },
+        },
+    },
+}
+
 export const EmptyEventsWithStaleToggle: Story = {
     render: (args) => {
         useMountedLogic(actionsModel)

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -14,6 +14,7 @@ import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/
 
 import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { useMocks } from '~/mocks/jest'
+import { Mocks } from '~/mocks/utils'
 import { initKeaTests } from '~/test/init'
 import { mockEventDefinitions, mockEventPropertyDefinitions } from '~/test/mocks'
 import { AppContext, PropertyDefinition, PropertyFilterType, PropertyOperator, PropertyType } from '~/types'
@@ -576,22 +577,46 @@ describe('infiniteListLogic', () => {
             })
         })
 
-        it('gives up on a request that never responds', async () => {
-            useMocks({
-                get: {
-                    '/api/projects/:team/event_definitions': () => new Promise(() => {}),
+        // Group names go out over the query endpoint instead of the list endpoint, so they need
+        // the abort signal wired separately - without it the watchdog fires against a controller
+        // nobody is listening to and the list keeps spinning.
+        const hangingListCases: { label: string; listGroupType: TaxonomicFilterGroupType; mocks: Mocks }[] = [
+            {
+                label: 'a list endpoint',
+                listGroupType: TaxonomicFilterGroupType.Events,
+                mocks: {
+                    get: { '/api/projects/:team/event_definitions': () => new Promise(() => {}) },
                 },
-            })
+            },
+            {
+                label: 'a group name query',
+                listGroupType: `${TaxonomicFilterGroupType.GroupNamesPrefix}_0` as TaxonomicFilterGroupType,
+                mocks: {
+                    get: {
+                        '/api/projects/:team/groups_types': [
+                            { group_type: 'organization', group_type_index: 0, name_singular: null, name_plural: null },
+                        ],
+                    },
+                    post: { '/api/environments/:team_id/query/': () => new Promise(() => {}) },
+                },
+            },
+        ]
+
+        it.each(hangingListCases)('gives up on $label that never responds', async ({ listGroupType, mocks }) => {
+            useMocks(mocks)
             initKeaTests()
             jest.useFakeTimers()
             try {
                 const hangingLogic = infiniteListLogic({
                     taxonomicFilterLogicKey: 'hangingList',
-                    listGroupType: TaxonomicFilterGroupType.Events,
-                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events],
+                    listGroupType,
+                    taxonomicGroupTypes: [listGroupType],
                     showNumericalPropsOnly: false,
                 })
                 hangingLogic.mount()
+                // Let the group type list arrive, so a group name list resolves its group index
+                // and takes the query path rather than falling back to the list endpoint.
+                await jest.advanceTimersByTimeAsync(1)
                 hangingLogic.actions.setSearchQuery('user_signed_up')
 
                 // Past the debounce, so the request is in flight rather than still queued.
@@ -600,6 +625,37 @@ describe('infiniteListLogic', () => {
 
                 await jest.advanceTimersByTimeAsync(30000)
                 expect(hangingLogic.values.showErrorState).toBe(true)
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('leaves a search that legitimately found nothing alone once the request timeout elapses', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': () => [200, { results: [], count: 0 }],
+                },
+            })
+            initKeaTests()
+            jest.useFakeTimers()
+            try {
+                const emptyLogic = infiniteListLogic({
+                    taxonomicFilterLogicKey: 'emptyList',
+                    listGroupType: TaxonomicFilterGroupType.Events,
+                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events],
+                    showNumericalPropsOnly: false,
+                })
+                emptyLogic.mount()
+                emptyLogic.actions.setSearchQuery('definitely_not_a_real_event')
+
+                await jest.advanceTimersByTimeAsync(600)
+                expect(emptyLogic.values.showEmptyState).toBe(true)
+
+                // Well past the watchdog: it bounds a request in flight, and this one already
+                // answered. "No results" must not decay into "couldn't load results".
+                await jest.advanceTimersByTimeAsync(31000)
+                expect(emptyLogic.values.showErrorState).toBe(false)
+                expect(emptyLogic.values.showEmptyState).toBe(true)
             } finally {
                 jest.useRealTimers()
             }

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -540,7 +540,7 @@ describe('infiniteListLogic', () => {
         beforeEach(silenceKeaLoadersErrors)
         afterEach(resumeKeaLoadersErrors)
 
-        it('falls back to the empty state instead of spinning forever when the fetch fails', async () => {
+        it('surfaces the error state instead of spinning forever or claiming no results', async () => {
             useMocks({
                 get: {
                     '/api/projects/:team/event_definitions': () => [500, { detail: 'server error' }],
@@ -562,18 +562,86 @@ describe('infiniteListLogic', () => {
                 .toFinishAllListeners()
                 .toMatchValues({
                     showLoadingState: false,
-                    showEmptyState: true,
+                    // A failure must not read as "this event doesn't exist" - that sends people
+                    // hunting for a tracking bug instead of retrying.
+                    showEmptyState: false,
+                    showErrorState: true,
                 })
 
-            // The failure lands on the same empty state as a genuine no-match, so telemetry is
-            // the only prod signal that the backend blipped — losing this capture makes the
-            // worst case ("event exists, fetch failed") invisible.
             const failedCalls = captureSpy.mock.calls.filter((c) => c[0] === 'taxonomic filter fetch failed')
             expect(failedCalls).toHaveLength(1)
             expect(failedCalls[0][1]).toMatchObject({
                 groupType: TaxonomicFilterGroupType.Events,
                 searchQuery: 'user_signed_up',
             })
+        })
+
+        it('gives up on a request that never responds', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': () => new Promise(() => {}),
+                },
+            })
+            initKeaTests()
+            jest.useFakeTimers()
+            try {
+                const hangingLogic = infiniteListLogic({
+                    taxonomicFilterLogicKey: 'hangingList',
+                    listGroupType: TaxonomicFilterGroupType.Events,
+                    taxonomicGroupTypes: [TaxonomicFilterGroupType.Events],
+                    showNumericalPropsOnly: false,
+                })
+                hangingLogic.mount()
+                hangingLogic.actions.setSearchQuery('user_signed_up')
+
+                // Past the debounce, so the request is in flight rather than still queued.
+                await jest.advanceTimersByTimeAsync(600)
+                expect(hangingLogic.values.showLoadingState).toBe(true)
+
+                await jest.advanceTimersByTimeAsync(30000)
+                expect(hangingLogic.values.showErrorState).toBe(true)
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+
+        it('clears the error state when a retry succeeds', async () => {
+            let attempts = 0
+            useMocks({
+                get: {
+                    '/api/projects/:team/event_definitions': () => {
+                        attempts += 1
+                        return attempts === 1
+                            ? [500, { detail: 'server error' }]
+                            : [200, { results: [{ name: 'user_signed_up', id: 'uuid-1' }], count: 1 }]
+                    },
+                },
+            })
+            initKeaTests()
+            const retryingLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: 'retryingList',
+                listGroupType: TaxonomicFilterGroupType.Events,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.Events],
+                showNumericalPropsOnly: false,
+            })
+            retryingLogic.mount()
+            await expectLogic(retryingLogic, () => {
+                retryingLogic.actions.setSearchQuery('user_signed_up')
+            })
+                .toDispatchActions(['loadRemoteItemsFailure'])
+                .toFinishAllListeners()
+                .toMatchValues({ showErrorState: true })
+
+            await expectLogic(retryingLogic, () => {
+                retryingLogic.actions.retryRemoteItems()
+            })
+                .toDispatchActions(['retryRemoteItems', 'loadRemoteItems', 'loadRemoteItemsSuccess'])
+                .toFinishAllListeners()
+                .toMatchValues({
+                    showErrorState: false,
+                    showEmptyState: false,
+                })
+            expect(retryingLogic.values.totalResultCount).toBeGreaterThan(0)
         })
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -16,7 +16,7 @@ import { loaders } from 'kea-loaders'
 import { combineUrl } from 'kea-router'
 import posthog from 'posthog-js'
 
-import api from 'lib/api'
+import api, { ApiMethodOptions } from 'lib/api'
 import { formatPropertyLabel } from 'lib/components/PropertyFilters/utils'
 import {
     expandRecentsForDisplay,
@@ -202,6 +202,9 @@ const createEmptyListStorage = (searchQuery = '', first = false): ListStorage =>
 
 // simple cache with a setTimeout expiry
 const API_CACHE_TIMEOUT = 60000
+// Well under the gateway's own ceiling, so a wedged list request surfaces as a retryable error
+// here rather than spinning until the proxy returns a 504.
+const REMOTE_ITEMS_REQUEST_TIMEOUT_MS = 30000
 let apiCache: Record<string, ListStorage> = {}
 let apiCacheTimers: Record<string, number> = {}
 
@@ -221,12 +224,16 @@ export function clearApiCache(): void {
     apiCacheTimers = {}
 }
 
-async function fetchCachedListResponse(path: string, searchParams: Record<string, any>): Promise<ListStorage> {
+async function fetchCachedListResponse(
+    path: string,
+    searchParams: Record<string, any>,
+    options?: ApiMethodOptions
+): Promise<ListStorage> {
     const url = combineUrl(path, searchParams).url
     if (apiCache[url]) {
         return apiCache[url]
     }
-    const response = await api.get(url)
+    const response = await api.get(url, options)
     // Never cache an empty response. A transient empty result (a backend blip, a race) would
     // otherwise be pinned for the full timeout, so an event that actually exists keeps reading as
     // "No results" for up to a minute — retrying the same query just re-reads the cached blank.
@@ -323,6 +330,7 @@ export interface infiniteListLogicValues {
         value: TaxonomicFilterValue | undefined
     }
     showEmptyState: boolean
+    showErrorState: boolean
     showLoadingState: boolean
     showNonCapturedEventOption: boolean
     showPopover: boolean
@@ -425,6 +433,9 @@ export interface infiniteListLogicActions {
     }
     remoteItemsFetchFailedForQuery: (searchQuery: string) => {
         searchQuery: string
+    }
+    retryRemoteItems: () => {
+        value: true
     }
     resetPinnedRowState: () => {
         value: true
@@ -554,6 +565,12 @@ export interface infiniteListLogicMeta {
             anyGroupStale: boolean,
             searchQuery: string
         ) => boolean
+        showErrorState: (
+            remoteFetchFailed: string | null,
+            searchQuery: string,
+            isLoading: boolean,
+            totalListCount: number
+        ) => boolean
         showEmptyState: (
             totalListCount: number,
             isLoading: boolean,
@@ -562,7 +579,8 @@ export interface infiniteListLogicMeta {
             hasRemoteDataSource: boolean,
             showNonCapturedEventOption: boolean,
             needsMoreSearchCharacters: boolean,
-            remoteResultsAreFresh: boolean
+            remoteResultsAreFresh: boolean,
+            showErrorState: boolean
         ) => boolean
         showLoadingState: (
             isLoading: boolean,
@@ -845,6 +863,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
         abortAnyRunningQuery: true,
         setHasMore: (hasMore: boolean) => ({ hasMore }),
         remoteItemsFetchFailedForQuery: (searchQuery: string) => ({ searchQuery }),
+        retryRemoteItems: true,
     }),
     loaders(({ actions, values, cache, props }) => ({
         remoteItems: [
@@ -926,26 +945,36 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             }
                         } else {
                             // Use the original REST API for non-groups endpoints
+                            const requestOptions = { signal: cache.abortController?.signal }
                             const [apiResponse, expandedApiResponse] = await Promise.all([
                                 // get the list of results
                                 fetchCachedListResponse(
                                     scopedRemoteEndpoint && !isExpanded ? scopedRemoteEndpoint : remoteEndpoint,
-                                    searchParams
+                                    searchParams,
+                                    requestOptions
                                 ),
                                 // if this is an unexpanded scoped list, get the count for the full list
                                 scopedRemoteEndpoint && !isExpanded
-                                    ? fetchCachedListResponse(remoteEndpoint, {
-                                          ...searchParams,
-                                          limit: 1,
-                                          offset: 0,
-                                      })
+                                    ? fetchCachedListResponse(
+                                          remoteEndpoint,
+                                          {
+                                              ...searchParams,
+                                              limit: 1,
+                                              offset: 0,
+                                          },
+                                          requestOptions
+                                      )
                                     : null,
                             ])
                             response = apiResponse
                             expandedCountResponse = expandedApiResponse
                         }
                     } catch (error: any) {
-                        if (!isBreakpoint(error)) {
+                        // An abort means either a newer query superseded this run, which owns the
+                        // outcome now, or the request timeout fired, which already recorded the
+                        // failure itself. Neither case belongs to this query.
+                        const aborted = error?.name === 'AbortError'
+                        if (!isBreakpoint(error) && !aborted) {
                             // Carry the query that was in flight when this run errored so the
                             // reducer can attribute the failure to the right query string.
                             actions.remoteItemsFetchFailedForQuery(searchQuery)
@@ -1267,6 +1296,21 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 searchQuery: string
             ): boolean => isSuggestedFilters && (anyGroupLoading || anyGroupStale) && searchQuery.trim().length > 0,
         ],
+        // A fetch that failed for the *current* query with nothing usable to fall back on. Kept
+        // separate from `showEmptyState` so a timeout or a 5xx doesn't read as "this project has
+        // no matching properties", which sends people looking for a tracking bug that isn't there.
+        showErrorState: [
+            (s) => [s.remoteFetchFailed, s.searchQuery, s.isLoading, s.totalListCount],
+            (
+                remoteFetchFailed: string | null,
+                searchQuery: string,
+                isLoading: boolean,
+                totalListCount: number
+            ): boolean =>
+                // Compare the exact query for the same reason `remoteResultsAreFresh` does: a stale
+                // failure from a superseded run must not surface against a newer query.
+                remoteFetchFailed === searchQuery && !isLoading && totalListCount === 0,
+        ],
         showEmptyState: [
             (s) => [
                 s.totalListCount,
@@ -1277,6 +1321,7 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 s.showNonCapturedEventOption,
                 s.needsMoreSearchCharacters,
                 s.remoteResultsAreFresh,
+                s.showErrorState,
             ],
             (
                 totalListCount: number,
@@ -1286,10 +1331,12 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 hasRemoteDataSource: boolean,
                 showNonCapturedEventOption: boolean,
                 needsMoreSearchCharacters: boolean,
-                remoteResultsAreFresh: boolean
+                remoteResultsAreFresh: boolean,
+                showErrorState: boolean
             ): boolean =>
                 (totalListCount === 0 &&
                     !isLoading &&
+                    !showErrorState &&
                     // Don't declare "No results" until the fetch for the *current* query has landed —
                     // otherwise a stale/empty list from the previous query masquerades as no matches.
                     remoteResultsAreFresh &&
@@ -2234,8 +2281,23 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                 const abortController = new AbortController()
                 // Store reference in cache for the fetch operation to use
                 cache.abortController = abortController
-                return () => abortController.abort()
+                // Some of these list endpoints have no server-side statement timeout, so a query
+                // that wedges only fails when the gateway gives up two minutes later. Giving up
+                // first bounds how long the list can sit in its loading state. The failure is
+                // recorded here rather than in the loader's catch, because the catch cannot tell
+                // this abort apart from the one a newer query triggers.
+                const timeoutId = window.setTimeout(() => {
+                    actions.remoteItemsFetchFailedForQuery(values.searchQuery)
+                    abortController.abort()
+                }, REMOTE_ITEMS_REQUEST_TIMEOUT_MS)
+                return () => {
+                    window.clearTimeout(timeoutId)
+                    abortController.abort()
+                }
             }, 'abortController')
+        },
+        retryRemoteItems: () => {
+            actions.loadRemoteItems({ offset: 0, limit: values.limit })
         },
     })),
     events(({ actions, values, props, cache }) => ({

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -434,10 +434,10 @@ export interface infiniteListLogicActions {
     remoteItemsFetchFailedForQuery: (searchQuery: string) => {
         searchQuery: string
     }
-    retryRemoteItems: () => {
+    resetPinnedRowState: () => {
         value: true
     }
-    resetPinnedRowState: () => {
+    retryRemoteItems: () => {
         value: true
     }
     selectSelected: () => {

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -922,17 +922,23 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     let response: any
                     let expandedCountResponse: any = null
 
+                    const runAbortController = cache.abortController
+                    const requestOptions = { signal: runAbortController?.signal }
+
                     try {
                         // Querying groups from /groups/ endpoint may result in query timeouts. Let's query clickhouse instead
                         const isGroupNamesFilter = values.listGroupType.startsWith(
                             TaxonomicFilterGroupType.GroupNamesPrefix
                         )
                         if (isGroupNamesFilter && values.group?.groupTypeIndex !== undefined) {
-                            const groupsResponse = await api.groups.listClickhouse({
-                                group_type_index: values.group.groupTypeIndex as GroupTypeIndex,
-                                search: searchQuery || '',
-                                limit,
-                            })
+                            const groupsResponse = await api.groups.listClickhouse(
+                                {
+                                    group_type_index: values.group.groupTypeIndex as GroupTypeIndex,
+                                    search: searchQuery || '',
+                                    limit,
+                                },
+                                requestOptions
+                            )
 
                             const transformedGroups = mapGroupQueryResponse(groupsResponse)
                             response = {
@@ -945,7 +951,6 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                             }
                         } else {
                             // Use the original REST API for non-groups endpoints
-                            const requestOptions = { signal: cache.abortController?.signal }
                             const [apiResponse, expandedApiResponse] = await Promise.all([
                                 // get the list of results
                                 fetchCachedListResponse(
@@ -974,18 +979,37 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                         // outcome now, or the request timeout fired, which already recorded the
                         // failure itself. Neither case belongs to this query.
                         const aborted = error?.name === 'AbortError'
+                        if (aborted) {
+                            // A superseded run must not settle the loader. kea-loaders keeps one
+                            // loading flag per loader, so failing here would clear the flag the
+                            // newer run just set, and the SuggestedFilters reveal barrier opens on
+                            // `!anyGroupLoading` — it would drop its skeletons and reveal partial
+                            // results while that run is still in flight. This throws for a
+                            // superseded run and does nothing for the watchdog's own abort, which
+                            // does need to settle as a failure.
+                            breakpoint()
+                        }
                         if (!isBreakpoint(error) && !aborted) {
                             // Carry the query that was in flight when this run errored so the
                             // reducer can attribute the failure to the right query string.
                             actions.remoteItemsFetchFailedForQuery(searchQuery)
                         }
                         throw error
+                    } finally {
+                        // Disarm the watchdog now this run has settled. It only bounds a request
+                        // that is still in flight, and left armed it would fire against a finished
+                        // one and turn a legitimately empty result into an error 30s later. A newer
+                        // run owns the shared disposable, so leave that one alone or we abort its
+                        // request instead.
+                        if (cache.abortController === runAbortController) {
+                            cache.disposables.dispose('abortController')
+                            cache.abortController = null
+                        }
                     }
                     breakpoint()
 
                     const queryChanged = values.remoteItems.searchQuery !== searchQuery
                     const existingResults = values.remoteItems.results
-                    cache.abortController = null
 
                     return {
                         results: appendAtIndex(


### PR DESCRIPTION
## Problem

- When a property or event list in the taxonomic filter fails to load, the dropdown shows "No results" for the search, so a backend failure looks like a project that has no matching property.
- People read that as missing tracking and go looking for a problem in their instrumentation instead of retrying the search.
- The filter also had no way to retry, so the only way out was to retype the query and hope.

## Changes

- A failed list fetch now says it could not load results and offers "Try again", separately from the empty state.
- The abort controller reaches the request, so one superseded by the next keystroke is actually cancelled instead of running to completion in the background. Group names go out over the query endpoint rather than a list endpoint, so `api.groups.listClickhouse` takes the signal too.
- A 30 second watchdog aborts a request that never responds, which bounds how long the list can sit in its loading state. It is disarmed once the request settles.
- A new story, `Filters/Taxonomic Filter/FailedFetchOffersRetry`, renders the state.

The error state is keyed on the query whose fetch failed, matching the existing `remoteResultsAreFresh` guard, and it also requires the list to be idle and empty. Both conditions matter: a failure from a superseded run must not surface against a newer query, and a partly loaded list is more useful than an error over the top of it.

The watchdog records the failure itself rather than letting the loader's `catch` do it. Both cancellation paths reject with an `AbortError`, so the `catch` cannot tell a timeout from a query the user superseded, and treating all aborts as failures would flash an error on every keystroke.

Making the abort real needed two things to change around it, because until now the signal never reached `fetch` and cancelling was inert:

- A superseded run takes the loader's breakpoint instead of settling it. kea-loaders keeps one loading flag per loader, so failing there cleared the flag the newer run had just set. `anyGroupLoading` then read false with a fetch still in flight, and the SuggestedFilters reveal barrier opened early and dropped its skeletons to show partial results, which is what the barrier exists to prevent.
- The watchdog is disarmed when a run settles. It was only cleared by the next load or by unmount, so after a request answered it stayed armed and fired against a finished one, rewriting a legitimately empty result as a failure 30 seconds later. That is the same "no results" lie this PR set out to fix, arriving on a delay.

> [!NOTE]
> The 30 second watchdog applies to every remote list in the taxonomic filter, not just property definitions. A list endpoint that normally takes longer than 30 seconds would now fail rather than eventually load.

## How did you test this code?

- `gives up on $label that never responds` drives a hanging endpoint with fake timers and asserts the list reaches the error state, parameterized over the list endpoint and the group name query. The group case is the first coverage of that branch anywhere in the suite; it fails without the signal on `listClickhouse`, and both cases fail with the watchdog disabled, so neither is vacuous.
- `leaves a search that legitimately found nothing alone once the request timeout elapses` pins the empty state across the watchdog window. It fails when the disarm is removed, which is how the stale-timer bug was found.
- `surfaces the error state instead of spinning forever or claiming no results` replaces an existing test that asserted the old silent-empty behavior. It now pins `showEmptyState: false` alongside `showErrorState: true`, which is the actual regression: a 5xx must not read as "no matching properties".
- `clears the error state when a retry succeeds` covers the retry action end to end, since nothing else exercises `retryRemoteItems`.
- The reveal-barrier regression is already covered by `renders a skeleton row per non-meta group while the reveal barrier is closed` in `TaxonomicFilter.test.tsx`, so it needed no new test. That test failed on the first commit here and passes now; I bisected it to `infiniteListLogic.ts` and confirmed it passes with master's copy of that file.
- 610 tests across the `TaxonomicFilter` and `Search` suites pass locally.
- No screenshot: my sandbox could not build the nested `@posthog/quill` workspace that Storybook needs, so I added the story instead and left the image to Visual Review on this PR.
- Also not checked: the repo-wide `tsgo` typecheck here reports 290 pre-existing errors from that same unbuilt workspace, none in the files this PR touches. CI is the authority on both.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Cursor's Opus 5 agent) wrote this at Eli's direction, as the client half of an investigation into gateway timeouts on `GET /api/projects/:id/property_definitions`. [#78607](https://github.com/PostHog/posthog/pull/78607) is the server half, which turns those timeouts into a 503 instead of a 504. The two are independent: this PR improves any list failure, and does not depend on that one landing.

The watchdog changed shape during the session. It first aborted with an explicit reason so the loader's `catch` could tell a timeout from a superseded query, but `handleFetch` in `lib/api.ts` only rethrows a `DOMException` named `AbortError` verbatim and wraps everything else in an `ApiError`, which made that distinction depend on how the wrapper behaved. Recording the failure in the timeout callback removes the guesswork.

The second commit came out of Greptile's review. Its finding on the group name path was correct, and closing it surfaced the other two: the reveal-barrier regression was a real test failure on the first commit that the flaky-test report had listed alongside genuine flakes, and the stale watchdog turned up while re-reading the diff. All three share one cause — `abortAnyRunningQuery` has always created and aborted a controller, but the signal never reached `fetch`, so nothing downstream had ever had to cope with a cancelled request.

Skills invoked: `/writing-pr-descriptions`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`.
