### PR TITLE
fix(hubspot): stop tied-cursor drain paging past HubSpot's 10k search cap

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/hubspot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/hubspot.py
@@ -700,6 +700,7 @@ def get_rows_via_search(
             anchor_id = next_anchor_id
             after: Optional[str] = None
             got_any = False
+            anchor_result_count = 0
 
             while True:
                 body: dict[str, Any] = {
@@ -723,6 +724,7 @@ def get_rows_via_search(
                 if not results:
                     break
                 got_any = True
+                anchor_result_count += len(results)
 
                 if config.associations:
                     _backfill_associations_into_results(
@@ -745,6 +747,12 @@ def get_rows_via_search(
                         next_anchor_id = result_id
 
                 yield from _process_results(results)
+
+                # HubSpot rejects paging a single query past SEARCH_RESULT_CAP results ("Attempting
+                # to page beyond 10,000"). Restart with the advanced anchor before that happens,
+                # rather than waiting for `after` to run out.
+                if anchor_result_count >= SEARCH_RESULT_CAP:
+                    break
 
                 next_cursor = data.get("paging", {}).get("next", {}).get("after")
                 if not next_cursor:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py
@@ -904,6 +904,73 @@ class TestGetRowsViaSearch:
         assoc_ids_seen = {i for call in mock_batch.call_args_list for i in call.kwargs["ids"]}
         assert {drain_id_1, drain_id_2} <= assoc_ids_seen
 
+    def test_drain_tied_cursor_restarts_anchor_before_paging_past_cap(self) -> None:
+        # Regression: if a single hs_object_id anchor itself has more than SEARCH_RESULT_CAP
+        # tied-cursor records, continuing to page it via `after` crosses HubSpot's per-query
+        # cap and returns a 400 ("Attempting to page beyond 10,000"). The drain must restart
+        # with an advanced anchor once it hits the cap, even though `after` still had more.
+        identical_cursor = 1_799_000_000_000
+        pages_in_cap = SEARCH_RESULT_CAP // SEARCH_PAGE_SIZE
+
+        def _tied_pages(start_id: int, mark_more_after_last: bool) -> list[dict[str, Any]]:
+            pages = []
+            for i in range(pages_in_cap):
+                batch = [
+                    _result(str(start_id + i * SEARCH_PAGE_SIZE + j), identical_cursor) for j in range(SEARCH_PAGE_SIZE)
+                ]
+                is_last = i == pages_in_cap - 1
+                after = f"c{i}" if not is_last or mark_more_after_last else None
+                pages.append(_search_page(batch, after=after))
+            return pages
+
+        # First window sub-slice hits the cap with every record sharing one cursor value.
+        window_pages = _tied_pages(start_id=0, mark_more_after_last=False)
+        # The first drain anchor (-1) itself has more than SEARCH_RESULT_CAP tied records —
+        # its last page still carries an `after` token, signalling more are available.
+        anchor_pages = _tied_pages(start_id=SEARCH_RESULT_CAP, mark_more_after_last=True)
+        max_anchor_id = SEARCH_RESULT_CAP + pages_in_cap * SEARCH_PAGE_SIZE - 1
+
+        responses = (
+            [_make_response(200, p) for p in window_pages]
+            + [_make_response(200, p) for p in anchor_pages]
+            + [_make_response(200, _search_page([]))]  # fresh query, advanced anchor: exhausted
+            + [_make_response(200, _search_page([]))]  # window resumes past the tied cursor
+        )
+        side_effect, captured = _setup_search_post(responses)
+        manager = _make_manager()
+        logger = MagicMock()
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.hubspot.hubspot.make_tracked_session",
+            new=lambda *_a, **_k: type("_S", (), {"post": staticmethod(side_effect)})(),
+        ):
+            tables = list(
+                get_rows_via_search(
+                    api_key="k",
+                    refresh_token="r",
+                    endpoint="deals",
+                    logger=logger,
+                    resumable_source_manager=manager,
+                    db_incremental_field_last_value=str(identical_cursor - 1),
+                    include_custom_props=False,
+                    now_ms=identical_cursor + 1_000,
+                    api_version=HUBSPOT_API_VERSION_V3,
+                )
+            )
+
+        assert sum(t.num_rows for t in tables) == SEARCH_RESULT_CAP * 2
+
+        # The request right after the anchor's own cap is hit must be a fresh query (no
+        # `after`) anchored past the highest id seen — not a continuation of the anchor's
+        # `after` token, even though that token was available.
+        restart_request = captured[pages_in_cap * 2]["json"]
+        assert "after" not in restart_request
+        assert {
+            "propertyName": "hs_object_id",
+            "operator": "GT",
+            "value": str(max_anchor_id),
+        } in restart_request["filterGroups"][0]["filters"]
+
     def test_drain_tied_cursor_skips_records_with_non_numeric_id(self) -> None:
         # Defensive: a record with a missing/non-numeric id must not crash the drain — it's
         # still batched, just excluded from the id-anchor advance for that record.


### PR DESCRIPTION
## Problem

HubSpot contacts imports can fail outright when one bulk-import batch stamps more than 10,000 records with the identical `lastmodifieddate`.

- Error tracking issue: [HTTPError: 400 Client Error: Bad Request for url: .../contacts/search](https://us.posthog.com/project/2/error_tracking/019fd466-8c35-70e2-b4cc-7d41c9518401)
- HubSpot's search endpoint rejects paging a single query past 10,000 results ("Attempting to page beyond 10,000"), no matter how the `after` cursor got there.

## Changes

- `_drain_tied_cursor` (the fallback path for records that share one cursor value) already restarts with an advanced `hs_object_id` anchor once an anchor's own pagination naturally runs dry, but it had no cap on how far a single anchor's `after` chain could grow.
- If more than 10,000 records shared one anchor and one tied cursor value, the drain kept paging that same query past HubSpot's cap and got a 400, failing the sync.
- The drain now counts results per anchor and restarts with an advanced anchor once it reaches `SEARCH_RESULT_CAP`, the same cap check the window loop already uses for the same reason.

## How did you test this code?

Added `test_drain_tied_cursor_restarts_anchor_before_paging_past_cap` in `test_hubspot_search.py`: it gives a single anchor more than `SEARCH_RESULT_CAP` tied-cursor records (with `after` still available past the cap) and asserts the next request is a fresh, anchor-advanced query with no `after`, rather than a continuation that would cross HubSpot's limit. No existing test exercises an anchor session that itself exceeds the cap.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_hubspot_search.py` (59 passed), `ruff check`/`ruff format`, and a full-repo `mypy --cache-fine-grained .` (no issues).

Not run: an end-to-end sync against a live HubSpot portal.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry/pagination behavior, no user-facing or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog error tracking MCP tools (issue details, sampled event, full stack trace) to confirm the failure originates in `hubspot.py`, then confirmed HubSpot's dated-version URL rewrite is correct against HubSpot's own docs before finding the real cause in `_drain_tied_cursor`'s pagination.
- Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.
- Checked for duplicate open PRs (including the reporting maintainer's own) before opening this one; found none addressing this cap.