### PR TITLE
fix(clerk): stop retrying saml_connections 422s from unsupported accounts

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/source.py
@@ -108,6 +108,12 @@ The secret key starts with `sk_live_`.
             # Clerk answers 410 for endpoints it has removed. Schema discovery retires the table
             # within a few hours, so this only covers runs that start in between.
             "410 Client Error: Gone for url: https://api.clerk.com": "Clerk removed this endpoint from its API, so this table can't sync any more. Turn off syncing for this table.",
+            # Clerk's own API spec documents only 402/403/422 as possible error responses for this
+            # (deprecated) list endpoint — no successful, well-formed request should ever hit this,
+            # so a 422 here means SAML connections (Enterprise SSO) aren't available on this Clerk
+            # instance. Scoped to this path, not all of api.clerk.com, since 422 elsewhere can mean
+            # a genuinely bad request that's worth investigating rather than an account limitation.
+            "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/saml_connections": "SAML connections (Enterprise SSO) aren't available on your Clerk plan or instance. Turn off syncing for this table, or enable SAML connections in your Clerk dashboard.",
             **{reason: reason for reason in RETIRED_ENDPOINTS.values()},
         }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk_source.py
@@ -38,6 +38,7 @@ class TestClerkSource:
         [
             "401 Client Error: Unauthorized for url: https://api.clerk.com",
             "403 Client Error: Forbidden for url: https://api.clerk.com",
+            "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/saml_connections",
         ],
     )
     def test_non_retryable_errors_includes_clerk_key(self, expected_key):
@@ -45,10 +46,16 @@ class TestClerkSource:
 
         assert expected_key in errors
 
-    def test_non_retryable_errors_matches_observed_error_message(self):
-        # Matches the full error string seen in production for the `users` endpoint.
-        observed_error = "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/users?limit=100"
-
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            # `users` endpoint, invalid/revoked secret key.
+            "401 Client Error: Unauthorized for url: https://api.clerk.com/v1/users?limit=100",
+            # `saml_connections` endpoint, SAML/Enterprise SSO not available on the account's plan.
+            "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/saml_connections?limit=100",
+        ],
+    )
+    def test_non_retryable_errors_matches_observed_error_message(self, observed_error):
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert any(key in observed_error for key in non_retryable_errors)
 
@@ -63,6 +70,16 @@ class TestClerkSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
 
         assert not any(key in other_vendor_error for key in non_retryable_errors)
+
+    def test_non_retryable_errors_does_not_match_422_on_other_clerk_endpoints(self):
+        # A 422 from a different endpoint is a genuinely bad request worth investigating, not an
+        # account limitation — the match must stay scoped to `saml_connections`.
+        other_endpoint_error = (
+            "422 Client Error: Unprocessable Entity for url: https://api.clerk.com/v1/users?limit=100"
+        )
+
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_endpoint_error for key in non_retryable_errors)
 
     def test_get_schemas(self):
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

Clerk data warehouse syncs for the `saml_connections` table fail with a 422 error across several unrelated accounts, seen in [this error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd687-b7a6-7200-baa3-6e0b59f394f3).

Clerk's own API spec documents only 402, 403, and 422 as possible error responses for this list endpoint, and SAML connections are gated behind the Organizations / Enterprise SSO feature on Clerk's plans. A 422 here means the feature isn't available on the account's Clerk instance, not a malformed request on our side, so retrying it can never succeed.

## Changes

- Add a non-retryable entry for 422 responses from `saml_connections`, scoped to that endpoint's path so a 422 from a different Clerk endpoint (a genuinely bad request worth investigating) still fails loudly.
- The surfaced message tells the customer to turn off syncing for the table or enable SAML connections in their Clerk dashboard.

## How did you test this code?

- Added a parameterized case pinning the exact production error text as non-retryable, and a new test confirming a 422 from a different Clerk endpoint (`/users`) is not matched - guards the path scoping.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/`: all 142 tests passed.
- Not run: a live call against the real Clerk API, since this environment has no test credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed; no user-facing behavior or documented API changed beyond the internal retry classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to pull the issue's stack trace, confirming the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py` while paginating `saml_connections`. Cross-checked Clerk's public OpenAPI spec repo (`clerk/openapi-specs`) to confirm this list endpoint's documented response set is limited to 402/403/422, and Clerk's own docs confirm SAML connections are gated behind Organizations/Enterprise SSO. Checked for an existing fix first: found PR #78763 from the same maintainer, which fixes an unrelated Clerk billing-endpoint rename, not a duplicate of this issue. Invoked `/writing-tests` before extending the test file and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*