### PR TITLE
chore(batch-exports): drop replay branch for stage result patch

### DIFF
--- a/products/batch_exports/backend/temporal/pipeline/entrypoint.py
+++ b/products/batch_exports/backend/temporal/pipeline/entrypoint.py
@@ -207,26 +207,19 @@ async def execute_batch_export_using_internal_stage(
                 non_retryable_error_types=["InvalidFilterError", "DataIntervalEndInFutureError"],
             ),
         }
-        # The stage activity's return type changed from `str` (just the folder) to
-        # `InternalStageResult`. Guard with `workflow.patched` so workflows whose history
-        # recorded the old bare-string result still replay correctly during a rolling deploy.
-        # TODO: clean up once new code is fully rolled out
-        if workflow.patched("batch-exports-stage-result"):
-            stage_result = await workflow.execute_activity(
-                insert_into_internal_stage_activity, stage_inputs, **stage_activity_kwargs
-            )
-            batch_export_inputs.stage_folder = stage_result.stage_folder
-            batch_export_inputs.records_total = stage_result.records_total
-            if stage_result.records_total is not None:
-                workflow.set_current_details(details.add("Staged records", stage_result.records_total).render())
-        else:
-            # Pass the activity by name (not the typed callable): `execute_activity` overrides
-            # `result_type` with the callable's annotation, which would force the old recorded
-            # `str` result to deserialize as `InternalStageResult` and fail. The string form
-            # honors `result_type=str`.
-            batch_export_inputs.stage_folder = await workflow.execute_activity(
-                "insert_into_internal_stage_activity", stage_inputs, result_type=str, **stage_activity_kwargs
-            )
+        # All workers now run the `InternalStageResult` path, so the pre-patch bare-string
+        # branch is gone. `deprecate_patch` keeps the marker compatible for any execution
+        # still in flight that recorded it.
+        # See https://docs.temporal.io/develop/python/workflows/versioning#deprecated-patches
+        # TODO: delete this call once those histories have drained.
+        workflow.deprecate_patch("batch-exports-stage-result")
+        stage_result = await workflow.execute_activity(
+            insert_into_internal_stage_activity, stage_inputs, **stage_activity_kwargs
+        )
+        batch_export_inputs.stage_folder = stage_result.stage_folder
+        batch_export_inputs.records_total = stage_result.records_total
+        if stage_result.records_total is not None:
+            workflow.set_current_details(details.add("Staged records", stage_result.records_total).render())
         result = await workflow.execute_activity(
             activity,
             inputs,


### PR DESCRIPTION
## Problem

PR #64918 added a breaking change to our workflow due to an activity returning a different type from before. Due to this we needed to follow [Temporal's versioning system](https://docs.temporal.io/develop/python/workflows/versioning). Now that the code has been running for a while we want to clean it up.

## Changes

- `workflow.patched` becomes `workflow.deprecate_patch`, rather than disappearing. Deleting the call outright would fail replay for any execution still open that recorded the marker, because Temporal fails a Workflow Task when history holds a patch marker the code does not produce. A deprecated marker is tolerated instead.
- We then need to remove the `deprecate_patch` call in a later PR, once there are no open executions that predate this deployment.

## How did you test this code?

I didn't. Relying on Temporal's docs and our automated test suite.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus 5). Skills invoked: `/create-pr` and `/writing-pr-descriptions`.
