### PR TITLE
feat(dashboards): copy warehouse views when copying a template across projects

### DIFF
--- a/posthog/models/resource_transfer/dashboard_template_views.py
+++ b/posthog/models/resource_transfer/dashboard_template_views.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+
+from posthog.models.resource_transfer.inter_project_transferer import duplicate_resource_to_new_team
+from posthog.models.resource_transfer.resource_transfer import ResourceTransfer
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+logger = structlog.get_logger(__name__)
+
+
+def copy_warehouse_views_by_name(
+    *,
+    view_names: set[str],
+    source_team: Team,
+    target_team: Team,
+    created_by: User,
+) -> dict[str, str]:
+    """Copy the named data warehouse views from ``source_team`` into ``target_team``.
+
+    Each view is copied with the resource-transfer engine, which also pulls in its upstream view
+    dependencies and lands every copy unmaterialized. Names that don't resolve to a view in the source
+    team (physical tables, source connections) are skipped — they need their own setup in the target.
+
+    The copy does not bring the underlying source data across, so a copied view resolves but may return
+    no rows until the target project has data behind it.
+
+    Returns a ``{original_name: new_name}`` remap for any view that a name collision in the target forced
+    to be renamed, so callers can repoint references at the new name. Views whose names were free keep
+    them and are absent from the remap.
+    """
+    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+
+    source_views = list(DataWarehouseSavedQuery.objects.filter(team=source_team, name__in=view_names, deleted=False))
+    if not source_views:
+        return {}
+
+    name_remap: dict[str, str] = {}
+    for view in source_views:
+        original_name = view.name
+        duplicate_resource_to_new_team(view, target_team, created_by=created_by)
+        new_name = _copied_view_name(source_pk=view.pk, target_team=target_team)
+        if new_name and new_name != original_name:
+            name_remap[original_name] = new_name
+
+    logger.info(
+        "resource_transfer.warehouse_views_copied_by_name",
+        source_team_id=source_team.pk,
+        target_team_id=target_team.pk,
+        view_count=len(source_views),
+        renamed=len(name_remap),
+    )
+    return name_remap
+
+
+def _copied_view_name(*, source_pk: Any, target_team: Team) -> str | None:
+    """Resolve the destination name of a just-copied view via its transfer record."""
+    from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+
+    record = (
+        ResourceTransfer.objects.filter(
+            resource_kind="DataWarehouseSavedQuery",
+            resource_id=str(source_pk),
+            destination_team=target_team,
+        )
+        .order_by("-last_transferred_at")
+        .first()
+    )
+    if record is None:
+        return None
+    copy = DataWarehouseSavedQuery.objects.filter(pk=record.duplicated_resource_id).first()
+    return copy.name if copy else None

--- a/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
+++ b/posthog/models/resource_transfer/test/__snapshots__/test_visitor_field_snapshots.ambr
@@ -57,6 +57,21 @@
     'last_modified_at',
   ])
 # ---
