### PR TITLE
fix(data-imports): reconcile decimal scale before full-refresh Delta appends

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_writer.py
@@ -407,6 +407,45 @@ class TestAppendDecimalReconciliation:
             )
 
 
+class TestFullRefreshDecimalReconciliation:
+    """A later batch of a full_refresh (or first incremental) sync infers its own decimal type
+    independently of earlier batches, same as the incremental-merge and append-continuation
+    paths. Without reconciling to the table's already-established stored type before writing,
+    a batch whose inferred scale is wider than the stored column hits delta-rs's merge-schema
+    SchemaMismatchError, since schema_mode="merge" can't widen a stored column's scale in place.
+    """
+
+    @pytest.mark.asyncio
+    async def test_wider_scale_batch_is_rounded_to_stored_type(self, tmp_path: Path) -> None:
+        delta_path = str(tmp_path / "table")
+        # First batch establishes a narrower-scale decimal column, as independent per-batch
+        # inference would.
+        deltalake.write_deltalake(
+            delta_path,
+            pa.table(
+                {"id": pa.array([1], type=pa.int64()), "amount": pa.array([Decimal("1.0")], type=pa.decimal128(4, 1))}
+            ),
+        )
+        helper = make_local_table_ref(delta_path)
+
+        # Second batch's own values infer a wider scale.
+        batch = pa.table(
+            {
+                "id": pa.array([2], type=pa.int64()),
+                "amount": pa.array([Decimal("2.23456")], type=pa.decimal128(8, 5)),
+            }
+        )
+
+        result = await DeltaWriter(helper).write(
+            data=batch, write_type="full_refresh", should_overwrite_table=False, primary_keys=None
+        )
+
+        final = result.to_pyarrow_table()
+        assert final.schema.field("amount").type == pa.decimal128(4, 1)
+        assert set(final.column("id").to_pylist()) == {1, 2}
+        assert Decimal("2.2") in final.column("amount").to_pylist()
+
+
 class TestSchemaEvolutionNullability:
     """A column added mid-table-lifetime always predates its own addition: every file the
     table already holds was written without it, so `optimize.compact()` must be able to

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
@@ -472,6 +472,15 @@ class DeltaWriter:
                     mode="ignore",
                 )
 
+            if mode == "append":
+                # Each batch of a full_refresh (or first incremental sync) infers its own decimal
+                # types independently, same as the incremental-merge and append-continuation paths
+                # above. Without reconciling to the table's already-established type here, a later
+                # batch whose inferred scale is wider than an earlier one hits delta-rs's
+                # merge-schema SchemaMismatchError, since schema_mode="merge" can't widen a stored
+                # column's type in place.
+                data = align_incoming_decimals_to_delta(data, delta_table.schema())
+
             try:
                 await asyncio.to_thread(
                     _write_deltalake,


### PR DESCRIPTION
## Problem

A data warehouse sync using full refresh, or a first incremental sync, can abort partway through with an unhandled `DeltaError`, even though every batch involved writes otherwise valid data.
Each batch infers its own decimal precision and scale independently. A later batch that needs a wider scale than an earlier batch already established fails to write, and the built-in retry fails too.
Seen live in PostHog error tracking: https://us.posthog.com/project/2/error_tracking/019fd717-0a51-7420-9481-b3ea636dae2b, on a `_browser_version` column.

## Changes

- The full-refresh append path in `DeltaWriter.write()` now reconciles each batch's decimal columns against the Delta table's stored type before writing.
- The incremental-merge and append-continuation paths in the same file already do this reconciliation; this closes the last gap.
- Reuses the existing `align_incoming_decimals_to_delta` helper, no new logic.

## How did you test this code?

- Added `TestFullRefreshDecimalReconciliation` in `test_writer.py`. It seeds a real local Delta table with a narrow-scale decimal column, then writes a second batch needing a wider scale through the full-refresh append path.
- Reverting the fix locally reproduces the bug: the test then fails with `DeltaError: Schema overwrite not supported for Append`.
- Ran `delta/test/test_writer.py` locally: all 53 cases pass.
- Not run: `delta/test/test_table.py` in the same directory, which needs the dev-stack object storage service; its 7 failures are pre-existing and unrelated to this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is an internal pipeline fix with no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue: pulled the stack trace and sampled exception events, traced the failing frame to `DeltaWriter.write()`'s full-refresh branch, and compared it against the sibling incremental-merge and append-continuation branches in the same file, which already call `align_incoming_decimals_to_delta` before writing.
Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
Checked for duplicate PRs (search on the exception type, the module path, and the maintainer's own open PRs). [#78201](https://github.com/PostHog/posthog/pull/78201), "widen stored delta columns instead of failing the sync", is thematically adjacent but fixes a different failure (a value that no longer fits an already-stored column type) and doesn't touch `delta/writer.py`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*