### PR TITLE
fix(desktop): preserve Pi web search on OSS models

### DIFF
--- a/products/desktop/packages/harness/src/extensions/posthog-provider/models.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/models.test.ts
@@ -7,18 +7,18 @@ import {
 } from "./models";
 
 describe("gatewayBaseUrlForApi", () => {
-  it("routes openai-responses through the gateway's /v1 surface", () => {
-    expect(gatewayBaseUrlForApi("openai-responses", "us")).toBe(
-      `${getLlmGatewayUrl("us")}/v1`,
-    );
-  });
+  it.each(["openai-responses", "openai-completions"])(
+    "routes %s through the gateway's /v1 surface",
+    (api) => {
+      expect(gatewayBaseUrlForApi(api, "us")).toBe(
+        `${getLlmGatewayUrl("us")}/v1`,
+      );
+    },
+  );
 
-  it("routes every other api through the gateway's product root", () => {
+  it("routes anthropic messages through the gateway's product root", () => {
     expect(gatewayBaseUrlForApi("anthropic-messages", "eu")).toBe(
       getLlmGatewayUrl("eu"),
-    );
-    expect(gatewayBaseUrlForApi("openai-completions", "dev")).toBe(
-      getLlmGatewayUrl("dev"),
     );
   });
 
@@ -29,6 +29,9 @@ describe("gatewayBaseUrlForApi", () => {
     expect(gatewayBaseUrlForApi("openai-responses", "us", "http://proxy")).toBe(
       "http://proxy/v1",
     );
+    expect(
+      gatewayBaseUrlForApi("openai-completions", "us", "http://proxy"),
+    ).toBe("http://proxy/v1");
     expect(
       gatewayBaseUrlForApi("openai-responses", "us", "http://proxy/v1"),
     ).toBe("http://proxy/v1");
@@ -209,7 +212,8 @@ describe("resolveModelConfigs", () => {
 
     const configs = await resolveModelConfigs("us");
 
-    expect(configs[0]?.api).toBe("anthropic-messages");
+    expect(configs[0]?.api).toBe("openai-completions");
+    expect(configs[0]?.baseUrl).toBe(`${getLlmGatewayUrl("us")}/v1`);
     expect(configs[0]?.maxTokens).toBe(32000);
   });
 

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/models.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/models.ts
@@ -50,9 +50,8 @@ function detectFamily(model: GatewayModel): ModelFamily {
 
 /**
  * The gateway URL a model of the given pi `api` should be routed through for
- * a given region. `openai-responses` models are served off the gateway's
- * `/v1` surface; every other API this provider uses is served off the
- * product root.
+ * a given region. OpenAI-compatible models are served off the gateway's `/v1`
+ * surface; Anthropic Messages is served off the product root.
  */
 export function gatewayBaseUrlForApi(
   api: string,
@@ -60,7 +59,7 @@ export function gatewayBaseUrlForApi(
   baseUrl = getLlmGatewayUrl(region),
 ): string {
   const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
-  if (api !== "openai-responses" || normalizedBaseUrl.endsWith("/v1")) {
+  if (!api.startsWith("openai-") || normalizedBaseUrl.endsWith("/v1")) {
     return normalizedBaseUrl;
   }
 
@@ -102,7 +101,8 @@ function toModelConfig(
     return {
       id: model.id,
       name,
-      api: "anthropic-messages",
+      api: "openai-completions",
+      baseUrl: gatewayBaseUrlForApi("openai-completions", region),
       reasoning: false,
       input,
       cost: ZERO_COST,

--- a/products/desktop/packages/harness/src/extensions/posthog-provider/provider.test.ts
+++ b/products/desktop/packages/harness/src/extensions/posthog-provider/provider.test.ts
@@ -70,7 +70,7 @@ describe("buildPosthogProvider", () => {
     ).toBe(true);
     expect(
       (config.models ?? [])
-        .filter((model) => model.api === "openai-responses")
+        .filter((model) => model.api?.startsWith("openai-"))
         .every((model) => model.baseUrl === "http://127.0.0.1:1234/v1"),
     ).toBe(true);
   });
@@ -256,14 +256,15 @@ describe("model classification", () => {
     }
   });
 
-  it("exposes the GLM model via the anthropic-messages surface", () => {
+  it("routes GLM through chat completions so Pi function tools stay local", () => {
     const glm = byId("us").get("@cf/zai-org/glm-5.2");
     expect(glm).toBeDefined();
-    expect(glm?.api).toBe("anthropic-messages");
+    expect(glm?.api).toBe("openai-completions");
+    expect(glm?.baseUrl).toBe("https://gateway.us.posthog.com/posthog_code/v1");
     expect(glm?.input).toEqual(["text"]);
   });
 
-  it("routes gateway-advertised DeepSeek through anthropic-messages without reasoning", () => {
+  it("routes DeepSeek through chat completions so Pi function tools stay local", () => {
     const [deepseek] = resolveModelConfigsFromGatewayModels(
       [
         {
@@ -274,9 +275,11 @@ describe("model classification", () => {
       ],
       "us",
     );
-    expect(deepseek?.api).toBe("anthropic-messages");
+    expect(deepseek?.api).toBe("openai-completions");
     expect(deepseek?.reasoning).toBe(false);
-    expect(deepseek?.baseUrl).toBeUndefined();
+    expect(deepseek?.baseUrl).toBe(
+      "https://gateway.us.posthog.com/posthog_code/v1",
+    );
     expect(deepseek?.contextWindow).toBe(1_048_000);
   });
 


### PR DESCRIPTION
## Problem

Pi runs using GLM or DeepSeek fail before the model can use the local web-search tool.

LiteLLM mistakes Pi's local function for hosted OpenAI search and sends an unsupported option to the inference provider.

**Why:** Pi should retain its local tools when using OpenAI-compatible models
