### PR TITLE
fix(data-warehouse): keep Redshift server cursor on single-node clusters

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
@@ -116,6 +116,13 @@ SYSTEM_REDSHIFT_SCHEMAS = ["pg_catalog", "information_schema", "pg_internal", "p
 # `pa.Table.from_pydict` raises a `KeyError`. The `padb_internal` prefix is Redshift-reserved.
 REDSHIFT_INTERNAL_COLUMN_LIKE = "padb_internal%"
 
+# A single-node Redshift cluster rejects any `FETCH FORWARD` above 1000 rows with
+# "Fetch size N exceeds the limit of 1000 for a single node configuration". The limit is fixed by
+# the node topology, so a cluster that rejects one fetch rejects every fetch: without a retry at
+# this size the server cursor is unreachable on such clusters and every sync degrades to a
+# client-side read of the whole table.
+REDSHIFT_SINGLE_NODE_FETCH_LIMIT = 1000
+
 
 def _display_name(schema_name: str, table_name: str, *, qualify: bool) -> str:
     """Discovery key for a table: dotted `schema.table` in multi-schema mode, bare table otherwise."""
@@ -293,20 +300,53 @@ def _explain_query(cursor: psycopg.Cursor, query: sql.Composed, logger: Filterin
             pass
 
 
+def _is_fetch_size_error(error: Exception) -> bool:
+    """Is this Redshift rejecting the FETCH size rather than the cursor itself?
+
+    Matched on the message because Redshift reports it as a generic `InternalError_`/
+    `FeatureNotSupported` with no distinguishing SQLSTATE. Both halves are required so an
+    unrelated "exceeds the limit" (e.g. the cumulative result-set cap, which shrinking the fetch
+    cannot fix) doesn't trigger a pointless retry.
+    """
+    message = str(error).lower()
+    return "fetch size" in message and "exceeds the limit" in message
+
+
 def _fetch_arrow_batches(
     cursor: psycopg.Cursor,
     chunk_size: int,
     arrow_schema: pa.Schema,
+    fetch_size: int | None = None,
 ) -> Iterator[pa.Table]:
-    """Yield one Arrow table per `chunk_size` rows drawn from an already-executed `cursor`."""
-    column_names = [column.name for column in cursor.description or []]
+    """Yield one Arrow table per `chunk_size` rows drawn from an already-executed `cursor`.
 
+    `fetch_size` decouples the per-`FETCH` page from the Arrow batch: rows accumulate across
+    pages until `chunk_size` is reached. Redshift caps a single `FETCH` on a single-node cluster
+    (see `REDSHIFT_SINGLE_NODE_FETCH_LIMIT`) far below the chunk sizes we target, so paging is
+    the only way to keep the server cursor and still write batches the Delta writer sizes well.
+    Defaults to `chunk_size`, i.e. one `FETCH` per Arrow table.
+    """
+    column_names = [column.name for column in cursor.description or []]
+    page_size = fetch_size or chunk_size
+
+    def to_arrow(rows: list[Any]) -> pa.Table:
+        return table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
+
+    pending: list[Any] = []
     while True:
-        rows = cursor.fetchmany(chunk_size)
+        rows = cursor.fetchmany(page_size)
         if not rows:
             break
 
-        yield table_from_iterator((dict(zip(column_names, row)) for row in rows), arrow_schema)
+        pending.extend(rows)
+        # Overshoots by at most `page_size - 1` rows, which is bounded and far below the byte
+        # budget `chunk_size` was derived from.
+        if len(pending) >= chunk_size:
+            yield to_arrow(pending)
+            pending = []
+
+    if pending:
+        yield to_arrow(pending)
 
 
 def _stream_arrow_batches(
@@ -327,34 +367,53 @@ def _stream_arrow_batches(
     doesn't fit), which is what keeps the worker's footprint proportional to `chunk_size`.
 
     Redshift constrains cursors in ways Postgres doesn't: cumulative result sets are capped per node
-    type, and single-node clusters reject a `FETCH FORWARD` above 1000 rows. Both surface before any
-    batch reaches the caller, so a failure there falls back to the client-side read instead of
-    failing the sync — no better than having no server cursor at all, but no worse either. Once a
-    batch has been yielded the fallback is off the table: re-running the query would re-emit rows the
-    pipeline has already consumed, so later errors propagate.
+    type, and single-node clusters reject a `FETCH FORWARD` above 1000 rows. The fetch cap is a
+    property of the cluster, not the table, so on a single-node cluster it rejects the *first* fetch
+    of every sync — the retry at `REDSHIFT_SINGLE_NODE_FETCH_LIMIT` is what keeps those clusters on
+    the server cursor at all. Anything else that makes the cursor unusable falls back to the
+    client-side read instead of failing the sync — no better than having no server cursor at all, but
+    no worse either. Once a batch has been yielded both recoveries are off the table: re-running the
+    query would re-emit rows the pipeline has already consumed, so later errors propagate.
     """
     yielded = False
-    try:
-        # `close()` is a no-op while the transaction is aborted (psycopg checks the status first),
-        # so this never masks the original failure with a CLOSE error.
-        with connection.cursor(name=cursor_name) as server_cursor:
-            server_cursor.execute(query)
-            for batch in _fetch_arrow_batches(server_cursor, chunk_size, arrow_schema):
-                yielded = True
-                yield batch
-        return
-    except Exception as e:
-        if yielded:
-            raise
-        logger.debug(
-            f"Server-side cursor unusable ({e}); falling back to a client-side read of the full result set",
-            exc_info=e,
-        )
+    fetch_sizes = [chunk_size]
+    if chunk_size > REDSHIFT_SINGLE_NODE_FETCH_LIMIT:
+        fetch_sizes.append(REDSHIFT_SINGLE_NODE_FETCH_LIMIT)
 
-    # A failed DECLARE/FETCH leaves the transaction aborted, and Redshift has no savepoints to scope
-    # it — roll back so the client-side retry below isn't killed by `InFailedSqlTransaction`.
-    if connection.info.transaction_status == TransactionStatus.INERROR:
-        connection.rollback()
+    for attempt, fetch_size in enumerate(fetch_sizes):
+        try:
+            # `close()` is a no-op while the transaction is aborted (psycopg checks the status
+            # first), so this never masks the original failure with a CLOSE error.
+            with connection.cursor(name=cursor_name) as server_cursor:
+                server_cursor.execute(query)
+                for batch in _fetch_arrow_batches(server_cursor, chunk_size, arrow_schema, fetch_size):
+                    yielded = True
+                    yield batch
+            return
+        except Exception as e:
+            if yielded:
+                raise
+
+            # A failed DECLARE/FETCH leaves the transaction aborted, and Redshift has no savepoints
+            # to scope it. Roll back so the next attempt isn't killed by `InFailedSqlTransaction` —
+            # and because that is also what frees `cursor_name` for a re-DECLARE, since an aborted
+            # transaction turns the block's `CLOSE` into a no-op.
+            if connection.info.transaction_status == TransactionStatus.INERROR:
+                connection.rollback()
+
+            is_last_attempt = attempt == len(fetch_sizes) - 1
+            if not is_last_attempt and _is_fetch_size_error(e):
+                logger.debug(
+                    f"Server cursor rejected a {fetch_size}-row FETCH ({e}); "
+                    f"retrying at {REDSHIFT_SINGLE_NODE_FETCH_LIMIT} rows per fetch"
+                )
+                continue
+
+            logger.debug(
+                f"Server-side cursor unusable ({e}); falling back to a client-side read of the full result set",
+                exc_info=e,
+            )
+            break
 
     with connection.cursor() as client_cursor:
         client_cursor.execute(query)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -19,10 +19,12 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
     RedshiftSourceConfig,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.redshift.redshift import (
+    REDSHIFT_SINGLE_NODE_FETCH_LIMIT,
     RedshiftColumn,
     RedshiftImplementation,
     _build_query,
     _explain_query,
+    _fetch_arrow_batches,
     _stream_arrow_batches,
     filter_redshift_incremental_fields,
 )
@@ -561,6 +563,24 @@ def _ids(tables) -> list[list[int]]:
     return [table.column("id").to_pylist() for table in tables]
 
 
+class TestFetchArrowBatches:
+    def test_accumulates_small_fetches_into_chunk_sized_batches(self):
+        # Paging the FETCH must not shrink the Arrow batch too: one table per 1000-row fetch would
+        # hand the Delta writer 20x more, 20x smaller batches than the chunk size budgets for.
+        cursor = _stream_cursor([[(1,), (2,)], [(3,), (4,)], [(5,), (6,)], [(7,)]])
+
+        tables = list(_fetch_arrow_batches(cursor, 5, _STREAM_SCHEMA, fetch_size=2))
+
+        assert _ids(tables) == [[1, 2, 3, 4, 5, 6], [7]]
+        assert [c.args[0] for c in cursor.fetchmany.call_args_list] == [2, 2, 2, 2, 2]
+
+    def test_fetches_a_whole_chunk_at_a_time_by_default(self):
+        cursor = _stream_cursor([[(1,), (2,)]])
+
+        assert _ids(list(_fetch_arrow_batches(cursor, 2, _STREAM_SCHEMA))) == [[1, 2]]
+        assert [c.args[0] for c in cursor.fetchmany.call_args_list] == [2, 2]
+
+
 class TestStreamArrowBatches:
     def test_streams_through_a_server_side_cursor(self, logger):
         server_cursor = _stream_cursor([[(1,), (2,)], [(3,)]])
@@ -578,9 +598,9 @@ class TestStreamArrowBatches:
     @pytest.mark.parametrize(
         "failure_point,error",
         [
-            # Cumulative cursor result sets are capped per node type.
-            ("declare", psycopg.errors.FeatureNotSupported("cursor result set too large")),
-            # Single-node clusters reject a FETCH FORWARD above 1000 rows.
+            # Cumulative cursor result sets are capped per node type. It says "exceeds the limit"
+            # too, but shrinking the fetch can't fix it, so it must not trigger the retry below.
+            ("declare", psycopg.errors.FeatureNotSupported("cursor result set size exceeds the limit")),
             ("fetch", psycopg.errors.InvalidCursorName("cursor does not exist")),
         ],
     )
@@ -598,6 +618,48 @@ class TestStreamArrowBatches:
         assert _ids(tables) == [[1, 2]]
         # Without the rollback the fallback dies on `InFailedSqlTransaction` instead of syncing.
         connection.rollback.assert_called_once()
+
+    def test_retries_at_the_single_node_limit_instead_of_falling_back(self, logger):
+        # A single-node cluster rejects the first FETCH of every sync. Falling back here reads the
+        # whole table into the worker, which is what OOM-killed the pod in production.
+        server_cursor = _stream_cursor([[(1,), (2,)]])
+        server_cursor.fetchmany.side_effect = [
+            psycopg.errors.InternalError_("Fetch size 20000 exceeds the limit of 1000 for a single node configuration"),
+            [(1,), (2,)],
+            [],
+        ]
+        client_cursor = _stream_cursor([[(9,)]])
+        connection = _stream_connection(server_cursor, client_cursor, TransactionStatus.INERROR)
+
+        tables = list(_stream_arrow_batches(connection, _STREAM_QUERY, 20_000, _STREAM_SCHEMA, "cur", logger))
+
+        assert _ids(tables) == [[1, 2]]
+        client_cursor.execute.assert_not_called()
+        assert connection.cursor.call_args_list == [call(name="cur"), call(name="cur")]
+        # The retry has to actually shrink the fetch, or Redshift rejects it identically.
+        assert [c.args[0] for c in server_cursor.fetchmany.call_args_list] == [
+            20_000,
+            REDSHIFT_SINGLE_NODE_FETCH_LIMIT,
+            REDSHIFT_SINGLE_NODE_FETCH_LIMIT,
+        ]
+
+    def test_does_not_retry_when_the_chunk_already_fits_the_single_node_limit(self, logger):
+        # Re-DECLARE-ing at the size that was just rejected would loop the same failure.
+        server_cursor = _stream_cursor([])
+        server_cursor.fetchmany.side_effect = psycopg.errors.InternalError_(
+            "Fetch size 1000 exceeds the limit of 1000 for a single node configuration"
+        )
+        client_cursor = _stream_cursor([[(1,)]])
+        connection = _stream_connection(server_cursor, client_cursor, TransactionStatus.INERROR)
+
+        tables = list(
+            _stream_arrow_batches(
+                connection, _STREAM_QUERY, REDSHIFT_SINGLE_NODE_FETCH_LIMIT, _STREAM_SCHEMA, "cur", logger
+            )
+        )
+
+        assert _ids(tables) == [[1]]
+        assert connection.cursor.call_args_list == [call(name="cur"), call()]
 
     def test_does_not_fall_back_once_a_batch_has_been_yielded(self, logger):
         server_cursor = _stream_cursor([])


### PR DESCRIPTION
## Problem

A Redshift import from a single-node cluster OOM-kills its worker pod, so the table never syncs.

- #78156 put the extraction behind a server-side cursor so the worker holds one chunk at a time instead of the whole result set.
- Single-node Redshift rejects any `FETCH FORWARD` above 1000 rows. Our chunk size is 20000.
- The first fetch of every sync fails, before any batch reaches the pipeline.
- `_stream_arrow_batches` treats that as an unusable cursor and falls back to a client-side read, which buffers the whole result set. That is the OOM the cursor was added to remove.
- The cap comes from the node topology, not the table, so the cursor never engages on these clusters at all.

Every server-cursor fallback logged in the last 48 hours carries the same message: `Fetch size 20000 exceeds the limit of 1000 for a single node configuration`. Ranked by pod OOM: [Data warehouse - OOM problematic tables](https://us.posthog.com/project/2/insights/6ocMIxBi).

## Changes

- `_stream_arrow_batches` retries the server cursor at 1000 rows per fetch before it falls back.
- `_fetch_arrow_batches` takes a `fetch_size` separate from `chunk_size`, and accumulates pages into one Arrow table.
- The Delta writer still gets `chunk_size`-row batches, so the byte budget behind that number holds.
- `_is_fetch_size_error` requires both `fetch size` and `exceeds the limit`. The cumulative result-set cap also says `exceeds the limit`, and a smaller fetch cannot fix it, so that one still falls back.
- The client-side fallback stays for every other reason a cursor is unusable.
- The rollback moved into the failure handler, because it is also what frees the cursor name for a re-`DECLARE`.

> [!NOTE]
> A single-node cluster now issues 20 times more `FETCH` round trips per Arrow batch. 1000 is the only fetch size Redshift accepts there, and it replaces a read that could not finish.

## How did you test this code?

I (actually Claude) ran the Redshift source suite locally. Each new test names a regression no existing test caught:

- `test_retries_at_the_single_node_limit_instead_of_falling_back` catches the shipped bug: a fetch-size rejection that degrades to the client-side full-table read.
- `test_does_not_retry_when_the_chunk_already_fits_the_single_node_limit` catches a retry that re-declares at the size Redshift just rejected.
- `TestFetchArrowBatches` catches paging shrinking the Arrow batch along with the fetch, which would hand the Delta writer 20 times more, 20 times smaller batches.
- The existing fallback test's `declare` case now says `exceeds the limit`, so dropping the `fetch size` half of the matcher fails.

Not run: any live Redshift cluster. I have no single-node cluster to reproduce against, so the 1000-row cap comes from the production log message and AWS's documented limit, not from a local repro.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior or configuration changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) did the investigation and the change. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The starting point was a table still OOMing after #78156 and #78302. I read the source, then queried the pod-OOM insight and the worker logs in Loki to find why the cursor was not bounding memory. The log message named the cause outright, so no guessing was needed about which of the two documented Redshift cursor limits was firing.

I first considered clamping the fetch size to 1000 unconditionally, and rejected it: multi-node clusters would pay 20 times the round trips for a limit that does not apply to them. Detecting and retrying keeps the fast path intact. I also left the client-side fallback in place rather than making an unusable cursor fatal, since that changes failure behavior for cases we have not seen in production.
