### PR TITLE
fix(desktop): publish releases from monorepo

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -4,6 +4,15 @@ on:
     push:
         tags:
             - 'desktop-v*'
+    workflow_dispatch:
+        inputs:
+            release_tag:
+                description: 'Existing desktop-v* tag to release'
+                required: true
+                type: string
+
+env:
+    RELEASE_TAG: ${{ inputs.release_tag || github.ref_name }}
 
 concurrency:
     group: desktop-release
@@ -25,8 +34,15 @@ jobs:
 
             - name: Extract version from tag
               id: version
+              env:
+                  GH_TOKEN: ${{ github.token }}
               run: |
-                  TAG_VERSION="${GITHUB_REF#refs/tags/desktop-v}"
+                  if [[ ! "$RELEASE_TAG" =~ ^desktop-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "Release tag must match desktop-v<major>.<minor>.<patch>: $RELEASE_TAG"
+                    exit 1
+                  fi
+                  gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" >/dev/null
+                  TAG_VERSION="${RELEASE_TAG#desktop-v}"
                   echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Create draft release if absent
@@ -89,6 +105,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
+                  ref: ${{ inputs.release_tag || github.ref }}
                   fetch-depth: 0
                   filter: blob:none
                   token: ${{ steps.app-token.outputs.token }}
@@ -108,7 +125,7 @@ jobs:
             - name: Extract version from tag
               id: version
               run: |
-                  TAG_VERSION="${GITHUB_REF#refs/tags/desktop-v}"
+                  TAG_VERSION="${RELEASE_TAG#desktop-v}"
                   echo "Version: $TAG_VERSION"
                   echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -315,6 +332,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
+                  ref: ${{ inputs.release_tag || github.ref }}
                   fetch-depth: 0
                   filter: blob:none
                   token: ${{ steps.app-token.outputs.token }}
@@ -334,10 +352,8 @@ jobs:
             - name: Extract version from tag
               id: version
               shell: pwsh
-              env:
-                  GITHUB_REF: ${{ github.ref }}
               run: |
-                  $tagVersion = "$env:GITHUB_REF" -replace "refs/tags/desktop-v", ""
+                  $tagVersion = "$env:RELEASE_TAG" -replace "^desktop-v", ""
                   echo "Version: $tagVersion"
                   echo "version=$tagVersion" >> $env:GITHUB_OUTPUT
 
@@ -498,6 +514,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
               with:
+                  ref: ${{ inputs.release_tag || github.ref }}
                   fetch-depth: 0
                   filter: blob:none
                   token: ${{ steps.app-token.outputs.token }}
@@ -525,7 +542,7 @@ jobs:
             - name: Extract version from tag
               id: version
               run: |
-                  TAG_VERSION="${GITHUB_REF#refs/tags/desktop-v}"
+                  TAG_VERSION="${RELEASE_TAG#desktop-v}"
                   echo "Version: $TAG_VERSION"
                   echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -660,12 +677,13 @@ jobs:
             - name: Extract version from tag
               id: version
               run: |
-                  TAG_VERSION="${GITHUB_REF#refs/tags/desktop-v}"
+                  TAG_VERSION="${RELEASE_TAG#desktop-v}"
                   echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
             - name: Checkout release scripts
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
+                  ref: ${{ inputs.release_tag || github.ref }}
                   fetch-depth: 0
                   filter: blob:none
                   sparse-checkout: |

--- a/products/desktop/MIGRATION.md
+++ b/products/desktop/MIGRATION.md
@@ -168,7 +168,7 @@ separate project.
 | test.yml | desktop-test.yml | gating: `workflow_call` child of desktop-ci.yml + `Desktop Tests Pass`; live-gateway e2e kept with `POSTHOG_CODE_E2E_*` org secrets |
 | code-storybook.yml | _(not ported)_ | removed post-merge: the code-signed VR baseline flagged every story as new from this repo (see the Visual Review baseline note). Do not re-port on resync unless VR is re-registered against posthog/posthog first |
 | code-build-test.yml | desktop-build-test.yml | `workflow_dispatch` only; the source's `refactor/electron-vite` push trigger is a code-repo branch and is dropped |
-| code-release.yml | desktop-release.yml | tags `desktop-v*`; legacy publishing to PostHog/code releases kept (see below) |
+| code-release.yml | desktop-release.yml | tags `desktop-v*`; manual dispatch accepts an existing desktop tag; legacy publishing to PostHog/code releases kept (see below) |
 | code-tag.yml | desktop-tag.yml | computes and pushes `desktop-v*` tags; quiet-period check and patch count scoped `-- products/desktop/` (monorepo master always has fresh commits; unscoped counts would be meaningless) |
 | code-update-e2e.yml | desktop-update-e2e.yml | nightly + dispatch; the source's temporary push trigger for `test/macos-auto-update-e2e` is dropped (code-repo branch, and default-only triggers exempt its caches from the cache-write lint) |
 | cleanup-draft-releases.yml | desktop-cleanup-draft-releases.yml | targets PostHog/code explicitly via the releaser app token: `github.repository` is now the monorepo, whose drafts belong to other products |


### PR DESCRIPTION
## Problem

Desktop maintainers cannot manually retry the release workflow after the move into the monorepo.

A bare manual trigger would also risk building `master` under an invalid release version.

## Changes

- Add a manual workflow trigger requiring an existing `desktop-vX.Y.Z` tag.
- Validate the tag before creating a draft release.
- Check out the requested tag across all build and finalization jobs.
- Preserve the existing automatic tag-push behavior.

**Why:** Maintainers need a safe way to retry a tagged desktop release without creating another tag.

## How did you test this code?

- Parsed the changed workflow as YAML.
- Ran `git diff --check`.
- Verified tag parsing against the existing `desktop-v0.60.46` tag.
- Verified the tag through the GitHub API.
- Did not run the release because it signs and publishes production artifacts.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the desktop migration contract to preserve manual dispatch during future resyncs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with PostHog Code. The implementation restored direct manual release control with explicit tag validation and tag-pinned checkouts. No repository-provided skill was invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*