### PR TITLE
feat(workflows): poll AWS SES account reputation for alerting

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -124,6 +124,7 @@ from products.web_analytics.backend.tasks.heatmap_screenshot import (
     reap_stale_prewarm_heatmaps,
     report_stuck_heatmap_screenshots,
 )
+from products.workflows.backend.tasks.ses_account_reputation import poll_ses_account_reputation
 
 TWENTY_FOUR_HOURS = 24 * 60 * 60
 
@@ -346,6 +347,15 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(minute="*/10"),
         reconcile_loop_trigger_schedules_task.s(),
         name="reconcile loop trigger schedules",
+    )
+
+    # AWS SES account reputation → gauges for team-facing alerting (charts alerts/specs/ses.yaml)
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="*/10"),
+        poll_ses_account_reputation.s(),
+        name="poll SES account reputation",
+        expires_seconds=10 * 60,
     )
 
     # Flags cache sync - hourly

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -102,9 +102,9 @@ class SESProvider:
 
     def _iter_open_recommendations(self, finding_filter: dict[Any, str] | None) -> Iterator["RecommendationTypeDef"]:
         """
-        Walk every page of ListRecommendations, yielding only OPEN recommendations. STATUS is
-        filtered locally because the documented AWS-side two-key filter combinations
-        (STATUS+IMPACT, STATUS+TYPE) can't be combined with the scopes we query by.
+        Walk every page of ListRecommendations, yielding only OPEN recommendations. The local
+        STATUS check exists for RESOURCE_ARN-filtered calls: AWS documents STATUS as combinable
+        only with IMPACT or TYPE, so tenant-scoped listings must drop FIXED entries client-side.
         """
         kwargs: dict[str, Any] = {"Filter": finding_filter} if finding_filter else {}
         while True:
