### PR TITLE
fix(mcp): validate org fetch before committing session, matches switch-project pattern

### DIFF
--- a/services/mcp/src/tools/organizations/setActive.ts
+++ b/services/mcp/src/tools/organizations/setActive.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 
+import { wrapError } from '@/lib/errors'
 import { buildActiveEnvironmentContextPrompt } from '@/lib/instructions'
 import { OrganizationSetActiveSchema } from '@/schema/tool-inputs'
 import type { CachedOrg, CachedProject, CachedUser, Context, ToolBase } from '@/tools/types'
@@ -15,16 +16,24 @@ export const setActiveHandler: ToolBase<typeof schema, Result>['handler'] = asyn
     params: Params
 ) => {
     const { orgId } = params
-    await context.cache.set('orgId', orgId)
 
-    // Fetch fresh org data and cache it
-    let org: CachedOrg | undefined
+    // Validate before committing the session: only switch to an org the user can
+    // actually access. Previously the orgId was cached before the fetch, so a bad
+    // id (or an org the session can't reach) silently "succeeded" and every later
+    // call failed with an opaque error instead.
     const orgResult = await context.api.organizations().get({ orgId })
-    if (orgResult.success) {
-        org = orgResult.data
-        await context.cache.set(`cachedOrg:${orgId}` as const, org)
-        await context.cache.set(`cachedOrgFetchedAt:${orgId}` as const, Date.now())
+    if (!orgResult.success) {
+        throw wrapError(
+            `Could not switch to organization ${orgId}: it was not found or you don't have access to it. ` +
+                'Use \`organizations-get\` to list your organizations.',
+            orgResult.error
+        )
     }
+
+    const org: CachedOrg = orgResult.data
+    await context.cache.set('orgId', orgId)
+    await context.cache.set(`cachedOrg:${orgId}` as const, org)
+    await context.cache.set(`cachedOrgFetchedAt:${orgId}` as const, Date.now())
 
     // Read cached user and project for full metadata block
     const distinctId = (await context.cache.get('distinctId')) ?? 'unknown'


### PR DESCRIPTION
## Problem

`switch-organization` writes `orgId` to the session cache **before** (and independently of) fetching the organization, and returns a success string whether or not that fetch succeeded. This means an agent calling `switch-organization` with an id it cannot access is told the switch worked, while subsequent org-nested reads fail with opaque 403/404s that don't mention the switch.

`switch-project` had the same shape, was identified as a bug, and was fixed (PR #71976) — the fix was not applied to the organization tool.

## Fix

Follow the same pattern as `setActive.ts` in `projects/`: validate the org fetch **before** committing the `orgId` to the session cache, and throw a descriptive error when the fetch fails so the agent can recover.

Changes:
1. Import `wrapError` from `@/lib/errors`
2. Move `context.cache.set('orgId', orgId)` after the org fetch validation
3. Throw a descriptive error on fetch failure (matching the project tool pattern)
4. Remove unused `let` declaration in favor of `const`

Fixes #78629

## Type of change

- [x] Bug fix

No bounty on this issue — this is a pure contribution to PostHog.