### PR TITLE
feat(dashboards): suggest the user interactions template in two places

### DIFF
--- a/frontend/src/scenes/activity/live/LiveEventsTable.tsx
+++ b/frontend/src/scenes/activity/live/LiveEventsTable.tsx
@@ -12,6 +12,10 @@ import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ActivitySceneTabs } from 'scenes/activity/ActivitySceneTabs'
+import {
+    SuggestedTemplateBanner,
+    USER_INTERACTIONS_TEMPLATE_NAME,
+} from 'scenes/dashboard/dashboards/templates/SuggestedTemplateBanner'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 
@@ -58,6 +62,15 @@ export function LiveEventsTable(): JSX.Element {
                     Learn more
                 </Link>
             </LemonBanner>
+            <SuggestedTemplateBanner
+                templateName={USER_INTERACTIONS_TEMPLATE_NAME}
+                tileLocation="activity_live"
+                dismissKey="user-interactions-template-activity"
+                className="mb-4"
+            >
+                Clicks, form submissions, and input changes are already in this stream. The user interactions dashboard
+                charts them, including the clicks that do nothing.
+            </SuggestedTemplateBanner>
             <SceneTitleSection
                 name={sceneConfigurations[Scene.Activity].name}
                 description={sceneConfigurations[Scene.Activity].description}

--- a/frontend/src/scenes/dashboard/dashboards/templates/SuggestedTemplateBanner.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/SuggestedTemplateBanner.test.ts
@@ -1,0 +1,10 @@
+import userInteractionsSeed from '../../../../../../products/demo/backend/logic/dashboard_template_seeds/09_user_interactions.json'
+import { USER_INTERACTIONS_TEMPLATE_NAME } from './SuggestedTemplateBanner'
+
+describe('SuggestedTemplateBanner', () => {
+    it('matches the seeded template name', () => {
+        // The banner finds its template by name and renders nothing when there is no match, so a
+        // rename on either side would take the suggestion away without any visible error.
+        expect(userInteractionsSeed.template_name).toEqual(USER_INTERACTIONS_TEMPLATE_NAME)
+    })
+})

--- a/frontend/src/scenes/dashboard/dashboards/templates/SuggestedTemplateBanner.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/templates/SuggestedTemplateBanner.tsx
@@ -1,0 +1,66 @@
+import { useActions, useValues } from 'kea'
+import { useMemo } from 'react'
+
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+
+import { dashboardTemplateChooserLogic } from './dashboardTemplateChooserLogic'
+import type { DashboardTemplateTileLocation } from './dashboardTemplateChooserLogic'
+
+/** Name of the official template that turns autocaptured events into charts. */
+export const USER_INTERACTIONS_TEMPLATE_NAME = 'User interactions'
+
+export interface SuggestedTemplateBannerProps {
+    /** Matched against `template_name`. */
+    templateName: string
+    /** Where the suggestion was shown, reported on the template-clicked event. */
+    tileLocation: DashboardTemplateTileLocation
+    children: React.ReactNode
+    dismissKey?: string
+    className?: string
+}
+
+/**
+ * Suggests one named dashboard template outside the chooser.
+ *
+ * Renders nothing when no template matches, because official templates are seeded by a
+ * management command rather than on deploy, so the name can be absent in a given environment.
+ */
+export function SuggestedTemplateBanner({
+    templateName,
+    tileLocation,
+    children,
+    dismissKey,
+    className,
+}: SuggestedTemplateBannerProps): JSX.Element | null {
+    // Keyed on scope and availability contexts, so this shares the chooser's instance and its
+    // click flow, including the template-clicked event.
+    const chooserLogic = dashboardTemplateChooserLogic({})
+    const { allTemplates, isLoading } = useValues(chooserLogic)
+    const { templateTileClicked } = useActions(chooserLogic)
+
+    const template = useMemo(
+        () => allTemplates.find((candidate) => candidate.template_name === templateName),
+        [allTemplates, templateName]
+    )
+
+    if (!template) {
+        return null
+    }
+
+    return (
+        <LemonBanner
+            type="info"
+            className={className}
+            dismissKey={dismissKey}
+            action={{
+                children: 'Create dashboard',
+                onClick: () => templateTileClicked(template, tileLocation),
+                loading: isLoading,
+                disabledReason: isLoading ? 'Creating your dashboard' : undefined,
+                'data-attr': 'create-dashboard-from-suggested-template',
+            }}
+        >
+            {children}
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/templates/dashboardTemplateChooserLogic.ts
@@ -12,6 +12,14 @@ import { DashboardTemplateProps, dashboardTemplatesLogic } from './dashboardTemp
 
 export type DashboardTemplateChooserLogicProps = DashboardTemplateProps
 
+/** Surface a template was picked from, reported as `tile_location` on the template-clicked event. */
+export type DashboardTemplateTileLocation =
+    | 'featured_row'
+    | 'main_grid'
+    | 'team_section'
+    | 'onboarding'
+    | 'activity_live'
+
 function availabilityContextsKey(contexts: DashboardTemplateProps['availabilityContexts']): string {
     if (!contexts?.length) {
         return 'any'
@@ -97,10 +105,10 @@ export interface dashboardTemplateChooserLogicActions {
     }
     templateTileClicked: (
         template: DashboardTemplateType,
-        tileLocation: 'featured_row' | 'main_grid' | 'team_section'
+        tileLocation: DashboardTemplateTileLocation
     ) => {
         template: DashboardTemplateType
-        tileLocation: 'featured_row' | 'main_grid' | 'team_section'
+        tileLocation: DashboardTemplateTileLocation
     }
 }
 
@@ -154,10 +162,7 @@ export const dashboardTemplateChooserLogic = kea<dashboardTemplateChooserLogicTy
         ],
     })),
     actions({
-        templateTileClicked: (
-            template: DashboardTemplateType,
-            tileLocation: 'main_grid' | 'featured_row' | 'team_section'
-        ) => ({
+        templateTileClicked: (template: DashboardTemplateType, tileLocation: DashboardTemplateTileLocation) => ({
             template,
             tileLocation,
         }),

--- a/products/product_analytics/frontend/onboarding/steps.tsx
+++ b/products/product_analytics/frontend/onboarding/steps.tsx
@@ -1,6 +1,10 @@
 import { useValues } from 'kea'
 
 import { SetupTaskId } from 'lib/components/ProductSetup'
+import {
+    SuggestedTemplateBanner,
+    USER_INTERACTIONS_TEMPLATE_NAME,
+} from 'scenes/dashboard/dashboards/templates/SuggestedTemplateBanner'
 import { newDashboardLogic } from 'scenes/dashboard/newDashboardLogic'
 import { OnboardingProductConfiguration } from 'scenes/onboarding/legacy/OnboardingProductConfiguration'
 import { type ProductConfigOption } from 'scenes/onboarding/legacy/onboardingProductConfigurationLogic'
@@ -37,10 +41,30 @@ const sessionReplayOnboardingToggle = (
     }
 }
 
-const ProductAnalyticsConfigStep = ({ options }: { options: ProductConfigOption[] }): JSX.Element => {
+const ProductAnalyticsConfigStep = ({
+    options,
+    autocaptureEnabled,
+}: {
+    options: ProductConfigOption[]
+    autocaptureEnabled: boolean
+}): JSX.Element => {
     // mount newDashboardLogic for the entire onboarding flow — same intent as the legacy view
     useValues(newDashboardLogic)
-    return <OnboardingProductConfiguration options={options} />
+    return (
+        <>
+            <OnboardingProductConfiguration options={options} />
+            {autocaptureEnabled ? (
+                <SuggestedTemplateBanner
+                    templateName={USER_INTERACTIONS_TEMPLATE_NAME}
+                    tileLocation="onboarding"
+                    className="mt-4"
+                >
+                    With autocapture on, you collect clicks and form interactions without writing tracking code. The
+                    user interactions dashboard charts them for you.
+                </SuggestedTemplateBanner>
+            ) : null}
+        </>
+    )
 }
 
 export const productAnalyticsOnboarding: ProductOnboardingProvider = {
@@ -139,7 +163,12 @@ export const productAnalyticsOnboarding: ProductOnboardingProvider = {
                 productKey: ProductKey.PRODUCT_ANALYTICS,
                 stepKey: OnboardingStepKey.PRODUCT_CONFIGURATION,
                 role: ctx.role,
-                render: () => <ProductAnalyticsConfigStep options={filteredOptions} />,
+                render: () => (
+                    <ProductAnalyticsConfigStep
+                        options={filteredOptions}
+                        autocaptureEnabled={!ctx.currentTeam?.autocapture_opt_out}
+                    />
+                ),
             },
             {
                 id: `${OnboardingStepKey.SESSION_REPLAY}:${ProductKey.PRODUCT_ANALYTICS}`,


### PR DESCRIPTION
## Problem

Stacked on #78796, which adds the "User interactions" template. That PR only makes the template exist. A template nobody finds changes nothing, and today the only way to reach it is to open the dashboard chooser and read the grid.

The people who would benefit most are the ones least likely to go looking: someone who just finished onboarding, or who is watching events arrive and has not built anything yet.

## Changes

Adds `SuggestedTemplateBanner`, which offers a single named template outside the chooser, and puts it on two surfaces.

- Product analytics onboarding, in the configuration step, right where autocapture is toggled.
- The Activity scene's Live tab, next to the existing `posthog-live` banner.

Design notes for reviewers:

- The banner delegates to the chooser logic's `templateTileClicked`, so the creation flow and the `dashboard template chooser template clicked` event both stay in one place. Two new `tile_location` values (`onboarding`, `activity_live`) make the surfaces separable in analytics, and the union is now a named exported type instead of being spelled out at three call sites.
- It renders nothing when no template matches the name. Official templates are seeded by `ensure_migration_defaults` or `generate_demo_data`, not on deploy, so the name can legitimately be absent in an environment. Failing closed beats a button that does nothing.
- Onboarding only shows it when the team still has autocapture enabled. Suggesting an autocapture dashboard to someone who just turned autocapture off would be wrong.
- Both banners are `LemonBanner` with the `dismissKey` idiom already used on the Activity scene, rather than a new component.

## How did you test this code?

Automated, run by me:

- `jest frontend/src/scenes/dashboard frontend/src/scenes/activity`: 25 suites, 358 passed, 1 skipped.
- Added one test asserting the exported template-name constant equals `template_name` in the seed file, importing the seed so both sides read one source of truth. The regression: rename the template on either side and the banner stops rendering everywhere, with no error, forever. I mutation-checked it by changing the constant and confirming the test fails.
- `pnpm typescript:check` reports no errors in the files this PR touches, and the tree-wide error count is unchanged from before the branch (290, all pre-existing, from unbuilt nested workspaces in this environment).

Not done, and why:

- I did not render either surface. No dev stack or browser in this environment, so the banner's appearance, placement, and the click-through to a created dashboard are unverified. This is the main thing worth checking by hand before it leaves draft, and no screenshots are attached for the same reason.
- I did not verify the two new `tile_location` values arriving in analytics, since that needs a running app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with the PostHog Slack app (Claude Code). Repo skills read and followed: `writing-tests` and `writing-user-facing-copy`.

Two things changed shape during the session. The banner first reimplemented the capture plus creation flow itself; that was dropped once `dashboardTemplateChooserLogic.templateTileClicked` turned out to do both already, which also kept the event shape consistent. It also briefly passed `redirectAfterCreation: true` into that logic, removed after checking that the logic is keyed on scope and availability contexts, so a shared instance would use first-mount props and the explicit prop would read as meaningful without being so.

The test started as a component render asserting the empty case, and became a pure constant-versus-seed assertion instead, per the guidance to extract rather than escalate to a more expensive test rung.

Context came from an internal analysis of dashboard template and autocapture usage. No figures, customer names, or session content from that analysis appear in this PR. All copy is written fresh.

*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B9A53J8RF/p1786009555351299)*
