### PR TITLE
fix(sessions): Use max_inserted_at for Sessions model

### DIFF
--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -451,8 +451,9 @@ async def _get_backfill_info_for_sessions(
 ) -> tuple[dt.datetime | None, int | None]:
     """Get earliest timestamp and estimated record count for sessions model.
 
-    Queries the sessions table via HogQL, filtering by $end_timestamp
-    (this logic is the same as the actual export query, which aliases `$end_timestamp` as `_inserted_at`).
+    Queries the sessions table via HogQL, filtering by $end_timestamp. This matches
+    the event-time semantics of backfill export queries (see
+    `SessionsRecordBatchModel.get_hogql_query` with `is_backfill=True`).
 
     Returns:
         A tuple of (min_timestamp, estimated_records_count).

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -263,7 +263,11 @@ async def insert_into_internal_stage_activity(
         set_status_to_running_task(run_id=inputs.run_id),
     ):
         _, record_batch_model, model_name, fields, filters, extra_query_parameters = resolve_batch_exports_model(
-            inputs.team_id, inputs.batch_export_model, inputs.batch_export_schema, inputs.batch_export_id
+            inputs.team_id,
+            inputs.batch_export_model,
+            inputs.batch_export_schema,
+            inputs.batch_export_id,
+            is_backfill=inputs.backfill_details is not None,
         )
         data_interval_start = (
             dt.datetime.fromisoformat(inputs.data_interval_start) if inputs.data_interval_start else None

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -185,12 +185,6 @@ class SessionsRecordBatchModel(RecordBatchModel):
                         left=ast.Field(chain=["_inserted_at"]),
                         right=ast.Constant(value=data_interval_start),
                     ),
-                    # include $end_timestamp because hogql uses this to add a where clause to the inner query
-                    ast.CompareOperation(
-                        op=ast.CompareOperationOp.GtEq,
-                        left=ast.Field(chain=["$end_timestamp"]),
-                        right=ast.Constant(value=data_interval_start),
-                    ),
                 ]
             )
 
@@ -238,7 +232,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
 
         return ast.SelectQuery(
             select=[
-                parse_expr("toTimeZone(min($end_timestamp), 'UTC') as min_timestamp"),
+                parse_expr("toTimeZone(min(greatest(max_inserted_at, $end_timestamp)), 'UTC') as min_timestamp"),
                 parse_expr("count() as record_count"),
             ],
             select_from=ast.JoinExpr(table=ast.Field(chain=["sessions"])),

--- a/products/batch_exports/backend/temporal/record_batch_model.py
+++ b/products/batch_exports/backend/temporal/record_batch_model.py
@@ -26,7 +26,7 @@ from products.batch_exports.backend.hogql_source import (
 from products.batch_exports.backend.service import BatchExportModel, BatchExportSchema
 from products.batch_exports.backend.temporal.metrics import log_query_duration
 from products.batch_exports.backend.temporal.sql.common import HogQLQueryBatchExportSettings, get_s3_function_call
-from products.batch_exports.backend.temporal.sql.sessions import SELECT_FROM_SESSIONS_HOGQL
+from products.batch_exports.backend.temporal.sql.sessions import SELECT_FROM_SESSIONS_HOGQL, SESSIONS_LOOKBACK_DAYS
 
 LOGGER = get_write_only_logger()
 
@@ -149,7 +149,18 @@ INSERT INTO FUNCTION {s3_function}
 
 
 class SessionsRecordBatchModel(RecordBatchModel):
-    """A model to produce record batches from the sessions table."""
+    """A model to produce record batches from the sessions table.
+
+    Attributes:
+        is_backfill: Whether this model serves a backfill run. Incremental runs select
+            sessions using `_inserted_at` (when the session's events were ingested), so
+            sessions receiving late events are re-exported so that they can be updated.
+            Backfill runs select instead by `$end_timestamp`.
+    """
+
+    def __init__(self, team_id: int, batch_export_id: str | None = None, is_backfill: bool = False):
+        super().__init__(team_id=team_id, batch_export_id=batch_export_id)
+        self.is_backfill = is_backfill
 
     def get_hogql_query(
         self, data_interval_start: dt.datetime | None, data_interval_end: dt.datetime
@@ -157,36 +168,66 @@ class SessionsRecordBatchModel(RecordBatchModel):
         """Return the HogQLQuery used for the sessions model."""
         hogql_query = clone_expr(SELECT_FROM_SESSIONS_HOGQL)
 
-        where_and = ast.And(
-            exprs=[
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Eq,
-                    left=ast.Field(chain=["sessions", "team_id"]),
-                    right=ast.Constant(value=self.team_id),
-                ),
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["_inserted_at"]),
-                    right=ast.Constant(value=data_interval_end),
-                ),
-                # include $end_timestamp because hogql uses this to add a where clause to the inner query
-                ast.CompareOperation(
-                    op=ast.CompareOperationOp.Lt,
-                    left=ast.Field(chain=["$end_timestamp"]),
-                    right=ast.Constant(value=data_interval_end),
-                ),
-            ]
+        team_id_filter = ast.CompareOperation(
+            op=ast.CompareOperationOp.Eq,
+            left=ast.Field(chain=["sessions", "team_id"]),
+            right=ast.Constant(value=self.team_id),
         )
-        if data_interval_start is not None:
-            where_and.exprs.extend(
-                [
+
+        if self.is_backfill:
+            where_and = ast.And(
+                exprs=[
+                    team_id_filter,
                     ast.CompareOperation(
-                        op=ast.CompareOperationOp.GtEq,
-                        left=ast.Field(chain=["_inserted_at"]),
-                        right=ast.Constant(value=data_interval_start),
+                        op=ast.CompareOperationOp.Lt,
+                        left=ast.Field(chain=["$end_timestamp"]),
+                        right=ast.Constant(value=data_interval_end),
                     ),
                 ]
             )
+            if data_interval_start is not None:
+                where_and.exprs.append(
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.GtEq,
+                        left=ast.Field(chain=["$end_timestamp"]),
+                        right=ast.Constant(value=data_interval_start),
+                    ),
+                )
+        else:
+            where_and = ast.And(
+                exprs=[
+                    team_id_filter,
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Lt,
+                        left=ast.Field(chain=["_inserted_at"]),
+                        right=ast.Constant(value=data_interval_end),
+                    ),
+                    # include $end_timestamp because hogql uses this to add a where clause to the inner query
+                    ast.CompareOperation(
+                        op=ast.CompareOperationOp.Lt,
+                        left=ast.Field(chain=["$end_timestamp"]),
+                        right=ast.Constant(value=data_interval_end),
+                    ),
+                ]
+            )
+            if data_interval_start is not None:
+                where_and.exprs.extend(
+                    [
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.GtEq,
+                            left=ast.Field(chain=["_inserted_at"]),
+                            right=ast.Constant(value=data_interval_start),
+                        ),
+                        # Sessions whose events are ingested more than SESSIONS_LOOKBACK_DAYS
+                        # after the session ended are not picked up by incremental runs. This
+                        # is a trade-off to avoid a full table scan.
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.GtEq,
+                            left=ast.Field(chain=["$end_timestamp"]),
+                            right=ast.Constant(value=data_interval_start - SESSIONS_LOOKBACK_DAYS),
+                        ),
+                    ]
+                )
 
         hogql_query.where = where_and
 
@@ -212,6 +253,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
             ]
         )
 
+        # The estimate mirrors backfill runs, which $end_timestamp semantics.
         if end_at is not None:
             where_and.exprs.append(
                 ast.CompareOperation(
@@ -232,7 +274,7 @@ class SessionsRecordBatchModel(RecordBatchModel):
 
         return ast.SelectQuery(
             select=[
-                parse_expr("toTimeZone(min(greatest(max_inserted_at, $end_timestamp)), 'UTC') as min_timestamp"),
+                parse_expr("toTimeZone(min($end_timestamp), 'UTC') as min_timestamp"),
                 parse_expr("count() as record_count"),
             ],
             select_from=ast.JoinExpr(table=ast.Field(chain=["sessions"])),
@@ -342,6 +384,7 @@ def resolve_batch_exports_model(
     batch_export_model: BatchExportModel | None = None,
     batch_export_schema: BatchExportSchema | None = None,
     batch_export_id: str | None = None,
+    is_backfill: bool = False,
 ):
     """Resolve which model and model parameters to use for a batch export.
 
@@ -360,7 +403,9 @@ def resolve_batch_exports_model(
             filters = model.filters
 
             if model_name == "sessions":
-                record_batch_model = SessionsRecordBatchModel(team_id=team_id, batch_export_id=batch_export_id)
+                record_batch_model = SessionsRecordBatchModel(
+                    team_id=team_id, batch_export_id=batch_export_id, is_backfill=is_backfill
+                )
             elif model_name == "hogql":
                 if model.hogql_query is None:
                     raise UnsupportedHogQLQueryError("Batch export model is 'hogql' but no HogQL query was provided")

--- a/products/batch_exports/backend/temporal/sql/sessions.py
+++ b/products/batch_exports/backend/temporal/sql/sessions.py
@@ -56,6 +56,7 @@ SELECT_FROM_SESSIONS_HOGQL = ast.SelectQuery(
         parse_expr("$exit_current_url as exit_current_url"),
         parse_expr("$exit_pathname as exit_pathname"),
         parse_expr("$vitals_lcp as vitals_lcp"),
+        # nosemgrep: semgrep.rules.security.hogql-fstring-audit
         parse_expr(f"{SESSIONS_INSERTED_AT_SQL} as _inserted_at"),
         parse_expr("$entry_gclsrc as entry_gclsrc"),
         parse_expr("$entry_dclid as entry_dclid"),

--- a/products/batch_exports/backend/temporal/sql/sessions.py
+++ b/products/batch_exports/backend/temporal/sql/sessions.py
@@ -1,9 +1,23 @@
 """SQL for the sessions batch export model."""
 
+import datetime as dt
+
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_expr
 
 from products.batch_exports.backend.temporal.sql.common import HogQLQueryBatchExportSettings
+
+# max_inserted_at is only available since around end of 2025. Before
+# that, it is the zero value (unix epoch). We use greatest to pick
+# $end_timestamp for backfills from before max_inserted_at was available.
+SESSIONS_INSERTED_AT_SQL = "greatest(max_inserted_at, $end_timestamp)"
+
+# Lookback days based on the timestamp field of the events that make up a session.
+# Sessions is an aggregate table which is not sorted by inserted_at. So, we need
+# a filter on $end_timestamp to avoid a full scan of the table. Backfills use
+# $end_timestamp rather than max_inserted_at, so this lookback period only applies
+# to regular runs. While testing, 3 days catched almost all sessions.
+SESSIONS_LOOKBACK_DAYS = dt.timedelta(days=3)
 
 SELECT_FROM_SESSIONS_HOGQL = ast.SelectQuery(
     select=[
@@ -42,10 +56,7 @@ SELECT_FROM_SESSIONS_HOGQL = ast.SelectQuery(
         parse_expr("$exit_current_url as exit_current_url"),
         parse_expr("$exit_pathname as exit_pathname"),
         parse_expr("$vitals_lcp as vitals_lcp"),
-        # max_inserted_at is only available since around end of 2025. Before
-        # that, it is the zero value (unix epoch). We use greatest to pick
-        # $end_timestamp for backfills from before max_inserted_at was available.
-        parse_expr("greatest(max_inserted_at, $end_timestamp) as _inserted_at"),
+        parse_expr(f"{SESSIONS_INSERTED_AT_SQL} as _inserted_at"),
         parse_expr("$entry_gclsrc as entry_gclsrc"),
         parse_expr("$entry_dclid as entry_dclid"),
         parse_expr("$entry_gbraid as entry_gbraid"),

--- a/products/batch_exports/backend/temporal/sql/sessions.py
+++ b/products/batch_exports/backend/temporal/sql/sessions.py
@@ -42,7 +42,10 @@ SELECT_FROM_SESSIONS_HOGQL = ast.SelectQuery(
         parse_expr("$exit_current_url as exit_current_url"),
         parse_expr("$exit_pathname as exit_pathname"),
         parse_expr("$vitals_lcp as vitals_lcp"),
-        parse_expr("$end_timestamp as _inserted_at"),
+        # max_inserted_at is only available since around end of 2025. Before
+        # that, it is the zero value (unix epoch). We use greatest to pick
+        # $end_timestamp for backfills from before max_inserted_at was available.
+        parse_expr("greatest(max_inserted_at, $end_timestamp) as _inserted_at"),
         parse_expr("$entry_gclsrc as entry_gclsrc"),
         parse_expr("$entry_dclid as entry_dclid"),
         parse_expr("$entry_gbraid as entry_gbraid"),

--- a/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
+++ b/products/batch_exports/backend/tests/temporal/backfills/test_get_backfill_info.py
@@ -725,10 +725,12 @@ class TestGetBackfillInfoForSessions:
             end_time: dt.datetime | None = None,
             count: int = 10,
             count_other_team: int = 0,
+            inserted_at: dt.datetime | None = None,
         ):
             """Generate events with unique session IDs and derive sessions from them.
 
             Each event gets a unique $session_id, so the number of sessions equals count.
+            Events are ingested at their event time unless `inserted_at` says otherwise.
             """
             for i in range(count):
                 event_time = start_time + dt.timedelta(seconds=i)
@@ -739,7 +741,7 @@ class TestGetBackfillInfoForSessions:
                     start_time=event_time,
                     end_time=(end_time or event_time + dt.timedelta(minutes=2)),
                     count=1,
-                    inserted_at=event_time,
+                    inserted_at=inserted_at or event_time,
                     table="sharded_events",
                     event_name="test-event",
                     count_outside_range=0,
@@ -815,6 +817,32 @@ class TestGetBackfillInfoForSessions:
 
         assert result.adjusted_start_at == dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC).isoformat()
         assert result.total_records_count == 8
+
+    async def test_counts_late_ingested_sessions_by_event_time(
+        self, generate_sessions, create_batch_export, run_get_backfill_info
+    ):
+        """The estimate must mirror backfill runs, which select sessions by event time: a
+        session whose events were ingested late counts towards the backfill range covering
+        its $end_timestamp, not the one covering its ingestion time."""
+        event_time = dt.datetime(2021, 1, 10, 12, 0, 0, tzinfo=dt.UTC)
+        ingested_time = dt.datetime(2021, 1, 20, 6, 30, 0, tzinfo=dt.UTC)
+        await generate_sessions(start_time=event_time, count=3, inserted_at=ingested_time)
+
+        batch_export = await create_batch_export()
+        result_event_range = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 11, 0, 0, 0, tzinfo=dt.UTC),
+        )
+        result_ingestion_range = await run_get_backfill_info(
+            batch_export,
+            start_at=dt.datetime(2021, 1, 20, 0, 0, 0, tzinfo=dt.UTC),
+            end_at=dt.datetime(2021, 1, 21, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert result_event_range.adjusted_start_at == dt.datetime(2021, 1, 10, 12, 0, 0, tzinfo=dt.UTC).isoformat()
+        assert result_event_range.total_records_count == 3
+        assert result_ingestion_range.total_records_count == 0
 
     async def test_counts_only_sessions_before_end_at(
         self, generate_sessions, create_batch_export, run_get_backfill_info

--- a/products/batch_exports/backend/tests/temporal/test_record_batch_model.py
+++ b/products/batch_exports/backend/tests/temporal/test_record_batch_model.py
@@ -1,10 +1,14 @@
+import datetime as dt
+
 import pytest
 
 from posthog.hogql.hogql import ast
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 
 from posthog.credentials import AWSKeyPair
+from posthog.models.utils import uuid7
 from posthog.sync import database_sync_to_async
+from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
 from products.batch_exports.backend.hogql_source import UnsupportedHogQLQueryError
 from products.batch_exports.backend.service import BatchExportModel
@@ -13,6 +17,8 @@ from products.batch_exports.backend.temporal.record_batch_model import (
     SessionsRecordBatchModel,
     resolve_batch_exports_model,
 )
+from products.batch_exports.backend.temporal.sql.sessions import SESSIONS_LOOKBACK_DAYS
+from products.batch_exports.backend.tests.temporal.utils.clickhouse import truncate_events, truncate_sessions
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -28,10 +34,48 @@ class TestSessionsRecordBatchModel:
             left=ast.Field(chain=["sessions", "team_id"]),
             right=ast.Constant(value=ateam.id),
         )
+        # the $end_timestamp lower bound is what lets hogql prune raw_sessions partitions,
+        # shifted back to still catch sessions ingested up to SESSIONS_MAX_LATENESS late
+        lateness_filter = ast.CompareOperation(
+            op=ast.CompareOperationOp.GtEq,
+            left=ast.Field(chain=["$end_timestamp"]),
+            right=ast.Constant(value=data_interval_start - SESSIONS_LOOKBACK_DAYS),
+        )
 
         assert hogql_query.where is not None
         assert isinstance(hogql_query.where, ast.And)
         assert team_id_filter in hogql_query.where.exprs
+        assert lateness_filter in hogql_query.where.exprs
+
+    async def test_get_hogql_query_for_backfill(self, ateam, data_interval_start, data_interval_end):
+        """Backfill runs select sessions by event time ($end_timestamp), not by the
+        _inserted_at watermark, so sessions ingested beyond SESSIONS_MAX_LATENESS can
+        still be exported by backfilling their $end_timestamp range."""
+        model = SessionsRecordBatchModel(team_id=ateam.id, is_backfill=True)
+        hogql_query = model.get_hogql_query(data_interval_start, data_interval_end)
+
+        lower_bound = ast.CompareOperation(
+            op=ast.CompareOperationOp.GtEq,
+            left=ast.Field(chain=["$end_timestamp"]),
+            right=ast.Constant(value=data_interval_start),
+        )
+        upper_bound = ast.CompareOperation(
+            op=ast.CompareOperationOp.Lt,
+            left=ast.Field(chain=["$end_timestamp"]),
+            right=ast.Constant(value=data_interval_end),
+        )
+
+        assert hogql_query.where is not None
+        assert isinstance(hogql_query.where, ast.And)
+        assert lower_bound in hogql_query.where.exprs
+        assert upper_bound in hogql_query.where.exprs
+        # no _inserted_at bounds: backfill selection is purely by event time
+        assert not any(
+            isinstance(expr, ast.CompareOperation)
+            and isinstance(expr.left, ast.Field)
+            and expr.left.chain == ["_inserted_at"]
+            for expr in hogql_query.where.exprs
+        )
 
     async def test_as_query_with_parameters(self, ateam, data_interval_start, data_interval_end):
         model = SessionsRecordBatchModel(
@@ -46,6 +90,11 @@ class TestSessionsRecordBatchModel:
             in printed_query
         )
         assert f"less(_inserted_at, toDateTime64('{data_interval_end:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')" in printed_query
+        # the $end_timestamp lower bound is shifted back by lookback days
+        assert (
+            f"toDateTime64('{data_interval_start - SESSIONS_LOOKBACK_DAYS:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')"
+            in printed_query
+        )
 
         # check that we have a date range set on the inner query using the session ID
         assert (
@@ -118,6 +167,11 @@ class TestSessionsRecordBatchModel:
             in printed_query
         )
         assert f"less(_inserted_at, toDateTime64('{data_interval_end:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')" in printed_query
+        # the $end_timestamp lower bound is shifted back by the lateness horizon
+        assert (
+            f"toDateTime64('{data_interval_start - SESSIONS_LOOKBACK_DAYS:%Y-%m-%d %H:%M:%S.%f}', 6, 'UTC')"
+            in printed_query
+        )
 
         # check that we have a date range set on the inner query using the session ID
         assert (
@@ -157,6 +211,119 @@ class TestSessionsRecordBatchModel:
             in printed_query
         )
         assert "PARTITION BY rand() %% 5" in printed_query
+
+
+class TestSessionsRecordBatchModelSelection:
+    """Run the sessions model query against ClickHouse to verify which intervals select a session."""
+
+    @pytest.fixture(autouse=True)
+    async def truncate_tables(self, clickhouse_client):
+        await truncate_events(clickhouse_client)
+        await truncate_sessions(clickhouse_client)
+
+    async def _generate_session(
+        self,
+        clickhouse_client,
+        team_id: int,
+        event_time: dt.datetime,
+        inserted_at: dt.datetime,
+    ) -> str:
+        session_id = str(uuid7(unix_ms_time=int(event_time.timestamp() * 1000)))
+        await generate_test_events_in_clickhouse(
+            client=clickhouse_client,
+            team_id=team_id,
+            start_time=event_time,
+            end_time=event_time + dt.timedelta(minutes=2),
+            count=1,
+            count_outside_range=0,
+            count_other_team=0,
+            inserted_at=inserted_at,
+            table="sharded_events",
+            event_name="test-event",
+            properties={"$session_id": session_id},
+            insert_sessions=True,
+        )
+        return session_id
+
+    async def _select_session_ids(
+        self,
+        clickhouse_client,
+        model: SessionsRecordBatchModel,
+        interval_start: dt.datetime,
+        interval_end: dt.datetime,
+    ) -> list[str]:
+        printed_query, parameters = await model._print_query(interval_start, interval_end, output_format="JSONEachRow")
+        rows = await clickhouse_client.read_query_as_jsonl(printed_query, query_parameters=parameters)
+        return [row["session_id"] for row in rows]
+
+    async def test_selects_late_session_by_interval_covering_its_ingestion(self, clickhouse_client, ateam):
+        """A session whose events are ingested late (within SESSIONS_LOOKBACK_DAYS) is selected
+        by the interval covering its ingestion time, not the one covering its event timestamps."""
+        event_time = dt.datetime(2021, 1, 18, 12, 0, 0, tzinfo=dt.UTC)
+        ingested_at = dt.datetime(2021, 1, 20, 6, 30, 0, tzinfo=dt.UTC)
+        session_id = await self._generate_session(clickhouse_client, ateam.pk, event_time, ingested_at)
+        model = SessionsRecordBatchModel(team_id=ateam.pk)
+
+        selected_by_event_interval = await self._select_session_ids(
+            clickhouse_client,
+            model,
+            dt.datetime(2021, 1, 18, 12, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 18, 13, 0, 0, tzinfo=dt.UTC),
+        )
+        selected_by_ingestion_interval = await self._select_session_ids(
+            clickhouse_client,
+            model,
+            dt.datetime(2021, 1, 20, 6, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 20, 7, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert selected_by_event_interval == []
+        assert selected_by_ingestion_interval == [session_id]
+
+    async def test_session_ingested_beyond_lateness_horizon_requires_backfill(self, clickhouse_client, ateam):
+        """A session ingested more than SESSIONS_LOOKBACK_DAYS after it ended is skipped by
+        incremental runs (the prunable $end_timestamp bound excludes it), but a backfill of
+        its event-time range picks it up."""
+        event_time = dt.datetime(2021, 1, 10, 12, 0, 0, tzinfo=dt.UTC)
+        ingested_at = dt.datetime(2021, 1, 20, 6, 30, 0, tzinfo=dt.UTC)
+        session_id = await self._generate_session(clickhouse_client, ateam.pk, event_time, ingested_at)
+
+        incremental_model = SessionsRecordBatchModel(team_id=ateam.pk)
+        selected_by_ingestion_interval = await self._select_session_ids(
+            clickhouse_client,
+            incremental_model,
+            dt.datetime(2021, 1, 20, 6, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 20, 7, 0, 0, tzinfo=dt.UTC),
+        )
+
+        backfill_model = SessionsRecordBatchModel(team_id=ateam.pk, is_backfill=True)
+        selected_by_backfill_of_event_range = await self._select_session_ids(
+            clickhouse_client,
+            backfill_model,
+            dt.datetime(2021, 1, 10, 0, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 11, 0, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert selected_by_ingestion_interval == []
+        assert selected_by_backfill_of_event_range == [session_id]
+
+    async def test_sessions_without_max_inserted_at_fall_back_to_end_timestamp(self, clickhouse_client, ateam):
+        """Sessions from before raw_sessions had max_inserted_at carry the epoch value; the
+        watermark falls back to $end_timestamp, so they are still selected by their event-time
+        interval."""
+        event_time = dt.datetime(2021, 1, 15, 10, 30, 0, tzinfo=dt.UTC)
+        epoch = dt.datetime(1970, 1, 1, 0, 0, 0, tzinfo=dt.UTC)
+        session_id = await self._generate_session(clickhouse_client, ateam.pk, event_time, epoch)
+        model = SessionsRecordBatchModel(team_id=ateam.pk)
+
+        selected = await self._select_session_ids(
+            clickhouse_client,
+            model,
+            dt.datetime(2021, 1, 15, 10, 0, 0, tzinfo=dt.UTC),
+            dt.datetime(2021, 1, 15, 11, 0, 0, tzinfo=dt.UTC),
+        )
+
+        assert selected == [session_id]
 
 
 class TestHogQLQueryRecordBatchModel:


### PR DESCRIPTION
<!-- This has to stand on its own: a reader who opens no files should still know why the PR is necessary and what it does. Length tracks the change, so a small diff gets a few bullets rather than a full-length body, and a section you have nothing for gets one line or "None". -->

## Problem

$end_timestamp is just the timestamp of the last event of the session. It can cause session rows to be missed if the events arrive with a big delay.

<!-- Who are we building for, what are their needs, why is this important? -->
<!-- First line: what is different for a person, and who they are. A fix says what breaks; a feature says what someone can now do; a chore says who is blocked. The code path goes underneath. -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Use max_inserted_at instead. This is an aggregate: The maximum `inserted_at` of the events in the session. So, if new events arrive late (Relative to their `timestamp`) `max_inserted_at` changes even if the `$end_timestamp` stays the same.

However, this has a lot of caveats:
* The `events` table is not sorted by `inserted_at`, so we cannot completely remove the `$end_timestamp` filters: That will cause a full-table scan. We must use an old trick from batch exports: Have a filter that looks back a certain amount of days, and then filter on `max_inserted_at` just during those days. This is set to 3 days as during testing this got REALLY close to catching all sessions.
* Similarly to batch exports, backfills use `$end_timestamp`. Backfills deal with historical data, so we assume everything has arrived and has been ingested (i.e. no delayed events).

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

I prompted claude to add some unit tests for this.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->
<!-- Don't recite pass counts for suites CI runs; the checks report those with more authority. Link the evidence instead (run, permalink, error tracking issue), and say what you did not check. Long transcripts go in a <details> block. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

We should mention that sessions with really late events will be missed, maybe one day we'll figure out a permanent solution.
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

I had claude test the fix, and also write some tests.
<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
     - Public artifact: nothing in this PR — code, fixtures and sample data, comments, commit messages, or this description — carries material from the agent session that isn't already public. If the work drew on a customer conversation, ticket, or log, say so here and state that the committed data is invented. Renaming people, hosts, and identifiers does not clear real material; see AGENTS.md "Public open source repo guidance".
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way: what changed across the session. The reason the shipped design beats the obvious alternative goes in Changes instead, where a reviewer will actually see it.
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session — that applies to every part of this PR, not just this section.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Stack instead of stuffing: if the diff holds two or more separable steps (migration then behavior, rename then rewrite), open a stack rather than one big PR. See AGENTS.md, "Stacked PRs" and /stacking-prs.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- Shape and style: invoke the `/writing-pr-descriptions` skill before writing this body. In short: lead with the effect a person sees rather than the code path behind it, make the body stand alone for a reader who opens no files, size it to the change, link evidence rather than asserting what CI already reports, then hold what's left to one fact per bullet in under 25 words. A body that got longer as bullets was not cut.
-->
