### PR TITLE
fix(billing): preserve product deep-link scrolling

### DIFF
--- a/frontend/src/scenes/billing/billingLogic.test.ts
+++ b/frontend/src/scenes/billing/billingLogic.test.ts
@@ -1,0 +1,52 @@
+import { router } from 'kea-router'
+
+import { billingLogic } from 'scenes/billing/billingLogic'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+describe('billingLogic', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it.each(['/organization/billing', '/organization/billing/overview'])(
+        'restores product deep-link scrolling from %s after mount',
+        (pathname) => {
+            billingLogic.mount()
+            router.actions.push(pathname, { products: ProductKey.REPLAY_VISION })
+
+            expect(billingLogic.values.scrollToProductKey).toBe(ProductKey.REPLAY_VISION)
+        }
+    )
+
+    it.each(['/organization/billing', '/organization/billing/overview'])(
+        'restores product deep-link scrolling from %s on initial mount',
+        (pathname) => {
+            router.actions.push(pathname, { products: ProductKey.REPLAY_VISION })
+            billingLogic.mount()
+
+            expect(billingLogic.values.scrollToProductKey).toBe(ProductKey.REPLAY_VISION)
+        }
+    )
+
+    it.each(['/organization/billing/usage', '/organization/billing/spend'])(
+        'does not restore product deep-link scrolling from %s after mount',
+        (pathname) => {
+            billingLogic.mount()
+            router.actions.push(pathname, { products: ProductKey.REPLAY_VISION })
+
+            expect(billingLogic.values.scrollToProductKey).toBe(null)
+        }
+    )
+
+    it.each(['/organization/billing/usage', '/organization/billing/spend'])(
+        'does not restore product deep-link scrolling from %s on initial mount',
+        (pathname) => {
+            router.actions.push(pathname, { products: ProductKey.REPLAY_VISION })
+            billingLogic.mount()
+
+            expect(billingLogic.values.scrollToProductKey).toBe(null)
+        }
+    )
+})

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -1,4 +1,4 @@
-import { MakeLogicType, actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { MakeLogicType, actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { FieldNamePath, capitalizeFirstLetter, forms } from 'kea-forms'
 import type { DeepPartial, DeepPartialMap, FieldName, ValidationErrorType } from 'kea-forms'
 import { lazyLoaders } from 'kea-loaders'
@@ -1563,9 +1563,12 @@ export const billingLogic = kea<billingLogicType>([
             })
         },
     })),
