### PR TITLE
fix(desktop): correct agent npm provenance repository

### DIFF
--- a/products/desktop/packages/agent/package.json
+++ b/products/desktop/packages/agent/package.json
@@ -1,7 +1,11 @@
 {
   "name": "@posthog/agent",
   "version": "0.0.0-dev",
-  "repository": "https://github.com/PostHog/code",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PostHog/posthog.git",
+    "directory": "products/desktop/packages/agent"
+  },
   "description": "TypeScript agent framework wrapping Claude Agent SDK with Git-based task execution for PostHog",
   "exports": {
     ".": {


### PR DESCRIPTION
## Problem

Desktop agent releases cannot publish to npm because the package repository metadata does not match the GitHub provenance source