### PR TITLE
feat(desktop): mobile collapsible session files box

### DIFF
--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.test.tsx
@@ -22,6 +22,10 @@ vi.mock("@/lib/openExternalUrl", () => ({ openExternalUrl: vi.fn() }));
 vi.mock("phosphor-react-native", () => ({
   ArrowSquareOut: (props: Record<string, unknown>) =>
     createElement("ArrowSquareOut", props),
+  CaretDown: (props: Record<string, unknown>) =>
+    createElement("CaretDown", props),
+  CaretRight: (props: Record<string, unknown>) =>
+    createElement("CaretRight", props),
   File: (props: Record<string, unknown>) => createElement("File", props),
 }));
 
@@ -29,7 +33,7 @@ vi.mock("@/lib/theme", () => ({
   useThemeColors: () => ({ gray: { 9: "#777", 11: "#555" } }),
 }));
 
-function render(artifacts: TaskRunArtifact[] | undefined) {
+function mount(artifacts: TaskRunArtifact[] | undefined) {
   mockUseTaskArtifacts.mockReturnValue({ data: artifacts });
   let renderer: ReturnType<typeof create> | null = null;
   act(() => {
@@ -42,7 +46,22 @@ function render(artifacts: TaskRunArtifact[] | undefined) {
     );
   });
   if (!renderer) throw new Error("Renderer not created");
-  return JSON.stringify((renderer as ReturnType<typeof create>).toJSON());
+  return renderer as ReturnType<typeof create>;
+}
+
+function json(renderer: ReturnType<typeof create>) {
+  return JSON.stringify(renderer.toJSON());
+}
+
+function render(artifacts: TaskRunArtifact[] | undefined) {
+  return json(mount(artifacts));
+}
+
+function pressHeader(renderer: ReturnType<typeof create>) {
+  const header = renderer.root.findByProps({ accessibilityRole: "button" });
+  act(() => {
+    header.props.onPress();
+  });
 }
 
 describe("TaskArtifacts", () => {
@@ -51,15 +70,30 @@ describe("TaskArtifacts", () => {
     expect(render(undefined)).toBe("null");
   });
 
-  it("lists artifact names and sizes", () => {
+  it("lists artifact names and sizes, expanded by default", () => {
     const output = render([
       { id: "a1", name: "report.md", type: "output", size: 2_400 },
       { id: "a2", name: "chart.png", type: "output", size: 512 },
     ]);
-    expect(output).toContain("Files");
+    expect(output).toContain("Files (2)");
     expect(output).toContain("report.md");
     expect(output).toContain("chart.png");
     expect(output).toContain("2 KB");
     expect(output).toContain("512 B");
+  });
+
+  it("hides the list when the header is tapped and shows it again", () => {
+    const renderer = mount([
+      { id: "a1", name: "report.md", type: "output", size: 2_400 },
+    ]);
+    expect(json(renderer)).toContain("report.md");
+
+    pressHeader(renderer);
+    const collapsed = json(renderer);
+    expect(collapsed).toContain("Files (1)");
+    expect(collapsed).not.toContain("report.md");
+
+    pressHeader(renderer);
+    expect(json(renderer)).toContain("report.md");
   });
 });

--- a/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
+++ b/products/desktop/apps/mobile/src/features/tasks/components/TaskArtifacts.tsx
@@ -1,5 +1,10 @@
 import type { TaskRunArtifact } from "@posthog/shared";
-import { ArrowSquareOut, File as FileIcon } from "phosphor-react-native";
+import {
+  ArrowSquareOut,
+  CaretDown,
+  CaretRight,
+  File as FileIcon,
+} from "phosphor-react-native";
 import { useCallback, useState } from "react";
 import { ActivityIndicator, Alert, Pressable, Text, View } from "react-native";
 import { openExternalUrl } from "@/lib/openExternalUrl";
@@ -21,6 +26,7 @@ export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
   const { data: artifacts } = useTaskArtifacts(taskId, runId, enabled);
   const [preview, setPreview] = useState<TaskRunArtifact | null>(null);
   const [sharingId, setSharingId] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
 
   const shareArtifact = useCallback(
     async (artifact: TaskRunArtifact): Promise<void> => {
@@ -46,53 +52,71 @@ export function TaskArtifacts({ taskId, runId, enabled }: TaskArtifactsProps) {
 
   return (
     <View className="mx-4 mb-2 rounded-lg border border-gray-5 bg-gray-2 p-3">
-      <Text className="mb-2 font-semibold text-[13px] text-gray-12">Files</Text>
-      <View className="gap-1">
-        {artifacts.map((artifact) => {
-          const sharingKey = artifact.id ?? artifact.storage_path;
-          const size = formatArtifactSize(artifact.size);
-          const canPreview = Boolean(artifact.id);
-          return (
-            <View
-              key={sharingKey ?? artifact.name}
-              className="flex-row items-center gap-3 rounded-md bg-background px-2 py-1.5"
-            >
-              <Pressable
-                className="min-w-0 flex-1 flex-row items-center gap-2 active:opacity-70"
-                disabled={!canPreview}
-                onPress={() => setPreview(artifact)}
+      <Pressable
+        onPress={() => setCollapsed((value) => !value)}
+        hitSlop={6}
+        accessibilityRole="button"
+        accessibilityLabel={`Files (${artifacts.length})`}
+        accessibilityState={{ expanded: !collapsed }}
+        className="flex-row items-center gap-1.5 self-start py-1 active:opacity-60"
+      >
+        {collapsed ? (
+          <CaretRight size={14} color={themeColors.gray[12]} />
+        ) : (
+          <CaretDown size={14} color={themeColors.gray[12]} />
+        )}
+        <Text className="font-semibold text-[13px] text-gray-12">
+          Files ({artifacts.length})
+        </Text>
+      </Pressable>
+      {collapsed ? null : (
+        <View className="mt-2 gap-1">
+          {artifacts.map((artifact) => {
+            const sharingKey = artifact.id ?? artifact.storage_path;
+            const size = formatArtifactSize(artifact.size);
+            const canPreview = Boolean(artifact.id);
+            return (
+              <View
+                key={sharingKey ?? artifact.name}
+                className="flex-row items-center gap-3 rounded-md bg-background px-2 py-1.5"
               >
-                <FileIcon size={16} color={themeColors.gray[11]} />
-                <Text
-                  className="flex-shrink text-[13px] text-gray-12"
-                  numberOfLines={1}
+                <Pressable
+                  className="min-w-0 flex-1 flex-row items-center gap-2 active:opacity-70"
+                  disabled={!canPreview}
+                  onPress={() => setPreview(artifact)}
                 >
-                  {artifact.name ?? "artifact"}
-                </Text>
-                {size ? (
-                  <Text className="text-[12px] text-gray-9">{size}</Text>
-                ) : null}
-              </Pressable>
-              <Pressable
-                hitSlop={8}
-                className="active:opacity-60"
-                disabled={!artifact.storage_path}
-                onPress={() => void shareArtifact(artifact)}
-                accessibilityLabel="Open externally"
-              >
-                {sharingId === sharingKey ? (
-                  <ActivityIndicator
-                    size="small"
-                    color={themeColors.gray[11]}
-                  />
-                ) : (
-                  <ArrowSquareOut size={16} color={themeColors.gray[11]} />
-                )}
-              </Pressable>
-            </View>
-          );
-        })}
-      </View>
+                  <FileIcon size={16} color={themeColors.gray[11]} />
+                  <Text
+                    className="flex-shrink text-[13px] text-gray-12"
+                    numberOfLines={1}
+                  >
+                    {artifact.name ?? "artifact"}
+                  </Text>
+                  {size ? (
+                    <Text className="text-[12px] text-gray-9">{size}</Text>
+                  ) : null}
+                </Pressable>
+                <Pressable
+                  hitSlop={8}
+                  className="active:opacity-60"
+                  disabled={!artifact.storage_path}
+                  onPress={() => void shareArtifact(artifact)}
+                  accessibilityLabel="Open externally"
+                >
+                  {sharingId === sharingKey ? (
+                    <ActivityIndicator
+                      size="small"
+                      color={themeColors.gray[11]}
+                    />
+                  ) : (
+                    <ArrowSquareOut size={16} color={themeColors.gray[11]} />
+                  )}
+                </Pressable>
+              </View>
+            );
+          })}
+        </View>
+      )}
 
       {preview?.id ? (
         <ArtifactPreview


### PR DESCRIPTION
## Problem

On the mobile task session screen, the "Files" artifact card always shows its full list of files, pushing the rest of the thread down when a run produces several outputs. Port of #78681, which made the same box collapsible on desktop.

## Changes

- The "Files" header is now a tappable row that hides and shows the file list.
- The header shows the artifact count alongside the label, as `Files (<count>)`.
- A caret reflects state: down when expanded, right when collapsed.
- The box defaults to expanded and never collapses on its own.
- Collapse state is per task and in-memory only, held in local component state, matching desktop's ephemeral semantics.

No new dependencies: the caret uses `phosphor-react-native` icons already in the app, and the toggle mirrors the existing inbox "Signals" disclosure.

This is a visual change. I could not capture a screenshot in this environment (no running React Native simulator).

## How did you test this code?

`pnpm --filter @posthog/mobile test TaskArtifacts` — added cases covering the new toggle behavior that existing tests did not: files visible by default, tapping the header hides the list, tapping again shows it, and the header displays the artifact count. The prior tests only checked the always-expanded render.

Not run: the simulator, so the change is unverified on a device.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) ported the desktop change in #78681 to the mobile `TaskArtifacts` component. The desktop version keeps collapse state in a per-task view store; the mobile screen has no equivalent session-view store and the component mounts per task, so I used local component state rather than inventing a persisted store. I invoked `/writing-tests`, `/simplify`, and `/writing-pr-descriptions` while producing this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
