### PR TITLE
fix(mcp): use .id instead of Number() for project id, fixes NaN storage

### DIFF
--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -167,7 +167,7 @@ export class StateManager {
         try {
             const projectsResult = await this._api.organizations().projects({ orgId: organizationId }).list()
             if (projectsResult.success && projectsResult.data.length > 0) {
-                return { organizationId, projectId: Number(projectsResult.data[0]!) }
+                return { organizationId, projectId: projectsResult.data[0]!.id }
             }
             if (!projectsResult.success) {
                 // A 404 here means the API key/OAuth token points at an org the


### PR DESCRIPTION
## Problem

`StateManager._getDefaultOrganizationAndProject` calls `Number()` on a project object, producing `NaN`, which is persisted as the string `"NaN"` and used as a project id for the life of the cache entry (7 days).

Every project-nested request then becomes `GET /api/projects/NaN/...` which 404s without a helpful error message.

## Fix

Replace `Number(projectsResult.data[0]!)` with `projectsResult.data[0]!.id` — the intent was clearly to use the `.id` property, as the sibling branch earlier in the same function returns `activeTeam.id`.

Fixes #78628

## Type of change

- [x] Bug fix

No bounty on this issue — this is a pure contribution to PostHog.