### PR TITLE
fix(postgres): treat FDW column-width mismatches as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -758,6 +758,20 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "include the value used on the remote server, or remove the foreign table from the "
                 "sync, then re-enable the sync."
             ),
+            # A selected relation is a postgres_fdw foreign table whose locally-declared character
+            # column is narrower than the data actually stored on the remote server (SQLSTATE 22001,
+            # "value too long for type character varying(<n>)"). Postgres enforces length constraints
+            # at write time on ordinary tables, so this can only surface via a foreign table's
+            # separately-declared width. The schema drift lives on the customer's side and is
+            # deterministic, so retrying re-reads into the same row every time. Match the stable
+            # message and exclude the volatile declared width and the CONTEXT line's column/table names.
+            "value too long for type character": (
+                "One of the tables you selected to sync is a foreign table (postgres_fdw) whose "
+                "locally-declared column is narrower than the data on the remote server "
+                '(PostgreSQL reported "value too long for type character..."). Widen the local '
+                "column's declared length to match the remote server, or remove the foreign table "
+                "from the sync, then re-enable the sync."
+            ),
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1116,6 +1116,27 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
+            'value too long for type character varying(3)\nCONTEXT:  column "currency" of foreign table "accounttransaction"',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "StringDataRightTruncation: value too long for type character varying(3)",
+        ],
+    )
+    def test_fdw_string_truncation_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"FDW column-width mismatch error should be non-retryable: {error_msg}"
+
+    def test_fdw_string_truncation_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = 'value too long for type character varying(3)\nCONTEXT:  column "currency" of foreign table "accounttransaction"'
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "FDW column-width mismatch error should surface an actionable message"
+        assert "Widen the local" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

A Postgres sync that reads a `postgres_fdw` foreign table fails forever when the foreign table's locally-declared column is narrower than the actual data on the remote server. PostgreSQL raises `StringDataRightTruncation` ("value too long for type character varying(n)") reading the same row on every attempt, since the schema mismatch lives on the customer's side and never changes between retries.

Confirmed via an [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd406-efb9-7323-a621-c2a60238609b) whose stack trace shows the failure originating in `get_rows` in this source's own code, while fetching rows through a server-side cursor.

## Changes

- Add `"value too long for type character"` to `PostgresSource.get_non_retryable_errors`, next to the existing FDW enum-mismatch and user-mapping entries that cover the same class of foreign-table schema drift.
- The surfaced message tells the customer to widen the local column's declared length or remove the foreign table from the sync.

## How did you test this code?

- Added two test cases to `TestPostgresSourceNonRetryableErrors`, mirroring the existing FDW enum-mismatch tests: one asserts both the raw and Temporal-wrapped message forms are recognized as non-retryable, the other asserts the friendly message is surfaced. These catch a regression where the new pattern stops matching (e.g. a message-wording change upstream) and syncs go back to retrying indefinitely.
- Ran the full `test_postgres.py` suite; all tests that don't require a live database pass (pre-existing `RealDb`/live-connection tests fail in this sandbox with no Postgres server, unrelated to this change).
- Ran `ruff check`/`ruff format` and `mypy` on the two changed files; both clean. Not run: the full repo-wide `mypy` pass CI uses, which was still executing at time of writing — the change only adds two string literals to an existing `dict[str, str | None]`, so type-checking risk is minimal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled events with stack traces) to confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py`. Skills invoked: `/writing-tests` before adding the test cases, `/writing-pr-descriptions` before writing this body.