### PR TITLE
feat(frontend): add delayed hover dropdown opening

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 
 import { LemonDropdown } from './LemonDropdown'
 
@@ -8,6 +8,32 @@ describe('LemonDropdown', () => {
     // jest.setupAfterEnv does not enable RTL auto-cleanup; unmount between tests so the portal stays isolated.
     afterEach(() => {
         cleanup()
+        jest.useRealTimers()
+    })
+
+    it('delays opening a hover dropdown when configured', () => {
+        jest.useFakeTimers()
+        const onVisibilityChange = jest.fn()
+
+        render(
+            <LemonDropdown
+                trigger="hover"
+                hoverOpenDelayMs={500}
+                onVisibilityChange={onVisibilityChange}
+                overlay={<div>Menu</div>}
+            >
+                <button>Open</button>
+            </LemonDropdown>
+        )
+
+        fireEvent.mouseEnter(screen.getByText('Open'))
+        expect(onVisibilityChange).not.toHaveBeenCalled()
+
+        act(() => jest.advanceTimersByTime(499))
+        expect(onVisibilityChange).not.toHaveBeenCalled()
+
+        act(() => jest.advanceTimersByTime(1))
+        expect(onVisibilityChange).toHaveBeenCalledWith(true)
     })
 
     // `e.relatedTarget` on a mouseleave is null when the cursor leaves the document and can be a

--- a/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
+++ b/frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEventHandler, useContext, useRef, useState } from 'react'
+import React, { MouseEventHandler, useContext, useEffect, useRef, useState } from 'react'
 
 import { Popover, PopoverOverlayContext, PopoverProps } from '../Popover'
 
@@ -18,6 +18,7 @@ export interface LemonDropdownProps extends Omit<PopoverProps, 'children' | 'vis
     closeOnClickInside?: boolean
     /** @default 'click' */
     trigger?: 'click' | 'hover'
+    hoverOpenDelayMs?: number
     children: React.ReactElement<
         Record<string, any> & {
             onClick: MouseEventHandler
@@ -38,6 +39,7 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
             onMouseLeaveInside,
             closeOnClickInside = true,
             trigger = 'click',
+            hoverOpenDelayMs = 0,
             children,
             startVisible,
             ...popoverProps
@@ -51,6 +53,23 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
 
         const floatingRef = useRef<HTMLDivElement>(null)
         const referenceRef = useRef<HTMLSpanElement>(null)
+        const hoverOpenTimeoutRef = useRef<number | null>(null)
+
+        const clearHoverOpenTimeout = (): void => {
+            if (hoverOpenTimeoutRef.current !== null) {
+                window.clearTimeout(hoverOpenTimeoutRef.current)
+                hoverOpenTimeoutRef.current = null
+            }
+        }
+
+        useEffect(
+            () => () => {
+                if (hoverOpenTimeoutRef.current !== null) {
+                    window.clearTimeout(hoverOpenTimeoutRef.current)
+                }
+            },
+            []
+        )
 
         const effectiveVisible = visible ?? localVisible
 
@@ -94,6 +113,7 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
             >
                 {React.cloneElement(children, {
                     onClick: (e: React.MouseEvent): void => {
+                        clearHoverOpenTimeout()
                         setVisible(!effectiveVisible)
                         children.props.onClick?.(e)
                         if (parentPopoverLevel > -1) {
@@ -104,10 +124,19 @@ export const LemonDropdown = React.forwardRef<HTMLDivElement, LemonDropdownProps
                     },
                     onMouseEnter: (): void => {
                         if (trigger === 'hover') {
-                            setVisible(true)
+                            clearHoverOpenTimeout()
+                            if (hoverOpenDelayMs > 0) {
+                                hoverOpenTimeoutRef.current = window.setTimeout(() => {
+                                    hoverOpenTimeoutRef.current = null
+                                    setVisible(true)
+                                }, hoverOpenDelayMs)
+                            } else {
+                                setVisible(true)
+                            }
                         }
                     },
                     onMouseLeave: (e: React.MouseEvent): void => {
+                        clearHoverOpenTimeout()
                         const relatedTarget = e.relatedTarget
                         if (
                             trigger === 'hover' &&


### PR DESCRIPTION
<!-- pr-stack:start -->
## PR stack

Merge in this order:
1. **https://github.com/PostHog/posthog/pull/78799 - this PR**
2. https://github.com/PostHog/posthog/pull/78800
3. https://github.com/PostHog/posthog/pull/78801
4. https://github.com/PostHog/posthog/pull/78802

Depends on: none

Followed by: https://github.com/PostHog/posthog/pull/78800

This PR targets `master`. After it merges, run `gh stack sync --prune` before merging the next layer.
<!-- pr-stack:end -->

## Problem

- Hover dropdowns open immediately in dense lists, which makes accidental popovers easy to trigger.
- Error Tracking timestamps need a short delay without changing every hover dropdown.

## Changes

- Add an optional `hoverOpenDelayMs` prop to `LemonDropdown`.
- Cancel pending opens when the pointer leaves, the trigger is clicked, or the component unmounts.
- Preserve immediate opening as the default behavior.

## How did you test this code?

- `hogli test frontend/src/lib/lemon-ui/LemonDropdown/LemonDropdown.test.tsx`
- The new test verifies that the dropdown waits for the configured delay.
- `hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update is required for this internal component option.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi split this prerequisite from the Error Tracking modernization stack.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/stacking-prs`, `/split-pr`, and `/writing-pr-descriptions`.
- This layer keeps the reusable timing behavior separate from its Error Tracking consumer.
