### PR TITLE
chore(ci): map canvas scope to the desktop label

### DIFF
--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -10,7 +10,7 @@
             "labels": ["team/feature-flags", "feature/cohorts"]
         },
         {
-            "scopes": ["desktop", "tasks", "agent-proxy"],
+            "scopes": ["desktop", "tasks", "agent-proxy", "canvas"],
             "labels": ["feature/desktop"]
         }
     ]

--- a/.github/scripts/label-pr-from-title.test.js
+++ b/.github/scripts/label-pr-from-title.test.js
@@ -141,7 +141,7 @@ for (const scope of ['flag', 'feature-flag', 'feature_flags', 'feature_flag']) {
 // to the shipped config so an edit that drops or mislabels one regresses
 // loudly here. Asserts containment rather than the exact list so the rule can
 // gain labels without breaking.
-for (const scope of ['desktop', 'tasks', 'agent-proxy']) {
+for (const scope of ['desktop', 'tasks', 'agent-proxy', 'canvas']) {
     test(`the shipped config maps the ${scope} scope to the desktop label`, () => {
         assert.ok(
             labelsForTitle(`feat(${scope}): x`, loadRules()).includes('feature/desktop'),


### PR DESCRIPTION
## Problem

Canvas PRs miss the `feature/desktop` label. Canvases are a desktop feature, but the auto-label workflow maps only the `desktop`, `tasks` and `agent-proxy` title scopes, so `fix(canvas): ...` PRs (like #78694) go unlabeled.

## Changes

- Added `canvas` to the desktop rule in `.github/auto-assign-labels.json`.
- Added `canvas` to the parameterized test binding each desktop scope to the shipped config, so dropping it regresses loudly.

## How did you test this code?

- `node --test .github/scripts/label-pr-from-title.test.js` passes with the new case.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, follow-up to #78693/#78694 where the canvas half missed the label. Skills invoked: writing-tests, writing-pr-descriptions.
