### PR TITLE
fix(clickhouse): exclude ALIAS/EPHEMERAL columns from the sync query

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -881,11 +881,16 @@ def _is_materialized_view_engine(engine: str | None) -> bool:
 
 def _get_table(client: ClickHouseClient, database: str, table_name: str) -> Table[ClickHouseColumn]:
     """Read columns + table type for a single table from system tables."""
+    # Skip ALIAS and EPHEMERAL columns, matching `get_schemas`'s discovery query — see its
+    # comment for why: our `SELECT *` expands to an explicit column list, and an included
+    # ALIAS whose defining expression no longer resolves fails the whole sync query with
+    # UNKNOWN_IDENTIFIER (code 47), while EPHEMERAL columns aren't selectable at all.
     cols_result = client.query(
         """
         SELECT name, type
         FROM system.columns
         WHERE database = %(database)s AND table = %(table)s
+          AND default_kind NOT IN ('ALIAS', 'EPHEMERAL')
         ORDER BY position ASC
         """,
         parameters={"database": database, "table": table_name},

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1070,6 +1070,28 @@ class TestGetSchemas:
         assert set(schemas.keys()) == {"events"}
 
 
+class TestGetTable:
+    """Tests `_get_table`, used by the sync path to build the SELECT column list."""
+
+    def _make_mock_client(self, cols_rows, engine: str | None = "MergeTree"):
+        client = MagicMock()
+        cols_result = MagicMock()
+        cols_result.result_rows = cols_rows
+        engine_result = MagicMock()
+        engine_result.result_rows = [(engine,)] if engine is not None else []
+        client.query.side_effect = [cols_result, engine_result]
+        return client
+
+    def test_excludes_alias_and_ephemeral_columns_from_query(self):
+        from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse import clickhouse as ch_module
+
+        client = self._make_mock_client([("id", "UInt64")])
+        ch_module._get_table(client, "default", "events")
+
+        cols_query = client.query.call_args_list[0].args[0]
+        assert "default_kind NOT IN ('ALIAS', 'EPHEMERAL')" in cols_query
+
+
 class TestSourceClassValidateCredentials:
     """High-level checks on validate_credentials error mapping."""
 


### PR DESCRIPTION
## Problem

A ClickHouse data warehouse sync fails with `DB::Exception: Unknown expression identifier` (code 47, UNKNOWN_IDENTIFIER) when a synced table has an ALIAS column whose defining expression no longer resolves — for example after the underlying column it references was dropped or renamed. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd676-6357-7311-b7b0-bd66b21a5d2a).

The sync's own schema-discovery query (`get_schemas`) already excludes ALIAS and EPHEMERAL columns for this exact reason. The actual data-extraction path (`_get_table`, used by `clickhouse_source`) queried `system.columns` without that filter, so a broken ALIAS reached the extraction query and crashed the sync.

## Changes

- `_get_table` now excludes `ALIAS`/`EPHEMERAL` columns from its `system.columns` query, matching `get_schemas`.
- A native `SELECT *` skips ALIAS/EPHEMERAL columns; our explicit column list previously didn't, so it evaluated ALIAS expressions ClickHouse would otherwise never touch.

## How did you test this code?

- Added `TestGetTable::test_excludes_alias_and_ephemeral_columns_from_query`, asserting `_get_table`'s query carries the same `default_kind NOT IN ('ALIAS', 'EPHEMERAL')` filter as `get_schemas` — this would have caught the sync-path/discovery-path asymmetry that caused the reported error.
- Ran the full `clickhouse` source test suite locally: 247 passed (1 unrelated pre-existing error from a Postgres-backed test with no local DB connection in this sandbox — not exercised by this change).
- Ran `ruff check`/`ruff format --check` and `mypy` on the changed file: clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal bug fix, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was produced autonomously by an agent triaging a live error-tracking alert for the ClickHouse data warehouse source, with no human directing the session. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.

Investigation: pulled the error tracking issue and a full stack trace, confirmed the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`'s `get_rows`, then traced the query back to `_get_table` and found it lacked the ALIAS/EPHEMERAL filter that `get_schemas` already has (with a comment documenting this exact failure mode). Searched open PRs (human-authored and bot-authored) for a duplicate fix; found none.

No sensitive data (hostnames, table/column names, customer identifiers) from the original error is included in this PR — the fix and test use generic examples.