### PR TITLE
fix(cdp): give the hobby and dev-full stacks a valkey to dual-write to

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -176,6 +176,20 @@ services:
             timeout: 10s
             retries: 10
 
+    # Shadow store the CDP services dual-write to alongside redis7. Plain mode, unlike the
+    # dev stack's cluster-enabled valkey-cluster: reproducing the CROSSSLOT rejection of a
+    # cluster only earns its complexity where CDP changes get tested. Mirror data is
+    # disposable, so there's no volume and eviction under the cap is fine.
+    valkey:
+        image: valkey/valkey:8.1-alpine
+        restart: on-failure
+        command: valkey-server --maxmemory-policy allkeys-lru --maxmemory 200mb
+        healthcheck:
+            test: ['CMD', 'valkey-cli', 'ping']
+            interval: 3s
+            timeout: 10s
+            retries: 10
+
     clickhouse:
         image: ${CLICKHOUSE_SERVER_IMAGE:-clickhouse/clickhouse-server:26.6.2.158}
         restart: on-failure

--- a/docker-compose.dev-full.yml
+++ b/docker-compose.dev-full.yml
@@ -37,6 +37,11 @@ services:
         ports:
             - '6379:6379'
 
+    valkey:
+        extends:
+            file: docker-compose.base.yml
+            service: valkey
+
     clickhouse:
         extends:
             file: docker-compose.base.yml
@@ -192,9 +197,13 @@ services:
             - .:/app/posthog
         environment:
             - DOCKER=1
+            # Every CDP process dual-writes to Valkey and refuses to start without a host.
+            - CDP_VALKEY_HOST=valkey
+            - CDP_VALKEY_PORT=6379
         depends_on:
             - db
             - redis7
+            - valkey
             - clickhouse
             - kafka
             - objectstorage

--- a/docker-compose.hobby.yml
+++ b/docker-compose.hobby.yml
@@ -32,6 +32,12 @@ services:
         volumes:
             - redis7-data:/data
 
+    valkey:
+        extends:
+            file: docker-compose.base.yml
+            service: valkey
+        logging: *default-logging
+
     clickhouse:
         extends:
             file: docker-compose.base.yml
@@ -199,6 +205,9 @@ services:
             OBJECT_STORAGE_ENABLED: true
             CDP_REDIS_HOST: redis7
             CDP_REDIS_PORT: 6379
+            # Every CDP process dual-writes to Valkey and refuses to start without a host.
+            CDP_VALKEY_HOST: valkey
+            CDP_VALKEY_PORT: 6379
             ENCRYPTION_SALT_KEYS: $ENCRYPTION_SALT_KEYS
             CYCLOTRON_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
             PERSONS_DATABASE_URL: 'postgres://posthog:posthog@db:5432/posthog'
@@ -209,6 +218,7 @@ services:
         depends_on:
             - db
             - redis7
+            - valkey
             - clickhouse
             - kafka
             - objectstorage


### PR DESCRIPTION
## Problem

A self-hosted (hobby) install would lose all CDP destinations and workflows the moment [#78250](https://github.com/PostHog/posthog/pull/78250) ships: the `plugins` container fails at startup instead of running.

- That PR makes `CDP_VALKEY_HOST` required, and a CDP process without it throws.
- The hobby `plugins` service runs with no `PLUGIN_SERVER_MODE`, which resolves to `CAPABILITIES_CDP_WORKFLOWS`, so it builds the CDP core services.
- Neither `docker-compose.hobby.yml` nor `docker-compose.dev-full.yml` sets that host, and neither stack runs a Valkey. `docker-compose.dev.yml` already does.

`dev-full` backs the hogbox preview tool, so it breaks the same way.

## Changes

- Adds a `valkey` service to `docker-compose.base.yml` and points both stacks' `plugins` service at it.
- Uses plain Valkey, not the cluster-enabled `valkey-cluster` of the dev stack. Cluster mode exists there to reproduce ElastiCache's CROSSSLOT rejection, which only earns its complexity where CDP changes get tested. Plain mode accepts everything cluster mode accepts, so it cannot fail where cloud would pass.
- Caps memory at 200mb with `allkeys-lru` and mounts no volume. Mirror data is disposable.

I rejected pointing `CDP_VALKEY_HOST` at the existing `redis7`. The mirror writes the same keys as the primary, so the HogWatcher token buckets would be deducted twice on one instance.

This is inert against `master`: without `CDP_VALKEY_DUAL_ENABLED` the factory still returns null and nothing mirrors. It can land before #78250 and should, so that PR does not break self-hosted on the way in.

## How did you test this code?

No new tests. The change is compose configuration, and nothing in CI runs the hobby stack.

- `docker compose -f docker-compose.hobby.yml config` resolves `CDP_VALKEY_HOST: valkey` on `plugins` with `valkey` in `depends_on`. Same for `dev-full`.
- I started the hobby `valkey` service on its own. It reached healthy, served `set`/`get`, and reported the 200mb cap and `allkeys-lru` policy.
- `docker compose -f docker-compose.dev.yml config` still shows only `valkey-cluster`, so the new service does not leak into the dev stack.
- Not run: the full hobby stack end to end, and the `plugins` container against #78250's code. That needs a `posthog-node` image built from that branch, which I did not build. The reasoning above is from the capability resolution in `nodejs/src/capabilities.ts` and the factory in `nodejs/src/cdp/cdp-services.ts`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No file under `docs/` names the CDP Valkey configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Code, Opus 5) found this while validating that the Helm charts set `CDP_VALKEY_HOST` on every CDP deployment for #78250. The charts are complete: all 22 CDP ApplicationSets inherit the `valkey.cdp` block from `shared/cdp/common.yaml`, and I rendered every app across dev, prod-us and prod-eu to confirm. The compose stacks were the only gap, and `dev-full` turned up while checking whether anything else extends the base `plugins` service.

Skills invoked: `/writing-pr-descriptions`, `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
