### PR TITLE
fix(tasks): prewarm repo-less cloud tasks

### DIFF
--- a/products/desktop/packages/api-client/src/posthog-client.test.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.test.ts
@@ -1187,6 +1187,32 @@ describe("PostHogAPIClient", () => {
       );
     });
 
+    it("supports warming a repo-less sandbox", async () => {
+      const fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: async () =>
+          JSON.stringify({ task_id: "task-1", run_id: "run-1" }),
+      });
+      const client = makeClient(fetch);
+
+      await client.warmTask({ repository: null, github_integration: null });
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          overrides: {
+            body: JSON.stringify({
+              repository: null,
+              github_integration: null,
+              branch: null,
+              runtime_adapter: null,
+              model: null,
+              reasoning_effort: null,
+            }),
+          },
+        }),
+      );
+    });
+
     it("returns null on an empty 200 body (feature disabled / capped / no-op)", async () => {
       const fetch = vi.fn().mockResolvedValue({
         ok: true,

--- a/products/desktop/packages/api-client/src/posthog-client.ts
+++ b/products/desktop/packages/api-client/src/posthog-client.ts
@@ -3019,8 +3019,8 @@ export class PostHogAPIClient {
   }
 
   async warmTask(options: {
-    repository: string;
-    github_integration: number;
+    repository?: string | null;
+    github_integration?: number | null;
     branch?: string | null;
     runtime_adapter?: string | null;
     model?: string | null;

--- a/products/desktop/packages/core/src/task-detail/taskCreationHost.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationHost.ts
@@ -111,7 +111,7 @@ export interface ITaskCreationHost {
    * no warm run is known client-side.
    */
   takeWarmTaskLease(args: {
-    repository: string;
+    repository?: string | null;
     branch?: string | null;
     runtimeAdapter?: string | null;
     model?: string | null;

--- a/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
+++ b/products/desktop/packages/core/src/task-detail/taskCreationSaga.ts
@@ -734,9 +734,9 @@ export class TaskCreationSaga extends Saga<
     };
 
     const lease =
-      input.repository && input.runtime !== "pi"
+      (input.repository || input.allowNoRepo) && input.runtime !== "pi"
         ? this.deps.host.takeWarmTaskLease({
-            repository: input.repository,
+            repository: input.repository ?? null,
             branch: input.branch ?? null,
             runtimeAdapter: input.adapter ?? null,
             model: input.model ?? null,

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskInput.tsx
@@ -860,6 +860,7 @@ export function TaskInput({
     workspaceMode,
     selectedRepository: selectedCloudRepository,
     githubIntegrationId: orgGithubIntegrationId,
+    allowNoRepo,
     branch: workspaceMode === "cloud" ? selectedBranch : null,
     editorIsEmpty,
     runtimeAdapter: adapter ?? null,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useWarmTask.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useWarmTask.test.tsx
@@ -24,6 +24,7 @@ interface Props {
   workspaceMode: WorkspaceMode;
   selectedRepository?: string | null;
   githubIntegrationId?: number;
+  allowNoRepo?: boolean;
   branch?: string | null;
   editorIsEmpty: boolean;
   runtimeAdapter?: string | null;
@@ -116,6 +117,41 @@ describe("useWarmTask", () => {
     rerender(cloudTyping);
     await flushDebounce();
     expect(mockClient.warmTask).toHaveBeenCalledOnce();
+  });
+
+  it("warms a repo-less cloud task when repositories are optional", async () => {
+    renderHook((props: Props) => useWarmTask(props), {
+      initialProps: {
+        ...cloudTyping,
+        selectedRepository: null,
+        githubIntegrationId: undefined,
+        allowNoRepo: true,
+      },
+    });
+
+    await flushDebounce();
+
+    expect(mockClient.warmTask).toHaveBeenCalledWith({
+      repository: null,
+      github_integration: null,
+      branch: "main",
+      ...NULL_RUNTIME,
+    });
+  });
+
+  it("ignores a stale repository selection for a repo-less cloud task", async () => {
+    renderHook((props: Props) => useWarmTask(props), {
+      initialProps: { ...cloudTyping, allowNoRepo: true },
+    });
+
+    await flushDebounce();
+
+    expect(mockClient.warmTask).toHaveBeenCalledWith({
+      repository: null,
+      github_integration: null,
+      branch: "main",
+      ...NULL_RUNTIME,
+    });
   });
 
   it("does not re-fire for the same selection (backend dedups, client guards)", async () => {

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/useWarmTask.ts
@@ -16,6 +16,7 @@ interface UseWarmTaskOptions {
   workspaceMode: WorkspaceMode;
   selectedRepository?: string | null;
   githubIntegrationId?: number;
+  allowNoRepo?: boolean;
   branch?: string | null;
   editorIsEmpty: boolean;
   runtimeAdapter?: string | null;
@@ -29,6 +30,7 @@ export function useWarmTask({
   workspaceMode,
   selectedRepository,
   githubIntegrationId,
+  allowNoRepo = false,
   branch,
   editorIsEmpty,
   runtimeAdapter,
@@ -51,17 +53,22 @@ export function useWarmTask({
   const normalizedReasoningEffort = reasoningEffort ?? null;
   const normalizedSandboxEnvironmentId = sandboxEnvironmentId ?? null;
   const normalizedCustomImageId = customImageId ?? null;
+  // Repo-less channel tasks deliberately discard any persisted/stale picker
+  // selection on submit, so warming and lease matching must do the same.
+  const warmRepository = allowNoRepo ? null : (selectedRepository ?? null);
+  const warmGithubIntegrationId = allowNoRepo
+    ? null
+    : (githubIntegrationId ?? null);
   const eligible =
     enabled &&
     isCloud &&
     !!client &&
-    !!selectedRepository &&
-    githubIntegrationId !== undefined &&
+    (allowNoRepo || (!!warmRepository && warmGithubIntegrationId !== null)) &&
     !editorIsEmpty;
   const key =
-    selectedRepository && githubIntegrationId !== undefined
-      ? `${githubIntegrationId}:${buildWarmTaskLeaseKey({
-          repository: selectedRepository,
+    allowNoRepo || (warmRepository && warmGithubIntegrationId !== null)
+      ? `${warmGithubIntegrationId ?? ""}:${buildWarmTaskLeaseKey({
+          repository: warmRepository,
           branch: normalizedBranch,
           runtimeAdapter: normalizedRuntimeAdapter,
           model: normalizedModel,
@@ -80,7 +87,7 @@ export function useWarmTask({
       }
     };
 
-    if (!eligible || !key || !selectedRepository || !client) {
+    if (!eligible || !key || !client) {
       clearDebounce();
       return;
     }
@@ -88,8 +95,8 @@ export function useWarmTask({
       return;
     }
 
-    const repository = selectedRepository;
-    const githubIntegration = githubIntegrationId as number;
+    const repository = warmRepository;
+    const githubIntegration = warmGithubIntegrationId;
     const warmBranch = normalizedBranch;
     const warmRuntimeAdapter = normalizedRuntimeAdapter;
     const warmModel = normalizedModel;
@@ -141,8 +148,8 @@ export function useWarmTask({
     eligible,
     key,
     client,
-    selectedRepository,
-    githubIntegrationId,
+    warmRepository,
+    warmGithubIntegrationId,
     normalizedBranch,
     normalizedRuntimeAdapter,
     normalizedModel,

--- a/products/desktop/packages/ui/src/features/task-detail/hooks/warmTaskLease.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/hooks/warmTaskLease.ts
@@ -4,7 +4,7 @@ export interface WarmTaskLease {
 }
 
 export interface WarmTaskLeaseKeyParts {
-  repository: string;
+  repository?: string | null;
   branch?: string | null;
   runtimeAdapter?: string | null;
   model?: string | null;
@@ -15,7 +15,7 @@ export interface WarmTaskLeaseKeyParts {
 
 export function buildWarmTaskLeaseKey(parts: WarmTaskLeaseKeyParts): string {
   return [
-    parts.repository,
+    parts.repository ?? "",
     parts.branch ?? "",
     parts.runtimeAdapter ?? "",
     parts.model ?? "",

--- a/products/desktop/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
+++ b/products/desktop/packages/ui/src/features/task-detail/taskCreationHostImpl.ts
@@ -157,7 +157,7 @@ export class TrpcTaskCreationHost implements ITaskCreationHost {
   }
 
   takeWarmTaskLease(args: {
-    repository: string;
+    repository?: string | null;
     branch?: string | null;
     runtimeAdapter?: string | null;
     model?: string | null;

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4278,14 +4278,13 @@ def create_task(
     if (
         warm_branch_provided
         and validated_data["origin_product"] == Task.OriginProduct.USER_CREATED
-        and validated_data.get("repository")
         and len(validated_data.get("repositories", [])) <= 1
         and user_id is not None
     ):
         warm_run = _find_idling_warm_run(
             team_id,
             user_id,
-            repository=validated_data["repository"],
+            repository=validated_data.get("repository"),
             branch=warm_branch,
             runtime_adapter=warm_runtime_adapter,
             model=warm_model,
@@ -4662,7 +4661,7 @@ def _find_idling_warm_run(
 ) -> TaskRun | None:
     """Most-recent idling pre-warmed Run matching this user's cloud composing selection, or ``None``.
 
-    A warm Run is a non-terminal ``USER_CREATED`` Run for the same repo+branch still awaiting its
+    A warm Run is a non-terminal ``USER_CREATED`` Run for the same optional repo+branch still awaiting its
     first user message (the ``await_user_message`` state marker). This is the backend's single source
     of truth for the warm pool: it dedupes warm provisioning (so a repeated ``warm`` call reuses the
     live Run instead of spawning a second) and lets the normal create+run path transparently reuse a
@@ -4670,20 +4669,21 @@ def _find_idling_warm_run(
 
     Reuse also requires the warm Run's runtime, sandbox environment, and custom image selections to
     match the request. A mismatch returns ``None`` so the caller cold-creates on the correct sandbox.
-    The repo/branch/``await_user_message`` predicates stay in the query; the remaining selection is
+    The optional repo/branch/``await_user_message`` predicates stay in the query; the remaining selection is
     matched in Python over the small candidate set.
     """
-    if user_id is None or not repository:
+    if user_id is None:
         return None
+    repository_filter = {"task__repository__iexact": repository} if repository else {"task__repository__isnull": True}
     candidates = (
         TaskRun.objects.filter(  # nosemgrep: idor-lookup-without-team — team_id filter applied via the task FK below
             task__team_id=team_id,
             task__created_by_id=user_id,
             task__origin_product=Task.OriginProduct.USER_CREATED,
-            task__repository__iexact=repository,
             task__deleted=False,
             state__await_user_message=True,
             branch=branch or None,
+            **repository_filter,
         )
         .exclude(status__in=_TERMINAL_TASK_RUN_STATUSES)
         .select_related("task")
@@ -4814,8 +4814,8 @@ def warm_task_sandbox(
     team_id: int,
     user_id: int,
     *,
-    repository: str,
-    github_integration_id: int,
+    repository: str | None,
+    github_integration_id: int | None,
     branch: str | None,
     runtime_adapter: str | None = None,
     model: str | None = None,
@@ -4827,7 +4827,7 @@ def warm_task_sandbox(
     """Warm a full idling Run for a Code-app cloud task while the user composes.
 
     Births a draft Task (``USER_CREATED``), then ``SandboxWarmer.warm()`` provisions an interactive
-    Run that boots + clones + checks out ``branch`` + starts the agent on the selected
+    Run that boots, optionally clones and checks out ``branch``, then starts the agent on the selected
     ``runtime_adapter``/``model``/``reasoning_effort`` (carried on the Run state and read by the
     agent-server at launch, so the sandbox boots on the right runtime), then idles awaiting the first
     ``user_message``. The Run is dispatched with ``create_pr=True`` so that, once activated on submit,
@@ -4837,8 +4837,8 @@ def warm_task_sandbox(
     (``QuotaLimitExceeded``), product not enabled (``PermissionDenied``), or the warm pool is full
     (``Throttled``). The caller treats ``None`` as "no warm run; fall through to a cold create+run".
 
-    ``github_integration_id`` must already be re-scoped to ``team_id`` by the caller
-    (see :func:`resolve_team_github_integration_id`).
+    When present, ``github_integration_id`` must already be re-scoped to ``team_id`` by the caller
+    (see :func:`resolve_team_github_integration_id`). Repository-less warms omit it.
     """
     from rest_framework.exceptions import (  # noqa: PLC0415 — keep DRF exception types off the api import path
         PermissionDenied,
@@ -4857,8 +4857,12 @@ def warm_task_sandbox(
     )
 
     team = Team.objects.get(id=team_id)
-    github_integration = Integration.objects.filter(id=github_integration_id, team_id=team_id, kind="github").first()
-    if github_integration is None:
+    github_integration = None
+    if github_integration_id is not None:
+        github_integration = Integration.objects.filter(
+            id=github_integration_id, team_id=team_id, kind="github"
+        ).first()
+    if bool(repository) != bool(github_integration):
         return None
 
     sandbox_environment = None

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -2603,17 +2603,23 @@ class WarmTaskRequestSerializer(serializers.Serializer):
     """Request body for warming a full idling Run while composing a Code-app cloud task.
 
     Collection-level: no task exists yet at typing time. The warmer births a draft Task and an
-    interactive Run that boots, clones, checks out `branch`, and starts the agent, then idles awaiting
-    the first message. `github_integration` is a plain integration PK (an integer); the view re-scopes
-    it to the caller's team before use.
+    interactive Run that boots and starts the agent, optionally cloning and checking out a repository,
+    then idles awaiting the first message. `github_integration` is a plain integration PK (an integer);
+    the view re-scopes it to the caller's team before use.
     """
 
     repository = serializers.CharField(
+        required=False,
+        default=None,
+        allow_null=True,
         max_length=255,
-        help_text="Target GitHub repository to clone, in `organization/repo` format (e.g. `posthog/posthog`).",
+        help_text="Optional GitHub repository to clone, in `organization/repo` format (e.g. `posthog/posthog`).",
     )
     github_integration = serializers.IntegerField(
-        help_text="Primary key of the team's GitHub integration to clone with.",
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Primary key of the team's GitHub integration to clone with when a repository is selected.",
     )
     branch = serializers.CharField(
         required=False,
@@ -2661,12 +2667,21 @@ class WarmTaskRequestSerializer(serializers.Serializer):
         help_text="Optional custom base image to provision before the task is submitted; takes precedence over the environment's image.",
     )
 
-    def validate_repository(self, value: str) -> str:
+    def validate_repository(self, value: str | None) -> str | None:
+        if value is None:
+            return None
         normalized = value.strip().lower()
         parts = normalized.split("/")
         if len(parts) != 2 or not parts[0] or not parts[1]:
             raise serializers.ValidationError("Repository must be in the format organization/repository")
         return normalized
+
+    def validate(self, attrs):
+        if bool(attrs.get("repository")) != bool(attrs.get("github_integration")):
+            raise serializers.ValidationError(
+                "Repository and GitHub integration must either both be provided or both be omitted."
+            )
+        return attrs
 
 
 class WarmTaskResponseSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -840,6 +840,9 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 response=WarmTaskResponseSerializer,
                 description="Warm Run provisioned (`task_id`/`run_id` to activate on submit), or an empty body when the feature is off, capped, or the integration didn't resolve.",
             ),
+            429: OpenApiResponse(
+                response=TaskRunErrorResponseSerializer, description="Team is over its posthog_code usage limit"
+            ),
         },
         summary="Warm a task sandbox",
         description=(
@@ -860,16 +863,19 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if user_id is None:
             return Response(status=status.HTTP_200_OK)
 
-        github_integration_id = tasks_facade.resolve_team_github_integration_id(
-            self.team_id, request.validated_data["github_integration"]
-        )
-        if github_integration_id is None:
-            return Response(status=status.HTTP_200_OK)
+        if limit_response := usage_limit_response(request.user, self.team_id):
+            return limit_response
+
+        github_integration_id = request.validated_data.get("github_integration")
+        if github_integration_id is not None:
+            github_integration_id = tasks_facade.resolve_team_github_integration_id(self.team_id, github_integration_id)
+            if github_integration_id is None:
+                return Response(status=status.HTTP_200_OK)
 
         result = tasks_facade.warm_task_sandbox(
             self.team_id,
             user_id,
-            repository=request.validated_data["repository"],
+            repository=request.validated_data.get("repository"),
             github_integration_id=github_integration_id,
             branch=request.validated_data.get("branch"),
             runtime_adapter=request.validated_data.get("runtime_adapter"),

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -10712,6 +10712,20 @@ class TestCloudUsageGate(BaseTaskAPITest):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @patch("products.tasks.backend.facade.api.warm_task_sandbox")
+    @patch("products.tasks.backend.presentation.views.api.TaskViewSet._warm_enabled", return_value=True)
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
+    def test_warm_repo_less_over_limit_returns_429_and_does_not_provision(
+        self, mock_gate, _mock_warm_enabled, mock_warm
+    ):
+        mock_gate.return_value = self.OVER_LIMIT
+
+        response = self.client.post("/api/projects/@current/tasks/warm/", {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(response.json()["code"], "usage_limit_exceeded")
+        mock_warm.assert_not_called()
+
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
     def test_run_without_code_access_still_runs(self, mock_gate, mock_workflow):

--- a/products/tasks/backend/tests/test_warm_facade.py
+++ b/products/tasks/backend/tests/test_warm_facade.py
@@ -96,6 +96,21 @@ class TestWarmTaskSandbox(APIBaseTest):
         assert mock_warm.call_args.kwargs["sandbox_environment_id"] == sandbox_environment.id
         assert mock_warm.call_args.kwargs["custom_image_id"] == custom_image.id
 
+    @patch("products.tasks.backend.presentation.views.api.TaskViewSet._warm_enabled", return_value=True)
+    @patch("products.tasks.backend.facade.api.warm_task_sandbox")
+    def test_warm_endpoint_accepts_repo_less_request(self, mock_warm, _mock_warm_enabled):
+        mock_warm.return_value = None
+
+        response = self.client.post(
+            "/api/projects/@current/tasks/warm/",
+            {"repository": None, "github_integration": None, "branch": None},
+            format="json",
+        )
+
+        assert response.status_code == 200, response.content
+        assert mock_warm.call_args.kwargs["repository"] is None
+        assert mock_warm.call_args.kwargs["github_integration_id"] is None
+
     def test_provisions_selected_sandbox_environment_and_custom_image(self):
         sandbox_environment = SandboxEnvironment.objects.create(
             team=self.team,
@@ -142,6 +157,18 @@ class TestWarmTaskSandbox(APIBaseTest):
         assert task.github_integration_id == self.integration.id
         assert task.description == ""
         assert task.runs.filter(id=result.run_id).exists()
+
+    def test_births_repo_less_draft_and_returns_warm_dto(self):
+        def fake_warm(self_warmer, **kwargs):
+            run = self_warmer.task.create_run(mode="interactive", extra_state={"await_user_message": True})
+            return WarmResult(run=run, just_created=True)
+
+        with patch(f"{WARM_SRC}.warm", autospec=True, side_effect=fake_warm):
+            result = self._warm(repository=None, github_integration_id=None, branch=None)
+
+        assert result is not None
+        task = Task.objects.get(id=result.task_id)
+        assert task.repository is None
 
     def test_returns_none_and_soft_deletes_draft_when_capped(self):
         with patch(f"{WARM_SRC}.warm", side_effect=Throttled()):
@@ -273,7 +300,7 @@ class TestCreateTaskWarmReuse(APIBaseTest):
             origin_product=Task.OriginProduct.USER_CREATED,
             created_by=created_by or self.user,
             repository=repository,
-            github_integration=self.integration,
+            github_integration=self.integration if repository else None,
         )
         run = task.create_run(
             mode="interactive",
@@ -305,6 +332,15 @@ class TestCreateTaskWarmReuse(APIBaseTest):
         # The agent-server re-reads run state on the forwarded first message, so this
         # must be persisted for the warm run to honor the setting.
         assert run.state.get("auto_publish") is True
+
+    def test_reuses_matching_repo_less_warm_task(self):
+        warm_task, run = self._warm_run(repository=None, branch=None)
+        with patch(f"{FACADE}.signal_task_run_user_message", return_value=True):
+            dto = self._create(repository=None, branch=None)
+
+        assert str(dto.id) == str(warm_task.id)
+        run.refresh_from_db()
+        assert "await_user_message" not in run.state
 
     def test_does_not_overwrite_existing_warm_description(self):
         warm_task, _ = self._warm_run()

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -3959,18 +3959,22 @@ export interface PaginatedTaskSummaryDTOListApi {
  * Request body for warming a full idling Run while composing a Code-app cloud task.
  *
  * Collection-level: no task exists yet at typing time. The warmer births a draft Task and an
- * interactive Run that boots, clones, checks out `branch`, and starts the agent, then idles awaiting
- * the first message. `github_integration` is a plain integration PK (an integer); the view re-scopes
- * it to the caller's team before use.
+ * interactive Run that boots and starts the agent, optionally cloning and checking out a repository,
+ * then idles awaiting the first message. `github_integration` is a plain integration PK (an integer);
+ * the view re-scopes it to the caller's team before use.
  */
 export interface WarmTaskRequestApi {
     /**
-     * Target GitHub repository to clone, in `organization/repo` format (e.g. `posthog/posthog`).
+     * Optional GitHub repository to clone, in `organization/repo` format (e.g. `posthog/posthog`).
      * @maxLength 255
+     * @nullable
      */
-    repository: string
-    /** Primary key of the team's GitHub integration to clone with. */
-    github_integration: number
+    repository?: string | null
+    /**
+     * Primary key of the team's GitHub integration to clone with when a repository is selected.
+     * @nullable
+     */
+    github_integration?: number | null
     /**
      * Branch to check out in the warm sandbox. Defaults to the repository's default branch when omitted.
      * @maxLength 255

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -2507,7 +2507,7 @@ export const getTasksWarmCreateUrl = (projectId: string) => {
  */
 export const tasksWarmCreate = async (
     projectId: string,
-    warmTaskRequestApi: WarmTaskRequestApi,
+    warmTaskRequestApi?: WarmTaskRequestApi,
     options?: RequestInit
 ): Promise<WarmTaskResponseApi> => {
     return apiMutator<WarmTaskResponseApi>(getTasksWarmCreateUrl(projectId), {

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -3070,8 +3070,12 @@ export const TasksWarmCreateBody = /* @__PURE__ */ zod
         repository: zod
             .string()
             .max(tasksWarmCreateBodyRepositoryMax)
-            .describe('Target GitHub repository to clone, in `organization\/repo` format (e.g. `posthog\/posthog`).'),
-        github_integration: zod.number().describe("Primary key of the team's GitHub integration to clone with."),
+            .nullish()
+            .describe('Optional GitHub repository to clone, in `organization\/repo` format (e.g. `posthog\/posthog`).'),
+        github_integration: zod
+            .number()
+            .nullish()
+            .describe("Primary key of the team's GitHub integration to clone with when a repository is selected."),
         branch: zod
             .string()
             .max(tasksWarmCreateBodyBranchMax)
@@ -3116,5 +3120,5 @@ export const TasksWarmCreateBody = /* @__PURE__ */ zod
             ),
     })
     .describe(
-        "Request body for warming a full idling Run while composing a Code-app cloud task.\n\nCollection-level: no task exists yet at typing time. The warmer births a draft Task and an\ninteractive Run that boots, clones, checks out `branch`, and starts the agent, then idles awaiting\nthe first message. `github_integration` is a plain integration PK (an integer); the view re-scopes\nit to the caller's team before use."
+        "Request body for warming a full idling Run while composing a Code-app cloud task.\n\nCollection-level: no task exists yet at typing time. The warmer births a draft Task and an\ninteractive Run that boots and starts the agent, optionally cloning and checking out a repository,\nthen idles awaiting the first message. `github_integration` is a plain integration PK (an integer);\nthe view re-scopes it to the caller's team before use."
     )

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -76157,18 +76157,22 @@ export namespace Schemas {
      * Request body for warming a full idling Run while composing a Code-app cloud task.
      *
      * Collection-level: no task exists yet at typing time. The warmer births a draft Task and an
-     * interactive Run that boots, clones, checks out `branch`, and starts the agent, then idles awaiting
-     * the first message. `github_integration` is a plain integration PK (an integer); the view re-scopes
-     * it to the caller's team before use.
+     * interactive Run that boots and starts the agent, optionally cloning and checking out a repository,
+     * then idles awaiting the first message. `github_integration` is a plain integration PK (an integer);
+     * the view re-scopes it to the caller's team before use.
      */
     export interface WarmTaskRequest {
       /**
-         * Target GitHub repository to clone, in `organization/repo` format (e.g. `posthog/posthog`).
+         * Optional GitHub repository to clone, in `organization/repo` format (e.g. `posthog/posthog`).
          * @maxLength 255
+         * @nullable
          */
-      repository: string;
-      /** Primary key of the team's GitHub integration to clone with. */
-      github_integration: number;
+      repository?: string | null;
+      /**
+         * Primary key of the team's GitHub integration to clone with when a repository is selected.
+         * @nullable
+         */
+      github_integration?: number | null;
       /**
          * Branch to check out in the warm sandbox. Defaults to the repository's default branch when omitted.
          * @maxLength 255


### PR DESCRIPTION
## Problem

Repo-less cloud tasks start from a cold VM because pre-warming currently requires a selected repository and GitHub integration.

## Changes

- Pre-warm a scratch VM and agent session while composing a repo-less cloud task.
- Reuse the warm run when the task is submitted, including attachment handoff.
- Keep repository selection hidden and optional for channel tasks.
- Preserve repository-backed pre-warming for other cloud task flows.