### PR TITLE
fix(hogli): upload pr-assets with signed commits

### DIFF
--- a/tools/hogli-commands/hogli_commands/pr_assets.py
+++ b/tools/hogli-commands/hogli_commands/pr_assets.py
@@ -1,32 +1,40 @@
 """Shared client for the public PostHog/pr-assets evidence repo.
 
-pr:upload-image and pr:upload-video both publish files here through the GitHub
-contents API; this module owns the storage concerns they share - the repo
+pr:upload-image and pr:upload-video both publish files here through a local
+signed git commit; this module owns the storage concerns they share - the repo
 constant, the public-and-permanent warning, the object-key scheme, path
-validation, and the upload PUT with its concurrent-commit retry. The commands
-keep what differs between them: allowed extensions, the markdown they print,
-and their flags.
+validation, and the signed git upload flow. The commands keep what differs
+between them: allowed extensions, the markdown they print, and their flags.
 """
 
 from __future__ import annotations
 
-import base64
+import shutil
+import tempfile
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final
 from uuid import uuid4
 
 import click
-import requests
-
-from hogli_commands.github_auth import github_headers
 
 REPO: Final = "PostHog/pr-assets"
+REMOTE: Final = f"git@github.com:{REPO}.git"
+DEFAULT_BRANCH: Final = "main"
 PUBLIC_WARNING: Final = (
     "⚠  PUBLIC + PERMANENT upload to PostHog/pr-assets.\n"
     "   SHA-pinned URLs keep serving even after the file is deleted, so an upload cannot be taken back.\n"
     "   Never upload customer data, secrets, tokens, or internal-only information."
 )
+
+
+@dataclass(frozen=True)
+class AssetUpload:
+    path: Path
+    key: str
 
 
 def escape_markdown_label(text: str) -> str:
@@ -63,51 +71,92 @@ def validate(path: Path, allowed_exts: frozenset[str], max_mb: int) -> str:
     return ext
 
 
-def _encode_base64(path: Path) -> str:
-    """Base64-encode the file as a single newline-free line.
+def upload_many(uploads: Sequence[AssetUpload], message: str) -> str:
+    """Upload files in one signed commit and return that commit's sha."""
+    if not uploads:
+        raise click.ClickException("no files to upload")
 
-    The contents API wants raw base64 with no line breaks; ``b64encode`` (unlike
-    ``encodebytes``) never inserts them.
-    """
-    return base64.b64encode(path.read_bytes()).decode("ascii")
+    with tempfile.TemporaryDirectory(prefix="hogli-pr-assets-") as tempdir:
+        repo_dir = Path(tempdir) / "pr-assets"
+        clone = _git(["clone", "--depth", "1", REMOTE, str(repo_dir)])
+        _check_git(clone, f"clone {REPO}")
 
+        for upload in uploads:
+            destination = repo_dir.joinpath(*upload.key.split("/"))
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(upload.path, destination)
 
-def _put(session: requests.Session, url: str, token: str, body: dict[str, str]) -> requests.Response:
-    """PUT to the contents API, turning a network error into a friendly ClickException."""
-    try:
-        return session.put(url, headers=github_headers(token), json=body, timeout=120)
-    except requests.RequestException as exc:
-        raise click.ClickException(f"GitHub request failed: {exc}")
+        keys = [upload.key for upload in uploads]
+        add = _git(["add", "--", *keys], cwd=repo_dir)
+        _check_git(add, "stage pr-assets upload")
 
+        commit = _git(["commit", "-S", "-m", message], cwd=repo_dir)
+        _check_git(commit, "create a signed pr-assets commit")
 
-def upload(path: Path, key: str, token: str, session: requests.Session, message: str) -> str:
-    """PUT the file to the contents API, returning the created commit sha.
+        _push(repo_dir)
 
