### PR TITLE
fix(desktop): preserve task space in activity

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
@@ -19,6 +19,20 @@ const notificationBus = {
   ),
 } as unknown as NotificationBus;
 
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    task_number: 1,
+    slug: "channel-task",
+    title: "Channel task",
+    description: "Test task",
+    created_at: "2026-07-27T08:00:00Z",
+    updated_at: "2026-07-27T09:00:00Z",
+    origin_product: "code",
+    ...overrides,
+  };
+}
+
 describe("TaskActivityContribution", () => {
   let queryClient: QueryClient;
   let contribution: TaskActivityContribution;
@@ -77,10 +91,10 @@ describe("TaskActivityContribution", () => {
         pageParams: [undefined],
       },
     );
-    queryClient.setQueryData<Task>(taskKeys.detail("task-1"), {
-      id: "task-1",
-      channel: "channel-1",
-    } as Task);
+    queryClient.setQueryData<Task>(
+      taskKeys.detail("task-1"),
+      task({ channel: "channel-1" }),
+    );
 
     activityListener?.({
       taskId: "task-1",
@@ -125,10 +139,10 @@ describe("TaskActivityContribution", () => {
         pageParams: [undefined],
       },
     );
-    queryClient.setQueryData<Task>(taskKeys.detail("task-1"), {
-      id: "task-1",
-      channel: "stale-channel",
-    } as Task);
+    queryClient.setQueryData<Task>(
+      taskKeys.detail("task-1"),
+      task({ channel: "stale-channel" }),
+    );
 
     activityListener?.({
       taskId: "task-1",

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.test.ts
@@ -1,9 +1,10 @@
-import type { TaskActivityPage } from "@posthog/shared/domain-types";
+import type { Task, TaskActivityPage } from "@posthog/shared/domain-types";
 import { AUTH_SCOPED_QUERY_META } from "@posthog/ui/features/auth/useCurrentUser";
 import type {
   NotificationBus,
   TaskActivitySignal,
 } from "@posthog/ui/features/notifications/notifications";
+import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import { type InfiniteData, QueryClient } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskActivityContribution } from "./taskActivity.contribution";
@@ -57,11 +58,89 @@ describe("TaskActivityContribution", () => {
         {
           task_id: "task-1",
           task_title: "Channel task",
+          channel_id: null,
           activity_kind: "awaiting_input",
           is_unread: true,
         },
       ],
     });
+  });
+
+  it("uses the cached task channel for new activity", () => {
+    queryClient.setQueryDefaults(["task-activity"], {
+      meta: AUTH_SCOPED_QUERY_META,
+    });
+    queryClient.setQueryData<InfiniteData<TaskActivityPage>>(
+      ["task-activity"],
+      {
+        pages: [{ results: [], unread_count: 0 }],
+        pageParams: [undefined],
+      },
+    );
+    queryClient.setQueryData<Task>(taskKeys.detail("task-1"), {
+      id: "task-1",
+      channel: "channel-1",
+    } as Task);
+
+    activityListener?.({
+      taskId: "task-1",
+      taskTitle: "Channel task",
+      activityKind: "completed",
+      activityAt: "2026-07-27T10:00:00Z",
+    });
+
+    const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
+      "task-activity",
+    ]);
+    expect(cached?.pages[0]?.results[0]?.channel_id).toBe("channel-1");
+  });
+
+  it("preserves existing activity channel data", () => {
+    queryClient.setQueryDefaults(["task-activity"], {
+      meta: AUTH_SCOPED_QUERY_META,
+    });
+    queryClient.setQueryData<InfiniteData<TaskActivityPage>>(
+      ["task-activity"],
+      {
+        pages: [
+          {
+            results: [
+              {
+                id: "activity-1",
+                task_id: "task-1",
+                task_title: "Channel task",
+                channel_id: null,
+                channel_name: null,
+                activity_at: "2026-07-27T09:00:00Z",
+                activity_kind: "created",
+                snippet: "",
+                latest_author: null,
+                latest_message_id: null,
+                is_unread: false,
+              },
+            ],
+            unread_count: 0,
+          },
+        ],
+        pageParams: [undefined],
+      },
+    );
+    queryClient.setQueryData<Task>(taskKeys.detail("task-1"), {
+      id: "task-1",
+      channel: "stale-channel",
+    } as Task);
+
+    activityListener?.({
+      taskId: "task-1",
+      taskTitle: "Channel task",
+      activityKind: "completed",
+      activityAt: "2026-07-27T10:00:00Z",
+    });
+
+    const cached = queryClient.getQueryData<InfiniteData<TaskActivityPage>>([
+      "task-activity",
+    ]);
+    expect(cached?.pages[0]?.results[0]?.channel_id).toBeNull();
   });
 
   it("does not recreate activity data after the authenticated query is removed", () => {

--- a/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
+++ b/products/desktop/packages/ui/src/features/canvas/task-activity/taskActivity.contribution.ts
@@ -1,9 +1,10 @@
 import type { Contribution } from "@posthog/di/contribution";
-import type { TaskActivityPage } from "@posthog/shared/domain-types";
+import type { Task, TaskActivityPage } from "@posthog/shared/domain-types";
 import {
   NotificationBus,
   type TaskActivitySignal,
 } from "@posthog/ui/features/notifications/notifications";
+import { taskKeys } from "@posthog/ui/features/tasks/taskKeys";
 import {
   IMPERATIVE_QUERY_CLIENT,
   type ImperativeQueryClient,
@@ -40,11 +41,19 @@ export class TaskActivityContribution implements Contribution {
         const previous = data?.pages
           .flatMap((page) => page.results)
           .find((row) => row.task_id === signal.taskId);
+        const cachedTask =
+          this.queryClient.getQueryData<Task>(taskKeys.detail(signal.taskId)) ??
+          this.queryClient
+            .getQueriesData<Task[]>({ queryKey: taskKeys.lists() })
+            .flatMap(([, tasks]) => tasks ?? [])
+            .find((task) => task.id === signal.taskId);
         const activity = {
           id: `local:${signal.taskId}`,
           task_id: signal.taskId,
           task_title: signal.taskTitle,
-          channel_id: previous?.channel_id ?? null,
+          channel_id: previous
+            ? (previous.channel_id ?? null)
+            : (cachedTask?.channel ?? null),
           channel_name: previous?.channel_name ?? null,
           activity_at: signal.activityAt,
           activity_kind: signal.activityKind,


### PR DESCRIPTION
## Problem

Fresh activity notifications could open a space task in the generic Code view, hiding the space thread drawer and Copy link action.

**Why:** Optimistic activity rows lost their space ID before the backend projection was available.

## Changes

- Restore the space ID from cached task data when inserting new activity.
- Preserve authoritative metadata from existing activity rows.
- Cover space-backed, unfiled, and existing-row behavior with regression tests.

## How did you test this code?

- `pnpm exec vitest run src/features/canvas/task-activity/taskActivity.contribution.test.ts`
- `pnpm --filter @posthog/ui typecheck`
- `pnpm exec biome check` on the changed files

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. No repo-provided skills were invoked; the PR-description skill named by the template was not available in this session.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*