### PR TITLE
fix(notion): stop dropped-connection retries reporting error tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
@@ -55,7 +55,13 @@ class NotionSource(ResumableSource[NotionSourceConfig, NotionResumeConfig]):
         # tenacity-wrapped _request, which honors Notion's Retry-After on 429s); if those retries
         # still exhaust, the failure is transient and self-recovering, so let Temporal retry the
         # activity without surfacing it as tracked exception noise.
-        return {"Notion API error (retryable)", "Notion rate limited"}
+        #
+        # A dropped/reset connection (SSL handshake failure, connection reset, proxy error) is
+        # retried by that same tenacity decorator via requests.ConnectionError. urllib3 wraps all of
+        # these in a MaxRetryError before requests re-raises them as the specific subclass, so they
+        # share this message regardless of the underlying reason. Same self-recovering reasoning
+        # applies once that budget exhausts.
+        return {"Notion API error (retryable)", "Notion rate limited", "Max retries exceeded with url"}
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
@@ -160,12 +160,19 @@ class TestNotionSource:
                 "rate_limit_after_tenacity_exhausted",
                 "Notion rate limited: url=https://api.notion.com/v1/comments, retry_after=33.0",
             ),
+            (
+                "dropped_connection_after_tenacity_exhausted",
+                "HTTPSConnectionPool(host='api.notion.com', port=443): Max retries exceeded with url: "
+                "/v1/comments?block_id=abc&page_size=100 (Caused by SSLError(SSLEOFError(8, "
+                "'[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032)')))",
+            ),
         ]
     )
     def test_retryable_marker_matches_raised_message(self, _name: str, error_message: str) -> None:
-        # notion.py's _request raises these exact messages on a 5xx or 429 after tenacity's internal
-        # retries exhaust; matching them here keeps that self-recovering failure out of error
-        # tracking as noise instead of being logged as an unclassified exception.
+        # notion.py's _request raises these messages after tenacity's internal retries exhaust
+        # (5xx, 429 rate limits, and dropped connections routed through requests.ConnectionError);
+        # matching them here keeps that self-recovering failure out of error tracking as noise
+        # instead of being logged as an unclassified exception.
         markers = self.source.get_retryable_errors()
         assert markers
         assert any(marker in error_message for marker in markers)


### PR DESCRIPTION
## Problem

A Notion sync reports an unclassified exception when the connection to Notion's API drops mid-request (SSL reset, connection reset, proxy error), even though the sync recovers on its own. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd45d-493f-7eb0-86cd-90a69fb03563) shows one such case: an `SSLError` while fetching comments.

## Changes

- `_request` in `notion.py` already retries a dropped connection internally via `tenacity`, matching on `requests.ConnectionError` (which `SSLError` and similar subclass).
- Once that retry budget exhausts, the exception re-raises and Temporal retries the whole activity - the failure is transient and self-recovering, the same reasoning already applied to Notion 5xx responses via `get_retryable_errors()`.
- `get_retryable_errors()` was missing a marker for this class of failure, so it still reported as tracked-exception noise instead of a `warning` log.
- Added `"Max retries exceeded with url"`, the message `urllib3` wraps every one of these connection failures in before `requests` re-raises them as the specific subclass.

This is not a customer credential or config issue, so it does not belong in `get_non_retryable_errors()`, and retries themselves are untouched.

## How did you test this code?

Extended `test_retryable_marker_matches_raised_message` in `test_notion_source.py` with a case for a dropped-connection message shape, guarding against the marker no longer matching what `notion.py` actually raises. Ran the full `test_notion_source.py` suite (23 passed) and `ruff check`/`ruff format` on the changed files.

Not run: a live sync against Notion's API, since this only changes error classification after the request layer already fails.

## Docs update

None - internal error-classification change only.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/notion/notion.py`. Skills invoked: `/writing-tests` before extending the test, `/writing-pr-descriptions` before writing this body. Searched open PRs for duplicates (excluding the bot) and found none addressing this connection-error path.