### PR TITLE
fix(desktop): add artifact view and download actions

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.test.tsx
@@ -1,11 +1,21 @@
 import type { Task, TaskRun, TaskRunArtifact } from "@posthog/shared";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   runs: [] as TaskRun[],
   openArtifactTab: vi.fn(),
   openExternalUrl: vi.fn(),
+  getCloudAttachmentPreviewUrl: vi.fn(),
+}));
+
+vi.mock("@posthog/core/sessions/sessionService", () => ({
+  SESSION_SERVICE: Symbol("SESSION_SERVICE"),
+}));
+vi.mock("@posthog/di/react", () => ({
+  useService: () => ({
+    getCloudAttachmentPreviewUrl: mocks.getCloudAttachmentPreviewUrl,
+  }),
 }));
 
 vi.mock("@posthog/ui/shell/openExternal", () => ({
@@ -71,6 +81,7 @@ describe("TaskArtifactsList", () => {
     mocks.runs = [run("run-1", { prNumber: 1 }), run("run-2", { prNumber: 2 })];
     mocks.openArtifactTab.mockReset();
     mocks.openExternalUrl.mockReset();
+    mocks.getCloudAttachmentPreviewUrl.mockReset();
     useReviewNavigationStore.setState({
       reviewModes: {},
       selectedPrUrls: {},
@@ -171,6 +182,54 @@ describe("TaskArtifactsList", () => {
       artifactId: "b",
       name: "new.md",
     });
+  });
+
+  it("shows permanent view and download actions for an artifact", () => {
+    mocks.runs = [
+      run("run-1", { artifacts: [outputFile({ id: "a", name: "report.md" })] }),
+    ];
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+
+    expect(screen.getByRole("button", { name: "View report.md" })).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Download report.md" }),
+    ).toBeTruthy();
+  });
+
+  it("downloads an artifact from its action", async () => {
+    mocks.runs = [
+      run("run-1", { artifacts: [outputFile({ id: "a", name: "report.md" })] }),
+    ];
+    mocks.getCloudAttachmentPreviewUrl.mockResolvedValue(
+      "https://files.example/report.md",
+    );
+    const fetchArtifact = vi
+      .spyOn(window, "fetch")
+      .mockResolvedValue(new Response("file contents"));
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:artifact");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+
+    render(<TaskArtifactsList task={task} timeline={[]} />);
+    fireEvent.click(screen.getByRole("button", { name: "Download report.md" }));
+
+    await waitFor(() => expect(click).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Download report.md" }),
+      ).toBeEnabled(),
+    );
+    expect(mocks.getCloudAttachmentPreviewUrl).toHaveBeenCalledWith(
+      "task-1",
+      "run-1",
+      "a",
+    );
+    expect(fetchArtifact).toHaveBeenCalledWith(
+      "https://files.example/report.md",
+    );
   });
 
   // Agents revise a deliverable and upload it again under the same name.

--- a/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/TaskArtifactsList.tsx
@@ -1,5 +1,7 @@
 import {
   ArrowSquareOutIcon,
+  DownloadSimpleIcon,
+  EyeIcon,
   PackageIcon,
   SlackLogoIcon,
 } from "@phosphor-icons/react";
@@ -10,11 +12,20 @@ import {
 } from "@posthog/core/canvas/runArtifactSchemas";
 import type { ThreadTimelineRow } from "@posthog/core/canvas/threadTimeline";
 import {
+  SESSION_SERVICE,
+  type SessionService,
+} from "@posthog/core/sessions/sessionService";
+import { useService } from "@posthog/di/react";
+import {
+  Button,
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@posthog/quill";
 import { readPrUrls } from "@posthog/shared";
 import type {
@@ -31,6 +42,7 @@ import { usePanelLayoutStore } from "@posthog/ui/features/panels/panelLayoutStor
 import { usePrComments } from "@posthog/ui/features/pr-review/usePrComments";
 import { usePrReviewThreads } from "@posthog/ui/features/pr-review/usePrReviewThreads";
 import { FileIcon } from "@posthog/ui/primitives/FileIcon";
+import { toast } from "@posthog/ui/primitives/toast";
 import { openExternalUrl } from "@posthog/ui/shell/openExternal";
 import { formatFileSize } from "@posthog/ui/utils/formatFileSize";
 import { type ReactNode, useMemo, useState } from "react";
@@ -129,6 +141,7 @@ function ArtifactListRow({
   external,
   onOpen,
   onOpenExternal,
+  fileActions,
   onHoverStart,
 }: {
   icon: ReactNode;
@@ -139,6 +152,10 @@ function ArtifactListRow({
   /** Renders a trailing button that leaves the app instead of opening the
    *  artifact in place. Absent when there is nowhere safe to send the user. */
   onOpenExternal?: () => void;
+  fileActions?: {
+    onDownload: () => void;
+    downloading: boolean;
+  };
   onHoverStart?: () => void;
 }) {
   return (
@@ -170,6 +187,41 @@ function ArtifactListRow({
         >
           <ArrowSquareOutIcon size={12} />
         </button>
+      )}
+      {fileActions && onOpen && (
+        <div className="flex shrink-0 items-center gap-0.5 border-border border-l px-1">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="default"
+                  size="icon-sm"
+                  aria-label={`View ${title}`}
+                  onClick={onOpen}
+                />
+              }
+            >
+              <EyeIcon size={14} />
+            </TooltipTrigger>
+            <TooltipContent>View</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="default"
+                  size="icon-sm"
+                  aria-label={`Download ${title}`}
+                  disabled={fileActions.downloading}
+                  onClick={fileActions.onDownload}
+                />
+              }
+            >
+              <DownloadSimpleIcon size={14} />
+            </TooltipTrigger>
+            <TooltipContent>Download</TooltipContent>
+          </Tooltip>
+        </div>
       )}
     </div>
   );
@@ -252,7 +304,9 @@ function FileRow({
   name: string;
   size: number | undefined;
 }) {
+  const sessionService = useService<SessionService>(SESSION_SERVICE);
   const openArtifactTab = usePanelLayoutStore((state) => state.openArtifactTab);
+  const [downloading, setDownloading] = useState(false);
   const canOpen = !!runId && !!artifactId;
   const onOpen = canOpen
     ? () => {
@@ -263,12 +317,45 @@ function FileRow({
         });
       }
     : undefined;
+  const onDownload = canOpen
+    ? async () => {
+        setDownloading(true);
+        try {
+          const url = await sessionService.getCloudAttachmentPreviewUrl(
+            taskId,
+            runId as string,
+            artifactId as string,
+          );
+          if (!url) {
+            toast.error("This file is no longer available");
+            return;
+          }
+          const response = await fetch(url);
+          if (!response.ok) throw new Error("Artifact download failed");
+          const objectUrl = URL.createObjectURL(await response.blob());
+          const anchor = document.createElement("a");
+          anchor.href = objectUrl;
+          anchor.download = name;
+          anchor.click();
+          URL.revokeObjectURL(objectUrl);
+        } catch {
+          toast.error("Couldn't download file");
+        } finally {
+          setDownloading(false);
+        }
+      }
+    : undefined;
   return (
     <ArtifactListRow
       icon={<FileIcon filename={name} size={14} />}
       title={name}
       detail={["File", formatFileSize(size)].filter(Boolean).join(" · ")}
       onOpen={onOpen}
+      fileActions={
+        onDownload
+          ? { onDownload: () => void onDownload(), downloading }
+          : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
## Problem

People can find generated files in the Artifacts sidebar, but the available preview and download actions are not explicit.

## Changes

- Add persistent View and Download icon buttons to generated-file rows.
- Add accessible labels and tooltips, and retain filename-click preview behavior.
- Download files through the existing signed attachment URL flow with failure feedback.

**Why:** Generated deliverables should be immediately viewable or downloadable from the place where they are listed.

## How did you test this code?

- `pnpm exec vitest run src/features/canvas/components/TaskArtifactsList.test.tsx`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm build`
- `pnpm exec biome check` on the changed files

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. No repo-provided skills were invoked. The file actions use compact icon buttons to keep the sidebar dense while exposing accessible names and hover tooltips. Test data is invented.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*