-    urlToAction(({ actions, values }) => ({
-        // IMPORTANT: This needs to be above the "*" so it takes precedence
-        '/*/billing': (_params, _search, hash) => {
+    urlToAction(({ actions, values }) => {
+        const handleBillingRoute = (
+            _params: Record<string, string>,
+            _search: Record<string, string>,
+            hash: Record<string, string>
+        ): void => {
             if (hash.license) {
                 actions.setShowLicenseDirectInput(true)
                 actions.setActivateLicenseValues({ license: hash.license })
@@ -1594,8 +1597,52 @@ export const billingLogic = kea<billingLogicType>([
             if (values.isOnboarding !== isOnboarding) {
                 actions.setIsOnboarding(isOnboarding)
             }
-        },
-        '*': () => {
+        }
+
+        return {
+            // IMPORTANT: These need to be above the "*" so they take precedence
+            '/*/billing': handleBillingRoute,
+            '/*/billing/overview': handleBillingRoute,
+            '*': () => {
+                const redirectPath = window.location.pathname.includes('/onboarding')
+                    ? window.location.pathname + window.location.search
+                    : ''
+                if (values.redirectPath !== redirectPath) {
+                    actions.setRedirectPath(redirectPath)
+                }
+                const isOnboarding = window.location.pathname.includes('/onboarding')
+                if (values.isOnboarding !== isOnboarding) {
+                    actions.setIsOnboarding(isOnboarding)
+                }
+            },
+        }
+    }),
+    events(({ actions, values }) => ({
+        afterMount: () => {
+            const { location, searchParams, hashParams } = router.values
+            const isBillingOverviewRoute =
+                location.pathname.endsWith('/billing') || location.pathname.endsWith('/billing/overview')
+
+            if (isBillingOverviewRoute) {
+                if (hashParams.license) {
+                    actions.setShowLicenseDirectInput(true)
+                    actions.setActivateLicenseValues({ license: hashParams.license })
+                    actions.submitActivateLicense()
+                }
+                if (searchParams.products) {
+                    const products = searchParams.products.split(',')
+                    actions.setScrollToProductKey(products[0])
+                }
+                if (searchParams.billing_error) {
+                    actions.setBillingAlert({
+                        status: 'error',
+                        title: 'Error',
+                        message: searchParams.billing_error,
+                        contactSupport: true,
+                    })
+                }
+            }
+
             const redirectPath = window.location.pathname.includes('/onboarding')
                 ? window.location.pathname + window.location.search
                 : ''

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -46,6 +46,15 @@ export const ALLOCATION_THRESHOLD_BLOCK = 1.2 // Threshold to block usage
 
 const BILLING_ALERT_DISMISS_PREFIX = 'scenes.billing.billingLogic.billingAlertDismissed.'
 
+const getFirstProductFromProductsParam = (productsParam: unknown): ProductKey | null => {
+    if (typeof productsParam !== 'string') {
+        return null
+    }
+
+    const [product] = productsParam.split(',')
+    return product ? (product as ProductKey) : null
+}
+
 export interface BillingAlertConfig {
     status: 'info' | 'warning' | 'error'
     title: string
@@ -1565,20 +1574,20 @@ export const billingLogic = kea<billingLogicType>([
     })),
     urlToAction(({ actions, values }) => {
         const handleBillingRoute = (
-            _params: Record<string, string>,
-            _search: Record<string, string>,
-            hash: Record<string, string>
+            _params: Record<string, string | undefined>,
+            _search: Record<string, unknown>,
+            hash: Record<string, unknown>
         ): void => {
-            if (hash.license) {
+            if (typeof hash.license === 'string') {
                 actions.setShowLicenseDirectInput(true)
                 actions.setActivateLicenseValues({ license: hash.license })
                 actions.submitActivateLicense()
             }
-            if (_search.products) {
-                const products = _search.products.split(',')
-                actions.setScrollToProductKey(products[0])
+            const product = getFirstProductFromProductsParam(_search.products)
+            if (product) {
+                actions.setScrollToProductKey(product)
             }
-            if (_search.billing_error) {
+            if (typeof _search.billing_error === 'string') {
                 actions.setBillingAlert({
                     status: 'error',
                     title: 'Error',
@@ -1624,16 +1633,16 @@ export const billingLogic = kea<billingLogicType>([
                 location.pathname.endsWith('/billing') || location.pathname.endsWith('/billing/overview')
 
             if (isBillingOverviewRoute) {
-                if (hashParams.license) {
+                if (typeof hashParams.license === 'string') {
                     actions.setShowLicenseDirectInput(true)
                     actions.setActivateLicenseValues({ license: hashParams.license })
                     actions.submitActivateLicense()
                 }
-                if (searchParams.products) {
-                    const products = searchParams.products.split(',')
-                    actions.setScrollToProductKey(products[0])
+                const product = getFirstProductFromProductsParam(searchParams.products)
+                if (product) {
+                    actions.setScrollToProductKey(product)
                 }
-                if (searchParams.billing_error) {
+                if (typeof searchParams.billing_error === 'string') {
                     actions.setBillingAlert({
                         status: 'error',
                         title: 'Error',

--- a/frontend/src/scenes/billing/billingProductLogic.test.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.test.ts
@@ -44,6 +44,37 @@ describe('billingProductLogic', () => {
         return logic
     }
 
+    describe('product deep-link scrolling', () => {
+        it('does not retrigger a stale product scroll when another product logic mounts later', () => {
+            billingLogic.mount()
+            billingLogic.actions.setScrollToProductKey('product_analytics' as any)
+
+            const scrollIntoView = jest.fn()
+            const productAnalyticsLogic = billingProductLogic({
+                product: productByType('product_analytics'),
+                productRef: { current: { scrollIntoView } as unknown as HTMLDivElement },
+            })
+
+            jest.useFakeTimers()
+            try {
+                productAnalyticsLogic.mount()
+                mounted.push(productAnalyticsLogic)
+                jest.runOnlyPendingTimers()
+
+                expect(scrollIntoView).toHaveBeenCalledTimes(1)
+                expect(productAnalyticsLogic.values.scrollToProductKey).toBe(null)
+
+                const sessionReplayLogic = mountProduct('session_replay')
+                expect(sessionReplayLogic.values.scrollToProductKey).toBe(null)
+                jest.runOnlyPendingTimers()
+
+                expect(scrollIntoView).toHaveBeenCalledTimes(1)
+            } finally {
+                jest.useRealTimers()
+            }
+        })
+    })
+
     describe('custom billing limit resolution', () => {
         // $0 is a real, meaningful limit (drop all usage) — it must not be conflated with
         // "no limit set" (unbounded spend). This guards the `=== 0` handling in the

--- a/frontend/src/scenes/billing/billingProductLogic.ts
+++ b/frontend/src/scenes/billing/billingProductLogic.ts
@@ -1172,6 +1172,7 @@ export const billingProductLogic = kea<billingProductLogicType>([
                             behavior: 'smooth',
                             block: 'center',
                         })
+                        actions.setScrollToProductKey(null)
                     }
                 }, 0)
             }
@@ -1386,9 +1387,11 @@ export const billingProductLogic = kea<billingProductLogicType>([
             },
         },
     })),
-    events(({ actions, values }) => ({
+    events(({ actions, values, props }) => ({
         afterMount: () => {
-            actions.setScrollToProductKey(values.scrollToProductKey)
+            if (values.scrollToProductKey === props.product.type) {
+                actions.setScrollToProductKey(values.scrollToProductKey)
+            }
             actions.billingLoaded()
         },
     })),


### PR DESCRIPTION
## Problem

Billing product links can lose or reuse their scroll target. A fresh billing overview URL with `products=...` may not land on that product, and a later product card mount can scroll the page back to the old target after someone expands another product.

## Changes

Restore the product scroll target for `/organization/billing` and `/organization/billing/overview`, including the initial page load path before `urlToAction` has another chance to run. Usage and spend sections intentionally ignore `products`, `billing_error`, and license hash params.

Product cards now only re-emit the product target when the mounted card is the target, and clear the target after a successful scroll. That makes product deep-link scrolling one-shot instead of leaving stale state around for later remounts.

Evidence:

- [Before: Replay vision target jumps back after Mobile session replay click](https://raw.githubusercontent.com/PostHog/pr-assets/f44a1860e57da4d5902d9ae9583ab8d6ad314696/2026/08/billing-scroll-before-replay-vision-mobile-click-rerecorded.mp4)
- [After: Replay vision target clears after landing](https://raw.githubusercontent.com/PostHog/pr-assets/f44a1860e57da4d5902d9ae9583ab8d6ad314696/2026/08/billing-scroll-after-replay-vision-mobile-click-rerecorded.mp4)

## How did you test this code?

- `bin/hogli test frontend/src/scenes/billing/billingLogic.test.ts frontend/src/scenes/billing/billingProductLogic.test.ts --runInBand --silent`
- Recorded the local demo billing page before and after the fix. Both recordings load the paid billing overview deep link to Replay vision, scroll up to Mobile session replay, and click it. The before run jumps back to Replay vision; the after run keeps Mobile session replay in place.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update needed. This fixes billing-page scroll behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used Codex with the repo frontend guide, `compound-engineering:ce-debug`, `posthog-frontend-testing`, `qa-frontend`, `compound-engineering:ce-commit-push-pr`, and `write-like-a-human` while investigating, testing, and preparing this PR. The browser recordings use local demo data only.
