### PR TITLE
feat(desktop): add a hosthog:build script for the web edition

### DIFF
--- a/products/desktop/package.json
+++ b/products/desktop/package.json
@@ -37,7 +37,8 @@
     "format": "biome format --write",
     "clean": "pnpm -r clean",
     "knip": "knip",
-    "skills:pull": "node scripts/pull-skills.mjs"
+    "skills:pull": "node scripts/pull-skills.mjs",
+    "hosthog:build": "pnpm install --frozen-lockfile --ignore-scripts --filter @posthog/web... && pnpm exec turbo build --filter=@posthog/web && ln -sfn apps/web/dist dist"
   },
   "keywords": [
     "posthog",


### PR DESCRIPTION
## Problem

The web edition of the desktop app has a hosted internal copy that is published by hand, so it drifts out of sync with the repo — anyone using the hosted copy can be days behind `master`, and keeping it current is manual toil for whoever owns it.

## Changes

- Adds one root script to the `products/desktop` workspace: `hosthog:build` — filtered install for `@posthog/web`, turbo build, and a symlink exposing `apps/web/dist` where the hosting platform's build contract picks it up.
- With it, the internal hosting platform can build this subtree directly from the repo: pushes to `master` touching `products/desktop` republish automatically, and PRs touching it get preview URLs; unrelated pushes and PRs are untouched.
- `--ignore-scripts` is deliberate: the workspace graph pulls in `node-pty`, whose native build needs a toolchain the build image doesn't carry — and the web bundle needs no native modules at build time (esbuild/tailwind ship platform binaries as optional dependencies, unaffected by the flag).

## How did you test this code?

No automated tests — build configuration only; no product code changes.

- Ran the exact script locally from a clean checkout with `node_modules` removed: install, 7/7 turbo tasks, `dist` symlink serving `apps/web/dist` with the built entry document.
- The same script built this repo end-to-end on the hosting platform from a since-deleted test branch, including verifying that a PR touching this subtree got a preview build (#78835) and a PR not touching it got none (#78836) — both were temporary probe drafts, closed after the check.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal build wiring only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored via a Claude Code session (Claude Fable) directed by the assignee. No repo-provided skills were invoked. The script's final shape came from iterating against real platform builds on the test branch: the install initially failed on `node-pty`'s native build (hence `--ignore-scripts`), and earlier environment workarounds became platform defaults, leaving this single script line as the entire repo-side footprint. No non-public material from the session appears in this PR.
