### PR TITLE
fix(clickhouse): stop cold-resume read timeouts reporting error tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -339,6 +339,13 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             # `_get_client`'s in-process retry never sees it; Temporal's activity retry
             # reopens a fresh tunnel + client and resumes from the last committed cursor.
             "Connection broken: IncompleteRead",
+            # requests/urllib3 raises this when the server accepts the connection but never
+            # answers within our timeout — typically ClickHouse Cloud still cold-resuming an
+            # idle service past our `METADATA_QUERY_TIMEOUT_SECONDS` allowance. Not in
+            # `_TRANSIENT_CONNECT_DROP_SUBSTRINGS`, so `_get_client` doesn't retry it in-process
+            # (a slow-to-wake service needs real wall-clock time, not an immediate re-dial);
+            # Temporal's activity retry provides that backoff and reopens a fresh connection.
+            "Read timed out",
         }
 
     @contextmanager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -729,6 +729,10 @@ class TestClickHouseSourceRetryableErrors:
             "('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))",
             "('Connection broken: IncompleteRead(12345 bytes read, 67 more expected)', "
             "IncompleteRead(12345 bytes read, 67 more expected))",
+            # The server accepted the connection but never answered within our timeout —
+            # typically ClickHouse Cloud still cold-resuming past our allowance.
+            "Error HTTPSConnectionPool(host='play.clickhouse.com', port=8443): Read timed out. "
+            "(read timeout=120) executing HTTP request attempt 1 (https://play.clickhouse.com:8443)",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

A ClickHouse source connection [reports an exception](https://us.posthog.com/project/2/error_tracking/019fd5b7-f009-7ea0-bab5-d2f9594f1500) every time it hits a 120-second read timeout while opening a client. The server accepted the connection but never answered in time, most likely a ClickHouse Cloud instance still cold-resuming from idle.

Temporal already retries the whole activity and the connection typically succeeds on the next attempt, so the exception is noise, not a real failure to fix.

## Changes

- Add `"Read timed out"` to `ClickHouseSource.get_retryable_errors()`, alongside the existing dropped-connection and 429/502/503/504 entries that already get this treatment.
- Classifying it as retryable (not non-retryable) keeps Temporal retrying the activity as usual; it only stops this self-recovering failure from being logged as a tracked exception.

## How did you test this code?

Added a case to `TestClickHouseSourceRetryableErrors::test_transient_errors_are_retryable` using the exact wrapped message shape from the error tracking issue (host/port redacted) - it asserts the pattern is recognized as retryable.

Ran locally:
- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py` - 246 passed (1 pre-existing error unrelated to this change: a Postgres-backed test failing because no local database is running in this environment)
- `ruff check` / `ruff format --check` - clean
- `uv run mypy --cache-fine-grained` on the changed files - clean
- `hogli ci:preflight --fix` - clean

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - this only changes internal error-classification logic, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to pull the full stack trace and confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`'s `_get_client`. Read the source and its existing `get_retryable_errors()`/`get_non_retryable_errors()` classification, and the shared `_handle_import_error` routing in `import_data_sync.py`, to confirm this is the established mechanism for suppressing self-recovering-failure noise. Invoked `/writing-tests` before adding the test case and `/writing-pr-descriptions` before writing this description. Searched open PRs (human-authored and the maintainer's own) for a prior fix targeting this specific error; found none.