### PR TITLE
feat(aio): capture blob render telemetry in the trace view

### DIFF
--- a/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/ConversationMessagesDisplay.tsx
@@ -12,7 +12,7 @@ import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { isObject } from 'lib/utils/guards'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { resolveAiBlobUrl, resolveDataUri } from '../aiBlob'
+import { aiBlobRenderHandlers, resolveAiBlobUrl, resolveDataUri } from '../aiBlob'
 import { getJsonContainerForDisplay, JSONValueDisplay } from '../components/JSONValueDisplay'
 import { MessageSentimentBar } from '../components/SentimentTag'
 import { LLMInputOutput } from '../LLMInputOutput'
@@ -386,7 +386,8 @@ export const ImageMessageDisplay = ({ message }: { message: ImageDisplayMessage 
     if (typeof content === 'string') {
         return <span>{content}</span>
     } else if (content?.image) {
-        return <img src={resolveAiBlobUrl(content.image, currentTeamId)} alt="User sent image" />
+        const src = resolveAiBlobUrl(content.image, currentTeamId)
+        return <img src={src} alt="User sent image" {...aiBlobRenderHandlers(src, 'image')} />
     }
 
     return <span>{String(content ?? '')}</span>
@@ -430,18 +431,27 @@ function renderContentItem(
     }
 
     if (isOpenAIImageURLMessage(item)) {
+        const src = resolveAiBlobUrl(item.image_url.url, currentTeamId)
         return (
             <img
-                src={resolveAiBlobUrl(item.image_url.url, currentTeamId)}
+                src={src}
                 alt="Message content"
                 className="max-w-full max-h-[400px] rounded"
+                {...aiBlobRenderHandlers(src, 'image')}
             />
         )
     }
 
     if (isAnthropicImageMessage(item)) {
         const src = resolveDataUri(item.source.data, item.source.media_type, currentTeamId)
-        return <img src={src} alt="Message content" className="max-w-full max-h-[400px] rounded" />
+        return (
+            <img
+                src={src}
+                alt="Message content"
+                className="max-w-full max-h-[400px] rounded"
+                {...aiBlobRenderHandlers(src, 'image')}
+            />
+        )
     }
 
     if (isGeminiImageMessage(item)) {
@@ -450,7 +460,14 @@ function renderContentItem(
             return null
         }
         const src = resolveDataUri(inlineData.data, inlineData.mime_type, currentTeamId)
-        return <img src={src} alt="Message content" className="max-w-full max-h-[400px] rounded" />
+        return (
+            <img
+                src={src}
+                alt="Message content"
+                className="max-w-full max-h-[400px] rounded"
+                {...aiBlobRenderHandlers(src, 'image')}
+            />
+        )
     }
 
     if (isOpenAIFileMessage(item)) {
@@ -499,7 +516,7 @@ function renderContentItem(
 
         return (
             <div className="space-y-2">
-                <audio controls className="w-[500px]" src={src} />
+                <audio controls className="w-[500px]" src={src} {...aiBlobRenderHandlers(src, 'audio')} />
                 {transcript && typeof transcript === 'string' && (
                     <div className="text-xs text-muted p-2 bg-bg-light rounded border">
                         <div className="font-semibold mb-1">Transcript:</div>

--- a/products/ai_observability/frontend/aiBlob.test.ts
+++ b/products/ai_observability/frontend/aiBlob.test.ts
@@ -90,6 +90,22 @@ describe('aiBlob', () => {
             })
         })
 
+        it('keeps capturing new srcs after the dedup cache fills up', () => {
+            for (let i = 0; i < 1000; i++) {
+                const src = `/api/projects/1/ai_blob/v1/sha256/${i.toString().padStart(64, '0')}`
+                aiBlobRenderHandlers(src, 'image').onLoad!()
+            }
+            jest.mocked(posthog.capture).mockClear()
+
+            const src = `/api/projects/1/ai_blob/v1/sha256/${'d'.repeat(64)}`
+            aiBlobRenderHandlers(src, 'image').onLoad!()
+
+            expect(posthog.capture).toHaveBeenCalledWith(
+                'llma ai blob render',
+                expect.objectContaining({ outcome: 'success', media_kind: 'image' })
+            )
+        })
+
         it('signals audio success via canplay, which media elements fire instead of load', () => {
             const src = `/api/projects/1/ai_blob/v1/sha256/${'c'.repeat(64)}`
             const handlers = aiBlobRenderHandlers(src, 'audio')

--- a/products/ai_observability/frontend/aiBlob.test.ts
+++ b/products/ai_observability/frontend/aiBlob.test.ts
@@ -1,4 +1,8 @@
-import { parseAiBlobPointer, resolveAiBlobUrl, resolveDataUri } from './aiBlob'
+import posthog from 'posthog-js'
+
+import { aiBlobRenderHandlers, parseAiBlobPointer, resolveAiBlobUrl, resolveDataUri } from './aiBlob'
+
+jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
 
 const HASH = 'a'.repeat(64)
 const POINTER = `phaiblob://v1/sha256/${HASH}?mime=image%2Fpng&size=131072`
@@ -48,5 +52,53 @@ describe('aiBlob', () => {
 
     it('builds a data: URI from raw base64 when the data field is not a pointer', () => {
         expect(resolveDataUri('AAAA', 'image/png', 1)).toBe('data:image/png;base64,AAAA')
+    })
+
+    describe('aiBlobRenderHandlers', () => {
+        beforeEach(() => {
+            jest.mocked(posthog.capture).mockClear()
+        })
+
+        it.each([
+            ['a data uri', 'data:image/png;base64,AAAA'],
+            ['an external url', 'https://example.com/a.png'],
+            ['an unresolved pointer', POINTER],
+        ])('attaches no handlers for %s', (_name, src) => {
+            expect(aiBlobRenderHandlers(src, 'image')).toEqual({})
+        })
+
+        it('captures success and error once per src, deduping repeat renders', () => {
+            const src = `/api/projects/1/ai_blob/v1/sha256/${'b'.repeat(64)}`
+            const handlers = aiBlobRenderHandlers(src, 'image')
+            handlers.onLoad!()
+            handlers.onLoad!()
+            handlers.onError!()
+            expect(posthog.capture).toHaveBeenCalledTimes(2)
+            expect(posthog.capture).toHaveBeenCalledWith('llma ai blob render', {
+                outcome: 'success',
+                media_kind: 'image',
+                transfer_size_bytes: null,
+                decoded_body_bytes: null,
+                from_browser_cache: null,
+            })
+            expect(posthog.capture).toHaveBeenCalledWith('llma ai blob render', {
+                outcome: 'error',
+                media_kind: 'image',
+                transfer_size_bytes: null,
+                decoded_body_bytes: null,
+                from_browser_cache: null,
+            })
+        })
+
+        it('signals audio success via canplay, which media elements fire instead of load', () => {
+            const src = `/api/projects/1/ai_blob/v1/sha256/${'c'.repeat(64)}`
+            const handlers = aiBlobRenderHandlers(src, 'audio')
+            expect(handlers.onLoad).toBeUndefined()
+            handlers.onCanPlay!()
+            expect(posthog.capture).toHaveBeenCalledWith(
+                'llma ai blob render',
+                expect.objectContaining({ outcome: 'success', media_kind: 'audio' })
+            )
+        })
     })
 })

--- a/products/ai_observability/frontend/aiBlob.ts
+++ b/products/ai_observability/frontend/aiBlob.ts
@@ -53,15 +53,21 @@ export function resolveDataUri(rawData: string, mimeType: string, teamId: number
 
 const BLOB_ENDPOINT_RE = /\/ai_blob\/v1\/sha256\/[0-9a-f]{64}$/
 
-const reportedRenders = new Set<string>()
+const reportedRenders = new Map<string, true>()
 const MAX_REPORTED_RENDERS = 1000
 
 function captureBlobRender(src: string, mediaKind: 'image' | 'audio', outcome: 'success' | 'error'): void {
     const key = `${outcome}:${src}`
-    if (reportedRenders.has(key) || reportedRenders.size >= MAX_REPORTED_RENDERS) {
+    if (reportedRenders.has(key)) {
         return
     }
-    reportedRenders.add(key)
+    if (reportedRenders.size >= MAX_REPORTED_RENDERS) {
+        const oldestKey = reportedRenders.keys().next().value
+        if (oldestKey !== undefined) {
+            reportedRenders.delete(oldestKey)
+        }
+    }
+    reportedRenders.set(key, true)
     const entries =
         typeof performance.getEntriesByName === 'function'
             ? performance.getEntriesByName(new URL(src, window.location.origin).toString())

--- a/products/ai_observability/frontend/aiBlob.ts
+++ b/products/ai_observability/frontend/aiBlob.ts
@@ -1,3 +1,5 @@
+import posthog from 'posthog-js'
+
 /** Frontend twin of the ingestion pointer module: the only place phaiblob:// URIs are interpreted. */
 export interface AiBlobPointer {
     version: string
@@ -47,4 +49,44 @@ export function resolveAiBlobUrl(value: string, teamId: number | string | null):
 export function resolveDataUri(rawData: string, mimeType: string, teamId: number | string | null): string {
     const resolved = resolveAiBlobUrl(rawData, teamId)
     return resolved !== rawData ? resolved : `data:${mimeType};base64,${rawData}`
+}
+
+const BLOB_ENDPOINT_RE = /\/ai_blob\/v1\/sha256\/[0-9a-f]{64}$/
+
+const reportedRenders = new Set<string>()
+const MAX_REPORTED_RENDERS = 1000
+
+function captureBlobRender(src: string, mediaKind: 'image' | 'audio', outcome: 'success' | 'error'): void {
+    const key = `${outcome}:${src}`
+    if (reportedRenders.has(key) || reportedRenders.size >= MAX_REPORTED_RENDERS) {
+        return
+    }
+    reportedRenders.add(key)
+    const entries =
+        typeof performance.getEntriesByName === 'function'
+            ? performance.getEntriesByName(new URL(src, window.location.origin).toString())
+            : []
+    const last = entries[entries.length - 1]
+    const timing = last && 'transferSize' in last ? (last as PerformanceResourceTiming) : undefined
+    posthog.capture('llma ai blob render', {
+        outcome,
+        media_kind: mediaKind,
+        transfer_size_bytes: timing ? timing.transferSize : null,
+        decoded_body_bytes: timing ? timing.decodedBodySize : null,
+        from_browser_cache: timing ? timing.transferSize === 0 && timing.decodedBodySize > 0 : null,
+    })
+}
+
+export function aiBlobRenderHandlers(
+    src: string,
+    mediaKind: 'image' | 'audio'
+): { onLoad?: () => void; onCanPlay?: () => void; onError?: () => void } {
+    if (!BLOB_ENDPOINT_RE.test(src)) {
+        return {}
+    }
+    const success = (): void => captureBlobRender(src, mediaKind, 'success')
+    return {
+        ...(mediaKind === 'image' ? { onLoad: success } : { onCanPlay: success }),
+        onError: (): void => captureBlobRender(src, mediaKind, 'error'),
+    }
 }


### PR DESCRIPTION
## Problem

A broken image in the trace view sends no signal anywhere: the blob read path has zero product telemetry.

- The media elements rendered from `phaiblob://` pointers have no load or error handlers, so a 404 (for example a bucket/prefix mismatch between the ingestion writer and the Django reader) shows a silent broken icon.
- The browser-cache hit rate for offloaded media is unknowable, so read-side cost assumptions cannot be checked.

## Changes

- Pointer-backed `<img>` and `<audio>` in `ConversationMessagesDisplay` now capture a `llma ai blob render` event on load, canplay, or error.
- Properties: `outcome`, `media_kind`, `transfer_size_bytes` and `decoded_body_bytes` from resource timing, and `from_browser_cache` (a zero-transfer fetch that produced a body came from the cache).
- Events dedupe per URL and outcome per pageload, behind a bounded set, so list re-renders do not spam capture.
- Inline `data:` URIs and external URLs attach no handlers, so only blob-endpoint fetches are measured.

No visible UI change; the diff only adds handlers.

## How did you test this code?

- Jest on `aiBlob.test.ts`: handler gating (no handlers for data URIs, external URLs, unresolved pointers), per-src dedup, capture payload shape, and audio signaling success via `canplay`. Regression caught: endpoint URL-shape drift silently killing the telemetry, or handlers firing on inline media and flooding capture.
- Not run locally: repo-wide `tsgo` (the nested quill workspace is unbuilt in this environment; none of the reported errors reference the changed files). CI covers it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None (internal instrumentation).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Carlos (@carlos-marchal-ph) directed the work and is DRI.

- Built in a PostHog Code session after an instrumentation audit found the read path fully dark while the write path has nine metrics.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
