### PR TITLE
fix(experiments): include retention metrics in daily timeseries recalc

### DIFF
--- a/posthog/management/commands/populate_experiment_timeseries.py
+++ b/posthog/management/commands/populate_experiment_timeseries.py
@@ -1,15 +1,15 @@
 import traceback
 from datetime import date, datetime, timedelta
-from typing import Union
 from zoneinfo import ZoneInfo
 
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
+from posthog.schema import ExperimentQuery
 
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
 from products.experiments.backend.models.experiment import Experiment, ExperimentMetricResult
+from products.experiments.backend.temporal.metric_resolution import METRIC_BUILDERS, build_metric
 
 
 class Command(BaseCommand):
@@ -64,15 +64,9 @@ class Command(BaseCommand):
             raise ValueError(f"Metric {metric_uuid} not found in experiment {experiment_id}")
 
         metric_type = metric.get("metric_type")
-        metric_obj: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
-        if metric_type == "mean":
-            metric_obj = ExperimentMeanMetric(**metric)
-        elif metric_type == "funnel":
-            metric_obj = ExperimentFunnelMetric(**metric)
-        elif metric_type == "ratio":
-            metric_obj = ExperimentRatioMetric(**metric)
-        else:
+        if metric_type not in METRIC_BUILDERS:
             raise ValueError(f"Unknown metric type: {metric_type}")
+        metric_obj = build_metric(metric)
 
         # Determine project timezone for display purposes
         project_tz = ZoneInfo(experiment.team.timezone) if experiment.team.timezone else ZoneInfo("UTC")

--- a/posthog/management/commands/populate_experiment_timeseries.py
+++ b/posthog/management/commands/populate_experiment_timeseries.py
@@ -7,9 +7,9 @@ from django.utils import timezone
 
 from posthog.schema import ExperimentQuery
 
+from products.experiments.backend.facade.timeseries import METRIC_BUILDERS, build_metric
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
 from products.experiments.backend.models.experiment import Experiment, ExperimentMetricResult
-from products.experiments.backend.temporal.metric_resolution import METRIC_BUILDERS, build_metric
 
 
 class Command(BaseCommand):

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Union
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from django.db import close_old_connections
@@ -8,7 +8,7 @@ from django.db.models import Q
 import structlog
 import temporalio.activity
 
-from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentQuery, ExperimentRatioMetric
+from posthog.schema import ExperimentQuery
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import tag_queries
@@ -34,6 +34,7 @@ from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricResult as ExperimentMetricResultModel,
 )
+from products.experiments.backend.temporal.metric_resolution import METRIC_BUILDERS, build_metric
 from products.experiments.stats.shared.statistics import StatisticError
 
 logger = structlog.get_logger(__name__)
@@ -155,14 +156,7 @@ def _calculate_experiment_regular_metric_sync(
         )
 
     metric_type = metric_dict.get("metric_type")
