### PR TITLE
feat(error-tracking): modernize issue event list

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6251,7 +6251,7 @@ snapshots:
     scenes-app-inbox-scene--self-driving-onboarding--light:
         hash: v1.k794b7964.8ef3184a453d8082e2e3b7ae2716c4f40ea8c99c1b5f8a579c5bbc138985ad09.LjMg91MLj3APANRgr6pCKk697oexyrwWR0kgBpE6s4s
     scenes-app-inbox-scene--self-driving-paused--dark:
-        hash: v1.k794b7964.2d33a4dbf4ef71f91b4e6d6b57c6f0acc84b2e75fa5b9a413094938538ce630d.iGThjI83HuDPntWAVdT9fXwDwkifTwfOZXZZ5UpjcAE
+        hash: v1.k794b7964.bd2bee28eee6668bfd9f1e5c00191e38189bc27ac734c8adf8ddc55da8381b1b.HFfADdkZDnQv2BGCHc-yzXZ4Z0Rpk-xn9cn7uRUXIyg
     scenes-app-inbox-scene--self-driving-paused--light:
         hash: v1.k794b7964.4af393b7f3b9cdb056c518fe5cfcc7c99e4503ad008af2b031867e6811560083.dF3I6JAteRnokBIPAdvOuUT0Gf6MwR1rhRHygDUW2V0
     scenes-app-inbox-tabs--pull-requests--dark:

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -95,15 +95,12 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
         )
     }
 
-    function renderRowTimelineIndicator(record: ErrorEventType): JSX.Element {
-        const color =
-            record.uuid === summary?.first_event_uuid
-                ? 'bg-[var(--brand-blue)]'
-                : record.uuid === summary?.last_event_uuid
-                  ? 'bg-[var(--brand-red)]'
-                  : 'bg-[var(--brand-yellow)]'
-
-        return <div className={cn('min-h-[56px] w-1', isEventSelected(record) ? color : 'bg-transparent')} />
+    function getRowTimelineIndicatorColor(record: ErrorEventType): string {
+        return record.uuid === summary?.first_event_uuid
+            ? 'border-l-brand-blue'
+            : record.uuid === summary?.last_event_uuid
+              ? 'border-l-brand-red'
+              : 'border-l-brand-yellow'
     }
 
     return (
@@ -127,7 +124,14 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                                 )}
                                 onClick={() => onEventSelect(record)}
                             >
-                                <TableCell className="w-1 p-0">{renderRowTimelineIndicator(record)}</TableCell>
+                                <TableCell
+                                    className={cn(
+                                        'w-1 border-l-4 p-0',
+                                        isEventSelected(record)
+                                            ? getRowTimelineIndicatorColor(record)
+                                            : 'border-l-transparent'
+                                    )}
+                                />
                                 <TableCell className="min-w-0 overflow-hidden p-0">
                                     <div className="flex w-full min-w-0 items-center">
                                         <div className="min-w-0 flex-1 overflow-hidden px-3 py-2">

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -15,6 +15,8 @@ import {
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
+    Skeleton,
+    SkeletonText,
     Spinner,
     Table,
     TableBody,
@@ -106,7 +108,7 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
 
     return (
         <div data-quill>
-            <Table fullWidth size="sm" tableClassName="table-fixed bg-transparent">
+            <Table fullWidth size="sm" tableClassName="table-fixed bg-transparent" aria-busy={itemsLoading}>
                 <colgroup>
                     <col className="w-1" />
                     <col />
@@ -142,8 +144,10 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                             </TableRow>
                         ))}
                     </TableBody>
