### PR TITLE
feat(desktop): flag payload transport, in-app deep-link dispatch, version comparator

### DIFF
--- a/products/desktop/apps/code/.storybook/withAppProviders.tsx
+++ b/products/desktop/apps/code/.storybook/withAppProviders.tsx
@@ -152,6 +152,7 @@ function createProviderStack(): ProviderStack {
   // every flag reads as enabled and useFeatureFlag's state never settles.
   bindings.bind<FeatureFlags>(FEATURE_FLAGS).toConstantValue({
     isEnabled: () => false,
+    getPayload: () => undefined,
     onFlagsLoaded: () => () => {},
   });
   const container = storyContainer(bindings);

--- a/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
+++ b/products/desktop/apps/code/src/renderer/platform-adapters/updates.ts
@@ -169,12 +169,29 @@ function maybeShowWhatsNew(): void {
     );
 }
 
+// The changelog defers to flag-driven surfaces (billing announcement, remote
+// announcements), so wait for flags before auto-opening — otherwise it can
+// open and immediately vanish behind an announcement that arrives with the
+// flag payload. The timeout keeps offline and keyless dev builds working.
+const FLAGS_SETTLE_TIMEOUT_MS = 3_000;
+
+function maybeShowWhatsNewOnceFlagsSettle(): void {
+  let evaluated = false;
+  const evaluate = () => {
+    if (evaluated) return;
+    evaluated = true;
+    maybeShowWhatsNew();
+  };
+  posthogFeatureFlags.onFlagsLoaded(evaluate);
+  setTimeout(evaluate, FLAGS_SETTLE_TIMEOUT_MS);
+}
+
 function onSettingsReady(): void {
   syncAutoDownload(useSettingsStore.getState().downloadUpdatesAutomatically);
   useSettingsStore.subscribe((state) =>
     syncAutoDownload(state.downloadUpdatesAutomatically),
   );
-  maybeShowWhatsNew();
+  maybeShowWhatsNewOnceFlagsSettle();
 }
 
 if (useSettingsStore.persist.hasHydrated()) {

--- a/products/desktop/apps/web/src/web-container.ts
+++ b/products/desktop/apps/web/src/web-container.ts
@@ -511,6 +511,7 @@ container.bind(FEATURE_FLAGS).toConstantValue({
   // same behavior as the old stub, but real flags light up once a key is set.
   isEnabled: (flagKey: string) =>
     flagKey === SYNC_CLOUD_TASKS_FLAG || posthogFeatureFlags.isEnabled(flagKey),
+  getPayload: posthogFeatureFlags.getPayload,
   onFlagsLoaded: posthogFeatureFlags.onFlagsLoaded,
 });
 

--- a/products/desktop/packages/core/src/updates/updates.test.ts
+++ b/products/desktop/packages/core/src/updates/updates.test.ts
@@ -105,7 +105,8 @@ const {
   };
 });
 
-import { isVersionNewer, UpdatesService } from "./updates";
+import { UpdatesService } from "./updates";
+import { isVersionNewer } from "./version";
 
 function injectPorts(service: UpdatesService): void {
   const s = service as unknown as Record<string, unknown>;

--- a/products/desktop/packages/core/src/updates/updates.ts
+++ b/products/desktop/packages/core/src/updates/updates.ts
@@ -29,25 +29,9 @@ import {
   type UpdatesStatusPayload,
 } from "./schemas";
 
+import { isVersionNewer } from "./version";
+
 type CheckSource = "user" | "periodic";
-
-function versionTriple(version: string): number[] {
-  return version
-    .replace(/^v/, "")
-    .split(".", 3)
-    .map((segment) => Number.parseInt(segment, 10) || 0);
-}
-
-export function isVersionNewer(candidate: string, current: string): boolean {
-  const a = versionTriple(candidate);
-  const b = versionTriple(current);
-  for (let i = 0; i < 3; i++) {
-    if ((a[i] ?? 0) !== (b[i] ?? 0)) {
-      return (a[i] ?? 0) > (b[i] ?? 0);
-    }
-  }
-  return false;
-}
 type UpdateState =
   | "idle"
   | "checking"

--- a/products/desktop/packages/core/src/updates/version.ts
+++ b/products/desktop/packages/core/src/updates/version.ts
@@ -1,0 +1,17 @@
+function versionTriple(version: string): number[] {
+  return version
+    .replace(/^v/, "")
+    .split(".", 3)
+    .map((segment) => Number.parseInt(segment, 10) || 0);
+}
+
+export function isVersionNewer(candidate: string, current: string): boolean {
+  const a = versionTriple(candidate);
+  const b = versionTriple(current);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) !== (b[i] ?? 0)) {
+      return (a[i] ?? 0) > (b[i] ?? 0);
+    }
+  }
+  return false;
+}

--- a/products/desktop/packages/host-router/src/routers/deep-link.router.ts
+++ b/products/desktop/packages/host-router/src/routers/deep-link.router.ts
@@ -54,9 +54,25 @@ import {
   type TaskLinkService,
 } from "@posthog/core/links/task-link";
 import { publicProcedure, router } from "@posthog/host-trpc/trpc";
+import {
+  DEEP_LINK_SERVICE,
+  type IDeepLinkRegistry,
+} from "@posthog/platform/deep-link";
 import type { NotificationTarget } from "@posthog/platform/notifications";
