### PR TITLE
fix(desktop): allow Cmd+W to close tabs on macOS by removing conflicting menu accelerator (Fixes #76278)

### DIFF
--- a/products/desktop/apps/code/src/main/menu.ts
+++ b/products/desktop/apps/code/src/main/menu.ts
@@ -354,5 +354,22 @@ function buildViewMenu(): MenuItemConstructorOptions {
 }
 
 function buildWindowMenu(): MenuItemConstructorOptions {
-  return { role: "windowMenu" };
+  return {
+    label: "Window",
+    submenu: [
+      { role: "minimize" },
+      { role: "zoom" },
+      ...(process.platform === "darwin"
+        ? [
+            { type: "separator" as const },
+            {
+              label: "Close Window",
+              accelerator: "Cmd+Shift+W",
+              role: "close",
+            } as MenuItemConstructorOptions,
+            { role: "front" as const },
+          ]
+        : [{ role: "close" as const }]),
+    ],
+  };
 }


### PR DESCRIPTION
## Summary

On macOS, pressing `Cmd+W` closes the entire window instead of closing the focused tab. This happens because Electron's `{ role: "windowMenu" }` template includes a "Close Window" menu item with `Cmd+W` accelerator on macOS, which intercepts the keypress before it reaches the renderer's `usePanelKeyboardShortcuts` handler.

### Changes

- Replace `{ role: "windowMenu" }` with an explicit Window menu that:
  - Keeps `Minimize` (Cmd+M) and `Zoom`
  - On macOS: uses `Cmd+Shift+W` for "Close Window" (freeing `Cmd+W` for the renderer)
  - On non-macOS: behavior unchanged (the existing `role: "close"` works fine)

### Why this approach

The renderer already has a working `SHORTCUTS.CLOSE_TAB ("mod+w")` handler in `usePanelKeyboardShortcuts` that calls `event.preventDefault()` and closes the active tab. On Windows this works because `Ctrl+W` reaches the renderer before the menu. On macOS, the menu accelerator wins. By changing the menu's accelerator on macOS, the key reaches the renderer as intended.

Users can still close the window via the red traffic light button or the explicit `Cmd+Shift+W` menu item.

Fixes #76278