### PR TITLE
fix(desktop): keep relayed MCP designation past a run's terminal status

### DIFF
--- a/products/desktop/docs/cloud-mcp-relay.md
+++ b/products/desktop/docs/cloud-mcp-relay.md
@@ -12,9 +12,20 @@ Client coordination: `CloudTaskService.handleMcpRelayRequest`
 
 Implementation notes where reality refined the design: relay designations are
 held in memory by the creating client's main process — an app restart drops
-them, and relayed servers stop working for in-flight runs (they 503 after the
-liveness window) rather than surviving a handoff. Tool allowlisting for
-relayed servers persists for the session lifetime, not to the backend.
+them, and relayed servers stop working for in-flight runs rather than
+surviving a handoff. They do outlive the run itself, though: `resume_in_cloud`
+revives a terminal run under the same id, and its new sandbox rebuilds relay
+endpoints from the names Django persisted, so a designation must not be
+evicted when the run completes. Tool allowlisting for relayed servers persists
+for the session lifetime, not to the backend.
+
+A missing designation does not surface as a 503. The 503 gate keys on client
+reachability, and a desktop attached to the run's stream but missing the
+designation is reachable — it just never answers. The sandbox waits out the
+60 s timeout, the MCP client drops the server for the whole run, and the agent
+sees neither the relayed tools nor an error. `CloudTaskEngine` logs the drop,
+which is the only signal separating this from a server that was never
+configured at all.
 
 ## Problem
 
@@ -249,6 +260,7 @@ persisted, with caps and the no-secrets rule above.**
 | Desktop never attaches (offline from session start) | Request buffers until it times out (60 s) → agent gets JSON-RPC `-32001`; the endpoint does **not** 503 during startup (that would drop the server for the whole run). |
 | Desktop disconnects mid-run (was reachable, now gone) | Endpoint 503s (`everReachable && !reachable`); agent sees a clean "requires the desktop app" MCP error rather than a hang. |
 | Desktop disconnects mid-call | Sandbox timeout fires (60 s), agent gets JSON-RPC `-32001`. |
+| Desktop attached but designation lost (app restart, or the run reattached by a client that did not create it) | Requests are dropped silently, so the endpoint never 503s — the desktop is reachable, just not authorized. The session-start handshake times out and the MCP client drops the server for the whole run. Logged by `CloudTaskEngine`. |
 | Desktop reconnects after backlog | Replayed `mcp_request` events past `expiresAt` are dropped; unexpired ones are deduped by `requestId`. |
 | stdio process crashes | Desktop replies with `error`; next request lazily respawns. |
 | Two desktops attached | First `mcp_response` per `requestId` wins; later ones are dropped by the pending-map lookup (same as double permission responses). |

--- a/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task-engine.ts
@@ -476,7 +476,8 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
    * Relay-designated server names per run (docs/cloud-mcp-relay.md).
    * In-memory by design: only the client that created a run in this app
    * session may execute relay requests for it; requests for undesignated
-   * runs or names are dropped.
+   * runs or names are dropped. Entries live for the app session rather than
+   * the run, so a run resumed after completing keeps relaying.
    */
   private readonly relayDesignations = new Map<string, Set<string>>();
   /** requestId dedupe — the event stream is at-least-once and replays on reconnect. */
@@ -522,7 +523,14 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
     if (!this.mcpRelayExecutor) return;
     const designated = this.relayDesignations.get(watcher.runId);
     if (!designated?.has(data.server)) {
-      // Not created by this client, or a name the run never declared.
+      // Not created by this client, or a name the run never declared. Staying
+      // silent on the wire is deliberate, but the sandbox only sees a 60s
+      // timeout and then drops the server, so leave a trace of the real cause.
+      this.log.debug("Dropping relay request for an undesignated run/server", {
+        runId: watcher.runId,
+        server: data.server,
+        requestId: data.requestId,
+      });
       return;
     }
     if (this.handledRelayRequestIds.has(data.requestId)) return;
@@ -2175,10 +2183,11 @@ export class CloudTaskEngine extends TypedEventEmitter<CloudTaskEvents> {
       watcher.lastStatusUpdatedAt = updatedAt;
     }
 
-    // A terminal run gets no further relay requests; drop its designation and
-    // approval state so the maps don't grow for the lifetime of the app session.
+    // Approvals are scoped to a run's active life, so a resumed run re-prompts.
+    // The designation is not: resume_in_cloud revives a terminal run under the
+    // same id and its new sandbox rebuilds relay endpoints from the names
+    // Django persisted, so dropping ours would strand every relayed server.
     if (isTerminalStatus(watcher.lastStatus)) {
-      this.relayDesignations.delete(watcher.runId);
       this.evictRelayApprovalState(watcher.runId);
     }
 

