### PR TITLE
feat(max): teach the SQL tools the column-bound filters placeholder

### DIFF
--- a/ee/hogai/tools/execute_sql/prompts.py
+++ b/ee/hogai/tools/execute_sql/prompts.py
@@ -81,14 +81,18 @@ WHERE e.event IN (SELECT event FROM events WHERE ...)
 - You should not make formatting or casing changes if explicitly requested by the user.
 - You should not use double curly braces (`{{{{` or `}}}}`) for templating. The only templating syntax allowed is single curly braces with variables in the "variables" namespace (for example: `{{{{variables.org}}}}`).<%={{{{ }}}}=%>
 - SQL editor nodes can use `{filters}` placeholders. These placeholders are backed by `HogQLQuery.filters`, not by SQL text:
-  - If the current query contains `{filters}` and the user asks to change the date range or property filters, keep the placeholder in the SQL and pass updated `filters` to this tool.
-  - When keeping `{filters}` in the SQL, pass the complete desired `filters` object to this tool. Copy `current_query_node.source.filters` unchanged unless the user asked to change or remove filters.
-  - To remove all editor filters while preserving `{filters}`, pass an empty `filters` object (`{}`).
-  - Do not replace `{filters}` with explicit `timestamp` clauses when the user's request can be represented in `filters.dateRange`.
-  - Supported filter placeholders are `{filters}`, `{filters.dateRange.from}`, and `{filters.dateRange.to}`.
-  - `{filters}` can be used only in SELECT queries that select from PostHog event-like tables: `events`, `ai_events`, `sessions`, `logs`, log attributes, traces, or `groups`. It is not valid for arbitrary data warehouse/source tables.
+  - If the current query contains `{filters}` or a column-bound `{filters(...)}` and the user asks to change the date range or property filters, keep the placeholder in the SQL and pass updated `filters` to this tool.
+  - When keeping the placeholder in the SQL, pass the complete desired `filters` object to this tool. Copy `current_query_node.source.filters` unchanged unless the user asked to change or remove filters.
+  - To remove all editor filters while preserving the placeholder, pass an empty `filters` object (`{}`).
+  - Do not replace the placeholder with explicit `timestamp` clauses when the user's request can be represented in `filters.dateRange`.
+  - Supported filter placeholders are `{filters}`, `{filters.dateRange.from}`, `{filters.dateRange.to}`, and the column-bound form `{filters(expr AS key, ...)}`.
+  - Plain `{filters}` can be used only in SELECT queries that select from PostHog event-like tables: `events`, `ai_events`, `sessions`, `logs`, log attributes, traces, or `groups`.
   - Date filters map to `timestamp` for events/logs/traces, `$start_timestamp` for sessions, and `created_at` for groups.
   - `filters` can include `dateRange` (`date_from`, `date_to`), `filterTestAccounts`, and `properties`. Property filters apply to event scope on event/log/trace queries, group scope on `groups`, and session scope on `sessions` unless the query also includes `events`.
+  - For any other table, view, or join (including data warehouse/source tables), use the column-bound form, for example `{filters(created_at AS timestamp, account_id AS 'account_id')}`:
+    - The reserved key `timestamp` receives the date range. Any other key (a string alias like `'plan'` or `'$group_0'`) receives the property filters on that key, with full operator semantics.
+    - `null AS key` opts the query out of filtering on that key. An active filter with no binding raises an error, so bind or explicitly opt out of every filter key in use.
+    - Cohort filters and SQL-expression filters cannot be applied through bindings and raise an error if present.
 - If a filter is optional, ALWAYS implement via the variables namespace with guards:
   - ALWAYS use the "variables." prefix (e.g., variables.org, variables.browser) - never use bare variable names
   - Use coalesce() or IS NULL checks to handle optional values

--- a/ee/hogai/tools/execute_sql/tool.py
+++ b/ee/hogai/tools/execute_sql/tool.py
@@ -47,10 +47,10 @@ class ExecuteSQLToolArgs(BaseModel):
     filters: HogQLFilters | None = Field(
         default=None,
         description=(
-            "Optional filters applied through `{filters}` placeholders in the query. "
-            "Use this when editing a SQL editor query that already uses `{filters}` and the user asks to change "
+            "Optional filters applied through `{filters}` or column-bound `{filters(...)}` placeholders in the query. "
+            "Use this when editing a SQL editor query that already uses such a placeholder and the user asks to change "
             "dateRange, property filters, or test-account filtering. Set this to an empty object to clear existing "
-            "SQL editor filters while preserving the `{filters}` placeholder."
+            "SQL editor filters while preserving the placeholder."
         ),
     )
     viz_title: str = Field(

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -26591,7 +26591,7 @@
                 },
                 "filters": {
                     "$ref": "#/definitions/HogQLFilters",
-                    "description": "Extra filters applied to query via {filters}"
+                    "description": "Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder"
                 },
                 "globals": {
                     "description": "Extra globals for the query",
@@ -26735,7 +26735,8 @@
                     "type": "boolean"
                 },
                 "filters": {
-                    "$ref": "#/definitions/HogQLFilters"
+                    "$ref": "#/definitions/HogQLFilters",
+                    "description": "Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder"
                 },
                 "kind": {
                     "const": "HogQLQuery",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -601,6 +601,7 @@ export interface HogQLQuery extends DataNode<HogQLQueryResponse> {
     connectionId?: string
     /** Run the selected connection query directly without translating it through HogQL first */
     sendRawQuery?: boolean
+    /** Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder */
     filters?: HogQLFilters
     /** Variables to be substituted into the query */
     variables?: Record<string, HogQLVariable>
@@ -819,7 +820,7 @@ export interface HogQLMetadata extends DataNode<HogQLMetadataResponse> {
     sourceQuery?: AnyDataNode
     /** Extra globals for the query */
     globals?: Record<string, any>
-    /** Extra filters applied to query via {filters} */
+    /** Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder */
     filters?: HogQLFilters
     /** Variables to be subsituted into the query */
     variables?: Record<string, HogQLVariable>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -24120,7 +24120,12 @@ class HogQLQuery(BaseModel):
         ),
     )
     explain: bool | None = None
-    filters: HogQLFilters | None = None
+    filters: HogQLFilters | None = Field(
+        default=None,
+        description=(
+            "Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder"
+        ),
+    )
     kind: Literal["HogQLQuery"] = "HogQLQuery"
     modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
     name: str | None = Field(default=None, description="Client provided name of the query")
@@ -27813,7 +27818,12 @@ class HogQLMetadata(BaseModel):
         default=None,
         description="Enable more verbose output, usually run from the /debug page",
     )
