### PR TITLE
feat(insights): add chart display suggestions strip to trends editor

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -211,6 +211,7 @@ export const FEATURE_FLAGS = {
     HEATMAPS_RECORDING_CLICKMAP: 'heatmaps-recording-clickmap', // owner: #team-web-analytics
     HEATMAPS_SCREENSHOT_PREWARM: 'heatmaps-screenshot-prewarm', // owner: #team-web-analytics, pre-renders the screenshot while entering a URL in the wizard
     IMPROVED_COOKIELESS_MODE: 'improved-cookieless-mode', // owner: #team-web-analytics
+    INSIGHT_CHART_SUGGESTIONS: 'insight-chart-suggestions', // owner: #team-product-analytics, gates the alternative-visualization preview strip under trends charts
     LINEAGE_DEPENDENCY_VIEW: 'lineage-dependency-view', // owner: #team-data-modeling
     MEMBERS_CAN_USE_PERSONAL_API_KEYS: 'members-can-use-personal-api-keys', // owner: @yasen-posthog #team-platform-features
     METRIC_INSIGHT: 'metric-insight', // owner: @sampennington #team-product-analytics

--- a/frontend/src/queries/nodes/InsightViz/ChartDisplaySuggestions.stories.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ChartDisplaySuggestions.stories.tsx
@@ -1,0 +1,62 @@
+import { samplePersonProperties, sampleRetentionPeopleResponse } from 'scenes/insights/__mocks__/insight.mocks'
+
+import { Meta, StoryObj } from '@storybook/react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { createInsightStory } from 'scenes/insights/__mocks__/createInsightScene'
+
+import { mswDecorator } from '~/mocks/browser'
+
+import __trendsLineMulti from '../../../mocks/fixtures/api/projects/team_id/insights/trendsLineMulti.json'
+import __trendsNumber from '../../../mocks/fixtures/api/projects/team_id/insights/trendsNumber.json'
+
+type Story = StoryObj<{}>
+const meta: Meta = {
+    title: 'Components/ChartDisplaySuggestions',
+    parameters: {
+        layout: 'fullscreen',
+        testOptions: {
+            snapshotBrowsers: ['chromium'],
+            viewport: {
+                width: 1300,
+                height: 720,
+            },
+        },
+        viewMode: 'story',
+        mockDate: '2022-03-11',
+        featureFlags: [FEATURE_FLAGS.INSIGHT_CHART_SUGGESTIONS],
+    },
+    decorators: [
+        mswDecorator({
+            get: {
+                '/api/environments/:team_id/persons/retention': sampleRetentionPeopleResponse,
+                '/api/environments/:team_id/persons/properties': samplePersonProperties,
+                '/api/projects/:team_id/groups_types': [],
+            },
+            post: {
+                '/api/projects/:team_id/cohorts/': { id: 1 },
+            },
+        }),
+    ],
+}
+export default meta
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+export const TrendsLineWithSuggestions: Story = createInsightStory(__trendsLineMulti as any, 'edit')
+TrendsLineWithSuggestions.parameters = {
+    ...meta.parameters,
+    testOptions: {
+        ...meta.parameters?.testOptions,
+        waitForSelector: '[data-attr=chart-display-suggestions]',
+    },
+}
+
+export const TrendsNumberWithSuggestions: Story = createInsightStory(__trendsNumber as any, 'edit')
+TrendsNumberWithSuggestions.parameters = {
+    ...meta.parameters,
+    testOptions: {
+        ...meta.parameters?.testOptions,
+        waitForSelector: '[data-attr=chart-display-suggestions]',
+    },
+}
+/* eslint-enable @typescript-eslint/no-var-requires */

--- a/frontend/src/queries/nodes/InsightViz/ChartDisplaySuggestions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/ChartDisplaySuggestions.tsx
@@ -1,0 +1,157 @@
+import { useActions, useValues } from 'kea'
+
+import { IconGlobe, IconGraph, IconPieChart, IconTrends } from '@posthog/icons'
+
+import { dataColorVars } from 'lib/colors'
+import { Sparkline, SparklineTimeSeries } from 'lib/components/Sparkline'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { Icon123, IconAreaChart } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { ChartDisplayType } from '~/types'
+
+const MAX_PREVIEW_SERIES = 3
+const MAX_PREVIEW_POINTS = 16
+
+/** Thin long series so every thumbnail stays within Sparkline's medium width bucket. */
+function downsample(values: number[]): number[] {
+    if (values.length <= MAX_PREVIEW_POINTS) {
+        return values
+    }
+    const step = values.length / MAX_PREVIEW_POINTS
+    return Array.from({ length: MAX_PREVIEW_POINTS }, (_, i) => values[Math.floor(i * step)])
+}
+
+interface DisplaySuggestion {
+    value: ChartDisplayType
+    label: string
+    /** When set, the thumbnail is a live Sparkline of the fetched results instead of the icon. */
+    previewType?: 'line' | 'bar'
+    icon: JSX.Element
+}
+
+export function ChartDisplaySuggestions(): JSX.Element | null {
+    const { insightProps, canEditInsight } = useValues(insightLogic)
+    const { display, isTrends, isSingleSeriesOutput, formula, breakdownFilter, insightDataLoading } = useValues(
+        insightVizDataLogic(insightProps)
+    )
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { indexedResults } = useValues(trendsDataLogic(insightProps))
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    if (
+        !featureFlags[FEATURE_FLAGS.INSIGHT_CHART_SUGGESTIONS] ||
+        !isTrends ||
+        !canEditInsight ||
+        insightDataLoading ||
+        indexedResults.length === 0
+    ) {
+        return null
+    }
+
+    const currentDisplay = display || ChartDisplayType.ActionsLineGraph
+
+    const previewSeries: SparklineTimeSeries[] = indexedResults
+        .slice(0, MAX_PREVIEW_SERIES)
+        .map((result, index) => ({
+            name: result.label,
+            values: downsample(result.data ?? []),
+            color: dataColorVars[index % dataColorVars.length],
+        }))
+        .filter((series) => series.values.length > 1)
+    // Total value displays return one aggregate per series, not day-by-day data, so
+    // there is nothing to draw a live time series thumbnail from.
+    const hasTimeSeriesData = previewSeries.length > 0
+
+    const isCountryBreakdown =
+        breakdownFilter?.breakdown === '$geoip_country_code' || breakdownFilter?.breakdown === '$geoip_country_name'
+
+    const suggestions: DisplaySuggestion[] = [
+        {
+            value: ChartDisplayType.ActionsLineGraph,
+            label: 'Line chart',
+            previewType: 'line' as const,
+            icon: <IconTrends />,
+        },
+        {
+            value: ChartDisplayType.ActionsUnstackedBar,
+            label: 'Bar chart',
+            previewType: 'bar' as const,
+            icon: <IconGraph />,
+        },
+        {
+            value: ChartDisplayType.ActionsAreaGraph,
+            label: 'Area chart',
+            previewType: 'line' as const,
+            icon: <IconAreaChart />,
+        },
+        ...(isSingleSeriesOutput
+            ? [
+                  {
+                      value: ChartDisplayType.BoldNumber,
+                      label: 'Number',
+                      icon: <Icon123 />,
+                  },
+              ]
+            : []),
+        ...(isSingleSeriesOutput && featureFlags[FEATURE_FLAGS.METRIC_INSIGHT]
+            ? [
+                  {
+                      value: ChartDisplayType.Metric,
+                      label: 'Metric',
+                      icon: <IconTrends />,
+                  },
+              ]
+            : []),
+        {
+            value: ChartDisplayType.ActionsPie,
+            label: 'Pie chart',
+            icon: <IconPieChart />,
+        },
+        ...(isCountryBreakdown && !formula
+            ? [
+                  {
+                      value: ChartDisplayType.WorldMap,
+                      label: 'World map',
+                      icon: <IconGlobe />,
+                  },
+              ]
+            : []),
+    ].filter((suggestion) => suggestion.value !== currentDisplay)
+
+    if (suggestions.length === 0) {
+        return null
+    }
+
+    return (
+        <div className="flex items-center gap-2 flex-wrap border-t px-4 py-2" data-attr="chart-display-suggestions">
+            <span className="text-xs text-secondary shrink-0">View as</span>
+            {suggestions.map((suggestion) => (
+                <button
+                    key={suggestion.value}
+                    type="button"
+                    className="flex flex-col items-center justify-end gap-1 min-w-24 px-3 py-1.5 border rounded bg-surface-primary cursor-pointer hover:border-accent transition-colors"
+                    onClick={() => updateInsightFilter({ display: suggestion.value })}
+                    data-attr={`chart-display-suggestion-${suggestion.value}`}
+                >
+                    <div className="h-8 flex items-center justify-center pointer-events-none">
+                        {suggestion.previewType && hasTimeSeriesData ? (
+                            <Sparkline
+                                data={previewSeries}
+                                type={suggestion.previewType}
+                                maximumIndicator={false}
+                                className="h-8"
+                            />
+                        ) : (
+                            <span className="text-xl text-secondary">{suggestion.icon}</span>
+                        )}
+                    </div>
+                    <span className="text-xs">{suggestion.label}</span>
+                </button>
+            ))}
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -59,6 +59,7 @@ import {
     PropertyMathType,
 } from '~/types'
 
+import { ChartDisplaySuggestions } from './ChartDisplaySuggestions'
 import { InsightDisplayConfig } from './InsightDisplayConfig'
 import { InsightResultMetadata } from './InsightResultMetadata'
 import { ResultCustomizationsModal } from './ResultCustomizationsModal'
@@ -548,6 +549,7 @@ export function InsightVizDisplay({
                                 <>{renderActiveView()}</>
                             )}
                         </div>
+                        {actionable && !inSharedMode && !BlockingEmptyState && <ChartDisplaySuggestions />}
                     </>
                 )}
             </div>


### PR DESCRIPTION
## Problem

- Switching a trends insight to another chart type means picking blind from a dropdown: nothing shows what the data looks like as a bar chart, a number, or a pie before you commit.
- For many display types the switch is nearly free: line, bar, area, and stacked bar all render the same fetched results, so a live preview costs no extra query.
- This is a flagged prototype to explore whether inline previews help people discover display options.

## Changes

- Adds a "View as" strip under the chart in the trends insight editor, behind the new `insight-chart-suggestions` flag, edit mode only.
- Each card switches `trendsFilter.display` on click. Cards for the same data bucket show a live sparkline thumbnail of the fetched results; cross-bucket cards (number, pie, world map) show an icon and re-query on click.
- Suggestions adapt to the query: number and metric appear only for single-series output, world map only for a country breakdown.

Live previews on a multi-series line insight, after clicking the bar chart card:

<img width="1300" alt="Trends editor showing a bar chart with a View as strip of line, area, and pie suggestions" src="https://raw.githubusercontent.com/PostHog/pr-assets/006a25e64092240c5a63f553e3786eb3812aefcb/2026/08/insight-chart-suggestions-after-switch.png" />

The strip close up, with live thumbnails:

<img width="611" alt="View as strip with live bar and area thumbnails and a pie icon card" src="https://raw.githubusercontent.com/PostHog/pr-assets/006a25e64092240c5a63f553e3786eb3812aefcb/2026/08/insight-chart-suggestions-strip.png" />

Icon fallback on a number insight, where there is no time series to draw:

<img width="1300" alt="Number insight with icon-only suggestion cards" src="https://raw.githubusercontent.com/PostHog/pr-assets/006a25e64092240c5a63f553e3786eb3812aefcb/2026/08/insight-chart-suggestions-number.png" />

## How did you test this code?

- Two new Storybook stories snapshot the strip: live thumbnails on a multi-series line insight, and the icon fallback on a total-value insight. They catch regressions in the strip rendering and the flag gating.
- I verified both stories in a local Storybook with Playwright: the strip renders, clicking the bar chart card switches the main chart, and the strip re-offers the remaining types (screenshots above).
- Ran the frontend typecheck, oxlint/oxfmt, and `InsightVizDisplay.test.tsx`.
- Not run: the full jest suite and visual snapshot generation; CI covers both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the strip is behind a feature flag while we evaluate the idea.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with PostHog Code (Claude) in a session exploring how to help users discover other insight display options.
- Skills invoked: /writing-user-facing-copy, /writing-code-comments, /setting-feature-flags-in-storybook, /writing-pr-descriptions.
- Design note: the strip reuses `Sparkline` fed from `trendsDataLogic` results instead of mounting the real chart components, because those read their display type from the shared insight logic and cannot render an alternative type side by side.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
