### PR TITLE
feat(error-tracking): switch weekly digest to temporal schedule

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -14,7 +14,6 @@ from posthog.tasks.auth_token_cache_verification import verify_and_fix_auth_toke
 from posthog.tasks.calculate_cohort import finalize_cohort_backfill_runs
 from posthog.tasks.email import (
     EXTERNAL_DATA_DIGEST_DAY_BOUNDARY_HOUR_UTC,
-    send_error_tracking_weekly_digest,
     send_hog_functions_daily_digest,
     send_matview_failure_digest,
 )
@@ -537,13 +536,6 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour="9", minute="30"),
         send_hog_functions_daily_digest.s(),
         name="send HogFunctions daily digest",
-    )
-
-    # Send Error Tracking weekly digest at 8:30 AM UTC on Monday
-    sender.add_periodic_task(
-        crontab(hour="8", minute="30", day_of_week="mon"),
-        send_error_tracking_weekly_digest.s(),
-        name="send Error Tracking weekly digest",
     )
 
     # Send materialized view failure digest daily at morning local time per region

--- a/posthog/temporal/schedule.py
+++ b/posthog/temporal/schedule.py
@@ -91,6 +91,7 @@ from products.error_tracking.backend.facade.temporal import (
     RecommendationsRefreshInputs,
     create_error_tracking_spike_event_cleanup_schedule,
     create_error_tracking_symbol_set_cleanup_schedule,
+    create_error_tracking_weekly_digest_schedule,
 )
 from products.experiments.backend.temporal.schedule import create_experiment_precompute_canary_schedule
 from products.exports.backend.temporal.subscriptions.types import ScheduleAllSubscriptionsWorkflowInputs
@@ -862,6 +863,7 @@ schedules = [
     create_business_knowledge_refresh_coordinator_schedule,
     create_error_tracking_symbol_set_cleanup_schedule,
     create_error_tracking_spike_event_cleanup_schedule,
+    create_error_tracking_weekly_digest_schedule,
     create_wa_weekly_digest_schedule,
     create_wa_digest_notification_schedule,
     create_logs_alert_check_schedule,


### PR DESCRIPTION
## Problem

The error tracking weekly digest email still goes out from the legacy Celery beat task, and its Temporal replacement never runs.

- The Temporal workflow, activities, and schedule definition are already merged and wired to the worker.
- The schedule was never added to the bootstrap list, so Temporal never created it.

## Changes

- Registers `create_error_tracking_weekly_digest_schedule` in the Temporal schedule bootstrap, so the digest sends via the Temporal workflow.
- The Temporal schedule fires Mondays at 08:30 UTC, the same slot as the removed Celery entry.
- Removes the Celery beat entry. The `send_error_tracking_weekly_digest` Celery task stays for manual runs.

> [!NOTE]
> The Celery entry disappears on deploy, and the Temporal schedule appears when the schedule bootstrap next runs. A rollout that straddles a Monday 08:30 UTC slot could skip one send.

## How did you test this code?

- I verified the digest workflow and activities are registered on `ERROR_TRACKING_TASK_QUEUE`, the queue the schedule targets.
- I verified the Temporal calendar spec matches the Celery crontab: `day_of_week=1` is Monday in Temporal, at 08:30 UTC.
- I verified the schedule passes `dry_run=False`, so scheduled runs send for real.
- Not run: the workflow against a live Temporal server. No new tests, since the change only registers an existing schedule.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal scheduling change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code (Claude Fable 5).
- Skills invoked: /writing-pr-descriptions.
- The workflow, activities, schedule definition, and worker wiring predate this session. This session only registered the schedule and removed the Celery beat entry.
