### PR TITLE
fix(error-tracking): stop reporting expected 403s as frontend errors

### DIFF
--- a/frontend/src/initKea.test.ts
+++ b/frontend/src/initKea.test.ts
@@ -1,0 +1,63 @@
+import { kea, path } from 'kea'
+import { loaders } from 'kea-loaders'
+import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
+
+import { ApiError } from 'lib/api-error'
+
+import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
+import { initKeaTests } from '~/test/init'
+
+function makeFailingLogic(error: ApiError): any {
+    return kea<any>([
+        path(['test', 'initKea', 'failingLoader']),
+        loaders(() => ({
+            thing: [
+                null,
+                {
+                    loadThing: async () => {
+                        throw error
+                    },
+                },
+            ],
+        })),
+    ])
+}
+
+describe('initKea', () => {
+    let captureException: jest.SpyInstance
+
+    beforeEach(() => {
+        initKeaTests()
+        silenceKeaLoadersErrors()
+        captureException = jest.spyOn(posthog, 'captureException').mockImplementation(() => undefined as any)
+    })
+
+    afterEach(() => {
+        resumeKeaLoadersErrors()
+        captureException.mockRestore()
+    })
+
+    it.each([
+        ['two_factor_setup_required', false],
+        ['permission_denied', false],
+        // Read-only mode relies on the central `before_send` filter, so it must still be captured here.
+        ['read_only_blocked', true],
+    ])('a 403 with code %s reports to error tracking: %s', async (code, shouldCapture) => {
+        const logic = makeFailingLogic(new ApiError('nope', 403, undefined, { code }))
+        logic.mount()
+
+        await expectLogic(logic, () => logic.actions.loadThing()).toFinishAllListeners()
+
+        expect(captureException).toHaveBeenCalledTimes(shouldCapture ? 1 : 0)
+    })
+
+    it('reports a server error to error tracking', async () => {
+        const logic = makeFailingLogic(new ApiError('boom', 500))
+        logic.mount()
+
+        await expectLogic(logic, () => logic.actions.loadThing()).toFinishAllListeners()
+
+        expect(captureException).toHaveBeenCalledTimes(1)
+    })
+})

--- a/frontend/src/initKea.ts
+++ b/frontend/src/initKea.ts
@@ -8,7 +8,7 @@ import { waitForPlugin } from 'kea-waitfor'
 import { windowValuesPlugin } from 'kea-window-values'
 import posthog from 'posthog-js'
 
