### PR TITLE
fix(data-imports): don't parse ignored REST responses as JSON

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/config_setup.py
@@ -367,7 +367,9 @@ def _create_response_actions_hook(
         action_type = matched.get("action") if matched else None
 
         if action_type == "ignore":
-            logger.info(f"Ignoring response with code {response.status_code} and content '{response.json()}'.")
+            # Use response.text, not response.json(): an ignored response (e.g. a 404) often has an
+            # empty or non-JSON body, and parsing it here would raise before the ignore takes effect.
+            logger.info(f"Ignoring response with code {response.status_code} and content '{response.text[:500]}'.")
             raise IgnoreResponseException
 
         # Re-issue the request. This is how a source classifies an HTTP-200 body-level error

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_response_action_classification.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_response_action_classification.py
@@ -86,6 +86,30 @@ class TestResponseActionClassification:
 
     @patch("tenacity.nap.time.sleep")
     @patch(f"{MODULE}.make_tracked_session")
+    def test_ignore_action_with_non_json_body_is_skipped(self, MockSession, _sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        # A 404 whose body is empty (not JSON) — the shape an endpoint returns for a missing
+        # resource. The ignore must skip it, not blow up parsing the body.
+        resp = Response()
+        resp.status_code = 404
+        resp.reason = "Not Found"
+        resp._content = b""
+        resp.url = "https://api.example.com/items"
+        mock_session.send.return_value = resp
+        hooks = create_response_hooks([{"status_code": 404, "action": "ignore"}])
+
+        client = RESTClient(base_url="https://api.example.com", max_retry_attempts=1)
+        pages = list(
+            client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator(), hooks=hooks)
+        )
+
+        assert pages == []
+        assert mock_session.send.call_count == 1
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(f"{MODULE}.make_tracked_session")
     def test_unmatched_4xx_still_raises_for_status(self, MockSession, _sleep) -> None:
         mock_session = MockSession.return_value
         mock_session.headers = {}


### PR DESCRIPTION
## Problem

- A data warehouse sync of a REST source fails with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` when it should have skipped a response ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd664-0381-7251-88a4-af58a621f43b)).
- Sources tell the shared REST client to ignore certain responses, e.g. `{"status_code": 404, "action": "ignore"}` for a missing resource.
- The ignore handler logs the body with `response.json()` before raising `IgnoreResponseException`. An ignored 404 usually has an empty or non-JSON body, so `response.json()` raises first and the skip never happens.
- The exception escapes the source generator and fails the whole sync, in shared code that every REST-based source runs.

## Changes

- Log `response.text` (truncated) instead of `response.json()` in the ignore path, so the ignore takes effect whatever the body contains.

## How did you test this code?

- Added `test_ignore_action_with_non_json_body_is_skipped` to `test_response_action_classification.py`: an `ignore` rule matching a 404 with an empty body now yields no pages instead of raising. It catches this regression, which no existing case did — every other case in that file uses a JSON body.
- Confirmed the new test reproduces the reported `JSONDecodeError` when the fix is reverted, and passes with it.
- Not run: the database-backed and Temporal suites, which this change does not touch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by Claude (Claude Code) triaging a live error tracking issue in the data-imports pipeline.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the stack trace to the shared REST source response-action hook, confirmed the source config only supplies an `ignore` rule, and scoped the fix to the logging line rather than the source. The committed test uses invented, non-customer values.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