--- a/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
+++ b/products/desktop/packages/core/src/cloud-task/cloud-task.test.ts
@@ -3688,7 +3688,10 @@ describe("CloudTaskEngine MCP relay", () => {
     expect(lastPermissionRequestUpdate(updates)).toBeUndefined();
   });
 
-  it("evicts a run's relay designation once the run reaches a terminal status", async () => {
+  it("keeps a run's relay designation after it reaches a terminal status", async () => {
+    // resume_in_cloud revives a terminal run under the same id, and its new
+    // sandbox rebuilds relay endpoints from the names Django persisted. Evicting
+    // the designation here left the resumed run with no relayed servers at all.
     mockStreamFetch.mockResolvedValueOnce(
       createOpenSseResponse(
         `data: ${JSON.stringify({
@@ -3701,10 +3704,13 @@ describe("CloudTaskEngine MCP relay", () => {
     relayService.designateRelayedMcpServers("run-1", ["slack"]);
     watchRun("run-1");
 
-    await waitFor(() => mockStreamFetch.mock.calls.length > 0);
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await waitFor(() => mcpRelayExecutor.execute.mock.calls.length > 0);
 
-    expect(mcpRelayExecutor.execute).not.toHaveBeenCalled();
+    expect(mcpRelayExecutor.execute).toHaveBeenCalledWith(
+      "run-1",
+      "slack",
+      expect.objectContaining({ method: "initialize" }),
+    );
   });
 
   it("drops an expired relay request without executing it", async () => {


### PR DESCRIPTION
## Problem

Resume a completed cloud run and every desktop-relayed MCP server is gone for the rest of that run — no tools, no error, nothing in the transcript. The agent cannot tell this apart from a server that was never configured, so it reports the MCP as missing and moves on.

The desktop drops a run's relay designation the moment the run reaches a terminal status, on the premise that a terminal run gets no further relay requests. That premise is wrong: `resume_in_cloud` revives a terminal run under the same id, and the new sandbox rebuilds its relay endpoints from the names Django persisted on the run.

The failure is silent by construction. An undesignated request is dropped without a reply, and the endpoint never 503s because the desktop *is* attached to the run's stream — it reads as reachable, it just never answers. So the MCP client's session-start handshake waits out the 60s relay timeout and drops the server for the whole run.

## Changes

- Keep a run's relay designation for the app session; evict only the approval state on terminal status, which is what should re-prompt on resume.
- Log the dropped request in `CloudTaskEngine`. This was the missing signal — nothing on either side named the cause.
- Correct `docs/cloud-mcp-relay.md`, which claimed a lost designation surfaces as a 503, and add the designation-lost row to the failure-mode table.

Unchanged: designations are still in-memory and still scoped to the client that created the run, so an app restart still drops them. Making them durable would flip a deliberate trust boundary and is a separate decision.

## How did you test this code?

Automated only — I did not run the desktop app or reproduce against a live sandbox.

- Inverted the existing test that asserted the eviction (`cloud-task.test.ts`, "keeps a run's relay designation after it reaches a terminal status"). It drives a `task_run_state: completed` event followed by an `mcp_request` on the same stream and asserts the request still executes.
- Confirmed it fails without the one-line engine change and passes with it, so it catches this regression specifically rather than passing for an unrelated reason.
- `pnpm --filter @posthog/core exec vitest run`, `pnpm --filter @posthog/core typecheck`, and `biome lint packages/core` all clean.

Not checked: the app-restart path, and the sandbox-side behavior end to end.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`docs/cloud-mcp-relay.md` updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code (PostHog Code cloud task) after a relayed MCP server silently stopped working mid-task and the first pass misdiagnosed it as an auth or config-injection regression. No repo skills were invoked; I read `.agents/skills/writing-pr-descriptions` for this body.

The diagnosis turned on evidence that only exists inside a live sandbox: `/tmp/agent-server.log` and `~/.cache/claude-cli-nodejs/*/mcp-logs-<server>/`. Those show the relay endpoint being created and handshaking, which rules out the "never injected" reading that the absence of any `mcpServers` config entry suggests. Worth knowing for the next occurrence: servers are injected via SDK options, so an empty `~/.claude.json` is what a healthy session looks like.

I considered two larger fixes before settling here — reading the designation back from the run record (needs a new read-only API field, and would let any teammate's desktop self-designate) and persisting it locally (needs a new storage client and SQLite table). Both fix the app-restart case too, but both are bigger than this bug and the second changes a documented invariant. The eviction is the actual regression, so this PR is scoped to it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
