### PR TITLE
fix(clickhouse): reject a URL in the host field with an actionable message

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -62,6 +62,14 @@ GENERIC_CONNECTION_ERROR = (
     "your server, and that PostHog's IP addresses are allowed through any firewall."
 )
 
+# A pasted URL or connection string in the host field otherwise fails DNS resolution with a
+# misleading "check the spelling" message that echoes the raw value back (which can embed
+# credentials). Catch it early with an actionable message that never reflects the input.
+_HOST_IS_URL_ERROR = (
+    "Enter just the hostname in the host field (for example, play.clickhouse.com), not a full URL or "
+    "connection string. Remove any scheme (like https://) and any username, password, port, or path."
+)
+
 # A transient gateway/rate-limit response that survived the in-process connect
 # retries. The connection details are fine — the server is momentarily busy or
 # waking (idle ClickHouse Cloud services routinely 5xx the first request), so
@@ -482,6 +490,9 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
         is_ssh_valid, ssh_valid_errors = self.ssh_tunnel_is_valid(config, team_id)
         if not is_ssh_valid:
             return is_ssh_valid, ssh_valid_errors
+
+        if "://" in config.host:
+            return False, _HOST_IS_URL_ERROR
 
         valid_host, host_errors = self.is_database_host_valid(
             config.host, team_id, using_ssh_tunnel=config.ssh_tunnel.enabled if config.ssh_tunnel else False

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1097,6 +1097,26 @@ class TestSourceClassValidateCredentials:
         assert valid is False
         assert msg == "Invalid user or password"
 
+    def test_url_in_host_field_returns_actionable_message_without_reflecting_input(self):
+        from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse import source as source_module
+
+        source = source_module.ClickHouseSource()
+
+        config = MagicMock()
+        config.host = "https://secret.clickhouse.cloud"
+        config.ssh_tunnel = None
+
+        with patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None)):
+            with patch.object(source, "is_database_host_valid") as host_valid:
+                valid, msg = source.validate_credentials(config, team_id=1)
+
+        assert valid is False
+        assert "Enter just the hostname" in (msg or "")
+        # The pasted value can embed credentials — it must never be echoed back.
+        assert "secret.clickhouse.cloud" not in (msg or "")
+        # Short-circuits before we attempt DNS resolution of the bad host.
+        host_valid.assert_not_called()
+
     def test_returns_generic_message_for_unknown_error(self):
         from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse import source as source_module
         from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse.clickhouse import (


### PR DESCRIPTION
## Problem

A user setting up a ClickHouse source who pastes a full URL into the host field (for example `https://<id>.clickhouse.cloud`) hit a confusing DNS error that echoed the pasted value back, rather than being told to enter just the hostname.

- The host field expects a bare hostname; ClickHouse has a separate connection-string field for a URL.
- `validate_credentials` passed a URL straight to DNS resolution, which failed and reflected the raw input in the message.
- The reflected value can embed a username and password when a full connection string is pasted.

## Changes

- The host field now rejects a value containing `://` up front with a message that tells the user to enter just the hostname and never reflects their input.
- This mirrors the guard the Postgres source already applies.

## How did you test this code?

- Added `test_url_in_host_field_returns_actionable_message_without_reflecting_input`: catches a regression where a URL in the host field falls through to DNS resolution instead of the early actionable message, and asserts the pasted value is not echoed back.
- Ran the `TestSourceClassValidateCredentials` group locally; it passed. Did not run the ClickHouse-backed suites.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged data-warehouse source-creation failures and found one ClickHouse case where a URL in the host field produced an unhelpful DNS error that reflected the user's input. The Postgres source already handled the identical case, so I ported its guard. Invoked `/writing-tests` and `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
