### PR TITLE
fix(clerk): follow Clerk's rename of commerce endpoints to /billing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/settings.py
@@ -21,7 +21,7 @@ class ClerkEndpointConfig:
     name: str
     path: str
     # `None` for endpoints whose objects carry no creation timestamp, so there is nothing stable
-    # to partition on (Clerk's `/domains` and `/commerce/plans`).
+    # to partition on (Clerk's `/domains` and `/billing/plans`).
     partition_key: Optional[str] = "created_at"
     page_size: int = 100  # Clerk default, max is 500
     # Some Clerk endpoints return {data: [...], total_count: ...}, others return direct arrays
@@ -101,14 +101,15 @@ CLERK_ENDPOINTS: dict[str, ClerkEndpointConfig] = {
     "sms_templates": ClerkEndpointConfig(name="sms_templates", path="/templates/sms"),
     "commerce_plans": ClerkEndpointConfig(
         name="commerce_plans",
-        path="/commerce/plans",
+        # Clerk renamed this from /commerce/plans to /billing/plans; the old path now answers 400.
+        path="/billing/plans",
         partition_key=None,
         is_wrapped_response=True,
         gated_feature="Billing",
     ),
     "commerce_subscription_items": ClerkEndpointConfig(
         name="commerce_subscription_items",
-        path="/commerce/subscription_items",
+        path="/billing/subscription_items",
         is_wrapped_response=True,
         gated_feature="Billing",
     ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -289,6 +289,18 @@ class TestClerkSourceResumeBehavior:
 
 
 class TestClerkEndpoints:
+    @pytest.mark.parametrize(
+        ("endpoint", "path"),
+        [
+            # Clerk renamed these from /commerce/... to /billing/...; the old path now answers
+            # 400 Bad Request instead of serving the list.
+            ("commerce_plans", "/billing/plans"),
+            ("commerce_subscription_items", "/billing/subscription_items"),
+        ],
+    )
+    def test_commerce_endpoints_use_the_renamed_billing_path(self, endpoint: str, path: str) -> None:
+        assert CLERK_ENDPOINTS[endpoint].path == path
+
     @pytest.mark.parametrize("endpoint", sorted(CLERK_ENDPOINTS))
     def test_resource_targets_the_configured_path(self, endpoint: str) -> None:
         config = CLERK_ENDPOINTS[endpoint]


### PR DESCRIPTION
## Problem

Clerk data warehouse syncs for the `commerce_plans` and `commerce_subscription_items` tables fail with a 400 error, seen in [this error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd679-1265-7501-86a4-d8242cf5b888).

Clerk renamed these list endpoints from `/commerce/plans` and `/commerce/subscription_items` to `/billing/plans` and `/billing/subscription_items`. The old paths now answer 400 Bad Request instead of listing rows. I confirmed the rename (and that the response shape is unchanged) against Clerk's public [OpenAPI spec repo](https://github.com/clerk/openapi-specs): `/commerce/plans` is present through the `2025-04-10` spec and gone by `2025-11-10`, replaced by `/billing/plans` with the same operation ID and response schema.

## Changes

- Point `commerce_plans` and `commerce_subscription_items` at the renamed `/billing/...` paths.
- Table names, column mapping, and the existing "Billing not enabled" gating logic stay the same, since only the request path changed upstream.

## How did you test this code?

- Added a parameterized case pinning both endpoints to their new `/billing/...` paths, so a regression back to the deprecated `/commerce/...` path fails a test instead of only failing in production.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/` locally: all pass.
- Not run: a live call against the real Clerk API (no test credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed; no user-facing or documented behavior changed beyond the internal request path.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to pull the issue's stack trace and confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py`. Cloned Clerk's public OpenAPI spec repo to verify the endpoint rename and confirm the response schema was unchanged. Invoked `/writing-tests` before adding the regression test and `/writing-pr-descriptions` before writing this body.