### PR TITLE
fix(postgres): stop the connection-drop probe rollback masking the real error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2642,12 +2642,17 @@ def _get_table(
     # statement with QueryCanceled mid-discovery. Session, not LOCAL: the connection is autocommit,
     # so a LOCAL timeout has nothing to bind to and a scoping transaction's own `BEGIN` would itself
     # run under the short default. Best-effort: engines without statement_timeout (e.g. DuckDB)
-    # reject the SET, so clear any aborted transaction and fall back to the default.
+    # reject the SET, so clear any aborted transaction and fall back to the default. A genuine
+    # connection drop/limit (mirrors `_schemas_from_conn`) fails this statement too, and rolling
+    # that back raises a misleading "the connection is lost" that buries the real cause — re-raise
+    # instead so the discovery retry recovers on a fresh connection.
     try:
         cursor.execute(
             sql.SQL("SET statement_timeout = {timeout}").format(timeout=sql.Literal(METADATA_STATEMENT_TIMEOUT_MS))
         )
-    except psycopg.Error:
+    except psycopg.Error as e:
+        if _is_connection_dropped_error(e) or _is_connection_limit_error(e):
+            raise
         cursor.connection.rollback()
 
     is_mat_view_query = sql.SQL(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -6008,6 +6008,24 @@ class TestGetTable:
             assert set_timeout_idx < first_probe_idx < info_schema_idx
 
     @pytest.mark.django_db
+    def test_dropped_connection_on_statement_timeout_reraises_without_rollback(self):
+        # Before the fix, any `psycopg.Error` on the protective `SET statement_timeout` triggered a
+        # blind `cursor.connection.rollback()`. When the error meant the connection itself was
+        # dropped, rolling back a dead socket raised a fresh, misleading "the connection is lost"
+        # that buried the real cause instead of letting the caller retry on a fresh connection
+        # (mirrors the same fix already applied to `_schemas_from_conn`).
+        logger = structlog.get_logger()
+        cursor = mock.MagicMock()
+        drop_error = psycopg.OperationalError("server closed the connection unexpectedly")
+        cursor.execute.side_effect = drop_error
+
+        with pytest.raises(psycopg.OperationalError) as exc_info:
+            _get_table(cast(Any, cursor), "public", "test_get_table_dropped_conn", logger)
+
+        assert exc_info.value is drop_error
+        cursor.connection.rollback.assert_not_called()
+
+    @pytest.mark.django_db
     def test_schemas_from_conn_runs_under_scoped_statement_timeout(self):
         """`_schemas_from_conn` (the discovery path `sync_new_schemas_activity` and credential
         validation use) raises statement_timeout before scanning the catalog, so a short


### PR DESCRIPTION
## Problem

Postgres source discovery can report a misleading `OperationalError: the connection is lost` when the real cause is a dropped upstream connection, hiding what actually failed.

`_get_table`'s protective `SET statement_timeout` guard catches any `psycopg.Error` and unconditionally calls `cursor.connection.rollback()`. When the connection itself is dead, that rollback raises its own "connection is lost" error, which propagates instead of the original one and buries the true cause.

Reported by error tracking: https://us.posthog.com/project/2/error_tracking/019fd5fd-e250-74a2-842b-07c19fb60bc4

## Changes

- `_get_table` now re-raises when the `SET statement_timeout` failure is itself a dropped or connection-limited connection, instead of attempting a rollback that fails again.
- This mirrors the same guard already used in `_schemas_from_conn` and in `postgres_source`'s own statement_timeout probe — `_get_table` was the one site that never got it.
- Engines that merely reject `SET statement_timeout` (e.g. DuckDB) are unaffected: they still degrade quietly and fall back to the default timeout.

## How did you test this code?

- Added `test_dropped_connection_on_statement_timeout_reraises_without_rollback` to `TestGetTable`: asserts the original connection error propagates unchanged and `rollback()` is never called on the dead connection. This is the regression the masking bug above would have caused.
- Ran the full `products/warehouse_sources/.../postgres/test_postgres.py` suite locally: 627 passed.
- Ran `mypy --cache-fine-grained .` repo-wide: clean.
- Not run: a live Postgres connection drop against a real customer database (no such environment available here); coverage is via the unit test above.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-handling fix, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged this from a PostHog error tracking webhook for the `postgres` data-warehouse source. I pulled the issue's stack trace and sampled events via the error-tracking MCP tools, traced the exception chain to `_get_table`'s statement_timeout except-block, and found two sibling call sites in the same file (`_schemas_from_conn`, `postgres_source`) that already carry the connection-drop/limit re-raise guard this site was missing. Applied the same pattern here.

Skills invoked: `/writing-tests` (test placement and value-gate check), `/writing-pr-descriptions` (this body).