-    filters: HogQLFilters | None = Field(default=None, description="Extra filters applied to query via {filters}")
+    filters: HogQLFilters | None = Field(
+        default=None,
+        description=(
+            "Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder"
+        ),
+    )
     globals: dict[str, Any] | None = Field(default=None, description="Extra globals for the query")
     kind: Literal["HogQLMetadata"] = "HogQLMetadata"
     language: HogLanguage = Field(..., description="Language to validate")

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -5918,6 +5918,7 @@ export interface HogQLQueryApi {
     /** Optional id of a direct-query-capable external data source to run against instead of ClickHouse — a pure-direct source, or a synced source with direct query enabled. */
     connectionId?: string | null
     explain?: boolean | null
+    /** Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder */
     filters?: HogQLFiltersApi | null
     kind?: 'HogQLQuery'
     /** Modifiers used when performing the query */

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -5250,6 +5250,7 @@ export interface HogQLQueryApi {
     /** Optional id of a direct-query-capable external data source to run against instead of ClickHouse — a pure-direct source, or a synced source with direct query enabled. */
     connectionId?: string | null
     explain?: boolean | null
+    /** Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder */
     filters?: HogQLFiltersApi | null
     kind?: 'HogQLQuery'
     /** Modifiers used when performing the query */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4567,6 +4567,7 @@ export namespace Schemas {
       /** Optional id of a direct-query-capable external data source to run against instead of ClickHouse — a pure-direct source, or a synced source with direct query enabled. */
       connectionId?: string | null;
       explain?: boolean | null;
+      /** Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder */
       filters?: HogQLFilters | null;
       kind?: 'HogQLQuery';
       /** Modifiers used when performing the query */
@@ -36995,7 +36996,7 @@ export namespace Schemas {
       connectionId?: string | null;
       /** Enable more verbose output, usually run from the /debug page */
       debug?: boolean | null;
-      /** Extra filters applied to query via {filters} */
+      /** Extra filters applied to query via {filters} or the column-bound {filters(expr AS key, ...)} placeholder */
       filters?: HogQLFilters | null;
       /** Extra globals for the query */
       globals?: HogQLMetadataGlobals;


### PR DESCRIPTION
## TL;DR

PostHog AI and MCP clients learn about the new `{filters(...)}` placeholder. ELI5: Max's instructions said "dashboard filters don't work on warehouse tables, period". After [#76532](https://github.com/PostHog/posthog/pull/76532) that's wrong, so this updates what Max and the MCP schemas say.

## Problem

The execute_sql prompt tells Max that `{filters}` "is not valid for arbitrary data warehouse/source tables". Once #76532 ships the column-bound form, Max would deny a feature that exists. Raised in [review feedback on #76532](https://github.com/PostHog/posthog/pull/76532#issuecomment-5196032751) ("Will PostHog AI and the MCP know how to use it?").

## Changes

- `ee/hogai/tools/execute_sql/prompts.py`: the filters-placeholder section now covers the bound form (reserved `timestamp` key, string-alias property keys, `null` opt-outs, strict unbound errors, cohort/SQL-expression limits).
- `ee/hogai/tools/execute_sql/tool.py`: the `filters` arg description mentions both placeholder forms.
- `HogQLQuery.filters` and `HogQLMetadata.filters` schema descriptions mention the bound form. `HogQLQuery.filters` had no description at all before. Regenerated `schema.json` and `posthog/schema.py`; these descriptions flow into MCP tool schemas.

> [!NOTE]
> Stacked on #76532. Merge that first; GitHub retargets this PR to master automatically.

## How did you test this code?

Prose-only changes to prompt strings and schema descriptions. I ran `hogli ci:preflight --fix` (ruff lint/format pass), regenerated schema artifacts with `pnpm run schema:build` and `schema:build:python`, and confirmed the generated diffs contain only the description changes. Existing execute_sql tests assert SQL payloads, not prompt text, so no tests changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

A matching posthog.com docs PR is being opened separately.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) following up on review feedback on #76532. Decision: kept the plain-`{filters}` table list in the prompt unchanged and added the bound form as the escape hatch for every other table, mirroring the backend's actual behavior. Repo-wide mypy was not run on the task VM (string-literal changes only); ci:preflight passed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
