### PR TITLE
fix(desktop): scope release token to PostHog

### DIFF
--- a/.github/workflows/desktop-cleanup-draft-releases.yml
+++ b/.github/workflows/desktop-cleanup-draft-releases.yml
@@ -22,6 +22,7 @@ jobs:
               with:
                   app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
                   private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+                  scope: PostHog
 
             # Desktop release drafts live on PostHog/code (the legacy update feed), so
             # the cleanup targets that repo explicitly — never github.repository, which

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -22,6 +22,7 @@ jobs:
               with:
                   app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
                   private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+                  scope: PostHog
 
             - name: Extract version from tag
               id: version
@@ -85,6 +86,7 @@ jobs:
               with:
                   app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
                   private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+                  scope: PostHog
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -311,6 +313,7 @@ jobs:
               with:
                   app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
                   private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+                  scope: PostHog
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -494,6 +497,7 @@ jobs:
               with:
                   app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
                   private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+                  scope: PostHog
 
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -656,6 +660,7 @@ jobs:
               with:
                   app_id: ${{ secrets.GH_APP_ARRAY_RELEASER_APP_ID }}
                   private_key: ${{ secrets.GH_APP_ARRAY_RELEASER_PRIVATE_KEY }}
+                  scope: PostHog
 
             - name: Extract version from tag
               id: version

--- a/products/desktop/MIGRATION.md
+++ b/products/desktop/MIGRATION.md
@@ -282,7 +282,9 @@ ports from source using these rules.
   feed-only. This dual-publish retires once app-version telemetry shows the old feed is
   quiet. PostHog/code#3490 (S3 feed) simplifies this on its next resync into this import.
 - `desktop-cleanup-draft-releases.yml` cleans PostHog/code draft releases for the same
-  reason.
+  reason. Both cross-repository release workflows explicitly scope their releaser app
+  tokens to the PostHog organization; otherwise the token action can select a different
+  installation and GitHub rejects access to PostHog/code.
 - `products/desktop/packages/agent/package.json` still declares
   `"repository": "https://github.com/PostHog/code"` (apps/code/package.json has no
   repository field). Fix it alongside the npm trusted-publisher re-registration, ideally


### PR DESCRIPTION
## Problem

Desktop releases cannot create or update the legacy GitHub release feed because the releaser token can select the wrong installation.

The release workflow then receives a 403 when accessing `PostHog/code`.

## Changes

- Scope every desktop release token to the PostHog organization.
- Apply the same scope to stale draft cleanup.
- Preserve `PostHog/code` as the legacy updater feed.
- Document the cross-repository token requirement for future desktop resyncs.

**Why:** Existing desktop installations still poll releases in `PostHog/code`, so the workflow needs explicit cross-repository authorization