### PR TITLE
fix(aio): run cymbal-resolution in hobby so cymbal stops crash-looping

### DIFF
--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -641,6 +641,10 @@ services:
             REDIS_URL: 'redis://redis7:6379/'
             ISSUE_BUCKETS_REDIS_URL: 'redis://redis7:6379/'
             RUST_LOG: 'info'
+            # Processing offloads all symbol resolution to cymbal-resolution over gRPC. Both are
+            # mandatory: startup aborts when either is empty, so omitting them crash-loops cymbal.
+            CYMBAL_REMOTE_RESOLUTION_HOST: 'cymbal-resolution'
+            INTERNAL_API_SECRET: $POSTHOG_SECRET
         depends_on:
             kafka-init:
                 condition: service_completed_successfully
@@ -649,6 +653,36 @@ services:
             db:
                 condition: service_healthy
             redis7:
+                condition: service_healthy
+            cymbal-resolution:
+                condition: service_started
+
+    # The cymbal binary in resolution mode: the gRPC symbol-resolution service that cymbal's
+    # processing mode calls. Needs only Postgres and object storage — no Kafka or Redis — hence
+    # the narrower env than cymbal above.
+    cymbal-resolution:
+        image: ghcr.io/posthog/posthog/cymbal:master
+        build:
+            context: ./posthog/rust
+            args:
+                BIN: cymbal
+        restart: on-failure
+        logging: *default-logging
+        environment:
+            CYMBAL_MODE: resolution
+            GRPC_ADDRESS: '0.0.0.0:50061'
+            OBJECT_STORAGE_BUCKET: posthog
+            OBJECT_STORAGE_ACCESS_KEY_ID: 'any'
+            OBJECT_STORAGE_SECRET_ACCESS_KEY: 'any'
+            OBJECT_STORAGE_ENDPOINT: 'http://seaweedfs:8333'
+            OBJECT_STORAGE_FORCE_PATH_STYLE: 'true'
+            DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
+            INTERNAL_API_SECRET: $POSTHOG_SECRET
+            RUST_LOG: 'info'
+        depends_on:
+            seaweedfs:
+                condition: service_healthy
+            db:
                 condition: service_healthy
 
 volumes:


### PR DESCRIPTION
## Problem

**Self-hosted hobby instances have been unable to start `cymbal` since 2026-08-04.** The container panics on boot and restart-loops indefinitely:

```
thread 'main' panicked at cymbal/src/modes/processing/mod.rs:28:67:
called `Result::unwrap()` on an `Err` value: Other("CYMBAL_REMOTE_RESOLUTION_HOST is empty")
```

### Root cause

Before #76531, remote symbol resolution was opt-in behind `CYMBAL_REMOTE_RESOLUTION_ENABLED`, which defaulted to `false`. Hobby never set `CYMBAL_REMOTE_RESOLUTION_HOST`, and that was fine — the empty value was inert because remote resolution was switched off, and processing resolved symbols locally.

#76531 ("chore(cymbal): remove local processing resolution") deleted that flag and made remote resolution the only path. An empty host went from harmless to fatal: `RemoteResolutionConfig::from_config` now returns an error, and processing mode unwraps it. The same function rejects an empty `INTERNAL_API_SECRET`, which hobby also never set.

That PR updated `bin/start-rust-service` so local dev keeps working, and prod is configured separately in the charts repo (`apps/cymbal-processing/values.yaml` sets the host; `apps/cymbal-resolution/` runs the service). **`docker-compose.hobby.yml` was the deployment nobody updated** — it has no `cymbal-resolution` service at all.

### Who is affected

Real self-hosted users, not just CI. `bin/deploy-hobby` defaults to `POSTHOG_APP_TAG=latest`, which does `git reset --hard origin/master`, and the compose file pins `image: ghcr.io/posthog/posthog/cymbal:master`. So any hobby install or upgrade since 2026-08-04 pairs master's compose (missing the wiring) with master's cymbal image (which requires it).

Blast radius looks limited to error tracking: nothing in the hobby compose declares `depends_on: cymbal`, so the rest of the stack still comes up. The user-visible symptom is broken stack-frame symbolication plus a container stuck restarting.

It went unnoticed because E2E Hobby CI only runs when a PR touches its path filter (`Dockerfile`, `docker-compose.base.yml`, `docker-compose.hobby.yml`, the hobby scripts). Most PRs skip the job entirely, so the failure surfaced only when an unrelated PR happened to touch `docker-compose.base.yml`.

## Changes

Give hobby the same two-service topology that local dev and production already run:

- **Add a `cymbal-resolution` service** — the `cymbal` binary with `CYMBAL_MODE=resolution`, serving gRPC on the contract default port `50061`. It needs only Postgres and object storage (no Kafka or Redis), matching the narrower env in `bin/start-rust-service`.
- **Point processing at it** — `CYMBAL_REMOTE_RESOLUTION_HOST: cymbal-resolution` on the existing `cymbal` service, plus `INTERNAL_API_SECRET`, which the same config path also requires.

`INTERNAL_API_SECRET` uses the existing `$POSTHOG_SECRET` convention rather than a literal, so each deployment keeps its own generated secret — this file ships to self-hosted users.

## How did you test this code?

**Verified locally:** the compose file parses, and the resulting graph has `cymbal-resolution` present, `CYMBAL_REMOTE_RESOLUTION_HOST` resolving to it, `CYMBAL_MODE=resolution`, `GRPC_ADDRESS=0.0.0.0:50061`, and `cymbal` gaining a `depends_on` edge to the new service.

**Cross-checked against the two working deployments** rather than invented: the service env mirrors `bin/start-rust-service`'s `cymbal-resolution` block (local dev), and the topology mirrors the charts repo, where `apps/cymbal-resolution/` runs the same binary in the same mode and `apps/cymbal-processing/values.yaml:231` sets `CYMBAL_REMOTE_RESOLUTION_HOST` to the resolution service.

**What I could not test:** I have not booted a hobby instance. E2E Hobby CI provisions a DigitalOcean droplet, so this PR's own CI run is the first real execution — and because it touches `docker-compose.hobby.yml`, the job will actually run rather than skip. Please treat that run as the verification step.

**Reviewers from error tracking:** worth a look at whether a single-box hobby deployment should really run a second cymbal container, or whether processing should instead degrade gracefully when no resolution host is configured. This PR takes the first option because it matches dev and prod, but the graceful-degradation path is arguably the better fit for self-hosted and is your call.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed — restores intended behaviour, no new user-facing configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with PostHog Code (Claude Opus), directed by @carlos-marchal-ph.

Found while investigating a persistently red E2E Hobby CI check on an unrelated PR ([#78450](https://github.com/PostHog/posthog/pull/78450), multimodal ingestion tests). The first assumption was that our own change to `docker-compose.base.yml` had broken it. Ruling that out is what surfaced the real cause: `cymbal` is defined inline in `docker-compose.hobby.yml` and never extends the base file, the branch touched no Rust, and other PRs were not passing hobby so much as skipping it.

The fix originally rode along on that PR; it was split out here so the owning team can review and merge it independently, since it unbreaks self-hosted users regardless of what happens to the test PR.
