### PR TITLE
fix(charts): follow the cursor with chart tooltips by default

### DIFF
--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -16,6 +16,7 @@ const CHART_CONFIG_DEFAULTS = {
     showCrosshair: true,
     showGrid: true,
     barCornerRadius: 4,
+    tooltip: { placement: 'cursor' },
 } as const
 
 function chartThemeDefaults(isDarkModeOn: boolean): Partial<ChartTheme> {
@@ -72,7 +73,8 @@ export function useDateRangeZoom(
 }
 
 /** Builds a chart's config object, memoized on `deps`, applying `CHART_CONFIG_DEFAULTS` for any
- *  key the factory leaves undefined. Keys the factory sets explicitly always win over the defaults. */
+ *  key the factory leaves undefined. Keys the factory sets explicitly always win over the defaults.
+ *  `tooltip` merges key by key instead of being replaced wholesale. */
 export function useChartConfig<T extends object>(factory: () => T, deps: DependencyList): T
 export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined
 export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined {
@@ -83,6 +85,8 @@ export function useChartConfig<T extends object>(factory: () => T | undefined, d
             return config
         }
         const defined = Object.fromEntries(Object.entries(config).filter(([, value]) => value !== undefined))
-        return { ...CHART_CONFIG_DEFAULTS, ...defined } as T
+        // Nested, so a chart that sets any tooltip field would otherwise replace the whole default.
+        const tooltip = { ...CHART_CONFIG_DEFAULTS.tooltip, ...defined.tooltip }
+        return { ...CHART_CONFIG_DEFAULTS, ...defined, tooltip } as T
     }, deps)
 }


### PR DESCRIPTION
## Problem

Hovering a chart in the app leaves the tooltip sitting still while the cursor moves, because it anchors to the hovered data point rather than the pointer.
On a tall chart the tooltip can land far from where the person is actually looking.

Every surface that wanted the familiar behavior opted in by hand.
11 call sites already pass `tooltip: { placement: 'cursor' }` — box plot, experiment exposures, two survey charts, four mcp_analytics charts, error tracking rate limits, endpoints, and SQL insights.
That made cursor placement the convention in practice, and the wrong default in code.

## Changes

- `useChartConfig` now defaults `tooltip.placement` to `cursor`, so every app chart built through the shared hook follows the pointer.
- `tooltip` merges key by key instead of replacing the default wholesale. A chart that sets only `valueFormatter` would otherwise drop the placement and silently keep the old anchoring.
- The quill-charts library default stays `follow-data`. Changing it there would also move the desktop app and MCP apps, which this PR does not intend.

Nothing changes shape or color, so there is no before and after screenshot to show: the difference is where the tooltip sits as the pointer moves.
Measured on the marketing analytics attribution chart, holding x fixed and moving the cursor 207px down within one band:

| | tooltip top, cursor high | tooltip top, cursor low | movement |
| --- | --- | --- | --- |
| before | 709 | 709 | 0px |
| after | 517 | 725 | 208px |

Two follow-ups this PR leaves alone:

- The 11 explicit `placement: 'cursor'` lines are now redundant. A few build config outside `useChartConfig` and do not inherit the default, so removing them needs a per-file check rather than a sweep.
- `FunnelStepsBarChart` keeps `top` placement. It passes a module-level `CHART_CONFIG` rather than the hook, so this default does not reach it.

## How did you test this code?

I (actually Claude) measured the table above in the running dev app, hovering the attribution chart and reading the tooltip's client rect, with the change stashed and restored to get both rows.

- No new tests. The nested merge is the load-bearing part and is currently uncovered — `frontend/src/lib/charts/` has no test file for `hooks.ts`. A future edit back to a plain shallow spread would silently revert every chart that sets a tooltip field. Say the word and I will add one.
- Not run: the Jest and Playwright suites, and any check of the other chart surfaces. I confirmed the default reaches one chart and reasoned about the rest from the call sites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: `/writing-pr-descriptions`.

The change came out of testing an unrelated PR, where the static tooltip was noticed as a recurring papercut rather than a one-chart bug.
The first draft put the placement default in a second module-level constant beside `CHART_CONFIG_DEFAULTS`; review feedback moved it into the existing object, which is where defaults belong.
The nested merge survived that rewrite because the shallow spread would otherwise drop the default for exactly the charts that configure a tooltip.
