### PR TITLE
fix(error-tracking): don't query on half-written filters, show real error

### DIFF
--- a/frontend/src/queries/nodes/DataTable/queryFeatures.test.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.test.ts
@@ -11,6 +11,7 @@ describe('getQueryFeatures', () => {
             [NodeKind.EventsQuery, { kind: NodeKind.EventsQuery, select: ['*'] }],
             [NodeKind.SessionsQuery, { kind: NodeKind.SessionsQuery }],
             [NodeKind.HogQLQuery, { kind: NodeKind.HogQLQuery, query: 'SELECT 1' }],
+            [NodeKind.ErrorTrackingQuery, { kind: NodeKind.ErrorTrackingQuery, orderBy: 'last_seen' }],
         ])('%s should have displayResponseError enabled', (_, query) => {
             const features = getQueryFeatures(query)
             expect(features.has(QueryFeature.displayResponseError)).toBe(true)

--- a/frontend/src/queries/nodes/DataTable/queryFeatures.ts
+++ b/frontend/src/queries/nodes/DataTable/queryFeatures.ts
@@ -3,6 +3,7 @@ import {
     isAccountsQuery,
     isActorsQuery,
     isEndpointsUsageTableQuery,
+    isErrorTrackingQuery,
     isEventsQuery,
     isGroupsQuery,
     isHogQLQuery,
@@ -154,6 +155,10 @@ export function getQueryFeatures(query: Node): Set<QueryFeature> {
         features.add(QueryFeature.resultIsArrayOfArrays)
         features.add(QueryFeature.displayResponseError)
         features.add(QueryFeature.hideLoadNextButton)
+    }
+
+    if (isErrorTrackingQuery(query)) {
+        features.add(QueryFeature.displayResponseError)
     }
 
     if (isAccountsQuery(query)) {

--- a/products/error_tracking/frontend/queries.test.ts
+++ b/products/error_tracking/frontend/queries.test.ts
@@ -1,6 +1,6 @@
-import { ProductKey } from '~/queries/schema/schema-general'
+import { ErrorTrackingQuery, ProductKey } from '~/queries/schema/schema-general'
 
-import { FilterLogicalOperator } from '../../../frontend/src/types'
+import { FilterLogicalOperator, PropertyOperator, UniversalFilterValue } from '../../../frontend/src/types'
 import { errorTrackingIssueBreakdownQuery, errorTrackingIssueEventsQuery, errorTrackingQuery } from './queries'
 
 describe('queries', () => {
@@ -26,6 +26,44 @@ describe('queries', () => {
                     personId: undefined,
                 })
                 expect(actual).toMatchSnapshot()
+            })
+        })
+
+        it('omits a filter the user has not finished writing', () => {
+            const actual = errorTrackingQuery({
+                orderBy: 'users',
+                dateRange: { date_from: '-7d', date_to: null },
+                filterTestAccounts: false,
+                filterGroup: {
+                    type: FilterLogicalOperator.And,
+                    values: [
+                        {
+                            type: FilterLogicalOperator.And,
+                            values: [
+                                { key: 'url', value: null, operator: PropertyOperator.Exact, type: 'event' },
+                                {
+                                    key: '$browser',
+                                    value: ['Chrome'],
+                                    operator: PropertyOperator.Exact,
+                                    type: 'event',
+                                },
+                            ] as UniversalFilterValue[],
+                        },
+                    ],
+                },
+                columns: ['error', 'users', 'occurrences'],
+            })
+
+            expect((actual.source as ErrorTrackingQuery).filterGroup).toEqual({
+                type: FilterLogicalOperator.And,
+                values: [
+                    {
+                        type: FilterLogicalOperator.And,
+                        values: [
+                            { key: '$browser', value: ['Chrome'], operator: PropertyOperator.Exact, type: 'event' },
+                        ],
+                    },
+                ],
             })
         })
     })

