### PR TITLE
fix(notion): stop rate-limit retries reporting error tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
@@ -51,10 +51,11 @@ class NotionSource(ResumableSource[NotionSourceConfig, NotionResumeConfig]):
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # A 5xx is already retried internally with backoff (see notion.py's tenacity-wrapped
-        # _request); if those retries still exhaust, the failure is transient and self-recovering,
-        # so let Temporal retry the activity without surfacing it as tracked exception noise.
-        return {"Notion API error (retryable)"}
+        # A 5xx or a 429 is already retried internally with backoff (see notion.py's
+        # tenacity-wrapped _request, which honors Notion's Retry-After on 429s); if those retries
+        # still exhaust, the failure is transient and self-recovering, so let Temporal retry the
+        # activity without surfacing it as tracked exception noise.
+        return {"Notion API error (retryable)", "Notion rate limited"}
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
@@ -150,16 +150,25 @@ class TestNotionSource:
             for pattern in non_retryable
         )
 
-    def test_retryable_marker_matches_raised_message(self) -> None:
-        # notion.py's _request raises this exact message on a 5xx after tenacity's internal
-        # retries exhaust; matching it here keeps that self-recovering failure out of error
+    @parameterized.expand(
+        [
+            (
+                "5xx_after_tenacity_exhausted",
+                "Notion API error (retryable): status=522, url=https://api.notion.com/v1/comments",
+            ),
+            (
+                "rate_limit_after_tenacity_exhausted",
+                "Notion rate limited: url=https://api.notion.com/v1/comments, retry_after=33.0",
+            ),
+        ]
+    )
+    def test_retryable_marker_matches_raised_message(self, _name: str, error_message: str) -> None:
+        # notion.py's _request raises these exact messages on a 5xx or 429 after tenacity's internal
+        # retries exhaust; matching them here keeps that self-recovering failure out of error
         # tracking as noise instead of being logged as an unclassified exception.
         markers = self.source.get_retryable_errors()
         assert markers
-        assert any(
-            marker in "Notion API error (retryable): status=522, url=https://api.notion.com/v1/comments"
-            for marker in markers
-        )
+        assert any(marker in error_message for marker in markers)
 
 
 @pytest.mark.parametrize("status_code", [500, 503])


### PR DESCRIPTION
## Problem

A Notion sync that gets rate-limited (HTTP 429) reports a tracked exception even after Notion's own internal retry succeeds or is still within its normal backoff budget, adding noise to error tracking for a self-recovering condition. See [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd465-58d2-70d2-a2fd-93fa21f9d766).

`notion.py`'s `_request` already retries a 429 with backoff that honors Notion's `Retry-After` header, the same tenacity loop that retries a 5xx. The 5xx case is already excluded from tracked-exception noise via `get_retryable_errors`, but the 429 case was never added to that set, so once its retry budget exhausts it falls through to the generic exception path and gets reported.

## Changes

- Add the stable `"Notion rate limited"` message prefix to `NotionSource.get_retryable_errors()`, alongside the existing 5xx entry.

## How did you test this code?

- Added a parameterized case to `test_retryable_marker_matches_raised_message` asserting the rate-limit message is recognized as retryable, alongside the existing 5xx case.
- Ran `products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py` locally: 23 passed.
- Not run: a live sync against a rate-limited Notion integration (would need a real workspace under sustained load).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None – no user-facing behavior, API, or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to confirm the issue's stack frame originates in `notion.py`'s `_request`, then read `notion.py` and `source.py` to trace how `NotionRetryableError` messages are classified. No skills were invoked for the code change itself; `/writing-pr-descriptions` was invoked for this body.

I checked the maintainer's other open Notion PRs (#78636, #78637, #78638) — they extend the same `get_retryable_errors` set for connection-drop/SSL/read-timeout messages, a different root cause, so this isn't a duplicate.