### PR TITLE
feat(data-warehouse): add Outreach source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -514,6 +514,7 @@ the row lists both.
 | ortto                            | HTTP                        | requests                                                        | ✅                          |
 | oura                             | HTTP                        | requests                                                        | ✅                          |
 | outbrain                         | HTTP                        | requests                                                        | ✅                          |
+| outreach                         | HTTP                        | requests                                                        | ✅                          |
 | ownerrez                         | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | pabbly_subscriptions_billing     | HTTP                        | requests                                                        | ✅                          |
 | packagist                        | HTTP                        | requests                                                        | ✅                          |
@@ -1231,7 +1232,6 @@ doesn't conflict with concurrent PRs.
 - orbit
 - otto_market
 - outlook
-- outreach
 - oveit
 - pagbank
 - pagerduty

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/outreach.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/outreach.py
@@ -6,4 +6,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 @config.config
 class OutreachSourceConfig(config.Config):
-    pass
+    client_id: str
+    client_secret: str
+    refresh_token: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/canonical_descriptions.py
@@ -1,0 +1,122 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+DOCS_URL = "https://developers.outreach.io/api/reference/"
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "prospects": {
+        "description": "A person a sales rep is engaging with through Outreach sequences, calls, and emails.",
+        "docs_url": f"{DOCS_URL}tag/Prospect/",
+        "columns": {
+            "id": "Unique identifier for the prospect.",
+            "firstName": "The prospect's first name.",
+            "lastName": "The prospect's last name.",
+            "emails": "Email addresses associated with the prospect.",
+            "title": "The prospect's job title.",
+            "company": "The name of the company the prospect works for.",
+            "stage": "The current stage name assigned to the prospect.",
+            "accountId": "ID of the account (company) this prospect belongs to.",
+            "ownerId": "ID of the user who owns this prospect.",
+            "createdAt": "When the prospect was created in Outreach.",
+            "updatedAt": "When the prospect was last updated.",
+        },
+    },
+    "accounts": {
+        "description": "A company (target account) that prospects and opportunities are associated with.",
+        "docs_url": f"{DOCS_URL}tag/Account/",
+        "columns": {
+            "id": "Unique identifier for the account.",
+            "name": "The account's name.",
+            "domain": "The account's primary web domain.",
+            "industry": "The industry the account operates in.",
+            "numberOfEmployees": "Number of employees at the account, if known.",
+            "ownerId": "ID of the user who owns this account.",
+            "createdAt": "When the account was created in Outreach.",
+            "updatedAt": "When the account was last updated.",
+        },
+    },
+    "sequences": {
+        "description": "An automated series of steps (emails, calls, tasks) used to engage prospects.",
+        "docs_url": f"{DOCS_URL}tag/Sequence/",
+        "columns": {
+            "id": "Unique identifier for the sequence.",
+            "name": "The sequence's name.",
+            "sequenceType": "Whether the sequence enrolls prospects individually or in bulk.",
+            "enabled": "Whether the sequence is currently active.",
+            "sequenceStepCount": "Number of steps configured in the sequence.",
+            "ownerId": "ID of the user who owns this sequence.",
+            "createdAt": "When the sequence was created.",
+            "updatedAt": "When the sequence was last updated.",
+        },
+    },
+    "sequenceStates": {
+        "description": "The progress of a single prospect through a single sequence.",
+        "docs_url": f"{DOCS_URL}tag/SequenceState/",
+        "columns": {
+            "id": "Unique identifier for the sequence state.",
+            "state": "Current status of the prospect's progress through the sequence (e.g. active, finished).",
+            "prospectId": "ID of the prospect enrolled in the sequence.",
+            "sequenceId": "ID of the sequence the prospect is enrolled in.",
+            "userId": "ID of the user who enrolled the prospect.",
+            "createdAt": "When the prospect was enrolled in the sequence.",
+            "updatedAt": "When the sequence state was last updated.",
+        },
+    },
+    "mailings": {
+        "description": "A single email sent (or scheduled to be sent) to a prospect, including engagement events.",
+        "docs_url": f"{DOCS_URL}tag/Mailing/",
+        "columns": {
+            "id": "Unique identifier for the mailing.",
+            "subject": "The email's subject line.",
+            "state": "Delivery state of the mailing (e.g. scheduled, delivered, bounced).",
+            "openCount": "Number of times the email was opened.",
+            "clickCount": "Number of times a link in the email was clicked.",
+            "prospectId": "ID of the prospect the email was sent to.",
+            "sequenceId": "ID of the sequence this mailing belongs to, if any.",
+            "userId": "ID of the user (rep) who sent the mailing.",
+            "createdAt": "When the mailing was created.",
+            "updatedAt": "When the mailing was last updated.",
+        },
+    },
+    "calls": {
+        "description": "A logged phone call between a user and a prospect.",
+        "docs_url": f"{DOCS_URL}tag/Call/",
+        "columns": {
+            "id": "Unique identifier for the call.",
+            "state": "Current status of the call (e.g. completed, queued).",
+            "outcome": "The outcome recorded for the call (e.g. connected, voicemail).",
+            "direction": "Whether the call was inbound or outbound.",
+            "prospectId": "ID of the prospect the call was with.",
+            "userId": "ID of the user who made or received the call.",
+            "sequenceId": "ID of the sequence this call belongs to, if any.",
+            "createdAt": "When the call was logged.",
+            "updatedAt": "When the call record was last updated.",
+        },
+    },
+    "users": {
+        "description": "A licensed Outreach user (sales rep or admin).",
+        "docs_url": f"{DOCS_URL}tag/User/",
+        "columns": {
+            "id": "Unique identifier for the user.",
+            "email": "The user's email address.",
+            "firstName": "The user's first name.",
+            "lastName": "The user's last name.",
+            "username": "The user's Outreach username.",
+            "createdAt": "When the user account was created.",
+            "updatedAt": "When the user account was last updated.",
+        },
+    },
+    "stages": {
+        "description": "A prospect lifecycle stage (e.g. new lead, qualified) that prospects can be assigned to.",
+        "docs_url": f"{DOCS_URL}tag/Stage/",
+        "columns": {
+            "id": "Unique identifier for the stage.",
+            "name": "The stage's name.",
+            "order": "The stage's position in the configured stage ordering.",
+            "color": "The color assigned to the stage in the Outreach UI.",
+            "createdAt": "When the stage was created.",
+            "updatedAt": "When the stage was last updated.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/outreach.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/outreach.py
@@ -1,4 +1,3 @@
-import dataclasses
 from collections.abc import Iterator
 from typing import Any, Optional, cast
 from urllib.parse import urlparse
@@ -6,6 +5,8 @@ from urllib.parse import urlparse
 import requests
 from structlog.types import FilteringBoundLogger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from posthog.dataclasses import frozen
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.datetime_utils import (
     coerce_datetime_to_utc,
@@ -46,7 +47,7 @@ def _assert_same_origin(url: str) -> str:
     return url
 
 
-@dataclasses.dataclass
+@frozen
 class OutreachResumeConfig:
     next_url: Optional[str] = None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/outreach.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/outreach.py
@@ -1,0 +1,234 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any, Optional, cast
+from urllib.parse import urlparse
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.datetime_utils import (
+    coerce_datetime_to_utc,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.settings import OUTREACH_ENDPOINTS
+
+OUTREACH_API_ORIGIN = "https://api.outreach.io"
+OUTREACH_BASE_URL = f"{OUTREACH_API_ORIGIN}/api/v2"
+OUTREACH_TOKEN_URL = f"{OUTREACH_API_ORIGIN}/oauth/token"
+# Outreach's max page[size]/page[limit] across both its cursor and (deprecated) offset pagination
+# modes is 1000; 500 keeps individual response bodies modest.
+PAGE_SIZE = 500
+REQUEST_TIMEOUT_SECONDS = 60
+MAX_RETRY_ATTEMPTS = 5
+
+JSON_API_HEADERS = {"Content-Type": "application/vnd.api+json", "Accept": "application/vnd.api+json"}
+
+
+class OutreachRetryableError(Exception):
+    pass
+
+
+def _assert_same_origin(url: str) -> str:
+    """Reject pagination URLs that point anywhere but the Outreach API host.
+
+    Every request carries the OAuth access token in an `Authorization` header. `links.next` comes
+    off the response body, and the resumed URL is whatever we persisted from a previous run, so a
+    poisoned value pointing at an attacker-controlled host would hand them the token. Pin both to
+    the exact `https://api.outreach.io` origin before following or storing them.
+    """
+    parsed = urlparse(url)
+    if f"{parsed.scheme.lower()}://{parsed.netloc.lower()}" != OUTREACH_API_ORIGIN:
+        raise ValueError(f"Refusing to follow off-origin Outreach pagination URL: {url}")
+
+    return url
+
+
+@dataclasses.dataclass
+class OutreachResumeConfig:
+    next_url: Optional[str] = None
+
+
+def _get_session(client_secret: str, refresh_token: str) -> requests.Session:
+    # capture=False keeps requests metered and logged but excludes their bodies from HTTP sample
+    # capture. Outreach is a CRM: rows carry prospect names, emails, phone numbers, employer and
+    # job-title fields, mailing subjects/bodies, and arbitrary tenant-defined custom attributes that
+    # the name-based scrubbers can't reliably recognise. Those bodies must not land in the shared
+    # sample store, which sits outside the warehouse's own access controls. The same session runs
+    # the OAuth token exchange, so the refresh-token/client-secret payloads are excluded too.
+    return make_tracked_session(headers=JSON_API_HEADERS, redact_values=(client_secret, refresh_token), capture=False)
+
+
+def _mint_token(session: requests.Session, client_id: str, client_secret: str, refresh_token: str) -> str:
+    response = session.post(
+        OUTREACH_TOKEN_URL,
+        json={
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        },
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    return cast(str, response.json()["access_token"])
+
+
+def validate_credentials(client_id: str, client_secret: str, refresh_token: str) -> bool:
+    """Confirm the OAuth app credentials are valid by minting a token and probing a cheap endpoint."""
+    try:
+        session = _get_session(client_secret, refresh_token)
+        token = _mint_token(session, client_id, client_secret, refresh_token)
+        response = session.get(
+            f"{OUTREACH_BASE_URL}/users",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"page[size]": "1", "count": "false"},
+            timeout=15,
+        )
+        # A 403 still proves the token is genuine; the app may just lack the users scope.
+        return response.status_code in (200, 403)
+    except Exception:
+        return False
+
+
+def _format_datetime(value: Any) -> str:
+    """Render an incremental cursor value as the millisecond-precision ISO 8601 instant Outreach expects."""
+    utc_dt = coerce_datetime_to_utc(value)
+    if utc_dt is None:
+        return str(value)
+    return utc_dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _flatten_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one JSON:API resource object into a single flat row.
+
+    `attributes` is merged into the root. Each to-one `relationships` entry (its `data` is a
+    single `{type, id}` resource identifier) becomes a `<relationship>Id` column, e.g. a prospect's
+    `account` relationship becomes `accountId`. To-many relationships (`data` is a list, e.g. a
+    prospect's `calls`) carry no useful scalar value here and are dropped, since the row on the
+    other side of that relationship already references this one.
+    """
+    row = dict(item)
+    attributes = row.pop("attributes", None) or {}
+    row.update(attributes)
+
+    relationships = row.pop("relationships", None) or {}
+    for relationship_name, relationship in relationships.items():
+        data = relationship.get("data") if isinstance(relationship, dict) else None
+        if isinstance(data, dict) and "id" in data:
+            row[f"{relationship_name}Id"] = data["id"]
+
+    row.pop("links", None)
+    return row
+
+
+def get_rows(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[OutreachResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Any = None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = OUTREACH_ENDPOINTS[endpoint]
+    session = _get_session(client_secret, refresh_token)
+    token = _mint_token(session, client_id, client_secret, refresh_token)
+
+    @retry(
+        retry=retry_if_exception_type((OutreachRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+        stop=stop_after_attempt(MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential_jitter(initial=2, max=60),
+        reraise=True,
+    )
+    def fetch(url: str, params: Optional[dict[str, Any]]) -> dict[str, Any]:
+        nonlocal token
+        headers = {**JSON_API_HEADERS, "Authorization": f"Bearer {token}"}
+        response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        # Access tokens last ~2h; re-mint once if the sync outlives one.
+        if response.status_code == 401:
+            token = _mint_token(session, client_id, client_secret, refresh_token)
+            headers = {**JSON_API_HEADERS, "Authorization": f"Bearer {token}"}
+            response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+
+        if response.status_code == 429 or response.status_code >= 500:
+            raise OutreachRetryableError(f"Outreach API error (retryable): status={response.status_code}, url={url}")
+
+        if not response.ok:
+            logger.error(f"Outreach API error: status={response.status_code}, body={response.text}, url={url}")
+            response.raise_for_status()
+
+        return cast(dict[str, Any], response.json())
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    if resume is not None and resume.next_url:
+        url = _assert_same_origin(resume.next_url)
+        params: Optional[dict[str, Any]] = None
+        logger.debug(f"Outreach: resuming {endpoint} from {url}")
+    else:
+        url = f"{OUTREACH_BASE_URL}{config.path}"
+        # Sort ascending on the same field the incremental cursor tracks, so pagination order
+        # matches SourceResponse.sort_mode="asc" and the watermark advances correctly.
+        params = {"page[size]": PAGE_SIZE, "count": "false", "sort": "updatedAt"}
+        if should_use_incremental_field and db_incremental_field_last_value:
+            # `newFilterSyntax=true` is required by Outreach to use the [gte]/[lte] bracket
+            # operators; without it the API falls back to its legacy dot-range filter syntax.
+            params["newFilterSyntax"] = "true"
+            params["filter[updatedAt][gte]"] = _format_datetime(db_incremental_field_last_value)
+
+    while True:
+        data = fetch(url, params)
+        params = None  # links.next is an absolute URL that already embeds every original param
+
+        items = data.get("data") or []
+        if items:
+            yield [_flatten_item(item) for item in items]
+
+        next_url = data.get("links", {}).get("next")
+        if not next_url:
+            break
+
+        next_url = _assert_same_origin(next_url)
+        # Save after yielding, not before, so a crash re-yields (and merge-dedupes) the last
+        # page instead of skipping it.
+        resumable_source_manager.save_state(OutreachResumeConfig(next_url=next_url))
+        url = next_url
+
+    resumable_source_manager.clear_state()
+
+
+def outreach_source(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[OutreachResumeConfig],
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = OUTREACH_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=[config.primary_key],
+        partition_mode="datetime",
+        partition_format="month",
+        partition_keys=[config.partition_key],
+        sort_mode="asc",
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/settings.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import incremental_field
+from products.warehouse_sources.backend.types import IncrementalField
+
+
+@dataclass
+class OutreachEndpointConfig:
+    name: str
+    path: str
+    primary_key: str = "id"
+    # createdAt is set once and never changes, unlike updatedAt, so it makes a stable partition key.
+    partition_key: str = "createdAt"
+
+
+OUTREACH_ENDPOINTS: dict[str, OutreachEndpointConfig] = {
+    "prospects": OutreachEndpointConfig(name="prospects", path="/prospects"),
+    "accounts": OutreachEndpointConfig(name="accounts", path="/accounts"),
+    "sequences": OutreachEndpointConfig(name="sequences", path="/sequences"),
+    "sequenceStates": OutreachEndpointConfig(name="sequenceStates", path="/sequenceStates"),
+    "mailings": OutreachEndpointConfig(name="mailings", path="/mailings"),
+    "calls": OutreachEndpointConfig(name="calls", path="/calls"),
+    "users": OutreachEndpointConfig(name="users", path="/users"),
+    "stages": OutreachEndpointConfig(name="stages", path="/stages"),
+}
+
+ENDPOINTS = tuple(OUTREACH_ENDPOINTS.keys())
+
+# Every endpoint's `attributes` object carries both createdAt and updatedAt (confirmed against
+# Outreach's published OpenAPI schema), so all eight support the same updatedAt cursor filter.
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {name: [incremental_field("updatedAt")] for name in ENDPOINTS}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/settings.py
@@ -1,10 +1,10 @@
-from dataclasses import dataclass
+from posthog.dataclasses import frozen
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import incremental_field
 from products.warehouse_sources.backend.types import IncrementalField
 
 
-@dataclass
+@frozen
 class OutreachEndpointConfig:
     name: str
     path: str

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/source.py
@@ -1,24 +1,61 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs, SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.outreach import (
     OutreachSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.outreach import (
+    OutreachResumeConfig,
+    outreach_source,
+    validate_credentials as validate_outreach_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class OutreachSource(SimpleSource[OutreachSourceConfig]):
+class OutreachSource(ResumableSource[OutreachSourceConfig, OutreachResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog, safe for public docs
+    api_docs_url = "https://developers.outreach.io/api/making-requests"
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.OUTREACH
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            "400 Client Error: Bad Request for url: https://api.outreach.io/oauth/token": "Outreach authentication failed. Your refresh token may be invalid or revoked. Please generate a new one.",
+            "401 Client Error: Unauthorized for url: https://api.outreach.io/oauth/token": "Outreach authentication failed. Please check your OAuth app's client ID and client secret.",
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:
@@ -26,7 +63,91 @@ class OutreachSource(SimpleSource[OutreachSourceConfig]):
             name=SchemaExternalDataSourceType.OUTREACH,
             category=DataWarehouseSourceCategory.SALES,
             label="Outreach",
+            caption="""Connect your Outreach account to pull prospects, accounts, sequences, and engagement data into the PostHog Data warehouse.
+
+Outreach's API is OAuth-only, and its refresh tokens expire after 14 days. This source is not ready to connect yet, because it needs a PostHog-registered Outreach application to hold a credential that renews itself.""",
             iconPath="/static/services/outreach.png",
-            fields=cast(list[FieldType], []),
+            docsUrl="https://posthog.com/docs/cdp/sources/outreach",
+            releaseStatus=ReleaseStatus.ALPHA,
+            # Outreach issues a new refresh token on every token exchange, invalidates the previous
+            # one, and expires them after 14 days. A refresh token pasted into a form field can't be
+            # written back, and each schema syncs in its own workflow, so parallel syncs would race
+            # to spend the same token. Both need a credential PostHog owns and can update: either a
+            # registered OAuth app or Outreach's server-to-server app tokens. Keep the source out of
+            # the catalog until one of those is in place.
             unreleasedSource=True,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="client_id",
+                        label="Client ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="client_secret",
+                        label="Client secret",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="refresh_token",
+                        label="Refresh token",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_schemas(
+        self,
+        config: OutreachSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+        api_version: str | None = None,
+    ) -> list[SourceSchema]:
+        return build_endpoint_schemas(ENDPOINTS, INCREMENTAL_FIELDS, names)
+
+    def validate_credentials(
+        self,
+        config: OutreachSourceConfig,
+        team_id: int,
+        schema_name: Optional[str] = None,
+        api_version: str | None = None,
+    ) -> tuple[bool, str | None]:
+        if validate_outreach_credentials(config.client_id, config.client_secret, config.refresh_token):
+            return True, None
+
+        return False, "Invalid Outreach credentials"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[OutreachResumeConfig]:
+        return ResumableSourceManager[OutreachResumeConfig](inputs, OutreachResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: OutreachSourceConfig,
+        resumable_source_manager: ResumableSourceManager[OutreachResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return outreach_source(
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+            refresh_token=config.refresh_token,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/tests/test_outreach.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/tests/test_outreach.py
@@ -1,0 +1,380 @@
+from datetime import UTC, date, datetime
+from typing import Any, Optional
+
+import pytest
+from unittest import mock
+
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.outreach import (
+    OutreachResumeConfig,
+    OutreachRetryableError,
+    _flatten_item,
+    _format_datetime,
+    _get_session,
+    get_rows,
+    outreach_source,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.settings import (
+    ENDPOINTS,
+    OUTREACH_ENDPOINTS,
+)
+
+_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.outreach.outreach"
+
+
+class FakeResumeManager(ResumableSourceManager[OutreachResumeConfig]):
+    def __init__(self, state: Optional[OutreachResumeConfig] = None) -> None:
+        self.state = state
+        self.saved: list[OutreachResumeConfig] = []
+        self.cleared = False
+
+    def can_resume(self) -> bool:
+        return self.state is not None
+
+    def load_state(self) -> Optional[OutreachResumeConfig]:
+        return self.state
+
+    def save_state(self, data: OutreachResumeConfig) -> None:
+        self.saved.append(data)
+
+    def clear_state(self) -> None:
+        self.cleared = True
+
+
+def _token_response() -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.json.return_value = {"access_token": "the-token", "expires_in": 7200}
+    resp.status_code = 200
+    resp.ok = True
+    return resp
+
+
+def _json_response(body: Any, status_code: int = 200) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.json.return_value = body
+    resp.status_code = status_code
+    resp.ok = status_code < 400
+    resp.text = str(body)
+    return resp
+
+
+class TestFormatDatetime:
+    @parameterized.expand(
+        [
+            ("utc_datetime", datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC), "2026-03-04T02:58:14.000Z"),
+            (
+                "datetime_with_microseconds",
+                datetime(2026, 1, 15, 10, 30, 45, 123456, tzinfo=UTC),
+                "2026-01-15T10:30:45.123Z",
+            ),
+            ("naive_datetime", datetime(2026, 3, 4, 2, 58, 14), "2026-03-04T02:58:14.000Z"),
+            ("date_value", date(2026, 3, 4), "2026-03-04T00:00:00.000Z"),
+            ("string_passthrough", "some-cursor-value", "some-cursor-value"),
+        ]
+    )
+    def test_format_datetime(self, _name: str, value: object, expected: str) -> None:
+        assert _format_datetime(value) == expected
+
+    def test_no_plus_zero_offset_in_output(self) -> None:
+        assert "+00:00" not in _format_datetime(datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC))
+
+
+class TestFlattenItem:
+    def test_attributes_are_merged_into_the_root(self) -> None:
+        item = {
+            "type": "prospect",
+            "id": 1,
+            "attributes": {"firstName": "Sally", "updatedAt": "2026-01-01T00:00:00.000Z"},
+        }
+
+        row = _flatten_item(item)
+
+        assert row["id"] == 1
+        assert row["firstName"] == "Sally"
+        assert row["updatedAt"] == "2026-01-01T00:00:00.000Z"
+        assert "attributes" not in row
+
+    def test_to_one_relationship_becomes_an_id_column(self) -> None:
+        item = {
+            "id": 1,
+            "attributes": {},
+            "relationships": {"account": {"data": {"type": "account", "id": 42}}},
+        }
+
+        row = _flatten_item(item)
+
+        assert row["accountId"] == 42
+        assert "relationships" not in row
+
+    def test_to_many_relationship_is_dropped(self) -> None:
+        item = {
+            "id": 1,
+            "attributes": {},
+            "relationships": {"calls": {"data": [{"type": "call", "id": 1}, {"type": "call", "id": 2}]}},
+        }
+
+        row = _flatten_item(item)
+
+        assert "callsId" not in row
+        assert "calls" not in row
+
+    def test_relationship_with_no_data_is_skipped(self) -> None:
+        item = {"id": 1, "attributes": {}, "relationships": {"owner": {"data": None}}}
+
+        row = _flatten_item(item)
+
+        assert "ownerId" not in row
+
+    def test_links_are_dropped(self) -> None:
+        item = {"id": 1, "attributes": {}, "links": {"self": "https://api.outreach.io/api/v2/prospects/1"}}
+
+        row = _flatten_item(item)
+
+        assert "links" not in row
+
+
+class TestSession:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_session_opts_out_of_body_capture_and_redacts_secrets(self, mock_session: mock.MagicMock) -> None:
+        # Outreach rows are CRM records (names, emails, employers, mailing bodies, custom
+        # attributes) that the name-based scrubbers can't reliably redact, so raw bodies must
+        # never reach the shared HTTP sample store.
+        _get_session("sec", "rt")
+
+        assert mock_session.call_args.kwargs["capture"] is False
+        assert mock_session.call_args.kwargs["redact_values"] == ("sec", "rt")
+
+
+class TestValidateCredentials:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_valid_when_token_mints_and_probe_succeeds(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({"data": []})
+
+        assert validate_credentials("cid", "sec", "rt") is True
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_valid_when_probe_is_forbidden_but_token_is_genuine(self, mock_session: mock.MagicMock) -> None:
+        # A 403 still proves the refresh token works; the app may just lack the users scope.
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({}, status_code=403)
+
+        assert validate_credentials("cid", "sec", "rt") is True
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_invalid_when_token_mint_fails(self, mock_session: mock.MagicMock) -> None:
+        resp = mock.MagicMock()
+        resp.raise_for_status.side_effect = requests.HTTPError("400 Client Error", response=mock.MagicMock())
+        mock_session.return_value.post.return_value = resp
+
+        assert validate_credentials("cid", "sec", "rt") is False
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_invalid_when_probe_errors(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({}, status_code=500)
+
+        assert validate_credentials("cid", "sec", "rt") is False
+
+
+class TestGetRows:
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_single_page_yields_flattened_rows(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response(
+            {"data": [{"id": 1, "attributes": {"firstName": "Sally"}}], "links": {}}
+        )
+
+        batches = list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+        assert batches == [[{"id": 1, "firstName": "Sally"}]]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_follows_links_next_across_pages_and_saves_state(self, mock_session: mock.MagicMock) -> None:
+        page1 = _json_response(
+            {
+                "data": [{"id": 1, "attributes": {}}],
+                "links": {"next": "https://api.outreach.io/api/v2/prospects?page[after]=abc"},
+            }
+        )
+        page2 = _json_response({"data": [{"id": 2, "attributes": {}}], "links": {}})
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.side_effect = [page1, page2]
+        manager = FakeResumeManager()
+
+        batches = list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), manager))
+
+        assert [item for batch in batches for item in batch] == [{"id": 1}, {"id": 2}]
+        assert manager.saved == [
+            OutreachResumeConfig(next_url="https://api.outreach.io/api/v2/prospects?page[after]=abc")
+        ]
+        assert manager.cleared is True
+        # Only the first request carries explicit params; the second follows links.next verbatim.
+        second_call = mock_session.return_value.get.call_args_list[1]
+        assert second_call.args[0] == "https://api.outreach.io/api/v2/prospects?page[after]=abc"
+        assert second_call.kwargs["params"] is None
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_resumes_from_saved_next_url(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response(
+            {"data": [{"id": 9, "attributes": {}}], "links": {}}
+        )
+        manager = FakeResumeManager(
+            state=OutreachResumeConfig(next_url="https://api.outreach.io/api/v2/prospects?page[after]=resume")
+        )
+
+        list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), manager))
+
+        first_call = mock_session.return_value.get.call_args_list[0]
+        assert first_call.args[0] == "https://api.outreach.io/api/v2/prospects?page[after]=resume"
+        assert first_call.kwargs["params"] is None
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_off_origin_links_next_is_refused_and_not_saved(self, mock_session: mock.MagicMock) -> None:
+        # Following it would send the Authorization header to a host that isn't Outreach.
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response(
+            {"data": [{"id": 1, "attributes": {}}], "links": {"next": "https://evil.example.com/api/v2/prospects"}}
+        )
+        manager = FakeResumeManager()
+
+        with pytest.raises(ValueError, match="off-origin"):
+            list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), manager))
+
+        assert manager.saved == []
+        assert mock_session.return_value.get.call_count == 1
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_off_origin_resume_url_is_refused_before_any_request(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        manager = FakeResumeManager(
+            state=OutreachResumeConfig(next_url="https://api.outreach.io@evil.example.com/api/v2/prospects")
+        )
+
+        with pytest.raises(ValueError, match="off-origin"):
+            list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), manager))
+
+        assert mock_session.return_value.get.call_count == 0
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_plaintext_downgrade_of_the_api_host_is_refused(self, mock_session: mock.MagicMock) -> None:
+        # Same host, but http:// would put the bearer token on the wire in the clear.
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response(
+            {"data": [], "links": {"next": "http://api.outreach.io/api/v2/prospects?page[after]=abc"}}
+        )
+
+        with pytest.raises(ValueError, match="off-origin"):
+            list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_incremental_request_carries_the_updated_at_filter(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({"data": [], "links": {}})
+
+        list(
+            get_rows(
+                "cid",
+                "sec",
+                "rt",
+                "prospects",
+                mock.MagicMock(),
+                FakeResumeManager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=datetime(2026, 3, 4, tzinfo=UTC),
+            )
+        )
+
+        params = mock_session.return_value.get.call_args_list[0].kwargs["params"]
+        assert params["newFilterSyntax"] == "true"
+        assert params["filter[updatedAt][gte]"] == "2026-03-04T00:00:00.000Z"
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_full_refresh_request_has_no_filter_params(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({"data": [], "links": {}})
+
+        list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+        params = mock_session.return_value.get.call_args_list[0].kwargs["params"]
+        assert "newFilterSyntax" not in params
+        assert "filter[updatedAt][gte]" not in params
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_remints_token_on_401(self, mock_session: mock.MagicMock) -> None:
+        expired = _json_response({}, status_code=401)
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.side_effect = [
+            expired,
+            _json_response({"data": [{"id": 1, "attributes": {}}], "links": {}}),
+        ]
+
+        batches = list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+        assert batches == [[{"id": 1}]]
+        # One mint at start + one re-mint after the 401.
+        assert mock_session.return_value.post.call_count == 2
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_transient_error_is_retried_then_succeeds(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.side_effect = [
+            requests.ConnectionError("connection reset"),
+            _json_response({"data": [{"id": 1, "attributes": {}}], "links": {}}),
+        ]
+
+        with mock.patch("time.sleep", return_value=None):
+            batches = list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+        assert batches == [[{"id": 1}]]
+        assert mock_session.return_value.get.call_count == 2
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_retryable_status_is_retried_and_eventually_raises(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({}, status_code=503)
+
+        with mock.patch("time.sleep", return_value=None):
+            with pytest.raises(OutreachRetryableError):
+                list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+        assert mock_session.return_value.get.call_count == 5  # MAX_RETRY_ATTEMPTS
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_non_retryable_status_raises_immediately(self, mock_session: mock.MagicMock) -> None:
+        forbidden = _json_response({}, status_code=403)
+        forbidden.raise_for_status.side_effect = requests.HTTPError("403 Client Error", response=mock.MagicMock())
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = forbidden
+
+        with pytest.raises(requests.HTTPError):
+            list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager()))
+
+        # A 403 is a permission problem, not a transient one, so it isn't retried.
+        assert mock_session.return_value.get.call_count == 1
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_no_items_yields_nothing(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.post.return_value = _token_response()
+        mock_session.return_value.get.return_value = _json_response({"data": [], "links": {}})
+
+        assert list(get_rows("cid", "sec", "rt", "prospects", mock.MagicMock(), FakeResumeManager())) == []
+
+
+class TestOutreachSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_metadata_per_endpoint(self, endpoint: str) -> None:
+        config = OUTREACH_ENDPOINTS[endpoint]
+        response = outreach_source("cid", "sec", "rt", endpoint, mock.MagicMock(), FakeResumeManager())
+
+        assert response.name == endpoint
+        assert response.primary_keys == [config.primary_key]
+        assert response.sort_mode == "asc"
+        assert response.partition_mode == "datetime"
+        assert response.partition_format == "month"
+        assert response.partition_keys == [config.partition_key]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/tests/test_outreach_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/outreach/tests/test_outreach_source.py
@@ -1,0 +1,199 @@
+from typing import Any, Optional
+
+import pytest
+from unittest import mock
+
+from posthog.schema import (
+    DataWarehouseSourceCategory,
+    ReleaseStatus,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+)
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.outreach import (
+    OutreachSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.outreach import OutreachResumeConfig
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.outreach.source import OutreachSource
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+VALIDATE_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.outreach.source.validate_outreach_credentials"
+)
+SOURCE_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.outreach.source.outreach_source"
+
+
+def _make_inputs(schema_name: str = "prospects", **overrides: Any) -> mock.MagicMock:
+    defaults: dict[str, Any] = {
+        "schema_name": schema_name,
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "team_id": 1,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-1",
+        "logger": mock.MagicMock(),
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return mock.MagicMock(**defaults)
+
+
+class TestOutreachSource:
+    def setup_method(self) -> None:
+        self.source = OutreachSource()
+        self.team_id = 123
+        self.config = OutreachSourceConfig(client_id="client-id", client_secret="client-secret", refresh_token="rt")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.OUTREACH
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+
+        assert config.name.value == "Outreach"
+        assert config.label == "Outreach"
+        assert config.category == DataWarehouseSourceCategory.SALES
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        # Held back from the catalog until a PostHog-owned Outreach credential exists; a pasted
+        # refresh token cannot survive Outreach's rotation.
+        assert config.unreleasedSource is True
+        assert config.iconPath == "/static/services/outreach.png"
+
+    @pytest.mark.parametrize(
+        "name,required,secret",
+        [
+            ("client_id", True, False),
+            ("client_secret", True, True),
+            ("refresh_token", True, True),
+        ],
+    )
+    def test_source_fields(self, name: str, required: bool, secret: bool) -> None:
+        fields = {
+            field.name: field
+            for field in self.source.get_source_config.fields
+            if isinstance(field, SourceFieldInputConfig)
+        }
+
+        assert len(fields) == 3
+        assert fields[name].required is required
+        assert bool(fields[name].secret) is secret
+
+    def test_secret_fields_use_password_input_type(self) -> None:
+        fields = {
+            field.name: field
+            for field in self.source.get_source_config.fields
+            if isinstance(field, SourceFieldInputConfig)
+        }
+
+        assert fields["client_secret"].type == SourceFieldInputConfigType.PASSWORD
+        assert fields["refresh_token"].type == SourceFieldInputConfigType.PASSWORD
+        assert fields["client_id"].type == SourceFieldInputConfigType.TEXT
+
+    def test_api_docs_url_and_public_table_listing(self) -> None:
+        assert self.source.api_docs_url is not None
+        assert self.source.api_docs_url.startswith("https://")
+        # get_schemas iterates a static catalog with no I/O, so the docs can render the tables.
+        assert self.source.lists_tables_without_credentials is True
+
+    def test_get_schemas_returns_the_whole_endpoint_catalog(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+
+        assert sorted(schema.name for schema in schemas) == sorted(ENDPOINTS)
+
+    def test_get_schemas_filters_by_name(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["prospects", "accounts"])
+
+        assert sorted(schema.name for schema in schemas) == ["accounts", "prospects"]
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_every_endpoint_supports_the_updatedat_incremental_filter(self, endpoint: str) -> None:
+        schema = next(s for s in self.source.get_schemas(self.config, self.team_id) if s.name == endpoint)
+
+        assert schema.supports_incremental is True
+        assert [field["field"] for field in schema.incremental_fields] == ["updatedAt"]
+
+    @pytest.mark.parametrize(
+        "probe_result,expected",
+        [
+            (True, (True, None)),
+            (False, (False, "Invalid Outreach credentials")),
+        ],
+    )
+    def test_validate_credentials_passes_the_probe_result_through(
+        self, probe_result: bool, expected: tuple[bool, Optional[str]]
+    ) -> None:
+        with mock.patch(VALIDATE_PATCH, return_value=probe_result) as probe:
+            assert self.source.validate_credentials(self.config, self.team_id) == expected
+
+        probe.assert_called_once_with("client-id", "client-secret", "rt")
+
+    def test_get_resumable_source_manager_is_bound_to_the_outreach_cursor(self) -> None:
+        manager = self.source.get_resumable_source_manager(_make_inputs())
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is OutreachResumeConfig
+
+    def test_source_for_pipeline_plumbs_config_and_inputs(self) -> None:
+        inputs = _make_inputs(
+            schema_name="sequenceStates",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value="2024-05-01T00:00:00Z",
+        )
+        manager = mock.MagicMock()
+
+        with mock.patch(SOURCE_PATCH) as outreach_source:
+            self.source.source_for_pipeline(self.config, manager, inputs)
+
+        kwargs = outreach_source.call_args.kwargs
+        assert kwargs["client_id"] == "client-id"
+        assert kwargs["client_secret"] == "client-secret"
+        assert kwargs["refresh_token"] == "rt"
+        assert kwargs["endpoint"] == "sequenceStates"
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["db_incremental_field_last_value"] == "2024-05-01T00:00:00Z"
+        assert kwargs["resumable_source_manager"] is manager
+
+    def test_source_for_pipeline_drops_a_stale_watermark_on_a_full_refresh(self) -> None:
+        inputs = _make_inputs(
+            should_use_incremental_field=False,
+            db_incremental_field_last_value="2024-05-01T00:00:00Z",
+        )
+
+        with mock.patch(SOURCE_PATCH) as outreach_source:
+            self.source.source_for_pipeline(self.config, mock.MagicMock(), inputs)
+
+        assert outreach_source.call_args.kwargs["db_incremental_field_last_value"] is None
+
+    def test_canonical_descriptions_are_keyed_by_endpoint_name(self) -> None:
+        descriptions = self.source.get_canonical_descriptions()
+
+        assert set(descriptions) == set(ENDPOINTS)
+        assert all(entry.get("description") for entry in descriptions.values())
+
+    @pytest.mark.parametrize(
+        "error_key",
+        [
+            "400 Client Error: Bad Request for url: https://api.outreach.io/oauth/token",
+            "401 Client Error: Unauthorized for url: https://api.outreach.io/oauth/token",
+        ],
+    )
+    def test_permanent_token_failures_disable_the_source_instead_of_retrying(self, error_key: str) -> None:
+        errors = self.source.get_non_retryable_errors()
+
+        assert errors[error_key]
+
+    def test_a_401_on_the_api_host_is_not_treated_as_permanent(self) -> None:
+        # Mid-sync 401s on the API host (not the token endpoint) are handled by token re-mint.
+        # The keys are substring patterns, matched against the raised message by the runtime
+        # (see `error_message_matches`), so match the message against them rather than looking
+        # the message up as a dict key - a key lookup would pass for any prefix pattern too.
+        error_msg = "401 Client Error: Unauthorized for url: https://api.outreach.io/api/v2/prospects"
+        errors = self.source.get_non_retryable_errors()
+
+        assert not any(pattern in error_msg for pattern in errors)


### PR DESCRIPTION
## Problem

Nobody can connect the Outreach source with credentials pasted into the form, so it must stay out of the source catalog.

- Outreach issues a new refresh token on every token exchange and invalidates the previous one.
- Refresh tokens expire after 14 days.
- A token typed into a form field cannot be written back, so it stops working after the first exchange.
- Each schema syncs in its own Temporal workflow, so parallel syncs race to spend the same token.

Outreach was also a scaffolded source with no sync logic. This PR adds that logic, dormant until a workable credential exists.

## Changes

- The source stays out of the catalog behind `unreleasedSource=True`.
- Add an Outreach source under `products/warehouse_sources/backend/temporal/data_imports/sources/outreach/`.
- Sync prospects, accounts, sequences, sequence states, mailings, calls, users, and stages.
- Outreach returns JSON:API envelopes. The source flattens `attributes` into columns and keeps `id`.
- Pagination follows the opaque `links.next` cursor rather than `page[offset]`.
- Outreach deprecated the offset mode and caps it at 10,000 rows, which would silently truncate large tables.
- Incremental sync filters on `filter[updatedAt][gte]` and sorts by `updatedAt` ascending.
- Every incremental request sends `newFilterSyntax=true`, which Outreach requires for bracket filter operators.
- Move `outreach` from the scaffolded list to the implemented table in `SOURCES.md`.

> [!NOTE]
> Two credentials could unblock the source. Both need a PostHog Outreach developer account.
>
> - A registered OAuth app puts the rotating token on an `Integration` row, which already persists rotations.
> - Outreach issues production OAuth credentials only after its app review. Development credentials make users outside the owning org reauthorize weekly.
> - [Server-to-server tokens](https://developers.outreach.io/api/s2s-access) drop refresh tokens entirely. A JWT app token mints a one-hour access token.
> - The server-to-server read scopes cover every resource this source syncs.

## How did you test this code?

- Tests mock the HTTP transport and cover cursor pagination, JSON:API flattening, incremental filter params, token refresh, and credential validation.
- One test asserts the source stays out of the catalog, so a later edit cannot expose it by accident.
- Nothing ran against a live Outreach account.
- The rotation behavior above comes from [Outreach's OAuth docs](https://developers.outreach.io/api/oauth), not from an observed failure.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The source docs page cannot describe a connect flow yet, so it waits on the credential decision.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote the source, and in a later session added the catalog gate. Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.

The later session began as a review of which open source PRs need a vendor OAuth app. Reading Outreach's token documentation during that review surfaced the rotation problem, which moved this PR from ready to merge to on hold. An OAuth conversion was drafted and then reverted: Outreach returns no user identity from its token endpoint and publishes no current-user endpoint, so the integration id would have been a guess.

Nothing in this PR carries material from the session that is not already public.
