### PR TITLE
fix(data-imports): use dateReceived as the incremental field for Sentry event endpoints

### DIFF
--- a/products/warehouse_sources/backend/migrations/0120_fix_sentry_events_incremental_field.py
+++ b/products/warehouse_sources/backend/migrations/0120_fix_sentry_events_incremental_field.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+# The Sentry `issue_events` and `project_events` schemas fetch full event bodies (full=true),
+# which carry a `dateReceived` timestamp rather than the `dateCreated` field the lightweight
+# issue/event list serializers use. `dateCreated` was the only incremental field ever offered
+# for these two schemas, so every incremental sync of them failed at cursor extraction with
+# IncrementalFieldMissingFromDataError. Rewrite the stored config to the field Sentry actually
+# returns for these endpoints.
+
+AFFECTED_SCHEMA_NAMES = ("issue_events", "project_events")
+
+
+def forwards(apps, schema_editor):
+    ExternalDataSchema = apps.get_model("warehouse_sources", "ExternalDataSchema")
+
+    # One row per configured Sentry table (thousands, not events-scale) — a per-row loop is fine.
+    schemas = ExternalDataSchema.objects.filter(
+        source__source_type="Sentry",
+        deleted=False,
+        name__in=AFFECTED_SCHEMA_NAMES,
+        sync_type_config__incremental_field="dateCreated",
+    ).iterator()
+
+    for schema in schemas:
+        schema.sync_type_config["incremental_field"] = "dateReceived"
+        schema.save(update_fields=["sync_type_config"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [("warehouse_sources", "0119_scaffold_motion_source")]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0119_scaffold_motion_source
+0120_fix_sentry_events_incremental_field

--- a/products/warehouse_sources/backend/migrations/test/test_migration_0120.py
+++ b/products/warehouse_sources/backend/migrations/test/test_migration_0120.py
@@ -1,0 +1,51 @@
+import importlib
+
+import pytest
+
+from django.apps import apps
+
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
+
+migration_module = importlib.import_module(
+    "products.warehouse_sources.backend.migrations.0120_fix_sentry_events_incremental_field"
+)
+forwards = migration_module.forwards
+
+
+@pytest.fixture
+def schema_factory(team):
+    def _create(source_type, schema_name, incremental_field):
+        source = ExternalDataSource.objects.create(
+            source_id="src", connection_id="conn", team=team, source_type=source_type
+        )
+        return ExternalDataSchema.objects.create(
+            name=schema_name,
+            team=team,
+            source=source,
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+            sync_type_config={"incremental_field": incremental_field},
+        )
+
+    return _create
+
+
+@pytest.mark.django_db
+class TestFixSentryEventsIncrementalField:
+    @pytest.mark.parametrize(
+        "source_type, schema_name, incremental_field, expected",
+        [
+            ("Sentry", "issue_events", "dateCreated", "dateReceived"),  # broken value gets fixed
+            ("Sentry", "project_events", "dateCreated", "dateReceived"),  # both affected schemas fixed
+            ("Sentry", "issue_events", "dateReceived", "dateReceived"),  # already-correct value untouched
+            ("Sentry", "issues", "lastSeen", "lastSeen"),  # unrelated schema name untouched
+            ("Stripe", "issue_events", "dateCreated", "dateCreated"),  # unrelated source type untouched
+        ],
+    )
+    def test_forwards(self, schema_factory, source_type, schema_name, incremental_field, expected):
+        schema = schema_factory(source_type, schema_name, incremental_field)
+
+        forwards(apps, None)
+        forwards(apps, None)  # idempotent
+
+        schema.refresh_from_db()
+        assert schema.sync_type_config["incremental_field"] == expected

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/settings.py
@@ -50,10 +50,10 @@ FIRST_SEEN_INCREMENTAL: IncrementalField = {
     "field": "firstSeen",
     "field_type": IncrementalFieldType.DateTime,
 }
-DATE_CREATED_INCREMENTAL: IncrementalField = {
-    "label": "dateCreated",
+DATE_RECEIVED_INCREMENTAL: IncrementalField = {
+    "label": "dateReceived",
     "type": IncrementalFieldType.DateTime,
-    "field": "dateCreated",
+    "field": "dateReceived",
     "field_type": IncrementalFieldType.DateTime,
 }
 
@@ -83,8 +83,8 @@ EPOCH_TIMESTAMP_INCREMENTAL: IncrementalField = {
 }
 
 ISSUES_INCREMENTAL_FIELDS: list[IncrementalField] = [LAST_SEEN_INCREMENTAL, FIRST_SEEN_INCREMENTAL]
-DATE_CREATED_INCREMENTAL_FIELD: list[IncrementalField] = [
-    DATE_CREATED_INCREMENTAL,
+DATE_RECEIVED_INCREMENTAL_FIELD: list[IncrementalField] = [
+    DATE_RECEIVED_INCREMENTAL,
 ]
 LAST_SEEN_INCREMENTAL_FIELD: list[IncrementalField] = [
     LAST_SEEN_INCREMENTAL,
@@ -181,9 +181,12 @@ SENTRY_ENDPOINTS: dict[str, SentryEndpointConfig] = {
     "project_events": SentryEndpointConfig(
         name="project_events",
         path="/projects/{organization_slug}/{project_slug}/events/",
-        incremental_fields=DATE_CREATED_INCREMENTAL_FIELD,
-        default_incremental_field="dateCreated",
-        partition_key="date_created",
+        # full=true (below) makes Sentry return the full event body, which carries a
+        # `dateReceived` timestamp rather than the `dateCreated` field the lightweight
+        # issue/event list serializers use.
+        incremental_fields=DATE_RECEIVED_INCREMENTAL_FIELD,
+        default_incremental_field="dateReceived",
+        partition_key="date_received",
         primary_key=["project_id", "event_id"],
         fanout=DependentEndpointConfig(
             parent_name="projects",
@@ -239,9 +242,12 @@ SENTRY_ENDPOINTS: dict[str, SentryEndpointConfig] = {
     "issue_events": SentryEndpointConfig(
         name="issue_events",
         path="/organizations/{organization_slug}/issues/{issue_id}/events/",
-        incremental_fields=DATE_CREATED_INCREMENTAL_FIELD,
-        default_incremental_field="dateCreated",
-        partition_key="date_created",
+        # full=true (below) makes Sentry return the full event body, which carries a
+        # `dateReceived` timestamp rather than the `dateCreated` field the lightweight
+        # issue/event list serializers use.
+        incremental_fields=DATE_RECEIVED_INCREMENTAL_FIELD,
+        default_incremental_field="dateReceived",
+        partition_key="date_received",
         primary_key=["issue_id", "event_id"],
         fanout=DependentEndpointConfig(
             parent_name="issues",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -216,6 +216,21 @@ class TestSentryTransport:
 
     @parameterized.expand(
         [
+            ("issue_events",),
+            ("project_events",),
+        ]
+    )
+    def test_events_endpoints_default_to_date_received(self, endpoint) -> None:
+        # Both endpoints fetch full event bodies (child_params full=true), which carry a
+        # `dateReceived` timestamp rather than the `dateCreated` field the lightweight
+        # issue/event list serializers use. Defaulting to `dateCreated` here made every
+        # incremental sync of these tables fail with IncrementalFieldMissingFromDataError.
+        config = SENTRY_ENDPOINTS[endpoint]
+        assert config.default_incremental_field == "dateReceived"
+        assert [incremental_field["field"] for incremental_field in config.incremental_fields] == ["dateReceived"]
+
+    @parameterized.expand(
+        [
             ("projects", "/organizations/acme/projects/"),
             ("teams", "/organizations/acme/teams/"),
             ("members", "/organizations/acme/members/"),


### PR DESCRIPTION
## Problem

Every incremental sync of a Sentry `issue_events` or `project_events` table fails with `IncrementalFieldMissingFromDataError`, permanently pausing the schema. Confirmed in [error tracking](https://us.posthog.com/project/2/error_tracking/019fd673-7755-7962-9f4c-0a8f8ab9070b).

Both endpoints fetch full event bodies (`full=true`), which carry a `dateReceived` timestamp. `dateCreated` was the only incremental field ever offered for these two endpoints, so the configured cursor never matched a real column and every sync failed at cursor extraction.

## Changes

- Swap the `issue_events` and `project_events` endpoint configs to use `dateReceived` as the incremental field (and matching `partition_key`), the field Sentry's full event serializer actually returns.
- Add a data migration correcting already-configured schemas whose stored `incremental_field` is the broken `"dateCreated"` value, so existing paused schemas pick up the fix without manual reconfiguration.

## How did you test this code?

- Added `test_events_endpoints_default_to_date_received`, parameterized over both endpoints: guards against the default incremental field regressing to `dateCreated`.
- Added a migration test (mirroring the existing `test_migration_0075` pattern) covering the new data migration: fixes both affected schemas, is idempotent, and leaves unrelated schema names and source types untouched.
- Ran the full `test_sentry.py` suite (133 tests, all pass).
- Applied the new migration against a local dev database; `makemigrations --check` reports no model drift.
- Not run: a live sync against the real Sentry API (no test credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal source config only, no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue `019fd673-7755-7962-9f4c-0a8f8ab9070b`), reading the stack trace down to `get_incremental_field_value` in `pipelines/common/load.py`, then tracing the schema/pipeline-version properties on the exception event back to the Sentry `issue_events` source config. Confirmed the actual Sentry API field name via docs before changing the default. Skills invoked: `/django-migrations`, `/writing-tests`, `/writing-pr-descriptions`.