-    metric_obj: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
-    if metric_type == "mean":
-        metric_obj = ExperimentMeanMetric(**metric_dict)
-    elif metric_type == "funnel":
-        metric_obj = ExperimentFunnelMetric(**metric_dict)
-    elif metric_type == "ratio":
-        metric_obj = ExperimentRatioMetric(**metric_dict)
-    else:
+    if metric_type not in METRIC_BUILDERS:
         return ExperimentRegularMetricResult(
             experiment_id=experiment_id,
             metric_uuid=metric_uuid,
@@ -170,6 +164,7 @@ def _calculate_experiment_regular_metric_sync(
             success=False,
             error_message=f"Unknown metric type: {metric_type}",
         )
+    metric_obj = build_metric(metric_dict)
 
     if not experiment.start_date:
         return ExperimentRegularMetricResult(
@@ -460,14 +455,7 @@ def _calculate_experiment_saved_metric_sync(
         "fingerprint": fingerprint,
     }
     metric_type = query.get("metric_type")
-    metric_obj: Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]
-    if metric_type == "mean":
-        metric_obj = ExperimentMeanMetric(**query)
-    elif metric_type == "funnel":
-        metric_obj = ExperimentFunnelMetric(**query)
-    elif metric_type == "ratio":
-        metric_obj = ExperimentRatioMetric(**query)
-    else:
+    if metric_type not in METRIC_BUILDERS:
         return ExperimentSavedMetricResult(
             experiment_id=experiment_id,
             metric_uuid=metric_uuid,
@@ -475,6 +463,7 @@ def _calculate_experiment_saved_metric_sync(
             success=False,
             error_message=f"Unknown metric type: {metric_type}",
         )
+    metric_obj = build_metric(query)
 
     if not experiment.start_date:
         return ExperimentSavedMetricResult(

--- a/posthog/temporal/experiments/activities.py
+++ b/posthog/temporal/experiments/activities.py
@@ -24,7 +24,7 @@ from posthog.temporal.experiments.models import (
 )
 from posthog.temporal.experiments.utils import DEFAULT_EXPERIMENT_RECALCULATION_HOUR, check_significance_transition
 
-from products.experiments.backend.facade.timeseries import backfill_experiment_timeseries
+from products.experiments.backend.facade.timeseries import METRIC_BUILDERS, backfill_experiment_timeseries, build_metric
 from products.experiments.backend.hogql_queries.base_query_utils import experiment_window_end
 from products.experiments.backend.hogql_queries.error_handling import capture_experiment_metric_error_event
 from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
@@ -34,7 +34,6 @@ from products.experiments.backend.models.experiment import (
     Experiment,
     ExperimentMetricResult as ExperimentMetricResultModel,
 )
-from products.experiments.backend.temporal.metric_resolution import METRIC_BUILDERS, build_metric
 from products.experiments.stats.shared.statistics import StatisticError
 
 logger = structlog.get_logger(__name__)

--- a/posthog/temporal/experiments/test_cache_warming.py
+++ b/posthog/temporal/experiments/test_cache_warming.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import datetime
 from uuid import uuid4
 
@@ -8,13 +9,24 @@ from unittest.mock import patch
 from django.core.cache import cache
 from django.test import override_settings
 
-from posthog.schema import CachedExperimentQueryResponse, EventsNode, ExperimentMeanMetric, ExperimentQuery
+from parameterized import parameterized
+
+from posthog.schema import (
+    CachedExperimentQueryResponse,
+    EventsNode,
+    ExperimentMeanMetric,
+    ExperimentQuery,
+    ExperimentRetentionMetric,
+    FunnelConversionWindowTimeUnit,
+    StartHandling,
+)
 
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.temporal.experiments.activities import (
     _calculate_experiment_regular_metric_sync,
     _calculate_experiment_saved_metric_sync,
 )
+from posthog.temporal.experiments.models import ExperimentRegularMetricResult, ExperimentSavedMetricResult
 
 from products.experiments.backend.hogql_queries.experiment_metric_fingerprint import compute_metric_fingerprint
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
@@ -98,6 +110,60 @@ class TestTemporalRecalcWarmsResponseCache(ExperimentQueryRunnerBaseTest):
         assert mock_runner_class.call_args.kwargs["as_of"] == expected_query_to
         result_row = ExperimentMetricResult.objects.get(experiment=experiment, metric_uuid=metric_dict["uuid"])
         assert result_row.query_to == expected_query_to
+
+    # The regular and saved dispatches are separate code paths; each must accept every
+    # ExperimentMetric type, or the daily recalculation silently stores no timeseries row for it.
+    @parameterized.expand(["regular", "saved"])
+    @freeze_time("2020-01-10T12:00:00Z")
+    def test_recalc_activity_supports_retention_metrics(self, metric_kind: str):
+        feature_flag = self.create_feature_flag()
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2020, 1, 1, 0, 0, 0),
+            end_date=datetime(2020, 1, 5, 0, 0, 0),
+        )
+        metric = ExperimentRetentionMetric(
+            uuid=str(uuid4()),
+            start_event=EventsNode(event="signup"),
+            completion_event=EventsNode(event="purchase"),
+            retention_window_start=1,
+            retention_window_end=7,
+            retention_window_unit=FunnelConversionWindowTimeUnit.DAY,
+            start_handling=StartHandling.FIRST_SEEN,
+        )
+        metric_dict = metric.model_dump(mode="json")
+
+        calculate: Callable[..., ExperimentRegularMetricResult | ExperimentSavedMetricResult]
+        if metric_kind == "regular":
+            experiment.metrics = [metric_dict]
+            experiment.save()
+            calculate = _calculate_experiment_regular_metric_sync.func  # type: ignore[attr-defined]
+        else:
+            saved_metric = ExperimentSavedMetric.objects.create(
+                name="retention saved metric",
+                team=self.team,
+                query=metric_dict,
+                created_by=self.user,
+            )
+            ExperimentToSavedMetric.objects.create(
+                experiment=experiment,
+                saved_metric=saved_metric,
+                metadata={"type": "primary"},
+            )
+            calculate = _calculate_experiment_saved_metric_sync.func  # type: ignore[attr-defined]
+
+        with (
+            patch("posthog.temporal.experiments.activities.close_old_connections"),
+            patch("posthog.temporal.experiments.activities.ExperimentQueryRunner") as mock_runner_class,
+        ):
+            mock_runner_class.return_value.run.return_value.model_dump.return_value = {"variant_results": []}
+
+            activity_result = calculate(experiment.id, metric_dict["uuid"], "fingerprint")
+
+        self.assertTrue(activity_result.success, msg=activity_result.error_message)
+        built_metric = mock_runner_class.call_args.kwargs["query"].metric
+        assert isinstance(built_metric, ExperimentRetentionMetric)
+        assert ExperimentMetricResult.objects.filter(experiment=experiment, metric_uuid=metric_dict["uuid"]).exists()
 
     @freeze_time("2020-01-10T12:00:00Z")
     def test_temporal_activity_warms_query_cache(self):

--- a/posthog/temporal/experiments/utils.py
+++ b/posthog/temporal/experiments/utils.py
@@ -1,9 +1,6 @@
 from datetime import datetime
-from typing import Union
 
 import structlog
-
-from posthog.schema import ExperimentFunnelMetric, ExperimentMeanMetric, ExperimentRatioMetric
 
 from posthog.cdp.internal_events import InternalEventEvent, produce_internal_event
 
@@ -16,18 +13,6 @@ logger = structlog.get_logger(__name__)
 
 # Default hour (UTC) for experiment recalculation when team has no specific time set
 DEFAULT_EXPERIMENT_RECALCULATION_HOUR = 2  # 02:00 UTC
-
-
-def get_metric(metric_data: dict) -> Union[ExperimentMeanMetric, ExperimentFunnelMetric, ExperimentRatioMetric]:
-    metric_type = metric_data.get("metric_type")
-    if metric_type == "mean":
-        return ExperimentMeanMetric(**metric_data)
-    elif metric_type == "funnel":
-        return ExperimentFunnelMetric(**metric_data)
-    elif metric_type == "ratio":
-        return ExperimentRatioMetric(**metric_data)
-    else:
-        raise ValueError(f"Unknown metric type: {metric_type}")
 
 
 def _get_significant_variant_keys(result_dict: dict) -> set[str]:

--- a/products/experiments/backend/facade/timeseries.py
+++ b/products/experiments/backend/facade/timeseries.py
@@ -1,5 +1,6 @@
 """Timeseries backfill capability, re-exported for callers outside the experiments product."""
 
+from products.experiments.backend.temporal.metric_resolution import METRIC_BUILDERS, build_metric
 from products.experiments.backend.timeseries_backfill import backfill_experiment_timeseries
 
-__all__ = ["backfill_experiment_timeseries"]
+__all__ = ["METRIC_BUILDERS", "backfill_experiment_timeseries", "build_metric"]


### PR DESCRIPTION
## Problem

An experiment with a retention metric never gets automatic "results over time" data. The daily recalculation activities only dispatched mean, funnel, and ratio metrics, so retention metrics failed every run with "Unknown metric type: retention" and stored no timeseries row. The chart stayed empty unless someone found the manual Recalculate button, whose backfill path already supports retention.

Split out of #78614 so that PR only touches product analytics; this one carries the experiments-side fix.

## Changes

- The daily experiment recalculation activities (regular and saved metrics) and the `populate_experiment_timeseries` management command build metrics through the shared `METRIC_BUILDERS` map, which includes retention, instead of hand-rolled mean/funnel/ratio chains. Unknown metric types still fail gracefully.
- Removes the unused `get_metric` helper in `posthog/temporal/experiments/utils.py`, which carried the same gap and had no callers.

## How did you test this code?

- `pytest posthog/temporal/experiments/test_cache_warming.py`: 6/6 pass locally (run on the pre-split branch #78614, whose diff for these files is byte-identical), including a new parameterized test that runs a retention metric through both the regular and saved dispatch paths. Before the fix, both paths returned "Unknown metric type: retention" and stored no result row.
- Repo-wide `mypy --cache-fine-grained .` and `ruff` passed on the pre-split branch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). The gap was found by tracing why a retention metric's timeseries stays empty and confirming the manual backfill path supports retention while the daily path rejects it.
- Split out of #78614 at the author's request, preserving the original commits.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
