### PR TITLE
fix(data-warehouse): point filtered source search to other categories

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/SourceCatalog.tsx
@@ -121,8 +121,15 @@ function RequestSourceTile({ onRequest }: { onRequest: () => void }): JSX.Elemen
 
 export function SourceCatalog({ allowedSources }: SourceCatalogProps): JSX.Element {
     const logic = sourceCatalogLogic({ allowedSources })
-    const { filteredItems, categoriesWithCounts, search, selectedCategory, sourceRequestModalOpen, sourceRequestText } =
-        useValues(logic)
+    const {
+        filteredItems,
+        categoriesWithCounts,
+        search,
+        selectedCategory,
+        hasCrossCategoryMatches,
+        sourceRequestModalOpen,
+        sourceRequestText,
+    } = useValues(logic)
     const {
         setSearch,
         setSelectedCategory,
@@ -159,20 +166,27 @@ export function SourceCatalog({ allowedSources }: SourceCatalogProps): JSX.Eleme
                 <WarehouseWizardHint />
                 <LemonInput type="search" placeholder="Search sources..." value={search} onChange={setSearch} />
 
-                {filteredItems.length === 0 && (
-                    <div className="text-muted text-sm">
-                        No sources match.{' '}
-                        <Link
-                            onClick={() => {
-                                setSearch('')
-                                setSelectedCategory('all')
-                            }}
-                        >
-                            Clear filters
-                        </Link>{' '}
-                        or request one below.
-                    </div>
-                )}
+                {filteredItems.length === 0 &&
+                    (hasCrossCategoryMatches ? (
+                        <div className="text-muted text-sm">
+                            No sources match "{search.trim()}" in {selectedCategory}.{' '}
+                            <Link onClick={() => setSelectedCategory('all')}>Search all categories</Link> or request one
+                            below.
+                        </div>
+                    ) : (
+                        <div className="text-muted text-sm">
+                            No sources match.{' '}
+                            <Link
+                                onClick={() => {
+                                    setSearch('')
+                                    setSelectedCategory('all')
+                                }}
+                            >
+                                Clear filters
+                            </Link>{' '}
+                            or request one below.
+                        </div>
+                    ))}
 
                 <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
                     {filteredItems.map((item) => (

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -104,6 +104,7 @@ export interface sourceCatalogLogicValues {
     catalogItems: CatalogItem[]
     categoriesWithCounts: CatalogCategory[]
     filteredItems: CatalogItem[]
+    hasCrossCategoryMatches: boolean
     search: string
     selectedCategory: SourceCategoryFilter
     sourceRequestModalOpen: boolean
@@ -1442,6 +1443,7 @@ export interface sourceCatalogLogicMeta {
             search: string,
             selectedCategory: SourceCategoryFilter
         ) => CatalogItem[]
+        hasCrossCategoryMatches: (catalogFuse: Fuse, search: string, selectedCategory: SourceCategoryFilter) => boolean
     }
 }
 
@@ -1667,6 +1669,22 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                     }
                     return a.label.localeCompare(b.label)
                 })
+            },
+        ],
+
+        // With a category selected, a search that only matches sources in other categories leaves
+        // filteredItems empty even though the source exists. This flags that case so the empty
+        // state can offer an all-categories search instead of dead-ending on "no sources match".
+        hasCrossCategoryMatches: [
+            (s) => [s.catalogFuse, s.search, s.selectedCategory],
+            (catalogFuse: Fuse, search: string, selectedCategory: SourceCategoryFilter): boolean => {
+                const trimmed = search.trim()
+                if (!trimmed || selectedCategory === ALL_SOURCES_CATEGORY) {
+                    return false
+                }
+                return catalogFuse
+                    .search(trimmed)
+                    .some((r) => r.item.status !== 'coming_soon' && r.item.category !== selectedCategory)
             },
         ],
     }),

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
@@ -24,6 +24,15 @@ const AVAILABLE_SOURCES: Record<string, SourceConfig> = {
     // Connectable, and shares the "apple" token with the unreleased `Apple` above so a search for
     // "apple" fuzzy-matches both — used to assert connectable results outrank "Coming soon" ones.
     ApplePay: { name: 'ApplePay', label: 'Apple Pay', fields: [] } as unknown as SourceConfig,
+    // Two sources in distinct categories, used to assert that a category-filtered search which only
+    // matches a source in another category flags a cross-category hint instead of dead-ending.
+    Salesforce: { name: 'Salesforce', label: 'Salesforce', category: 'Sales', fields: [] } as unknown as SourceConfig,
+    Datadog: {
+        name: 'Datadog',
+        label: 'Datadog',
+        category: 'Engineering & monitoring',
+        fields: [],
+    } as unknown as SourceConfig,
 }
 
 describe('sourceCatalogLogic', () => {
@@ -106,6 +115,22 @@ describe('sourceCatalogLogic', () => {
         // find them instead of dead-ending on "no sources match".
         const names = logic.values.filteredItems.map((item) => item.name)
         expect(names).toContain('aws')
+    })
+
+    it('flags a cross-category match when a filtered search only hits another category', () => {
+        const logic = sourceCatalogLogic()
+        logic.actions.setSelectedCategory('Sales')
+        logic.actions.setSearch('Datadog')
+
+        // The category filter hides the only match, so the list dead-ends...
+        expect(logic.values.filteredItems).toHaveLength(0)
+        // ...but the hint knows the source exists in another category and can point the user there.
+        expect(logic.values.hasCrossCategoryMatches).toBe(true)
+
+        // The same search across all categories finds it, so the hint is no longer needed.
+        logic.actions.setSelectedCategory('all')
+        expect(logic.values.filteredItems.map((item) => item.name)).toContain('Datadog')
+        expect(logic.values.hasCrossCategoryMatches).toBe(false)
     })
 
     it('clears the request text when the modal is closed', () => {


### PR DESCRIPTION
## Problem

- A user setting up a new data warehouse source who filters the catalog by a category, then searches for a connector, sees "No sources match" even when the connector exists in another category.
- Session reviews of the onboarding flow show users searching for a connector inside a category filter, getting an empty result, and abandoning the setup.
- The catalog runs the search across all connectors, then applies the selected category as an exact filter. A match in a different category is removed, leaving an empty list.

## Changes

- The empty state now detects when the search matches connectable sources in other categories and shows "No sources match "<term>" in <category>" with a "Search all categories" link that clears only the category and keeps the term.
- When the search matches nothing anywhere, the existing "Clear filters" empty state is unchanged.
- Added a `hasCrossCategoryMatches` selector that reports whether the current search matches a connectable source outside the selected category.

## How did you test this code?

- Added a `sourceCatalogLogic` test: with a category selected and a search that only matches a source in another category, the list is empty and `hasCrossCategoryMatches` is true; searching across all categories finds the source and the flag clears. This guards against a regression where the search is re-scoped per category or the cross-category hint is dropped.
- Ran the `sourceCatalogLogic` Jest suite (9 tests pass) and `tsgo` type check over the touched files (no new errors).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing docs describe this empty state.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (actually Claude, via PostHog Code) made this change while reviewing friction in the data warehouse new-source onboarding flow surfaced by session summaries.
- Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-pr-descriptions`.
- The fix keeps the category filter and search behavior intact; it only improves the dead-end empty state so a filtered search points to the connector that exists elsewhere.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
