### PR TITLE
fix(data-imports): read Omnisend campaigns from the singular key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/omnisend/api_inventory.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/omnisend/api_inventory.md
@@ -19,16 +19,16 @@ changing endpoint behavior — see the `implementing-warehouse-sources` skill.
 | Schema     | Path          | Response array key | Primary key  | Partition (stable) |
 | ---------- | ------------- | ------------------ | ------------ | ------------------ |
 | contacts   | `/contacts`   | `contacts`         | `contactID`  | `createdAt`        |
-| campaigns  | `/campaigns`  | `campaigns`        | `campaignID` | `createdAt`        |
+| campaigns  | `/campaigns`  | `campaign`         | `campaignID` | `createdAt`        |
 | carts      | `/carts`      | `carts`            | `cartID`     | `createdAt`        |
 | orders     | `/orders`     | `orders`           | `orderID`    | `createdAt`        |
 | products   | `/products`   | `products`         | `productID`  | `createdAt`        |
 | categories | `/categories` | `categories`       | `categoryID` | —                  |
 
 Endpoint existence confirmed against the live API (all return non-404 without a key).
-Primary-key / response-key names follow Omnisend's consistent `<resource>` /
-`<resource>ID` v3 convention (the create-contact response returns `contactID`); exact
-shapes of the list responses were not re-verified with a live key.
+Primary keys follow Omnisend's `<resource>ID` v3 convention. Response array keys follow
+the plural `<resource>` convention **except `/campaigns`, which nests rows under the
+singular `campaign`** — confirmed against the live response body.
 
 ## Sync mode
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/omnisend/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/omnisend/settings.py
@@ -29,7 +29,9 @@ OMNISEND_ENDPOINTS: dict[str, OmnisendEndpointConfig] = {
     "campaigns": OmnisendEndpointConfig(
         name="campaigns",
         path="/campaigns",
-        data_key="campaigns",
+        # `/campaigns` is the one v3 list endpoint that nests its rows under the singular
+        # `campaign` key; every other resource uses the plural `<resource>` convention.
+        data_key="campaign",
         primary_key="campaignID",
         partition_key="createdAt",
     ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/omnisend/tests/test_omnisend.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/omnisend/tests/test_omnisend.py
@@ -133,6 +133,18 @@ class TestPagination:
         manager.save_state.assert_not_called()
 
     @mock.patch(CLIENT_SESSION_PATCH)
+    def test_campaigns_rows_read_from_singular_key(self, MockSession) -> None:
+        # Omnisend's `/campaigns` nests rows under the singular `campaign`, unlike every other
+        # endpoint's plural key. Extraction must follow that, or the sync fails loud on 0 rows.
+        session = MockSession.return_value
+        _wire(session, [_page([{"campaignID": "c1"}], next_url=None, key="campaign")])
+
+        manager = _make_manager()
+        rows = _rows(omnisend_source("test-key", "campaigns", team_id=1, job_id="j", resumable_source_manager=manager))
+
+        assert rows == [{"campaignID": "c1"}]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
     def test_empty_page_yields_nothing(self, MockSession) -> None:
         session = MockSession.return_value
         _wire(session, [_page([], next_url=None)])


### PR DESCRIPTION
## Problem

- Omnisend users syncing the `campaigns` table get no data: the sync fails every run instead of importing campaigns.
- The `/campaigns` list endpoint nests its rows under the singular key `campaign`. Every other Omnisend v3 resource uses the plural `<resource>` key.
- The source configured `data_key="campaigns"` on the assumption the plural convention held, so the shared selector check found no rows and raised `ValueError: Required data_selector 'campaigns' matched nothing in the response (body keys: ['campaign', 'paging'])`.
- Omnisend's own docs disagree with themselves here: the schema shows `campaigns`, the example shows `campaign`. The live response uses `campaign`.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fd643-172e-7c81-9c49-391ce61dcbae

## Changes

- Set the campaigns endpoint `data_key` to `campaign` so rows are extracted from the key the API actually returns.
- The shared fail-loud check in `rest_client.py` is unchanged and was working correctly. It caught a wrong config, not a bug in shared code.
- Update the Omnisend API inventory to record that `/campaigns` is the one endpoint keyed on the singular `campaign`.

## How did you test this code?

- Added `test_campaigns_rows_read_from_singular_key`: runs the campaigns endpoint against a page keyed under `campaign` and asserts the row comes through. No existing test exercised the campaigns endpoint (all used `contacts`).
- Confirmed the new test fails on the old config, reproducing the exact production error, and passes on the fix.
- Ran the `omnisend` source test suite locally.
- Not run: the database-backed and end-to-end warehouse suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from an error tracking webhook. The failing frame was in shared pipeline code (`rest_source/rest_client.py`), but the root cause was a source config that guessed Omnisend's response key from a convention the `/campaigns` endpoint does not follow. The API inventory doc already flagged that the campaigns key was assumed, not verified with a live key, which pointed straight at it.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

I considered relaxing the selector check or adding the error to `NonRetryableErrors`, and rejected both: the data is present and importable, so the correct fix is to read the right key, not to stop retrying or swallow the failure.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
