### PR TITLE
fix(desktop): preserve first message during cloud resume

### DIFF
--- a/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.test.ts
@@ -229,11 +229,12 @@ describe("CloudPiSessionClient", () => {
       taskId: "task-1",
       runId: "run-1",
       kind: "snapshot",
-      status: "queued",
+      status: "in_progress",
       newEntries: [{ type: "pi_run_started" }],
       totalEntryCount: 1,
     });
 
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
     expect(cloud.client.sendCommand).not.toHaveBeenCalled();
 
     cloud.sendUpdate({

--- a/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.test.ts
+++ b/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.test.ts
@@ -173,6 +173,37 @@ describe("CloudPiSessionClient", () => {
     expect(cloud.client.sendCommand).toHaveBeenCalledOnce();
   });
 
+  it("uses the readiness snapshot when opening an already-running session", async () => {
+    const cloud = createCloudTaskClient();
+    vi.mocked(cloud.client.sendCommand).mockResolvedValue({
+      success: true,
+      result: {
+        type: "response",
+        command: "get_state",
+        success: true,
+        data: { isStreaming: false },
+      },
+    });
+    const session = new CloudPiSessionClient(
+      cloud.client,
+      context("in_progress"),
+    );
+    session.onConversationEvent(vi.fn(), vi.fn());
+
+    const state = session.client.getState();
+    cloud.sendUpdate({
+      taskId: "task-1",
+      runId: "run-1",
+      kind: "snapshot",
+      status: "in_progress",
+      newEntries: [{ type: "pi_run_started" }],
+      totalEntryCount: 1,
+    });
+
+    await expect(state).resolves.toMatchObject({ isStreaming: false });
+    expect(cloud.client.sendCommand).toHaveBeenCalledOnce();
+  });
+
   it("does not fail while a sandbox takes longer than 30 seconds to boot", async () => {
     vi.useFakeTimers();
     try {

--- a/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.ts
+++ b/products/desktop/packages/core/src/pi-runtime/cloudPiSessionClient.ts
@@ -337,7 +337,9 @@ export class CloudPiSessionClient implements PiSession {
     onCloudStatus?: (status: TaskRunStatus) => void,
   ): void {
     const snapshotCanProveReadiness =
-      update.kind === "snapshot" && update.status === "in_progress";
+      update.kind === "snapshot" &&
+      this.context.runStatus === "in_progress" &&
+      update.status === "in_progress";
     const hasCurrentReadinessEvent =
       (update.kind === "logs" || snapshotCanProveReadiness) &&
       update.newEntries.some((entry) => entry.type === "pi_run_started");


### PR DESCRIPTION
## Problem

People lose their first message when they resume a Pi cloud session whose sandbox has stopped.

A historical `pi_run_started` entry can make the client send the message before the replacement sandbox is ready.

## Changes

- Resumed queued sessions now wait for a fresh runtime start before sending commands.
- Already-running sessions can still use their historical readiness snapshot.
- No screenshot: this changes session timing without changing the interface.

## How did you test this code?

- Updated the cloud Pi session regression test to cover an `in_progress` snapshot with a stale start event.
- Ran `pnpm --filter @posthog/core test`.
- Ran `pnpm --filter @posthog/core typecheck`.
- Ran `./bin/hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This fixes internal runtime readiness behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used repository file, edit, and shell tools. The session link is unavailable.

Skills invoked: `/posthog-desktop`, `/writing-tests`, `/running-ci-preflight`, and `/writing-pr-descriptions`.
