### PR TITLE
feat(error-tracking): modernize issue event list

### DIFF
--- a/frontend/src/lib/components/Errors/Exception/CollapsibleExceptionHeader.tsx
+++ b/frontend/src/lib/components/Errors/Exception/CollapsibleExceptionHeader.tsx
@@ -95,7 +95,7 @@ export function CollapsibleExceptionHeader({
                         role={!truncate && isClamped ? 'button' : undefined}
                         tabIndex={!truncate && isClamped ? 0 : undefined}
                         aria-expanded={!truncate && isClamped ? expanded : undefined}
-                        className={cn('text-[var(--gray-8)] leading-6 whitespace-pre-wrap', {
+                        className={cn('leading-6 whitespace-pre-wrap text-[var(--foreground)]', {
                             'line-clamp-1': truncate,
                             'line-clamp-3': !truncate && !expanded,
                             'cursor-pointer': !truncate && isClamped,

--- a/frontend/src/lib/components/Errors/Exception/known-exceptions/javascript/base.tsx
+++ b/frontend/src/lib/components/Errors/Exception/known-exceptions/javascript/base.tsx
@@ -2,7 +2,7 @@ import { LemonBanner } from '@posthog/lemon-ui'
 
 export function KnownExceptionBanner({ children }: { children: React.ReactNode }): JSX.Element {
     return (
-        <LemonBanner type="info" className="bg-surface-secondary">
+        <LemonBanner type="info" className="bg-info">
             {children}
         </LemonBanner>
     )

--- a/frontend/src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx
+++ b/frontend/src/lib/components/Errors/ExceptionList/CollapsibleExceptionList.tsx
@@ -81,7 +81,7 @@ function GroupedStackTraceRenderer({
     )
 
     return (
-        <div className="border-1 rounded overflow-hidden divide-y divide-solid">
+        <div className="border-1 divide-y divide-solid divide-border overflow-hidden rounded border-border bg-[var(--card)]">
             {frameGroups.map((group) => (
                 <Fragment key={group.type === 'frame' ? group.frame.raw_id : group.key}>
                     {group.type === 'frame'
@@ -139,7 +139,7 @@ export function CollapsibleExceptionList({
             <>
                 <button
                     type="button"
-                    className="flex w-full items-center justify-center gap-2 px-3 py-2 text-xs text-muted hover:text-primary hover:bg-fill-button-tertiary-hover"
+                    className="flex w-full items-center justify-center gap-2 bg-[var(--card)] px-3 py-2 text-xs text-muted-foreground hover:bg-fill-hover hover:text-[var(--foreground)]"
                     onClick={() => toggleVendorFrameGroup(group)}
                 >
                     <IconBox className="size-3 shrink-0" />
@@ -159,40 +159,42 @@ export function CollapsibleExceptionList({
     }
 
     return (
-        <div className={cn('flex flex-col gap-y-2', className)}>
-            <ExceptionListRenderer
-                exceptionList={exceptionList}
-                renderException={(exception, exceptionIndex) => {
-                    const exceptionKey = `${exception.id}:${exceptionIndex}`
-                    const part = getExceptionFingerprint(exception.id)
-                    return (
-                        <ExceptionRenderer
-                            exception={exception}
-                            renderExceptionHeader={(exception) => (
-                                <CollapsibleExceptionHeader
-                                    exception={exception}
-                                    loading={false}
-                                    fingerprint={part}
-                                    runtime={exceptionAttributes?.runtime}
-                                />
-                            )}
-                            renderResolvedTrace={(frames: ErrorTrackingStackFrame[]) => (
-                                <GroupedStackTraceRenderer
-                                    frames={frames}
-                                    exceptionId={exceptionKey}
-                                    expandSingleVendorGroupByDefault={exceptionIndex === 0}
-                                    stackFrameRecords={stackFrameRecords}
-                                    renderFrame={(frame, record) => renderFrame(exception, frame, record)}
-                                    renderVendorFrameGroup={renderVendorFrameGroup}
-                                />
-                            )}
-                            renderUndefinedTrace={(exception, known) => (
-                                <EmptyStackTrace exception={exception} knownException={known} />
-                            )}
-                        />
-                    )
-                }}
-            />
+        <div data-quill className="contents">
+            <div data-not-quill className={cn('flex flex-col gap-y-2', className)}>
+                <ExceptionListRenderer
+                    exceptionList={exceptionList}
+                    renderException={(exception, exceptionIndex) => {
+                        const exceptionKey = `${exception.id}:${exceptionIndex}`
+                        const part = getExceptionFingerprint(exception.id)
+                        return (
+                            <ExceptionRenderer
+                                exception={exception}
+                                renderExceptionHeader={(exception) => (
+                                    <CollapsibleExceptionHeader
+                                        exception={exception}
+                                        loading={false}
+                                        fingerprint={part}
+                                        runtime={exceptionAttributes?.runtime}
+                                    />
+                                )}
+                                renderResolvedTrace={(frames: ErrorTrackingStackFrame[]) => (
+                                    <GroupedStackTraceRenderer
+                                        frames={frames}
+                                        exceptionId={exceptionKey}
+                                        expandSingleVendorGroupByDefault={exceptionIndex === 0}
+                                        stackFrameRecords={stackFrameRecords}
+                                        renderFrame={(frame, record) => renderFrame(exception, frame, record)}
+                                        renderVendorFrameGroup={renderVendorFrameGroup}
+                                    />
+                                )}
+                                renderUndefinedTrace={(exception, known) => (
+                                    <EmptyStackTrace exception={exception} knownException={known} />
+                                )}
+                            />
+                        )
+                    }}
+                />
+            </div>
         </div>
     )
 }

--- a/frontend/src/lib/components/Errors/ExceptionList/ExceptionListRenderer.tsx
+++ b/frontend/src/lib/components/Errors/ExceptionList/ExceptionListRenderer.tsx
@@ -18,13 +18,13 @@ export function ExceptionListRenderer({
             {exceptionList.map((exception, index) => (
                 <div key={exception.id}>
                     {index > 0 && (
-                        <div className="flex items-center gap-2 my-2 ml-2 text-xs font-semibold text-muted uppercase tracking-wide">
+                        <div className="ml-2 my-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                             <span>↳</span>
                             <span>Caused by</span>
                             <div className="flex-1 border-t border-dashed border-border" />
                         </div>
                     )}
-                    <div className={cn(index > 0 && 'ml-4 pl-4 border-l-2 border-warning')}>
+                    <div className={cn(index > 0 && 'ml-4 border-l-2 border-warning-foreground pl-4')}>
                         {renderException(exception, index)}
                     </div>
                 </div>

--- a/frontend/src/lib/components/Errors/Frame/CodeVariablesInlineBanner.tsx
+++ b/frontend/src/lib/components/Errors/Frame/CodeVariablesInlineBanner.tsx
@@ -25,7 +25,7 @@ export function CodeVariablesInlineBanner(): JSX.Element | null {
     }
 
     return (
-        <div className="border-t border-border bg-fill-secondary px-3 py-2 text-xs text-muted-alt">
+        <div className="border-t border-border bg-fill-expanded px-3 py-2 text-xs text-muted-foreground">
             <div className="flex items-center justify-between gap-2">
                 <div className="flex-1">
                     <span className="italic">Code variables would appear here. </span>
@@ -42,7 +42,7 @@ export function CodeVariablesInlineBanner(): JSX.Element | null {
                     icon={<IconX />}
                     onClick={dismiss}
                     tooltip="Dismiss"
-                    className="text-muted-alt hover:text-default"
+                    className="text-muted-foreground hover:text-[var(--foreground)]"
                 />
             </div>
         </div>

--- a/frontend/src/lib/components/Errors/Frame/CollapsibleFrameHeader.tsx
+++ b/frontend/src/lib/components/Errors/Frame/CollapsibleFrameHeader.tsx
@@ -57,7 +57,7 @@ export function CollapsibleFrameHeader({
     }, [functionRef, sourceContent])
 
     return (
-        <div className={cn('flex w-full h-7')}>
+        <div className={cn('flex h-7 w-full bg-[var(--card)]')}>
             <Collapsible.Trigger
                 className={cn('collapsible-frame-header grow max-w-[calc(100%-30px)]', {
                     'cursor-progress': recordLoading,
@@ -116,7 +116,7 @@ function NoContextIcon({ lang, raw_id }: { lang: string; raw_id: string }): JSX.
 function SpinnerIcon(): JSX.Element {
     return (
         <Tooltip title="Loading source code...">
-            <IconSpinner className="text-secondary animate-spin" fontSize={15} />
+            <IconSpinner className="animate-spin text-muted-foreground" fontSize={15} />
         </Tooltip>
     )
 }
@@ -124,7 +124,7 @@ function SpinnerIcon(): JSX.Element {
 function VendorIcon(): JSX.Element {
     return (
         <Tooltip title="Vendor frame">
-            <IconBox className="text-secondary" fontSize={15} />
+            <IconBox className="text-muted-foreground" fontSize={15} />
         </Tooltip>
     )
 }
@@ -139,12 +139,12 @@ function UnresolvedIcon({ resolve_failure }: { resolve_failure: string | null })
                         Upload your symbol sets to improve issue grouping, see unminified source code and get release
                         information.
                     </p>
-                    <p className="text-xs text-secondary">{resolve_failure}</p>
+                    <p className="text-xs text-muted-foreground">{resolve_failure}</p>
                 </>
             }
             docLink="https://posthog.com/docs/error-tracking/upload-source-maps"
         >
-            <IconWarning className="text-secondary" fontSize={15} />
+            <IconWarning className="text-muted-foreground" fontSize={15} />
         </Tooltip>
     )
 }

--- a/frontend/src/lib/components/Errors/Frame/FrameContext.tsx
+++ b/frontend/src/lib/components/Errors/Frame/FrameContext.tsx
@@ -12,7 +12,7 @@ export function FrameContext({
 }): JSX.Element {
     const { before, line, after } = context
     return (
-        <div className="overflow-x-auto [&_span]:!whitespace-pre">
+        <div className="overflow-x-auto overscroll-x-none bg-[var(--card)] [&_span]:!whitespace-pre">
             <div className="w-fit min-w-full">
                 <FrameContextLine lines={before} language={language} />
                 <FrameContextLine lines={[line]} language={language} highlight />

--- a/frontend/src/lib/components/Errors/Frame/FrameContextLine.tsx
+++ b/frontend/src/lib/components/Errors/Frame/FrameContextLine.tsx
@@ -16,21 +16,24 @@ export function FrameContextLine({
     highlight?: boolean
 }): JSX.Element {
     const sortedLines = useMemo(() => [...lines].sort((a, b) => a.number - b.number), [lines])
+    const backgroundClassName = highlight
+        ? 'bg-[var(--card)] shadow-[inset_0_0_0_9999px_color-mix(in_oklab,var(--destructive)_50%,transparent)]'
+        : 'bg-[var(--card)]'
+
     return (
-        <div
-            className={clsx(
-                'border-l-2',
-                highlight
-                    ? 'border-l-danger bg-[color-mix(in_oklab,var(--color-bg-fill-error-highlight)_50%,transparent)]'
-                    : 'border-l-transparent bg-surface-primary'
-            )}
-        >
+        <div className={backgroundClassName}>
             {sortedLines.map(({ number, line }) => (
                 <div key={number} className="flex">
-                    <div className="w-12 shrink-0 pr-3 text-right text-secondary tabular-nums select-none">
+                    <div
+                        className={clsx(
+                            'sticky left-0 z-10 w-16 shrink-0 border-l-2 pr-5 text-right text-muted-foreground tabular-nums select-none',
+                            highlight ? 'border-l-[var(--destructive-foreground)]' : 'border-l-[var(--card)]',
+                            backgroundClassName
+                        )}
+                    >
                         {number}
                     </div>
-                    <CodeLine text={line} wrapLines={true} language={language} />
+                    <CodeLine text={line} wrapLines={false} language={language} />
                 </div>
             ))}
         </div>

--- a/frontend/src/lib/components/Errors/StackTrace/FilteredStackTrace.tsx
+++ b/frontend/src/lib/components/Errors/StackTrace/FilteredStackTrace.tsx
@@ -11,9 +11,9 @@ export function FilteredStackTrace({
     onShowAllFrames: () => void
 }): JSX.Element {
     return (
-        <div className="border-1 rounded flex justify-between items-center p-1 text-secondary">
-            <p className="text-xs font-medium my-0 pl-1 text-secondary">{framesCount} vendor frames</p>
-            <ButtonPrimitive onClick={onShowAllFrames} size="xs" className="text-secondary">
+        <div className="border-1 flex items-center justify-between rounded border-border p-1 text-muted-foreground">
+            <p className="my-0 pl-1 text-xs font-medium text-muted-foreground">{framesCount} vendor frames</p>
+            <ButtonPrimitive onClick={onShowAllFrames} size="xs" className="text-muted-foreground">
                 <IconBox />
                 Show all frames
             </ButtonPrimitive>

--- a/frontend/src/lib/components/SessionTimeline/SessionTimeline.scss
+++ b/frontend/src/lib/components/SessionTimeline/SessionTimeline.scss
@@ -1,8 +1,8 @@
 .SessionTimeline__scroll-container {
     // Session timeline only: reserve a visible gutter so the scrollbar area
     // doesn't visually blend into row actions.
-    box-shadow: inset -12px 0 0 var(--color-bg-fill-tertiary);
-    scrollbar-color: var(--trace-3000) var(--color-bg-fill-tertiary);
+    box-shadow: inset -12px 0 0 var(--muted);
+    scrollbar-color: var(--muted-foreground) var(--muted);
 
     &::-webkit-scrollbar {
         width: 0.75rem;
@@ -10,6 +10,6 @@
     }
 
     &::-webkit-scrollbar-track {
-        background: var(--color-bg-fill-tertiary);
+        background: var(--muted);
     }
 }

--- a/frontend/src/lib/components/SessionTimeline/SessionTimeline.stories.tsx
+++ b/frontend/src/lib/components/SessionTimeline/SessionTimeline.stories.tsx
@@ -39,7 +39,7 @@ function mockRenderer(category: ItemCategory): ItemRenderer<MockItem> {
         render: ({ item }) => (
             <div className="flex justify-between items-center gap-2">
                 <span className="font-medium text-xs truncate">{item.payload.label}</span>
-                <span className="text-secondary text-xs shrink-0">{item.payload.typeLabel}</span>
+                <span className="shrink-0 text-xs text-muted-foreground">{item.payload.typeLabel}</span>
             </div>
         ),
     }

--- a/frontend/src/lib/components/SessionTimeline/SessionTimeline.tsx
+++ b/frontend/src/lib/components/SessionTimeline/SessionTimeline.tsx
@@ -120,8 +120,8 @@ export const SessionTimeline = forwardRef<SessionTimelineHandle, SessionTimeline
     }, [activeCategories.length, items.length])
 
     return (
-        <div className={cn('flex h-full', className)}>
-            <div className="flex flex-col justify-between items-center p-1 border-r border-gray-3 shrink-0">
+        <div className={cn('flex h-full w-full min-w-0 overflow-hidden', className)}>
+            <div className="flex shrink-0 flex-col items-center justify-between border-r border-border p-1">
                 <CategoryToggleGroup>
                     {allCategories.map((cat) => (
                         <ItemCategoryToggle
@@ -149,7 +149,7 @@ export const SessionTimeline = forwardRef<SessionTimelineHandle, SessionTimeline
             <div
                 ref={setContainerRef}
                 data-attr="session-timeline-scroll-container"
-                className="SessionTimeline__scroll-container h-full w-full overflow-y-auto relative"
+                className="SessionTimeline__scroll-container relative h-full min-w-0 flex-1 overflow-y-auto"
                 style={{ scrollbarGutter: 'stable both-edges' }}
             >
                 <div className="pr-3">
@@ -184,8 +184,8 @@ const itemContainer = cva({
     base: 'w-full',
     variants: {
         selected: {
-            true: 'bg-[var(--gray-1)] border-1 border-accent',
-            false: 'border-b border-[var(--gray-2)]',
+            true: 'border-1 border-[var(--primary)] bg-fill-selected',
+            false: 'border-b border-border',
         },
     },
 })
@@ -209,7 +209,7 @@ function LoadingRow(): JSX.Element {
     return (
         <div className={cn(itemContainer({ selected: false }), 'flex items-center gap-2 px-2 h-[2rem]')}>
             <Spinner />
-            <span className="text-secondary text-xs">Loading...</span>
+            <span className="text-xs text-muted-foreground">Loading...</span>
         </div>
     )
 }
@@ -218,8 +218,8 @@ function EmptyTimelineState({ title, description }: { title: string; description
     return (
         <div className="h-full min-h-[160px] w-full flex items-center justify-center px-4">
             <div className="text-center">
-                <div className="text-sm text-secondary">{title}</div>
-                {description ? <div className="text-xs text-tertiary mt-1">{description}</div> : null}
+                <div className="text-sm text-muted-foreground">{title}</div>
+                {description ? <div className="mt-1 text-xs text-subtle-foreground">{description}</div> : null}
             </div>
         </div>
     )
@@ -239,8 +239,8 @@ function TimelineTimestampCell({
             type="button"
             disabled={!onTimeClick}
             className={cn(
-                'border-r-1 shrink-0 w-[96px] h-full flex items-center gap-1.5 px-2 text-xs text-tertiary',
-                onTimeClick ? 'cursor-pointer hover:bg-fill-button-tertiary-hover hover:text-primary' : 'cursor-default'
+                'border-r-1 flex h-full w-[96px] shrink-0 items-center gap-1.5 border-border px-2 text-xs text-subtle-foreground',
+                onTimeClick ? 'cursor-pointer hover:bg-fill-hover hover:text-[var(--foreground)]' : 'cursor-default'
             )}
             onClick={() => onTimeClick?.(item.timestamp)}
             aria-label={`Open recording at ${item.timestamp.format('HH:mm:ss')}`}
@@ -259,11 +259,11 @@ function TimelineRowMenu({ menuItems }: { menuItems: TimelineMenuItem[] }): JSX.
     }
 
     return (
-        <div className="border-l-1 shrink-0 w-7 h-full">
+        <div className="border-l-1 h-full w-7 shrink-0 border-border">
             <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                     <ButtonPrimitive
-                        className="h-full w-7 rounded-none outline-none text-tertiary hover:text-primary hover:bg-fill-button-tertiary-hover flex items-center justify-center"
+                        className="flex h-full w-7 items-center justify-center rounded-none text-subtle-foreground outline-none hover:bg-fill-hover hover:text-[var(--foreground)]"
                         aria-label="More actions"
                         data-attr="session-timeline-row-more"
                     >
@@ -323,7 +323,7 @@ const SessionTimelineItemContainer = forwardRef<HTMLDivElement, SessionTimelineI
                     <TimelineTimestampCell item={item} onTimeClick={onTimeClick} SourceIcon={renderer.sourceIcon} />
                     <div
                         className={cn(
-                            'flex items-center gap-2 flex-1 min-w-0 h-full pl-2 transition-colors hover:bg-fill-button-tertiary-hover',
+                            'flex h-full min-w-0 flex-1 items-center gap-2 pl-2 transition-colors hover:bg-fill-hover',
                             canExpand && 'cursor-pointer'
                         )}
                         onClick={toggleExpanded}
@@ -339,7 +339,7 @@ const SessionTimelineItemContainer = forwardRef<HTMLDivElement, SessionTimelineI
                             <renderer.render item={item} sessionId={sessionId} />
                         </div>
                         {canExpand ? (
-                            <span className="shrink-0 pr-2 text-tertiary flex items-center justify-center">
+                            <span className="flex shrink-0 items-center justify-center pr-2 text-subtle-foreground">
                                 {expanded ? <IconCollapse /> : <IconExpand />}
                             </span>
                         ) : null}
@@ -348,13 +348,13 @@ const SessionTimelineItemContainer = forwardRef<HTMLDivElement, SessionTimelineI
                 </div>
 
                 {expanded ? (
-                    <div className="w-full border-t border-border bg-surface-secondary">
+                    <div className="w-full border-t border-border bg-fill-expanded">
                         {renderer.renderExpanded ? (
                             <div className="text-xs p-2">
                                 <renderer.renderExpanded item={item} sessionId={sessionId} />
                             </div>
                         ) : (
-                            <div className="text-xs p-2 text-secondary">No details available</div>
+                            <div className="p-2 text-xs text-muted-foreground">No details available</div>
                         )}
                     </div>
                 ) : null}
@@ -369,7 +369,7 @@ function CategoryToggleGroup({ children }: { children: React.ReactNode }): JSX.E
             className={cn(
                 'flex flex-col gap-0.5',
                 '[&>button]:rounded [&>button]:border-0 [&>button]:px-2 [&>button]:py-1.5',
-                '[&>button:hover]:bg-fill-button-tertiary-hover'
+                '[&>button:hover]:bg-fill-hover'
             )}
         >
             {children}
@@ -381,8 +381,8 @@ const itemCategoryToggle = cva({
     base: 'shrink-0 transition-colors',
     variants: {
         active: {
-            true: 'text-accent',
-            false: 'text-muted opacity-50',
+            true: 'text-[var(--primary)]',
+            false: 'text-muted-foreground opacity-50',
         },
     },
 })

--- a/frontend/src/lib/components/SessionTimeline/timeline/items/base.tsx
+++ b/frontend/src/lib/components/SessionTimeline/timeline/items/base.tsx
@@ -11,7 +11,10 @@ export function BasePreview({
         <div className="flex justify-between items-center">
             <span className="font-medium">{name}</span>
             {description && (
-                <span className="text-secondary text-xs line-clamp-1 max-w-2/3 text-right" title={descriptionTitle}>
+                <span
+                    className="max-w-2/3 line-clamp-1 text-right text-xs text-muted-foreground"
+                    title={descriptionTitle}
+                >
                     {description}
                 </span>
             )}
@@ -114,7 +117,7 @@ export function StandardizedPreview({
     const primary = <span className="truncate block">{truncatedPrimaryText}</span>
 
     const secondary = (
-        <span className={secondaryMuted ? 'text-tertiary truncate block' : 'truncate block'}>
+        <span className={secondaryMuted ? 'block truncate text-subtle-foreground' : 'block truncate'}>
             {truncatedSecondaryText}
         </span>
     )
@@ -130,7 +133,7 @@ export function StandardizedPreview({
                 </div>
                 {truncatedSecondaryText ? (
                     <>
-                        <span aria-hidden className="text-tertiary text-[10px] leading-none shrink-0 mx-1">
+                        <span aria-hidden className="mx-1 shrink-0 text-[10px] leading-none text-subtle-foreground">
                             •
                         </span>
                         <div

--- a/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
+++ b/frontend/src/lib/components/SessionTimeline/timeline/items/eventDetails.tsx
@@ -186,7 +186,7 @@ export const LazyEventDetailsRenderer: React.FC<RendererProps<TimelineItem>> = (
 
     if (loading) {
         return (
-            <div className="p-2 text-xs text-secondary flex items-center gap-2">
+            <div className="flex items-center gap-2 p-2 text-xs text-muted-foreground">
                 <Spinner textColored />
                 <span>Loading event details...</span>
             </div>
@@ -194,7 +194,7 @@ export const LazyEventDetailsRenderer: React.FC<RendererProps<TimelineItem>> = (
     }
 
     if (!event) {
-        return <div className="p-2 text-xs text-secondary">Event details unavailable</div>
+        return <div className="p-2 text-xs text-muted-foreground">Event details unavailable</div>
     }
 
     return <SessionEventDetails event={event} errorDisplayIdSuffix="session-timeline-expanded" />

--- a/frontend/src/lib/components/SessionTimeline/timeline/items/logs.tsx
+++ b/frontend/src/lib/components/SessionTimeline/timeline/items/logs.tsx
@@ -36,7 +36,7 @@ export const consoleLogRenderer: ItemRenderer<ConsoleLogItem> = {
 
         return (
             <div className="space-y-1">
-                <div className="text-xs text-tertiary">Level: {levelLabel}</div>
+                <div className="text-xs text-subtle-foreground">Level: {levelLabel}</div>
                 <pre className="text-xs whitespace-pre-wrap break-words mb-0">{item.payload.message}</pre>
             </div>
         )

--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 import { LemonDropdown } from './LemonDropdown'
 
@@ -8,6 +8,32 @@ describe('LemonDropdown', () => {
     // jest.setupAfterEnv does not enable RTL auto-cleanup; unmount between tests so the portal stays isolated.
     afterEach(() => {
         cleanup()
+        jest.useRealTimers()
+    })
+
+    it('delays opening a hover dropdown when configured', () => {
+        jest.useFakeTimers()
+        const onVisibilityChange = jest.fn()
+
+        render(
+            <LemonDropdown
+                trigger="hover"
+                hoverOpenDelayMs={500}
+                onVisibilityChange={onVisibilityChange}
+                overlay={<div>Menu</div>}
+            >
+                <button>Open</button>
+            </LemonDropdown>
+        )
+
+        fireEvent.mouseEnter(screen.getByText('Open'))
+        expect(onVisibilityChange).not.toHaveBeenCalled()
+
+        act(() => jest.advanceTimersByTime(499))
+        expect(onVisibilityChange).not.toHaveBeenCalled()
+
+        act(() => jest.advanceTimersByTime(1))
+        expect(onVisibilityChange).toHaveBeenCalledWith(true)
     })
 
     // `e.relatedTarget` on a mouseleave is null when the cursor leaves the document and can be a

--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useContext, useRef, useState } from 'react'
+import React, { MouseEventHandler, useContext, useEffect, useRef, useState } from 'react'
 
 import { Popover, PopoverOverlayContext, PopoverProps } from '../Popover'
 
@@ -18,6 +18,7 @@ export interface LemonDropdownProps extends Omit<PopoverProps, 'children' | 'vis
     closeOnClickInside?: boolean
     /** @default 'click' */
     trigger?: 'click' | 'hover'
+    hoverOpenDelayMs?: number
     children: React.ReactElement<
         Record<string, any> & {
             onClick: MouseEventHandler
@@ -38,6 +39,7 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
             onMouseLeaveInside,
             closeOnClickInside = true,
             trigger = 'click',
+            hoverOpenDelayMs = 0,
             children,
             startVisible,
             ...popoverProps
@@ -51,6 +53,23 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
 
         const floatingRef = useRef<HTMLDivElement>(null)
         const referenceRef = useRef<HTMLSpanElement>(null)
+        const hoverOpenTimeoutRef = useRef<number | null>(null)
+
+        const clearHoverOpenTimeout = (): void => {
+            if (hoverOpenTimeoutRef.current !== null) {
+                window.clearTimeout(hoverOpenTimeoutRef.current)
+                hoverOpenTimeoutRef.current = null
+            }
+        }
+
+        useEffect(
+            () => () => {
+                if (hoverOpenTimeoutRef.current !== null) {
+                    window.clearTimeout(hoverOpenTimeoutRef.current)
+                }
+            },
+            []
+        )
 
         const effectiveVisible = visible ?? localVisible
 
@@ -94,6 +113,7 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
             >
                 {React.cloneElement(children, {
                     onClick: (e: React.MouseEvent): void => {
+                        clearHoverOpenTimeout()
                         setVisible(!effectiveVisible)
                         children.props.onClick?.(e)
                         if (parentPopoverLevel > -1) {
@@ -104,10 +124,19 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
                     },
                     onMouseEnter: (): void => {
                         if (trigger === 'hover') {
-                            setVisible(true)
+                            clearHoverOpenTimeout()
+                            if (hoverOpenDelayMs > 0) {
+                                hoverOpenTimeoutRef.current = window.setTimeout(() => {
+                                    hoverOpenTimeoutRef.current = null
+                                    setVisible(true)
+                                }, hoverOpenDelayMs)
+                            } else {
+                                setVisible(true)
+                            }
                         }
                     },
                     onMouseLeave: (e: React.MouseEvent): void => {
+                        clearHoverOpenTimeout()
                         const relatedTarget = e.relatedTarget
                         if (
                             trigger === 'hover' &&

--- a/products/error_tracking/frontend/ErrorTracking.stories.tsx
+++ b/products/error_tracking/frontend/ErrorTracking.stories.tsx
@@ -4,12 +4,106 @@ import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
 import { mswDecorator } from '~/mocks/browser'
+import { ErrorTrackingQueryResponse, NodeKind } from '~/queries/schema/schema-general'
 
-import {
-    errorTrackingEventsQueryResponse,
-    errorTrackingQueryResponse,
-    errorTrackingTypeIssue,
-} from './__mocks__/error_tracking_query'
+import { errorTrackingQueryResponse, errorTrackingTypeIssue } from './__mocks__/error_tracking_query'
+import { TEST_EVENTS } from './__mocks__/events'
+import { results as stackFrameResults } from './__mocks__/stack_frames/batch_get'
+
+const ISSUE_ID = 'issue-id'
+const FINGERPRINT = String(TEST_EVENTS.javascript_resolved.properties.$exception_fingerprint)
+const STORY_STACK_FRAME_RESULTS = stackFrameResults.map((record) => ({
+    ...record,
+    raw_id: record.raw_id.includes('/') ? record.raw_id : `${record.raw_id}/0`,
+}))
+const STORY_TIMESTAMPS = [
+    '2024-07-08T15:42:00.000Z',
+    '2024-07-08T13:18:00.000Z',
+    '2024-07-08T09:05:00.000Z',
+    '2024-07-07T21:51:00.000Z',
+    '2024-07-07T16:27:00.000Z',
+    '2024-07-07T11:03:00.000Z',
+    '2024-07-06T18:34:00.000Z',
+    '2024-07-06T08:12:00.000Z',
+]
+const STORY_EVENT_UUIDS = STORY_TIMESTAMPS.map((_, index) => `story-event-${index}`)
+const STORY_EVENT_PROPERTIES = JSON.stringify({
+    ...TEST_EVENTS.javascript_resolved.properties,
+    $exception_fingerprint: FINGERPRINT,
+})
+const STORY_EXCEPTION_LIST = TEST_EVENTS.javascript_resolved.properties.$exception_list
+const STORY_TIMELINE_RESPONSE = {
+    results: STORY_TIMESTAMPS.map((timestamp, index) => [
+        STORY_EVENT_UUIDS[index],
+        '$exception',
+        timestamp,
+        'web',
+        null,
+        STORY_EXCEPTION_LIST,
+        FINGERPRINT,
+        ISSUE_ID,
+    ]),
+}
+const STORY_PERSON = {
+    id: 'story-person',
+    uuid: 'story-person',
+    distinct_id: 'story-person',
+    created_at: '2024-07-01T10:00:00.000Z',
+    properties: { email: 'developer@example.com' },
+}
+const STORY_EVENTS_RESPONSE = {
+    columns: ['*', 'timestamp', 'person'],
+    hasMore: false,
+    results: STORY_TIMESTAMPS.map((timestamp, index) => [
+        {
+            uuid: STORY_EVENT_UUIDS[index],
+            event: '$exception',
+            distinct_id: STORY_PERSON.distinct_id,
+            properties: JSON.parse(STORY_EVENT_PROPERTIES),
+        },
+        timestamp,
+        STORY_PERSON,
+    ]),
+}
+const STORY_POSITION_EVENT = {
+    uuid: STORY_EVENT_UUIDS[0],
+    distinct_id: STORY_PERSON.distinct_id,
+    timestamp: STORY_TIMESTAMPS[0],
+    properties: STORY_EVENT_PROPERTIES,
+}
+const STORY_ISSUE = {
+    ...errorTrackingTypeIssue,
+    id: ISSUE_ID,
+    name: 'Non-OK response',
+    description: 'The billing request returned an unsuccessful response.',
+    first_seen: STORY_TIMESTAMPS.at(-1)!,
+}
+const STORY_SUMMARY_RESPONSE: ErrorTrackingQueryResponse = {
+    ...errorTrackingQueryResponse,
+    results: [
+        {
+            ...errorTrackingQueryResponse.results[0],
+            ...STORY_ISSUE,
+            first_seen: STORY_TIMESTAMPS.at(-1)!,
+            last_seen: STORY_TIMESTAMPS[0],
+            first_event: {
+                ...STORY_POSITION_EVENT,
+                uuid: STORY_EVENT_UUIDS.at(-1)!,
+                timestamp: STORY_TIMESTAMPS.at(-1)!,
+            },
+            last_event: STORY_POSITION_EVENT,
+            aggregations: {
+                occurrences: 38,
+                sessions: 21,
+                users: 8,
+                volume_buckets: Array.from({ length: 32 }, (_, index) => ({
+                    label: new Date(Date.UTC(2024, 6, 2, index * 5)).toISOString(),
+                    value: [0, 1, 2, 1, 3, 5, 2, 4][index % 8],
+                })),
+            },
+        },
+    ],
+}
 
 const meta: Meta = {
     component: App,
@@ -19,16 +113,54 @@ const meta: Meta = {
         viewMode: 'story',
         mockDate: '2024-07-09', // To stabilize relative dates
         pageUrl: urls.errorTracking(),
-        testOptions: { viewport: { width: 1300, height: 2000 } },
+        testOptions: { viewport: { width: 1440, height: 1000 } },
     },
     decorators: [
         mswDecorator({
             get: {
-                'api/projects/:team_id/error_tracking/issue/:id': () => [200, errorTrackingTypeIssue],
+                '/api/organizations/:organization_id/product_push_campaign/active/': [204, null],
+                '/api/environments/:team_id/health_issues/summary/': [200, {}],
+                '/api/projects/:team_id/logs_config/': [
+                    200,
+                    {
+                        logs_distinct_id_attribute_key: 'posthogDistinctId',
+                        logs_distinct_id_attribute_keys: ['posthogDistinctId'],
+                        logs_session_id_attribute_keys: ['posthogSessionId'],
+                    },
+                ],
+                '/api/environments/:team_id/error_tracking/issues/exists/': [200, { exists: true }],
+                '/api/environments/:team_id/error_tracking/issues/:id/': [200, STORY_ISSUE],
+                '/api/environments/:team_id/error_tracking/fingerprints': [
+                    200,
+                    {
+                        next: null,
+                        results: [
+                            {
+                                fingerprint: FINGERPRINT,
+                                issue_id: ISSUE_ID,
+                                created_at: STORY_TIMESTAMPS.at(-1),
+                            },
+                        ],
+                    },
+                ],
+                '/api/environments/:team_id/error_tracking/spike_events': [200, { results: [] }],
             },
             post: {
-                '/api/environments/:team_id/query/ErrorTrackingQuery': () => [200, errorTrackingQueryResponse],
-                '/api/environments/:team_id/query/EventsQuery': () => [200, errorTrackingEventsQueryResponse],
+                '/api/environments/:team_id/query/:kind/': async ({ request }) => {
+                    const body = (await request.json()) as { query?: { kind?: string; select?: string[] } }
+                    if (body.query?.kind === NodeKind.EventsQuery) {
+                        return body.query.select?.includes('properties.$exception_list')
+                            ? [200, STORY_TIMELINE_RESPONSE]
+                            : [200, STORY_EVENTS_RESPONSE]
+                    }
+                    return body.query?.kind === NodeKind.HogQLQuery
+                        ? [200, { results: [] }]
+                        : [200, STORY_SUMMARY_RESPONSE]
+                },
+                '/api/environments/:team_id/error_tracking/stack_frames/batch_get/': [
+                    200,
+                    { results: STORY_STACK_FRAME_RESULTS },
+                ],
             },
         }),
     ],
@@ -37,4 +169,7 @@ export default meta
 
 type Story = StoryObj<{}>
 export const ListPage: Story = {}
-export const GroupPage: Story = { parameters: { pageUrl: urls.errorTrackingIssue('id') } }
+export const GroupPage: Story = {
+    name: 'Issue scene',
+    parameters: { pageUrl: urls.errorTrackingIssue(ISSUE_ID) },
+}

--- a/products/error_tracking/frontend/components/Assignee/ErrorTrackingAssigneeSelectButton.tsx
+++ b/products/error_tracking/frontend/components/Assignee/ErrorTrackingAssigneeSelectButton.tsx
@@ -26,17 +26,19 @@ export function ErrorTrackingAssigneeSelectButton({
     return (
         <AssigneeSelect assignee={assignee ?? null} onChange={onChange} fullWidth={fullWidth}>
             {(displayAssignee) => (
-                <LemonButton type="secondary" size="small" fullWidth={fullWidth}>
-                    <span className="flex items-center gap-1 min-w-0">
-                        <AssigneeIconDisplay assignee={displayAssignee} size="small" />
-                        <AssigneeLabelDisplay
-                            assignee={displayAssignee}
-                            placeholder={placeholder}
-                            size="small"
-                            className="truncate"
-                        />
-                    </span>
-                </LemonButton>
+                <div data-not-quill className="contents">
+                    <LemonButton type="secondary" size="small" fullWidth={fullWidth}>
+                        <span className="flex items-center gap-1 min-w-0">
+                            <AssigneeIconDisplay assignee={displayAssignee} size="small" />
+                            <AssigneeLabelDisplay
+                                assignee={displayAssignee}
+                                placeholder={placeholder}
+                                size="small"
+                                className="truncate"
+                            />
+                        </span>
+                    </LemonButton>
+                </div>
             )}
         </AssigneeSelect>
     )

--- a/products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.tsx
+++ b/products/error_tracking/frontend/components/ContextDisplay/ContextDisplay.tsx
@@ -102,7 +102,7 @@ export function ContextDisplay({
         <>
             {match(loading)
                 .with(true, () => (
-                    <div className="flex justify-center w-full h-32 items-center">
+                    <div data-not-quill className="flex justify-center w-full h-32 items-center">
                         <Spinner />
                     </div>
                 ))

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -1,29 +1,41 @@
-import clsx from 'clsx'
+import { useValues } from 'kea'
+import { router } from 'kea-router'
 
-import { IconAI } from '@posthog/icons'
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { IconAI, IconEllipsis, IconLive } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
 
 import { ErrorEventType } from 'lib/components/Errors/types'
-import { getExceptionAttributes, getRecordingStatus, getSessionId } from 'lib/components/Errors/utils'
+import { getRecordingStatus, getRuntimeFromLib, getSessionId } from 'lib/components/Errors/utils'
 import { TZLabel } from 'lib/components/TZLabel'
-import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
-import { IconLink } from 'lib/lemon-ui/icons'
-import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { useRecordingButton } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import { IconLink, IconPlayCircle } from 'lib/lemon-ui/icons'
+import {
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Spinner,
+    Table,
+    TableBody,
+    TableCell,
+    TableEmpty,
+    TableFooter,
+    TableRow,
+} from 'lib/ui/quill'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 import { asDisplay } from 'scenes/persons/person-utils'
-import { PersonDisplay, PersonIcon } from 'scenes/persons/PersonDisplay'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
 
 import { EventsQuery } from '~/queries/schema/schema-general'
 
-import { ViewLogsButton } from 'products/logs/frontend/components/ViewLogsButton'
+import { useViewLogsButton } from 'products/logs/frontend/components/ViewLogsButton'
 
-import { useErrorTagRenderer } from '../../hooks/use-error-tag-renderer'
+import { errorTrackingIssueSceneLogic } from '../../scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic'
 import { cancelEvent } from '../../utils'
-import { DataSourceTable, DataSourceTableColumn } from '../DataSourceTable'
-import { ExceptionAttributesPreview } from '../ExceptionAttributesPreview'
-import { CustomSeparator } from '../TableColumns'
+import { RuntimeIcon } from '../RuntimeIcon'
 import { eventsSourceLogic } from './eventsSourceLogic'
 
 export interface EventsTableProps {
@@ -34,76 +46,126 @@ export interface EventsTableProps {
 }
 
 export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: EventsTableProps): JSX.Element {
-    const tagRenderer = useErrorTagRenderer()
     const dataSource = eventsSourceLogic({ queryKey, query })
+    const { items, itemsLoading, canLoadNextData } = useValues(dataSource)
+    const { summary } = useValues(errorTrackingIssueSceneLogic)
 
     function isEventSelected(record: ErrorEventType): boolean {
         return selectedEvent ? selectedEvent.uuid === record.uuid : false
     }
 
     function renderTitle(record: ErrorEventType): JSX.Element {
+        const library = record.properties.$lib
+        const runtime = getRuntimeFromLib(typeof library === 'string' ? library : null)
+
         return (
-            <LemonTableLink
-                title={
-                    <div className="flex gap-x-1">
-                        <Link onClick={() => onEventSelect(record)} subtle className="line-clamp-1">
-                            {record.properties.$exception_types[0]}
-                        </Link>
-                        {tagRenderer(record)}
-                    </div>
-                }
-                description={
-                    <div className="space-y-0.5">
-                        <span className="line-clamp-1">{record.properties.$exception_values[0]}</span>
-                        <div className="flex items-center">
-                            <div>{renderTime(record)}</div>
-                            <CustomSeparator />
-                            <Person person={record.person} />
-                        </div>
-                    </div>
-                }
-                className="w-full"
-            />
+            <div className="grid w-full min-w-0 grid-cols-[0.75rem_minmax(0,1fr)] items-center gap-x-2 gap-y-0.5 py-0.5">
+                <RuntimeIcon runtime={runtime} fontSize="0.75rem" />
+                <div className="min-w-0 truncate text-sm font-semibold">{record.properties.$exception_types[0]}</div>
+                <div className="col-span-2 min-w-0 truncate text-xs text-muted-foreground">
+                    {record.properties.$exception_values[0]}
+                </div>
+            </div>
         )
     }
 
-    function renderAttributes(record: ErrorEventType): JSX.Element {
+    function renderMetadata(record: ErrorEventType): JSX.Element {
+        const hasPerson = Boolean(record.person?.id || record.person?.uuid)
+
         return (
-            <div className="flex justify-end gap-1">
-                <ExceptionAttributesPreview attributes={getExceptionAttributes(record.properties)} />
+            <div className="flex w-full min-w-0 flex-col items-end justify-center overflow-hidden whitespace-nowrap text-xs text-muted-foreground">
+                {hasPerson && (
+                    <div className="flex w-full min-w-0 justify-end overflow-hidden">
+                        <Person person={record.person} />
+                    </div>
+                )}
+                <div className="shrink-0">{renderTime(record)}</div>
             </div>
         )
     }
 
     function renderTime(record: ErrorEventType): JSX.Element {
-        return <TZLabel time={record.timestamp} />
-    }
-
-    function renderRowSelectedIndicator(record: ErrorEventType): JSX.Element {
         return (
-            <div
-                className={cn(
-                    'w-1 min-h-[84px]',
-                    isEventSelected(record)
-                        ? 'bg-primary-3000 hover:bg-primary-3000'
-                        : 'hover:bg-color-accent-highlight-secondary'
-                )}
-            />
+            <span data-not-quill className="contents">
+                <TZLabel time={record.timestamp} hoverOpenDelayMs={500} />
+            </span>
         )
     }
 
+    function renderRowTimelineIndicator(record: ErrorEventType): JSX.Element {
+        const color =
+            record.uuid === summary?.first_event_uuid
+                ? 'bg-[var(--brand-blue)]'
+                : record.uuid === summary?.last_event_uuid
+                  ? 'bg-[var(--brand-red)]'
+                  : 'bg-[var(--brand-yellow)]'
+
+        return <div className={cn('min-h-[56px] w-1', isEventSelected(record) ? color : 'bg-transparent')} />
+    }
+
     return (
-        <DataSourceTable<ErrorEventType>
-            dataSource={dataSource}
-            embedded
-            onRowClick={(record) => onEventSelect(record)}
-            className="overflow-auto"
-        >
-            <DataSourceTableColumn<ErrorEventType> className="p-0" cellRenderer={renderRowSelectedIndicator} />
-            <DataSourceTableColumn<ErrorEventType> title="Exception" cellRenderer={renderTitle} />
-            <DataSourceTableColumn<ErrorEventType> title="Labels" align="right" cellRenderer={renderAttributes} />
-            <DataSourceTableColumn<ErrorEventType> title="Actions" align="right" cellRenderer={Actions} />
-        </DataSourceTable>
+        <Table fullWidth size="sm" tableClassName="table-fixed bg-transparent">
+            <colgroup>
+                <col className="w-1" />
+                <col />
+            </colgroup>
+            {items.length > 0 ? (
+                <TableBody>
+                    {items.map((record) => (
+                        <TableRow
+                            key={record.uuid}
+                            data-state={isEventSelected(record) ? 'selected' : undefined}
+                            className={cn(
+                                'cursor-pointer',
+                                isEventSelected(record)
+                                    ? '[&_[data-slot=table-cell]]:!bg-[var(--fill-selected)] [&:hover_[data-slot=table-cell]]:!bg-[var(--fill-expanded)]'
+                                    : '[&:hover_[data-slot=table-cell]]:!bg-[var(--fill-hover)]'
+                            )}
+                            onClick={() => onEventSelect(record)}
+                        >
+                            <TableCell className="w-1 p-0">{renderRowTimelineIndicator(record)}</TableCell>
+                            <TableCell className="min-w-0 overflow-hidden p-0">
+                                <div className="flex w-full min-w-0 items-center">
+                                    <div className="min-w-0 flex-1 overflow-hidden px-3 py-2">
+                                        {renderTitle(record)}
+                                    </div>
+                                    <div className="w-[35%] min-w-28 max-w-56 shrink-0 overflow-hidden py-2 pl-3 pr-4 text-right">
+                                        {renderMetadata(record)}
+                                    </div>
+                                    <div className="flex w-10 shrink-0 justify-end py-2 pr-4">
+                                        <EventActions record={record} />
+                                    </div>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            ) : (
+                <TableEmpty className="py-6 text-muted-foreground">
+                    {itemsLoading ? 'Loading exceptions...' : 'No exceptions found.'}
+                </TableEmpty>
+            )}
+            {items.length > 0 && (
+                <TableFooter>
+                    <TableRow>
+                        <TableCell colSpan={2} className="bg-transparent! p-1">
+                            <div className="flex h-7 items-center justify-center gap-1 text-xs text-muted-foreground">
+                                {itemsLoading ? (
+                                    <>
+                                        <Spinner className="size-3" />
+                                        Loading...
+                                    </>
+                                ) : canLoadNextData ? (
+                                    'Scroll to load more'
+                                ) : (
+                                    'No more entries'
+                                )}
+                            </div>
+                        </TableCell>
+                    </TableRow>
+                </TableFooter>
+            )}
+        </Table>
     )
 }
 
@@ -111,74 +173,90 @@ const Person = ({ person }: { person: ErrorEventType['person'] }): JSX.Element =
     const display = asDisplay(person)
 
     return (
-        <PersonDisplay person={person} noLink>
-            <Link subtle className={clsx('flex items-center')}>
-                <PersonIcon displayName={display} person={person} size="md" />
-                <span className={clsx('ph-no-capture', 'truncate')}>{display}</span>
-            </Link>
-        </PersonDisplay>
+        <span data-not-quill className="contents">
+            <PersonDisplay person={person} noLink className="inline-flex max-w-full min-w-0 overflow-hidden">
+                <Link subtle className="inline-flex max-w-full min-w-0 items-center overflow-hidden">
+                    <span className="ph-no-capture truncate">{display}</span>
+                </Link>
+            </PersonDisplay>
+        </span>
     )
 }
 
-const Actions = (record: ErrorEventType): JSX.Element => {
+const EventActions = ({ record }: { record: ErrorEventType }): JSX.Element => {
     const sessionId = getSessionId(record.properties)
     const recordingStatus = getRecordingStatus(record.properties)
     const hasRecording = record.properties.$has_recording as boolean | undefined
+    const {
+        onClick: viewRecording,
+        disabledReason: recordingDisabledReason,
+        warningReason: recordingWarningReason,
+    } = useRecordingButton({
+        sessionId: sessionId ?? '',
+        recordingStatus,
+        hasRecording,
+        timestamp: record.timestamp,
+    })
+    const logs = useViewLogsButton({ sessionId, timestamp: record.timestamp })
+    const recordingTooltip =
+        typeof recordingDisabledReason === 'string' ? recordingDisabledReason : recordingWarningReason
 
     return (
-        <div className="flex justify-end gap-1">
-            <div className="flex justify-end align-middle items-center" onClick={(event) => cancelEvent(event)}>
-                <ViewRecordingButton
-                    type="secondary"
-                    sessionId={sessionId ?? ''}
-                    recordingStatus={recordingStatus}
-                    hasRecording={hasRecording}
-                    timestamp={record.timestamp}
-                    size="xsmall"
-                    data-attr="error-tracking-view-recording"
-                    iconOnly
-                />
-            </div>
-            <div className="flex justify-end align-middle items-center" onClick={(event) => cancelEvent(event)}>
-                <ViewLogsButton
-                    type="secondary"
-                    sessionId={sessionId}
-                    timestamp={record.timestamp}
-                    size="xsmall"
-                    data-attr="error-tracking-view-logs"
-                    iconOnly
-                />
-            </div>
-            {record.properties.$ai_trace_id && (
-                <LemonButton
-                    size="small"
-                    icon={<IconAI />}
-                    onClick={(event) => {
-                        cancelEvent(event)
-                        urls.aiObservabilityTrace(record.properties.$ai_trace_id, {
-                            event: record.uuid,
-                            timestamp: record.timestamp,
-                        })
-                    }}
-                    disabledReason={
-                        !record.properties.$ai_trace_id ? 'There is no LLM Trace ID on this event' : undefined
-                    }
-                    tooltip={record.properties.$ai_trace_id ? 'View LLM Trace' : undefined}
-                />
-            )}
-            <LemonButton
-                size="small"
-                icon={<IconLink />}
-                data-attr="events-table-event-link"
-                onClick={(event) => {
-                    cancelEvent(event)
-                    void copyToClipboard(
-                        urls.absolute(urls.currentProject(urls.event(String(record.uuid), record.timestamp))),
-                        'link to event'
-                    )
-                }}
-                tooltip="Copy link to exception event"
-            />
+        <div onClick={(event) => cancelEvent(event)}>
+            <DropdownMenu>
+                <DropdownMenuTrigger render={<Button variant="default" size="icon-sm" aria-label="More actions" />}>
+                    <IconEllipsis />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-auto min-w-44">
+                    <DropdownMenuItem
+                        disabled={Boolean(recordingDisabledReason)}
+                        onClick={viewRecording}
+                        title={recordingTooltip}
+                        data-attr="error-tracking-view-recording"
+                    >
+                        <IconPlayCircle />
+                        View recording
+                    </DropdownMenuItem>
+                    {logs.enabled && (
+                        <DropdownMenuItem
+                            disabled={logs.loading || !logs.onClick}
+                            onClick={logs.onClick}
+                            title={logs.disabledReason}
+                            data-attr="error-tracking-view-logs"
+                        >
+                            {logs.loading ? <Spinner /> : <IconLive />}
+                            View logs
+                        </DropdownMenuItem>
+                    )}
+                    {record.properties.$ai_trace_id && (
+                        <DropdownMenuItem
+                            onClick={() =>
+                                router.actions.push(
+                                    urls.aiObservabilityTrace(record.properties.$ai_trace_id, {
+                                        event: record.uuid,
+                                        timestamp: record.timestamp,
+                                    })
+                                )
+                            }
+                        >
+                            <IconAI />
+                            View LLM trace
+                        </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                        data-attr="events-table-event-link"
+                        onClick={() => {
+                            void copyToClipboard(
+                                urls.absolute(urls.currentProject(urls.event(String(record.uuid), record.timestamp))),
+                                'link to event'
+                            )
+                        }}
+                    >
+                        <IconLink />
+                        Copy event link
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
         </div>
     )
 }

--- a/products/error_tracking/frontend/components/ExceptionCard/ExceptionCard.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/ExceptionCard.tsx
@@ -2,12 +2,11 @@ import { BindLogic, useActions, useValues } from 'kea'
 import { useEffect, useMemo } from 'react'
 
 import { IconLogomark } from '@posthog/icons'
-import { LemonCard } from '@posthog/lemon-ui'
 
 import { ErrorPropertiesLogicProps, errorPropertiesLogic } from 'lib/components/Errors/errorPropertiesLogic'
 import { ErrorEventType } from 'lib/components/Errors/types'
 import { TZLabel } from 'lib/components/TZLabel'
-import { TabsPrimitive, TabsPrimitiveList, TabsPrimitiveTrigger } from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { Tabs, TabsList, TabsTrigger } from 'lib/ui/quill'
 
 import { releasePreviewLogic } from '../ExceptionAttributesPreview/ReleasesPreview/releasePreviewLogic'
 import { exceptionCardLogic } from './exceptionCardLogic'
@@ -77,37 +76,41 @@ function ExceptionCardContent({
     const { setCurrentTab } = useActions(exceptionCardLogic)
 
     return (
-        <LemonCard hoverEffect={false} className="p-0 relative w-full h-full border-0 rounded-none flex flex-col">
-            <TabsPrimitive value={currentTab} onValueChange={setCurrentTab} className="flex flex-col flex-1 min-h-0">
-                <div className="flex justify-between h-[2rem] items-center w-full px-2 border-b shrink-0">
-                    <TabsPrimitiveList className="flex justify-between w-full h-full items-center">
+        <div className="relative flex h-full w-full flex-col bg-[var(--card)]">
+            <Tabs value={currentTab} onValueChange={setCurrentTab} className="min-h-0 flex-1 gap-0">
+                <div className="flex h-9 w-full shrink-0 items-center justify-between border-b border-border px-2">
+                    <TabsList variant="line" className="flex h-full w-full items-center justify-between p-0">
                         <div className="w-full h-full">
                             <div className="flex items-center gap-1 text-lg h-full">
                                 <IconLogomark />
                                 <span className="text-sm">Exception</span>
                             </div>
                         </div>
-                        <div className="flex gap-2 w-full justify-center h-full">
-                            <TabsPrimitiveTrigger className="px-2 whitespace-nowrap" value="stack_trace">
+                        <div className="flex h-full w-full items-center justify-center gap-2">
+                            <TabsTrigger className="h-auto flex-none px-2 whitespace-nowrap" value="stack_trace">
                                 Stack Trace
-                            </TabsPrimitiveTrigger>
-                            <TabsPrimitiveTrigger className="px-2 whitespace-nowrap" value="properties">
+                            </TabsTrigger>
+                            <TabsTrigger className="h-auto flex-none px-2 whitespace-nowrap" value="properties">
                                 Properties
-                            </TabsPrimitiveTrigger>
-                            <TabsPrimitiveTrigger className="px-2 whitespace-nowrap" value="session">
+                            </TabsTrigger>
+                            <TabsTrigger className="h-auto flex-none px-2 whitespace-nowrap" value="session">
                                 Session
-                            </TabsPrimitiveTrigger>
+                            </TabsTrigger>
                         </div>
                         <div className="w-full flex gap-2 justify-end items-center">
-                            {!hideEventMeta && timestamp && <TZLabel className="text-muted text-xs" time={timestamp} />}
+                            {!hideEventMeta && timestamp && (
+                                <span data-not-quill className="contents">
+                                    <TZLabel className="text-xs text-muted-foreground" time={timestamp} />
+                                </span>
+                            )}
                             {!hideEventMeta && label}
                         </div>
-                    </TabsPrimitiveList>
+                    </TabsList>
                 </div>
                 <StackTraceTab value="stack_trace" renderActions={renderStackTraceActions} className="flex-1 min-h-0" />
                 <PropertiesTab value="properties" className="flex-1 min-h-0" />
                 <SessionTab value="session" timestamp={timestamp} className="flex-1 min-h-0" />
-            </TabsPrimitive>
-        </LemonCard>
+            </Tabs>
+        </div>
     )
 }

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/PropertiesTab.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/PropertiesTab.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import type { ComponentProps } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
 
@@ -13,27 +14,37 @@ import {
     DropdownMenuItemIndicator,
     DropdownMenuTrigger,
 } from 'lib/ui/DropdownMenu/DropdownMenu'
-import { TabsPrimitiveContent, TabsPrimitiveContentProps } from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { TabsContent } from 'lib/ui/quill'
 import { cn } from 'lib/utils/css-classes'
 
 import { ContextDisplay } from '../../ContextDisplay/ContextDisplay'
 import { exceptionCardLogic } from '../exceptionCardLogic'
 import { SubHeader } from './SubHeader'
 
-export interface PropertiesTabProps extends TabsPrimitiveContentProps {}
+export interface PropertiesTabProps extends ComponentProps<typeof TabsContent> {}
 
 export function PropertiesTab({ className, ...props }: PropertiesTabProps): JSX.Element {
     const { properties, exceptionAttributes, additionalProperties } = useValues(errorPropertiesLogic)
     const { loading, showJSONProperties, showAdditionalProperties } = useValues(exceptionCardLogic)
 
     return (
-        <TabsPrimitiveContent {...props} className={cn('flex flex-col', className)}>
+        <TabsContent {...props} className={cn('flex flex-col', className)}>
             <SubHeader className="justify-end shrink-0">
-                <ShowDropDownMenu />
+                <div data-not-quill className="contents">
+                    <ShowDropDownMenu />
+                </div>
             </SubHeader>
             <div className="flex-1 min-h-0 overflow-y-auto">
                 {showJSONProperties ? (
-                    <JSONViewer src={properties} name="event" collapsed={1} collapseStringsAfterLength={80} sortKeys />
+                    <div data-not-quill className="contents">
+                        <JSONViewer
+                            src={properties}
+                            name="event"
+                            collapsed={1}
+                            collapseStringsAfterLength={80}
+                            sortKeys
+                        />
+                    </div>
                 ) : (
                     <ContextDisplay
                         loading={loading}
@@ -42,7 +53,7 @@ export function PropertiesTab({ className, ...props }: PropertiesTabProps): JSX.
                     />
                 )}
             </div>
-        </TabsPrimitiveContent>
+        </TabsContent>
     )
 }
 

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/SessionTab/SessionRecordingTab.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/SessionTab/SessionRecordingTab.tsx
@@ -4,7 +4,7 @@ import { match } from 'ts-pattern'
 
 import { LemonBanner, Spinner } from '@posthog/lemon-ui'
 
-import { TabsPrimitiveContent } from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { TabsContent } from 'lib/ui/quill'
 import { SessionRecordingPlayer } from 'scenes/session-recordings/player/SessionRecordingPlayer'
 import { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 
@@ -14,18 +14,18 @@ import { sessionTabLogic } from './sessionTabLogic'
 export function SessionRecordingTab(): JSX.Element {
     const { loading } = useValues(exceptionCardLogic)
     return (
-        <TabsPrimitiveContent value="recording" className="flex-1 min-h-0 overflow-y-auto">
+        <TabsContent value="recording" className="min-h-0 min-w-0 flex-1 overflow-y-auto">
             {match(loading)
                 .with(true, () => <SessionRecordingLoading />)
                 .with(false, () => <SessionRecordingContent />)
                 .exhaustive()}
-        </TabsPrimitiveContent>
+        </TabsContent>
     )
 }
 
 export function SessionRecordingLoading(): JSX.Element {
     return (
-        <div className="flex justify-center w-full h-[300px] items-center">
+        <div data-not-quill className="flex justify-center w-full h-[300px] items-center">
             <Spinner />
         </div>
     )
@@ -52,14 +52,16 @@ export function SessionRecordingContent(): JSX.Element {
     }, [seekToTimestamp, recordingTimestamp, setPlay, isNotFound, sessionPlayerMetaDataLoading])
 
     return (
-        <div className="h-full flex flex-col">
+        <div className="flex h-full min-w-0 flex-col overflow-hidden">
             {isTimestampOutsideRecording && (
-                <LemonBanner type="info" className="m-2">
-                    The exception occurred outside the recorded session timeframe. It is attached to a session but not
-                    visible in the recording.
-                </LemonBanner>
+                <div data-not-quill className="contents">
+                    <LemonBanner type="info" className="m-2">
+                        The exception occurred outside the recorded session timeframe. It is attached to a session but
+                        not visible in the recording.
+                    </LemonBanner>
+                </div>
             )}
-            <div className="flex-1 flex justify-center items-center min-h-0">
+            <div data-not-quill className="flex min-h-0 min-w-0 flex-1 items-center justify-center overflow-hidden">
                 <SessionRecordingPlayer
                     {...recordingProps}
                     mode={SessionRecordingPlayerMode.Standard}

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/SessionTab/index.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/SessionTab/index.tsx
@@ -1,5 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, type ComponentProps } from 'react'
 import { P, match } from 'ts-pattern'
 
 import { LemonBanner, Link, Spinner } from '@posthog/lemon-ui'
@@ -19,13 +19,7 @@ import {
 import { ConsoleLogLoader, consoleLogRenderer } from 'lib/components/SessionTimeline/timeline/items/logs'
 import { pageRenderer } from 'lib/components/SessionTimeline/timeline/items/page'
 import { Dayjs, dayjs } from 'lib/dayjs'
-import {
-    TabsPrimitive,
-    TabsPrimitiveContent,
-    TabsPrimitiveContentProps,
-    TabsPrimitiveList,
-    TabsPrimitiveTrigger,
-} from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from 'lib/ui/quill'
 import { cn } from 'lib/utils/css-classes'
 
 import { ViewLogsButton } from 'products/logs/frontend/components/ViewLogsButton'
@@ -35,7 +29,7 @@ import { SubHeader } from '../SubHeader'
 import { SessionRecordingTab } from './SessionRecordingTab'
 import { sessionTabLogic } from './sessionTabLogic'
 
-export interface SessionTabProps extends TabsPrimitiveContentProps {
+export interface SessionTabProps extends ComponentProps<typeof TabsContent> {
     timestamp?: string
 }
 
@@ -45,30 +39,33 @@ export function SessionTab({ timestamp, className, ...props }: SessionTabProps):
     const { setCurrentSessionTab } = useActions(exceptionCardLogic)
 
     return (
-        <TabsPrimitiveContent {...props} className={cn('flex flex-col', className)}>
+        <TabsContent {...props} className={cn('flex min-w-0 flex-col overflow-hidden', className)}>
             {match([loading, sessionId])
                 .with([true, P.any], () => (
-                    <div className="flex justify-center items-center h-[300px]">
+                    <div data-not-quill className="flex justify-center items-center h-[300px]">
                         <Spinner />
                     </div>
                 ))
                 .with([false, P.nullish], () => <NoSessionStepsView timestamp={timestamp} />)
                 .with([false, P.string], ([_, sessionId]) => (
                     <BindLogic logic={sessionTabLogic} props={{ timestamp, sessionId }}>
-                        <TabsPrimitive
+                        <Tabs
                             value={currentSessionTab}
                             onValueChange={setCurrentSessionTab}
-                            className="flex flex-col flex-1 min-h-0"
+                            className="min-h-0 min-w-0 flex-1 gap-0"
                         >
                             <SubHeader className="p-0 shrink-0">
-                                <TabsPrimitiveList className="flex justify-start gap-2 w-full h-full items-center">
-                                    <TabsPrimitiveTrigger className="px-2 h-full" value="timeline">
+                                <TabsList
+                                    variant="line"
+                                    className="flex h-full w-full items-center justify-start gap-2 p-0 pl-1"
+                                >
+                                    <TabsTrigger className="h-auto flex-none px-2" value="timeline">
                                         Timeline
-                                    </TabsPrimitiveTrigger>
-                                    <TabsPrimitiveTrigger className="px-2 h-full" value="recording">
+                                    </TabsTrigger>
+                                    <TabsTrigger className="h-auto flex-none px-2" value="recording">
                                         Recording
-                                    </TabsPrimitiveTrigger>
-                                    <div className="ml-auto pr-1">
+                                    </TabsTrigger>
+                                    <div data-not-quill className="ml-auto pr-1">
                                         <ViewLogsButton
                                             sessionId={sessionId}
                                             timestamp={timestamp}
@@ -76,15 +73,15 @@ export function SessionTab({ timestamp, className, ...props }: SessionTabProps):
                                             data-attr="error-tracking-session-view-logs"
                                         />
                                     </div>
-                                </TabsPrimitiveList>
+                                </TabsList>
                             </SubHeader>
                             <SessionTimelineTab />
                             <SessionRecordingTab />
-                        </TabsPrimitive>
+                        </Tabs>
                     </BindLogic>
                 ))
                 .exhaustive()}
-        </TabsPrimitiveContent>
+        </TabsContent>
     )
 }
 
@@ -118,16 +115,18 @@ export function SessionTimelineTab(): JSX.Element {
     }, [properties, sessionId, timestamp, uuid])
 
     return (
-        <TabsPrimitiveContent value="timeline" className="flex-1 min-h-0 overflow-y-auto">
+        <TabsContent value="timeline" className="min-h-0 min-w-0 flex-1 overflow-y-auto">
             {collector && (
-                <SessionTimeline
-                    ref={sessionTimelineRef}
-                    collector={collector}
-                    selectedItemId={uuid}
-                    onTimeClick={onTimeClick}
-                />
+                <div data-not-quill className="contents">
+                    <SessionTimeline
+                        ref={sessionTimelineRef}
+                        collector={collector}
+                        selectedItemId={uuid}
+                        onTimeClick={onTimeClick}
+                    />
+                </div>
             )}
-        </TabsPrimitiveContent>
+        </TabsContent>
     )
 }
 
@@ -147,7 +146,7 @@ function NoSessionStepsView({ timestamp }: { timestamp?: string }): JSX.Element 
     }
 
     return (
-        <div className="flex flex-col flex-1 min-h-0">
+        <div data-not-quill className="flex flex-col flex-1 min-h-0">
             <LemonBanner type="info" className="m-2 shrink-0">
                 No session ID associated with this exception — showing exception steps only.{' '}
                 <Link to="https://posthog.com/docs/data/sessions#server-sdks-and-sessions" target="_blank">
@@ -163,7 +162,7 @@ function NoSessionStepsView({ timestamp }: { timestamp?: string }): JSX.Element 
 
 export function NoSessionIdFound(): JSX.Element {
     return (
-        <div className="flex justify-center w-full h-[300px] items-center">
+        <div data-not-quill className="flex justify-center w-full h-[300px] items-center">
             <EmptyMessage
                 title="No session found"
                 description="There is no $session_id associated with this exception. If it was captured from a server SDK, you can read our doc on how to forward session IDs"

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/index.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/StackTraceTab/index.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
+import type { ComponentProps } from 'react'
 
 import { errorPropertiesLogic } from 'lib/components/Errors/errorPropertiesLogic'
 import { CollapsibleExceptionList } from 'lib/components/Errors/ExceptionList/CollapsibleExceptionList'
 import { LoadingExceptionList } from 'lib/components/Errors/ExceptionList/LoadingExceptionList'
-import { TabsPrimitiveContent, TabsPrimitiveContentProps } from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { TabsContent } from 'lib/ui/quill'
 import { cn } from 'lib/utils/css-classes'
 
 import { ExceptionAttributesPreview } from '../../../ExceptionAttributesPreview'
@@ -11,7 +12,7 @@ import { ReleasePreviewPill } from '../../../ReleasesPreview/ReleasePreviewPill'
 import { exceptionCardLogic } from '../../exceptionCardLogic'
 import { SubHeader } from './../SubHeader'
 
-export interface StackTraceTabProps extends Omit<TabsPrimitiveContentProps, 'children'> {
+export interface StackTraceTabProps extends Omit<ComponentProps<typeof TabsContent>, 'children'> {
     onExplain?: () => void
 
     renderActions?: () => JSX.Element | null
@@ -22,18 +23,20 @@ export function StackTraceTab({ className, renderActions, ...props }: StackTrace
     const { exceptionAttributes, release } = useValues(errorPropertiesLogic)
 
     return (
-        <TabsPrimitiveContent {...props} className={cn('flex flex-col', className)}>
+        <TabsContent {...props} className={cn('flex flex-col', className)}>
             <SubHeader className="justify-between shrink-0">
-                <div className="flex items-center gap-1">
+                <div data-not-quill className="flex items-center gap-1">
                     <ExceptionAttributesPreview attributes={exceptionAttributes} loading={loading} />
                     {release && <ReleasePreviewPill release={release} />}
                 </div>
-                {renderActions?.()}
+                <div data-not-quill className="contents">
+                    {renderActions?.()}
+                </div>
             </SubHeader>
-            <div className="flex-1 min-h-0 overflow-y-auto">
+            <div data-not-quill className="flex-1 min-h-0 overflow-y-auto">
                 <StacktraceIssueDisplay className="p-2" />
             </div>
-        </TabsPrimitiveContent>
+        </TabsContent>
     )
 }
 

--- a/products/error_tracking/frontend/components/ExceptionCard/Tabs/SubHeader.tsx
+++ b/products/error_tracking/frontend/components/ExceptionCard/Tabs/SubHeader.tsx
@@ -4,6 +4,9 @@ import { cn } from 'lib/utils/css-classes'
 
 export function SubHeader({ className, ...props }: HTMLProps<HTMLDivElement>): JSX.Element {
     return (
-        <div className={cn('flex gap-1 items-center border-b-1 bg-[var(--gray-1)] px-2 h-9', className)} {...props} />
+        <div
+            className={cn('flex h-9 items-center gap-1 border-b-1 border-border bg-[var(--muted)] px-2', className)}
+            {...props}
+        />
     )
 }

--- a/products/error_tracking/frontend/components/Indicators.tsx
+++ b/products/error_tracking/frontend/components/Indicators.tsx
@@ -32,15 +32,17 @@ export const LabelIndicator = React.forwardRef<HTMLDivElement, LabelIndicatorPro
     ref
 ): JSX.Element {
     return (
-        <LemonTooltip title={tooltip} placement={tooltipPlacement}>
-            <div
-                ref={ref}
-                className={clsx('flex items-center', tooltip && 'cursor-help', className, sizeVariants[size])}
-            >
-                <LemonBadge status={intent} size="small" />
-                <div>{label}</div>
-            </div>
-        </LemonTooltip>
+        <div data-not-quill className="contents">
+            <LemonTooltip title={tooltip} placement={tooltipPlacement}>
+                <div
+                    ref={ref}
+                    className={clsx('flex items-center', tooltip && 'cursor-help', className, sizeVariants[size])}
+                >
+                    <LemonBadge status={intent} size="small" />
+                    <div>{label}</div>
+                </div>
+            </LemonTooltip>
+        </div>
     )
 })
 

--- a/products/error_tracking/frontend/components/IssueFilters/Status.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/Status.tsx
@@ -52,23 +52,25 @@ export function ErrorTrackingStatusSelect({
     disabledReason,
 }: ErrorTrackingStatusSelectProps): JSX.Element {
     return (
-        <LemonSelect
-            fullWidth={fullWidth}
-            size={size}
-            disabled={disabled}
-            disabledReason={disabledReason}
-            value={value}
-            onChange={(next) => {
-                if (next) {
-                    onChange(next)
-                }
-            }}
-            placeholder="Select status"
-            options={STATUS_OPTIONS.map((key) => ({
-                value: key,
-                label: statusOptionLabel(key),
-            }))}
-        />
+        <div data-not-quill className="contents">
+            <LemonSelect
+                fullWidth={fullWidth}
+                size={size}
+                disabled={disabled}
+                disabledReason={disabledReason}
+                value={value}
+                onChange={(next) => {
+                    if (next) {
+                        onChange(next)
+                    }
+                }}
+                placeholder="Select status"
+                options={STATUS_OPTIONS.map((key) => ({
+                    value: key,
+                    label: statusOptionLabel(key),
+                }))}
+            />
+        </div>
     )
 }
 

--- a/products/error_tracking/frontend/components/IssueMetadata.tsx
+++ b/products/error_tracking/frontend/components/IssueMetadata.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { PropsWithChildren, useCallback, useMemo, useRef } from 'react'
+import { PropsWithChildren, UIEvent, useCallback, useMemo, useRef } from 'react'
 import { match } from 'ts-pattern'
 
 import { IconChevronRight, IconTrending } from '@posthog/icons'
@@ -21,7 +21,11 @@ import { errorTrackingVolumeSparklineLogic } from './VolumeSparkline/errorTracki
 import type { SparklineDatum, SparklineEvent, VolumeSparklineHoverSelection } from './VolumeSparkline/types'
 import { VolumeSparkline } from './VolumeSparkline/VolumeSparkline'
 
-export const Metadata = ({ children, className }: PropsWithChildren<{ className?: string }>): JSX.Element => {
+export const Metadata = ({
+    children,
+    className,
+    onScrollNearEnd,
+}: PropsWithChildren<{ className?: string; onScrollNearEnd?: () => void }>): JSX.Element => {
     const { aggregations, summaryLoading, issueLoading, firstSeen, lastSeen, issueId, spikeEvents } =
         useValues(errorTrackingIssueSceneLogic)
     const { setDateRange } = useActions(errorTrackingIssueSceneLogic)
@@ -50,6 +54,13 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
         [setClickedSpike]
     )
 
+    const handleScroll = (event: UIEvent<HTMLDivElement>): void => {
+        const { clientHeight, scrollHeight, scrollTop } = event.currentTarget
+        if (scrollHeight - scrollTop - clientHeight <= 400) {
+            onScrollNearEnd?.()
+        }
+    }
+
     const matchedSpikeEvent = useMemo<ErrorTrackingSpikeEvent | null>(() => {
         if (!clickedSpike || sparklineData.length < 2) {
             return null
@@ -66,73 +77,77 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
 
     return (
         <div className={className}>
-            <div className="flex justify-between items-center h-[40px] px-4 shrink-0">
-                <div className="flex justify-end items-center h-full">
-                    {match(hoverSelection)
-                        .when(
-                            (data) => shouldRenderIssueMetrics(data),
-                            () => <IssueMetrics aggregations={aggregations} summaryLoading={summaryLoading} />
-                        )
-                        .with({ kind: 'bin' }, (data) => renderDataPoint(data.datum))
-                        .with({ kind: 'event' }, (data) => renderEventPoint(data.event))
-                        .otherwise(() => null)}
+            <div className="flex-1 min-h-0 overflow-y-auto" onScroll={handleScroll}>
+                <div className="flex justify-between items-center h-[40px] px-4">
+                    <div data-not-quill className="flex justify-end items-center h-full">
+                        {match(hoverSelection)
+                            .when(
+                                (data) => shouldRenderIssueMetrics(data),
+                                () => <IssueMetrics aggregations={aggregations} summaryLoading={summaryLoading} />
+                            )
+                            .with({ kind: 'bin' }, (data) => renderDataPoint(data.datum))
+                            .with({ kind: 'event' }, (data) => renderEventPoint(data.event))
+                            .otherwise(() => null)}
+                    </div>
+                    <div className="flex justify-end items-center h-full">
+                        {match(hoverSelection)
+                            .with({ kind: 'bin' }, (data) => renderDate(data.datum.date))
+                            .with({ kind: 'event' }, (data) => renderDate(data.event.date))
+                            .otherwise(() => (
+                                <>
+                                    <TimeBoundary
+                                        time={firstSeen}
+                                        loading={issueLoading}
+                                        label="First Seen"
+                                        updateDateRange={(dateRange) => {
+                                            dateRange.date_from = firstSeen?.toISOString()
+                                            return dateRange
+                                        }}
+                                    />
+                                    <IconChevronRight />
+                                    <TimeBoundary
+                                        time={lastSeen}
+                                        loading={summaryLoading}
+                                        label="Last Seen"
+                                        updateDateRange={(dateRange) => {
+                                            dateRange.date_to = lastSeen?.endOf('minute').toISOString()
+                                            return dateRange
+                                        }}
+                                    />
+                                </>
+                            ))}
+                    </div>
                 </div>
-                <div className="flex justify-end items-center h-full">
-                    {match(hoverSelection)
-                        .with({ kind: 'bin' }, (data) => renderDate(data.datum.date))
-                        .with({ kind: 'event' }, (data) => renderDate(data.event.date))
-                        .otherwise(() => (
-                            <>
-                                <TimeBoundary
-                                    time={firstSeen}
-                                    loading={issueLoading}
-                                    label="First Seen"
-                                    updateDateRange={(dateRange) => {
-                                        dateRange.date_from = firstSeen?.toISOString()
-                                        return dateRange
-                                    }}
-                                />
-                                <IconChevronRight />
-                                <TimeBoundary
-                                    time={lastSeen}
-                                    loading={summaryLoading}
-                                    label="Last Seen"
-                                    updateDateRange={(dateRange) => {
-                                        dateRange.date_to = lastSeen?.endOf('minute').toISOString()
-                                        return dateRange
-                                    }}
-                                />
-                            </>
-                        ))}
+                <div
+                    onClick={cancelEvent}
+                    ref={sparklineContainerRef}
+                    className="relative w-full min-h-[160px] flex flex-col px-4"
+                >
+                    <VolumeSparkline
+                        data={sparklineData}
+                        layout="detailed"
+                        xAxis="full"
+                        events={sparklineEvents}
+                        sparklineKey={sparklineKey}
+                        className="h-full min-h-[160px]"
+                        onRangeSelect={handleRangeSelect}
+                        onSpikeClick={handleSpikeClick}
+                    />
                 </div>
+                {clickedSpike && (
+                    <div data-not-quill className="contents">
+                        <SpikeDetailsPopover
+                            datum={clickedSpike.datum}
+                            clientX={clickedSpike.clientX}
+                            clientY={clickedSpike.clientY}
+                            spikeEvent={matchedSpikeEvent}
+                            onClose={() => setClickedSpike(null)}
+                            sparklineContainerRef={sparklineContainerRef}
+                        />
+                    </div>
+                )}
+                {children}
             </div>
-            <div
-                onClick={cancelEvent}
-                ref={sparklineContainerRef}
-                className="relative w-full min-h-[160px] shrink-0 flex flex-col px-4"
-            >
-                <VolumeSparkline
-                    data={sparklineData}
-                    layout="detailed"
-                    xAxis="full"
-                    events={sparklineEvents}
-                    sparklineKey={sparklineKey}
-                    className="h-full min-h-[160px]"
-                    onRangeSelect={handleRangeSelect}
-                    onSpikeClick={handleSpikeClick}
-                />
-            </div>
-            {clickedSpike && (
-                <SpikeDetailsPopover
-                    datum={clickedSpike.datum}
-                    clientX={clickedSpike.clientX}
-                    clientY={clickedSpike.clientY}
-                    spikeEvent={matchedSpikeEvent}
-                    onClose={() => setClickedSpike(null)}
-                    sparklineContainerRef={sparklineContainerRef}
-                />
-            )}
-            <div className="flex-1 min-h-0 overflow-y-auto">{children}</div>
         </div>
     )
 }
@@ -171,7 +186,7 @@ function IssueMetrics({
 
 function renderMetric(name: string, value: number | undefined, loading: boolean, tooltip?: string): JSX.Element {
     return (
-        <>
+        <span data-not-quill className="contents">
             {match([loading])
                 .with([true], () => <LemonSkeleton className="w-[50px] h-2" />)
                 .with([false], () => (
@@ -180,18 +195,20 @@ function renderMetric(name: string, value: number | undefined, loading: boolean,
                             <div className="text-lg font-bold inline-block">
                                 {value == null ? '0' : humanFriendlyLargeNumber(value)}
                             </div>
-                            <div className="text-xs text-muted inline-block">{name}</div>
+                            <div className="inline-block text-xs text-muted-foreground">{name}</div>
                         </div>
                     </Tooltip>
                 ))
                 .exhaustive()}
-        </>
+        </span>
     )
 }
 
 function renderDate(date: Date): JSX.Element {
     return (
-        <div className="text-xs text-muted whitespace-nowrap">{dayjs(date).utc().format('D MMM YYYY HH:mm (UTC)')}</div>
+        <div className="whitespace-nowrap text-xs text-muted-foreground">
+            {dayjs(date).utc().format('D MMM YYYY HH:mm (UTC)')}
+        </div>
     )
 }
 
@@ -200,10 +217,10 @@ function renderDataPoint(d: SparklineDatum): JSX.Element {
         <div className="flex items-center h-full gap-3">
             {renderMetric('Occurrences', d.value, false)}
             {d.animated && (
-                <div className="flex items-center gap-1.5 text-warning-dark">
+                <div className="flex items-center gap-1.5 text-warning-foreground">
                     <IconTrending className="text-base" />
                     <span className="text-xs font-semibold">Spike</span>
-                    <span className="text-xs text-muted">— click to see details</span>
+                    <span className="text-xs text-muted-foreground">— click to see details</span>
                 </div>
             )}
         </div>

--- a/products/error_tracking/frontend/components/IssueStatusButton.tsx
+++ b/products/error_tracking/frontend/components/IssueStatusButton.tsx
@@ -1,6 +1,17 @@
-import { LemonButton, LemonMenuOverlay } from '@posthog/lemon-ui'
+import { IconChevronDown } from '@posthog/icons'
 
 import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
+import {
+    Button,
+    ButtonGroup,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from 'lib/ui/quill'
 
 import { ErrorTrackingIssue } from '~/queries/schema/schema-general'
 
@@ -24,42 +35,38 @@ export const IssueStatusButton = ({
         }
     }
 
+    const intentLabel =
+        status === 'active' ? ISSUE_STATUS_CONFIG.resolved.intentLabel : ISSUE_STATUS_CONFIG.active.intentLabel
+
     return (
         <>
             <HogfettiComponent />
-            <LemonButton
-                type="primary"
-                onClick={handleResolve}
-                tooltip={
-                    status === 'active'
-                        ? ISSUE_STATUS_CONFIG.resolved.intentLabel
-                        : ISSUE_STATUS_CONFIG.active.intentLabel
-                }
-                data-attr="error-tracking-resolve"
-                sideAction={
-                    status === 'active'
-                        ? {
-                              dropdown: {
-                                  placement: 'bottom-end',
-                                  overlay: (
-                                      <LemonMenuOverlay
-                                          items={[
-                                              {
-                                                  label: 'Suppress',
-                                                  onClick: () => onChange('suppressed'),
-                                                  tooltip: ISSUE_STATUS_CONFIG.suppressed.intentLabel,
-                                              },
-                                          ]}
-                                      />
-                                  ),
-                              },
-                          }
-                        : undefined
-                }
-                size="small"
-            >
-                {status === 'active' ? 'Resolve' : 'Reopen'}
-            </LemonButton>
+            <ButtonGroup>
+                <Tooltip>
+                    <TooltipTrigger render={<Button variant="primary" size="default" onClick={handleResolve} />}>
+                        {status === 'active' ? 'Resolve' : 'Reopen'}
+                    </TooltipTrigger>
+                    <TooltipContent>{intentLabel}</TooltipContent>
+                </Tooltip>
+                {status === 'active' && (
+                    <DropdownMenu>
+                        <DropdownMenuTrigger
+                            render={
+                                <Button
+                                    variant="primary"
+                                    size="icon"
+                                    aria-label={ISSUE_STATUS_CONFIG.suppressed.intentLabel}
+                                />
+                            }
+                        >
+                            <IconChevronDown />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-auto min-w-32">
+                            <DropdownMenuItem onClick={() => onChange('suppressed')}>Suppress</DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
+                )}
+            </ButtonGroup>
         </>
     )
 }

--- a/products/error_tracking/frontend/components/PropertiesTable.tsx
+++ b/products/error_tracking/frontend/components/PropertiesTable.tsx
@@ -1,6 +1,7 @@
 import { IconCopy, IconFilter, IconInfo } from '@posthog/icons'
-import { LemonButton, LemonTable, Link, Tooltip } from '@posthog/lemon-ui'
 
+import { Link } from 'lib/lemon-ui/Link'
+import { Button, Table, TableBody, TableCell, TableRow, Tooltip, TooltipContent, TooltipTrigger } from 'lib/ui/quill'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 
 type PropertyTableRow = {
@@ -31,72 +32,73 @@ export function PropertiesTable({
         .filter((entry) => entry.value !== undefined)
 
     return (
-        <LemonTable
-            embedded
-            size="small"
-            dataSource={rows}
-            showHeader={false}
-            columns={[
-                {
-                    title: 'Key',
-                    key: 'key',
-                    dataIndex: 'key',
-                    width: 0,
-                    className: 'font-medium bg-inherit',
-                    render: (dataValue, record) => (
-                        <div className="flex gap-x-2 justify-between items-center">
-                            <div>{String(dataValue)}</div>
-                            <div className="flex items-center gap-1">
-                                {onFilterValue &&
-                                    record.filterKey &&
-                                    getFilterableValue(record.filterValue ?? record.value) !== null && (
-                                        <LemonButton
-                                            size="xsmall"
-                                            tooltip="Filter by this value"
-                                            className="invisible group-hover:visible"
-                                            onClick={() => {
-                                                const filterableValue = getFilterableValue(
-                                                    record.filterValue ?? record.value
-                                                )
-                                                if (filterableValue !== null) {
-                                                    onFilterValue(record.filterKey as string, filterableValue)
+        <Table fullWidth size="sm">
+            <TableBody>
+                {rows.map((record, index) => {
+                    const filterableValue = getFilterableValue(record.filterValue ?? record.value)
+
+                    return (
+                        <TableRow
+                            key={`${record.key}-${index}`}
+                            className={
+                                alternatingColors
+                                    ? 'group odd:bg-[var(--card)] even:bg-[var(--muted)]'
+                                    : 'group bg-[var(--card)]'
+                            }
+                        >
+                            <TableCell className="sticky left-0 z-10 bg-inherit font-medium">
+                                <div className="flex items-center justify-between gap-x-2">
+                                    <div>{record.key}</div>
+                                    <div className="flex items-center gap-1">
+                                        {onFilterValue && record.filterKey && filterableValue !== null && (
+                                            <Tooltip>
+                                                <TooltipTrigger
+                                                    render={
+                                                        <Button
+                                                            variant="default"
+                                                            size="icon-xs"
+                                                            className="invisible group-hover:visible"
+                                                            onClick={() =>
+                                                                onFilterValue(record.filterKey!, filterableValue)
+                                                            }
+                                                            aria-label="Filter by this value"
+                                                        />
+                                                    }
+                                                >
+                                                    <IconFilter />
+                                                </TooltipTrigger>
+                                                <TooltipContent>Filter by this value</TooltipContent>
+                                            </Tooltip>
+                                        )}
+                                        <Tooltip>
+                                            <TooltipTrigger
+                                                render={
+                                                    <Button
+                                                        variant="default"
+                                                        size="icon-xs"
+                                                        className="invisible group-hover:visible"
+                                                        onClick={() =>
+                                                            copyToClipboard(copyValue(record.value)).catch((error) => {
+                                                                console.error('Failed to copy to clipboard:', error)
+                                                            })
+                                                        }
+                                                        aria-label="Copy value"
+                                                    />
                                                 }
-                                            }}
-                                        >
-                                            <IconFilter />
-                                        </LemonButton>
-                                    )}
-                                <LemonButton
-                                    size="xsmall"
-                                    tooltip="Copy value"
-                                    className="invisible group-hover:visible"
-                                    onClick={() =>
-                                        copyToClipboard(copyValue(record.value)).catch((error) => {
-                                            console.error('Failed to copy to clipboard:', error)
-                                        })
-                                    }
-                                >
-                                    <IconCopy />
-                                </LemonButton>
-                            </div>
-                        </div>
-                    ),
-                },
-                {
-                    title: 'Value',
-                    key: 'value',
-                    dataIndex: 'value',
-                    className: 'whitespace-nowrap',
-                    render: (value) => {
-                        return <div className="whitespace-nowrap">{renderValue(value)}</div>
-                    },
-                },
-            ]}
-            rowClassName={
-                alternatingColors ? 'even:bg-fill-tertiary odd:bg-surface-primary group' : 'bg-fill-secondary group'
-            }
-            firstColumnSticky
-        />
+                                            >
+                                                <IconCopy />
+                                            </TooltipTrigger>
+                                            <TooltipContent>Copy value</TooltipContent>
+                                        </Tooltip>
+                                    </div>
+                                </div>
+                            </TableCell>
+                            <TableCell className="whitespace-nowrap">{renderValue(record.value)}</TableCell>
+                        </TableRow>
+                    )
+                })}
+            </TableBody>
+        </Table>
     )
 }
 
@@ -182,9 +184,11 @@ function renderValue(value: unknown, level = 0): React.ReactNode {
                 return value
             }
             return (
-                <Link to={value as string} target="_blank">
-                    {value}
-                </Link>
+                <span data-not-quill className="contents">
+                    <Link to={value} target="_blank">
+                        {value}
+                    </Link>
+                </span>
             )
         }
         return value // no quotes
@@ -195,8 +199,11 @@ function renderValue(value: unknown, level = 0): React.ReactNode {
 export function MaskedValue({ value, tooltip }: { value: string; tooltip: string }): JSX.Element {
     return (
         <span className="inline-flex items-center gap-1">
-            <Tooltip title={tooltip}>
-                <IconInfo className="text-muted text-sm" />
+            <Tooltip>
+                <TooltipTrigger render={<span className="inline-flex" tabIndex={0} aria-label={tooltip} />}>
+                    <IconInfo className="text-sm text-muted-foreground" />
+                </TooltipTrigger>
+                <TooltipContent>{tooltip}</TooltipContent>
             </Tooltip>
             {value}
         </span>

--- a/products/error_tracking/frontend/components/StyleVariables/StyleVariables.scss
+++ b/products/error_tracking/frontend/components/StyleVariables/StyleVariables.scss
@@ -1,25 +1,5 @@
-body[theme='light'] .ErrorTrackingVariables {
-    --gray-1: var(--color-neutral-50);
-    --gray-2: var(--color-neutral-100);
-    --gray-3: var(--color-neutral-200);
-    --gray-4: var(--color-neutral-300);
-    --gray-5: var(--color-neutral-400);
-    --gray-6: var(--color-neutral-500);
-    --gray-7: var(--color-neutral-600);
-    --gray-8: var(--color-neutral-700);
-    --gray-9: var(--color-neutral-800);
-    --gray-10: var(--color-neutral-900);
-}
-
-body[theme='dark'] .ErrorTrackingVariables {
-    --gray-1: var(--color-neutral-900);
-    --gray-2: var(--color-neutral-800);
-    --gray-3: var(--color-neutral-700);
-    --gray-4: var(--color-neutral-600);
-    --gray-5: var(--color-neutral-500);
-    --gray-6: var(--color-neutral-400);
-    --gray-7: var(--color-neutral-300);
-    --gray-8: var(--color-neutral-200);
-    --gray-9: var(--color-neutral-100);
-    --gray-10: var(--color-neutral-50);
+@layer components {
+    .ErrorTrackingStyleVariables [data-not-quill] :is(.LemonButton, .button-primitive) {
+        --radius: 0.375rem !important;
+    }
 }

--- a/products/error_tracking/frontend/components/StyleVariables/StyleVariables.tsx
+++ b/products/error_tracking/frontend/components/StyleVariables/StyleVariables.tsx
@@ -1,7 +1,5 @@
 import './StyleVariables.scss'
 
-import { cn } from 'lib/utils/css-classes'
-
 export function StyleVariables({
     children,
     className,
@@ -9,5 +7,11 @@ export function StyleVariables({
     children: React.ReactNode
     className?: string
 }): JSX.Element {
-    return <div className={cn('ErrorTrackingVariables', className)}>{children}</div>
+    return (
+        <div data-quill className={`ErrorTrackingStyleVariables ${className ?? ''}`}>
+            <div data-not-quill className="contents">
+                {children}
+            </div>
+        </div>
+    )
 }

--- a/products/error_tracking/frontend/components/TableColumns.tsx
+++ b/products/error_tracking/frontend/components/TableColumns.tsx
@@ -113,12 +113,12 @@ export const IssueListTitleColumn = (props: {
                 <IssueTitle record={record} issueUrl={issueUrl} runtime={runtime} />
                 <div
                     title={record.description || undefined}
-                    className="font-medium line-clamp-1 text-[var(--gray-8)] h-(--line-height)"
+                    className="line-clamp-1 h-(--line-height) font-medium text-[var(--foreground)]"
                 >
                     {record.description}
                 </div>
                 {(record.function || record.source) && (
-                    <div className="line-clamp-1 text-[var(--gray-6)] italic font-light h-(--line-height)">
+                    <div className="line-clamp-1 h-(--line-height) font-light text-[var(--muted-foreground)] italic">
                         {record.function}
                         {record.source ? <> in {sourceDisplay(record.source)}</> : <></>}
                     </div>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.scss
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.scss
@@ -1,15 +1,16 @@
-.ErrorTrackingIssue {
-    .ErrorTrackingIssue__search .quill-input-group {
-        background-color: color-mix(in oklab, var(--muted) 30%, transparent);
-        border-color: color-mix(in oklab, var(--foreground) 10%, transparent);
+@layer components {
+    .ErrorTrackingIssueScene [data-not-quill] :is(.LemonButton, .button-primitive) {
+        --radius: 0.375rem !important;
     }
 
-    // Needed for the NotFound state inside SessionRecordingPlayer
-    .NotFoundComponent {
-        margin: 0 auto;
-    }
-}
+    .ErrorTrackingIssue {
+        .quill-tabs__list--variant-line .quill-tabs__trigger[data-active] {
+            background-color: rgb(0 0 0 / 0%) !important;
+        }
 
-:is(.dark, [theme='dark']) .ErrorTrackingIssue .ErrorTrackingIssue__search .quill-input-group {
-    border-color: color-mix(in oklab, var(--foreground) 15%, transparent);
+        // Needed for the NotFound state inside SessionRecordingPlayer
+        .NotFoundComponent {
+            margin: 0 auto;
+        }
+    }
 }

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -6,23 +6,15 @@ import posthog from 'posthog-js'
 import { useEffect, useRef } from 'react'
 
 import { IconFilter, IconList, IconRefresh, IconRewindPlay, IconX } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { TZLabel } from 'lib/components/TZLabel'
-import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
-import { Button, Separator, Tooltip, TooltipContent, TooltipTrigger } from 'lib/ui/quill'
-import {
-    TabsPrimitive,
-    TabsPrimitiveContent,
-    TabsPrimitiveList,
-    TabsPrimitiveTrigger,
-} from 'lib/ui/TabsPrimitive/TabsPrimitive'
+import { Button, Tabs, TabsContent, TabsList, TabsTrigger, Tooltip, TooltipContent, TooltipTrigger } from 'lib/ui/quill'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -49,7 +41,6 @@ import { issueFiltersLogic } from '../../components/IssueFilters/issueFiltersLog
 import { Metadata } from '../../components/IssueMetadata'
 import { IssueStatusButton } from '../../components/IssueStatusButton'
 import { ErrorTrackingSetupPrompt } from '../../components/SetupPrompt/SetupPrompt'
-import { StyleVariables } from '../../components/StyleVariables'
 import { useErrorTagRenderer } from '../../hooks/use-error-tag-renderer'
 import { getIssueReplayDateRange } from '../../utils'
 import {
@@ -97,135 +88,149 @@ export function ErrorTrackingIssueScene(): JSX.Element {
     }, [issueId])
 
     return (
-        <StyleVariables>
-            <ErrorTrackingSetupPrompt>
+        <ErrorTrackingSetupPrompt>
+            <div data-quill className="ErrorTrackingIssueScene">
                 <BindLogic logic={issueFiltersLogic} props={{ logicKey: ERROR_TRACKING_ISSUE_SCENE_LOGIC_KEY }}>
                     <BindLogic logic={miniBreakdownsLogic} props={{ issueId }}>
                         {issue && (
                             <div className="flex flex-col h-[calc(var(--scene-layout-rect-height))]">
-                                {sceneMenuBarEnabled && (
-                                    <SceneMenuBar>
-                                        <SceneMenuBarMenu label="File" dataAttr="issue-menubar-file">
-                                            <SceneMenuBarFileItems dataAttrKey="issue" />
-                                            {hasIssueSplitting && (
+                                <div data-not-quill className="contents">
+                                    {sceneMenuBarEnabled && (
+                                        <SceneMenuBar>
+                                            <SceneMenuBarMenu label="File" dataAttr="issue-menubar-file">
+                                                <SceneMenuBarFileItems dataAttrKey="issue" />
+                                                {hasIssueSplitting && (
+                                                    <SceneMenuBarItem
+                                                        onClick={() =>
+                                                            window.open(
+                                                                urls.errorTrackingIssueFingerprints(issue.id),
+                                                                '_self'
+                                                            )
+                                                        }
+                                                        data-attr="issue-menubar-fingerprints"
+                                                    >
+                                                        Manage fingerprints
+                                                    </SceneMenuBarItem>
+                                                )}
+                                            </SceneMenuBarMenu>
+                                            <SceneMenuBarMenu label="View" dataAttr="issue-menubar-view">
                                                 <SceneMenuBarItem
-                                                    onClick={() =>
-                                                        window.open(
-                                                            urls.errorTrackingIssueFingerprints(issue.id),
-                                                            '_self'
-                                                        )
-                                                    }
-                                                    data-attr="issue-menubar-fingerprints"
-                                                >
-                                                    Manage fingerprints
-                                                </SceneMenuBarItem>
-                                            )}
-                                        </SceneMenuBarMenu>
-                                        <SceneMenuBarMenu label="View" dataAttr="issue-menubar-view">
-                                            <SceneMenuBarItem
-                                                onClick={() => {
-                                                    const url = urls.replay(ReplayTabs.Home, {
-                                                        ...getIssueReplayDateRange(issue.first_seen, lastSeen),
-                                                        filter_group: {
-                                                            type: FilterLogicalOperator.And,
-                                                            values: [
-                                                                {
-                                                                    type: FilterLogicalOperator.And,
-                                                                    values: [
-                                                                        {
-                                                                            key: '$exception_issue_id',
-                                                                            type: PropertyFilterType.Event,
-                                                                            operator: PropertyOperator.Exact,
-                                                                            value: [issue.id],
-                                                                        },
-                                                                    ],
-                                                                },
-                                                            ],
-                                                        },
-                                                    })
-                                                    newInternalTab(url)
-                                                }}
-                                                data-attr="issue-menubar-view-recordings"
-                                            >
-                                                <IconRewindPlay />
-                                                View recordings
-                                            </SceneMenuBarItem>
-                                        </SceneMenuBarMenu>
-                                    </SceneMenuBar>
-                                )}
-                                <SceneTitleSection
-                                    canEdit
-                                    name={issue.name ?? undefined}
-                                    onNameChange={updateName}
-                                    description={null}
-                                    resourceType={{ type: 'error_tracking' }}
-                                    className={clsx(
-                                        'pl-4 pr-2 h-[50px] @2xl/main-content:relative top-[0px] mt-0 mx-0 mb-0',
-                                        isMobile
-                                            ? '[&>.scene-title-section]:flex-row [&>.scene-title-section]:items-center [&>.scene-title-section>*:last-child]:order-last'
-                                            : undefined
-                                    )}
-                                    actions={
-                                        isMobile ? undefined : (
-                                            <div className="flex items-center gap-1">
-                                                <StatusIndicator status={issue.status} withTooltip />
-                                                <IssueAssigneeSelect
-                                                    assignee={issue.assignee}
-                                                    onChange={updateAssignee}
-                                                    disabled={issue.status != 'active'}
-                                                />
-                                                <ViewRecordingsPlaylistButton
-                                                    filters={{
-                                                        ...getIssueReplayDateRange(issue.first_seen, lastSeen),
-                                                        filter_group: {
-                                                            type: FilterLogicalOperator.And,
-                                                            values: [
-                                                                {
-                                                                    type: FilterLogicalOperator.And,
-                                                                    values: [
-                                                                        {
-                                                                            key: '$exception_issue_id',
-                                                                            type: PropertyFilterType.Event,
-                                                                            operator: PropertyOperator.Exact,
-                                                                            value: [issue.id],
-                                                                        },
-                                                                    ],
-                                                                },
-                                                            ],
-                                                        },
+                                                    onClick={() => {
+                                                        const url = urls.replay(ReplayTabs.Home, {
+                                                            ...getIssueReplayDateRange(issue.first_seen, lastSeen),
+                                                            filter_group: {
+                                                                type: FilterLogicalOperator.And,
+                                                                values: [
+                                                                    {
+                                                                        type: FilterLogicalOperator.And,
+                                                                        values: [
+                                                                            {
+                                                                                key: '$exception_issue_id',
+                                                                                type: PropertyFilterType.Event,
+                                                                                operator: PropertyOperator.Exact,
+                                                                                value: [issue.id],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                ],
+                                                            },
+                                                        })
+                                                        newInternalTab(url)
                                                     }}
-                                                    size="small"
-                                                    type="secondary"
-                                                    data-attr="error-tracking-issue-view-recordings"
-                                                />
-                                                <IssueStatusButton status={issue.status} onChange={updateStatus} />
-                                            </div>
-                                        )
-                                    }
-                                />
-
-                                {isMobile && (
-                                    <div className="flex items-center gap-1.5 px-2 py-1.5 border-b flex-wrap">
-                                        <StatusIndicator status={issue.status} withTooltip />
-                                        <IssueAssigneeSelect
-                                            assignee={issue.assignee}
-                                            onChange={updateAssignee}
-                                            disabled={issue.status != 'active'}
-                                        />
-                                        <IssueStatusButton status={issue.status} onChange={updateStatus} />
-                                        {!mobileDetailOpen && (
-                                            <LemonButton
-                                                size="small"
-                                                type="secondary"
-                                                onClick={() => setMobileDetailOpen(true)}
-                                            >
-                                                Details
-                                            </LemonButton>
+                                                    data-attr="issue-menubar-view-recordings"
+                                                >
+                                                    <IconRewindPlay />
+                                                    View recordings
+                                                </SceneMenuBarItem>
+                                            </SceneMenuBarMenu>
+                                        </SceneMenuBar>
+                                    )}
+                                    <SceneTitleSection
+                                        canEdit
+                                        name={issue.name ?? undefined}
+                                        onNameChange={updateName}
+                                        description={null}
+                                        resourceType={{ type: 'error_tracking' }}
+                                        className={clsx(
+                                            'pl-4 pr-2 h-[50px] @2xl/main-content:relative top-[0px] mt-0 mx-0 mb-0',
+                                            isMobile
+                                                ? '[&>.scene-title-section]:flex-row [&>.scene-title-section]:items-center [&>.scene-title-section>*:last-child]:order-last'
+                                                : undefined
                                         )}
-                                    </div>
-                                )}
+                                        actions={
+                                            isMobile ? undefined : (
+                                                <div className="flex items-center gap-1">
+                                                    <div className="flex h-7 items-center">
+                                                        <div className="flex h-7 items-center">
+                                                            <StatusIndicator status={issue.status} withTooltip />
+                                                        </div>
+                                                    </div>
+                                                    <IssueAssigneeSelect
+                                                        assignee={issue.assignee}
+                                                        onChange={updateAssignee}
+                                                    />
+                                                    <Button
+                                                        variant="outline"
+                                                        size="default"
+                                                        data-attr="error-tracking-issue-view-recordings"
+                                                        onClick={() => {
+                                                            newInternalTab(
+                                                                urls.replay(ReplayTabs.Home, {
+                                                                    ...getIssueReplayDateRange(
+                                                                        issue.first_seen,
+                                                                        lastSeen
+                                                                    ),
+                                                                    filter_group: {
+                                                                        type: FilterLogicalOperator.And,
+                                                                        values: [
+                                                                            {
+                                                                                type: FilterLogicalOperator.And,
+                                                                                values: [
+                                                                                    {
+                                                                                        key: '$exception_issue_id',
+                                                                                        type: PropertyFilterType.Event,
+                                                                                        operator:
+                                                                                            PropertyOperator.Exact,
+                                                                                        value: [issue.id],
+                                                                                    },
+                                                                                ],
+                                                                            },
+                                                                        ],
+                                                                    },
+                                                                })
+                                                            )
+                                                        }}
+                                                    >
+                                                        View recordings
+                                                        <IconRewindPlay />
+                                                    </Button>
+                                                    <IssueStatusButton status={issue.status} onChange={updateStatus} />
+                                                </div>
+                                            )
+                                        }
+                                    />
 
-                                <ErrorTrackingIssueScenePanel issue={issue} />
+                                    {isMobile && (
+                                        <div className="flex items-center gap-1.5 px-2 py-1.5 border-b flex-wrap">
+                                            <div className="flex h-7 items-center">
+                                                <StatusIndicator status={issue.status} withTooltip />
+                                            </div>
+                                            <IssueAssigneeSelect assignee={issue.assignee} onChange={updateAssignee} />
+                                            <IssueStatusButton status={issue.status} onChange={updateStatus} />
+                                            {!mobileDetailOpen && (
+                                                <Button
+                                                    size="sm"
+                                                    variant="outline"
+                                                    onClick={() => setMobileDetailOpen(true)}
+                                                >
+                                                    Details
+                                                </Button>
+                                            )}
+                                        </div>
+                                    )}
+
+                                    <ErrorTrackingIssueScenePanel issue={issue} />
+                                </div>
 
                                 <div className="ErrorTrackingIssue flex flex-grow min-h-0 overflow-hidden">
                                     <div className="relative flex flex-1 h-full w-full min-h-0">
@@ -241,8 +246,8 @@ export function ErrorTrackingIssueScene(): JSX.Element {
                         )}
                     </BindLogic>
                 </BindLogic>
-            </ErrorTrackingSetupPrompt>
-        </StyleVariables>
+            </div>
+        </ErrorTrackingSetupPrompt>
     )
 }
 
@@ -265,29 +270,37 @@ const RightHandColumn = ({
     return (
         <div
             className={clsx(
-                'flex flex-col flex-1 gap-1 min-h-0',
-                isMobile ? 'absolute inset-0 z-20 bg-surface-primary' : 'min-w-[375px]'
+                'flex min-h-0 flex-1 flex-col gap-1 bg-[var(--background)]',
+                isMobile ? 'absolute inset-0 z-20' : 'min-w-[375px]'
             )}
         >
             {isMobile && (
                 <div className="flex items-center justify-between p-1 shrink-0">
-                    <div className="flex items-center gap-1 pl-1">
+                    <div data-not-quill className="flex items-center gap-1 pl-1">
                         {selectedEvent?.timestamp && (
-                            <TZLabel className="text-muted text-xs" time={selectedEvent.timestamp} />
+                            <TZLabel className="text-xs text-muted-foreground" time={selectedEvent.timestamp} />
                         )}
                         {tagRenderer(selectedEvent)}
                     </div>
-                    <LemonButton icon={<IconX />} size="small" onClick={onClose} aria-label="Close detail" />
+                    <Button variant="outline" size="icon-sm" onClick={onClose} aria-label="Close detail">
+                        <IconX />
+                    </Button>
                 </div>
             )}
-            <PostHogSDKIssueBanner event={selectedEvent} />
+            <div data-not-quill className="contents">
+                <PostHogSDKIssueBanner event={selectedEvent} />
+            </div>
             <div className="flex-1 min-h-0 flex flex-col">
                 <ExceptionCard
                     issueId={issue?.id ?? 'no-issue'}
                     issueName={issue?.name ?? null}
                     loading={issueLoading || initialEventLoading}
                     event={selectedEvent ?? undefined}
-                    label={tagRenderer(selectedEvent)}
+                    label={
+                        <span data-not-quill className="contents">
+                            {tagRenderer(selectedEvent)}
+                        </span>
+                    }
                     hideEventMeta={isMobile}
                     renderStackTraceActions={() => {
                         return issue ? <StackTraceActions issue={issue} /> : null
@@ -325,37 +338,37 @@ const LeftHandColumn = ({ isMobile }: { isMobile: boolean }): JSX.Element => {
                           minWidth: 320,
                       }
             }
-            className={clsx('flex flex-col h-full relative bg-surface-primary', isMobile && 'flex-1 max-w-full')}
+            className={clsx('relative flex h-full flex-col bg-[var(--background)]', isMobile && 'max-w-full flex-1')}
         >
-            <TabsPrimitive
+            <Tabs
                 value={category}
                 onValueChange={(value) => {
                     setCategory(value as ErrorTrackingIssueSceneCategory)
                     posthog.capture('error_tracking_issue_tab_viewed', { issue_id: issueId, tab: value })
                 }}
-                className="flex flex-col flex-1 min-h-0"
+                className="min-h-0 flex-1 gap-0"
             >
                 <div>
-                    <ScrollableShadows direction="horizontal" className="border-b" hideScrollbars>
-                        <TabsPrimitiveList className="flex space-x-0.5 gap-2">
-                            <TabsPrimitiveTrigger className="flex items-center px-2 py-1.5" value="exceptions">
+                    <ScrollableShadows direction="horizontal" className="border-b border-border" hideScrollbars>
+                        <TabsList variant="line" className="flex space-x-0.5 gap-2">
+                            <TabsTrigger className="flex flex-none items-center px-2 py-1.5" value="exceptions">
                                 <IconList className="mr-1" />
                                 <span className="text-nowrap">Exceptions</span>
-                            </TabsPrimitiveTrigger>
-                            <TabsPrimitiveTrigger className="flex items-center px-2 py-1.5" value="breakdowns">
+                            </TabsTrigger>
+                            <TabsTrigger className="flex flex-none items-center px-2 py-1.5" value="breakdowns">
                                 <IconFilter className="mr-1" />
                                 <span className="text-nowrap">Breakdowns</span>
-                            </TabsPrimitiveTrigger>
-                        </TabsPrimitiveList>
+                            </TabsTrigger>
+                        </TabsList>
                     </ScrollableShadows>
                 </div>
-                <TabsPrimitiveContent value="exceptions" className="h-full min-h-0">
+                <TabsContent value="exceptions" className="h-full min-h-0">
                     <ExceptionsTab />
-                </TabsPrimitiveContent>
-                <TabsPrimitiveContent value="breakdowns" className="flex-1 min-h-0">
+                </TabsContent>
+                <TabsContent value="breakdowns" className="flex-1 min-h-0">
                     <BreakdownsTab />
-                </TabsPrimitiveContent>
-            </TabsPrimitive>
+                </TabsContent>
+            </Tabs>
 
             {!isMobile && <Resizer {...resizerLogicProps} />}
         </div>
@@ -367,52 +380,58 @@ const ExceptionsTab = (): JSX.Element => {
         useValues(errorTrackingIssueSceneLogic)
     const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
     const eventsDataSource = eventsSourceLogic({ query: eventsQuery, queryKey: eventsQueryKey })
-    const { itemsLoading } = useValues(eventsDataSource)
-    const { loadData } = useActions(eventsDataSource)
+    const { itemsLoading, canLoadNextData } = useValues(eventsDataSource)
+    const { loadData, loadNextData } = useActions(eventsDataSource)
 
     return (
         <div className="flex flex-col h-full min-h-0">
-            <div className="shrink-0 px-2 py-2">
-                <ErrorFilters.Root>
-                    <div className="flex w-full flex-col gap-1">
-                        <div className="flex w-full flex-wrap items-center gap-1">
-                            <Tooltip>
-                                <TooltipTrigger
-                                    render={
-                                        <Button
-                                            variant="outline"
-                                            size="icon"
-                                            loading={itemsLoading}
-                                            aria-label="Reload exceptions"
-                                            onClick={() => loadData()}
-                                        />
-                                    }
-                                >
-                                    <IconRefresh />
-                                </TooltipTrigger>
-                                <TooltipContent>Reload exceptions</TooltipContent>
-                            </Tooltip>
-                            <ErrorFilters.DateRange />
-                            <div className="ml-auto shrink-0">
-                                <ErrorFilters.InternalAccounts />
+            <Metadata
+                className="flex flex-col flex-1 min-h-0"
+                onScrollNearEnd={() => {
+                    if (canLoadNextData && !itemsLoading) {
+                        loadNextData()
+                    }
+                }}
+            >
+                <div className="sticky top-0 z-10 shrink-0 border-y border-border bg-[var(--background)] px-2 py-2">
+                    <ErrorFilters.Root className="w-full">
+                        <div className="flex w-full flex-col gap-1">
+                            <div className="flex w-full flex-wrap items-center gap-1">
+                                <Tooltip>
+                                    <TooltipTrigger
+                                        render={
+                                            <Button
+                                                variant="outline"
+                                                size="icon"
+                                                loading={itemsLoading}
+                                                aria-label="Reload exceptions"
+                                                onClick={() => loadData()}
+                                            />
+                                        }
+                                    >
+                                        <IconRefresh />
+                                    </TooltipTrigger>
+                                    <TooltipContent>Reload exceptions</TooltipContent>
+                                </Tooltip>
+                                <ErrorFilters.DateRange />
+                                <div className="ml-auto shrink-0">
+                                    <ErrorFilters.InternalAccounts />
+                                </div>
+                            </div>
+                            <div className="flex w-full flex-wrap items-center gap-1">
+                                <ErrorFilters.Search
+                                    className="w-auto min-w-40 flex-1 shrink"
+                                    placeholder="Search exceptions"
+                                />
+                                <ErrorFilters.FilterGroup />
                             </div>
                         </div>
-                        <div className="flex w-full flex-wrap items-center gap-1">
-                            <ErrorFilters.Search
-                                className="ErrorTrackingIssue__search w-auto min-w-40 flex-1 shrink"
-                                placeholder="Search exceptions"
-                            />
-                            <ErrorFilters.FilterGroup />
-                        </div>
-                    </div>
-                </ErrorFilters.Root>
-            </div>
-            <Separator className="shrink-0" />
-            <Metadata className="flex flex-col flex-1 min-h-0">
+                    </ErrorFilters.Root>
+                </div>
                 {issueFingerprintsLoading ? (
-                    <div className="text-muted text-sm px-2 py-3">Loading exceptions...</div>
+                    <div className="px-2 py-3 text-sm text-muted-foreground">Loading exceptions...</div>
                 ) : issueFingerprints.length === 0 ? (
-                    <div className="text-muted text-sm px-2 py-3">No exceptions found for this issue.</div>
+                    <div className="px-2 py-3 text-sm text-muted-foreground">No exceptions found for this issue.</div>
                 ) : (
                     <EventsTable
                         query={eventsQuery}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/IssueAssigneeSelect.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ScenePanel/IssueAssigneeSelect.tsx
@@ -1,5 +1,6 @@
-import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
-import { MenuOpenIndicator } from 'lib/ui/Menus/Menus'
+import { IconChevronDown } from '@posthog/icons'
+
+import { Button } from 'lib/ui/quill'
 
 import { ErrorTrackingIssueAssignee } from '~/queries/schema/schema-general'
 
@@ -8,24 +9,20 @@ import { AssigneeSelect } from '../../../components/Assignee/AssigneeSelect'
 
 export const IssueAssigneeSelect = ({
     assignee,
-    disabled,
     onChange,
 }: {
     assignee: ErrorTrackingIssueAssignee | null
-    disabled: boolean
     onChange: (assignee: ErrorTrackingIssueAssignee | null) => void
 }): JSX.Element => {
     return (
         <div>
             <AssigneeSelect assignee={assignee} onChange={onChange}>
                 {(anyAssignee, isOpen) => (
-                    <ButtonPrimitive disabled={disabled} data-state={isOpen ? 'open' : 'closed'}>
-                        <div className="flex items-center">
-                            <AssigneeIconDisplay assignee={anyAssignee} size="small" />
-                            <AssigneeLabelDisplay assignee={anyAssignee} className="ml-1" size="small" />
-                        </div>
-                        {!disabled && <MenuOpenIndicator className="ml-auto" />}
-                    </ButtonPrimitive>
+                    <Button variant="default" size="default" data-state={isOpen ? 'open' : 'closed'}>
+                        <AssigneeIconDisplay assignee={anyAssignee} size="small" />
+                        <AssigneeLabelDisplay assignee={anyAssignee} size="small" />
+                        <IconChevronDown />
+                    </Button>
                 )}
             </AssigneeSelect>
         </div>

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts
@@ -5,7 +5,7 @@ import { ErrorTrackingFingerprint } from 'lib/components/Errors/types'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
+import { errorTrackingIssueSceneLogic, toErrorTrackingIssueSummary } from './errorTrackingIssueSceneLogic'
 
 const makeFingerprints = (fingerprint: string = 'fp-1'): ErrorTrackingFingerprint[] => [
     { fingerprint, issue_id: 'issue-1', created_at: '2026-01-01T00:00:00Z' },
@@ -64,6 +64,34 @@ describe('errorTrackingIssueSceneLogic', () => {
         })
             .toDispatchActions(['loadInitialEventSuccess'])
             .toMatchValues({ initialEvent: null })
+    })
+
+    it('keeps stable first and last event IDs in the issue summary', () => {
+        expect(
+            toErrorTrackingIssueSummary({
+                first_seen: '2026-01-01T00:00:00Z',
+                last_seen: '2026-01-02T00:00:00Z',
+                first_event: {
+                    uuid: 'first-event',
+                    distinct_id: 'first-person',
+                    timestamp: '2026-01-01T00:00:00Z',
+                    properties: '{}',
+                },
+                last_event: {
+                    uuid: 'last-event',
+                    distinct_id: 'last-person',
+                    timestamp: '2026-01-02T00:00:00Z',
+                    properties: '{}',
+                },
+                aggregations: { occurrences: 2, sessions: 2, users: 2, volume_buckets: [] },
+            })
+        ).toEqual({
+            first_seen: '2026-01-01T00:00:00Z',
+            last_seen: '2026-01-02T00:00:00Z',
+            first_event_uuid: 'first-event',
+            last_event_uuid: 'last-event',
+            aggregations: { occurrences: 2, sessions: 2, users: 2, volume_buckets: [] },
+        })
     })
 
     // A malformed `timestamp` URL param used to be stored and fed to getNarrowDateRange, where

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
@@ -717,23 +717,15 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                         searchQuery: values.searchQuery,
                         volumeResolution: ERROR_TRACKING_DETAILS_RESOLUTION,
                         withAggregations: true,
-                        withFirstEvent: false,
-                        withLastEvent: false,
+                        withFirstEvent: true,
+                        withLastEvent: true,
                     }),
                     { refresh: 'blocking' }
                 )
                 if (!response.results.length) {
                     return null
                 }
-                const summary = response.results[0]
-                if (!summary.aggregations) {
-                    return null
-                }
-                return {
-                    first_seen: summary.first_seen,
-                    last_seen: summary.last_seen,
-                    aggregations: summary.aggregations,
-                }
+                return toErrorTrackingIssueSummary(response.results[0])
             },
         },
         issueFingerprints: [
@@ -981,5 +973,23 @@ function getNarrowDateRange(timestamp: Dayjs | string): DateRange {
 export type ErrorTrackingIssueSummary = {
     last_seen?: string
     first_seen?: string
+    first_event_uuid?: string
+    last_event_uuid?: string
     aggregations: ErrorTrackingIssueAggregations
+}
+
+export function toErrorTrackingIssueSummary(
+    summary: Pick<ErrorTrackingIssue, 'first_seen' | 'last_seen' | 'first_event' | 'last_event' | 'aggregations'>
+): ErrorTrackingIssueSummary | null {
+    if (!summary.aggregations) {
+        return null
+    }
+
+    return {
+        first_seen: summary.first_seen,
+        last_seen: summary.last_seen,
+        first_event_uuid: summary.first_event?.uuid,
+        last_event_uuid: summary.last_event?.uuid,
+        aggregations: summary.aggregations,
+    }
 }

--- a/products/logs/frontend/components/ViewLogsButton.tsx
+++ b/products/logs/frontend/components/ViewLogsButton.tsx
@@ -16,23 +16,15 @@ export interface ViewLogsButtonProps extends Pick<LemonButtonProps, 'size' | 'ty
     iconOnly?: boolean
 }
 
-// Opens the logs viewer modal filtered to one session, using the team's configured
-// session ID attribute keys. The session-replay / error-tracking counterpart of
-// logs' own ViewRecordingButton usage. Gated here rather than at call sites so
-// every surface of the logs-in-error-tracking rollout toggles with one flag.
-export function ViewLogsButton({
-    sessionId,
-    timestamp,
-    iconOnly,
-    ...buttonProps
-}: ViewLogsButtonProps): JSX.Element | null {
+export function useViewLogsButton({ sessionId, timestamp }: Pick<ViewLogsButtonProps, 'sessionId' | 'timestamp'>): {
+    enabled: boolean
+    onClick: (() => void) | undefined
+    loading: boolean
+    disabledReason: string | undefined
+} {
     const { configuredSessionIdKeys, logsConfigLoading } = useValues(logsConfigLogic)
     const { openLogsViewerModal } = useActions(logsViewerModalLogic)
     const enabled = useFeatureFlag('LOGS_IN_ERROR_TRACKING')
-
-    if (!enabled) {
-        return null
-    }
 
     // Until the team's logs config resolves we don't know which session-ID keys to filter on.
     // Opening with the fallback key here would silently show logs filtered by the wrong
@@ -47,13 +39,34 @@ export function ViewLogsButton({
                   })
             : undefined
 
+    return {
+        enabled,
+        onClick,
+        loading: logsConfigLoading,
+        disabledReason: sessionId ? undefined : 'No session ID associated with this event',
+    }
+}
+
+// The shared hook keeps the feature flag and configured session ID keys consistent across every logs entry point.
+export function ViewLogsButton({
+    sessionId,
+    timestamp,
+    iconOnly,
+    ...buttonProps
+}: ViewLogsButtonProps): JSX.Element | null {
+    const { enabled, onClick, loading, disabledReason } = useViewLogsButton({ sessionId, timestamp })
+
+    if (!enabled) {
+        return null
+    }
+
     return (
         <LemonButton
             icon={<IconLive />}
             onClick={onClick}
-            loading={logsConfigLoading}
+            loading={loading}
             tooltip={iconOnly ? 'View logs from this session' : undefined}
-            disabledReason={sessionId ? undefined : 'No session ID associated with this event'}
+            disabledReason={disabledReason}
             {...buttonProps}
         >
             {iconOnly ? null : 'View logs'}


### PR DESCRIPTION
## Problem

- The issue scene mixes legacy controls with Quill surfaces, which creates inconsistent interaction states and spacing.
- The event list hides useful metadata and requires explicit pagination during issue investigation.

## Changes

- Replace the event list presentation with compact Quill rows, semantic markers, and near-bottom pagination.
- Add two-line exception metadata, person timestamps, and a compact action menu.
- Use Quill tabs and controls while isolating remaining LemonUI components with `data-not-quill` boundaries.
- Stabilize source-code gutters, Session timeline sizing, recording layouts, and semantic interaction states.
- Preserve the standard LemonUI button radius inside Quill-scoped Error Tracking screens.

> [!NOTE]
> Screenshot upload is pending because the public asset repository now requires signed commits.

## How did you test this code?

- Focused Jest suites passed for LemonDropdown, Indicators, issue scene logic, and Session timeline behavior.
- Storybook browser checks covered Stack Trace, Properties, Session, menus, tabs, and source scrolling in light and dark themes.
- Local Playwright QA covered Issues, Insights, Recommendations, Configuration, and fingerprint routes in light and dark themes.
- `./bin/hogli ci:preflight --fix` found no known CI failure class.
- The full TypeScript check remains blocked by unrelated generated-type errors on this checkout.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update is required for this visual and interaction change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi implemented the user-directed migration and local browser QA.
- Skills invoked: `/error-tracking`, `/qa-frontend`, `/run-posthog`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-kea-logics`, `/adopting-generated-api-types`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `/pr`.
- The migration uses a broad Quill issue-scene scope with targeted LemonUI escape hatches to minimize visual drift.
