### PR TITLE
chore(skills): raise bundled file limit from 50 to 200

### DIFF
--- a/products/review_hog/backend/reviewer/lazy_seed.py
+++ b/products/review_hog/backend/reviewer/lazy_seed.py
@@ -56,7 +56,7 @@ _ALLOWED_BUNDLE_SUBDIRS = ("references", "scripts")
 # bypasses the service layer, so they're checked at parse time).
 _MAX_SKILL_BODY_BYTES = 1_000_000
 _MAX_SKILL_FILE_BYTES = 1_000_000
-_MAX_SKILL_FILE_COUNT = 50
+_MAX_SKILL_FILE_COUNT = 200
 _MAX_SKILL_FILE_PATH_LENGTH = 500
 
 # Stamped on `LLMSkill.metadata.seeded_by` for every ReviewHog-managed row. Its presence is the

--- a/products/signals/backend/scout_harness/lazy_seed.py
+++ b/products/signals/backend/scout_harness/lazy_seed.py
@@ -54,7 +54,7 @@ _ALLOWED_BUNDLE_SUBDIRS = ("references", "scripts")
 # from this module's call sites. Keep the values in sync with skill_services.py.
 _MAX_SKILL_BODY_BYTES = 1_000_000
 _MAX_SKILL_FILE_BYTES = 1_000_000
-_MAX_SKILL_FILE_COUNT = 50
+_MAX_SKILL_FILE_COUNT = 200
 # Matches `LLMSkillFile.path` model `max_length` — checked at parse time so an oversized
 # canonical path fails with a clear error instead of a Postgres `value too long` DataError.
 _MAX_SKILL_FILE_PATH_LENGTH = 500