-    Retries once on HTTP 409 with the same key, since concurrent commits to the repo's
-    default branch can race.
-    """
-    url = f"https://api.github.com/repos/{REPO}/contents/{key}"
-    body = {"message": message, "content": _encode_base64(path)}
-
-    resp = _put(session, url, token, body)
-    if resp.status_code == 409:
-        # a concurrent commit to the default branch raced us; retry once with the same key
-        resp = _put(session, url, token, body)
-
-    if resp.status_code in (403, 404):
-        raise click.ClickException(_denied_message(path))
-    if not resp.ok:
-        raise click.ClickException(f"upload of {path.name} failed (HTTP {resp.status_code})")
-    try:
-        return resp.json()["commit"]["sha"]
-    except (ValueError, KeyError, TypeError) as exc:
-        raise click.ClickException(f"GitHub returned an unexpected response uploading {path.name}: {exc}")
+        rev_parse = _git(["rev-parse", "HEAD"], cwd=repo_dir)
+        _check_git(rev_parse, "read the pr-assets commit sha")
+        return rev_parse.stdout.strip()
 
 
-def _denied_message(path: Path) -> str:
-    """Explain a 403/404: the token can't write to pr-assets (not an org member, or missing scope)."""
+def _push(repo_dir: Path) -> None:
+    """Push the current HEAD, retrying once if another upload raced us."""
+    push = _git(["push", "origin", f"HEAD:{DEFAULT_BRANCH}"], cwd=repo_dir)
+    if push.returncode == 0:
+        return
+
+    if _is_non_fast_forward(push):
+        rebase = _git(["pull", "--rebase", "origin", DEFAULT_BRANCH], cwd=repo_dir)
+        _check_git(rebase, "rebase on the latest pr-assets commit")
+        push = _git(["push", "origin", f"HEAD:{DEFAULT_BRANCH}"], cwd=repo_dir)
+
+    _check_git(push, "push the signed pr-assets commit")
+
+
+def _git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _check_git(result: subprocess.CompletedProcess[str], action: str) -> None:
+    if result.returncode == 0:
+        return
+
+    output = _git_output(result)
+    hint = _hint_for_git_error(output)
+    message = f"could not {action}"
+    if hint:
+        message = f"{message}. {hint}"
+    if output:
+        message = f"{message}\n\nGit said:\n{output}"
+    raise click.ClickException(message)
+
+
+def _git_output(result: subprocess.CompletedProcess[str]) -> str:
+    return "\n".join(part.strip() for part in (result.stdout, result.stderr) if part and part.strip())
+
+
+def _hint_for_git_error(output: str) -> str:
+    lower = output.lower()
+    if "verified signatures" in lower or "gpg failed to sign" in lower or "signing failed" in lower:
+        return f"{REPO} requires verified signed commits; make sure `git commit -S` works in a normal terminal."
+    if "could not resolve hostname" in lower or "temporary failure in name resolution" in lower:
+        return "could not resolve GitHub; check network/DNS access and retry."
+    if "permission denied (publickey)" in lower or "could not read from remote repository" in lower:
+        return f"make sure your GitHub SSH key can write to {REPO}."
+    return ""
+
+
+def _is_non_fast_forward(result: subprocess.CompletedProcess[str]) -> bool:
+    output = _git_output(result).lower()
     return (
-        f"upload of {path.name} was denied. Writing to {REPO} needs write access to a public PostHog repo: "
-        "confirm your token is a PostHog org account with the `repo` scope "
-        "(gh users: `gh auth refresh -s repo`; or set GH_TOKEN to a PAT with the repo scope)."
+        "non-fast-forward" in output
+        or "fetch first" in output
+        or "remote contains work that you do not have locally" in output
     )

--- a/tools/hogli-commands/hogli_commands/tests/test_pr_assets.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_pr_assets.py
@@ -1,19 +1,17 @@
 """Tests for the shared pr-assets client.
 
 Moved here with the plumbing when it was extracted from upload_image: the exact key
-shape, the base64 content body, the single retry on a concurrent-commit 409, the
-denied-PUT guidance, and the validation gates both upload commands share.
+shape, the signed git upload, the single retry on a concurrent push race, the
+signed-commit guidance, and the validation gates both upload commands share.
 """
 
 from __future__ import annotations
 
 import re
-import base64
+import subprocess
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
-from unittest.mock import Mock
 
 from hogli_commands import pr_assets
 
@@ -28,18 +26,10 @@ def png(tmp_path: Path) -> Path:
     return path
 
 
