### PR TITLE
fix(error-tracking): validate Jira issue responses

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3201,27 +3201,24 @@ class JiraIntegration:
         except Exception:
             logger.warning("JiraIntegration: token refresh pre-check failed", exc_info=True)
 
-    @staticmethod
-    def _create_issue_error_message(response_body: Any) -> str:
-        fallback = "Could not create the Jira issue. Check the project's issue settings and try again."
-        if not isinstance(response_body, dict):
-            return fallback
-
-        error_messages = response_body.get("errorMessages", [])
-        details = (
-            [message for message in error_messages if isinstance(message, str)]
-            if isinstance(error_messages, list)
-            else []
-        )
-        field_errors = response_body.get("errors", {})
-        if isinstance(field_errors, dict):
-            details.extend(
-                f"{field}: {message}"
-                for field, message in field_errors.items()
-                if isinstance(field, str) and isinstance(message, str)
+    def _raise_create_issue_error(self, response: requests.Response, response_body: Any) -> NoReturn:
+        properties: dict[str, Any] = {
+            "jira_status_code": response.status_code,
+            "jira_response_content_type": response.headers.get("Content-Type"),
+            "integration_id": self.integration.id,
+            "team_id": self.integration.team_id,
+        }
+        if isinstance(response_body, dict):
+            properties.update(
+                {
+                    "jira_error_messages": response_body.get("errorMessages"),
+                    "jira_field_errors": response_body.get("errors"),
+                    "jira_response_keys": list(response_body.keys()),
+                }
             )
 
-        return f"{fallback} Jira reported: {'; '.join(details)}" if details else fallback
+        capture_exception(Exception("Jira issue creation failed"), additional_properties=properties)
+        raise ValidationError("Could not create the Jira issue. Check the project's issue settings and try again.")
 
     def list_projects(self) -> list[dict]:
         """List all Jira projects accessible to the user"""
@@ -3288,13 +3285,13 @@ class JiraIntegration:
         try:
             issue = response.json()
         except ValueError:
-            issue = {}
+            issue = None
 
         if response.status_code != 201:
-            raise ValidationError(self._create_issue_error_message(issue))
+            self._raise_create_issue_error(response, issue)
 
-        if not issue.get("key"):
-            raise ValidationError(self._create_issue_error_message(issue))
+        if not isinstance(issue, dict) or not issue.get("key"):
+            self._raise_create_issue_error(response, issue)
 
         return {"key": issue["key"], "id": issue.get("id", "")}
 

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3263,8 +3263,15 @@ class JiraIntegration:
             timeout=10,
         )
 
+        error_message = "Could not create the Jira issue. Check the project's issue settings and try again."
+        if response.status_code != 201:
+            raise ValidationError(error_message)
+
         issue = response.json()
-        return {"key": issue.get("key", ""), "id": issue.get("id", "")}
+        if not issue.get("key"):
+            raise ValidationError(error_message)
+
+        return {"key": issue["key"], "id": issue.get("id", "")}
 
 
 # Default branches change rarely; a multi-hour TTL is plenty to avoid hitting

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3201,6 +3201,28 @@ class JiraIntegration:
         except Exception:
             logger.warning("JiraIntegration: token refresh pre-check failed", exc_info=True)
 
+    @staticmethod
+    def _create_issue_error_message(response_body: Any) -> str:
+        fallback = "Could not create the Jira issue. Check the project's issue settings and try again."
+        if not isinstance(response_body, dict):
+            return fallback
+
+        error_messages = response_body.get("errorMessages", [])
+        details = (
+            [message for message in error_messages if isinstance(message, str)]
+            if isinstance(error_messages, list)
+            else []
+        )
+        field_errors = response_body.get("errors", {})
+        if isinstance(field_errors, dict):
+            details.extend(
+                f"{field}: {message}"
+                for field, message in field_errors.items()
+                if isinstance(field, str) and isinstance(message, str)
+            )
+
+        return f"{fallback} Jira reported: {'; '.join(details)}" if details else fallback
+
     def list_projects(self) -> list[dict]:
         """List all Jira projects accessible to the user"""
         cloud_id = self.cloud_id()
@@ -3263,13 +3285,16 @@ class JiraIntegration:
             timeout=10,
         )
 
-        error_message = "Could not create the Jira issue. Check the project's issue settings and try again."
-        if response.status_code != 201:
-            raise ValidationError(error_message)
+        try:
+            issue = response.json()
+        except ValueError:
+            issue = {}
 
