### PR TITLE
fix(desktop): restore context menu rename

### DIFF
--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { InlineEditInput } from "./TaskItem";
+
+describe("InlineEditInput", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("waits for the desktop window to regain focus before focusing rename", async () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+
+    render(
+      <InlineEditInput
+        depth={0}
+        icon={null}
+        label="Original title"
+        isActive={false}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByRole("textbox");
+    expect(input).not.toHaveFocus();
+
+    fireEvent.focus(window);
+
+    await waitFor(() => expect(input).toHaveFocus());
+    expect(input).toHaveProperty("selectionStart", 0);
+    expect(input).toHaveProperty("selectionEnd", "Original title".length);
+  });
+});

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskItem.tsx
@@ -240,11 +240,30 @@ export function InlineEditInput({
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const input = inputRef.current;
-    if (input) {
-      input.focus();
-      input.select();
+    let focusFrame: number | undefined;
+
+    const focusInput = () => {
+      focusFrame = window.requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    };
+
+    // Electron's native context menu can resolve its action just before the
+    // renderer regains focus. Focusing synchronously in that gap immediately
+    // blurs the input and cancels rename, so wait for the window when needed.
+    if (document.hasFocus()) {
+      focusInput();
+    } else {
+      window.addEventListener("focus", focusInput, { once: true });
     }
+
+    return () => {
+      window.removeEventListener("focus", focusInput);
+      if (focusFrame !== undefined) {
+        window.cancelAnimationFrame(focusFrame);
+      }
+    };
   }, []);
 
   const handleSubmit = () => {


### PR DESCRIPTION
## Problem

Desktop users cannot rename a session from its right-click menu because the inline editor loses focus as the native menu closes.

**Why:** Renaming from the context menu should work as reliably as double-clicking a session title