### PR TITLE
chore(experiments): add retention coverage to the precompute canary

### DIFF
--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -6,7 +6,8 @@ scan (``PrecomputationMode.DIRECT``). Two checks per metric:
 
 - stability (A vs B): two precomputed reads seconds apart must agree. Funnel reads are fully frozen, so the
   tolerance is strict; mean/ratio metrics join live event values onto frozen exposures, so only the exposure
-  counts are held to the strict tolerance.
+  counts are held to the strict tolerance. Retention resolves both of its numbers from metric events, so
+  both get the loose tolerance.
 - correctness (B vs C): the precomputed read must agree with the events table within a loose tolerance that
   covers live ingestion between the cache writes and the direct scan.
 
@@ -87,8 +88,9 @@ LOOSE_TOLERANCE = 0.02
 # Below this, a single user moves a variant by more than the strict tolerance and comparison is meaningless.
 MIN_EXPOSURES_PER_VARIANT = 100
 
-# Only metric types that use the precompute path. Retention metrics don't, so a paired run tests nothing.
-ELIGIBLE_METRIC_TYPES = ("funnel", "mean", "ratio")
+# Metric types that use the precompute path: all of them read precomputed exposures, and funnel,
+# mean, and retention also read precomputed metric events when eligible.
+ELIGIBLE_METRIC_TYPES = ("funnel", "mean", "ratio", "retention")
 
 # Experiments must have been running this long to be sampled — comfortably past the runner's 12h
 # precomputation gate, with enough accumulated exposures for the comparison to be meaningful.
@@ -172,7 +174,12 @@ def sample_canary_targets_sync(inputs: ExperimentPrecomputeCanaryInputs) -> list
     if inputs.experiment_id is not None:
         return _forensics_targets(inputs.experiment_id, inputs.metric_uuids)
 
-    quotas = {"funnel": inputs.funnel_quota, "mean": inputs.mean_quota, "ratio": inputs.ratio_quota}
+    quotas = {
+        "funnel": inputs.funnel_quota,
+        "mean": inputs.mean_quota,
+        "ratio": inputs.ratio_quota,
+        "retention": inputs.retention_quota,
+    }
     experiments = _eligible_experiments()
     random.shuffle(experiments)
 
@@ -241,9 +248,13 @@ def _max_deviation(run_x: CanaryRunSnapshot, run_y: CanaryRunSnapshot) -> float:
 def _stability_violated(metric_type: str, run_a: CanaryRunSnapshot, run_b: CanaryRunSnapshot) -> bool:
     for key, stats_a in run_a.variants.items():
         stats_b = run_b.variants[key]
-        if relative_deviation(stats_a.number_of_samples, stats_b.number_of_samples) > STRICT_TOLERANCE:
+        # Funnel/mean/ratio sample counts come from frozen exposures. Retention counts users with
+        # a start event, resolved from metric events that can be live-scanned (flag off, or an
+        # ineligible metric), so its count gets the loose bound too.
+        samples_tolerance = LOOSE_TOLERANCE if metric_type == "retention" else STRICT_TOLERANCE
+        if relative_deviation(stats_a.number_of_samples, stats_b.number_of_samples) > samples_tolerance:
             return True
-        # Funnel sums are reads of frozen caches; mean/ratio sums join live event values and drift.
+        # Funnel sums are reads of frozen caches; mean/ratio/retention sums join live event values and drift.
         sum_tolerance = STRICT_TOLERANCE if metric_type == "funnel" else LOOSE_TOLERANCE
         if relative_deviation(stats_a.sum, stats_b.sum) > sum_tolerance:
             return True

--- a/products/experiments/backend/temporal/models.py
+++ b/products/experiments/backend/temporal/models.py
@@ -103,6 +103,10 @@ class ExperimentPrecomputeCanaryInputs:
     # Drop back toward ~10 once the mean table has a few clean weeks of canary history.
     mean_quota: int = 20
     ratio_quota: int = 4
+    # Bake-in level for the retention metric-events precompute path. Most retention metrics are
+    # eligible (breakdowns and data warehouse sources are rare on them), so nominal stays close
+    # to effective. Drop toward ~5 once retention has a few clean weeks of canary history.
+    retention_quota: int = 15
     per_experiment_cap: int = 3
     time_budget_seconds: int = 5400
     triggered_manually: bool = False

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -111,6 +111,22 @@ class TestEvaluateCanaryRuns:
                 OUTCOME_DIVERGENCE,
             ),
             (
+                "retention_samples_drift_between_precomputed_reads_passes",
+                "retention",
+                _BASE,
+                {"control": (1000.0, 10050), "test": (1100.0, 10000)},  # start counts read metric events: loose
+                {"control": (1000.0, 10050), "test": (1100.0, 10000)},
+                OUTCOME_PASS,
+            ),
+            (
+                "retention_samples_drift_beyond_loose_tolerance_diverges",
+                "retention",
+                _BASE,
+                {"control": (1000.0, 10300), "test": (1100.0, 10000)},  # 3% > 2%
+                {"control": (1000.0, 10300), "test": (1100.0, 10000)},
+                OUTCOME_DIVERGENCE,
+            ),
+            (
                 "direct_scan_within_loose_tolerance_passes",
                 "funnel",
                 _BASE,
@@ -255,11 +271,12 @@ class TestCanarySampling(BaseTest):
         Experiment.objects.filter(id=experiment.id).update(**resolved)
         assert sample_canary_targets_sync(ExperimentPrecomputeCanaryInputs()) == []
 
-    def test_retention_and_legacy_metrics_are_dropped(self):
+    def test_legacy_metrics_are_dropped_but_retention_is_sampled(self):
         self._enable_precompute()
         legacy = {"uuid": str(uuid.uuid4()), "kind": "ExperimentTrendsQuery"}  # no metric_type
         self._experiment([_inline_metric("retention"), legacy])
-        assert sample_canary_targets_sync(ExperimentPrecomputeCanaryInputs()) == []
+        targets = sample_canary_targets_sync(ExperimentPrecomputeCanaryInputs())
+        assert [t.metric_type for t in targets] == ["retention"]
 
     def test_quotas_and_per_experiment_cap(self):
         self._enable_precompute()


### PR DESCRIPTION
## Problem

The precompute canary does not sample retention metrics, so the retention metric-events path (#78699) would roll out unwatched. The comment saying retention does not use the precompute path is also stale: exposure precompute already serves retention today.

## Changes

- Added `retention` to the canary's eligible metric types, with a quota of 15. Like the mean quota, this is a raised level for the rollout and can drop to ~5 once retention has a few clean weeks.
- Relaxed the stability tolerance for retention sample counts. For funnel, mean, and ratio the count comes from frozen exposures, so it is held to the strict bound. Retention counts users with a start event, read from metric events that can be live-scanned, so it gets the loose bound like mean sums.
- This lands before the retention flag is enabled anywhere, so the first enabled team is watched from day one.

## How did you test this code?

- Updated the sampling test: legacy metrics are still dropped, retention is now sampled.
- Two new verdict cases: retention sample-count drift within the loose bound passes, drift beyond it diverges. Both would have been wrongly judged by the strict bound before this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The tolerance rules live in the module docstring, updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code from the retention precompute feature plan (item P12). Skills invoked: /wt, /writing-tests, /writing-pr-descriptions.
