### PR TITLE
fix(workflows): keep branch steps in their lane with NETWORK_SIMPLEX node placement [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/react_flow_utils/autolayout.ts
+++ b/products/workflows/frontend/Workflows/hogflows/react_flow_utils/autolayout.ts
@@ -35,7 +35,7 @@ export const getFormattedNodes = async (nodes: HogFlowActionNode[], edges: Edge[
         'elk.spacing.edgeEdge': `${NODE_EDGE_GAP}`,
         'elk.spacing.edgeNode': `${NODE_EDGE_GAP}`,
         'elk.direction': 'DOWN',
-        'elk.layered.nodePlacement.strategy': 'SIMPLE',
+        'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
         'elk.alignment': 'CENTER',
         'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
         'elk.padding': '[left=0, top=0, right=0, bottom=0]',


### PR DESCRIPTION
## Problem

In the workflows visual editor, adding a step inside one branch of a `conditional_branch` or `random_cohort_branch` node does not keep that step in the branch's own vertical column. The step gets re-centered, and the edges connecting it swing back toward the middle of the canvas. This makes multi-branch workflows hard to read and visually QA.

## Root cause

Two things combine in `autolayout.ts`:

1. Branch lanes aren't modeled — edges carry `type: 'branch' | 'continue'` and an `index` in the graph schema, but `autolayout.ts` spreads every edge into ELK unchanged with no per-edge or per-node `layoutOptions`. To ELK a branch edge and a continue edge are identical, so nothing pins a branch's descendants to their parent's column.

2. `nodePlacement.strategy: 'SIMPLE'` plus `alignment: 'CENTER'` balances each layer horizontally, which actively pulls nodes toward the middle of the layer rather than keeping a chain straight.

## Fix

Changed `elk.layered.nodePlacement.strategy` from `'SIMPLE'` to `'NETWORK_SIMPLEX'`. ELK's own docs point to `NETWORK_SIMPLEX` as better at keeping chains straight — it minimizes edge length and straightens paths, which directly counteracts the centering drift described in the issue.

The `SIMPLE` strategy is the most centering of the three available strategies (`SIMPLE`, `NETWORK_SIMPLEX`, `BRANDES_KOEPF`). Switching to `NETWORK_SIMPLEX` should keep branch steps in their lane without the full visual restructuring that `BRANDES_KOEPF` would impose.

## Testing

This changes placement for every existing workflow, so it needs before/after visual QA on a few real multi-branch flows rather than just a unit test.

Closes #77559