### PR TITLE
feat(customer-analytics): show accounts above persons in command palette

### DIFF
--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -1571,6 +1571,15 @@ export const searchLogic = kea<searchLogicType>([
                         })
                     }
 
+                    // Add accounts
+                    if (accountItems.length > 0 || accountSearchResultsLoading) {
+                        categories.push({
+                            key: 'accounts',
+                            items: accountItems,
+                            isLoading: accountSearchResultsLoading,
+                        })
+                    }
+
                     // Add persons
                     if (personItems.length > 0 || personSearchResultsLoading) {
                         categories.push({
@@ -1586,15 +1595,6 @@ export const searchLogic = kea<searchLogicType>([
                             key: 'groups',
                             items: groupItems,
                             isLoading: groupSearchResultsLoading,
-                        })
-                    }
-
-                    // Add accounts
-                    if (accountItems.length > 0 || accountSearchResultsLoading) {
-                        categories.push({
-                            key: 'accounts',
-                            items: accountItems,
-                            isLoading: accountSearchResultsLoading,
                         })
                     }
                 }


### PR DESCRIPTION
## Problem

When searching in the cmd+K palette, accounts appeared below persons and groups, so a user searching for a company had to scroll past individual people first.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Follow-up to https://github.com/PostHog/posthog/pull/78548.

## Changes

- Show the accounts category above persons and groups in the palette results.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Not tested beyond the existing suite. Pure reorder of `categories.push` calls in `searchLogic.tsx`; only the display order changes.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored by PostHog Code, human-driven.

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the account-search PR #78548, which merged before this reorder was raised. The change moves the accounts `push` block above persons/groups in the `allCategories` selector.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*