### PR TITLE
fix(data-imports): stop retrying an import after its schema is deleted mid-sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -185,7 +185,10 @@ async def _import_data_with_reporting(inputs: ImportDataActivityInputs, logger: 
         await logger.adebug(f"schema.sync_type_config = {schema.sync_type_config}")
         await logger.adebug(f"reset_pipeline = {reset_pipeline}")
 
-        schema = await _get_external_data_schema(inputs.schema_id, inputs.team_id)
+        try:
+            schema = await _get_external_data_schema(inputs.schema_id, inputs.team_id)
+        except ExternalDataSchema.DoesNotExist as e:
+            await _handle_import_error(job_inputs, logger, e)
 
         processed_incremental_last_value = None
         processed_incremental_earliest_value = None
@@ -382,6 +385,15 @@ async def _handle_import_error(
     """
     source_cls = SourceRegistry.get_source(job_inputs.job_type)
     error_msg = str(error)
+
+    # The schema this activity is running for can be deleted (or soft-deleted) between the job
+    # being created and this activity's mid-run re-fetch of it — every retry re-reads the same
+    # gone row, so it never turns into data regardless of source. Classify it here by type rather
+    # than depending on each source listing the message in get_non_retryable_errors.
+    if isinstance(error, ExternalDataSchema.DoesNotExist):
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     # The shared REST engine raises RESTClientNonRetryableError only for responses retrying can
     # never turn into data (a non-JSON body on an otherwise-successful response). Honor that

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -173,6 +173,27 @@ async def test_unparseable_config_routes_through_handler():
 
 
 @pytest.mark.asyncio
+async def test_schema_deleted_mid_sync_routes_through_handler():
+    # The schema can be deleted (or soft-deleted) between the job being created and this
+    # activity's mid-run re-fetch of it, e.g. a user removes the table while its sync is in
+    # flight. Every retry re-reads the same gone row, so it must be treated as non-retryable
+    # instead of crash-looping on every attempt.
+    error = ExternalDataSchema.DoesNotExist("ExternalDataSchema matching query does not exist.")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+
+    with _patched_activity(source) as handle_mock:
+        module._get_external_data_schema.side_effect = error
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await import_data_activity_sync(_inputs())
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args.args[5] is error
+    source.parse_config.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_source_classified_retryable_error_logged_as_warning_not_exception():
     # A rate-limit / transient error the source retries internally reaches _handle_import_error only
     # once those retries exhaust. Temporal retries the whole activity, so it must be logged at

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -182,8 +182,10 @@ async def test_schema_deleted_mid_sync_routes_through_handler():
     source = mock.MagicMock(spec=SimpleSource)
     source.get_non_retryable_errors.return_value = {}
 
-    with _patched_activity(source) as handle_mock:
-        module._get_external_data_schema.side_effect = error
+    with (
+        _patched_activity(source) as handle_mock,
+        mock.patch.object(module, "_get_external_data_schema", new=mock.AsyncMock(side_effect=error)),
+    ):
         handle_mock.side_effect = NonRetryableException()
         with pytest.raises(NonRetryableException):
             await import_data_activity_sync(_inputs())


### PR DESCRIPTION
## Problem

- A Stripe `SubscriptionItem` full-refresh sync failed repeatedly with `ExternalDataSchema.DoesNotExist` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd6e5-db17-7b42-9649-444119a80ee8)).
- The schema was deleted (or soft-deleted) between the job being created and the activity's mid-run re-fetch of it, e.g. a user removes the table while its sync is in flight.
- That re-fetch (`_get_external_data_schema`, shared code used by every source) wasn't classified as non-retryable, so the activity retried its full budget — every attempt re-reading the same gone row and reporting to error tracking again — before finally giving up.

## Changes

- Catch `ExternalDataSchema.DoesNotExist` around the mid-run schema re-fetch in `_import_data_with_reporting` and route it through `_handle_import_error`, the same handler already used for other unrecoverable setup errors in this file.
- Classify it by exception type inside `_handle_import_error`, matching how that function already treats other shared, cross-source "this can never succeed" errors (corrupt stored config, an unresolvable DNS host, a changed Delta column type) — so every source stops retrying, not just ones that happen to list the message string in `get_non_retryable_errors`.

## How did you test this code?

- Added `test_schema_deleted_mid_sync_routes_through_handler`, mirroring the existing `test_unparseable_config_routes_through_handler` shape: asserts the activity routes a `DoesNotExist` raised by the mid-run re-fetch through `handle_non_retryable_error` instead of retrying. This is the regression the fix addresses — before it, the exception propagated uncaught.
- Ran `test_import_data_sync.py` locally: 19 passed (including the new test). One unrelated DB-backed test in the same file errored on a stale test-database migration state in this sandbox, not touched by this change.
- `ruff check` / `ruff format --check` clean on both changed files. `mypy --cache-fine-grained` clean on the changed module; the full repo-wide run was killed by the sandbox's memory limit, so CI's mypy check is the authoritative one here.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-handling fix, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue (Stripe sync, shared pipeline code). Checked for a duplicate PR by exception type, message text, and module path, and reviewed the maintainer's own open PRs — [#78410](https://github.com/PostHog/posthog/pull/78410) and [#78224](https://github.com/PostHog/posthog/pull/78224) touch nearby non-retryable-error handling but address different failures (reporting noise on an already-classified error, and consecutive-failure backoff); neither covers this race.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*