@@ -123,7 +123,9 @@ class SESProvider:
         classified by the resource it references. AWS opens findings well before it enforces,
         so this is the earliest account-scoped warning available.
         """
-        enforcement_status: str = self.ses_v2_client.get_account().get("EnforcementStatus", "HEALTHY")
+        # Strict access on purpose: a response without EnforcementStatus must fail the poll
+        # (surfacing via the staleness alert) rather than be reported as healthy.
+        enforcement_status: str = self.ses_v2_client.get_account()["EnforcementStatus"]
         findings = [
             {
                 "finding_type": recommendation.get("Type", ""),
@@ -131,14 +133,15 @@ class SESProvider:
                 "scope": self._finding_scope(recommendation.get("ResourceArn", "")),
                 "description": recommendation.get("Description", ""),
             }
-            for recommendation in self._iter_open_recommendations(None)
+            for recommendation in self._iter_open_recommendations({"STATUS": "OPEN"})
         ]
         return {"enforcement_status": enforcement_status, "findings": findings}
 
     @staticmethod
     def _finding_scope(resource_arn: str) -> str:
         # Tenant and identity findings are a customer's sender health; anything else
-        # (configuration sets, the account itself) is shared infrastructure, i.e. ours.
+        # (configuration sets, the account itself, an unrecognized or missing ARN) is
+        # treated as shared infrastructure so classification errs toward alerting us.
         if ":tenant/" in resource_arn:
             return "tenant"
         if ":identity/" in resource_arn:

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -1,6 +1,6 @@
 import re
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
@@ -15,6 +15,7 @@ from rest_framework import exceptions
 if TYPE_CHECKING:
     from types_boto3_ses.client import SESClient
     from types_boto3_sesv2.client import SESV2Client
+    from types_boto3_sesv2.type_defs import RecommendationTypeDef
 
 logger = logging.getLogger(__name__)
 
@@ -82,34 +83,67 @@ class SESProvider:
             sending_status = entity.get("SendingStatusAggregate", sending_status)
 
             # RESOURCE_ARN is the only filter key AWS documents as usable on its own with this
-            # scoping; STATUS is filtered locally because the documented two-key combinations
-            # (STATUS+IMPACT, STATUS+TYPE) don't include RESOURCE_ARN.
-            finding_filter: dict[Any, str] = {"RESOURCE_ARN": tenant_arn}
-            next_token: str | None = None
-            while True:
-                if next_token:
-                    page = self.ses_v2_client.list_recommendations(Filter=finding_filter, NextToken=next_token)
-                else:
-                    page = self.ses_v2_client.list_recommendations(Filter=finding_filter)
-                findings.extend(
-                    {
-                        "finding_type": recommendation.get("Type", ""),
-                        "impact": recommendation.get("Impact", "LOW"),
-                        "description": recommendation.get("Description", ""),
-                        "last_updated_at": recommendation.get("LastUpdatedTimestamp"),
-                    }
-                    for recommendation in page.get("Recommendations", [])
-                    if recommendation.get("Status") == "OPEN"
-                )
-                next_token = page.get("NextToken")
-                if not next_token:
-                    break
+            # scoping (see _iter_open_recommendations for why STATUS is filtered locally).
+            findings.extend(
+                {
+                    "finding_type": recommendation.get("Type", ""),
+                    "impact": recommendation.get("Impact", "LOW"),
+                    "description": recommendation.get("Description", ""),
+                    "last_updated_at": recommendation.get("LastUpdatedTimestamp"),
+                }
+                for recommendation in self._iter_open_recommendations({"RESOURCE_ARN": tenant_arn})
+            )
 
         return {
             "sending_status": sending_status,
             "reputation_impact": reputation_impact,
             "findings": findings,
         }
+
+    def _iter_open_recommendations(self, finding_filter: dict[Any, str] | None) -> Iterator["RecommendationTypeDef"]:
+        """
+        Walk every page of ListRecommendations, yielding only OPEN recommendations. STATUS is
+        filtered locally because the documented AWS-side two-key filter combinations
+        (STATUS+IMPACT, STATUS+TYPE) can't be combined with the scopes we query by.
+        """
+        kwargs: dict[str, Any] = {"Filter": finding_filter} if finding_filter else {}
+        while True:
+            page = self.ses_v2_client.list_recommendations(**kwargs)
+            for recommendation in page.get("Recommendations", []):
+                if recommendation.get("Status") == "OPEN":
+                    yield recommendation
+            next_token = page.get("NextToken")
+            if not next_token:
+                return
+            kwargs["NextToken"] = next_token
+
+    def get_account_reputation(self) -> dict[str, Any]:
+        """
+        Account-level SES verdict: enforcement status plus every open reputation finding,
+        classified by the resource it references. AWS opens findings well before it enforces,
+        so this is the earliest account-scoped warning available.
+        """
+        enforcement_status: str = self.ses_v2_client.get_account().get("EnforcementStatus", "HEALTHY")
+        findings = [
+            {
+                "finding_type": recommendation.get("Type", ""),
+                "impact": recommendation.get("Impact", "LOW"),
+                "scope": self._finding_scope(recommendation.get("ResourceArn", "")),
+                "description": recommendation.get("Description", ""),
+            }
+            for recommendation in self._iter_open_recommendations(None)
+        ]
+        return {"enforcement_status": enforcement_status, "findings": findings}
+
+    @staticmethod
+    def _finding_scope(resource_arn: str) -> str:
+        # Tenant and identity findings are a customer's sender health; anything else
+        # (configuration sets, the account itself) is shared infrastructure, i.e. ours.
+        if ":tenant/" in resource_arn:
+            return "tenant"
+        if ":identity/" in resource_arn:
+            return "identity"
+        return "account"
 
     @cached_property
     def _aws_account_id(self) -> str:

--- a/products/workflows/backend/tasks/__init__.py
+++ b/products/workflows/backend/tasks/__init__.py
@@ -1,3 +1,3 @@
-from . import hog_flows
+from . import hog_flows, ses_account_reputation
 
-__all__ = ["hog_flows"]
+__all__ = ["hog_flows", "ses_account_reputation"]

--- a/products/workflows/backend/tasks/ses_account_reputation.py
+++ b/products/workflows/backend/tasks/ses_account_reputation.py
@@ -1,0 +1,56 @@
+import time
+from collections import Counter
+
+from celery import shared_task
+from prometheus_client import Gauge
+from structlog import get_logger
+
+from posthog.metrics import pushed_metrics_registry
+from posthog.tasks.utils import CeleryQueue
+
+from products.workflows.backend.providers.ses import SESProvider
+
+logger = get_logger(__name__)
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+def poll_ses_account_reputation() -> None:
+    """
+    Export AWS's account-level SES verdict as gauges for alerting: enforcement status, open
+    reputation findings, and a poll timestamp. The timestamp exists because pushgateway
+    gauges never expire — without it, a dead poller freezes the last "healthy" values
+    forever and nothing would fire.
+    """
+    try:
+        reputation = SESProvider().get_account_reputation()
+    except Exception:
+        # Regions without SES access (self-hosted, dev) land here every tick; a stale
+        # last_poll_timestamp is the alertable signal for genuine poller breakage in cloud.
+        logger.warning("SES account reputation poll failed", exc_info=True)
+        return
+
+    finding_counts = Counter(
+        (finding["scope"], finding["finding_type"], finding["impact"]) for finding in reputation["findings"]
+    )
+
+    with pushed_metrics_registry("ses_account_reputation") as registry:
+        Gauge(
+            "posthog_ses_account_enforcement_healthy",
+            "1 while AWS SES reports the account EnforcementStatus as HEALTHY, 0 otherwise.",
+            registry=registry,
+        ).set(1 if reputation["enforcement_status"] == "HEALTHY" else 0)
+
+        findings_gauge = Gauge(
+            "posthog_ses_open_reputation_findings",
+            "Open AWS SES reputation findings (ListRecommendations), by referenced resource scope.",
+            labelnames=["scope", "finding_type", "impact"],
+            registry=registry,
+        )
+        for (scope, finding_type, impact), count in finding_counts.items():
+            findings_gauge.labels(scope=scope, finding_type=finding_type, impact=impact).set(count)
+
+        Gauge(
+            "posthog_ses_account_reputation_last_poll_timestamp_seconds",
+            "Unix timestamp of the last successful SES account reputation poll.",
+            registry=registry,
+        ).set(time.time())

--- a/products/workflows/backend/test/test_ses_account_reputation_task.py
+++ b/products/workflows/backend/test/test_ses_account_reputation_task.py
@@ -1,0 +1,74 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+from parameterized import parameterized
+from prometheus_client import CollectorRegistry
+
+from products.workflows.backend.tasks.ses_account_reputation import poll_ses_account_reputation
+
+
+class TestPollSesAccountReputation(TestCase):
+    def setUp(self):
+        self.registry = CollectorRegistry()
+        registry_context = MagicMock()
+        registry_context.__enter__ = MagicMock(return_value=self.registry)
+        registry_context.__exit__ = MagicMock(return_value=False)
+        self.registry_patcher = patch(
+            "products.workflows.backend.tasks.ses_account_reputation.pushed_metrics_registry",
+            return_value=registry_context,
+        )
+        self.mock_registry_factory = self.registry_patcher.start()
+        self.addCleanup(self.registry_patcher.stop)
+
+        provider_patcher = patch("products.workflows.backend.tasks.ses_account_reputation.SESProvider")
+        self.mock_provider = provider_patcher.start().return_value
+        self.addCleanup(provider_patcher.stop)
+
+    @parameterized.expand(
+        [
+            ("HEALTHY", 1.0),
+            ("PROBATION", 0.0),
+            ("SHUTDOWN", 0.0),
+        ]
+    )
+    def test_exports_enforcement_health_gauge(self, status, expected):
+        self.mock_provider.get_account_reputation.return_value = {"enforcement_status": status, "findings": []}
+
+        poll_ses_account_reputation()
+
+        assert self.registry.get_sample_value("posthog_ses_account_enforcement_healthy") == expected
+
+    @patch("products.workflows.backend.tasks.ses_account_reputation.time.time", return_value=1700000000.0)
+    def test_exports_finding_counts_and_poll_timestamp(self, _mock_time):
+        self.mock_provider.get_account_reputation.return_value = {
+            "enforcement_status": "HEALTHY",
+            "findings": [
+                {"finding_type": "BOUNCE", "impact": "LOW", "scope": "tenant"},
+                {"finding_type": "BOUNCE", "impact": "LOW", "scope": "tenant"},
+                {"finding_type": "COMPLAINT", "impact": "HIGH", "scope": "account"},
+            ],
+        }
+
+        poll_ses_account_reputation()
+
+        def finding_count(scope, finding_type, impact):
+            return self.registry.get_sample_value(
+                "posthog_ses_open_reputation_findings",
+                {"scope": scope, "finding_type": finding_type, "impact": impact},
+            )
+
+        assert finding_count("tenant", "BOUNCE", "LOW") == 2
+        assert finding_count("account", "COMPLAINT", "HIGH") == 1
+        assert (
+            self.registry.get_sample_value("posthog_ses_account_reputation_last_poll_timestamp_seconds") == 1700000000.0
+        )
+
+    def test_provider_failure_does_not_raise_and_pushes_nothing(self):
+        self.mock_provider.get_account_reputation.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "GetAccount"
+        )
+
+        poll_ses_account_reputation()
+
+        self.mock_registry_factory.assert_not_called()

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -387,6 +387,20 @@ class TestSESResponseShapeContract(TestCase):
                 "AWS SES v2 ResourceTenantMetadata no longer exposes `TenantName`. "
                 "Update _list_identity_tenants in products/workflows/backend/providers/ses.py.",
             ),
+            (
+                "get_account_enforcement_status",
+                "EnforcementStatus",
+                lambda m: m.operation_model("GetAccount").output_shape.members.keys(),
+                "AWS SES v2 GetAccount response no longer exposes `EnforcementStatus`. "
+                "Update get_account_reputation in products/workflows/backend/providers/ses.py.",
+            ),
+            (
+                "recommendation_resource_arn",
+                "ResourceArn",
+                lambda m: m.shape_for("Recommendation").members.keys(),
+                "AWS SES v2 Recommendation no longer exposes `ResourceArn`. "
+                "Update get_account_reputation in products/workflows/backend/providers/ses.py.",
+            ),
         ]
     )
     def test_sdk_shape_exposes_field(self, _name, expected_key, get_members, message):
@@ -506,3 +520,76 @@ class TestGetTenantReputation(TestCase):
         first_call, second_call = self.mock_client.list_recommendations.call_args_list
         assert first_call.kwargs["Filter"] == {"RESOURCE_ARN": self.TENANT_ARN}
         assert second_call.kwargs["NextToken"] == "page-2"
+
+
+class TestGetAccountReputation(TestCase):
+    def setUp(self):
+        patcher = patch("products.workflows.backend.providers.ses.boto3.client")
+        mock_boto3_client = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.mock_client = mock_boto3_client.return_value
+        self.provider = SESProvider()
+
+    def test_returns_enforcement_status_and_open_findings_across_pages(self):
+        self.mock_client.get_account.return_value = {"EnforcementStatus": "PROBATION"}
+        self.mock_client.list_recommendations.side_effect = [
+            {
+                "Recommendations": [
+                    {
+                        "Type": "BOUNCE",
+                        "Impact": "LOW",
+                        "Status": "OPEN",
+                        "ResourceArn": "arn:aws:ses:us-east-1:123:tenant/team-1/tn-abc",
+                        "Description": "Bounce rate exceeded 10%",
+                    },
+                    # FIXED findings come back too (no status filter on the AWS side) and must be dropped
+                    {
+                        "Type": "SPF",
+                        "Impact": "HIGH",
+                        "Status": "FIXED",
+                        "ResourceArn": "arn:aws:ses:us-east-1:123:identity/fixed.example.com",
+                        "Description": "SPF1",
+                    },
+                ],
+                "NextToken": "page-2",
+            },
+            {
+                "Recommendations": [
+                    {
+                        "Type": "DMARC",
+                        "Impact": "HIGH",
+                        "Status": "OPEN",
+                        "ResourceArn": "arn:aws:ses:us-east-1:123:identity/customer.example.com",
+                        "Description": "DMARC5",
+                    },
+                    {
+                        "Type": "COMPLAINT",
+                        "Impact": "HIGH",
+                        "Status": "OPEN",
+                        "ResourceArn": "arn:aws:ses:us-east-1:123:configuration-set/posthog-messaging",
+                        "Description": "Complaint rate elevated",
+                    },
+                ]
+            },
+        ]
+
+        result = self.provider.get_account_reputation()
+
+        assert result["enforcement_status"] == "PROBATION"
+        assert [(f["finding_type"], f["impact"], f["scope"]) for f in result["findings"]] == [
+            ("BOUNCE", "LOW", "tenant"),
+            ("DMARC", "HIGH", "identity"),
+            ("COMPLAINT", "HIGH", "account"),
+        ]
+        # The listing must be unfiltered (account-wide) and walk every page
+        first_call, second_call = self.mock_client.list_recommendations.call_args_list
+        assert "Filter" not in first_call.kwargs
+        assert second_call.kwargs["NextToken"] == "page-2"
+
+    def test_missing_enforcement_status_defaults_to_healthy(self):
+        self.mock_client.get_account.return_value = {}
+        self.mock_client.list_recommendations.return_value = {"Recommendations": []}
+
+        result = self.provider.get_account_reputation()
+
+        assert result == {"enforcement_status": "HEALTHY", "findings": []}

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -542,14 +542,6 @@ class TestGetAccountReputation(TestCase):
                         "ResourceArn": "arn:aws:ses:us-east-1:123:tenant/team-1/tn-abc",
                         "Description": "Bounce rate exceeded 10%",
                     },
-                    # FIXED findings come back too (no status filter on the AWS side) and must be dropped
-                    {
-                        "Type": "SPF",
-                        "Impact": "HIGH",
-                        "Status": "FIXED",
-                        "ResourceArn": "arn:aws:ses:us-east-1:123:identity/fixed.example.com",
-                        "Description": "SPF1",
-                    },
                 ],
                 "NextToken": "page-2",
             },
@@ -581,15 +573,14 @@ class TestGetAccountReputation(TestCase):
             ("DMARC", "HIGH", "identity"),
             ("COMPLAINT", "HIGH", "account"),
         ]
-        # The listing must be unfiltered (account-wide) and walk every page
+        # The listing must be account-wide with OPEN filtered server-side, and walk every page
         first_call, second_call = self.mock_client.list_recommendations.call_args_list
-        assert "Filter" not in first_call.kwargs
+        assert first_call.kwargs["Filter"] == {"STATUS": "OPEN"}
         assert second_call.kwargs["NextToken"] == "page-2"
 
-    def test_missing_enforcement_status_defaults_to_healthy(self):
+    def test_missing_enforcement_status_fails_the_poll(self):
         self.mock_client.get_account.return_value = {}
         self.mock_client.list_recommendations.return_value = {"Recommendations": []}
 
-        result = self.provider.get_account_reputation()
-
-        assert result == {"enforcement_status": "HEALTHY", "findings": []}
+        with pytest.raises(KeyError):
+            self.provider.get_account_reputation()


### PR DESCRIPTION
## Problem

The workflows team learns AWS has a problem with the shared SES account only by opening the AWS console.

- The existing account-level alerts (charts `alerts/specs/ses.yaml`) threshold CloudWatch reputation rates. The exporter's samples go stale between CloudWatch datapoints, which resets the alerts' `for:` timer, so they sit in pending indefinitely.
- Even when firing, those rates only approximate AWS's judgment. AWS computes complaint rate against feedback-loop sends only and applies volume rules it does not publish.
- AWS publishes its actual verdict per account (`GetAccount` enforcement status, `ListRecommendations` findings), and nothing consumes it.

## Changes

- A new celery task, `poll_ses_account_reputation`, polls AWS's verdict every 10 minutes and pushes three pushgateway gauges: enforcement health, open reputation findings by scope/type/impact, and a last-poll timestamp.
- The companion charts PR (PostHog/charts#13982) alerts on the gauges: non-HEALTHY enforcement pages, a new shared-scope finding goes to Slack.

> [!WARNING]
> Deploy order: PostHog/posthog-cloud-infra#9857 must apply first. The `k8s-django-worker` role currently denies `ses:GetAccount` (verified with the IAM policy simulator in both prod accounts), so without that grant every poll fails with AccessDenied. Then this PR, then the charts PR.
- `SESProvider.get_account_reputation()` reads the two APIs and classifies each finding by the resource its ARN references: a customer's tenant or identity, or shared infrastructure.
- The last-poll timestamp exists because pushgateway gauges never expire. A dead poller would freeze the last healthy values, so charts alerts on the timestamp's age instead of `absent()`.
- The task logs and returns on provider errors rather than retrying. Environments without SES access hit that path every tick, and the staleness alert covers real breakage in cloud.
- Refactor: the ListRecommendations pagination loop moves out of `get_tenant_reputation` into a helper both reputation methods share.

## How did you test this code?

- Two new SDK shape-contract tests pin `EnforcementStatus` and `ResourceArn` against the live boto3 service model. They catch a response-key rename or typo that mock-based tests cannot, the failure mode of #62844.
- Provider tests catch a broken pagination loop, an inverted OPEN filter, and wrong scope classification, each of which would silently undercount findings.
- Task tests catch an inverted health mapping (HEALTHY must export 1, anything else 0) and miswired gauge labels.
- Not run: the poller against live AWS. The API calls mirror read-only `aws sesv2 get-account` / `list-recommendations` invocations verified by hand in both production accounts.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal alerting infrastructure, no user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: /writing-tests, /writing-pr-descriptions, /query-clickhouse-via-metabase (investigation).
- The session started as an investigation into why the existing SES alerts never fired; the poller design came out of finding that AWS's own verdict APIs already carry the graded signal the rate thresholds try to approximate.
- Verified response shapes against the types_boto3_sesv2 service model rather than assuming field names, per reviewer request.


