### PR TITLE
feat(billing): separate usage and spend type pickers

### DIFF
--- a/ee/hogai/tools/read_billing_tool/tool.py
+++ b/ee/hogai/tools/read_billing_tool/tool.py
@@ -36,6 +36,16 @@ USAGE_TYPES = [
     {"label": "PostHog AI", "value": "ai_credits_used_in_period"},
     {"label": "Inbox credits", "value": "signals_credits_used_in_period"},
     {"label": "PostHog Desktop credits", "value": "posthog_code_credits_used_in_period"},
+    {"label": "PostHog Desktop token credits", "value": "posthog_code_token_credits_used_in_period"},
+    {"label": "Sandbox compute credits", "value": "sandbox_compute_credits_used_in_period"},
+    {
+        "label": "Sandbox compute CPU millicore-seconds",
+        "value": "sandbox_compute_cpu_millicore_seconds_in_period",
+    },
+    {
+        "label": "Sandbox compute memory MiB-seconds",
+        "value": "sandbox_compute_memory_mib_seconds_in_period",
+    },
     {"label": "Replay vision credits", "value": "replay_vision_credits_used_in_period"},
     {"label": "Workflow emails", "value": "workflow_emails_sent_in_period"},
     {"label": "Workflow push notifications", "value": "workflow_push_sent_in_period"},

--- a/frontend/src/scenes/billing/BillingSpendView.tsx
+++ b/frontend/src/scenes/billing/BillingSpendView.tsx
@@ -17,7 +17,7 @@ import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 
 import { AccessControlLevel, AccessControlResourceType, ExporterFormat } from '~/types'
 
-import { buildBillingCsv, currencyFormatter, getUsageTypeOptions } from './billing-utils'
+import { buildBillingCsv, currencyFormatter, getSpendTypeOptions } from './billing-utils'
 import { BillingDataTable } from './BillingDataTable'
 import { BillingEarlyAccessBanner } from './BillingEarlyAccessBanner'
 import { BillingEmptyState } from './BillingEmptyState'
@@ -105,7 +105,7 @@ export function BillingSpendView(): JSX.Element {
                             value={filters.usage_types || []}
                             onChange={(value: string[]) => setFilters({ usage_types: value })}
                             placeholder="All products"
-                            options={getUsageTypeOptions(featureFlags)}
+                            options={getSpendTypeOptions(featureFlags)}
                             allowCustomValues={false}
                         />
                     </div>

--- a/frontend/src/scenes/billing/billing-utils.test.ts
+++ b/frontend/src/scenes/billing/billing-utils.test.ts
@@ -1,8 +1,12 @@
 import { FEATURE_FLAGS } from 'lib/constants'
 import type { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 
-import { buildSpendTrackingProperties, getSpendTypeOptions, getUsageTypeOptions } from './billing-utils'
-import { SPEND_TYPES } from './constants'
+import {
+    buildSpendTrackingProperties,
+    filterSpendUsageTypes,
+    getSpendTypeOptions,
+    getUsageTypeOptions,
+} from './billing-utils'
 
 describe('getUsageTypeOptions', () => {
     it.each<[string, FeatureFlagsSet, boolean]>([
@@ -35,15 +39,36 @@ describe('getUsageTypeOptions', () => {
         }
     })
 
-    it('reports only selectable Spend types in Spend interaction analytics', () => {
-        const properties = buildSpendTrackingProperties('filters_changed', {
-            filters: {},
-            dateFrom: '2026-08-01',
-            dateTo: '2026-08-06',
-            excludeEmptySeries: false,
-            teamOptions: [],
-        })
+    it.each<[string, FeatureFlagsSet]>([
+        ['on', { [FEATURE_FLAGS.REPLAY_VISION]: true }],
+        ['off', { [FEATURE_FLAGS.REPLAY_VISION]: false }],
+    ])(
+        'reports only selectable Spend types in interaction analytics when Replay Vision is %s',
+        (_name, featureFlags) => {
+            const properties = buildSpendTrackingProperties(
+                'filters_changed',
+                {
+                    filters: {},
+                    dateFrom: '2026-08-01',
+                    dateTo: '2026-08-06',
+                    excludeEmptySeries: false,
+                    teamOptions: [],
+                },
+                featureFlags
+            )
 
-        expect(properties.usage_types_total).toBe(SPEND_TYPES.length)
+            expect(properties.usage_types_total).toBe(getSpendTypeOptions(featureFlags).length)
+        }
+    )
+
+    it('removes Usage-only types when switching to Spend', () => {
+        expect(
+            filterSpendUsageTypes([
+                'posthog_code_token_credits_used_in_period',
+                'sandbox_compute_credits_used_in_period',
+                'event_count_in_period',
+            ])
+        ).toEqual(['event_count_in_period'])
+        expect(filterSpendUsageTypes(['sandbox_compute_cpu_millicore_seconds_in_period'])).toEqual([])
     })
 })

--- a/frontend/src/scenes/billing/billing-utils.test.ts
+++ b/frontend/src/scenes/billing/billing-utils.test.ts
@@ -1,7 +1,8 @@
 import { FEATURE_FLAGS } from 'lib/constants'
 import type { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 
-import { getSpendTypeOptions, getUsageTypeOptions } from './billing-utils'
+import { buildSpendTrackingProperties, getSpendTypeOptions, getUsageTypeOptions } from './billing-utils'
+import { SPEND_TYPES } from './constants'
 
 describe('getUsageTypeOptions', () => {
     it.each<[string, FeatureFlagsSet, boolean]>([
@@ -32,5 +33,17 @@ describe('getUsageTypeOptions', () => {
             expect(usageOptions.some((option) => option.key === usageType)).toBe(true)
             expect(spendOptions.some((option) => option.key === usageType)).toBe(false)
         }
+    })
+
+    it('reports only selectable Spend types in Spend interaction analytics', () => {
+        const properties = buildSpendTrackingProperties('filters_changed', {
+            filters: {},
+            dateFrom: '2026-08-01',
+            dateTo: '2026-08-06',
+            excludeEmptySeries: false,
+            teamOptions: [],
+        })
+
+        expect(properties.usage_types_total).toBe(SPEND_TYPES.length)
     })
 })

--- a/frontend/src/scenes/billing/billing-utils.test.ts
+++ b/frontend/src/scenes/billing/billing-utils.test.ts
@@ -1,7 +1,7 @@
 import { FEATURE_FLAGS } from 'lib/constants'
 import type { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 
-import { getUsageTypeOptions } from './billing-utils'
+import { getSpendTypeOptions, getUsageTypeOptions } from './billing-utils'
 
 describe('getUsageTypeOptions', () => {
     it.each<[string, FeatureFlagsSet, boolean]>([
@@ -17,4 +17,20 @@ describe('getUsageTypeOptions', () => {
             expect(options.some((opt) => opt.key === 'event_count_in_period')).toBe(true)
         }
     )
+
+    it('includes informational Desktop component metrics in Usage but not Spend', () => {
+        const usageOptions = getUsageTypeOptions({})
+        const spendOptions = getSpendTypeOptions({})
+        const componentTypes = [
+            'posthog_code_token_credits_used_in_period',
+            'sandbox_compute_credits_used_in_period',
+            'sandbox_compute_cpu_millicore_seconds_in_period',
+            'sandbox_compute_memory_mib_seconds_in_period',
+        ]
+
+        for (const usageType of componentTypes) {
+            expect(usageOptions.some((option) => option.key === usageType)).toBe(true)
+            expect(spendOptions.some((option) => option.key === usageType)).toBe(false)
+        }
+    })
 })

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -509,8 +509,9 @@ export function buildTrackingProperties(
 
 export const buildSpendTrackingProperties = (
     action: BillingUsageInteractionProps['action'],
-    values: Parameters<typeof buildTrackingProperties>[1]
-): BillingUsageInteractionProps => buildTrackingProperties(action, values, SPEND_TYPES.length)
+    values: Parameters<typeof buildTrackingProperties>[1],
+    featureFlags: FeatureFlagsSet
+): BillingUsageInteractionProps => buildTrackingProperties(action, values, getSpendTypeOptions(featureFlags).length)
 
 // The Replay vision entry stays hidden until the replay-vision flag rolls out with the pricing launch
 export const getUsageTypeOptions = (featureFlags: FeatureFlagsSet): { key: string; label: string }[] =>
@@ -522,6 +523,11 @@ export const getSpendTypeOptions = (featureFlags: FeatureFlagsSet): { key: strin
     SPEND_TYPES.filter(
         (opt) => opt.value !== 'replay_vision_credits_used_in_period' || featureFlags[FEATURE_FLAGS.REPLAY_VISION]
     ).map((opt) => ({ key: opt.value, label: opt.label }))
+
+const SPEND_TYPE_VALUES = new Set<string>(SPEND_TYPES.map((option) => option.value))
+
+export const filterSpendUsageTypes = (usageTypes: string[] | undefined): string[] =>
+    usageTypes?.filter((usageType) => SPEND_TYPE_VALUES.has(usageType)) ?? []
 
 export const isAddonVisible = (
     product: BillingProductV2Type,

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -489,7 +489,8 @@ export function buildTrackingProperties(
         dateTo: string
         excludeEmptySeries: boolean
         teamOptions: { key: string; label: string }[]
-    }
+    },
+    usageTypesTotal: number = USAGE_TYPES.length
 ): BillingUsageInteractionProps {
     return {
         action,
@@ -498,13 +499,18 @@ export function buildTrackingProperties(
         date_to: values.dateTo,
         exclude_empty: values.excludeEmptySeries,
         usage_types_count: values.filters.usage_types?.length || 0,
-        usage_types_total: USAGE_TYPES.length,
+        usage_types_total: usageTypesTotal,
         teams_count: values.filters.team_ids?.length || 0,
         teams_total: values.teamOptions.length,
         has_team_breakdown: (values.filters.breakdowns || []).includes('team'),
         interval: values.filters.interval || 'day',
     }
 }
+
+export const buildSpendTrackingProperties = (
+    action: BillingUsageInteractionProps['action'],
+    values: Parameters<typeof buildTrackingProperties>[1]
+): BillingUsageInteractionProps => buildTrackingProperties(action, values, SPEND_TYPES.length)
 
 // The Replay vision entry stays hidden until the replay-vision flag rolls out with the pricing launch
 export const getUsageTypeOptions = (featureFlags: FeatureFlagsSet): { key: string; label: string }[] =>

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -14,7 +14,7 @@ import { Params } from 'scenes/sceneTypes'
 
 import { BillingPeriod, BillingProductV2AddonType, BillingProductV2Type, BillingTierType, BillingType } from '~/types'
 
-import { USAGE_TYPES } from './constants'
+import { SPEND_TYPES, USAGE_TYPES } from './constants'
 import type { BillingFilters, BillingSeriesForCsv, BillingUsageInteractionProps, BuildBillingCsvOptions } from './types'
 import { BillingGaugeItemKind, BillingGaugeItemType } from './types'
 
@@ -509,6 +509,11 @@ export function buildTrackingProperties(
 // The Replay vision entry stays hidden until the replay-vision flag rolls out with the pricing launch
 export const getUsageTypeOptions = (featureFlags: FeatureFlagsSet): { key: string; label: string }[] =>
     USAGE_TYPES.filter(
+        (opt) => opt.value !== 'replay_vision_credits_used_in_period' || featureFlags[FEATURE_FLAGS.REPLAY_VISION]
+    ).map((opt) => ({ key: opt.value, label: opt.label }))
+
+export const getSpendTypeOptions = (featureFlags: FeatureFlagsSet): { key: string; label: string }[] =>
+    SPEND_TYPES.filter(
         (opt) => opt.value !== 'replay_vision_credits_used_in_period' || featureFlags[FEATURE_FLAGS.REPLAY_VISION]
     ).map((opt) => ({ key: opt.value, label: opt.label }))
 

--- a/frontend/src/scenes/billing/billingSpendLogic.ts
+++ b/frontend/src/scenes/billing/billingSpendLogic.ts
@@ -9,6 +9,7 @@ import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { dateMapping } from 'lib/utils/dateFilters'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { toParams } from 'lib/utils/url'
@@ -21,6 +22,7 @@ import type { BillingPeriod, BillingType } from '../../types'
 import {
     buildSpendTrackingProperties,
     calculateBillingPeriodMarkers,
+    filterSpendUsageTypes,
     syncBillingSearchParams,
     updateBillingSearchParams,
 } from './billing-utils'
@@ -542,8 +544,11 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
 
             const filtersFromUrl: Partial<BillingFilters> = {}
 
-            if (params.usage_types && !equal(params.usage_types, values.filters.usage_types)) {
-                filtersFromUrl.usage_types = params.usage_types
+            if (params.usage_types) {
+                const usageTypes = filterSpendUsageTypes(params.usage_types)
+                if (!equal(params.usage_types, usageTypes) || !equal(usageTypes, values.filters.usage_types)) {
+                    filtersFromUrl.usage_types = usageTypes
+                }
             }
             if (params.team_ids && !equal(params.team_ids, values.filters.team_ids)) {
                 filtersFromUrl.team_ids = params.team_ids
@@ -580,19 +585,25 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
         setFilters: async ({ shouldDebounce }, breakpoint) => {
             if (shouldDebounce) {
                 await breakpoint(200)
-                actions.reportBillingSpendInteraction(buildSpendTrackingProperties('filters_changed', values))
+                actions.reportBillingSpendInteraction(
+                    buildSpendTrackingProperties('filters_changed', values, featureFlagLogic.values.featureFlags)
+                )
             }
             actions.loadBillingSpend()
         },
         setDateRange: async ({ shouldDebounce }, breakpoint) => {
             if (shouldDebounce) {
                 await breakpoint(200)
-                actions.reportBillingSpendInteraction(buildSpendTrackingProperties('date_changed', values))
+                actions.reportBillingSpendInteraction(
+                    buildSpendTrackingProperties('date_changed', values, featureFlagLogic.values.featureFlags)
+                )
             }
             actions.loadBillingSpend()
         },
         resetFilters: async () => {
-            actions.reportBillingSpendInteraction(buildSpendTrackingProperties('filters_cleared', values))
+            actions.reportBillingSpendInteraction(
+                buildSpendTrackingProperties('filters_cleared', values, featureFlagLogic.values.featureFlags)
+            )
             actions.loadBillingSpend()
         },
         toggleAllSeries: () => {
@@ -602,7 +613,9 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
                 : series
             const ids = potentiallyVisible.map((s) => s.id)
             const isAllVisible = ids.length > 0 && ids.every((id) => !userHiddenSeries.includes(id))
-            actions.reportBillingSpendInteraction(buildSpendTrackingProperties('series_toggled', values))
+            actions.reportBillingSpendInteraction(
+                buildSpendTrackingProperties('series_toggled', values, featureFlagLogic.values.featureFlags)
+            )
 
             if (isAllVisible) {
                 // Hide all series
@@ -614,7 +627,9 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
         },
         toggleBreakdown: async (_payload, breakpoint) => {
             await breakpoint(200)
-            actions.reportBillingSpendInteraction(buildSpendTrackingProperties('breakdown_toggled', values))
+            actions.reportBillingSpendInteraction(
+                buildSpendTrackingProperties('breakdown_toggled', values, featureFlagLogic.values.featureFlags)
+            )
             actions.loadBillingSpend()
         },
     })),

--- a/frontend/src/scenes/billing/billingSpendLogic.ts
+++ b/frontend/src/scenes/billing/billingSpendLogic.ts
@@ -19,7 +19,7 @@ import { DateMappingOption, OrganizationType } from '~/types'
 
 import type { BillingPeriod, BillingType } from '../../types'
 import {
-    buildTrackingProperties,
+    buildSpendTrackingProperties,
     calculateBillingPeriodMarkers,
     syncBillingSearchParams,
     updateBillingSearchParams,
@@ -580,19 +580,19 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
         setFilters: async ({ shouldDebounce }, breakpoint) => {
             if (shouldDebounce) {
                 await breakpoint(200)
-                actions.reportBillingSpendInteraction(buildTrackingProperties('filters_changed', values))
+                actions.reportBillingSpendInteraction(buildSpendTrackingProperties('filters_changed', values))
             }
             actions.loadBillingSpend()
         },
         setDateRange: async ({ shouldDebounce }, breakpoint) => {
             if (shouldDebounce) {
                 await breakpoint(200)
-                actions.reportBillingSpendInteraction(buildTrackingProperties('date_changed', values))
+                actions.reportBillingSpendInteraction(buildSpendTrackingProperties('date_changed', values))
             }
             actions.loadBillingSpend()
         },
         resetFilters: async () => {
-            actions.reportBillingSpendInteraction(buildTrackingProperties('filters_cleared', values))
+            actions.reportBillingSpendInteraction(buildSpendTrackingProperties('filters_cleared', values))
             actions.loadBillingSpend()
         },
         toggleAllSeries: () => {
@@ -602,7 +602,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
                 : series
             const ids = potentiallyVisible.map((s) => s.id)
             const isAllVisible = ids.length > 0 && ids.every((id) => !userHiddenSeries.includes(id))
-            actions.reportBillingSpendInteraction(buildTrackingProperties('series_toggled', values))
+            actions.reportBillingSpendInteraction(buildSpendTrackingProperties('series_toggled', values))
 
             if (isAllVisible) {
                 // Hide all series
@@ -614,7 +614,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
         },
         toggleBreakdown: async (_payload, breakpoint) => {
             await breakpoint(200)
-            actions.reportBillingSpendInteraction(buildTrackingProperties('breakdown_toggled', values))
+            actions.reportBillingSpendInteraction(buildSpendTrackingProperties('breakdown_toggled', values))
             actions.loadBillingSpend()
         },
     })),

--- a/frontend/src/scenes/billing/constants.ts
+++ b/frontend/src/scenes/billing/constants.ts
@@ -1,6 +1,6 @@
 // sync with ee/hogai/tools/read_billing_tool/tool.py
 // Values are sent to the `billing` repo as `usage_types`; keep in sync with accepted types in `billing/types/usage.py`.
-export const USAGE_TYPES = [
+export const SPEND_TYPES = [
     { label: 'Events', value: 'event_count_in_period' },
     { label: 'Identified events', value: 'enhanced_persons_event_count_in_period' },
     { label: 'Group analytics', value: 'group_analytics' },
@@ -25,6 +25,15 @@ export const USAGE_TYPES = [
     { label: 'Logs ingested (MB)', value: 'logs_mb_in_period' },
     { label: 'Logs 30-day retention (MB)', value: 'logs_retention_30d_mb_in_period' },
 ] as const
+
+export const USAGE_ONLY_TYPES = [
+    { label: 'PostHog Desktop token credits', value: 'posthog_code_token_credits_used_in_period' },
+    { label: 'Sandbox compute credits', value: 'sandbox_compute_credits_used_in_period' },
+    { label: 'Sandbox compute CPU millicore-seconds', value: 'sandbox_compute_cpu_millicore_seconds_in_period' },
+    { label: 'Sandbox compute memory MiB-seconds', value: 'sandbox_compute_memory_mib_seconds_in_period' },
+] as const
+
+export const USAGE_TYPES = [...SPEND_TYPES, ...USAGE_ONLY_TYPES] as const
 
 export type UsageTypeOption = (typeof USAGE_TYPES)[number]
 export type UsageTypeValue = UsageTypeOption['value']


### PR DESCRIPTION
## Problem

The Billing Usage page cannot select informational Desktop component metrics, although Billing can return them.

The Spend page must continue offering only Stripe-backed metrics.

## Changes

- Add the four Desktop component metrics to the Usage picker.
- Keep informational metrics out of the Spend picker.
- Preserve replay-vision feature-flag filtering in both pickers.
- No screenshot: this changes picker options and depends on [Billing #2113](https://github.com/PostHog/billing/pull/2113).

## How did you test this code?

- Added a focused unit case that guards informational metrics appearing in Usage but leaking into Spend.
- Ran the billing utility Jest test and the frontend TypeScript check.
- Browser testing remains pending until [Billing #2113](https://github.com/PostHog/billing/pull/2113) is available.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. This updates existing billing filters.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change with the repository guidance for writing tests, user-facing copy, and PR descriptions.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*