### PR TITLE
fix(definition-popover): add more fallback placements to prevent sidebar overlap in narrow windows

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
+++ b/frontend/src/lib/components/DefinitionPopover/DefinitionPopoverContents.tsx
@@ -772,7 +772,7 @@ export function ControlledDefinitionPopover({
                 </DefinitionPopover.Wrapper>
             }
             placement="right"
-            fallbackPlacements={['left']}
+            fallbackPlacements={['bottom', 'top', 'left']}
             middleware={[hide()]} // Hide the definition popover when the reference is off-screen
         />
     )


### PR DESCRIPTION
## Problem

When the definition popover (shown when hovering a property in the taxonomic filter breakdown popover) is placed on the right side of the filter row, and the window is narrow, the `flip` middleware only has `['left']` as a fallback. This causes the popover to flip to the left side, overlapping the category column sidebar and making it impossible to select a property category.

Fixes #31486

## Changes

Changed `ControlledDefinitionPopover`'s `fallbackPlacements` from `['left']` to `['bottom', 'top', 'left']`. This way, in narrow viewports the popover first tries to appear below or above the row, keeping the category column accessible.

## How to test

1. Open a Trends insight
2. Click "Add breakdown" 
3. Make the browser window narrow
4. Hover over a property in the right column of the dropdown
5. The definition popover should appear below or above the row, not covering the category column on the left