+import { z } from "zod";
 
 export const deepLinkRouter = router({
+  // In-app surfaces (announcement CTAs) dispatch posthog-code:// urls through
+  // the same main-process handler OS-delivered links use — no OS round-trip,
+  // no browser bounce, and dev builds (posthog-code-dev scheme) stay in-app.
+  open: publicProcedure
+    .input(z.object({ url: z.string() }))
+    .mutation(({ ctx, input }) =>
+      ctx.container
+        .get<IDeepLinkRegistry>(DEEP_LINK_SERVICE)
+        .handleUrl(input.url),
+    ),
+
   onOpenTask: publicProcedure.subscription(async function* (opts) {
     const service = opts.ctx.container.get<TaskLinkService>(TASK_LINK_SERVICE);
     const iterable = service.toIterable(TaskLinkEvent.OpenTask, {

--- a/products/desktop/packages/platform/src/deep-link.ts
+++ b/products/desktop/packages/platform/src/deep-link.ts
@@ -7,6 +7,13 @@ export interface IDeepLinkRegistry {
   registerHandler(key: string, handler: DeepLinkHandler): void;
   unregisterHandler(key: string): void;
   getProtocol(): string;
+  /**
+   * Dispatch a deep-link URL through the registered handlers — the same path
+   * OS-delivered links take, callable from in-app surfaces without an OS hop.
+   * Lives on the platform interface because host-router forwards to it
+   * (deepLink.open) and cannot import the host's own service token.
+   */
+  handleUrl(url: string): boolean;
 }
 
 export const DEEP_LINK_SERVICE = Symbol.for("posthog.platform.deepLink");

--- a/products/desktop/packages/ui/src/features/feature-flags/identifiers.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/identifiers.ts
@@ -5,6 +5,12 @@
  */
 export interface FeatureFlags {
   isEnabled(flagKey: string): boolean;
+  /**
+   * Remote JSON payload attached to a matched flag; undefined when the flag
+   * is unmatched or flags haven't loaded. Validate with Zod at the
+   * consumption boundary — the shape is whatever was typed into PostHog.
+   */
+  getPayload(flagKey: string): unknown;
   onFlagsLoaded(handler: () => void): () => void;
 }
 

--- a/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagPayload.ts
+++ b/products/desktop/packages/ui/src/features/feature-flags/useFeatureFlagPayload.ts
@@ -1,0 +1,20 @@
+import { useService } from "@posthog/di/react";
+import { useEffect, useState } from "react";
+import { FEATURE_FLAGS, type FeatureFlags } from "./identifiers";
+
+export function useFeatureFlagPayload(flagKey: string): unknown {
+  const flags = useService<FeatureFlags>(FEATURE_FLAGS);
+  const [payload, setPayload] = useState<unknown>(() =>
+    flags.getPayload(flagKey),
+  );
+
+  useEffect(() => {
+    setPayload(flags.getPayload(flagKey));
+
+    return flags.onFlagsLoaded(() => {
+      setPayload(flags.getPayload(flagKey));
+    });
+  }, [flags, flagKey]);
+
+  return payload;
+}

--- a/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/session-update/UserMessage.test.tsx
@@ -13,6 +13,7 @@ import { UserMessage } from "./UserMessage";
 function renderWithFlags(node: ReactNode, bluebirdEnabled: boolean) {
   const flags: FeatureFlags = {
     isEnabled: () => bluebirdEnabled,
+    getPayload: () => undefined,
     onFlagsLoaded: () => () => {},
   };
   const container = new Container();

--- a/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
+++ b/products/desktop/packages/ui/src/shell/posthogAnalyticsImpl.ts
@@ -375,6 +375,18 @@ export function onFeatureFlagsLoaded(callback: () => void): () => void {
 }
 
 /**
+ * Remote JSON payload for a matched flag; undefined when uninitialized or
+ * unmatched. posthog-js returns the decoded value, not the raw string.
+ */
+export function getFeatureFlagPayload(flagKey: string): unknown {
+  if (!isInitialized) {
+    return undefined;
+  }
+
+  return posthog.getFeatureFlagPayload(flagKey);
+}
+
+/**
  * Reload feature flags from the server.
  * Useful after a person property change (e.g., invite code redemption).
  */
@@ -405,6 +417,7 @@ export const posthogAnalyticsTracker: AnalyticsTracker = {
  */
 export const posthogFeatureFlags: FeatureFlags = {
   isEnabled: isFeatureFlagEnabled,
+  getPayload: getFeatureFlagPayload,
   onFlagsLoaded: onFeatureFlagsLoaded,
 };
 


### PR DESCRIPTION
Bottom of the announcements stack — #78273 (core announcements) and #78657 (admin editor) sit on top. Reviewable standalone: nothing here knows about announcements.

Three small plumbing pieces:
- **Flag payload transport** — `getPayload` on the `FeatureFlags` service (posthog-js impl, web host, storybook stub) plus a `useFeatureFlagPayload` hook that re-reads whenever flags load.
- **In-app deep-link dispatch** — a `deepLink.open` tRPC route forwarding to `handleUrl` on the platform deep-link interface, so in-app surfaces can dispatch `posthog-code://` links through the same path OS-delivered links take, without an OS round trip.
- **`isVersionNewer` extraction** — the pure comparator moves out of `UpdatesService` so renderer code can version-gate without importing the service (and its DI graph). Also defers the What's New auto-open until flags settle, so flag-driven surfaces get first claim on the stage.

## Why

Splitting the announcements stack so the generic transport/plumbing can be reviewed apart from the feature that motivated it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*