### PR TITLE
fix(sql-editor): update filters menu copy for column-bound placeholder

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconFilter, IconWarning } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
+import { LemonButton, LemonMenu, LemonMenuItems, Link } from '@posthog/lemon-ui'
 
 import { CLICK_OUTSIDE_BLOCK_CLASS } from 'lib/hooks/useOutsideClickHandler'
 
@@ -72,15 +72,24 @@ export function QueryFiltersMenu(): JSX.Element | null {
                 >
                     {filtersMissingPlaceholder ? (
                         <div className="text-xs text-warning">
-                            Filters are present, but this SQL query doesn't include a <code>{'{filters}'}</code> tag.
-                            Add it to your SQL query <code>where</code> clause to apply these filters. Supported source
-                            tables are <code>events</code>, <code>sessions</code>, <code>groups</code>.
+                            Filters are set, but this SQL query doesn't include a <code>{'{filters}'}</code>{' '}
+                            placeholder, so they aren't applied. Add <code>{'{filters}'}</code> to your{' '}
+                            <code>where</code> clause when selecting from PostHog tables like <code>events</code>,{' '}
+                            <code>sessions</code>, or <code>groups</code>. For any other table or view, bind your own
+                            columns, for example <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
+                            <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
+                                Learn more
+                            </Link>
                         </div>
                     ) : (
                         <div className="text-xs text-muted">
                             Use <code>{'{filters}'}</code> in your SQL query <code>where</code> clause to apply these
-                            filters. Supported source tables are <code>events</code>, <code>sessions</code>,{' '}
-                            <code>groups</code>.
+                            filters when selecting from PostHog tables like <code>events</code>, <code>sessions</code>,
+                            or <code>groups</code>. For any other table or view, bind your own columns, for example{' '}
+                            <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
+                            <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
+                                Learn more
+                            </Link>
                         </div>
                     )}
                     <div className="space-y-1">

--- a/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
@@ -75,8 +75,9 @@ export function QueryFiltersMenu(): JSX.Element | null {
                             Filters are set, but this SQL query doesn't include a <code>{'{filters}'}</code>{' '}
                             placeholder, so they aren't applied. Add <code>{'{filters}'}</code> to your{' '}
                             <code>where</code> clause when selecting from PostHog tables like <code>events</code>,{' '}
-                            <code>sessions</code>, or <code>groups</code>. For any other table or view, bind your own
-                            columns, for example <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
+                            <code>sessions</code>, <code>groups</code>, or <code>persons</code>. For any other table or
+                            view, bind your own columns, for example{' '}
+                            <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
                             <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
                                 Learn more
                             </Link>
@@ -84,9 +85,9 @@ export function QueryFiltersMenu(): JSX.Element | null {
                     ) : (
                         <div className="text-xs text-muted">
                             Use <code>{'{filters}'}</code> in your SQL query <code>where</code> clause to apply these
-                            filters when selecting from PostHog tables like <code>events</code>, <code>sessions</code>,
-                            or <code>groups</code>. For any other table or view, bind your own columns, for example{' '}
-                            <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
+                            filters when selecting from PostHog tables like <code>events</code>, <code>sessions</code>,{' '}
+                            <code>groups</code>, or <code>persons</code>. For any other table or view, bind your own
+                            columns, for example <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
                             <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
                                 Learn more
                             </Link>

--- a/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
@@ -75,7 +75,7 @@ export function QueryFiltersMenu(): JSX.Element | null {
                             Filters are set, but this SQL query doesn't include a <code>{'{filters}'}</code>{' '}
                             placeholder, so they aren't applied. Add <code>{'{filters}'}</code> to your{' '}
                             <code>where</code> clause when selecting from PostHog tables like <code>events</code>,{' '}
-                            <code>sessions</code>, <code>groups</code>, or <code>persons</code>. For any other table or
+                            <code>persons</code>, <code>groups</code>, or <code>sessions</code>. For any other table or
                             view, bind your own columns, for example{' '}
                             <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
                             <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
@@ -85,8 +85,8 @@ export function QueryFiltersMenu(): JSX.Element | null {
                     ) : (
                         <div className="text-xs text-muted">
                             Use <code>{'{filters}'}</code> in your SQL query <code>where</code> clause to apply these
-                            filters when selecting from PostHog tables like <code>events</code>, <code>sessions</code>,{' '}
-                            <code>groups</code>, or <code>persons</code>. For any other table or view, bind your own
+                            filters when selecting from PostHog tables like <code>events</code>, <code>persons</code>,{' '}
+                            <code>groups</code>, or <code>sessions</code>. For any other table or view, bind your own
                             columns, for example <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
                             <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
                                 Learn more

--- a/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/QueryFiltersMenu.tsx
@@ -78,7 +78,10 @@ export function QueryFiltersMenu(): JSX.Element | null {
                             <code>persons</code>, <code>groups</code>, or <code>sessions</code>. For any other table or
                             view, bind your own columns, for example{' '}
                             <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
-                            <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
+                            <Link
+                                to="https://posthog.com/docs/data-warehouse/sql/variables#applying-dashboard-filters"
+                                target="_blank"
+                            >
                                 Learn more
                             </Link>
                         </div>
@@ -88,7 +91,10 @@ export function QueryFiltersMenu(): JSX.Element | null {
                             filters when selecting from PostHog tables like <code>events</code>, <code>persons</code>,{' '}
                             <code>groups</code>, or <code>sessions</code>. For any other table or view, bind your own
                             columns, for example <code>{"{filters(created_at AS timestamp, plan AS 'plan')}"}</code>.{' '}
-                            <Link to="https://posthog.com/docs/data-warehouse/sql/variables" target="_blank">
+                            <Link
+                                to="https://posthog.com/docs/data-warehouse/sql/variables#applying-dashboard-filters"
+                                target="_blank"
+                            >
                                 Learn more
                             </Link>
                         </div>


### PR DESCRIPTION
## TL;DR

The SQL editor's filters dropdown now explains the column-bound `{filters(...)}` form. ELI5: the menu used to say dashboard filters only work on three tables. Now it tells you how to apply them to any table, with an example and a docs link.

## Problem

The dropdown copy says `{filters}` supports events, sessions, and groups. That list was already missing logs and traces, and [#76532](https://github.com/PostHog/posthog/pull/76532) adds a column-bound form that works on every table. Raised in [review feedback on #76532](https://github.com/PostHog/posthog/pull/76532#issuecomment-5196032751).

## Changes

- Rewrote both copy variants in the filters dropdown (normal and "placeholder missing" warning). They now name the bound form with an example, describe the table list as non-exhaustive, and link to the SQL variables docs.

> [!NOTE]
> Stacked on #76532. Merge that first; GitHub retargets this PR to master automatically.

No screenshot: the task VM could not run Storybook or the app (whole-app builds get OOM-killed there). The change is text-only within the existing layout.

## How did you test this code?

Copy-only change, no tests added. I ran oxfmt and oxlint on the file. The whole-app `typescript:check` was OOM-killed on the task VM, so I (Claude) verified the new `Link` import against the `@posthog/lemon-ui` exports instead.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

A matching posthog.com docs PR documenting `{filters}` and the bound form is being opened separately.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) following up on review feedback on #76532. Skills invoked: /writing-user-facing-copy. Decision: the copy lists tables as "PostHog tables like events, sessions, or groups" instead of an exhaustive list, so it stays accurate as more tables gain plain `{filters}` support (a persons PR is in flight).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
