### PR TITLE
fix(aio): route hobby error tracking ingestion to cymbal

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -593,7 +593,6 @@ services:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
-            ERROR_TRACKING_CYMBAL_BASE_URL: 'http://cymbal:3302'
             CDP_REDIS_HOST: redis7
             ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -593,6 +593,7 @@ services:
             DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             KAFKA_HOSTS: 'kafka:9092'
             REDIS_URL: 'redis://redis7:6379/'
+            ERROR_TRACKING_CYMBAL_BASE_URL: 'http://cymbal:3302'
             CDP_REDIS_HOST: redis7
             ENCRYPTION_SALT_KEYS: '00beef0000beef0000beef0000beef00'
 

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -269,6 +269,7 @@ services:
         logging: *default-logging
         environment:
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
+            ERROR_TRACKING_CYMBAL_BASE_URL: 'http://cymbal:3302'
         depends_on:
             - db
             - redis7


### PR DESCRIPTION
## Problem

Self-hosted Compose deployments cannot process exception events because the error-tracking consumer calls Cymbal on its own container-local `localhost`.

Refs #58243

## Changes

Configure the consumer to reach Cymbal through the Compose service hostname at `http://cymbal:3302`. This complements #78781, which restores the required Cymbal resolution service.

## How did you test this code?

- Rendered `docker-compose.hobby.yml` with `docker compose config` and verified the resolved consumer environment.
- Ran `git diff --check`.
- Did not boot a full Hobby instance locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None; this restores the intended internal service wiring.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with Codex. No repository-provided skills were invoked; the requested PR-description skill was not available in this session.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*