+# name: TestVisitorFieldSnapshots.test_excluded_fields_DataWarehouseSavedQuery
+  list([
+    'deleted_name',
+    'expires_at',
+    'external_tables',
+    'folder',
+    'is_test',
+    'last_run_at',
+    'latest_error',
+    'managed_viewset',
+    'semantic_enrichment_hash',
+    'status',
+    'table',
+  ])
+# ---
 # name: TestVisitorFieldSnapshots.test_excluded_fields_EarlyAccessFeature
   list([
     'created_at',
@@ -196,6 +211,21 @@
     'description',
     'name',
     'widget_type',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_primitive_fields_DataWarehouseSavedQuery
+  list([
+    'column_order',
+    'columns',
+    'created_at',
+    'deleted',
+    'deleted_at',
+    'is_materialized',
+    'name',
+    'origin',
+    'query',
+    'sync_frequency_interval',
+    'updated_at',
   ])
 # ---
 # name: TestVisitorFieldSnapshots.test_primitive_fields_EarlyAccessFeature
@@ -365,6 +395,12 @@
   list([
     'created_by',
     'last_modified_by',
+    'team',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_relation_fields_DataWarehouseSavedQuery
+  list([
+    'created_by',
     'team',
   ])
 # ---
@@ -655,6 +691,65 @@
     'last_modified_at',
     'last_modified_by_id',
     'team_id',
+  ])
+# ---
+# name: TestVisitorFieldSnapshots.test_skipped_fields_DataWarehouseSavedQuery
+  list([
+    'DoesNotExist',
+    'MultipleObjectsReturned',
+    'Origin',
+    'Status',
+    '__doc__',
+    '__firstlineno__',
+    '__module__',
+    '__static_attributes__',
+    '_meta',
+    '_start_immediate_materialization',
+    'column_annotations',
+    'created_by_id',
+    'datamodelingjob_set',
+    'datawarehousemodelpath_set',
+    'datawarehousesavedquerydraft_set',
+    'datawarehouseviewlink_set',
+    'deleted_name',
+    'endpoint_versions',
+    'expires_at',
+    'external_tables',
+    'folder',
+    'folder_id',
+    'folder_path',
+    'get_clickhouse_column_type',
+    'get_columns',
+    'get_next_by_created_at',
+    'get_origin_display',
+    'get_previous_by_created_at',
+    'get_s3_tables',
+    'get_status_display',
+    'github_synced_model',
+    'hogql_definition',
+    'id',
+    'is_test',
+    'last_run_at',
+    'latest_error',
+    'managed_viewset',
+    'managed_viewset_id',
+    'name_chain',
+    'node_set',
+    'normalized_name',
+    'objects',
+    'revert_materialization',
+    's3_tables',
+    'save',
+    'schedule_materialization',
+    'semantic_enrichment_hash',
+    'set_columns',
+    'setup_model_paths',
+    'soft_delete',
+    'status',
+    'table',
+    'table_id',
+    'team_id',
+    'url_pattern',
   ])
 # ---
 # name: TestVisitorFieldSnapshots.test_skipped_fields_EarlyAccessFeature

--- a/posthog/models/resource_transfer/test/test_dashboard_template_view_copy.py
+++ b/posthog/models/resource_transfer/test/test_dashboard_template_view_copy.py
@@ -1,0 +1,48 @@
+from posthog.test.base import BaseTest
+
+from posthog.models import Project, Team
+from posthog.models.resource_transfer.dashboard_template_views import copy_warehouse_views_by_name
+
+from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+
+
+class TestCopyWarehouseViewsByName(BaseTest):
+    def _target_team(self) -> Team:
+        project = Project.objects.create(id=Team.objects.increment_id_sequence(), organization=self.organization)
+        return Team.objects.create(id=project.id, project=project, organization=self.organization)
+
+    def _view(self, team: Team, name: str, sql: str) -> DataWarehouseSavedQuery:
+        return DataWarehouseSavedQuery.objects.create(team=team, name=name, query={"query": sql})
+
+    def test_copies_referenced_view_without_renaming_when_name_is_free(self) -> None:
+        target = self._target_team()
+        self._view(self.team, "revenue", "SELECT amount FROM stripe_charges")
+
+        remap = copy_warehouse_views_by_name(
+            view_names={"revenue"}, source_team=self.team, target_team=target, created_by=self.user
+        )
+
+        assert remap == {}  # name was free, so no rewrite needed
+        assert DataWarehouseSavedQuery.objects.filter(team=target, name="revenue").exists()
+
+    def test_remaps_name_on_target_collision(self) -> None:
+        target = self._target_team()
+        self._view(target, "revenue", "SELECT 1")  # occupies the name in the target
+        self._view(self.team, "revenue", "SELECT amount FROM stripe_charges")
+
+        remap = copy_warehouse_views_by_name(
+            view_names={"revenue"}, source_team=self.team, target_team=target, created_by=self.user
+        )
+
+        assert remap == {"revenue": "revenue_copy"}
+        assert DataWarehouseSavedQuery.objects.filter(team=target, name="revenue_copy").exists()
+
+    def test_names_without_a_view_are_skipped(self) -> None:
+        target = self._target_team()
+
+        remap = copy_warehouse_views_by_name(
+            view_names={"a_physical_table"}, source_team=self.team, target_team=target, created_by=self.user
+        )
+
+        assert remap == {}
+        assert not DataWarehouseSavedQuery.objects.filter(team=target).exists()

--- a/products/dashboards/backend/api/dashboard_templates.py
+++ b/products/dashboards/backend/api/dashboard_templates.py
@@ -34,6 +34,10 @@ from posthog.user_permissions import UserPermissions
 from posthog.utils import str_to_bool
 
 from products.dashboards.backend.models.dashboard_templates import DashboardTemplate
+from products.dashboards.backend.warehouse_template_transfer import (
+    collect_warehouse_table_names,
+    copy_referenced_warehouse_views,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -82,22 +86,6 @@ def _dashboard_template_list_order_by(ordering: str | None) -> list[Any]:
     return ["-is_featured", Lower("template_name")]
 
 
-def _collect_warehouse_table_names(node: Any) -> set[str]:
-    """Recursively collect `DataWarehouseNode.table_name` values from a query JSON tree."""
-    names: set[str] = set()
-    if isinstance(node, dict):
-        if node.get("kind") == "DataWarehouseNode":
-            table_name = node.get("table_name")
-            if isinstance(table_name, str) and table_name:
-                names.add(table_name)
-        for value in node.values():
-            names |= _collect_warehouse_table_names(value)
-    elif isinstance(node, list):
-        for item in node:
-            names |= _collect_warehouse_table_names(item)
-    return names
-
-
 def detect_non_portable_references(tiles: list[Any]) -> dict[str, Any]:
     """Project-scoped references in template tiles that may not resolve when used in another project.
 
@@ -119,7 +107,7 @@ def detect_non_portable_references(tiles: list[Any]) -> dict[str, Any]:
             # Detection is best-effort; a malformed tile must never break serialization.
             logger.warning("dashboard_template_non_portable_reference_detection_failed", exc_info=exc)
             capture_exception(exc)
-        warehouse_tables |= _collect_warehouse_table_names(query)
+        warehouse_tables |= collect_warehouse_table_names(query)
     return {
         "actions": len(action_ids),
         "cohorts": len(cohort_ids),
@@ -571,16 +559,32 @@ class DashboardTemplateViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, views
         base_name = (source.template_name or "").strip() or "Untitled template"
         unique_name = _pick_unique_template_name_for_copy(team_id=target_team_id, base_name=base_name)
 
+        tiles = source.tiles or []
+        if user.is_authenticated:
+            try:
+                # Copy the data warehouse views the tiles read from into the target project so the
+                # copied template's insights resolve there. Best-effort: a failure here must not block
+                # the template copy — the tiles then keep the source names and behave as before.
+                tiles = copy_referenced_warehouse_views(
+                    tiles=tiles,
+                    source_team=source_team,
+                    target_team=target_team,
+                    created_by=user,
+                )
+            except Exception as exc:
+                logger.warning("dashboard_template_copy_warehouse_view_transfer_failed", exc_info=exc)
+                capture_exception(exc)
+
         new_instance = DashboardTemplate.objects.create(
             team_id=target_team_id,
             template_name=unique_name,
             dashboard_description=source.dashboard_description,
-            # TODO(analytics-platform): dashboard_filters and variables are copied verbatim; both can embed
-            # project-scoped references (e.g. cohort IDs in filter properties; variable defaults for events,
-            # actions, or properties) that do not exist or differ on the target project. Tile queries have the
-            # same class of issue. Consider validation and/or ID rewriting (cf. resource_transfer visitors).
+            # TODO(analytics-platform): dashboard_filters and variables are still copied verbatim; both can
+            # embed project-scoped references (e.g. cohort IDs in filter properties; variable defaults for
+            # events, actions, or properties) that do not exist or differ on the target project. Warehouse
+            # views referenced by tile queries are now copied above; cohorts/actions/filters are not yet.
             dashboard_filters=source.dashboard_filters,
-            tiles=source.tiles or [],
+            tiles=tiles,
             variables=source.variables,
             tags=source.tags or [],
             scope=DashboardTemplate.Scope.ONLY_TEAM,

--- a/products/dashboards/backend/test/test_warehouse_template_transfer.py
+++ b/products/dashboards/backend/test/test_warehouse_template_transfer.py
@@ -1,7 +1,16 @@
+from typing import cast
+
 from unittest import TestCase
 from unittest.mock import patch
 
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
 from products.dashboards.backend.warehouse_template_transfer import copy_referenced_warehouse_views
+
+# The DB / cross-project copy is mocked in these tests, so the team/user args are never dereferenced.
+_TEAM = cast(Team, None)
+_USER = cast(User, None)
 
 
 def _warehouse_tile(name: str, table_name: str) -> dict:
@@ -26,7 +35,7 @@ class TestWarehouseTemplateTileRewrite(TestCase):
     def test_renamed_view_rewrites_table_name(self, _copy) -> None:
         tiles = [_warehouse_tile("Revenue", "revenue")]
 
-        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=_TEAM, target_team=_TEAM, created_by=_USER)
 
         assert result[0]["query"]["source"]["series"][0]["table_name"] == "revenue_copy"
         # Original tiles are not mutated in place.
@@ -46,7 +55,7 @@ class TestWarehouseTemplateTileRewrite(TestCase):
             },
         ]
 
-        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=_TEAM, target_team=_TEAM, created_by=_USER)
 
         assert result[0]["query"]["source"]["series"][0]["table_name"] == "revenue_copy"
         assert result[1]["query"]["query"] == "SELECT amount FROM revenue_copy WHERE amount > 0"
@@ -55,7 +64,7 @@ class TestWarehouseTemplateTileRewrite(TestCase):
     def test_no_rename_returns_tiles_unchanged(self, _copy) -> None:
         tiles = [_warehouse_tile("Revenue", "revenue")]
 
-        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=_TEAM, target_team=_TEAM, created_by=_USER)
 
         assert result is tiles
 
@@ -73,7 +82,7 @@ class TestWarehouseTemplateTileRewrite(TestCase):
             }
         ]
 
-        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=_TEAM, target_team=_TEAM, created_by=_USER)
 
         assert result is tiles
         mock_copy.assert_not_called()

--- a/products/dashboards/backend/test/test_warehouse_template_transfer.py
+++ b/products/dashboards/backend/test/test_warehouse_template_transfer.py
@@ -1,0 +1,79 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from products.dashboards.backend.warehouse_template_transfer import copy_referenced_warehouse_views
+
+
+def _warehouse_tile(name: str, table_name: str) -> dict:
+    return {
+        "name": name,
+        "type": "INSIGHT",
+        "query": {
+            "kind": "InsightVizNode",
+            "source": {"kind": "TrendsQuery", "series": [{"kind": "DataWarehouseNode", "table_name": table_name}]},
+        },
+        "layouts": {},
+    }
+
+
+_MODULE = "products.dashboards.backend.warehouse_template_transfer.copy_warehouse_views_by_name"
+
+
+class TestWarehouseTemplateTileRewrite(TestCase):
+    """Tile rewriting is pure JSON, so the view copy (a DB / cross-project concern) is stubbed here."""
+
+    @patch(_MODULE, return_value={"revenue": "revenue_copy"})
+    def test_renamed_view_rewrites_table_name(self, _copy) -> None:
+        tiles = [_warehouse_tile("Revenue", "revenue")]
+
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+
+        assert result[0]["query"]["source"]["series"][0]["table_name"] == "revenue_copy"
+        # Original tiles are not mutated in place.
+        assert tiles[0]["query"]["source"]["series"][0]["table_name"] == "revenue"
+
+    @patch(_MODULE, return_value={"revenue": "revenue_copy"})
+    def test_renamed_view_also_rewrites_raw_hogql_reference(self, _copy) -> None:
+        # A DataWarehouseNode reference is what triggers the copy; a raw-SQL tile referencing the same
+        # renamed view is repointed too so the whole template stays consistent.
+        tiles = [
+            _warehouse_tile("Revenue", "revenue"),
+            {
+                "name": "SQL",
+                "type": "INSIGHT",
+                "query": {"kind": "HogQLQuery", "query": "SELECT amount FROM revenue WHERE amount > 0"},
+                "layouts": {},
+            },
+        ]
+
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+
+        assert result[0]["query"]["source"]["series"][0]["table_name"] == "revenue_copy"
+        assert result[1]["query"]["query"] == "SELECT amount FROM revenue_copy WHERE amount > 0"
+
+    @patch(_MODULE, return_value={})
+    def test_no_rename_returns_tiles_unchanged(self, _copy) -> None:
+        tiles = [_warehouse_tile("Revenue", "revenue")]
+
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+
+        assert result is tiles
+
+    @patch(_MODULE)
+    def test_no_warehouse_reference_skips_copy(self, mock_copy) -> None:
+        tiles = [
+            {
+                "name": "Events only",
+                "type": "INSIGHT",
+                "query": {
+                    "kind": "InsightVizNode",
+                    "source": {"kind": "TrendsQuery", "series": [{"kind": "EventsNode"}]},
+                },
+                "layouts": {},
+            }
+        ]
+
+        result = copy_referenced_warehouse_views(tiles=tiles, source_team=None, target_team=None, created_by=None)
+
+        assert result is tiles
+        mock_copy.assert_not_called()

--- a/products/dashboards/backend/warehouse_template_transfer.py
+++ b/products/dashboards/backend/warehouse_template_transfer.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from posthog.models.resource_transfer.dashboard_template_views import copy_warehouse_views_by_name
+from posthog.models.team.team import Team
+from posthog.models.user import User
+
+
+def collect_warehouse_table_names(node: Any) -> set[str]:
+    """Recursively collect `DataWarehouseNode.table_name` values from a query JSON tree."""
+    names: set[str] = set()
+    if isinstance(node, dict):
+        if node.get("kind") == "DataWarehouseNode":
+            table_name = node.get("table_name")
+            if isinstance(table_name, str) and table_name:
+                names.add(table_name)
+        for value in node.values():
+            names |= collect_warehouse_table_names(value)
+    elif isinstance(node, list):
+        for item in node:
+            names |= collect_warehouse_table_names(item)
+    return names
+
+
+def copy_referenced_warehouse_views(
+    *,
+    tiles: list[Any],
+    source_team: Team,
+    target_team: Team,
+    created_by: User,
+) -> list[Any]:
+    """Copy the data warehouse views a template's tiles read from into ``target_team``.
+
+    Template tiles reference warehouse views by name (``DataWarehouseNode.table_name``), so a copied
+    template's insights fail in another project unless the underlying views exist there too. We copy every
+    referenced view — and its upstream view dependencies — into the target project. When a name collision
+    there forces a ``_copy`` rename, the tile queries are rewritten to point at the new name so the
+    reference still resolves.
+
+    Returns the tiles, rewritten only where a referenced view was renamed on copy.
+    """
+    referenced_names: set[str] = set()
+    for tile in tiles:
+        if isinstance(tile, dict):
+            referenced_names |= collect_warehouse_table_names(tile.get("query"))
+    if not referenced_names:
+        return tiles
+
+    name_remap = copy_warehouse_views_by_name(
+        view_names=referenced_names,
+        source_team=source_team,
+        target_team=target_team,
+        created_by=created_by,
+    )
+    if not name_remap:
+        return tiles
+    return [_rewrite_tile_view_names(tile, name_remap) for tile in tiles]
+
+
+def _rewrite_tile_view_names(tile: Any, name_remap: dict[str, str]) -> Any:
+    if not isinstance(tile, dict):
+        return tile
+    query = tile.get("query")
+    if not isinstance(query, dict):
+        return tile
+    return {**tile, "query": _rewrite_query_view_names(query, name_remap)}
+
+
+def _rewrite_query_view_names(node: Any, name_remap: dict[str, str]) -> Any:
+    if isinstance(node, dict):
+        is_warehouse_node = node.get("kind") == "DataWarehouseNode"
+        result: dict[str, Any] = {}
+        for key, value in node.items():
+            if is_warehouse_node and key == "table_name" and isinstance(value, str) and value in name_remap:
+                result[key] = name_remap[value]
+            elif key == "query" and isinstance(value, str):
+                # Raw SQL nodes (e.g. HogQLQuery) reference views by name in the query text.
+                result[key] = _rewrite_sql_identifiers(value, name_remap)
+            else:
+                result[key] = _rewrite_query_view_names(value, name_remap)
+        return result
+    if isinstance(node, list):
+        return [_rewrite_query_view_names(item, name_remap) for item in node]
+    return node
+
+
+def _rewrite_sql_identifiers(sql: str, name_remap: dict[str, str]) -> str:
+    result = sql
+    for old_name, new_name in name_remap.items():
+        # Replace whole-identifier occurrences only, so we don't touch substrings or column names.
+        pattern = re.compile(rf"(?<![\w.]){re.escape(old_name)}(?![\w.])")
+        result = pattern.sub(new_name, result)
+    return result


### PR DESCRIPTION
## Problem

Promoting a dashboard to a template copies the insights but not the data warehouse views (saved queries) those insights read from. When the template is used in another project, the insights reference views that don't exist there, so they error. Reported for the promote → use-template flow.

This PR handles the cross-project **template copy** path — the one place where both projects are live, so the transfer primitive from #78123 drops in without a schema change.

## Changes

- `copy_between_projects` now copies the warehouse views a template's tiles reference into the target project, using the transfer engine from #78123 (lands unmaterialized, pulls in upstream view deps).
- Tile queries are repointed to the new view name when a name collision in the target forces a `_copy` rename; otherwise names are preserved and tiles are untouched.
- View-copying (which touches `data_modeling` models) lives in core — `posthog/models/resource_transfer/dashboard_template_views.py`. The dashboards product keeps only tile detection + JSON rewrite, so no new product-boundary dependency is added.
- View copying is best-effort: a failure is logged and the template copy still succeeds with the original tiles (prior behavior).

Not in this PR: the persisted promote → instantiate (`create_from_template`) path needs the template to *store* the view definitions so they survive persistence — that's a schema change and its own follow-up. Cohorts, actions, and filter/variable references are still copied verbatim (existing `TODO`).

## How did you test this code?

Automated tests added (I could not run the Postgres-backed suite in this environment — CI will):

- Core (`test_dashboard_template_view_copy.py`, DB-backed): a referenced view is copied name-preserved when free; a target collision renames it and returns the `{name: name_copy}` remap; names with no matching view are skipped.
- Dashboards (`test_warehouse_template_transfer.py`, pure, ran locally — 4 passed): a rename rewrites `DataWarehouseNode.table_name` and any raw-SQL reference to the same view; no rename leaves tiles unchanged; a template with no warehouse reference never triggers a copy.

Verified locally: `ruff` ✅, `tach check --dependencies --interfaces` ✅, `mypy` ✅ (no issues in the changed modules).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Second PR in a two-PR split requested by the DRI: keep #78123 scoped to the transferable-resource primitive, and put the template-flow wiring here so each is small to review. This PR stacks on #78123.

Key decision: the transfer engine copies live row→row between two teams, which fits `copy_between_projects` (both projects live) but not the persisted promote→instantiate path (the template is a decoupled blob, so it would need to store the view definitions — deferred as a follow-up). Split the code across the module boundary because `tach` forbids `products.dashboards` from importing `products.data_modeling`; the data_modeling-touching copy therefore lives in core (which #78123 already established can import the data_modeling facade), and the product keeps only pure JSON tile handling.

Tools: PostHog Slack app (Claude Code). No repo skills were invocable in this environment; followed the `/writing-tests` and `/improving-drf-endpoints` rules manually (no serializer/viewset schema changes were needed — the endpoint's behavior changed, not its request/response shape).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B4JF30R9D/p1785917100016579?thread_ts=1785917100.016579&cid=C0B4JF30R9D)*
