### PR TITLE
fix(marketing-analytics): apply app chart theme to attribution chart

### DIFF
--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -16,6 +16,7 @@ const CHART_CONFIG_DEFAULTS = {
     showCrosshair: true,
     showGrid: true,
     barCornerRadius: 4,
+    tooltip: { placement: 'cursor' },
 } as const
 
 function chartThemeDefaults(isDarkModeOn: boolean): Partial<ChartTheme> {
@@ -72,7 +73,8 @@ export function useDateRangeZoom(
 }
 
 /** Builds a chart's config object, memoized on `deps`, applying `CHART_CONFIG_DEFAULTS` for any
- *  key the factory leaves undefined. Keys the factory sets explicitly always win over the defaults. */
+ *  key the factory leaves undefined. Keys the factory sets explicitly always win over the defaults.
+ *  `tooltip` merges key by key instead of being replaced wholesale. */
 export function useChartConfig<T extends object>(factory: () => T, deps: DependencyList): T
 export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined
 export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined {
@@ -83,6 +85,8 @@ export function useChartConfig<T extends object>(factory: () => T | undefined, d
             return config
         }
         const defined = Object.fromEntries(Object.entries(config).filter(([, value]) => value !== undefined))
-        return { ...CHART_CONFIG_DEFAULTS, ...defined } as T
+        // Nested, so a chart that sets any tooltip field would otherwise replace the whole default.
+        const tooltip = { ...CHART_CONFIG_DEFAULTS.tooltip, ...defined.tooltip }
+        return { ...CHART_CONFIG_DEFAULTS, ...defined, tooltip } as T
     }, deps)
 }

--- a/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/AttributionTab/AttributionChart.tsx
+++ b/frontend/src/scenes/web-analytics/tabs/marketing-analytics/frontend/components/AttributionTab/AttributionChart.tsx
@@ -2,9 +2,10 @@ import clsx from 'clsx'
 import { useMemo } from 'react'
 
 import { LemonSkeleton } from '@posthog/lemon-ui'
-import type { Series } from '@posthog/quill-charts'
-import { BarChart, useChartTheme } from '@posthog/quill-charts'
+import type { BarChartConfig, Series } from '@posthog/quill-charts'
+import { BarChart } from '@posthog/quill-charts'
 
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { AttributionMode, MarketingAnalyticsAttributionRow } from '~/queries/schema/schema-general'
@@ -59,6 +60,18 @@ export function AttributionChart({
     // Rows arrive server-ordered by influenced conversions, so the slice is the top slice.
     const chartRows = useMemo(() => rows.slice(0, MAX_CHART_ROWS), [rows])
 
+    const config: BarChartConfig = useChartConfig(
+        () => ({
+            barLayout: 'grouped',
+            legend: { show: true, position: 'top' },
+            tooltip: {
+                valueFormatter: (value: number) => humanFriendlyNumber(value, 1),
+                sortedByValue: true,
+            },
+        }),
+        []
+    )
+
     const series: Series[] = useMemo(
         () =>
             models.map((model, index) => ({
@@ -99,14 +112,7 @@ export function AttributionChart({
                             series={series}
                             labels={chartRows.map((row) => row.breakdownValue || '(none)')}
                             theme={theme}
-                            config={{
-                                barLayout: 'grouped',
-                                legend: { show: true, position: 'top' },
-                                tooltip: {
-                                    valueFormatter: (value: number) => humanFriendlyNumber(value, 1),
-                                    sortedByValue: true,
-                                },
-                            }}
+                            config={config}
                         />
                     </div>
                 ) : (


### PR DESCRIPTION
## Problem

The "Conversions by attribution model" chart on the marketing analytics Attribution tab looks off compared to charts in product analytics and the rest of the app: flat bar corners, different grid, axis, and crosshair styling, and a tooltip that doesn't follow the app's dark-mode colors or z-index.

The chart pulled its theme from the raw `@posthog/quill-charts` `useChartTheme` instead of the app wrapper in `lib/charts/hooks` that every other quill chart in the app uses. It was the only consumer in the repo doing this.

Adopting the wrapper surfaced a second problem that is not specific to this chart. Hovering any app chart leaves the tooltip sitting still while the cursor moves, because it anchors to the hovered data point rather than the pointer. On a tall chart it can land far from where the person is looking. 11 call sites already opted out by hand with `tooltip: { placement: 'cursor' }` — box plot, experiment exposures, two survey charts, four mcp_analytics charts, error tracking rate limits, endpoints, and SQL insights. That made cursor placement the convention in practice, and the wrong default in code.

## Changes

https://github.com/user-attachments/assets/2cb1bb16-5a6e-4087-89e2-30d6408d67af


- `AttributionChart` now imports `useChartTheme` from `lib/charts/hooks`, which applies PostHog's design tokens, dark-mode-aware grid/axis/crosshair colors, and tooltip styling.
- The chart config now goes through `useChartConfig`, picking up the shared defaults (rounded bar corners, grid, axis lines, tick marks) that trends charts use.
- `useChartConfig` now defaults `tooltip.placement` to `cursor`, so every app chart built through the shared hook follows the pointer.
- `tooltip` merges key by key instead of replacing the default wholesale. A chart that sets only `valueFormatter` — including this one — would otherwise drop the placement and silently keep the old anchoring.
- The quill-charts library default stays `follow-data`. Changing it there would also move the desktop app and MCP apps, which this PR does not intend.

The tooltip change alters position rather than shape or color, so the video above carries it better than a still. Measured on this chart, holding x fixed and moving the cursor 207px down within one band:

| | tooltip top, cursor high | tooltip top, cursor low | movement |
| --- | --- | --- | --- |
| before | 709 | 709 | 0px |
| after | 517 | 725 | 208px |

Two follow-ups this PR leaves alone:

- The 11 explicit `placement: 'cursor'` lines are now redundant. A few build config outside `useChartConfig` and do not inherit the default, so removing them needs a per-file check rather than a sweep.
- `FunnelStepsBarChart` keeps `top` placement. It passes a module-level `CHART_CONFIG` rather than the hook, so this default does not reach it.

## How did you test this code?

The original commit was written in a sandbox that could not run the app. A later session ran it locally against seeded attribution data and confirmed the chart renders, then measured the table above by reading the tooltip's client rect with the change stashed and restored.

- No new tests. The nested tooltip merge is the load-bearing part and is uncovered — `frontend/src/lib/charts/` has no test file for `hooks.ts`. A future edit back to a plain shallow spread would silently revert every chart that sets a tooltip field.
- Not run: the Jest and Playwright suites, and any check of the other chart surfaces. I confirmed the new default reaches this chart and reasoned about the rest from the call sites.
- Not checked: dark mode. Forcing the app theme from the console did not take, and the theme swap is the part of the first commit most worth a human's eyes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code cloud task, then a local session). Skills invoked: /writing-pr-descriptions. The first session located the mismatch by comparing this chart's theme source against every other quill-charts consumer in the repo; no design alternatives were considered beyond adopting the shared hooks.

The tooltip default came out of testing this PR locally, where the static tooltip read as a recurring papercut rather than a one-chart bug. Its first draft put the default in a second module-level constant beside `CHART_CONFIG_DEFAULTS`; feedback moved it into the existing object, which is where defaults belong. The nested merge survived that rewrite because the shallow spread would otherwise drop the default for exactly the charts that configure a tooltip. It also briefly went out as its own PR before being moved here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