-def _resp(status: int, sha: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(
-        status_code=status,
-        ok=status < 400,
-        json=lambda: {"commit": {"sha": sha}} if sha is not None else {},
-    )
-
-
-def _session(*responses: SimpleNamespace) -> Mock:
-    session = Mock()
-    session.put.side_effect = responses
-    return session
+def _git_result(
+    args: list[str], returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["git", *args], returncode, stdout=stdout, stderr=stderr)
 
 
 def test_make_key_shape() -> None:
@@ -47,53 +37,115 @@ def test_make_key_shape() -> None:
     assert re.fullmatch(_KEY_RE + r"\.png", pr_assets.make_key("png"))
 
 
-def test_upload_puts_base64_body_and_returns_sha(png: Path) -> None:
-    session = _session(_resp(201, "deadbeef"))
-    sha = pr_assets.upload(png, "2026/07/abc.png", "tok", session, message="add screenshot")
+def test_upload_many_creates_signed_commit_and_returns_sha(
+    png: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[list[str], Path | None]] = []
+    checkout = tmp_path / "checkout"
+
+    class StaticTemporaryDirectory:
+        def __init__(self, prefix: str) -> None:
+            self.prefix = prefix
+
+        def __enter__(self) -> str:
+            checkout.mkdir()
+            return str(checkout)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        calls.append((args, cwd))
+        if args[:3] == ["clone", "--depth", "1"]:
+            Path(args[-1]).mkdir()
+        if args == ["rev-parse", "HEAD"]:
+            return _git_result(args, stdout="deadbeef\n")
+        return _git_result(args)
+
+    monkeypatch.setattr(pr_assets.tempfile, "TemporaryDirectory", StaticTemporaryDirectory)
+    monkeypatch.setattr(pr_assets, "_git", fake_git)
+
+    sha = pr_assets.upload_many([pr_assets.AssetUpload(path=png, key="2026/08/diagram.png")], "add screenshot")
 
     assert sha == "deadbeef"
-    url = session.put.call_args.args[0]
-    assert url == "https://api.github.com/repos/PostHog/pr-assets/contents/2026/07/abc.png"
-    body = session.put.call_args.kwargs["json"]
-    assert body["message"] == "add screenshot"
-    assert body["content"] == base64.b64encode(png.read_bytes()).decode()
-    assert "\n" not in body["content"]  # the contents API rejects line-wrapped base64
-    assert session.put.call_args.kwargs["headers"]["Authorization"] == "Bearer tok"
+    assert (checkout / "pr-assets" / "2026" / "08" / "diagram.png").read_bytes() == png.read_bytes()
+    assert (["commit", "-S", "-m", "add screenshot"], checkout / "pr-assets") in calls
+    assert (["push", "origin", "HEAD:main"], checkout / "pr-assets") in calls
 
 
-def test_upload_retries_once_on_409_with_same_key(png: Path) -> None:
-    session = _session(_resp(409), _resp(201, "sha2"))
-    sha = pr_assets.upload(png, "2026/07/abc.png", "tok", session, message="add screenshot")
+def test_upload_many_rebases_once_after_push_race(png: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pushes = 0
+    calls: list[list[str]] = []
 
-    assert sha == "sha2"
-    assert session.put.call_count == 2
-    # both attempts target the identical key; a fresh key on retry would orphan the first
-    urls = {call.args[0] for call in session.put.call_args_list}
-    assert urls == {"https://api.github.com/repos/PostHog/pr-assets/contents/2026/07/abc.png"}
+    class StaticTemporaryDirectory:
+        def __init__(self, prefix: str) -> None:
+            self.prefix = prefix
+
+        def __enter__(self) -> str:
+            return str(tmp_path)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        nonlocal pushes
+        calls.append(args)
+        if args[:3] == ["clone", "--depth", "1"]:
+            Path(args[-1]).mkdir()
+        if args == ["push", "origin", "HEAD:main"]:
+            pushes += 1
+            if pushes == 1:
+                return _git_result(args, returncode=1, stderr="! [rejected] HEAD -> main (fetch first)")
+        if args == ["rev-parse", "HEAD"]:
+            return _git_result(args, stdout="cafebabe\n")
+        return _git_result(args)
+
+    monkeypatch.setattr(pr_assets.tempfile, "TemporaryDirectory", StaticTemporaryDirectory)
+    monkeypatch.setattr(pr_assets, "_git", fake_git)
+
+    sha = pr_assets.upload_many([pr_assets.AssetUpload(path=png, key="2026/08/diagram.png")], "add screenshot")
+
+    assert sha == "cafebabe"
+    assert pushes == 2
+    assert ["pull", "--rebase", "origin", "main"] in calls
 
 
-def test_upload_gives_up_after_second_409(png: Path) -> None:
-    session = _session(_resp(409), _resp(409))
-    with pytest.raises(pr_assets.click.ClickException):
-        pr_assets.upload(png, "2026/07/x.png", "tok", session, message="add screenshot")
-    assert session.put.call_count == 2  # one retry, then surface the failure
+def test_upload_many_points_signed_commit_rejections_at_git_signing(
+    png: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class StaticTemporaryDirectory:
+        def __init__(self, prefix: str) -> None:
+            self.prefix = prefix
+
+        def __enter__(self) -> str:
+            return str(tmp_path)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def fake_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["clone", "--depth", "1"]:
+            Path(args[-1]).mkdir()
+        if args == ["push", "origin", "HEAD:main"]:
+            return _git_result(
+                args,
+                returncode=1,
+                stderr="GH013: Repository rule violations found\nCommits must have verified signatures.",
+            )
+        return _git_result(args)
+
+    monkeypatch.setattr(pr_assets.tempfile, "TemporaryDirectory", StaticTemporaryDirectory)
+    monkeypatch.setattr(pr_assets, "_git", fake_git)
+
+    with pytest.raises(pr_assets.click.ClickException, match="requires verified signed commits"):
+        pr_assets.upload_many([pr_assets.AssetUpload(path=png, key="2026/08/diagram.png")], "add screenshot")
 
 
-@pytest.mark.parametrize("status", [403, 404], ids=["forbidden", "not_found"])
-def test_permission_denied_points_at_org_access(png: Path, status: int) -> None:
-    # A denied PUT must explain the write-access fix, not surface a raw error; this is the
-    # "only PostHog org members can write" boundary.
-    session = _session(_resp(status))
-    with pytest.raises(pr_assets.click.ClickException, match="PostHog org"):
-        pr_assets.upload(png, "2026/07/x.png", "tok", session, message="add screenshot")
+def test_git_error_hint_keeps_dns_failures_distinct_from_ssh_auth() -> None:
+    hint = pr_assets._hint_for_git_error("ssh: Could not resolve hostname github.com")
 
-
-def test_upload_wraps_unexpected_response(png: Path) -> None:
-    # A 2xx whose body isn't the contents-API shape must surface as a ClickException, not a
-    # raw KeyError traceback.
-    session = _session(_resp(201))  # json() -> {} with no commit.sha
-    with pytest.raises(pr_assets.click.ClickException, match="unexpected response"):
-        pr_assets.upload(png, "2026/07/x.png", "tok", session, message="add screenshot")
+    assert "network/DNS" in hint
+    assert "SSH key" not in hint
 
 
 def test_validate_rejects_symlink_before_reading_target(tmp_path: Path) -> None:

--- a/tools/hogli-commands/hogli_commands/tests/test_upload_image.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_upload_image.py
@@ -1,23 +1,22 @@
 """Tests for hogli pr:upload-image.
 
 The framework's parametrized ``--help`` test covers command wellformedness, and the
-shared upload plumbing (key shape, base64 body, 409 retry, validation gates) is pinned
+shared upload plumbing (key shape, signed git upload, validation gates) is pinned
 in ``test_pr_assets``. These guard what is command-specific: the SHA-pinned image
 markdown that lands on stdout and nothing else, the --alt contract, the extension
-allowlist, and the --yes confirmation gate. Token sourcing lives in ``test_github_auth``.
+allowlist, and the --yes confirmation gate.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from click.testing import CliRunner
-from hogli_commands import github_auth, pr_assets, upload_image
+from hogli_commands import pr_assets, upload_image
 
 _KEY_RE = r"\d{4}/\d{2}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
@@ -29,24 +28,11 @@ def png(tmp_path: Path) -> Path:
     return path
 
 
-def _resp(status: int, sha: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(
-        status_code=status,
-        ok=status < 400,
-        json=lambda: {"commit": {"sha": sha}} if sha is not None else {},
-    )
-
-
-def _session(*responses: SimpleNamespace) -> Mock:
-    session = Mock()
-    session.put.side_effect = responses
-    return session
-
-
 def test_command_prints_only_sha_pinned_markdown_to_stdout(png: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GH_TOKEN", "tok")  # token via the real env path
-    with patch.object(upload_image.requests, "Session", return_value=_session(_resp(201, "abc123"))):
-        result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", str(png)])
+    upload_many = Mock(return_value="abc123")
+    monkeypatch.setattr(pr_assets, "upload_many", upload_many)
+
+    result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", str(png)])
 
     assert result.exit_code == 0
     line = result.stdout.strip()
@@ -56,6 +42,7 @@ def test_command_prints_only_sha_pinned_markdown_to_stdout(png: Path, monkeypatc
     # the public-repo warning must reach stderr, never stdout (stdout is piped into PRs verbatim)
     assert "PUBLIC" in result.stderr
     assert "PUBLIC" not in result.stdout
+    upload_many.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -71,9 +58,9 @@ def test_command_prints_only_sha_pinned_markdown_to_stdout(png: Path, monkeypatc
 def test_command_caption_rendering(png: Path, monkeypatch: pytest.MonkeyPatch, alt: str, expected_prefix: str) -> None:
     # --alt is used verbatim (empty stays empty, not replaced by the stem) and its markdown
     # metacharacters are escaped so a `]` can't truncate the embed.
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    with patch.object(upload_image.requests, "Session", return_value=_session(_resp(201, "abc123"))):
-        result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", "--alt", alt, str(png)])
+    monkeypatch.setattr(pr_assets, "upload_many", Mock(return_value="abc123"))
+
+    result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", "--alt", alt, str(png)])
 
     assert result.stdout.strip().startswith(expected_prefix)
 
@@ -81,25 +68,15 @@ def test_command_caption_rendering(png: Path, monkeypatch: pytest.MonkeyPatch, a
 def test_requires_yes_before_uploading(png: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # The gate: a first run without --yes must warn and abort without uploading, so the
     # caller has to read the warning and re-run to confirm the public upload.
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    session = _session(_resp(201, "x"))
-    with patch.object(upload_image.requests, "Session", return_value=session):
-        result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, [str(png)])
+    upload_many = Mock(return_value="x")
+    monkeypatch.setattr(pr_assets, "upload_many", upload_many)
+
+    result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, [str(png)])
 
     assert result.exit_code != 0
     assert "--yes" in result.stderr
     assert not result.stdout  # no markdown emitted
-    session.put.assert_not_called()
-
-
-def test_command_errors_without_a_token(png: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("GH_TOKEN", raising=False)
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setattr(github_auth.shutil, "which", lambda _: None)  # no env, no gh -> no token
-    result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", str(png)])
-
-    assert result.exit_code != 0
-    assert "token" in result.stderr.lower()
+    upload_many.assert_not_called()
 
 
 def test_rejects_alt_with_multiple_files(tmp_path: Path) -> None:
@@ -129,10 +106,10 @@ def test_symlink_is_rejected_on_stderr_without_any_upload(tmp_path: Path, monkey
     target.write_bytes(b"SECRET=1")
     link = tmp_path / "screenshot.png"
     link.symlink_to(target)
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    session = _session(_resp(201, "x"))
-    with patch.object(upload_image.requests, "Session", return_value=session):
-        result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", str(link)])
+    upload_many = Mock(return_value="x")
+    monkeypatch.setattr(pr_assets, "upload_many", upload_many)
+
+    result = CliRunner(mix_stderr=False).invoke(upload_image.upload_image, ["--yes", str(link)])
 
     assert result.exit_code != 0
-    session.put.assert_not_called()
+    upload_many.assert_not_called()

--- a/tools/hogli-commands/hogli_commands/tests/test_upload_video.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_upload_video.py
@@ -1,7 +1,7 @@
 """Tests for hogli pr:upload-video.
 
-The shared upload plumbing (key shape, base64 body, 409 retry, validation gates) is
-pinned in ``test_pr_assets``; these guard what is video-specific: the extension
+The shared upload plumbing (key shape, signed git upload, validation gates) is pinned
+in ``test_pr_assets``; these guard what is video-specific: the extension
 allowlist, the link-style markdown on stdout (a plain [label](url), never an image
 embed, since GitHub renders no player for raw-hosted video), the "add video" commit
 message, and the --yes gate.
@@ -11,10 +11,9 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from click.testing import CliRunner
 from hogli_commands import pr_assets, upload_video
@@ -29,20 +28,6 @@ def mp4(tmp_path: Path) -> Path:
     return path
 
 
-def _resp(status: int, sha: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(
-        status_code=status,
-        ok=status < 400,
-        json=lambda: {"commit": {"sha": sha}} if sha is not None else {},
-    )
-
-
-def _session(*responses: SimpleNamespace) -> Mock:
-    session = Mock()
-    session.put.side_effect = responses
-    return session
-
-
 @pytest.mark.parametrize("name", ["reel.gif", "still.png", "notes.txt"], ids=["gif", "png", "txt"])
 def test_video_allowlist_rejects_non_video_extensions(tmp_path: Path, name: str) -> None:
     # The video command's allowlist is its contract: mp4/webm only; images belong to
@@ -55,20 +40,20 @@ def test_video_allowlist_rejects_non_video_extensions(tmp_path: Path, name: str)
 
 
 def test_without_yes_uploads_nothing_and_exits_nonzero(mp4: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    session = _session(_resp(201, "x"))
-    with patch.object(upload_video.requests, "Session", return_value=session):
-        result = CliRunner(mix_stderr=False).invoke(upload_video.upload_video, [str(mp4)])
+    upload_many = Mock(return_value="x")
+    monkeypatch.setattr(pr_assets, "upload_many", upload_many)
+
+    result = CliRunner(mix_stderr=False).invoke(upload_video.upload_video, [str(mp4)])
 
     assert result.exit_code == 1
     assert not result.stdout
-    session.put.assert_not_called()
+    upload_many.assert_not_called()
 
 
 def test_stdout_is_link_markdown_not_image_embed(mp4: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    with patch.object(upload_video.requests, "Session", return_value=_session(_resp(201, "deadbeef"))):
-        result = CliRunner(mix_stderr=False).invoke(upload_video.upload_video, ["--yes", str(mp4)])
+    monkeypatch.setattr(pr_assets, "upload_many", Mock(return_value="deadbeef"))
+
+    result = CliRunner(mix_stderr=False).invoke(upload_video.upload_video, ["--yes", str(mp4)])
 
     assert result.exit_code == 0
     lines = result.stdout.strip().splitlines()
@@ -78,13 +63,13 @@ def test_stdout_is_link_markdown_not_image_embed(mp4: Path, monkeypatch: pytest.
 
 
 def test_upload_uses_video_commit_message(mp4: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    session = _session(_resp(201, "deadbeef"))
-    with patch.object(upload_video.requests, "Session", return_value=session):
-        result = CliRunner(mix_stderr=False).invoke(upload_video.upload_video, ["--yes", str(mp4)])
+    upload_many = Mock(return_value="deadbeef")
+    monkeypatch.setattr(pr_assets, "upload_many", upload_many)
+
+    result = CliRunner(mix_stderr=False).invoke(upload_video.upload_video, ["--yes", str(mp4)])
 
     assert result.exit_code == 0
-    assert session.put.call_args.kwargs["json"]["message"] == "add video"
+    assert upload_many.call_args.kwargs["message"] == "add video"
 
 
 def test_label_rejected_for_multiple_files(mp4: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,11 +77,11 @@ def test_label_rejected_for_multiple_files(mp4: Path, tmp_path: Path, monkeypatc
     # the public repo from a token-bearing machine.
     other = tmp_path / "second.webm"
     other.write_bytes(b"webm fake")
-    monkeypatch.setenv("GH_TOKEN", "tok")
-    session = _session(_resp(201, "x"))
-    with patch.object(upload_video.requests, "Session", return_value=session):
-        result = CliRunner(mix_stderr=False).invoke(
-            upload_video.upload_video, ["--yes", "--label", "demo", str(mp4), str(other)]
-        )
+    upload_many = Mock(return_value="x")
+    monkeypatch.setattr(pr_assets, "upload_many", upload_many)
+
+    result = CliRunner(mix_stderr=False).invoke(
+        upload_video.upload_video, ["--yes", "--label", "demo", str(mp4), str(other)]
+    )
     assert result.exit_code != 0
-    session.put.assert_not_called()
+    upload_many.assert_not_called()

--- a/tools/hogli-commands/hogli_commands/upload_image.py
+++ b/tools/hogli-commands/hogli_commands/upload_image.py
@@ -1,15 +1,12 @@
 """hogli pr:upload-image: upload screenshots to the public PostHog/pr-assets repo.
 
-Wraps the GitHub contents API upload documented in the pr-assets README so engineers
+Creates a signed git upload commit in PostHog/pr-assets so engineers
 and agents can turn a local screenshot into an embeddable, SHA-pinned markdown image
 line for a PR description with one command. Running through hogli means the usage is
 tracked by hogli's built-in command telemetry.
 
-Auth reuses a GitHub token from GH_TOKEN/GITHUB_TOKEN or the gh CLI (`gh auth token`),
-so it works with or without gh installed as long as a token with write access to a
-PostHog org repo is available. The target repo is public by design: GitHub renders PR
-images through its anonymous camo proxy, which requires anonymous read. The command
-warns about this on every run.
+The target repo is public by design: GitHub renders PR images through its anonymous
+camo proxy, which requires anonymous read. The command warns about this on every run.
 """
 
 from __future__ import annotations
@@ -18,10 +15,8 @@ from pathlib import Path
 from typing import Final
 
 import click
-import requests
 
 from hogli_commands import pr_assets
-from hogli_commands.github_auth import github_token
 
 # svg is excluded: raw.githubusercontent.com serves it as text/plain, so GitHub won't inline it
 _ALLOWED_EXTS: Final = frozenset({"png", "jpg", "jpeg", "gif", "webp"})
@@ -68,19 +63,18 @@ def upload_image(files: tuple[Path, ...], alt: str | None, yes: bool) -> None:
         )
         raise SystemExit(1)
 
-    token = github_token()
-    if token is None:
-        raise click.ClickException(
-            "no GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or install gh "
-            "(https://cli.github.com/) and run `gh auth login`."
-        )
-    session = requests.Session()
+    uploads = [pr_assets.AssetUpload(path=path, key=pr_assets.make_key(ext)) for path, ext in validated]
+    for upload in uploads:
+        click.secho(f"Uploading {upload.path.name} → {pr_assets.REPO}/{upload.key} …", fg="cyan", err=True)
 
-    for path, ext in validated:
-        key = pr_assets.make_key(ext)
-        click.secho(f"Uploading {path.name} → {pr_assets.REPO}/{key} …", fg="cyan", err=True)
-        sha = pr_assets.upload(path, key, token, session, message=_COMMIT_MESSAGE)
+    sha = pr_assets.upload_many(uploads, message=_COMMIT_MESSAGE)
+
+    for upload in uploads:
+        path = upload.path
         caption = alt if alt is not None else path.stem
-        markdown = f"![{pr_assets.escape_markdown_label(caption)}](https://raw.githubusercontent.com/{pr_assets.REPO}/{sha}/{key})"
+        markdown = (
+            f"![{pr_assets.escape_markdown_label(caption)}]"
+            f"(https://raw.githubusercontent.com/{pr_assets.REPO}/{sha}/{upload.key})"
+        )
         click.echo(markdown)  # stdout carries only the markdown, so callers can pipe it
         click.secho(f"✓ uploaded {path.name}", fg="green", err=True)

--- a/tools/hogli-commands/hogli_commands/upload_video.py
+++ b/tools/hogli-commands/hogli_commands/upload_video.py
@@ -13,10 +13,8 @@ from pathlib import Path
 from typing import Final
 
 import click
-import requests
 
 from hogli_commands import pr_assets
-from hogli_commands.github_auth import github_token
 
 _ALLOWED_EXTS: Final = frozenset({"mp4", "webm"})
 # GitHub's own inline-upload cap for videos on free plans, and roomy for the intended
@@ -64,21 +62,18 @@ def upload_video(files: tuple[Path, ...], label: str | None, yes: bool) -> None:
         )
         raise SystemExit(1)
 
-    token = github_token()
-    if token is None:
-        raise click.ClickException(
-            "no GitHub token found. Set GH_TOKEN or GITHUB_TOKEN, or install gh "
-            "(https://cli.github.com/) and run `gh auth login`."
-        )
-    session = requests.Session()
+    uploads = [pr_assets.AssetUpload(path=path, key=pr_assets.make_key(ext)) for path, ext in validated]
+    for upload in uploads:
+        click.secho(f"Uploading {upload.path.name} → {pr_assets.REPO}/{upload.key} …", fg="cyan", err=True)
 
-    for path, ext in validated:
-        key = pr_assets.make_key(ext)
-        click.secho(f"Uploading {path.name} → {pr_assets.REPO}/{key} …", fg="cyan", err=True)
-        sha = pr_assets.upload(path, key, token, session, message=_COMMIT_MESSAGE)
+    sha = pr_assets.upload_many(uploads, message=_COMMIT_MESSAGE)
+
+    for upload in uploads:
+        path = upload.path
         text = label if label is not None else path.stem
         markdown = (
-            f"[{pr_assets.escape_markdown_label(text)}](https://raw.githubusercontent.com/{pr_assets.REPO}/{sha}/{key})"
+            f"[{pr_assets.escape_markdown_label(text)}]"
+            f"(https://raw.githubusercontent.com/{pr_assets.REPO}/{sha}/{upload.key})"
         )
         click.echo(markdown)  # stdout carries only the markdown, so callers can pipe it
         click.secho(f"✓ uploaded {path.name}", fg="green", err=True)


### PR DESCRIPTION
## Problem

PostHog engineers and agents could not use `hogli pr:upload-image` after `PostHog/pr-assets` started requiring verified commits.

The command used GitHub's Contents API, which creates unsigned commits. GitHub rejected those uploads with a repository rule violation.

## Changes

- `pr:upload-image` and `pr:upload-video` now upload through one local signed git commit.
- The shared helper clones `PostHog/pr-assets`, stages generated keys, runs `git commit -S`, and pushes to `main`.
- Push races now rebase once and retry.
- Git errors now point signing, DNS, and SSH-auth failures at the right fix.

## How did you test this code?

- Added shared helper tests for the signed git path, push-race retry, signing rejection hint, and DNS hint.
- Added command tests that keep image and video markdown behavior unchanged.
- Ran `./bin/hogli test tools/hogli-commands/hogli_commands/tests/test_pr_assets.py tools/hogli-commands/hogli_commands/tests/test_upload_image.py tools/hogli-commands/hogli_commands/tests/test_upload_video.py`.
- Ran `uv run ruff check tools/hogli-commands/hogli_commands/pr_assets.py tools/hogli-commands/hogli_commands/upload_image.py tools/hogli-commands/hogli_commands/upload_video.py tools/hogli-commands/hogli_commands/tests/test_pr_assets.py tools/hogli-commands/hogli_commands/tests/test_upload_image.py tools/hogli-commands/hogli_commands/tests/test_upload_video.py`.
- Ran `./bin/hogli pr:upload-image --yes /private/tmp/hogli-pr-assets-verify.png`; it uploaded a generated 1x1 PNG: [live upload proof](https://raw.githubusercontent.com/PostHog/pr-assets/02f1d456478352a69a0844003fe5c6991717660e/2026/08/4b8073d6-d7df-48f7-a8bb-7178130caab6.png).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No docs update. This changes an internal hogli helper.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the patch from Pawel's direction. Tools used: Codex Desktop, local git, hogli, and the GitHub connector. Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.

The implementation moved from the failing GitHub Contents API path to a signed git flow after reproducing `PostHog/pr-assets`' verified-signature rule. The live proof used only a generated 1x1 PNG.