### PR TITLE
fix(google-sheets): give an actionable error for a non-Sheets URL

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -143,6 +143,15 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         try:
             client.open_by_url(config.spreadsheet_url)
             return True, None
+        except gspread.exceptions.NoValidUrlKeyFound:
+            # gspread couldn't find a spreadsheet key in the value — it isn't a Sheets URL. Its
+            # str() is empty, so the generic fallback below would surface a bare "Invalid
+            # credentials" for what's really a URL-format problem. Guide the user instead.
+            return (
+                False,
+                "That doesn't look like a Google Sheets URL. Paste the full URL of your sheet, "
+                "for example https://docs.google.com/spreadsheets/d/<id>/edit.",
+            )
         except gspread.SpreadsheetNotFound:
             return False, "Spreadsheet not found at URL provided"
         except PermissionError:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -676,6 +676,20 @@ def test_validate_credentials_maps_api_error_to_friendly_message(api_message, ex
     assert "APIError" not in (error_message or "")
 
 
+def test_validate_credentials_rejects_non_sheets_url_with_actionable_message():
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.source.google_sheets_client"
+    ) as mock_client:
+        # gspread raises this (with an empty str()) when the value has no spreadsheet key.
+        mock_client.return_value.open_by_url.side_effect = gspread.exceptions.NoValidUrlKeyFound()
+        config = GoogleSheetsSourceConfig(spreadsheet_url="https://example.com/not-a-sheet")
+        is_valid, error_message = GoogleSheetsSource().validate_credentials(config, team_id=1)
+
+    assert is_valid is False
+    # The empty str() would otherwise surface as a bare "Invalid credentials"; point at the URL.
+    assert "Google Sheets URL" in (error_message or "")
+
+
 def test_validate_credentials_permission_denied_names_service_account(settings):
     settings.GOOGLE_SHEETS_SERVICE_ACCOUNT_CLIENT_EMAIL = "svc@posthog.iam.gserviceaccount.com"
     with mock.patch(


### PR DESCRIPTION
## Problem

A user connecting a Google Sheet who pasted a value that is not a Sheets URL (a plain domain, or a link with no spreadsheet id) saw the message "Invalid credentials". They entered no credentials — they share the sheet with our service account — so the message pointed them at the wrong thing.

- gspread raises `NoValidUrlKeyFound` when it can't find a spreadsheet id in the value.
- That exception's `str()` is empty, so `validate_credentials` returned `(False, "")`.
- The source-create view turns a falsy error into the generic "Invalid credentials".

## Changes

- `validate_credentials` now catches `NoValidUrlKeyFound` and returns a message that names the URL as the problem and shows the expected format.

## How did you test this code?

- Added `test_validate_credentials_rejects_non_sheets_url_with_actionable_message`: catches a regression where the empty-string error reappears and the user again sees the misleading generic message.
- Ran the new test locally; it passed.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged data-warehouse source-creation failures and traced the Google Sheets "Invalid credentials" case to gspread's `NoValidUrlKeyFound` having an empty string, which the create view fell back to a generic message for. The fix handles that exception at the source. Invoked `/writing-tests` and `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
