### PR TITLE
fix(desktop): viewing a task clears its unread activity

### DIFF
--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -14,6 +14,7 @@ import { logger } from "../../../shell/logger";
 import { useArchiveTask } from "../../archive/useArchiveTask";
 import { ChannelBreadcrumb } from "../../canvas/components/ChannelBreadcrumb";
 import { CopyThreadLinkButton } from "../../canvas/components/CopyThreadLinkButton";
+import { useMarkTaskActivityRead } from "../../canvas/hooks/useMarkTaskActivityRead";
 import {
   LazyCloudReviewPage as CloudReviewPage,
   LazyReviewPage as ReviewPage,
@@ -128,6 +129,16 @@ export function TaskDetail({
       disableScope("taskDetail");
     };
   }, [enableScope, disableScope]);
+
+  // Mounting TaskDetail means the task was actually rendered in front of the
+  // user — that, not any API fetch of the task, is what clears the unread
+  // activity flag ("the agent is waiting for your reply"). Now-based rather
+  // than row-versioned since everything up to mount has been seen; a waiting
+  // flag landing after mount re-flags unread.
+  const { mutate: markTasksRead } = useMarkTaskActivityRead();
+  useEffect(() => {
+    markTasksRead([{ task_id: taskId, seen_before: new Date().toISOString() }]);
+  }, [markTasksRead, taskId]);
 
   useHotkeys("mod+p", () => openFilePicker(), {
     enableOnContentEditable: true,

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -134,7 +134,10 @@ export function TaskDetail({
   // user — that, not any API fetch of the task, is what clears the unread
   // activity flag ("the agent is waiting for your reply"). Now-based rather
   // than row-versioned since everything up to mount has been seen; a waiting
-  // flag landing after mount re-flags unread.
+  // flag landing after mount re-flags unread. Marking client-side rather than
+  // in the retrieve endpoint: a task fetch (list refresh, poll, prefetch)
+  // isn't a view.
+
   const { mutate: markTasksRead } = useMarkTaskActivityRead();
   useEffect(() => {
     markTasksRead([{ task_id: taskId, seen_before: new Date().toISOString() }]);


### PR DESCRIPTION
## Problem

PostHog Code users seeing an unread row in their Activity feed ("The agent is waiting for your reply", a completion, a mention) only had it cleared when they opened the task through a surface that explicitly called `mark_task_activity_read` — clicking the feed row, or opening the task's session/chat view (the panel that loads its `thread_messages` via `useTaskThread`). Opening the task directly (sidebar click, deep link, channel task view) without pulling up the chat left the row unread, so the feed kept claiming there was something new after you'd already seen it.

## Changes

One change in the desktop app, `products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx` (14 lines): mounting `TaskDetail` — the shared component behind both `/code/tasks/$taskId` and `/website/$channelId/tasks/$taskId` — marks the task's activity read via the existing `useMarkTaskActivityRead` hook, using the same useEffect + now-based `seen_before` pattern `ChannelFeedView` and `useTaskThread` already use.

Because activity read state is one row per (user, task) rather than per notification, this clears **any** unread activity for the task at view time — `awaiting_input`, `completed`, `mention`, `message` — whatever kind the row currently holds. Newest-wins on `activity_at` means anything landing after the view (a fresh waiting-for-reply while you're looking) still re-flags unread; other tasks and other users' rows are untouched.

Before / after:

| Scenario | Before | After |
| --- | --- | --- |
| Agent flags "waiting for your reply" → you open the task from the sidebar / deep link / channel view and answer | Row stays unread until you open the task's chat or click the feed row | Row clears the moment the task renders |
| Run completes while you have a different task open → you open the finished task from the sidebar | "Run finished" stays unread unless you came via the feed or chat | Clears on view |
| Teammate mentions you on a task → you visit the task via a copied link | Mention row stays unread until you pass through the feed | Clears on view |
| Agent flags "waiting for your reply" *while you're already viewing the task* | Unread re-flagged (projection lands after your last mark-read) | Unchanged: still re-flagged — `activity_at` is newer than the view-time marker |
| A list refresh / background poll / prefetch fetches the task | No read state change (and still none — marking lives in the component, not the retrieve API) | Unchanged |
| Task you never open in any surface | Stays unread | Unchanged |

Two deliberate boundary calls:

- **Client-side, not the retrieve API.** Viewed is literally viewed with your eyes: list refreshes, background polls, and prefetches all retrieve a task without anyone looking at it, so clearing unread in the endpoint would mark tasks "read" that were never on screen.
- **Backend `mark_read` endpoint untouched.** The change is scoped to view-time clearing; kind-specific clearing (e.g. only `awaiting_input`) isn't expressible on the endpoint today and "viewed the task → seen its current state" is the intended semantic.

**Not covered:** the mobile app has its own native task screen (`apps/mobile/src/app/task/[id].tsx`) that doesn't share this component — that surface is a follow-up if wanted.

## How did you test this code?

The effect is a 4-line application of the established `useMarkTaskActivityRead` pattern (identical shape to `ChannelFeedView`'s `markRead` and `useTaskThread`'s opening marker, both untested in this codebase). No new test added: a meaningful test would render `TaskDetail`, which pulls in chat/review/workspace subsystems and a dozen mocks for no behavioral coverage beyond "the hook is called," and dependencies aren't installed in this environment to run the desktop Vitest suite. Not verified by execution; the desktop team's CI runs the ui package's typecheck + tests.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — behavior fix only. Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code from a user-reported UX friction: their Activity feed kept showing "The agent is waiting for you to reply" as unread after they had replied. Direction changed twice during the session on reviewer feedback: first a server-side projection on the reply signal, then mark-on-retrieve in `TaskViewSet`, and finally this client-side mount-time mark-read — the reviewer framed it as 'viewed is literally viewed with my eyes', and an API fetch can happen for many non-view reasons. The all-kinds scope (not just `awaiting_input`) was also an explicit reviewer question; the before/after table above documents the semantics that answer it. No skills invoked. No sample data.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*