### PR TITLE
fix(toolbox): use device code flow for aws sso login

### DIFF
--- a/tools/infra-scripts/clitools/test_toolbox.py
+++ b/tools/infra-scripts/clitools/test_toolbox.py
@@ -16,6 +16,7 @@ from toolbox.kubernetes import (
     get_context_profile,
     get_current_context,
     kubectl_cmd,
+    login_to_sso,
     reset_sso,
     select_context,
     select_environment,
@@ -874,6 +875,16 @@ class TestToolbox(unittest.TestCase):
         self.assertTrue(reset_sso("prod-eu-eks", deadline=610))
         mock_run.assert_called_once_with(["aws", "sso", "logout"], check=False, timeout=600)
         mock_login.assert_called_once_with("prod-eu-eks", timeout=600)
+
+    @patch("subprocess.run")
+    def test_login_to_sso_forces_device_code_flow(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        self.assertTrue(login_to_sso("prod-us-eks", timeout=600))
+        mock_run.assert_called_once_with(
+            ["aws", "sso", "login", "--profile", "prod-us-eks", "--use-device-code"],
+            check=False,
+            timeout=600,
+        )
 
     @patch("toolbox.kubernetes.login_to_sso", return_value=True)
     @patch("toolbox.kubernetes.check_context_access", return_value=(True, ""))

--- a/tools/infra-scripts/clitools/toolbox/kubernetes.py
+++ b/tools/infra-scripts/clitools/toolbox/kubernetes.py
@@ -185,9 +185,16 @@ def login_to_sso(profile: str, *, timeout: float) -> bool:
     """Run the AWS CLI's interactive SSO login for a kubeconfig-derived profile."""
     print(f"🔐 Your AWS SSO session needs refreshing. Logging in with profile '{profile}'...")  # noqa: T201
     try:
+        # Force the device-authorization grant. Since AWS CLI v2.22.0 the default is the PKCE
+        # authorization-code flow, which only completes if the browser can reach an OAuth
+        # callback server the CLI spins up on localhost. When it can't (remote/SSH/container
+        # sessions, some corporate browsers), the user sees a green success page in the browser
+        # but `aws sso login` hangs until our access deadline. The device-code flow polls AWS
+        # for the token instead of waiting for a callback, so it completes regardless of where
+        # the browser runs.
         return (
             subprocess.run(
-                ["aws", "sso", "login", "--profile", profile],
+                ["aws", "sso", "login", "--profile", profile, "--use-device-code"],
                 check=False,
                 timeout=max(1, timeout),
             ).returncode
@@ -241,7 +248,8 @@ def wait_for_context_access(context: str, namespace: str, *, initial_diagnostic:
         sso_login_attempted = True
         if not login_to_sso(profile, timeout=deadline - time.monotonic()):
             print(  # noqa: T201
-                f"❌ AWS SSO login failed. Try `aws sso login --profile {profile}` and rerun the toolbox."
+                f"❌ AWS SSO login failed. Try `aws sso login --profile {profile} --use-device-code` "
+                "and rerun the toolbox."
             )
             return False
 
@@ -283,7 +291,7 @@ def wait_for_context_access(context: str, namespace: str, *, initial_diagnostic:
 
     print(  # noqa: T201
         "❌ Access was not available after 10 minutes. "
-        f"After approval, rerun or use `aws sso login --profile {profile}`."
+        f"After approval, rerun or use `aws sso login --profile {profile} --use-device-code`."
     )
     return False
 


### PR DESCRIPTION
## Problem

**Why:** connecting to Prod US with the toolbox hung at AWS sign-in. The browser showed a green success page, but the CLI never finished, forcing manual credential copying from the AWS console.

- Since AWS CLI v2.22.0, `aws sso login` defaults to the PKCE authorization-code flow.
- PKCE completes only when the browser delivers an OAuth callback to a localhost server the CLI starts.
- When the browser can't reach that server (remote, container, or restricted-browser sessions), the CLI waits forever.
- The toolbox caps the login at its 10-minute access deadline, so the run blocks and then fails.

## Changes

- `login_to_sso` now runs `aws sso login --profile <p> --use-device-code`.
- The device code flow polls AWS for the token, so it needs no localhost callback.
- The two printed retry hints now suggest the same `--use-device-code` command.

> [!NOTE]
> Device code sign-in adds one confirmation click in the browser. On dual-stack IAM Identity Center instances it needs `AWS_USE_DUALSTACK_ENDPOINT=true` ([aws/aws-cli#10507](https://github.com/aws/aws-cli/issues/10507)).

## How did you test this code?

- Ran `python3 -m unittest test_toolbox` in `tools/infra-scripts/clitools`: 75 tests pass.
- Added `test_login_to_sso_forces_device_code_flow`, pinning the login argv like the existing `aws sso logout` test.
- It catches the regression of dropping the flag, which would silently re-break remote sessions. No existing test exercises `login_to_sso`.
- I (Claude) did not run the interactive login; this sandbox has no browser. Verify by running the toolbox with an expired SSO session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. `tools/infra-scripts/clitools/README.md` does not name the login command, and documented behavior is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- PostHog Code session (Claude). Skills invoked: /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions.
- Decision: always force device code instead of adding an opt-in flag. PKCE's only advantage is one fewer browser click; device code works in every environment the toolbox targets.
- `hogli ci:preflight` was unavailable in the sandbox. I ran `ruff check` and `ruff format --check` on the touched files directly; both pass.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