--- a/products/signals/backend/test/test_scout_harness_lazy_seed.py
+++ b/products/signals/backend/test/test_scout_harness_lazy_seed.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from products.signals.backend.models import SignalScoutConfig
 from products.signals.backend.scout_harness.config_registry import register_missing_configs
 from products.signals.backend.scout_harness.lazy_seed import (
+    _MAX_SKILL_FILE_COUNT,
     CanonicalSkill,
     CanonicalSkillFile,
     CanonicalSkillParseError,
@@ -363,8 +364,8 @@ class TestDiscoverCanonicalSkills:
             discover_canonical_skills(tmp_path)
 
     def test_too_many_bundled_files_raises(self, tmp_path: Path) -> None:
-        # File count limit mirrors MAX_SKILL_FILE_COUNT (200).
-        bundled = {f"references/file_{i:03d}.md": f"# file {i}\n" for i in range(201)}
+        # File count limit mirrors MAX_SKILL_FILE_COUNT.
+        bundled = {f"references/file_{i:03d}.md": f"# file {i}\n" for i in range(_MAX_SKILL_FILE_COUNT + 1)}
         _write_canonical_skill(
             tmp_path,
             dir_name="signals-scout-too-many",
@@ -377,7 +378,7 @@ class TestDiscoverCanonicalSkills:
             body="# Body\n",
             bundled_files=bundled,
         )
-        with pytest.raises(CanonicalSkillParseError, match="exceeding the 50 limit"):
+        with pytest.raises(CanonicalSkillParseError, match=f"exceeding the {_MAX_SKILL_FILE_COUNT} limit"):
             discover_canonical_skills(tmp_path)
 
     def test_overlong_path_raises(self, tmp_path: Path) -> None:

--- a/products/signals/backend/test/test_scout_harness_lazy_seed.py
+++ b/products/signals/backend/test/test_scout_harness_lazy_seed.py
@@ -363,8 +363,8 @@ class TestDiscoverCanonicalSkills:
             discover_canonical_skills(tmp_path)
 
     def test_too_many_bundled_files_raises(self, tmp_path: Path) -> None:
-        # File count limit mirrors MAX_SKILL_FILE_COUNT (50).
-        bundled = {f"references/file_{i:03d}.md": f"# file {i}\n" for i in range(51)}
+        # File count limit mirrors MAX_SKILL_FILE_COUNT (200).
+        bundled = {f"references/file_{i:03d}.md": f"# file {i}\n" for i in range(201)}
         _write_canonical_skill(
             tmp_path,
             dir_name="signals-scout-too-many",

--- a/products/skills/backend/api/skill_serializers.py
+++ b/products/skills/backend/api/skill_serializers.py
@@ -31,7 +31,7 @@ DEFAULT_VERSION_PAGE_SIZE = 50
 _LIST_EXCLUDED_FIELDS = ("body", "body_total_length", "body_next_offset", "files")
 MAX_SKILL_BODY_BYTES = 1_000_000
 MAX_SKILL_FILE_BYTES = 1_000_000
-MAX_SKILL_FILE_COUNT = 50
+MAX_SKILL_FILE_COUNT = 200
 # Ownership is a short routing list, not an ACL — cap it so a create/update can't resolve membership,
 # clear the owner set, and insert an owner row per entry for an oversized input before being rejected.
 MAX_SKILL_OWNERS = 25

--- a/products/skills/backend/api/skill_services.py
+++ b/products/skills/backend/api/skill_services.py
@@ -18,7 +18,7 @@ from ..models.skills import (
 MAX_SKILL_VERSION = 2000
 MAX_SKILL_BODY_BYTES = 1_000_000
 MAX_SKILL_FILE_BYTES = 1_000_000
-MAX_SKILL_FILE_COUNT = 50
+MAX_SKILL_FILE_COUNT = 200
 
 
 class LLMSkillNotFoundError(Exception):

--- a/products/skills/backend/api/skills.py
+++ b/products/skills/backend/api/skills.py
@@ -98,7 +98,7 @@ from .skill_services import (
 
 logger = structlog.get_logger(__name__)
 
-# Generous ceiling for an uploaded skill zip — per-skill content (body, 50 files × 1 MB) is
+# Generous ceiling for an uploaded skill zip — per-skill content (body, 200 files × 1 MB) is
 # already bounded by create_skill, this just caps the upload before we read it into memory.
 MAX_IMPORT_ZIP_BYTES = 10_000_000
 

--- a/products/skills/backend/api/test/test_skills.py
+++ b/products/skills/backend/api/test/test_skills.py
@@ -230,7 +230,7 @@ class TestLLMSkillAPI(APIBaseTest):
                 "name": "many-files-skill",
                 "description": "Has too many files.",
                 "body": "# Body",
-                "files": [{"path": f"file-{i}.txt", "content": "content"} for i in range(51)],
+                "files": [{"path": f"file-{i}.txt", "content": "content"} for i in range(201)],
             },
             format="json",
         )

--- a/products/skills/backend/marketplace/packaging.py
+++ b/products/skills/backend/marketplace/packaging.py
@@ -29,9 +29,10 @@ SPEC_DESCRIPTION_MAX_LENGTH = 1024
 
 # Zip-bomb defense for import: bound member count and per-member *decompressed* read so a small
 # zip can't inflate into GBs of memory. These are coarse hard stops — the precise per-field/per-file
-# size caps are enforced downstream by the import validator. Kept comfortably above legit limits
-# (a SKILL.md body / bundled file is capped at ~1 MB each, ≤50 files).
-_MAX_ZIP_MEMBERS = 200
+# size caps are enforced downstream by the import validator. Member count is kept comfortably above
+# legit limits (≤200 bundled files plus SKILL.md and directory entries); the total is a memory stop
+# rather than a content limit, since MAX_IMPORT_ZIP_BYTES already bounds the compressed upload.
+_MAX_ZIP_MEMBERS = 500
 _MAX_ZIP_MEMBER_BYTES = 2_000_000
 _MAX_ZIP_TOTAL_UNCOMPRESSED_BYTES = 80_000_000
 

--- a/products/skills/frontend/llmSkillLogic.test.ts
+++ b/products/skills/frontend/llmSkillLogic.test.ts
@@ -77,13 +77,13 @@ describe('llmSkillLogic file uploads', () => {
         )
     })
 
-    it('caps a folder drop at 50 files and says so instead of silently failing on publish', async () => {
-        await upload(Array.from({ length: 55 }, (_, i) => asUpload(`content ${i}`, `references/file-${i}.txt`)))
+    it('caps a folder drop at 200 files and says so instead of silently failing on publish', async () => {
+        await upload(Array.from({ length: 205 }, (_, i) => asUpload(`content ${i}`, `references/file-${i}.txt`)))
 
-        expect(logic.values.skillForm.files).toHaveLength(50)
-        expect(logic.values.skillForm.files[49].path).toBe('references/file-49.txt')
+        expect(logic.values.skillForm.files).toHaveLength(200)
+        expect(logic.values.skillForm.files[199].path).toBe('references/file-199.txt')
         expect(jest.mocked(lemonToast.error)).toHaveBeenCalledWith(
-            "Some files weren't added: a skill can have at most 50 bundled files"
+            "Some files weren't added: a skill can have at most 200 bundled files"
         )
     })
 })

--- a/products/skills/frontend/skillConstants.ts
+++ b/products/skills/frontend/skillConstants.ts
@@ -2,7 +2,7 @@ export const SKILL_NAME_MAX_LENGTH = 64
 export const SKILL_DESCRIPTION_MAX_LENGTH = 4096
 // Kept in sync with MAX_SKILL_FILE_BYTES and MAX_SKILL_FILE_COUNT in the backend skill_serializers.
 export const SKILL_FILE_MAX_BYTES = 1_000_000
-export const SKILL_FILE_MAX_COUNT = 50
+export const SKILL_FILE_MAX_COUNT = 200
 
 // Names that collide with reserved /skills routes: 'new' (the create form) and the category-tab
 // slugs registered under /skills/<slug> in manifest.tsx. A skill with one of these names would be


### PR DESCRIPTION
## Problem

Anyone publishing a skill with a large reference bundle hits a hard stop at 50 bundled files — the upload silently truncates in the UI and the API rejects the create. Skills that carry per-topic reference docs or scripts have outgrown that ceiling.

## Changes

- `MAX_SKILL_FILE_COUNT` goes from 50 to 200 in the skills serializers and service layer, with the frontend mirror (`SKILL_FILE_MAX_COUNT`) kept in sync.
- The canonical-seed copies of the limit in signals (`scout_harness`) and review_hog are bumped to match, so seeding a scout or perspective with more bundled files no longer fails at parse time.
- The zip import member hard stop rises from 200 to 500 so a 200-file skill can still be imported. The 10 MB compressed upload cap and the 1 MB per-file cap are unchanged, and the total-uncompressed stop stays as a memory guard.

## How did you test this code?

I updated the existing limit tests to the new ceiling rather than adding new ones: the API create test (201 files), the scout canonical-seed test (201 files), and the frontend folder-drop cap test (205 files, 200 kept). No new regression is introduced by this diff that those tests don't already cover.

I did not run the suites — this workspace has a sparse checkout of `products/skills`, `products/signals`, and `products/review_hog` only, without the Python venv or `node_modules`, so I'm relying on CI for the backend and Jest runs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No user-facing docs reference the file count.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude). The ask was to bump the 50-file limit to 200; the work was finding every copy of it. The limit is duplicated in five places — two in `products/skills/backend`, the frontend constants file, and inlined again in the signals and review_hog lazy seeds (deliberately, to dodge a circular import) — so bumping only the serializer would have left seeding broken at 51 files. The zip member cap was the non-obvious one: at 200 it would have blocked importing a skill the API now accepts.

No repo skills were invoked; the change is a constant bump with no new API surface.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