-        issue = response.json()
+        if response.status_code != 201:
+            raise ValidationError(self._create_issue_error_message(issue))
+
         if not issue.get("key"):
-            raise ValidationError(error_message)
+            raise ValidationError(self._create_issue_error_message(issue))
 
         return {"key": issue["key"], "id": issue.get("id", "")}
 

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -235,20 +235,45 @@ class TestLinearIntegrationModel(BaseTest):
 
 
 class TestJiraIntegrationModel:
-    @patch("posthog.models.integration.requests.post")
-    def test_create_issue_rejects_an_unsuccessful_response(self, mock_post):
-        mock_post.return_value.status_code = 400
-        mock_post.return_value.json.return_value = {"errorMessages": ["Issue type is not available"]}
-        integration = MagicMock(
+    @staticmethod
+    def integration() -> MagicMock:
+        return MagicMock(
             kind=Integration.IntegrationKind.JIRA,
             config={"cloud_id": "cloud-id"},
             sensitive_config={"access_token": "access-token"},
         )
 
-        with pytest.raises(ValidationError, match="Could not create the Jira issue"):
-            JiraIntegration(integration).create_issue(
+    @patch("posthog.models.integration.requests.post")
+    def test_create_issue_exposes_structured_error_details(self, mock_post):
+        mock_post.return_value.status_code = 400
+        mock_post.return_value.json.return_value = {
+            "errorMessages": ["Issue type is not available"],
+            "errors": {"summary": "Summary is required"},
+        }
+
+        with pytest.raises(ValidationError) as error:
+            JiraIntegration(self.integration()).create_issue(
                 {"project_key": "ENG", "title": "Checkout failed", "description": "Details"}
             )
+
+        assert error.value.detail[0] == (
+            "Could not create the Jira issue. Check the project's issue settings and try again. "
+            "Jira reported: Issue type is not available; summary: Summary is required"
+        )
+
+    @patch("posthog.models.integration.requests.post")
+    def test_create_issue_uses_safe_fallback_for_non_json_error(self, mock_post):
+        mock_post.return_value.status_code = 502
+        mock_post.return_value.json.side_effect = ValueError
+
+        with pytest.raises(ValidationError) as error:
+            JiraIntegration(self.integration()).create_issue(
+                {"project_key": "ENG", "title": "Checkout failed", "description": "Details"}
+            )
+
+        assert error.value.detail[0] == (
+            "Could not create the Jira issue. Check the project's issue settings and try again."
+        )
 
 
 class TestOauthIntegrationModel(BaseTest):

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -238,14 +238,18 @@ class TestJiraIntegrationModel:
     @staticmethod
     def integration() -> MagicMock:
         return MagicMock(
+            id=123,
+            team_id=456,
             kind=Integration.IntegrationKind.JIRA,
             config={"cloud_id": "cloud-id"},
             sensitive_config={"access_token": "access-token"},
         )
 
+    @patch("posthog.models.integration.capture_exception")
     @patch("posthog.models.integration.requests.post")
-    def test_create_issue_exposes_structured_error_details(self, mock_post):
+    def test_create_issue_captures_structured_error_details(self, mock_post, mock_capture_exception):
         mock_post.return_value.status_code = 400
+        mock_post.return_value.headers = {"Content-Type": "application/json"}
         mock_post.return_value.json.return_value = {
             "errorMessages": ["Issue type is not available"],
             "errors": {"summary": "Summary is required"},
@@ -256,14 +260,27 @@ class TestJiraIntegrationModel:
                 {"project_key": "ENG", "title": "Checkout failed", "description": "Details"}
             )
 
-        assert error.value.detail[0] == (
-            "Could not create the Jira issue. Check the project's issue settings and try again. "
-            "Jira reported: Issue type is not available; summary: Summary is required"
+        assert (
+            error.value.detail[0]
+            == "Could not create the Jira issue. Check the project's issue settings and try again."
         )
+        captured_error = mock_capture_exception.call_args.args[0]
+        assert str(captured_error) == "Jira issue creation failed"
+        assert mock_capture_exception.call_args.kwargs["additional_properties"] == {
+            "jira_status_code": 400,
+            "jira_response_content_type": "application/json",
+            "integration_id": 123,
+            "team_id": 456,
+            "jira_error_messages": ["Issue type is not available"],
+            "jira_field_errors": {"summary": "Summary is required"},
+            "jira_response_keys": ["errorMessages", "errors"],
+        }
 
+    @patch("posthog.models.integration.capture_exception")
     @patch("posthog.models.integration.requests.post")
-    def test_create_issue_uses_safe_fallback_for_non_json_error(self, mock_post):
+    def test_create_issue_captures_non_json_response_metadata(self, mock_post, mock_capture_exception):
         mock_post.return_value.status_code = 502
+        mock_post.return_value.headers = {"Content-Type": "text/html"}
         mock_post.return_value.json.side_effect = ValueError
 
         with pytest.raises(ValidationError) as error:
@@ -274,6 +291,12 @@ class TestJiraIntegrationModel:
         assert error.value.detail[0] == (
             "Could not create the Jira issue. Check the project's issue settings and try again."
         )
+        assert mock_capture_exception.call_args.kwargs["additional_properties"] == {
+            "jira_status_code": 502,
+            "jira_response_content_type": "text/html",
+            "integration_id": 123,
+            "team_id": 456,
+        }
 
 
 class TestOauthIntegrationModel(BaseTest):

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -260,9 +260,8 @@ class TestJiraIntegrationModel:
                 {"project_key": "ENG", "title": "Checkout failed", "description": "Details"}
             )
 
-        assert (
-            error.value.detail[0]
-            == "Could not create the Jira issue. Check the project's issue settings and try again."
+        assert error.value.args[0] == (
+            "Could not create the Jira issue. Check the project's issue settings and try again."
         )
         captured_error = mock_capture_exception.call_args.args[0]
         assert str(captured_error) == "Jira issue creation failed"
@@ -288,7 +287,7 @@ class TestJiraIntegrationModel:
                 {"project_key": "ENG", "title": "Checkout failed", "description": "Details"}
             )
 
-        assert error.value.detail[0] == (
+        assert error.value.args[0] == (
             "Could not create the Jira issue. Check the project's issue settings and try again."
         )
         assert mock_capture_exception.call_args.kwargs["additional_properties"] == {

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -49,6 +49,7 @@ from posthog.models.integration import (
     GoogleCloudIntegration,
     GoogleCloudServiceAccountIntegration,
     Integration,
+    JiraIntegration,
     LinearIntegration,
     OauthIntegration,
     PostgreSQLIntegration,
@@ -231,6 +232,23 @@ class TestLinearIntegrationModel(BaseTest):
         assert attachment_variables["issueId"] == "LIN-123"
         assert attachment_variables["title"] == "PostHog issue"
         assert attachment_variables["url"].endswith(f'/project/{self.team.id}/error_tracking/issue-id" }} mutation {{')
+
+
+class TestJiraIntegrationModel:
+    @patch("posthog.models.integration.requests.post")
+    def test_create_issue_rejects_an_unsuccessful_response(self, mock_post):
+        mock_post.return_value.status_code = 400
+        mock_post.return_value.json.return_value = {"errorMessages": ["Issue type is not available"]}
+        integration = MagicMock(
+            kind=Integration.IntegrationKind.JIRA,
+            config={"cloud_id": "cloud-id"},
+            sensitive_config={"access_token": "access-token"},
+        )
+
+        with pytest.raises(ValidationError, match="Could not create the Jira issue"):
+            JiraIntegration(integration).create_issue(
+                {"project_key": "ENG", "title": "Checkout failed", "description": "Details"}
+            )
 
 
 class TestOauthIntegrationModel(BaseTest):


### PR DESCRIPTION
## Problem

Creating an external Jira issue can return a misleading missing-context error when Atlassian rejects the request. The failed response is treated as a created issue and only breaks later while serializing its empty reference.

**Why:** People need failed Jira responses rejected before PostHog stores an invalid external reference, with enough diagnostic context for investigation.

## Changes

- Reject Jira responses without a successful status and issue key before persisting external context.
- Return generic, actionable guidance without exposing provider details to the user.
- Capture a backend exception with Jira status, structured errors, response metadata, and integration context.

## How did you test this code?

- Added focused regression tests for structured Jira errors and non-JSON responses.
- Ran the focused pytest tests, Ruff lint and format checks, and git diff validation.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code using the investigating-error-issue and querying-posthog-data skills. The regression fixtures are invented and contain no customer data. The PR is unassigned because no GitHub handle was provided.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*