### PR TITLE
HostHog scope probe (out-of-scope) — will be closed shortly

### DIFF
--- a/.hosthog-scope-probe
+++ b/.hosthog-scope-probe
@@ -1,1 +1,2 @@
 hosthog scoping probe — outside the desktop subtree; branch-only, never for master
+outside probe


### PR DESCRIPTION
Temporary draft against a test branch to validate HostHog produces zero footprint on PRs that do not touch the connected subtree. No review needed; closing after the check. 🤖