### PR TITLE
fix(desktop): clear Pi permission footer state

### DIFF
--- a/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
+++ b/products/desktop/packages/ui/src/features/pi-sessions/PiSessionView.tsx
@@ -701,6 +701,7 @@ export function PiSessionView({
           taskId={taskId}
           repoPath={repoPath}
           promptRecallRef={promptRecallRef}
+          hasPendingPermission={Boolean(mcpPermission)}
         />
       </Box>
       <Box

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -1143,6 +1143,7 @@ interface SharedChatThreadProps {
   task?: Task;
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
+  hasPendingPermission?: boolean;
 }
 
 export interface ChatThreadProps extends SharedChatThreadProps {
@@ -1216,6 +1217,7 @@ function ChatThreadRenderer({
   task,
   taskId,
   footerState,
+  hasPendingPermission,
   promptRecallRef,
 }: ChatThreadRendererProps) {
   const diffWorkerFactory = useService<DiffWorkerFactory>(DIFF_WORKER_FACTORY);
@@ -1342,6 +1344,7 @@ function ChatThreadRenderer({
         task={task}
         taskId={taskId}
         footerState={footerState}
+        hasPendingPermission={hasPendingPermission}
       />
     </>
   );

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { resolvePendingPermissionVisibility } from "./pendingPermissionVisibility";
+
+describe("resolvePendingPermissionVisibility", () => {
+  it.each([
+    [undefined, 0, false],
+    [undefined, 1, true],
+    [true, 0, true],
+    [false, 1, false],
+  ])(
+    "uses override %s with %i stored permissions",
+    (override, storedCount, expected) => {
+      expect(resolvePendingPermissionVisibility(override, storedCount)).toBe(
+        expected,
+      );
+    },
+  );
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThreadFooter.tsx
@@ -9,6 +9,7 @@ import {
   useSessionForTask,
 } from "@posthog/ui/features/sessions/sessionStore";
 import { useSettingsStore } from "@posthog/ui/features/settings/settingsStore";
+import { resolvePendingPermissionVisibility } from "./pendingPermissionVisibility";
 
 interface ChatThreadFooterProps {
   events: AcpMessage[];
@@ -17,6 +18,7 @@ interface ChatThreadFooterProps {
   task?: Task;
   taskId?: string;
   footerState?: Omit<BuildResult, "items">;
+  hasPendingPermission?: boolean;
 }
 
 /**
@@ -35,6 +37,7 @@ export function ChatThreadFooter({
   task,
   taskId,
   footerState,
+  hasPendingPermission,
 }: ChatThreadFooterProps) {
   const showDebugLogs = useSettingsStore((s) => s.debugLogsCloudRuns);
   const eventFooterState = useConversationItems(events, isPromptPending, {
@@ -48,6 +51,10 @@ export function ChatThreadFooter({
     footerState?.completedToolCallCount ??
     eventFooterState.completedToolCallCount;
   const pendingPermissions = usePendingPermissionsForTask(taskId ?? "");
+  const pendingPermissionVisible = resolvePendingPermissionVisibility(
+    hasPendingPermission,
+    pendingPermissions.size,
+  );
   const queuedCount = useQueuedMessagesForTask(taskId).length;
   const session = useSessionForTask(taskId);
   const pausedDurationMs = session?.pausedDurationMs ?? 0;
@@ -65,7 +72,7 @@ export function ChatThreadFooter({
         }
         lastStopReason={lastTurnInfo?.stopReason}
         queuedCount={queuedCount}
-        hasPendingPermission={pendingPermissions.size > 0}
+        hasPendingPermission={pendingPermissionVisible}
         pausedDurationMs={pausedDurationMs}
         isCompacting={isCompacting}
         completedToolCallCount={completedToolCallCount}

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/pendingPermissionVisibility.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/pendingPermissionVisibility.ts
@@ -1,0 +1,6 @@
+export function resolvePendingPermissionVisibility(
+  override: boolean | undefined,
+  storedCount: number,
+): boolean {
+  return override ?? storedCount > 0;
+}


### PR DESCRIPTION
## Problem

After a cloud Pi MCP approval succeeds, the conversation footer can continue showing “Awaiting permission...” even though the tool has resumed. The footer reads the general session permission state, while Pi tracks the resolved request separately.

## Changes

- Let chat surfaces provide the current permission state to the shared footer.
- Use Pi’s permission state in Pi sessions so the footer clears immediately after approval.
- Keep existing session behavior as the default for other chat surfaces.

## How did you test this code?

- Added a focused state-resolution test covering a stale stored permission after Pi reports no pending request.
- Ran the affected UI tests, UI typecheck, Biome, and `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi and the repository coding tools were used. The `/posthog-desktop`, `/writing-tests`, `/writing-user-facing-copy`, and `/running-ci-preflight` skills were applied. This follows the merged Pi MCP cloud approval work and only corrects the stale footer display.