--- a/products/error_tracking/frontend/queries.ts
+++ b/products/error_tracking/frontend/queries.ts
@@ -27,6 +27,7 @@ import {
     ERROR_TRACKING_DETAILS_RESOLUTION,
     ERROR_TRACKING_LISTING_RESOLUTION,
     SEARCHABLE_EXCEPTION_PROPERTIES,
+    withFiltersReadyToQuery,
 } from './utils'
 
 export const errorTrackingQuery = ({
@@ -73,7 +74,7 @@ export const errorTrackingQuery = ({
             dateRange,
             assignee,
             volumeResolution,
-            filterGroup: filterGroup as PropertyGroupFilter,
+            filterGroup: withFiltersReadyToQuery(filterGroup) as PropertyGroupFilter,
             filterTestAccounts: filterTestAccounts,
             searchQuery: searchQuery,
             limit: limit,
@@ -122,7 +123,7 @@ export const errorTrackingIssueQuery = ({
         kind: NodeKind.ErrorTrackingQuery,
         issueId,
         dateRange,
-        filterGroup: filterGroup as PropertyGroupFilter,
+        filterGroup: withFiltersReadyToQuery(filterGroup) as PropertyGroupFilter,
         orderBy: 'last_seen',
         filterTestAccounts,
         searchQuery,

--- a/products/error_tracking/frontend/utils.test.ts
+++ b/products/error_tracking/frontend/utils.test.ts
@@ -1,8 +1,17 @@
 import { Dayjs, dayjs } from 'lib/dayjs'
 
 import { ErrorTrackingIssue, ErrorTrackingIssueAggregations } from '~/queries/schema/schema-general'
+import {
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyFilterValue,
+    PropertyOperator,
+    UniversalFilterValue,
+    UniversalFiltersGroup,
+    UniversalFiltersGroupValue,
+} from '~/types'
 
-import { generateDateRangeLabel, mergeIssues, sourceDisplay } from './utils'
+import { generateDateRangeLabel, mergeIssues, sourceDisplay, withFiltersReadyToQuery } from './utils'
 
 function wrapVolumeBuckets(
     initialDate: Dayjs,
@@ -188,5 +197,67 @@ describe('sourceDisplay', () => {
                 '../../node_modules/.pnpm/kea-loaders@3.0.0_kea@3.1.5_react@18.2.0_/node_modules/kea-loaders/src/index.ts'
             )
         ).toEqual('kea-loaders.src.index')
+    })
+})
+
+describe('withFiltersReadyToQuery', () => {
+    const group = (...values: UniversalFiltersGroupValue[]): UniversalFiltersGroup => ({
+        type: FilterLogicalOperator.And,
+        values,
+    })
+    const filter = (value: PropertyFilterValue): UniversalFilterValue =>
+        ({
+            key: 'error_source',
+            value,
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        }) as UniversalFilterValue
+
+    it.each([
+        ['a null value', null],
+        ['an undefined value', undefined],
+        ['an empty array value', []],
+        ['an empty string value', ''],
+    ])('drops a filter with %s', (_name, value) => {
+        expect(withFiltersReadyToQuery(group(filter(value as PropertyFilterValue)))).toEqual(group())
+    })
+
+    it.each([
+        ['a populated array', ['sentry']],
+        ['a plain string', 'sentry'],
+        ['a boolean false', false],
+        ['a zero', 0],
+    ])('keeps a filter with %s', (_name, value) => {
+        const filterGroup = group(filter(value as PropertyFilterValue))
+        expect(withFiltersReadyToQuery(filterGroup)).toEqual(filterGroup)
+    })
+
+    it('keeps a valueless filter whose operator needs no value', () => {
+        const filterGroup = group({
+            key: 'error_source',
+            value: null,
+            operator: PropertyOperator.IsSet,
+            type: PropertyFilterType.Event,
+        } as UniversalFilterValue)
+        expect(withFiltersReadyToQuery(filterGroup)).toEqual(filterGroup)
+    })
+
+    it('keeps a HogQL filter, which holds its expression in the key', () => {
+        const filterGroup = group({
+            type: PropertyFilterType.HogQL,
+            key: "properties.$lib = 'posthog-python'",
+            value: null,
+        } as UniversalFilterValue)
+        expect(withFiltersReadyToQuery(filterGroup)).toEqual(filterGroup)
+    })
+
+    it('passes through an absent filter group', () => {
+        expect(withFiltersReadyToQuery(undefined)).toBeUndefined()
+    })
+
+    it('drops half-written filters nested inside a group', () => {
+        expect(withFiltersReadyToQuery(group(group(filter(null), filter(['sentry']))))).toEqual(
+            group(group(filter(['sentry'])))
+        )
     })
 })

--- a/products/error_tracking/frontend/utils.ts
+++ b/products/error_tracking/frontend/utils.ts
@@ -4,13 +4,23 @@ import { routerType } from 'kea-router/lib/routerType'
 import { MouseEvent } from 'react'
 
 import { ErrorTrackingException } from 'lib/components/Errors/types'
+import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { componentsToDayJs, dateStringToComponents, dateStringToDayJs, isStringDateRegex } from 'lib/utils/dateFilters'
+import { isOperatorFlag } from 'lib/utils/operators'
 import { Params } from 'scenes/sceneTypes'
 
 import { DateRange, ErrorTrackingIssue } from '~/queries/schema/schema-general'
-import { AccessControlLevel, AccessControlResourceType } from '~/types'
+import {
+    AccessControlLevel,
+    AccessControlResourceType,
+    PropertyFilterType,
+    PropertyOperator,
+    UniversalFilterValue,
+    UniversalFiltersGroup,
+    UniversalFiltersGroupValue,
+} from '~/types'
 
 /** Reason error tracking write actions are disabled, or null when the user has editor access. */
 export function errorTrackingEditAccessDisabledReason(): string | null {
@@ -168,6 +178,44 @@ export function updateSearchParams<T>(searchParams: Params, key: string, value: 
         searchParams[key] = value
     } else {
         delete searchParams[key]
+    }
+}
+
+function isFilterReadyToQuery(filter: UniversalFilterValue): boolean {
+    if (!('type' in filter) || filter.type === PropertyFilterType.HogQL) {
+        // A HogQL filter carries its expression in `key` and never holds a value.
+        return !('key' in filter) || !!filter.key
+    }
+    // Cast is safe because isOperatorFlag is a membership test: a logical operator just isn't a member.
+    const operator = 'operator' in filter ? (filter.operator as PropertyOperator | undefined) : undefined
+    if (operator && isOperatorFlag(operator)) {
+        return true
+    }
+    if (!('value' in filter)) {
+        return true
+    }
+    const { value } = filter
+    return Array.isArray(value) ? value.length > 0 : value !== null && value !== undefined && value !== ''
+}
+
+/**
+ * Picking a property commits a filter before the user has typed a value into it. Sending that
+ * half-written filter fails the whole query, so the list dead-ends between the two clicks it
+ * takes to add a filter. Leave such filters in place in the UI and just omit them from the query.
+ */
+export function withFiltersReadyToQuery(filterGroup?: UniversalFiltersGroup): UniversalFiltersGroup | undefined {
+    return filterGroup ? filterGroupReadyToQuery(filterGroup) : filterGroup
+}
+
+function filterGroupReadyToQuery(filterGroup: UniversalFiltersGroup): UniversalFiltersGroup {
+    return {
+        ...filterGroup,
+        values: filterGroup.values.flatMap((value: UniversalFiltersGroupValue): UniversalFiltersGroupValue[] => {
+            if (isUniversalGroupFilterLike(value)) {
+                return [filterGroupReadyToQuery(value)]
+            }
+            return isFilterReadyToQuery(value) ? [value] : []
+        }),
     }
 }
 


### PR DESCRIPTION
## Problem

Adding a filter to the Error Tracking issues list breaks the list. Picking a property commits the filter before you have typed a value into it, and that valueless filter goes straight to the query endpoint, which fails the whole request. So between the two clicks it takes to add a filter, the list dead-ends on "There was a problem completing this query".

The only offered action is "Try again", and it cannot work: it re-runs the identical query, incomplete filter included. Nothing on the screen says the filter is the problem, because the issues list falls through to the generic error state rather than the one that shows what the server actually said.

The same query builder and table power the Error Tracking tile on Web Analytics, so it fails the same way.

## Changes

- Omit filters that aren't ready to query when building `ErrorTrackingQuery`. A filter is not ready when its operator needs a value and none has been entered yet. The filter stays visible and editable in the UI, and starts applying once it has a value.
- Grant `ErrorTrackingQuery` the `displayResponseError` feature, so the table shows the real server error (and the cancelled-query title) like other table queries already do, instead of the generic fallback.
- Both changes land in shared code, so the Web Analytics error tracking tile is covered too.

Filtering at query-build time rather than in filter state is deliberate: dropping the filter from state would make it vanish from the UI as soon as you picked it.

No screenshots — I could not run the app in this environment.

## How did you test this code?

Automated only. I was not able to run the app or reproduce a server error against a real backend, so the end-to-end behavior is unverified.

Tests I ran locally:

- `products/error_tracking/frontend/` — 18 suites, all passing.
- `frontend/src/queries/nodes/DataTable` and `frontend/src/scenes/web-analytics` — passing, covering the `queryFeatures` change.
- Full `typescript:check`: no new errors in the changed files. Pre-existing unrelated errors remain across products that import `lib/ui/quill`, which does not resolve without the quill workspace built.

New tests and the regression each catches:

- `withFiltersReadyToQuery` unit tests — a valueless filter reaching the query at all. Covers null, undefined, empty array, and empty string values; keeps `false` and `0`, which are real values; keeps valueless filters whose operator needs no value (`is_set`); keeps HogQL filters, which carry their expression in `key`; and recurses into nested groups.
- `errorTrackingQuery` wiring test — someone removing the call from the query builder while the helper stays green. I confirmed it fails when the call is reverted.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Assignee is unset: I could not verify the requester's GitHub handle in this session, and guessing one would tag an unrelated account. Please assign the DRI on triage.

Written by the PostHog Slack app (Claude Code) from a [Slack thread](https://posthog.slack.com/archives/C0BLVN5C77F/p1785967935260939?thread_ts=1785967935.260939&cid=C0BLVN5C77F) investigating error tracking query failures. Skills invoked: none — the repo skill listing was consulted, but the change did not touch a DRF endpoint, migration, or generated API type.

The investigation started from the retry button, on the theory that retry gave no feedback. Reading the code ruled that out: retry does force a cache-busting re-run and the surface does swap to a loading state. The real defect is that the query is deterministically bad, so retry is the wrong affordance for it. That reframing moved the fix from the button to the query.

I also checked whether wide date ranges or large event volume explained the failures. Neither does for the bulk of them: failing loads overwhelmingly use the default or shortest windows, and most come from low-volume projects. A separate elevated failure rate does show up on the very largest projects, which this PR does not address — that one looks like a query cost problem and wants its own investigation.

One caveat for the reviewer: I have correlational evidence that incomplete filters fail, not a reproduced stack trace. Reading the backend, `property_to_expr` appears to handle null and empty values without raising, so the exact 500 mechanism is unconfirmed. The client-side guard is still right on its own merits — an incomplete filter is not a query anyone meant to run — but it may not be the whole story, and `_filter_value_to_ast` has no exception handling, so a non-`ExposedHogQLError` from anywhere in the property chain still becomes a raw 500 rather than a 400.
