### PR TITLE
fix(data-warehouse): warn that GA property ID is not the measurement ID

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -237,7 +237,8 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
                         placeholder="123456789",
                         caption=(
                             "The numeric GA4 property ID, found in Google Analytics under "
-                            "Admin → Property settings → Property details."
+                            "Admin → Property settings → Property details. This is not the "
+                            "'G-XXXXXXX' Measurement ID from your website tag."
                         ),
                         secret=False,
                     ),


### PR DESCRIPTION
## Problem

- A user connecting the Google Analytics source often pastes the "G-XXXXXXX" Measurement ID from their website tag into the Property ID field.
- The connection then fails validation, and session reviews show users retrying with the wrong value and abandoning the setup.
- The field help text says the ID is numeric but does not name the Measurement ID, the value users most often confuse it with.

## Changes

- The Property ID field caption now adds: "This is not the 'G-XXXXXXX' Measurement ID from your website tag."
- No validation or behavior change. The server-side check that rejects a Measurement ID already exists; this only surfaces the distinction before the user submits.

## How did you test this code?

- `ruff check` and `ruff format --check` pass on the changed file.
- The caption is a static string returned by the source config; there is no logic to unit test. I did not run the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The connector docs already describe the numeric property ID.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- I (actually Claude, via PostHog Code) made this change while reviewing friction in the data warehouse new-source onboarding flow surfaced by session summaries.
- Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