+                ) : itemsLoading ? (
+                    <EventsTableLoadingBody />
                 ) : (
-                    <EventsTableEmpty loading={itemsLoading} />
+                    <EventsTableEmpty />
                 )}
                 {items.length > 0 && (
                     <TableFooter>
@@ -175,19 +179,52 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
 export function EventsTableLoading(): JSX.Element {
     return (
         <div data-quill>
-            <Table fullWidth size="sm" tableClassName="table-fixed bg-transparent">
-                <EventsTableEmpty loading />
+            <Table
+                fullWidth
+                size="sm"
+                tableClassName="table-fixed bg-transparent"
+                aria-busy="true"
+                aria-label="Loading exceptions"
+            >
+                <colgroup>
+                    <col className="w-1" />
+                    <col />
+                </colgroup>
+                <EventsTableLoadingBody />
             </Table>
         </div>
     )
 }
 
-function EventsTableEmpty({ loading }: { loading: boolean }): JSX.Element {
+function EventsTableLoadingBody(): JSX.Element {
     return (
-        <TableEmpty className="py-6 text-muted-foreground">
-            {loading ? 'Loading exceptions...' : 'No exceptions found.'}
-        </TableEmpty>
+        <TableBody aria-hidden="true">
+            {[0, 1, 2].map((row) => (
+                <TableRow key={row}>
+                    <TableCell className="w-1 p-0" />
+                    <TableCell className="min-w-0 overflow-hidden p-0">
+                        <div className="flex min-h-[56px] w-full min-w-0 items-center">
+                            <div className="flex min-w-0 flex-1 flex-col gap-0.5 px-3 py-2">
+                                <SkeletonText lines={1} maxWidth={40} className="text-sm" />
+                                <SkeletonText lines={1} maxWidth={70} className="text-xs" />
+                            </div>
+                            <div className="flex w-[35%] min-w-28 max-w-56 shrink-0 flex-col items-end gap-1.5 px-3 py-2">
+                                <Skeleton className="h-2.5 w-20" />
+                                <Skeleton className="h-2.5 w-14" />
+                            </div>
+                            <div className="flex w-10 shrink-0 justify-end py-2 pr-4">
+                                <Skeleton className="size-5" />
+                            </div>
+                        </div>
+                    </TableCell>
+                </TableRow>
+            ))}
+        </TableBody>
     )
+}
+
+function EventsTableEmpty(): JSX.Element {
+    return <TableEmpty className="py-6 text-muted-foreground">No exceptions found.</TableEmpty>
 }
 
 const Person = ({ person }: { person: ErrorEventType['person'] }): JSX.Element => {

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -1,29 +1,41 @@
-import clsx from 'clsx'
+import { useValues } from 'kea'
+import { router } from 'kea-router'
 
-import { IconAI } from '@posthog/icons'
-import { LemonButton, Link } from '@posthog/lemon-ui'
+import { IconAI, IconEllipsis, IconLive } from '@posthog/icons'
+import { Link } from '@posthog/lemon-ui'
 
 import { ErrorEventType } from 'lib/components/Errors/types'
-import { getExceptionAttributes, getRecordingStatus, getSessionId } from 'lib/components/Errors/utils'
+import { getRecordingStatus, getRuntimeFromLib, getSessionId } from 'lib/components/Errors/utils'
 import { TZLabel } from 'lib/components/TZLabel'
-import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
-import { IconLink } from 'lib/lemon-ui/icons'
-import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { useRecordingButton } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import { IconLink, IconPlayCircle } from 'lib/lemon-ui/icons'
+import {
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Spinner,
+    Table,
+    TableBody,
+    TableCell,
+    TableEmpty,
+    TableFooter,
+    TableRow,
+} from 'lib/ui/quill'
 import { copyToClipboard } from 'lib/utils/copyToClipboard'
 import { cn } from 'lib/utils/css-classes'
 import { asDisplay } from 'scenes/persons/person-utils'
-import { PersonDisplay, PersonIcon } from 'scenes/persons/PersonDisplay'
+import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
 
 import { EventsQuery } from '~/queries/schema/schema-general'
 
-import { ViewLogsButton } from 'products/logs/frontend/components/ViewLogsButton'
+import { useViewLogsButton } from 'products/logs/frontend/components/ViewLogsButton'
 
-import { useErrorTagRenderer } from '../../hooks/use-error-tag-renderer'
+import { errorTrackingIssueSceneLogic } from '../../scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic'
 import { cancelEvent } from '../../utils'
-import { DataSourceTable, DataSourceTableColumn } from '../DataSourceTable'
-import { ExceptionAttributesPreview } from '../ExceptionAttributesPreview'
-import { CustomSeparator } from '../TableColumns'
+import { RuntimeIcon } from '../RuntimeIcon'
 import { eventsSourceLogic } from './eventsSourceLogic'
 
 export interface EventsTableProps {
@@ -34,76 +46,128 @@ export interface EventsTableProps {
 }
 
 export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: EventsTableProps): JSX.Element {
-    const tagRenderer = useErrorTagRenderer()
     const dataSource = eventsSourceLogic({ queryKey, query })
+    const { items, itemsLoading, canLoadNextData } = useValues(dataSource)
+    const { summary } = useValues(errorTrackingIssueSceneLogic)
 
     function isEventSelected(record: ErrorEventType): boolean {
         return selectedEvent ? selectedEvent.uuid === record.uuid : false
     }
 
     function renderTitle(record: ErrorEventType): JSX.Element {
+        const library = record.properties.$lib
+        const runtime = getRuntimeFromLib(typeof library === 'string' ? library : null)
+
         return (
-            <LemonTableLink
-                title={
-                    <div className="flex gap-x-1">
-                        <Link onClick={() => onEventSelect(record)} subtle className="line-clamp-1">
-                            {record.properties.$exception_types[0]}
-                        </Link>
-                        {tagRenderer(record)}
-                    </div>
-                }
-                description={
-                    <div className="space-y-0.5">
-                        <span className="line-clamp-1">{record.properties.$exception_values[0]}</span>
-                        <div className="flex items-center">
-                            <div>{renderTime(record)}</div>
-                            <CustomSeparator />
-                            <Person person={record.person} />
-                        </div>
-                    </div>
-                }
-                className="w-full"
-            />
+            <div className="grid w-full min-w-0 grid-cols-[0.75rem_minmax(0,1fr)] items-center gap-x-2 gap-y-0.5 py-0.5">
+                <RuntimeIcon runtime={runtime} fontSize="0.75rem" />
+                <div className="min-w-0 truncate text-sm font-semibold">{record.properties.$exception_types[0]}</div>
+                <div className="col-span-2 min-w-0 truncate text-xs text-muted-foreground">
+                    {record.properties.$exception_values[0]}
+                </div>
+            </div>
         )
     }
 
-    function renderAttributes(record: ErrorEventType): JSX.Element {
+    function renderMetadata(record: ErrorEventType): JSX.Element {
+        const hasPerson = Boolean(record.person?.id || record.person?.uuid)
+
         return (
-            <div className="flex justify-end gap-1">
-                <ExceptionAttributesPreview attributes={getExceptionAttributes(record.properties)} />
+            <div className="flex w-full min-w-0 flex-col items-end justify-center overflow-hidden whitespace-nowrap text-xs text-muted-foreground">
+                {hasPerson && (
+                    <div className="flex w-full min-w-0 justify-end overflow-hidden">
+                        <Person person={record.person} />
+                    </div>
+                )}
+                <div className="shrink-0">{renderTime(record)}</div>
             </div>
         )
     }
 
     function renderTime(record: ErrorEventType): JSX.Element {
-        return <TZLabel time={record.timestamp} />
-    }
-
-    function renderRowSelectedIndicator(record: ErrorEventType): JSX.Element {
         return (
-            <div
-                className={cn(
-                    'w-1 min-h-[84px]',
-                    isEventSelected(record)
-                        ? 'bg-primary-3000 hover:bg-primary-3000'
-                        : 'hover:bg-color-accent-highlight-secondary'
-                )}
-            />
+            <span className="contents">
+                <TZLabel time={record.timestamp} hoverOpenDelayMs={500} />
+            </span>
         )
     }
 
+    function renderRowTimelineIndicator(record: ErrorEventType): JSX.Element {
+        const color =
+            record.uuid === summary?.first_event_uuid
+                ? 'bg-[var(--brand-blue)]'
+                : record.uuid === summary?.last_event_uuid
+                  ? 'bg-[var(--brand-red)]'
+                  : 'bg-[var(--brand-yellow)]'
+
+        return <div className={cn('min-h-[56px] w-1', isEventSelected(record) ? color : 'bg-transparent')} />
+    }
+
     return (
-        <DataSourceTable<ErrorEventType>
-            dataSource={dataSource}
-            embedded
-            onRowClick={(record) => onEventSelect(record)}
-            className="overflow-auto"
-        >
-            <DataSourceTableColumn<ErrorEventType> className="p-0" cellRenderer={renderRowSelectedIndicator} />
-            <DataSourceTableColumn<ErrorEventType> title="Exception" cellRenderer={renderTitle} />
-            <DataSourceTableColumn<ErrorEventType> title="Labels" align="right" cellRenderer={renderAttributes} />
-            <DataSourceTableColumn<ErrorEventType> title="Actions" align="right" cellRenderer={Actions} />
-        </DataSourceTable>
+        <div data-quill>
+            <Table fullWidth size="sm" tableClassName="table-fixed bg-transparent">
+                <colgroup>
+                    <col className="w-1" />
+                    <col />
+                </colgroup>
+                {items.length > 0 ? (
+                    <TableBody>
+                        {items.map((record) => (
+                            <TableRow
+                                key={record.uuid}
+                                data-state={isEventSelected(record) ? 'selected' : undefined}
+                                className={cn(
+                                    'cursor-pointer',
+                                    isEventSelected(record)
+                                        ? '[&_[data-slot=table-cell]]:!bg-[var(--fill-selected)] [&:hover_[data-slot=table-cell]]:!bg-[var(--fill-expanded)]'
+                                        : '[&:hover_[data-slot=table-cell]]:!bg-[var(--fill-hover)]'
+                                )}
+                                onClick={() => onEventSelect(record)}
+                            >
+                                <TableCell className="w-1 p-0">{renderRowTimelineIndicator(record)}</TableCell>
+                                <TableCell className="min-w-0 overflow-hidden p-0">
+                                    <div className="flex w-full min-w-0 items-center">
+                                        <div className="min-w-0 flex-1 overflow-hidden px-3 py-2">
+                                            {renderTitle(record)}
+                                        </div>
+                                        <div className="w-[35%] min-w-28 max-w-56 shrink-0 overflow-hidden py-2 pl-3 pr-4 text-right">
+                                            {renderMetadata(record)}
+                                        </div>
+                                        <div className="flex w-10 shrink-0 justify-end py-2 pr-4">
+                                            <EventActions record={record} />
+                                        </div>
+                                    </div>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                ) : (
+                    <TableEmpty className="py-6 text-muted-foreground">
+                        {itemsLoading ? 'Loading exceptions...' : 'No exceptions found.'}
+                    </TableEmpty>
+                )}
+                {items.length > 0 && (
+                    <TableFooter>
+                        <TableRow>
+                            <TableCell colSpan={2} className="bg-transparent! p-1">
+                                <div className="flex h-7 items-center justify-center gap-1 text-xs text-muted-foreground">
+                                    {itemsLoading ? (
+                                        <>
+                                            <Spinner className="size-3" />
+                                            Loading...
+                                        </>
+                                    ) : canLoadNextData ? (
+                                        'Scroll to load more'
+                                    ) : (
+                                        'No more entries'
+                                    )}
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    </TableFooter>
+                )}
+            </Table>
+        </div>
     )
 }
 
@@ -111,74 +175,90 @@ const Person = ({ person }: { person: ErrorEventType['person'] }): JSX.Element =
     const display = asDisplay(person)
 
     return (
-        <PersonDisplay person={person} noLink>
-            <Link subtle className={clsx('flex items-center')}>
-                <PersonIcon displayName={display} person={person} size="md" />
-                <span className={clsx('ph-no-capture', 'truncate')}>{display}</span>
-            </Link>
-        </PersonDisplay>
+        <span className="contents">
+            <PersonDisplay person={person} noLink className="inline-flex max-w-full min-w-0 overflow-hidden">
+                <Link subtle className="inline-flex max-w-full min-w-0 items-center overflow-hidden">
+                    <span className="ph-no-capture truncate">{display}</span>
+                </Link>
+            </PersonDisplay>
+        </span>
     )
 }
 
-const Actions = (record: ErrorEventType): JSX.Element => {
+const EventActions = ({ record }: { record: ErrorEventType }): JSX.Element => {
     const sessionId = getSessionId(record.properties)
     const recordingStatus = getRecordingStatus(record.properties)
     const hasRecording = record.properties.$has_recording as boolean | undefined
+    const {
+        onClick: viewRecording,
+        disabledReason: recordingDisabledReason,
+        warningReason: recordingWarningReason,
+    } = useRecordingButton({
+        sessionId: sessionId ?? '',
+        recordingStatus,
+        hasRecording,
+        timestamp: record.timestamp,
+    })
+    const logs = useViewLogsButton({ sessionId, timestamp: record.timestamp })
+    const recordingTooltip =
+        typeof recordingDisabledReason === 'string' ? recordingDisabledReason : recordingWarningReason
 
     return (
-        <div className="flex justify-end gap-1">
-            <div className="flex justify-end align-middle items-center" onClick={(event) => cancelEvent(event)}>
-                <ViewRecordingButton
-                    type="secondary"
-                    sessionId={sessionId ?? ''}
-                    recordingStatus={recordingStatus}
-                    hasRecording={hasRecording}
-                    timestamp={record.timestamp}
-                    size="xsmall"
-                    data-attr="error-tracking-view-recording"
-                    iconOnly
-                />
-            </div>
-            <div className="flex justify-end align-middle items-center" onClick={(event) => cancelEvent(event)}>
-                <ViewLogsButton
-                    type="secondary"
-                    sessionId={sessionId}
-                    timestamp={record.timestamp}
-                    size="xsmall"
-                    data-attr="error-tracking-view-logs"
-                    iconOnly
-                />
-            </div>
-            {record.properties.$ai_trace_id && (
-                <LemonButton
-                    size="small"
-                    icon={<IconAI />}
-                    onClick={(event) => {
-                        cancelEvent(event)
-                        urls.aiObservabilityTrace(record.properties.$ai_trace_id, {
-                            event: record.uuid,
-                            timestamp: record.timestamp,
-                        })
-                    }}
-                    disabledReason={
-                        !record.properties.$ai_trace_id ? 'There is no LLM Trace ID on this event' : undefined
-                    }
-                    tooltip={record.properties.$ai_trace_id ? 'View LLM Trace' : undefined}
-                />
-            )}
-            <LemonButton
-                size="small"
-                icon={<IconLink />}
-                data-attr="events-table-event-link"
-                onClick={(event) => {
-                    cancelEvent(event)
-                    void copyToClipboard(
-                        urls.absolute(urls.currentProject(urls.event(String(record.uuid), record.timestamp))),
-                        'link to event'
-                    )
-                }}
-                tooltip="Copy link to exception event"
-            />
+        <div onClick={(event) => cancelEvent(event)}>
+            <DropdownMenu>
+                <DropdownMenuTrigger render={<Button variant="default" size="icon-sm" aria-label="More actions" />}>
+                    <IconEllipsis />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-auto min-w-44">
+                    <DropdownMenuItem
+                        disabled={Boolean(recordingDisabledReason)}
+                        onClick={viewRecording}
+                        title={recordingTooltip}
+                        data-attr="error-tracking-view-recording"
+                    >
+                        <IconPlayCircle />
+                        View recording
+                    </DropdownMenuItem>
+                    {logs.enabled && (
+                        <DropdownMenuItem
+                            disabled={logs.loading || !logs.onClick}
+                            onClick={logs.onClick}
+                            title={logs.disabledReason}
+                            data-attr="error-tracking-view-logs"
+                        >
+                            {logs.loading ? <Spinner /> : <IconLive />}
+                            View logs
+                        </DropdownMenuItem>
+                    )}
+                    {record.properties.$ai_trace_id && (
+                        <DropdownMenuItem
+                            onClick={() =>
+                                router.actions.push(
+                                    urls.aiObservabilityTrace(record.properties.$ai_trace_id, {
+                                        event: record.uuid,
+                                        timestamp: record.timestamp,
+                                    })
+                                )
+                            }
+                        >
+                            <IconAI />
+                            View LLM trace
+                        </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                        data-attr="events-table-event-link"
+                        onClick={() => {
+                            void copyToClipboard(
+                                urls.absolute(urls.currentProject(urls.event(String(record.uuid), record.timestamp))),
+                                'link to event'
+                            )
+                        }}
+                    >
+                        <IconLink />
+                        Copy event link
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
         </div>
     )
 }

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -42,22 +42,14 @@ export interface EventsTableProps {
     query: EventsQuery
     queryKey: string
     selectedEvent: ErrorEventType | null
-    loading?: boolean
     onEventSelect: (event: ErrorEventType | null) => void
 }
 
-export function EventsTable({
-    query,
-    queryKey,
-    onEventSelect,
-    selectedEvent,
-    loading = false,
-}: EventsTableProps): JSX.Element {
+export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: EventsTableProps): JSX.Element {
     const dataSource = eventsSourceLogic({ queryKey, query })
     const { items, itemsLoading, canLoadNextData } = useValues(dataSource)
     const { loadNextData } = useActions(dataSource)
     const { summary } = useValues(errorTrackingIssueSceneLogic)
-    const isLoading = loading || itemsLoading
 
     function isEventSelected(record: ErrorEventType): boolean {
         return selectedEvent ? selectedEvent.uuid === record.uuid : false
@@ -151,16 +143,14 @@ export function EventsTable({
                         ))}
                     </TableBody>
                 ) : (
-                    <TableEmpty className="py-6 text-muted-foreground">
-                        {isLoading ? 'Loading exceptions...' : 'No exceptions found.'}
-                    </TableEmpty>
+                    <EventsTableEmpty loading={itemsLoading} />
                 )}
                 {items.length > 0 && (
                     <TableFooter>
                         <TableRow>
                             <TableCell colSpan={2} className="bg-transparent! p-1">
                                 <div className="flex h-7 items-center justify-center gap-1 text-xs text-muted-foreground">
-                                    {isLoading ? (
+                                    {itemsLoading ? (
                                         <>
                                             <Spinner className="size-3" />
                                             Loading...
@@ -179,6 +169,24 @@ export function EventsTable({
                 )}
             </Table>
         </div>
+    )
+}
+
+export function EventsTableLoading(): JSX.Element {
+    return (
+        <div data-quill>
+            <Table fullWidth size="sm" tableClassName="table-fixed bg-transparent">
+                <EventsTableEmpty loading />
+            </Table>
+        </div>
+    )
+}
+
+function EventsTableEmpty({ loading }: { loading: boolean }): JSX.Element {
+    return (
+        <TableEmpty className="py-6 text-muted-foreground">
+            {loading ? 'Loading exceptions...' : 'No exceptions found.'}
+        </TableEmpty>
     )
 }
 

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -42,14 +42,22 @@ export interface EventsTableProps {
     query: EventsQuery
     queryKey: string
     selectedEvent: ErrorEventType | null
+    loading?: boolean
     onEventSelect: (event: ErrorEventType | null) => void
 }
 
-export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: EventsTableProps): JSX.Element {
+export function EventsTable({
+    query,
+    queryKey,
+    onEventSelect,
+    selectedEvent,
+    loading = false,
+}: EventsTableProps): JSX.Element {
     const dataSource = eventsSourceLogic({ queryKey, query })
     const { items, itemsLoading, canLoadNextData } = useValues(dataSource)
     const { loadNextData } = useActions(dataSource)
     const { summary } = useValues(errorTrackingIssueSceneLogic)
+    const isLoading = loading || itemsLoading
 
     function isEventSelected(record: ErrorEventType): boolean {
         return selectedEvent ? selectedEvent.uuid === record.uuid : false
@@ -144,7 +152,7 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                     </TableBody>
                 ) : (
                     <TableEmpty className="py-6 text-muted-foreground">
-                        {itemsLoading ? 'Loading exceptions...' : 'No exceptions found.'}
+                        {isLoading ? 'Loading exceptions...' : 'No exceptions found.'}
                     </TableEmpty>
                 )}
                 {items.length > 0 && (
@@ -152,7 +160,7 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                         <TableRow>
                             <TableCell colSpan={2} className="bg-transparent! p-1">
                                 <div className="flex h-7 items-center justify-center gap-1 text-xs text-muted-foreground">
-                                    {itemsLoading ? (
+                                    {isLoading ? (
                                         <>
                                             <Spinner className="size-3" />
                                             Loading...

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -97,10 +97,10 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
 
     function getRowTimelineIndicatorColor(record: ErrorEventType): string {
         return record.uuid === summary?.first_event_uuid
-            ? 'border-l-brand-blue'
+            ? 'bg-brand-blue'
             : record.uuid === summary?.last_event_uuid
-              ? 'border-l-brand-red'
-              : 'border-l-brand-yellow'
+              ? 'bg-brand-red'
+              : 'bg-brand-yellow'
     }
 
     return (
@@ -124,14 +124,16 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                                 )}
                                 onClick={() => onEventSelect(record)}
                             >
-                                <TableCell
-                                    className={cn(
-                                        'w-1 border-l-4 p-0',
-                                        isEventSelected(record)
-                                            ? getRowTimelineIndicatorColor(record)
-                                            : 'border-l-transparent'
-                                    )}
-                                />
+                                <TableCell className="relative w-1 p-0">
+                                    <div
+                                        className={cn(
+                                            'absolute inset-y-0 left-0 w-1',
+                                            isEventSelected(record)
+                                                ? getRowTimelineIndicatorColor(record)
+                                                : 'bg-transparent'
+                                        )}
+                                    />
+                                </TableCell>
                                 <TableCell className="min-w-0 overflow-hidden p-0">
                                     <div className="flex w-full min-w-0 items-center">
                                         <div className="min-w-0 flex-1 overflow-hidden px-3 py-2">

--- a/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
+++ b/products/error_tracking/frontend/components/EventsTable/EventsTable.tsx
@@ -1,4 +1,4 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
 import { IconAI, IconEllipsis, IconLive } from '@posthog/icons'
@@ -48,6 +48,7 @@ export interface EventsTableProps {
 export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: EventsTableProps): JSX.Element {
     const dataSource = eventsSourceLogic({ queryKey, query })
     const { items, itemsLoading, canLoadNextData } = useValues(dataSource)
+    const { loadNextData } = useActions(dataSource)
     const { summary } = useValues(errorTrackingIssueSceneLogic)
 
     function isEventSelected(record: ErrorEventType): boolean {
@@ -157,7 +158,9 @@ export function EventsTable({ query, queryKey, onEventSelect, selectedEvent }: E
                                             Loading...
                                         </>
                                     ) : canLoadNextData ? (
-                                        'Scroll to load more'
+                                        <Button variant="link-muted" size="xs" onClick={() => loadNextData()}>
+                                            Load more
+                                        </Button>
                                     ) : (
                                         'No more entries'
                                     )}

--- a/products/error_tracking/frontend/components/IssueFilters/Search.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/Search.tsx
@@ -20,7 +20,7 @@ export function IssueSearchInput({
 
     return (
         <div className={cn('w-64 max-w-full shrink-0', className)}>
-            <InputGroup className="h-7">
+            <InputGroup className="h-7 border-muted-foreground/20 focus-within:border-ring/50">
                 <InputGroupAddon>
                     <IconSearch />
                 </InputGroupAddon>

--- a/products/error_tracking/frontend/components/IssueMetadata.tsx
+++ b/products/error_tracking/frontend/components/IssueMetadata.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { PropsWithChildren, useCallback, useMemo, useRef } from 'react'
+import { PropsWithChildren, UIEvent, useCallback, useMemo, useRef } from 'react'
 import { match } from 'ts-pattern'
 
 import { IconChevronRight, IconTrending } from '@posthog/icons'
@@ -21,7 +21,11 @@ import { errorTrackingVolumeSparklineLogic } from './VolumeSparkline/errorTracki
 import type { SparklineDatum, SparklineEvent, VolumeSparklineHoverSelection } from './VolumeSparkline/types'
 import { VolumeSparkline } from './VolumeSparkline/VolumeSparkline'
 
-export const Metadata = ({ children, className }: PropsWithChildren<{ className?: string }>): JSX.Element => {
+export const Metadata = ({
+    children,
+    className,
+    onScrollNearEnd,
+}: PropsWithChildren<{ className?: string; onScrollNearEnd?: () => void }>): JSX.Element => {
     const { aggregations, summaryLoading, issueLoading, firstSeen, lastSeen, issueId, spikeEvents } =
         useValues(errorTrackingIssueSceneLogic)
     const { setDateRange } = useActions(errorTrackingIssueSceneLogic)
@@ -50,6 +54,13 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
         [setClickedSpike]
     )
 
+    const handleScroll = (event: UIEvent<HTMLDivElement>): void => {
+        const { clientHeight, scrollHeight, scrollTop } = event.currentTarget
+        if (scrollHeight - scrollTop - clientHeight <= 400) {
+            onScrollNearEnd?.()
+        }
+    }
+
     const matchedSpikeEvent = useMemo<ErrorTrackingSpikeEvent | null>(() => {
         if (!clickedSpike || sparklineData.length < 2) {
             return null
@@ -66,73 +77,77 @@ export const Metadata = ({ children, className }: PropsWithChildren<{ className?
 
     return (
         <div className={className}>
-            <div className="flex justify-between items-center h-[40px] px-4 shrink-0">
-                <div className="flex justify-end items-center h-full">
-                    {match(hoverSelection)
-                        .when(
-                            (data) => shouldRenderIssueMetrics(data),
-                            () => <IssueMetrics aggregations={aggregations} summaryLoading={summaryLoading} />
-                        )
-                        .with({ kind: 'bin' }, (data) => renderDataPoint(data.datum))
-                        .with({ kind: 'event' }, (data) => renderEventPoint(data.event))
-                        .otherwise(() => null)}
+            <div className="flex-1 min-h-0 overflow-y-auto" onScroll={handleScroll}>
+                <div className="flex justify-between items-center h-[40px] px-4">
+                    <div className="flex justify-end items-center h-full">
+                        {match(hoverSelection)
+                            .when(
+                                (data) => shouldRenderIssueMetrics(data),
+                                () => <IssueMetrics aggregations={aggregations} summaryLoading={summaryLoading} />
+                            )
+                            .with({ kind: 'bin' }, (data) => renderDataPoint(data.datum))
+                            .with({ kind: 'event' }, (data) => renderEventPoint(data.event))
+                            .otherwise(() => null)}
+                    </div>
+                    <div className="flex justify-end items-center h-full">
+                        {match(hoverSelection)
+                            .with({ kind: 'bin' }, (data) => renderDate(data.datum.date))
+                            .with({ kind: 'event' }, (data) => renderDate(data.event.date))
+                            .otherwise(() => (
+                                <>
+                                    <TimeBoundary
+                                        time={firstSeen}
+                                        loading={issueLoading}
+                                        label="First Seen"
+                                        updateDateRange={(dateRange) => {
+                                            dateRange.date_from = firstSeen?.toISOString()
+                                            return dateRange
+                                        }}
+                                    />
+                                    <IconChevronRight />
+                                    <TimeBoundary
+                                        time={lastSeen}
+                                        loading={summaryLoading}
+                                        label="Last Seen"
+                                        updateDateRange={(dateRange) => {
+                                            dateRange.date_to = lastSeen?.endOf('minute').toISOString()
+                                            return dateRange
+                                        }}
+                                    />
+                                </>
+                            ))}
+                    </div>
                 </div>
-                <div className="flex justify-end items-center h-full">
-                    {match(hoverSelection)
-                        .with({ kind: 'bin' }, (data) => renderDate(data.datum.date))
-                        .with({ kind: 'event' }, (data) => renderDate(data.event.date))
-                        .otherwise(() => (
-                            <>
-                                <TimeBoundary
-                                    time={firstSeen}
-                                    loading={issueLoading}
-                                    label="First Seen"
-                                    updateDateRange={(dateRange) => {
-                                        dateRange.date_from = firstSeen?.toISOString()
-                                        return dateRange
-                                    }}
-                                />
-                                <IconChevronRight />
-                                <TimeBoundary
-                                    time={lastSeen}
-                                    loading={summaryLoading}
-                                    label="Last Seen"
-                                    updateDateRange={(dateRange) => {
-                                        dateRange.date_to = lastSeen?.endOf('minute').toISOString()
-                                        return dateRange
-                                    }}
-                                />
-                            </>
-                        ))}
+                <div
+                    onClick={cancelEvent}
+                    ref={sparklineContainerRef}
+                    className="relative w-full min-h-[160px] flex flex-col px-4"
+                >
+                    <VolumeSparkline
+                        data={sparklineData}
+                        layout="detailed"
+                        xAxis="full"
+                        events={sparklineEvents}
+                        sparklineKey={sparklineKey}
+                        className="h-full min-h-[160px]"
+                        onRangeSelect={handleRangeSelect}
+                        onSpikeClick={handleSpikeClick}
+                    />
                 </div>
+                {clickedSpike && (
+                    <div className="contents">
+                        <SpikeDetailsPopover
+                            datum={clickedSpike.datum}
+                            clientX={clickedSpike.clientX}
+                            clientY={clickedSpike.clientY}
+                            spikeEvent={matchedSpikeEvent}
+                            onClose={() => setClickedSpike(null)}
+                            sparklineContainerRef={sparklineContainerRef}
+                        />
+                    </div>
+                )}
+                {children}
             </div>
-            <div
-                onClick={cancelEvent}
-                ref={sparklineContainerRef}
-                className="relative w-full min-h-[160px] shrink-0 flex flex-col px-4"
-            >
-                <VolumeSparkline
-                    data={sparklineData}
-                    layout="detailed"
-                    xAxis="full"
-                    events={sparklineEvents}
-                    sparklineKey={sparklineKey}
-                    className="h-full min-h-[160px]"
-                    onRangeSelect={handleRangeSelect}
-                    onSpikeClick={handleSpikeClick}
-                />
-            </div>
-            {clickedSpike && (
-                <SpikeDetailsPopover
-                    datum={clickedSpike.datum}
-                    clientX={clickedSpike.clientX}
-                    clientY={clickedSpike.clientY}
-                    spikeEvent={matchedSpikeEvent}
-                    onClose={() => setClickedSpike(null)}
-                    sparklineContainerRef={sparklineContainerRef}
-                />
-            )}
-            <div className="flex-1 min-h-0 overflow-y-auto">{children}</div>
         </div>
     )
 }
@@ -171,7 +186,7 @@ function IssueMetrics({
 
 function renderMetric(name: string, value: number | undefined, loading: boolean, tooltip?: string): JSX.Element {
     return (
-        <>
+        <span className="contents">
             {match([loading])
                 .with([true], () => <LemonSkeleton className="w-[50px] h-2" />)
                 .with([false], () => (
@@ -180,18 +195,20 @@ function renderMetric(name: string, value: number | undefined, loading: boolean,
                             <div className="text-lg font-bold inline-block">
                                 {value == null ? '0' : humanFriendlyLargeNumber(value)}
                             </div>
-                            <div className="text-xs text-muted inline-block">{name}</div>
+                            <div className="inline-block text-xs text-muted-foreground">{name}</div>
                         </div>
                     </Tooltip>
                 ))
                 .exhaustive()}
-        </>
+        </span>
     )
 }
 
 function renderDate(date: Date): JSX.Element {
     return (
-        <div className="text-xs text-muted whitespace-nowrap">{dayjs(date).utc().format('D MMM YYYY HH:mm (UTC)')}</div>
+        <div className="whitespace-nowrap text-xs text-muted-foreground">
+            {dayjs(date).utc().format('D MMM YYYY HH:mm (UTC)')}
+        </div>
     )
 }
 
@@ -200,10 +217,10 @@ function renderDataPoint(d: SparklineDatum): JSX.Element {
         <div className="flex items-center h-full gap-3">
             {renderMetric('Occurrences', d.value, false)}
             {d.animated && (
-                <div className="flex items-center gap-1.5 text-warning-dark">
+                <div className="flex items-center gap-1.5 text-warning-foreground">
                     <IconTrending className="text-base" />
                     <span className="text-xs font-semibold">Spike</span>
-                    <span className="text-xs text-muted">— click to see details</span>
+                    <span className="text-xs text-muted-foreground">— click to see details</span>
                 </div>
             )}
         </div>

--- a/products/error_tracking/frontend/components/IssueMetadata.tsx
+++ b/products/error_tracking/frontend/components/IssueMetadata.tsx
@@ -77,7 +77,7 @@ export const Metadata = ({
 
     return (
         <div className={className}>
-            <div className="flex-1 min-h-0 overflow-y-auto" onScroll={handleScroll}>
+            <div className="flex-1 min-h-0 overflow-y-auto [scrollbar-gutter:stable]" onScroll={handleScroll}>
                 <div className="flex justify-between items-center h-[40px] px-4">
                     <div className="flex justify-end items-center h-full">
                         {match(hoverSelection)

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -381,7 +381,7 @@ const ExceptionsTab = (): JSX.Element => {
                     }
                 }}
             >
-                <div className="sticky top-0 z-10 shrink-0 border-y border-border bg-surface-primary px-2 py-2">
+                <div className="sticky top-0 z-10 shrink-0 border-y border-primary bg-surface-primary px-2 py-2">
                     <ErrorFilters.Root className="w-full">
                         <div className="flex w-full flex-col gap-1">
                             <div className="flex w-full flex-wrap items-center gap-1">

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -40,7 +40,7 @@ import { BreakdownsSearchBar } from '../../components/Breakdowns/BreakdownsSearc
 import { MiniBreakdowns } from '../../components/Breakdowns/MiniBreakdowns'
 import { miniBreakdownsLogic } from '../../components/Breakdowns/miniBreakdownsLogic'
 import { eventsSourceLogic } from '../../components/EventsTable/eventsSourceLogic'
-import { EventsTable } from '../../components/EventsTable/EventsTable'
+import { EventsTable, EventsTableLoading } from '../../components/EventsTable/EventsTable'
 import { ExceptionCard } from '../../components/ExceptionCard'
 import { StackTraceActions } from '../../components/ExceptionCard/Tabs/StackTraceTab/StackTraceActions'
 import { StatusIndicator } from '../../components/Indicators'
@@ -416,14 +416,15 @@ const ExceptionsTab = (): JSX.Element => {
                         </div>
                     </ErrorFilters.Root>
                 </div>
-                {!issueFingerprintsLoading && issueFingerprints.length === 0 ? (
+                {issueFingerprintsLoading ? (
+                    <EventsTableLoading />
+                ) : issueFingerprints.length === 0 ? (
                     <div className="px-2 py-3 text-sm text-muted-foreground">No exceptions found for this issue.</div>
                 ) : (
                     <EventsTable
                         query={eventsQuery}
                         queryKey={eventsQueryKey}
                         selectedEvent={selectedEvent}
-                        loading={eventsLoading}
                         onEventSelect={(selectedEvent) => {
                             if (selectedEvent) {
                                 selectEvent(selectedEvent)

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -16,7 +16,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import ViewRecordingsPlaylistButton from 'lib/components/ViewRecordingButton/ViewRecordingsPlaylistButton'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useWindowSize } from 'lib/hooks/useWindowSize'
-import { Button, Separator, Tooltip, TooltipContent, TooltipTrigger } from 'lib/ui/quill'
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'lib/ui/quill'
 import {
     TabsPrimitive,
     TabsPrimitiveContent,
@@ -367,52 +367,58 @@ const ExceptionsTab = (): JSX.Element => {
         useValues(errorTrackingIssueSceneLogic)
     const { selectEvent } = useActions(errorTrackingIssueSceneLogic)
     const eventsDataSource = eventsSourceLogic({ query: eventsQuery, queryKey: eventsQueryKey })
-    const { itemsLoading } = useValues(eventsDataSource)
-    const { loadData } = useActions(eventsDataSource)
+    const { itemsLoading, canLoadNextData } = useValues(eventsDataSource)
+    const { loadData, loadNextData } = useActions(eventsDataSource)
 
     return (
         <div className="flex flex-col h-full min-h-0">
-            <div className="shrink-0 px-2 py-2">
-                <ErrorFilters.Root>
-                    <div className="flex w-full flex-col gap-1">
-                        <div className="flex w-full flex-wrap items-center gap-1">
-                            <Tooltip>
-                                <TooltipTrigger
-                                    render={
-                                        <Button
-                                            variant="outline"
-                                            size="icon"
-                                            loading={itemsLoading}
-                                            aria-label="Reload exceptions"
-                                            onClick={() => loadData()}
-                                        />
-                                    }
-                                >
-                                    <IconRefresh />
-                                </TooltipTrigger>
-                                <TooltipContent>Reload exceptions</TooltipContent>
-                            </Tooltip>
-                            <ErrorFilters.DateRange />
-                            <div className="ml-auto shrink-0">
-                                <ErrorFilters.InternalAccounts />
+            <Metadata
+                className="flex flex-col flex-1 min-h-0"
+                onScrollNearEnd={() => {
+                    if (canLoadNextData && !itemsLoading) {
+                        loadNextData()
+                    }
+                }}
+            >
+                <div className="sticky top-0 z-10 shrink-0 border-y border-border bg-surface-primary px-2 py-2">
+                    <ErrorFilters.Root className="w-full">
+                        <div className="flex w-full flex-col gap-1">
+                            <div className="flex w-full flex-wrap items-center gap-1">
+                                <Tooltip>
+                                    <TooltipTrigger
+                                        render={
+                                            <Button
+                                                variant="outline"
+                                                size="icon"
+                                                loading={itemsLoading}
+                                                aria-label="Reload exceptions"
+                                                onClick={() => loadData()}
+                                            />
+                                        }
+                                    >
+                                        <IconRefresh />
+                                    </TooltipTrigger>
+                                    <TooltipContent>Reload exceptions</TooltipContent>
+                                </Tooltip>
+                                <ErrorFilters.DateRange />
+                                <div className="ml-auto shrink-0">
+                                    <ErrorFilters.InternalAccounts />
+                                </div>
+                            </div>
+                            <div className="flex w-full flex-wrap items-center gap-1">
+                                <ErrorFilters.Search
+                                    className="w-auto min-w-40 flex-1 shrink"
+                                    placeholder="Search exceptions"
+                                />
+                                <ErrorFilters.FilterGroup />
                             </div>
                         </div>
-                        <div className="flex w-full flex-wrap items-center gap-1">
-                            <ErrorFilters.Search
-                                className="ErrorTrackingIssue__search w-auto min-w-40 flex-1 shrink"
-                                placeholder="Search exceptions"
-                            />
-                            <ErrorFilters.FilterGroup />
-                        </div>
-                    </div>
-                </ErrorFilters.Root>
-            </div>
-            <Separator className="shrink-0" />
-            <Metadata className="flex flex-col flex-1 min-h-0">
+                    </ErrorFilters.Root>
+                </div>
                 {issueFingerprintsLoading ? (
-                    <div className="text-muted text-sm px-2 py-3">Loading exceptions...</div>
+                    <div className="px-2 py-3 text-sm text-muted-foreground">Loading exceptions...</div>
                 ) : issueFingerprints.length === 0 ? (
-                    <div className="text-muted text-sm px-2 py-3">No exceptions found for this issue.</div>
+                    <div className="px-2 py-3 text-sm text-muted-foreground">No exceptions found for this issue.</div>
                 ) : (
                     <EventsTable
                         query={eventsQuery}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/ErrorTrackingIssueScene.tsx
@@ -369,13 +369,14 @@ const ExceptionsTab = (): JSX.Element => {
     const eventsDataSource = eventsSourceLogic({ query: eventsQuery, queryKey: eventsQueryKey })
     const { itemsLoading, canLoadNextData } = useValues(eventsDataSource)
     const { loadData, loadNextData } = useActions(eventsDataSource)
+    const eventsLoading = issueFingerprintsLoading || itemsLoading
 
     return (
         <div className="flex flex-col h-full min-h-0">
             <Metadata
                 className="flex flex-col flex-1 min-h-0"
                 onScrollNearEnd={() => {
-                    if (canLoadNextData && !itemsLoading) {
+                    if (canLoadNextData && !eventsLoading) {
                         loadNextData()
                     }
                 }}
@@ -390,7 +391,7 @@ const ExceptionsTab = (): JSX.Element => {
                                             <Button
                                                 variant="outline"
                                                 size="icon"
-                                                loading={itemsLoading}
+                                                loading={eventsLoading}
                                                 aria-label="Reload exceptions"
                                                 onClick={() => loadData()}
                                             />
@@ -415,15 +416,14 @@ const ExceptionsTab = (): JSX.Element => {
                         </div>
                     </ErrorFilters.Root>
                 </div>
-                {issueFingerprintsLoading ? (
-                    <div className="px-2 py-3 text-sm text-muted-foreground">Loading exceptions...</div>
-                ) : issueFingerprints.length === 0 ? (
+                {!issueFingerprintsLoading && issueFingerprints.length === 0 ? (
                     <div className="px-2 py-3 text-sm text-muted-foreground">No exceptions found for this issue.</div>
                 ) : (
                     <EventsTable
                         query={eventsQuery}
                         queryKey={eventsQueryKey}
                         selectedEvent={selectedEvent}
+                        loading={eventsLoading}
                         onEventSelect={(selectedEvent) => {
                             if (selectedEvent) {
                                 selectEvent(selectedEvent)

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts
@@ -5,7 +5,7 @@ import { ErrorTrackingFingerprint } from 'lib/components/Errors/types'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { errorTrackingIssueSceneLogic } from './errorTrackingIssueSceneLogic'
+import { errorTrackingIssueSceneLogic, toErrorTrackingIssueSummary } from './errorTrackingIssueSceneLogic'
 
 const makeFingerprints = (fingerprint: string = 'fp-1'): ErrorTrackingFingerprint[] => [
     { fingerprint, issue_id: 'issue-1', created_at: '2026-01-01T00:00:00Z' },
@@ -64,6 +64,34 @@ describe('errorTrackingIssueSceneLogic', () => {
         })
             .toDispatchActions(['loadInitialEventSuccess'])
             .toMatchValues({ initialEvent: null })
+    })
+
+    it('keeps stable first and last event IDs in the issue summary', () => {
+        expect(
+            toErrorTrackingIssueSummary({
+                first_seen: '2026-01-01T00:00:00Z',
+                last_seen: '2026-01-02T00:00:00Z',
+                first_event: {
+                    uuid: 'first-event',
+                    distinct_id: 'first-person',
+                    timestamp: '2026-01-01T00:00:00Z',
+                    properties: '{}',
+                },
+                last_event: {
+                    uuid: 'last-event',
+                    distinct_id: 'last-person',
+                    timestamp: '2026-01-02T00:00:00Z',
+                    properties: '{}',
+                },
+                aggregations: { occurrences: 2, sessions: 2, users: 2, volume_buckets: [] },
+            })
+        ).toEqual({
+            first_seen: '2026-01-01T00:00:00Z',
+            last_seen: '2026-01-02T00:00:00Z',
+            first_event_uuid: 'first-event',
+            last_event_uuid: 'last-event',
+            aggregations: { occurrences: 2, sessions: 2, users: 2, volume_buckets: [] },
+        })
     })
 
     // A malformed `timestamp` URL param used to be stored and fed to getNarrowDateRange, where

--- a/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.ts
@@ -280,20 +280,12 @@ export interface errorTrackingIssueSceneLogicActions {
         errorObject?: any
     }
     loadSummarySuccess: (
-        summary: {
-            aggregations: ErrorTrackingIssueAggregations
-            first_seen: string
-            last_seen: string
-        } | null,
+        summary: ErrorTrackingIssueSummary | null,
         payload?: {
             value: true
         }
     ) => {
-        summary: {
-            aggregations: ErrorTrackingIssueAggregations
-            first_seen: string
-            last_seen: string
-        } | null
+        summary: ErrorTrackingIssueSummary | null
         payload?: {
             value: true
         }
@@ -717,23 +709,15 @@ export const errorTrackingIssueSceneLogic = kea<errorTrackingIssueSceneLogicType
                         searchQuery: values.searchQuery,
                         volumeResolution: ERROR_TRACKING_DETAILS_RESOLUTION,
                         withAggregations: true,
-                        withFirstEvent: false,
-                        withLastEvent: false,
+                        withFirstEvent: true,
+                        withLastEvent: true,
                     }),
                     { refresh: 'blocking' }
                 )
                 if (!response.results.length) {
                     return null
                 }
-                const summary = response.results[0]
-                if (!summary.aggregations) {
-                    return null
-                }
-                return {
-                    first_seen: summary.first_seen,
-                    last_seen: summary.last_seen,
-                    aggregations: summary.aggregations,
-                }
+                return toErrorTrackingIssueSummary(response.results[0])
             },
         },
         issueFingerprints: [
@@ -981,5 +965,23 @@ function getNarrowDateRange(timestamp: Dayjs | string): DateRange {
 export type ErrorTrackingIssueSummary = {
     last_seen?: string
     first_seen?: string
+    first_event_uuid?: string
+    last_event_uuid?: string
     aggregations: ErrorTrackingIssueAggregations
+}
+
+export function toErrorTrackingIssueSummary(
+    summary: Pick<ErrorTrackingIssue, 'first_seen' | 'last_seen' | 'first_event' | 'last_event' | 'aggregations'>
+): ErrorTrackingIssueSummary | null {
+    if (!summary.aggregations) {
+        return null
+    }
+
+    return {
+        first_seen: summary.first_seen,
+        last_seen: summary.last_seen,
+        first_event_uuid: summary.first_event?.uuid,
+        last_event_uuid: summary.last_event?.uuid,
+        aggregations: summary.aggregations,
+    }
 }

--- a/products/logs/frontend/components/ViewLogsButton.tsx
+++ b/products/logs/frontend/components/ViewLogsButton.tsx
@@ -16,23 +16,15 @@ export interface ViewLogsButtonProps extends Pick<LemonButtonProps, 'size' | 'ty
     iconOnly?: boolean
 }
 
-// Opens the logs viewer modal filtered to one session, using the team's configured
-// session ID attribute keys. The session-replay / error-tracking counterpart of
-// logs' own ViewRecordingButton usage. Gated here rather than at call sites so
-// every surface of the logs-in-error-tracking rollout toggles with one flag.
-export function ViewLogsButton({
-    sessionId,
-    timestamp,
-    iconOnly,
-    ...buttonProps
-}: ViewLogsButtonProps): JSX.Element | null {
+export function useViewLogsButton({ sessionId, timestamp }: Pick<ViewLogsButtonProps, 'sessionId' | 'timestamp'>): {
+    enabled: boolean
+    onClick: (() => void) | undefined
+    loading: boolean
+    disabledReason: string | undefined
+} {
     const { configuredSessionIdKeys, logsConfigLoading } = useValues(logsConfigLogic)
     const { openLogsViewerModal } = useActions(logsViewerModalLogic)
     const enabled = useFeatureFlag('LOGS_IN_ERROR_TRACKING')
-
-    if (!enabled) {
-        return null
-    }
 
     // Until the team's logs config resolves we don't know which session-ID keys to filter on.
     // Opening with the fallback key here would silently show logs filtered by the wrong
@@ -47,13 +39,34 @@ export function ViewLogsButton({
                   })
             : undefined
 
+    return {
+        enabled,
+        onClick,
+        loading: logsConfigLoading,
+        disabledReason: sessionId ? undefined : 'No session ID associated with this event',
+    }
+}
+
+// The shared hook keeps the feature flag and configured session ID keys consistent across every logs entry point.
+export function ViewLogsButton({
+    sessionId,
+    timestamp,
+    iconOnly,
+    ...buttonProps
+}: ViewLogsButtonProps): JSX.Element | null {
+    const { enabled, onClick, loading, disabledReason } = useViewLogsButton({ sessionId, timestamp })
+
+    if (!enabled) {
+        return null
+    }
+
     return (
         <LemonButton
             icon={<IconLive />}
             onClick={onClick}
-            loading={logsConfigLoading}
+            loading={loading}
             tooltip={iconOnly ? 'View logs from this session' : undefined}
-            disabledReason={sessionId ? undefined : 'No session ID associated with this event'}
+            disabledReason={disabledReason}
             {...buttonProps}
         >
             {iconOnly ? null : 'View logs'}


### PR DESCRIPTION
<!-- pr-stack:start -->
## PR stack

Merge in this order:
1. https://github.com/PostHog/posthog/pull/78799
2. **https://github.com/PostHog/posthog/pull/78800 - this PR**
3. https://github.com/PostHog/posthog/pull/78801
4. https://github.com/PostHog/posthog/pull/78802

Depends on: https://github.com/PostHog/posthog/pull/78799 (merged)

Followed by: https://github.com/PostHog/posthog/pull/78801

This PR targets `master`. After it merges, run `gh stack sync --prune` before merging the next layer.
<!-- pr-stack:end -->

## Problem

- The issue event list separates useful metadata across wide table columns.
- Investigators must request each additional page explicitly.

## Changes

- Replace the event table presentation with compact Quill rows.
- Show runtime, exception details, person, and timestamp in each row.
- Add one semantic marker for the first, selected, or last event.
- Move recording, logs, trace, and copy-link actions into a compact menu.
- Load the next event page when the shared scroll container nears its end.
- Give the sticky filter controls an opaque surface above scrolling event rows.

| Master | PR #78800 |
| --- | --- |
| ![Issue scene on master](https://raw.githubusercontent.com/PostHog/pr-assets/7fc46fc75a120b4f1f88e3ddf7901252b4cc7ad4/2026/08/error-tracking-master-comparison.png) | ![Issue scene in PR #78800](https://raw.githubusercontent.com/PostHog/pr-assets/7fc46fc75a120b4f1f88e3ddf7901252b4cc7ad4/2026/08/error-tracking-pr-78800-comparison.png) |

## How did you test this code?

- `hogli test products/error_tracking/frontend/scenes/ErrorTrackingIssueScene/errorTrackingIssueSceneLogic.test.ts`
- The summary test verifies stable first and last event UUIDs.
- Local Playwright QA covered event selection, actions, filters, and near-bottom loading.
- `hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- No documentation update is required for this interaction change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Pi split and validated the event-list layer from the aggregate modernization draft.
- Skills invoked: `/error-tracking`, `/qa-frontend`, `/writing-tests`, `/stacking-prs`, `/split-pr`, and `/writing-pr-descriptions`.
- A local Quill scope keeps this layer independently reviewable before the scene-wide scope lands.


