### PR TITLE
feat(aio): add 0/1 eval result format and numeric verdict score

### DIFF
--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -2374,6 +2374,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "The boolean verdict of the evaluation (true = pass, false = fail).",
             "examples": [True, False],
         },
+        "$ai_evaluation_score": {
+            "label": "AI Evaluation Score (LLM)",
+            "description": "Numeric form of the evaluation verdict (1 = pass, 0 = fail). Omitted when the result is N/A or the run was skipped, so averaging it gives the pass rate.",
+            "examples": [1, 0],
+        },
         "$ai_evaluation_reasoning": {
             "label": "AI Evaluation Reasoning (LLM)",
             "description": "The LLM's explanation for why the evaluation passed or failed.",

--- a/posthog/temporal/ai_observability/eval_reports/output_types.py
+++ b/posthog/temporal/ai_observability/eval_reports/output_types.py
@@ -30,7 +30,7 @@ _OUTCOME_DEFINITIONS: Mapping[str, EvaluationReportOutcomeDefinition] = {
         event_predicate=f"(properties.$ai_evaluation_result_type = 'boolean' OR isNull(properties.$ai_evaluation_result_type)) AND {_NOT_SKIPPED_PREDICATE}",
         result_expression="properties.$ai_evaluation_result",
         applicable_expression="properties.$ai_evaluation_applicable",
-        score_expression="NULL",
+        score_expression="properties.$ai_evaluation_score",
     ),
     "sentiment": EvaluationReportOutcomeDefinition(
         outcomes=("positive", "neutral", "negative"),

--- a/posthog/temporal/ai_observability/evaluation_hog.py
+++ b/posthog/temporal/ai_observability/evaluation_hog.py
@@ -153,7 +153,13 @@ def execute_hog_eval_bytecode(bytecode: list, globals_dict: dict[str, Any], allo
     if response.result is None and allows_na:
         return {"verdict": None, "applicable": False, "reasoning": reasoning, "error": None}
 
-    if not isinstance(response.result, bool):
+    # 1 and 0 are accepted as aliases for true/false so Hog ported from numeric-scoring
+    # eval frameworks works unchanged.
+    verdict = response.result
+    if isinstance(verdict, int) and not isinstance(verdict, bool) and verdict in (0, 1):
+        verdict = bool(verdict)
+
+    if not isinstance(verdict, bool):
         hint = " (or null if N/A is enabled)" if allows_na else ""
         return {
             "verdict": None,
@@ -161,7 +167,7 @@ def execute_hog_eval_bytecode(bytecode: list, globals_dict: dict[str, Any], allo
             "error": f"Must return boolean{hint}, got {type(response.result).__name__}: {response.result}",
         }
 
-    result: dict[str, Any] = {"verdict": response.result, "reasoning": reasoning, "error": None}
+    result: dict[str, Any] = {"verdict": verdict, "reasoning": reasoning, "error": None}
     if allows_na:
         result["applicable"] = True
     return result

--- a/posthog/temporal/ai_observability/evaluation_workflow_activities.py
+++ b/posthog/temporal/ai_observability/evaluation_workflow_activities.py
@@ -261,13 +261,23 @@ def build_evaluation_event_properties(
             properties["$ai_sentiment_message_count"] = result.get("sentiment_message_count")
     else:
         properties["$ai_evaluation_allows_na"] = allows_na
+        if (evaluation.get("output_config") or {}).get("result_format") == "zero_one":
+            properties["$ai_evaluation_result_format"] = "zero_one"
+        # Skip paths still set verdict=False when N/A is disallowed, so the numeric score is
+        # gated on a real graded verdict: avg($ai_evaluation_score) must read as a true pass rate.
+        verdict = result.get("verdict")
+        graded_verdict = verdict if not result.get("skipped") and isinstance(verdict, bool) else None
         if allows_na:
             applicable = result.get("applicable", True)
             properties["$ai_evaluation_applicable"] = applicable
             if applicable:
                 properties["$ai_evaluation_result"] = result["verdict"]
+                if graded_verdict is not None:
+                    properties["$ai_evaluation_score"] = int(graded_verdict)
         else:
             properties["$ai_evaluation_result"] = result["verdict"]
+            if graded_verdict is not None:
+                properties["$ai_evaluation_score"] = int(graded_verdict)
 
     return properties
 

--- a/posthog/temporal/ai_observability/test_run_evaluation.py
+++ b/posthog/temporal/ai_observability/test_run_evaluation.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -39,6 +39,7 @@ from .evaluation_errors import (
     terminal_user_error_result_from_application_error,
 )
 from .evaluation_llm_judge import JUDGE_EVENT_MAX_CHARS
+from .evaluation_workflow_activities import build_evaluation_event_properties
 from .run_evaluation import (
     BooleanEvalResult,
     BooleanWithNAEvalResult,
@@ -180,7 +181,7 @@ class TestRunEvaluationWorkflow:
             assert result["evaluation_type"] == "llm_judge"
             assert result["evaluation_config"] == {"prompt": "Is this response factually accurate?"}
             assert result["output_type"] == "boolean"
-            assert result["output_config"] == {"allows_na": False}
+            assert result["output_config"] == {"allows_na": False, "result_format": "true_false"}
 
     @pytest.mark.django_db(transaction=True)
     def test_execute_llm_judge_activity(self, setup_data, active_key_config):
@@ -370,6 +371,8 @@ class TestRunEvaluationWorkflow:
                 assert call_kwargs["process_person_profile"] is True
                 props = call_kwargs["properties"]
                 assert props["$ai_evaluation_result"] is True
+                assert props["$ai_evaluation_score"] == 1
+                assert "$ai_evaluation_result_format" not in props
                 assert props["$ai_evaluation_result_type"] == "boolean"
                 assert props["$ai_model"] == "gpt-5-mini"
                 assert props["$ai_provider"] == "openai"
@@ -1040,6 +1043,7 @@ class TestRunEvaluationWorkflow:
                 mock_capture.assert_called_once()
                 props = mock_capture.call_args[1]["properties"]
                 assert props["$ai_evaluation_result"] is True
+                assert props["$ai_evaluation_score"] == 1
                 assert props["$ai_evaluation_result_type"] == "boolean"
                 assert props["$ai_evaluation_applicable"] is True
                 assert props["$ai_evaluation_allows_na"] is True
@@ -1088,6 +1092,7 @@ class TestRunEvaluationWorkflow:
                 props = mock_capture.call_args[1]["properties"]
                 assert props["$ai_evaluation_result_type"] == "boolean"
                 assert "$ai_evaluation_result" not in props
+                assert "$ai_evaluation_score" not in props
                 assert props["$ai_evaluation_applicable"] is False
                 assert props["$ai_evaluation_allows_na"] is True
 
@@ -1911,6 +1916,61 @@ class TestEvalResultModels:
             BooleanWithNAEvalResult(reasoning="Not applicable", applicable=False, verdict=True)
 
 
+class TestBuildEvaluationEventProperties:
+    _START_TIME = datetime(2024, 1, 1, 12, 0, 0)
+
+    def _build(self, result_fields: dict[str, Any], output_config: dict[str, Any] | None = None) -> dict[str, Any]:
+        evaluation: dict[str, Any] = {"id": "eval-1", "name": "Test Evaluation", "evaluation_type": "hog"}
+        if output_config is not None:
+            evaluation["output_config"] = output_config
+        result = cast(EvaluationActivityResult, {"result_type": "boolean", "reasoning": "r", **result_fields})
+        return build_evaluation_event_properties(evaluation, result, self._START_TIME)
+
+    @parameterized.expand(
+        [
+            ("pass_scores_one", {"verdict": True, "allows_na": False}, 1),
+            ("fail_scores_zero", {"verdict": False, "allows_na": False}, 0),
+            ("applicable_pass_scores_one", {"verdict": True, "allows_na": True, "applicable": True}, 1),
+        ]
+    )
+    def test_graded_verdicts_emit_int_score(self, _name, result_fields, expected_score):
+        props = self._build(result_fields)
+
+        assert props["$ai_evaluation_score"] == expected_score
+        # An int JSON-serializes as a number so the property type-infers Numeric; a bool would
+        # serialize as true/false and break avg() aggregation.
+        assert type(props["$ai_evaluation_score"]) is int
+
+    @parameterized.expand(
+        [
+            ("not_applicable", {"verdict": None, "allows_na": True, "applicable": False}),
+            (
+                "skipped_with_fallback_false_verdict",
+                {"verdict": False, "allows_na": False, "skipped": True, "skip_reason": "hog_error"},
+            ),
+        ]
+    )
+    def test_ungraded_runs_emit_no_score(self, _name, result_fields):
+        props = self._build(result_fields)
+
+        assert "$ai_evaluation_score" not in props
+
+    @parameterized.expand(
+        [
+            ("zero_one", {"result_format": "zero_one"}, "zero_one"),
+            ("default_true_false", {"result_format": "true_false"}, None),
+            ("missing_output_config", None, None),
+        ]
+    )
+    def test_result_format_stamped_only_for_zero_one(self, _name, output_config, expected_stamp):
+        props = self._build({"verdict": True, "allows_na": False}, output_config=output_config)
+
+        if expected_stamp is None:
+            assert "$ai_evaluation_result_format" not in props
+        else:
+            assert props["$ai_evaluation_result_format"] == expected_stamp
+
+
 class TestRunHogEvalAllowsNA:
     @pytest.fixture(autouse=True)
     def _compile(self):
@@ -1938,6 +1998,8 @@ class TestRunHogEvalAllowsNA:
         [
             ("true_result", "return true", True, True),
             ("false_result", "return false", False, True),
+            ("one_result", "return 1", True, True),
+            ("zero_result", "return 0", False, True),
         ]
     )
     def test_bool_result_with_allows_na(self, _name, source, expected_verdict, expected_applicable):

--- a/products/ai_observability/backend/api/evaluations.py
+++ b/products/ai_observability/backend/api/evaluations.py
@@ -94,7 +94,7 @@ logger = structlog.get_logger(__name__)
                 "properties": {
                     "source": {
                         "type": "string",
-                        "description": "Hog source code. Must return true (pass), false (fail), or null for N/A.",
+                        "description": "Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.",
                         "minLength": 1,
                     }
                 },
@@ -128,7 +128,16 @@ class _EvaluationConfigField(serializers.JSONField):
                 "type": "boolean",
                 "description": "Whether the evaluation can return N/A for non-applicable generations.",
                 "default": False,
-            }
+            },
+            "result_format": {
+                "type": "string",
+                "enum": ["true_false", "zero_one"],
+                "description": (
+                    "How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. "
+                    "N/A results are labeled N/A either way."
+                ),
+                "default": "true_false",
+            },
         },
         "additionalProperties": False,
     }
@@ -305,7 +314,10 @@ class EvaluationSerializer(serializers.ModelSerializer):
     )
     output_config = _OutputConfigField(
         required=False,
-        help_text="Output config. For 'boolean' output_type: {allows_na} to permit N/A results.",
+        help_text=(
+            "Output config. For 'boolean' output_type: {allows_na} to permit N/A results, "
+            "{result_format: 'zero_one'} to label verdicts 1/0 instead of True/False."
+        ),
     )
     target_config = _TargetConfigField(
         required=False,

--- a/products/ai_observability/backend/api/test/test_evaluations.py
+++ b/products/ai_observability/backend/api/test/test_evaluations.py
@@ -147,7 +147,7 @@ class TestEvaluationConfigsApi(APIBaseTest):
         self.assertEqual(evaluation_config.evaluation_type, "llm_judge")
         self.assertEqual(evaluation_config.evaluation_config, {"prompt": "Test prompt"})
         self.assertEqual(evaluation_config.output_type, "boolean")
-        self.assertEqual(evaluation_config.output_config, {"allows_na": False})
+        self.assertEqual(evaluation_config.output_config, {"allows_na": False, "result_format": "true_false"})
         self.assertEqual(len(evaluation_config.conditions), 1)
         self.assertEqual(evaluation_config.conditions[0]["id"], "test-condition")
         self.assertEqual(evaluation_config.team, self.team)
@@ -165,6 +165,39 @@ class TestEvaluationConfigsApi(APIBaseTest):
         self.assertTrue(report.enabled)
         self.assertFalse(report.deleted)
         self.assertEqual(report.delivery_targets, [])
+
+    def test_can_create_evaluation_with_zero_one_result_format(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/evaluations/",
+            {
+                "name": "Zero one",
+                "evaluation_type": "llm_judge",
+                "model_configuration": _DEFAULT_MODEL_CONFIGURATION,
+                "evaluation_config": {"prompt": "Test prompt"},
+                "output_type": "boolean",
+                "output_config": {"result_format": "zero_one"},
+                "conditions": [{"id": "test-condition", "rollout_percentage": 50, "properties": []}],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["output_config"], {"allows_na": False, "result_format": "zero_one"})
+
+    def test_rejects_unknown_result_format(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/evaluations/",
+            {
+                "name": "Bad format",
+                "evaluation_type": "llm_judge",
+                "model_configuration": _DEFAULT_MODEL_CONFIGURATION,
+                "evaluation_config": {"prompt": "Test prompt"},
+                "output_type": "boolean",
+                "output_config": {"result_format": "one_zero"},
+                "conditions": [{"id": "test-condition", "rollout_percentage": 50, "properties": []}],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_target_defaults_to_generation(self):
         response = self.client.post(

--- a/products/ai_observability/backend/models/evaluation_configs.py
+++ b/products/ai_observability/backend/models/evaluation_configs.py
@@ -51,6 +51,10 @@ class BooleanOutputConfig(BaseModel):
     """Configuration for boolean output type"""
 
     allows_na: bool = False
+    result_format: Literal["true_false", "zero_one"] = Field(
+        default="true_false",
+        description="How verdicts are labeled: True/False or 1/0.",
+    )
 
 
 class SentimentEvalConfig(BaseModel):

--- a/products/ai_observability/frontend/ConversationDisplay/EvaluationDisplay.test.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/EvaluationDisplay.test.tsx
@@ -43,4 +43,20 @@ describe('EvaluationDisplay', () => {
         expect(screen.getByText('N/A')).toBeInTheDocument()
         expect(screen.queryByText('False')).not.toBeInTheDocument()
     })
+
+    it('labels a stamped zero_one result as 1 instead of True', () => {
+        render(
+            <Provider>
+                <EvaluationDisplay
+                    eventProperties={{
+                        $ai_evaluation_result: true,
+                        $ai_evaluation_result_format: 'zero_one',
+                    }}
+                />
+            </Provider>
+        )
+
+        expect(screen.getByText('1')).toBeInTheDocument()
+        expect(screen.queryByText('True')).not.toBeInTheDocument()
+    })
 })

--- a/products/ai_observability/frontend/ConversationDisplay/EvaluationDisplay.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/EvaluationDisplay.tsx
@@ -24,6 +24,7 @@ export function EvaluationDisplay({ eventProperties }: { eventProperties: EventT
             rawResultType: eventProperties.$ai_evaluation_result_type,
             rawSentimentLabel: eventProperties.$ai_sentiment_label,
             rawSentimentScore: eventProperties.$ai_sentiment_score,
+            rawResultFormat: eventProperties.$ai_evaluation_result_format,
         }),
     }
 

--- a/products/ai_observability/frontend/components/EvaluationResultTag.test.tsx
+++ b/products/ai_observability/frontend/components/EvaluationResultTag.test.tsx
@@ -1,0 +1,24 @@
+import { getEvaluationResultDisplay } from './EvaluationResultTag'
+
+describe('getEvaluationResultDisplay', () => {
+    it.each([
+        [undefined, true, 'True'],
+        [undefined, false, 'False'],
+        ['zero_one' as const, true, '1'],
+        ['zero_one' as const, false, '0'],
+    ])('with result_format %p labels result %p as %s', (result_format, result, expectedLabel) => {
+        const display = getEvaluationResultDisplay({ status: 'completed', result, result_format })
+
+        expect(display.label).toBe(expectedLabel)
+        // Sorting and colors key off the verdict, so the format must not change them.
+        expect(display.sortValue).toBe(result ? 1 : 0)
+        expect(display.type).toBe(result ? 'success' : 'danger')
+    })
+
+    it.each([
+        ['N/A', { status: 'completed' as const, result: null, result_format: 'zero_one' as const }],
+        ['Skipped', { status: 'completed' as const, result: false, result_format: 'zero_one' as const, skipped: true }],
+    ])('keeps the %s label under zero_one', (expectedLabel, run) => {
+        expect(getEvaluationResultDisplay(run).label).toBe(expectedLabel)
+    })
+})

--- a/products/ai_observability/frontend/components/EvaluationResultTag.tsx
+++ b/products/ai_observability/frontend/components/EvaluationResultTag.tsx
@@ -7,7 +7,7 @@ import { capitalize } from '../sentimentUtils'
 
 type EvaluationResultLike = Pick<
     EvaluationRun,
-    'status' | 'result' | 'result_type' | 'evaluation_type' | 'sentiment_label' | 'skipped'
+    'status' | 'result' | 'result_type' | 'result_format' | 'evaluation_type' | 'sentiment_label' | 'skipped'
 >
 
 interface EvaluationResultDisplay {
@@ -55,9 +55,14 @@ export function getEvaluationResultDisplay(run: EvaluationResultLike): Evaluatio
         return { type: 'muted', icon: <IconMinus />, label: 'N/A', sortValue: 0.5 }
     }
     if (run.result) {
-        return { type: 'success', icon: <IconCheck />, label: 'True', sortValue: 1 }
+        return {
+            type: 'success',
+            icon: <IconCheck />,
+            label: run.result_format === 'zero_one' ? '1' : 'True',
+            sortValue: 1,
+        }
     }
-    return { type: 'danger', icon: <IconX />, label: 'False', sortValue: 0 }
+    return { type: 'danger', icon: <IconX />, label: run.result_format === 'zero_one' ? '0' : 'False', sortValue: 0 }
 }
 
 export function getEvaluationResultSortValue(run: EvaluationResultLike): number {

--- a/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
+++ b/products/ai_observability/frontend/evaluations/AIObservabilityEvaluation.tsx
@@ -63,7 +63,7 @@ import {
     llmEvaluationLogic,
 } from './llmEvaluationLogic'
 import { statusReasonLabel, statusReasonRecoveryLabel } from './statusDisplay'
-import { EvaluationSettleStrategy, EvaluationTarget, EvaluationType } from './types'
+import { EvaluationResultFormat, EvaluationSettleStrategy, EvaluationTarget, EvaluationType } from './types'
 
 export function AIObservabilityEvaluation(): JSX.Element {
     const {
@@ -89,6 +89,7 @@ export function AIObservabilityEvaluation(): JSX.Element {
         setEvaluationDescription,
         setEvaluationEnabled,
         setAllowsNA,
+        setResultFormat,
         saveEvaluation,
         resetEvaluation,
         setEvaluationType,
@@ -713,6 +714,38 @@ export function AIObservabilityEvaluation(): JSX.Element {
                                                                 : isHog
                                                                   ? 'Evaluation must return true or false'
                                                                   : 'Evaluation returns true or false'}
+                                                        </span>
+                                                    </div>
+                                                </Field>
+                                            )}
+
+                                            {isBooleanOutput && (
+                                                <Field
+                                                    name="result_format"
+                                                    label={
+                                                        <div className="flex items-center gap-1">
+                                                            <span>Result format</span>
+                                                            <Tooltip title="How pass and fail results are labeled. Applies to new runs. N/A results are labeled N/A either way.">
+                                                                <IconInfo className="text-muted text-base" />
+                                                            </Tooltip>
+                                                        </div>
+                                                    }
+                                                >
+                                                    <div className="flex items-center gap-2">
+                                                        <LemonSelect<EvaluationResultFormat>
+                                                            value={
+                                                                evaluation.output_config.result_format ?? 'true_false'
+                                                            }
+                                                            onChange={setResultFormat}
+                                                            options={[
+                                                                { value: 'true_false', label: 'True / False' },
+                                                                { value: 'zero_one', label: '1 / 0' },
+                                                            ]}
+                                                        />
+                                                        <span className="text-muted text-sm">
+                                                            {evaluation.output_config.result_format === 'zero_one'
+                                                                ? 'Results are labeled 1 (pass) and 0 (fail)'
+                                                                : 'Results are labeled True (pass) and False (fail)'}
                                                         </span>
                                                     </div>
                                                 </Field>

--- a/products/ai_observability/frontend/evaluations/components/EvaluationCodeEditor.tsx
+++ b/products/ai_observability/frontend/evaluations/components/EvaluationCodeEditor.tsx
@@ -188,8 +188,9 @@ const HOG_EVAL_GLOBALS_BY_TARGET = {
 }
 
 function HogTestResultsPanel(): JSX.Element | null {
-    const { hogTestResults, hogTestResultsLoading, hogTestMessage } = useValues(llmEvaluationLogic)
+    const { evaluation, hogTestResults, hogTestResultsLoading, hogTestMessage } = useValues(llmEvaluationLogic)
     const { clearHogTestResults } = useActions(llmEvaluationLogic)
+    const zeroOneFormat = evaluation?.output_config.result_format === 'zero_one'
 
     if (!hogTestResults && !hogTestResultsLoading) {
         return null
@@ -258,11 +259,11 @@ function HogTestResultsPanel(): JSX.Element | null {
                             }
                             return row.result ? (
                                 <LemonTag type="success" icon={<IconCheck />}>
-                                    Pass
+                                    {zeroOneFormat ? '1' : 'Pass'}
                                 </LemonTag>
                             ) : (
                                 <LemonTag type="danger" icon={<IconX />}>
-                                    Fail
+                                    {zeroOneFormat ? '0' : 'Fail'}
                                 </LemonTag>
                             )
                         },

--- a/products/ai_observability/frontend/evaluations/llmEvaluationLogic.test.ts
+++ b/products/ai_observability/frontend/evaluations/llmEvaluationLogic.test.ts
@@ -293,6 +293,19 @@ describe('llmEvaluationLogic', () => {
             })
         })
 
+        it('setResultFormat updates output config', async () => {
+            await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
+
+            logic.actions.setResultFormat('zero_one')
+
+            await expectLogic(logic).toMatchValues({
+                evaluation: expect.objectContaining({
+                    output_config: expect.objectContaining({ result_format: 'zero_one' }),
+                }),
+                hasUnsavedChanges: true,
+            })
+        })
+
         it('setTriggerConditions updates conditions', async () => {
             await expectLogic(logic).toDispatchActions(['loadEvaluationSuccess'])
 

--- a/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
+++ b/products/ai_observability/frontend/evaluations/llmEvaluationLogic.ts
@@ -39,6 +39,7 @@ import { EvaluationTemplateKey, defaultEvaluationTemplates } from './templates'
 import type {
     EvaluationConditionSet,
     EvaluationConfig,
+    EvaluationResultFormat,
     EvaluationRun,
     EvaluationSettleStrategy,
     EvaluationSummary,
@@ -115,7 +116,7 @@ function toLLMJudgeEvaluation(evaluation: EvaluationConfig): LLMJudgeEvaluation 
         evaluation_type: 'llm_judge',
         evaluation_config: { prompt: '' },
         output_type: 'boolean',
-        output_config: { allows_na: false },
+        output_config: { ...evaluation.output_config, allows_na: false },
     }
 }
 
@@ -396,6 +397,9 @@ export interface llmEvaluationLogicActions {
     setModelConfiguration: (modelConfiguration: ModelConfiguration | null) => {
         modelConfiguration: ModelConfiguration | null
     }
+    setResultFormat: (resultFormat: EvaluationResultFormat) => {
+        resultFormat: EvaluationResultFormat
+    }
     setSettleStrategy: (strategy: EvaluationSettleStrategy) => {
         strategy: EvaluationSettleStrategy
     }
@@ -505,6 +509,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
         setEvaluationPrompt: (prompt: string) => ({ prompt }),
         setEvaluationEnabled: (enabled: boolean) => ({ enabled }),
         setAllowsNA: (allowsNA: boolean) => ({ allowsNA }),
+        setResultFormat: (resultFormat: EvaluationResultFormat) => ({ resultFormat }),
         setTriggerConditions: (conditions: EvaluationConditionSet[]) => ({ conditions }),
         setModelConfiguration: (modelConfiguration: ModelConfiguration | null) => ({ modelConfiguration }),
         setEvaluationType: (evaluationType: EvaluationType) => ({ evaluationType }),
@@ -695,6 +700,10 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                     state && isBooleanEvaluationOutput(state.output_type)
                         ? { ...state, output_config: { ...state.output_config, allows_na: allowsNA } }
                         : state,
+                setResultFormat: (state, { resultFormat }) =>
+                    state && isBooleanEvaluationOutput(state.output_type)
+                        ? { ...state, output_config: { ...state.output_config, result_format: resultFormat } }
+                        : state,
                 setTriggerConditions: (state, { conditions }) =>
                     state
                         ? {
@@ -825,6 +834,7 @@ export const llmEvaluationLogic = kea<llmEvaluationLogicType>([
                 setEvaluationPrompt: () => true,
                 setEvaluationEnabled: () => true,
                 setAllowsNA: () => true,
+                setResultFormat: () => true,
                 setTriggerConditions: () => true,
                 setModelConfiguration: () => true,
                 setEvaluationType: () => true,

--- a/products/ai_observability/frontend/evaluations/types.ts
+++ b/products/ai_observability/frontend/evaluations/types.ts
@@ -13,6 +13,7 @@ export type EvaluationType = 'llm_judge' | 'hog' | 'sentiment'
 export type EvaluationTarget = 'generation' | 'trace' | 'session'
 export type EvaluationSettleStrategy = 'fixed_window' | 'inactivity'
 export type EvaluationOutputType = 'boolean' | 'sentiment'
+export type EvaluationResultFormat = 'true_false' | 'zero_one'
 export type EvaluationStatus = 'active' | 'paused' | 'error'
 export type EvaluationStatusReason =
     | 'provider_key_required'
@@ -34,6 +35,7 @@ export interface ModelConfiguration {
 
 export interface EvaluationOutputConfig {
     allows_na?: boolean
+    result_format?: EvaluationResultFormat
 }
 
 /** Settle config for aggregate targets (trace, session). A missing `strategy` resolves per target:
@@ -132,6 +134,8 @@ export interface EvaluationRun {
     evaluation_type?: EvaluationType
     result_type?: EvaluationOutputType
     result: boolean | null
+    // Stamped on the event at emit time; absent means true_false, including every historical run.
+    result_format?: EvaluationResultFormat
     sentiment_label?: string | null
     sentiment_score?: number | null
     applicable?: boolean

--- a/products/ai_observability/frontend/evaluations/types.ts
+++ b/products/ai_observability/frontend/evaluations/types.ts
@@ -135,7 +135,7 @@ export interface EvaluationRun {
     result_type?: EvaluationOutputType
     result: boolean | null
     // Stamped on the event at emit time; absent means true_false, including every historical run.
-    result_format?: EvaluationResultFormat
+    result_format?: EvaluationResultFormat | null
     sentiment_label?: string | null
     sentiment_score?: number | null
     applicable?: boolean

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -702,6 +702,17 @@ export const OutputTypeEnumApi = {
     Sentiment: 'sentiment',
 } as const
 
+/**
+ * How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way.
+ */
+export type EvaluationApiOutputConfigResultFormat =
+    (typeof EvaluationApiOutputConfigResultFormat)[keyof typeof EvaluationApiOutputConfigResultFormat]
+
+export const EvaluationApiOutputConfigResultFormat = {
+    TrueFalse: 'true_false',
+    ZeroOne: 'zero_one',
+} as const
+
 export type EvaluationConditionApiPropertiesItem = { [key: string]: unknown }
 
 /**
@@ -790,7 +801,7 @@ export type EvaluationApiEvaluationConfig =
       }
     | {
           /**
-           * Hog source code. Must return true (pass), false (fail), or null for N/A.
+           * Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.
            * @minLength 1
            */
           source: string
@@ -801,11 +812,13 @@ export type EvaluationApiEvaluationConfig =
       }
 
 /**
- * Output config. For 'boolean' output_type: {allows_na} to permit N/A results.
+ * Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False.
  */
 export type EvaluationApiOutputConfig = {
     /** Whether the evaluation can return N/A for non-applicable generations. */
     allows_na?: boolean
+    /** How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way. */
+    result_format?: EvaluationApiOutputConfigResultFormat
 }
 
 /**
@@ -875,7 +888,7 @@ export interface EvaluationApi {
      * * `boolean` - Boolean (Pass/Fail)
      * * `sentiment` - Sentiment */
     output_type: OutputTypeEnumApi
-    /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
+    /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False. */
     output_config?: EvaluationApiOutputConfig
     /** Trigger conditions that filter which events are evaluated. OR between condition sets, AND within each. Each set is {id, rollout_percentage, properties[]} — `rollout_percentage` (0-100, defaults to 100) is the sampling field the dispatcher reads. */
     conditions?: EvaluationConditionApi[]
@@ -919,7 +932,7 @@ export type PatchedEvaluationApiEvaluationConfig =
       }
     | {
           /**
-           * Hog source code. Must return true (pass), false (fail), or null for N/A.
+           * Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.
            * @minLength 1
            */
           source: string
@@ -930,11 +943,24 @@ export type PatchedEvaluationApiEvaluationConfig =
       }
 
 /**
- * Output config. For 'boolean' output_type: {allows_na} to permit N/A results.
+ * How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way.
+ */
+export type PatchedEvaluationApiOutputConfigResultFormat =
+    (typeof PatchedEvaluationApiOutputConfigResultFormat)[keyof typeof PatchedEvaluationApiOutputConfigResultFormat]
+
+export const PatchedEvaluationApiOutputConfigResultFormat = {
+    TrueFalse: 'true_false',
+    ZeroOne: 'zero_one',
+} as const
+
+/**
+ * Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False.
  */
 export type PatchedEvaluationApiOutputConfig = {
     /** Whether the evaluation can return N/A for non-applicable generations. */
     allows_na?: boolean
+    /** How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way. */
+    result_format?: PatchedEvaluationApiOutputConfigResultFormat
 }
 
 /**
@@ -1004,7 +1030,7 @@ export interface PatchedEvaluationApi {
      * * `boolean` - Boolean (Pass/Fail)
      * * `sentiment` - Sentiment */
     output_type?: OutputTypeEnumApi
-    /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
+    /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False. */
     output_config?: PatchedEvaluationApiOutputConfig
     /** Trigger conditions that filter which events are evaluated. OR between condition sets, AND within each. Each set is {id, rollout_percentage, properties[]} — `rollout_percentage` (0-100, defaults to 100) is the sampling field the dispatcher reads. */
     conditions?: EvaluationConditionApi[]

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -232,6 +232,7 @@ export const evaluationsCreateBodyNameMax = 400
 
 export const evaluationsCreateBodyEvaluationConfigThreeSourceDefault = `user_messages`
 export const evaluationsCreateBodyOutputConfigAllowsNaDefault = false
+export const evaluationsCreateBodyOutputConfigResultFormatDefault = `true_false`
 export const evaluationsCreateBodyConditionsItemIdMax = 100
 
 export const evaluationsCreateBodyConditionsItemRolloutPercentageDefault = 100
@@ -278,7 +279,9 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                 source: zod
                     .string()
                     .min(1)
-                    .describe('Hog source code. Must return true (pass), false (fail), or null for N\/A.'),
+                    .describe(
+                        'Hog source code. Must return true (pass), false (fail), or null for N\/A; 1 and 0 are accepted as aliases for true and false.'
+                    ),
             }),
             zod.object({
                 source: zod
@@ -303,9 +306,17 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                 .boolean()
                 .default(evaluationsCreateBodyOutputConfigAllowsNaDefault)
                 .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
+            result_format: zod
+                .enum(['true_false', 'zero_one'])
+                .default(evaluationsCreateBodyOutputConfigResultFormatDefault)
+                .describe(
+                    "How verdicts are labeled in the UI: 'true_false' shows True\/False, 'zero_one' shows 1\/0. N\/A results are labeled N\/A either way."
+                ),
         })
         .optional()
-        .describe("Output config. For 'boolean' output_type: {allows_na} to permit N\/A results."),
+        .describe(
+            "Output config. For 'boolean' output_type: {allows_na} to permit N\/A results, {result_format: 'zero_one'} to label verdicts 1\/0 instead of True\/False."
+        ),
     conditions: zod
         .array(
             zod
@@ -425,6 +436,7 @@ export const evaluationsUpdateBodyNameMax = 400
 
 export const evaluationsUpdateBodyEvaluationConfigThreeSourceDefault = `user_messages`
 export const evaluationsUpdateBodyOutputConfigAllowsNaDefault = false
+export const evaluationsUpdateBodyOutputConfigResultFormatDefault = `true_false`
 export const evaluationsUpdateBodyConditionsItemIdMax = 100
 
 export const evaluationsUpdateBodyConditionsItemRolloutPercentageDefault = 100
@@ -471,7 +483,9 @@ export const EvaluationsUpdateBody = /* @__PURE__ */ zod.object({
                 source: zod
                     .string()
                     .min(1)
-                    .describe('Hog source code. Must return true (pass), false (fail), or null for N\/A.'),
+                    .describe(
+                        'Hog source code. Must return true (pass), false (fail), or null for N\/A; 1 and 0 are accepted as aliases for true and false.'
+                    ),
             }),
             zod.object({
                 source: zod
@@ -496,9 +510,17 @@ export const EvaluationsUpdateBody = /* @__PURE__ */ zod.object({
                 .boolean()
                 .default(evaluationsUpdateBodyOutputConfigAllowsNaDefault)
                 .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
+            result_format: zod
+                .enum(['true_false', 'zero_one'])
+                .default(evaluationsUpdateBodyOutputConfigResultFormatDefault)
+                .describe(
+                    "How verdicts are labeled in the UI: 'true_false' shows True\/False, 'zero_one' shows 1\/0. N\/A results are labeled N\/A either way."
+                ),
         })
         .optional()
-        .describe("Output config. For 'boolean' output_type: {allows_na} to permit N\/A results."),
+        .describe(
+            "Output config. For 'boolean' output_type: {allows_na} to permit N\/A results, {result_format: 'zero_one'} to label verdicts 1\/0 instead of True\/False."
+        ),
     conditions: zod
         .array(
             zod
@@ -618,6 +640,7 @@ export const evaluationsPartialUpdateBodyNameMax = 400
 
 export const evaluationsPartialUpdateBodyEvaluationConfigThreeSourceDefault = `user_messages`
 export const evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault = false
+export const evaluationsPartialUpdateBodyOutputConfigResultFormatDefault = `true_false`
 export const evaluationsPartialUpdateBodyConditionsItemIdMax = 100
 
 export const evaluationsPartialUpdateBodyConditionsItemRolloutPercentageDefault = 100
@@ -665,7 +688,9 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 source: zod
                     .string()
                     .min(1)
-                    .describe('Hog source code. Must return true (pass), false (fail), or null for N\/A.'),
+                    .describe(
+                        'Hog source code. Must return true (pass), false (fail), or null for N\/A; 1 and 0 are accepted as aliases for true and false.'
+                    ),
             }),
             zod.object({
                 source: zod
@@ -691,9 +716,17 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 .boolean()
                 .default(evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault)
                 .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
+            result_format: zod
+                .enum(['true_false', 'zero_one'])
+                .default(evaluationsPartialUpdateBodyOutputConfigResultFormatDefault)
+                .describe(
+                    "How verdicts are labeled in the UI: 'true_false' shows True\/False, 'zero_one' shows 1\/0. N\/A results are labeled N\/A either way."
+                ),
         })
         .optional()
-        .describe("Output config. For 'boolean' output_type: {allows_na} to permit N\/A results."),
+        .describe(
+            "Output config. For 'boolean' output_type: {allows_na} to permit N\/A results, {result_format: 'zero_one'} to label verdicts 1\/0 instead of True\/False."
+        ),
     conditions: zod
         .array(
             zod

--- a/products/ai_observability/frontend/utils.test.ts
+++ b/products/ai_observability/frontend/utils.test.ts
@@ -38,6 +38,7 @@ interface EvaluationRunRowOverrides {
     sentimentScore?: EvaluationRunRow[12]
     sessionId?: EvaluationRunRow[13]
     skipped?: EvaluationRunRow[14]
+    resultFormat?: EvaluationRunRow[15]
 }
 
 function makeEvaluationRunRow({
@@ -49,6 +50,7 @@ function makeEvaluationRunRow({
     sentimentScore = null,
     sessionId = null,
     skipped = null,
+    resultFormat = null,
 }: EvaluationRunRowOverrides = {}): EvaluationRunRow {
     return [
         'run-1',
@@ -66,6 +68,7 @@ function makeEvaluationRunRow({
         sentimentScore,
         sessionId,
         skipped,
+        resultFormat,
     ]
 }
 
@@ -122,12 +125,20 @@ describe('mapEvaluationRunRow', () => {
         expect(run.skipped).toBe(expected)
     })
 
-    it.each([true, 'true', 'True', '1'])('maps explicit pass result %p', (result) => {
+    it.each([true, 'true', 'True', '1', 1])('maps explicit pass result %p', (result) => {
         expect(mapEvaluationRunRow(makeEvaluationRunRow({ result })).result).toBe(true)
     })
 
-    it.each([false, 'false', 'False', '0'])('maps explicit fail result %p', (result) => {
+    it.each([false, 'false', 'False', '0', 0])('maps explicit fail result %p', (result) => {
         expect(mapEvaluationRunRow(makeEvaluationRunRow({ result })).result).toBe(false)
+    })
+
+    it('maps the zero_one result format stamp', () => {
+        expect(mapEvaluationRunRow(makeEvaluationRunRow({ resultFormat: 'zero_one' })).result_format).toBe('zero_one')
+    })
+
+    it('leaves result_format undefined when the row is not stamped', () => {
+        expect(mapEvaluationRunRow(makeEvaluationRunRow()).result_format).toBeUndefined()
     })
 
     it('maps explicitly non-applicable rows to null', () => {

--- a/products/ai_observability/frontend/utils.test.ts
+++ b/products/ai_observability/frontend/utils.test.ts
@@ -137,8 +137,8 @@ describe('mapEvaluationRunRow', () => {
         expect(mapEvaluationRunRow(makeEvaluationRunRow({ resultFormat: 'zero_one' })).result_format).toBe('zero_one')
     })
 
-    it('leaves result_format undefined when the row is not stamped', () => {
-        expect(mapEvaluationRunRow(makeEvaluationRunRow()).result_format).toBeUndefined()
+    it('maps unstamped rows to a null result_format', () => {
+        expect(mapEvaluationRunRow(makeEvaluationRunRow()).result_format).toBeNull()
     })
 
     it('maps explicitly non-applicable rows to null', () => {

--- a/products/ai_observability/frontend/utils.ts
+++ b/products/ai_observability/frontend/utils.ts
@@ -1144,7 +1144,7 @@ export function normalizeEvaluationResultProperties({
         sentiment_label: sentimentLabel,
         sentiment_score: normalizeOptionalNumber(rawSentimentScore),
         applicable: normalizeEvaluationApplicable(rawApplicable),
-        result_format: rawResultFormat === 'zero_one' ? 'zero_one' : undefined,
+        result_format: rawResultFormat === 'zero_one' ? 'zero_one' : null,
     }
 }
 

--- a/products/ai_observability/frontend/utils.ts
+++ b/products/ai_observability/frontend/utils.ts
@@ -1045,7 +1045,7 @@ type RawEvaluationRunRow = [
     evaluation_name: string | null,
     generation_id: string,
     trace_id: string,
-    result: boolean | string | null,
+    result: boolean | string | number | null,
     reasoning: string | null,
     applicable: boolean | string | null,
     evaluation_type: string | null,
@@ -1054,6 +1054,7 @@ type RawEvaluationRunRow = [
     sentiment_score: number | string | null,
     session_id: string | null,
     skipped: boolean | string | null,
+    result_format: string | null,
 ]
 
 export function normalizeEvaluationType(value: unknown): EvaluationType | undefined {
@@ -1079,7 +1080,7 @@ export function normalizeOptionalNumber(value: unknown): number | null {
 }
 
 export function isExplicitEvaluationPass(value: unknown): boolean {
-    return value === true || value === 'true' || value === 'True' || value === '1'
+    return value === true || value === 1 || value === 'true' || value === 'True' || value === '1'
 }
 
 function isExplicitEvaluationNotApplicable(value: unknown): boolean {
@@ -1100,6 +1101,7 @@ export interface NormalizedEvaluationResultProperties {
     rawResultType?: unknown
     rawSentimentLabel?: unknown
     rawSentimentScore?: unknown
+    rawResultFormat?: unknown
 }
 
 export function normalizeEvaluationResultProperties({
@@ -1109,9 +1111,16 @@ export function normalizeEvaluationResultProperties({
     rawResultType,
     rawSentimentLabel,
     rawSentimentScore,
+    rawResultFormat,
 }: NormalizedEvaluationResultProperties): Pick<
     EvaluationRun,
-    'evaluation_type' | 'result_type' | 'result' | 'sentiment_label' | 'sentiment_score' | 'applicable'
+    | 'evaluation_type'
+    | 'result_type'
+    | 'result'
+    | 'sentiment_label'
+    | 'sentiment_score'
+    | 'applicable'
+    | 'result_format'
 > {
     const evaluationType = normalizeEvaluationType(rawEvaluationType)
     const sentimentLabel =
@@ -1135,6 +1144,7 @@ export function normalizeEvaluationResultProperties({
         sentiment_label: sentimentLabel,
         sentiment_score: normalizeOptionalNumber(rawSentimentScore),
         applicable: normalizeEvaluationApplicable(rawApplicable),
+        result_format: rawResultFormat === 'zero_one' ? 'zero_one' : undefined,
     }
 }
 
@@ -1146,6 +1156,7 @@ export function mapEvaluationRunRow(row: RawEvaluationRunRow): EvaluationRun {
         rawResultType: row[10],
         rawSentimentLabel: row[11],
         rawSentimentScore: row[12],
+        rawResultFormat: row[15],
     })
 
     return {
@@ -1201,7 +1212,8 @@ export async function queryEvaluationRuns(params: {
             properties.$ai_sentiment_label as sentiment_label,
             properties.$ai_sentiment_score as sentiment_score,
             properties.$ai_session_id as session_id,
-            properties.$ai_evaluation_skipped as skipped
+            properties.$ai_evaluation_skipped as skipped,
+            properties.$ai_evaluation_result_format as result_format
         FROM events
         WHERE
             event = '$ai_evaluation'

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27137,7 +27137,7 @@ export namespace Schemas {
       prompt: string;
     } | {
       /**
-         * Hog source code. Must return true (pass), false (fail), or null for N/A.
+         * Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.
          * @minLength 1
          */
       source: string;
@@ -27147,11 +27147,24 @@ export namespace Schemas {
     };
 
     /**
-     * Output config. For 'boolean' output_type: {allows_na} to permit N/A results.
+     * How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way.
+     */
+    export type EvaluationOutputConfigResultFormat = typeof EvaluationOutputConfigResultFormat[keyof typeof EvaluationOutputConfigResultFormat];
+
+
+    export const EvaluationOutputConfigResultFormat = {
+      TrueFalse: 'true_false',
+      ZeroOne: 'zero_one',
+    } as const;
+
+    /**
+     * Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False.
      */
     export type EvaluationOutputConfig = {
       /** Whether the evaluation can return N/A for non-applicable generations. */
       allows_na?: boolean;
+      /** How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way. */
+      result_format?: EvaluationOutputConfigResultFormat;
     };
 
     /**
@@ -27362,7 +27375,7 @@ export namespace Schemas {
        * * `boolean` - Boolean (Pass/Fail)
        * * `sentiment` - Sentiment */
       output_type: OutputTypeEnum;
-      /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
+      /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False. */
       output_config?: EvaluationOutputConfig;
       /** Trigger conditions that filter which events are evaluated. OR between condition sets, AND within each. Each set is {id, rollout_percentage, properties[]} — `rollout_percentage` (0-100, defaults to 100) is the sampling field the dispatcher reads. */
       conditions?: EvaluationCondition[];
@@ -52478,7 +52491,7 @@ export namespace Schemas {
       prompt: string;
     } | {
       /**
-         * Hog source code. Must return true (pass), false (fail), or null for N/A.
+         * Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.
          * @minLength 1
          */
       source: string;
@@ -52488,11 +52501,24 @@ export namespace Schemas {
     };
 
     /**
-     * Output config. For 'boolean' output_type: {allows_na} to permit N/A results.
+     * How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way.
+     */
+    export type PatchedEvaluationOutputConfigResultFormat = typeof PatchedEvaluationOutputConfigResultFormat[keyof typeof PatchedEvaluationOutputConfigResultFormat];
+
+
+    export const PatchedEvaluationOutputConfigResultFormat = {
+      TrueFalse: 'true_false',
+      ZeroOne: 'zero_one',
+    } as const;
+
+    /**
+     * Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False.
      */
     export type PatchedEvaluationOutputConfig = {
       /** Whether the evaluation can return N/A for non-applicable generations. */
       allows_na?: boolean;
+      /** How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way. */
+      result_format?: PatchedEvaluationOutputConfigResultFormat;
     };
 
     /**
@@ -52560,7 +52586,7 @@ export namespace Schemas {
        * * `boolean` - Boolean (Pass/Fail)
        * * `sentiment` - Sentiment */
       output_type?: OutputTypeEnum;
-      /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results. */
+      /** Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False. */
       output_config?: PatchedEvaluationOutputConfig;
       /** Trigger conditions that filter which events are evaluated. OR between condition sets, AND within each. Each set is {id, rollout_percentage, properties[]} — `rollout_percentage` (0-100, defaults to 100) is the sampling field the dispatcher reads. */
       conditions?: EvaluationCondition[];

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -562,6 +562,7 @@ export const evaluationsCreateBodyNameMax = 400
 
 export const evaluationsCreateBodyEvaluationConfigThreeSourceDefault = `user_messages`
 export const evaluationsCreateBodyOutputConfigAllowsNaDefault = false
+export const evaluationsCreateBodyOutputConfigResultFormatDefault = `true_false`
 export const evaluationsCreateBodyConditionsItemIdMax = 100
 
 export const evaluationsCreateBodyConditionsItemRolloutPercentageDefault = 100
@@ -608,7 +609,9 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                 source: zod
                     .string()
                     .min(1)
-                    .describe('Hog source code. Must return true (pass), false (fail), or null for N\/A.'),
+                    .describe(
+                        'Hog source code. Must return true (pass), false (fail), or null for N\/A; 1 and 0 are accepted as aliases for true and false.'
+                    ),
             }),
             zod.object({
                 source: zod
@@ -633,9 +636,17 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                 .boolean()
                 .default(evaluationsCreateBodyOutputConfigAllowsNaDefault)
                 .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
+            result_format: zod
+                .enum(['true_false', 'zero_one'])
+                .default(evaluationsCreateBodyOutputConfigResultFormatDefault)
+                .describe(
+                    "How verdicts are labeled in the UI: 'true_false' shows True\/False, 'zero_one' shows 1\/0. N\/A results are labeled N\/A either way."
+                ),
         })
         .optional()
-        .describe("Output config. For 'boolean' output_type: {allows_na} to permit N\/A results."),
+        .describe(
+            "Output config. For 'boolean' output_type: {allows_na} to permit N\/A results, {result_format: 'zero_one'} to label verdicts 1\/0 instead of True\/False."
+        ),
     conditions: zod
         .array(
             zod
@@ -773,6 +784,7 @@ export const evaluationsPartialUpdateBodyNameMax = 400
 
 export const evaluationsPartialUpdateBodyEvaluationConfigThreeSourceDefault = `user_messages`
 export const evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault = false
+export const evaluationsPartialUpdateBodyOutputConfigResultFormatDefault = `true_false`
 export const evaluationsPartialUpdateBodyConditionsItemIdMax = 100
 
 export const evaluationsPartialUpdateBodyConditionsItemRolloutPercentageDefault = 100
@@ -820,7 +832,9 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 source: zod
                     .string()
                     .min(1)
-                    .describe('Hog source code. Must return true (pass), false (fail), or null for N\/A.'),
+                    .describe(
+                        'Hog source code. Must return true (pass), false (fail), or null for N\/A; 1 and 0 are accepted as aliases for true and false.'
+                    ),
             }),
             zod.object({
                 source: zod
@@ -846,9 +860,17 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 .boolean()
                 .default(evaluationsPartialUpdateBodyOutputConfigAllowsNaDefault)
                 .describe('Whether the evaluation can return N\/A for non-applicable generations.'),
+            result_format: zod
+                .enum(['true_false', 'zero_one'])
+                .default(evaluationsPartialUpdateBodyOutputConfigResultFormatDefault)
+                .describe(
+                    "How verdicts are labeled in the UI: 'true_false' shows True\/False, 'zero_one' shows 1\/0. N\/A results are labeled N\/A either way."
+                ),
         })
         .optional()
-        .describe("Output config. For 'boolean' output_type: {allows_na} to permit N\/A results."),
+        .describe(
+            "Output config. For 'boolean' output_type: {allows_na} to permit N\/A results, {result_format: 'zero_one'} to label verdicts 1\/0 instead of True\/False."
+        ),
     conditions: zod
         .array(
             zod

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
@@ -74,7 +74,7 @@
                 {
                     "properties": {
                         "source": {
-                            "description": "Hog source code. Must return true (pass), false (fail), or null for N/A.",
+                            "description": "Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.",
                             "minLength": 1,
                             "type": "string"
                         }
@@ -162,12 +162,18 @@
             "type": "string"
         },
         "output_config": {
-            "description": "Output config. For 'boolean' output_type: {allows_na} to permit N/A results.",
+            "description": "Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False.",
             "properties": {
                 "allows_na": {
                     "default": false,
                     "description": "Whether the evaluation can return N/A for non-applicable generations.",
                     "type": "boolean"
+                },
+                "result_format": {
+                    "default": "true_false",
+                    "description": "How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way.",
+                    "enum": ["true_false", "zero_one"],
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
@@ -74,7 +74,7 @@
                 {
                     "properties": {
                         "source": {
-                            "description": "Hog source code. Must return true (pass), false (fail), or null for N/A.",
+                            "description": "Hog source code. Must return true (pass), false (fail), or null for N/A; 1 and 0 are accepted as aliases for true and false.",
                             "minLength": 1,
                             "type": "string"
                         }
@@ -166,12 +166,18 @@
             "type": "string"
         },
         "output_config": {
-            "description": "Output config. For 'boolean' output_type: {allows_na} to permit N/A results.",
+            "description": "Output config. For 'boolean' output_type: {allows_na} to permit N/A results, {result_format: 'zero_one'} to label verdicts 1/0 instead of True/False.",
             "properties": {
                 "allows_na": {
                     "default": false,
                     "description": "Whether the evaluation can return N/A for non-applicable generations.",
                     "type": "boolean"
+                },
+                "result_format": {
+                    "default": "true_false",
+                    "description": "How verdicts are labeled in the UI: 'true_false' shows True/False, 'zero_one' shows 1/0. N/A results are labeled N/A either way.",
+                    "enum": ["true_false", "zero_one"],
+                    "type": "string"
                 }
             },
             "type": "object"


### PR DESCRIPTION
## Problem

Evaluation results can only be read as True/False/N/A: the labels are fixed across every surface, and the only stored value is a boolean event property. So results can't be consumed as numbers - a pass-rate insight needs string-compare HogQL, `avg()` aggregation is impossible, and teams used to 0/1 scoring (which offline evals already use internally) can't get that representation.

## Changes

- Every boolean evaluation run now also emits `$ai_evaluation_score` (1 = pass, 0 = fail) on its `$ai_evaluation` event. The property is omitted for N/A and skipped runs, so `avg($ai_evaluation_score)` reads as a true pass rate.
- Evaluations gain a "Result format" option (`output_config.result_format`: `true_false` default, `zero_one`). Under `zero_one`, result tags across all surfaces read 1/0 instead of True/False. N/A stays N/A - it is not a 0.
- Events are stamped with `$ai_evaluation_result_format` when the format is `zero_one`, so every surface renders a run identically without loading the parent evaluation (4 of the 5 render surfaces don't have it), and historical runs keep their labels.
- Hog evaluations accept `return 1` / `return 0` as aliases for true/false; anything else still errors with the existing message.
- `$ai_evaluation_result` stays boolean, so existing pass-rate HogQL, report outcome predicates, and the summary API are untouched. The boolean report outcome definition now fills its previously `NULL` `score_expression` with the new property.
- I rejected adding a new numeric `output_type`: the `(evaluation_type, output_type)` pair keys the config registry, execution engines, report definitions, and frontend capability gates, and 0/1 verdicts are still pass/fail semantically.

No screenshots: this sandbox ran the test suites but not the app UI. The visible changes are a "Result format" select in the evaluation form and 1/0 result tags.

## How did you test this code?

- New parameterized unit tests on `build_evaluation_event_properties`: a score emitted for a skipped or N/A run would silently corrupt pass rates (skips carry `verdict=false` when N/A is disallowed), and a bool-typed score would break numeric property-type inference. No existing test covered the score/stamp contract.
- Hog gate tests: `return 1` / `return 0` grade as pass/fail; `return 42` still fails with the exact existing error string.
- API tests: `result_format` round-trips on create; unknown values return 400.
- Frontend tests: tag labels under `zero_one` (N/A, Skipped, and sort values unchanged), raw run-row mapping including numeric results, kea reducer + unsaved-changes tracking, event-view rendering.
- Ran locally: targeted pytest (temporal eval activities + full evaluations API suite), affected jest suites, repo-wide mypy, `tsgo --noEmit`, ruff, `hogli build:openapi`, `hogli ci:preflight --fix`. Not run: Playwright and Storybook.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None in-repo. The posthog.com docs (separate repo) may want a line on `$ai_evaluation_score` and the result format option.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude in a PostHog Code cloud session from a one-line feature request; the requester (Jake Sciotto) approved the implementation plan before any code was written. GitHub handle not verified in-session, so the PR is left unassigned for him to pick up.
- Skills invoked: /improving-drf-endpoints, /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions.
- Notable decisions along the way: stamping the format on each event instead of threading the evaluation config into renderers; gating the score on a real graded verdict after finding that skip paths emit `verdict=false`; widening the raw run-row type to `number` after tsgo flagged the new numeric test cases.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