-import { isAccessDeniedError } from 'lib/api-error'
+import { isAccessDeniedError, isExpectedAuthorizationError } from 'lib/api-error'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import {
     addProjectIdIfMissing,
@@ -188,7 +188,7 @@ export function initKea({
                 if (!errorsSilenced) {
                     console.error({ error, reducerKey, actionKey })
                 }
-                if (!TRANSIENT_GATEWAY_STATUSES.includes(error?.status)) {
+                if (!TRANSIENT_GATEWAY_STATUSES.includes(error?.status) && !isExpectedAuthorizationError(error)) {
                     posthog.captureException(error)
                 }
             },

--- a/frontend/src/lib/api-error.test.ts
+++ b/frontend/src/lib/api-error.test.ts
@@ -1,57 +1,77 @@
-import { ApiError } from './api-error'
+import { ApiError, isExpectedAuthorizationError } from './api-error'
 
-describe('ApiError.fromResponse', () => {
-    it.each([
-        ['error', { error: 'error message' }, 'error message'],
-        ['detail', { detail: 'detail message' }, 'detail message'],
-        ['message', { message: 'message value' }, 'message value'],
-    ])('uses the %s field as the error message', async (_, body, expected) => {
-        const response = new Response(JSON.stringify(body), { status: 400 })
+describe('api-error', () => {
+    describe('ApiError.fromResponse', () => {
+        it.each([
+            ['error', { error: 'error message' }, 'error message'],
+            ['detail', { detail: 'detail message' }, 'detail message'],
+            ['message', { message: 'message value' }, 'message value'],
+        ])('uses the %s field as the error message', async (_, body, expected) => {
+            const response = new Response(JSON.stringify(body), { status: 400 })
 
-        const error = await ApiError.fromResponse(response, 'fallback')
+            const error = await ApiError.fromResponse(response, 'fallback')
 
-        expect(error).toMatchObject({ message: expected, status: 400, data: body })
-    })
+            expect(error).toMatchObject({ message: expected, status: 400, data: body })
+        })
 
-    it('uses the fallback for a response without a recognized message', async () => {
-        const response = new Response('Bad gateway', { status: 502 })
+        it('uses the fallback for a response without a recognized message', async () => {
+            const response = new Response('Bad gateway', { status: 502 })
 
-        const error = await ApiError.fromResponse(response, 'Request failed')
+            const error = await ApiError.fromResponse(response, 'Request failed')
 
-        expect(error).toMatchObject({ message: 'Request failed', status: 502, data: null })
-    })
+            expect(error).toMatchObject({ message: 'Request failed', status: 502, data: null })
+        })
 
-    it('preserves response metadata and prioritizes error messages consistently', async () => {
-        const body = {
-            error: 'primary message',
-            detail: 'DRF detail',
-            message: 'secondary message',
-            code: 'permission_denied',
-        }
+        it('preserves response metadata and prioritizes error messages consistently', async () => {
+            const body = {
+                error: 'primary message',
+                detail: 'DRF detail',
+                message: 'secondary message',
+                code: 'permission_denied',
+            }
 
-        const error = await ApiError.fromResponse(new Response(JSON.stringify(body), { status: 403 }))
+            const error = await ApiError.fromResponse(new Response(JSON.stringify(body), { status: 403 }))
 
-        expect(error).toMatchObject({
-            message: 'primary message',
-            detail: 'DRF detail',
-            code: 'permission_denied',
-            status: 403,
-            data: body,
+            expect(error).toMatchObject({
+                message: 'primary message',
+                detail: 'DRF detail',
+                code: 'permission_denied',
+                status: 403,
+                data: body,
+            })
+        })
+
+        it('uses the default ApiError message for an empty response without a fallback', async () => {
+            const error = await ApiError.fromResponse(new Response(null, { status: 404 }))
+
+            expect(error).toMatchObject({ message: 'API request failed with status: 404', status: 404, data: null })
+        })
+
+        it('propagates an aborted response body read', async () => {
+            const abortError = new DOMException('Aborted', 'AbortError')
+            const response = {
+                json: jest.fn().mockRejectedValue(abortError),
+            } as unknown as Response
+
+            await expect(ApiError.fromResponse(response)).rejects.toBe(abortError)
         })
     })
 
-    it('uses the default ApiError message for an empty response without a fallback', async () => {
-        const error = await ApiError.fromResponse(new Response(null, { status: 404 }))
-
-        expect(error).toMatchObject({ message: 'API request failed with status: 404', status: 404, data: null })
-    })
-
-    it('propagates an aborted response body read', async () => {
-        const abortError = new DOMException('Aborted', 'AbortError')
-        const response = {
-            json: jest.fn().mockRejectedValue(abortError),
-        } as unknown as Response
-
-        await expect(ApiError.fromResponse(response)).rejects.toBe(abortError)
+    describe('isExpectedAuthorizationError', () => {
+        it.each([
+            ['a 2FA setup block', 403, 'two_factor_setup_required', true],
+            ['a 2FA verification block', 403, 'two_factor_verification_required', true],
+            ['a re-authentication block', 403, 'sensitive_action_required_reauth', true],
+            ['a verified-domain block', 403, 'verified_domain_required', true],
+            ['an access-denied response', 403, 'permission_denied', true],
+            // A 400 carrying an authorization code is form validation, e.g. inviting an
+            // outside-domain email — a real failure the user needs reported.
+            ['verified-domain form validation', 400, 'verified_domain_required', false],
+            // Read-only mode has its own `before_send` filter and must not be swallowed here.
+            ['a read-only block', 403, 'read_only_blocked', false],
+            ['a 403 with no code', 403, null, false],
+        ])('returns the right verdict for %s', (_, status, code, expected) => {
+            expect(isExpectedAuthorizationError({ status, code })).toBe(expected)
+        })
     })
 })

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -6,6 +6,30 @@ export function isAccessDeniedError(error: { status?: number; code?: string | nu
     return error.status === 403 && error.code === 'permission_denied'
 }
 
+/*
+403 codes where the backend is enforcing an authorization rule and the app already answers it —
+an access-denied gate, the 2FA setup modal, the re-authentication prompt. The status is scoped to
+403 deliberately: the same code on a 400 is form validation and still worth reporting.
+*/
+const EXPECTED_AUTHORIZATION_CODES = new Set([
+    'permission_denied',
+    'two_factor_setup_required',
+    'two_factor_verification_required',
+    'sensitive_action_required_reauth',
+    'verified_domain_required',
+])
+
+/**
+ * A 403 the app expects and handles, so error tracking should ignore it. One blocked page load
+ * fails every request the app makes on boot, and each call site fingerprints as its own issue —
+ * enough volume to bury real frontend errors.
+ */
+export function isExpectedAuthorizationError(error: unknown): boolean {
+    // Takes `unknown` because every call site is a catch block or kea's untyped loader error.
+    const { status, code } = (error ?? {}) as { status?: number; code?: string | null }
+    return status === 403 && !!code && EXPECTED_AUTHORIZATION_CODES.has(code)
+}
+
 export class ApiError extends Error {
     /** Django REST Framework `detail` - used in downstream error handling. */
     detail: string | null

--- a/frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.ts
+++ b/frontend/src/lib/components/ReverseProxyChecker/reverseProxyCheckerLogic.ts
@@ -3,6 +3,7 @@ import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { isExpectedAuthorizationError } from 'lib/api-error'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { sceneLogic } from 'scenes/sceneLogic'
 
@@ -81,9 +82,11 @@ export const reverseProxyCheckerLogic = kea<reverseProxyCheckerLogicType>([
                         // of `$exception_list`, so the central `before_send` filter in
                         // `selfReadOnlyModeLogic` can drop `ReadOnlyModeError` without
                         // assuming posthog-js serialises the cause chain.
-                        posthog.captureException(error, {
-                            posthog_source: 'reverseProxyCheckerLogic.loadHasReverseProxy',
-                        })
+                        if (!isExpectedAuthorizationError(error)) {
+                            posthog.captureException(error, {
+                                posthog_source: 'reverseProxyCheckerLogic.loadHasReverseProxy',
+                            })
+                        }
                         return values.hasReverseProxy
                     }
                 },


### PR DESCRIPTION
## Problem

A user whose organization enforces 2FA sees an empty home page for a moment before the setup modal appears, and every request the app makes on boot fails behind it. The app handles this correctly, but it also reports each failure to error tracking.

- The backend rejects requests from a session that has not completed 2FA setup with a 403 `two_factor_setup_required`.
- Kea loaders already suppress the toast for that code, because `apiStatusLogic` opens the 2FA setup modal instead. They still call `posthog.captureException`.
- The app fires around 20 parallel requests on boot, so one gated page load produces around 20 exceptions.
- Each call site fingerprints separately, so a single condition spawns dozens of issues rather than one.
- The result buries real frontend errors. See the [issue in error tracking](https://us.posthog.com/project/2/error_tracking/019fd344-3be8-7273-a609-67377773688b), which mixes several unrelated 403 messages under one fingerprint.

The same holds for the other 403 gates the app answers itself: 2FA verification, re-authentication, verified domain, and access denied.

## Changes

- Skip `posthog.captureException` for a 403 whose DRF code names an authorization gate the app already handles.
- Add `isExpectedAuthorizationError` to `lib/api-error`, next to the existing `isAccessDeniedError`.
- Scope the check to 403. The same code on a 400 is form validation, such as inviting an outside-domain email, and still reports.
- Apply it at the two capture sites: the kea loaders `onFailure` hook in `initKea`, and `reverseProxyCheckerLogic`, which captures directly.
- Leave read-only mode codes alone. They rely on the `before_send` filter in `selfReadOnlyModeLogic`.

The alternative was a second `before_send` filter. `selfReadOnlyModeLogic` documents that it owns that single config slot, so a second filter would fight it.

Toasts, modals, and gates are untouched, so nothing looks different to a user.

> [!NOTE]
> This covers the handled path, which is most of the volume. A smaller share arrives as unhandled rejections captured by posthog-js autocapture and is out of scope here.

## How did you test this code?

I (actually the PostHog Slack app) ran Jest on the three affected suites. I did not test manually, and I did not run the browser or backend suites.

- `frontend/src/initKea.test.ts` is new. It mounts a loader that rejects and asserts a 403 `two_factor_setup_required` and a 403 `permission_denied` do not reach `captureException`, while a 403 `read_only_blocked` and a 500 still do. It fails on two of three cases without the `initKea` change, which is the regression it exists to catch.
- `frontend/src/lib/api-error.test.ts` adds cases for the predicate. The ones that earn their place are the 400 with an authorization code and the 403 with no code, since both must still report.
- The `api-error.test.ts` diff is large only because the file now has one top-level `describe`, per the house rule. The existing cases are unchanged.
- `pnpm --filter=@posthog/frontend typescript:check` reports no errors in the touched files. It fails on pre-existing errors elsewhere, all from the unbuilt nested quill workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am the PostHog Slack app, running on Claude Code. The work started from an error tracking alert in Slack asking what the issue was and how users were affected. Investigation showed it was not a bug: 2FA enforcement works, and affected users go on to use the product normally. The problem was signal quality, so the fix targets the capture site rather than the auth flow.

Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.

Two decisions worth flagging for review. I widened the fix from `two_factor_setup_required` alone to the five 403 codes with dedicated UX, since they share one failure shape. Including `permission_denied` is the most debatable of those, and narrowing to the 2FA codes would still remove most of the volume.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1786007185977899?thread_ts=1786007185.977899&cid=C0A006STKHR)*
