### PR TITLE
fix(snowflake): stop login internal-error retries reporting as noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -314,6 +314,15 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # previous attempt doesn't carry over. Self-recovering, so keep retrying instead of
             # stopping the sync. The errno prefix is volatile, so we match the stable status text.
             "HTTP 400: Bad Request",
+            # Snowflake error 250001 (08001): the login-request endpoint itself responded with a
+            # generic "Internal error" (`auth/_auth.py` formats this as "Failed to connect to DB:
+            # {host}:{port}. {message}", where `message` is Snowflake's own internal-error text) —
+            # a transient blip on Snowflake's authentication service, not a credential or config
+            # problem. It isn't retried inside the connector's own auth flow, so without this marker
+            # every Temporal-level retry logs it as unclassified error-tracking noise instead of the
+            # self-recovering failure it is. The request id in brackets is volatile, so we match the
+            # stable phrase.
+            "Internal error:",
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -930,6 +930,17 @@ class TestSnowflakeSourceRetryableErrors:
         is_retryable = any(pattern in error_msg for pattern in retryable)
         assert is_retryable, f"Chunk-download bad-request error should be classified retryable: {error_msg}"
 
+    def test_login_internal_error_is_retryable(self, source):
+        # The real shape from production: the login-request endpoint responded with a generic
+        # internal-error message instead of a credential/config-specific one.
+        error_msg = (
+            "250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. "
+            "Internal error:  [f189e7a4-177b-4b96-a5cf-50a7193e2fff]"
+        )
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Snowflake login internal-error should be classified retryable: {error_msg}"
+
 
 class TestSnowflakeValidateCredentials:
     @pytest.fixture


### PR DESCRIPTION
## Problem

A Snowflake sync's login attempt can fail with a generic internal-error response from Snowflake's own authentication service, instead of a specific credential or config problem. Reported by [error tracking](https://us.posthog.com/project/2/error_tracking/019fd463-0f9a-7202-9ed9-330acd293902): `DatabaseError: 250001 (08001): None: Failed to connect to DB: <host>:443. Internal error: [request id]`, raised from `SnowflakeImplementation.connect` in `products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py`.

The sync already retries this by default (it doesn't match any existing classification), but each retry gets logged as unclassified error-tracking noise instead of the self-recovering failure it is.

## Changes

- Add `"Internal error:"` to `SnowflakeSource.get_retryable_errors()` so Temporal keeps retrying without also surfacing it as tracked exception noise, matching the connector's `auth/_auth.py` template (`"Failed to connect to DB: {host}:{port}. {message}"`) where `message` is Snowflake's own internal-error text.
- This mirrors the same "generic vendor-side internal error is transient, not a bug" pattern already used for Notion, Polar, BigQuery, Google Ads, and Google Sheets sources in this pipeline.
- Not classified as non-retryable: the occurrence pattern (a handful of calls within about a minute, never recurring) and the generic nature of the message point to a transient blip on Snowflake's side, not something a customer needs to fix.

## How did you test this code?

- Added `test_login_internal_error_is_retryable` to `TestSnowflakeSourceRetryableErrors` in `test_snowflake.py`, asserting the production message shape is classified retryable. Ran the full `test_snowflake.py` suite locally (109 passed) and `mypy` on the changed file (clean).
- Not run: no live Snowflake connection was exercised; this only changes string classification logic.

## Docs update

None — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged an error tracking issue delivered by webhook for the Snowflake warehouse source, confirmed the stack trace originates in this source's `connect` method, traced the message template back to the installed `snowflake-connector-python` package's `auth/_auth.py`, and found this exact "generic internal error is retryable" pattern already established across several other sources in this pipeline (Notion, Polar, BigQuery, Google Ads, Google Sheets). No open human-authored PR addressed this; skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*