### PR TITLE
fix(data-imports): tolerate a deleted issue's 404 in Sentry issue_hashes sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/fanout.py
@@ -11,6 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     Endpoint,
     EndpointResource,
     IncrementalConfig,
+    ResponseAction,
 )
 
 
@@ -31,6 +32,10 @@ class DependentEndpointConfig:
     parent_field_renames: dict[str, str] = field(default_factory=dict)
     parent_params: dict[str, Any] = field(default_factory=dict)
     child_params: dict[str, Any] = field(default_factory=dict)
+    # Applied to the CHILD request only. Use this to tolerate a per-parent-item failure (e.g. a
+    # 404 for a parent row deleted/merged between the parent listing and this child fetch)
+    # without failing the whole fan-out — see resource.py's response_actions "ignore" handling.
+    child_response_actions: list[ResponseAction] = field(default_factory=list)
 
 
 def rename_parent_fields(parent_name: str, renames: dict[str, str]) -> Callable[[dict[str, Any]], dict[str, Any]]:
@@ -126,6 +131,8 @@ def build_dependent_resource(
         "path": child_path,
         "params": child_params,
     }
+    if fanout.child_response_actions:
+        child_endpoint_config["response_actions"] = fanout.child_response_actions
     if child_endpoint_extra:
         if "params" in child_endpoint_extra:
             raise ValueError(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_fanout.py
@@ -183,6 +183,37 @@ def test_build_dependent_resource_merges_fanout_child_params(mock_rest_api_resou
 
 
 @patch("products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources")
+def test_build_dependent_resource_forwards_child_response_actions(mock_rest_api_resources) -> None:
+    mock_rest_api_resources.return_value = []
+    try:
+        build_dependent_resource(
+            endpoint_configs=_build_endpoint_configs(),
+            child_endpoint="children",
+            fanout=DependentEndpointConfig(
+                parent_name="parents",
+                resolve_param="parent_id",
+                resolve_field="id",
+                include_from_parent=["id"],
+                child_response_actions=[{"status_code": 404, "action": "ignore"}],
+            ),
+            client_config={"base_url": "https://example.com"},
+            path_format_values={},
+            team_id=1,
+            job_id="job-1",
+            db_incremental_field_last_value=None,
+        )
+    except StopIteration:
+        pass
+
+    config = mock_rest_api_resources.call_args.args[0]
+    parent_resource = config["resources"][0]
+    child_resource = config["resources"][1]
+    assert child_resource["endpoint"]["response_actions"] == [{"status_code": 404, "action": "ignore"}]
+    # The parent request has no such tolerance — a 404 there still means "org/list not found".
+    assert "response_actions" not in parent_resource["endpoint"]
+
+
+@patch("products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources")
 def test_build_dependent_resource_rejects_child_params_clobbering_resolve(mock_rest_api_resources) -> None:
     mock_rest_api_resources.return_value = []
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/settings.py
@@ -266,6 +266,10 @@ SENTRY_ENDPOINTS: dict[str, SentryEndpointConfig] = {
             include_from_parent=["id"],
             parent_field_renames={"id": "issue_id"},
             parent_params={"query": "", "sort": "date"},
+            # An issue can be deleted or merged into another between the `issues` listing and
+            # this per-issue fetch, which 404s. That's expected churn, not a broken sync — treat
+            # it as "no hashes for this issue" instead of failing the whole schema.
+            child_response_actions=[{"status_code": 404, "action": "ignore"}],
         ),
     ),
     "issue_tag_values": SentryEndpointConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -531,6 +531,31 @@ class TestSentrySourceValidation:
         child_resource = next(r for r in config["resources"] if r["name"] == endpoint)
         assert child_resource["endpoint"]["params"]["full"] == "true"
 
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.fanout.rest_api_resources"
+    )
+    def test_issue_hashes_tolerates_child_not_found(self, mock_rest_api_resources) -> None:
+        # An issue can be deleted/merged between the `issues` listing and this per-issue hashes
+        # fetch, which 404s. That single-issue 404 must not fail the whole schema (see
+        # SentrySource.get_non_retryable_errors' generic "404 Client Error" mapping).
+        mock_rest_api_resources.return_value = [
+            _FakeDltResource("issues", [{"id": "100"}]),
+            _FakeDltResource("issue_hashes", []),
+        ]
+
+        sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="issue_hashes",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        config = mock_rest_api_resources.call_args.args[0]
+        child_resource = next(r for r in config["resources"] if r["name"] == "issue_hashes")
+        assert child_resource["endpoint"]["response_actions"] == [{"status_code": 404, "action": "ignore"}]
+
     # ----- Issue fan-out: custom iterator (issue_tag_values) -----
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry.make_tracked_session")


### PR DESCRIPTION
## Problem

A Sentry `issue_hashes` full-refresh sync fails permanently when a single issue is deleted or merged between the `issues` listing and the per-issue hashes fetch that follows it: that fetch 404s ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd72e-8824-7552-852e-b5f024593bbe)).

`SentrySource.get_non_retryable_errors` maps any bare 404 to "organization not found", so one missing issue permanently pauses the entire schema with a misleading message, even though the credentials and organization are fine.

## Changes

- Adds `child_response_actions` to the shared fan-out config (`DependentEndpointConfig` in `rest_source/fanout.py`). A fan-out's child request can now opt into the engine's existing response-action "ignore" handling per parent item, without touching the shared pagination loop.
- Sets it on Sentry's `issue_hashes` endpoint, so a 404 for one issue's hashes syncs as an empty result for that issue and the fan-out continues to the next one, instead of failing the whole schema.
- The endpoint's parent request (the `issues` listing) is untouched, so a genuine "organization not found" 404 there still surfaces and is classified non-retryable as before.

## How did you test this code?

- Added `test_build_dependent_resource_forwards_child_response_actions` in `test_fanout.py`: asserts `child_response_actions` flows into the child endpoint config and the parent endpoint is unaffected.
- Added `test_issue_hashes_tolerates_child_not_found` in `test_sentry.py`: asserts `sentry_source(endpoint="issue_hashes", ...)` wires the 404-ignore action into the resource config passed to the REST engine.
- Ran the full `test_fanout.py` + `test_sentry.py` suites locally: 144 passed.
- `ruff check`/`ruff format` clean on all changed files; repo-wide `mypy --cache-fine-grained .` clean.
- Not run: an end-to-end sync against the real Sentry API (no live credentials in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-handling fix, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error tracking issue in the data-warehouse import pipeline (Sentry sync, shared fan-out code). Traced the stack trace through `rest_client.py`'s `_send_request` into the generic parent→child fan-out (`build_dependent_resource`/`paginate_dependent_resource`), confirmed via error tracking event properties that the failing schema was `issue_hashes` on a `full_refresh` sync. Surveyed the other ~25 sources using the same fan-out mechanism to confirm this is a shared-code bug class, not Sentry-specific, then chose the engine's existing `response_actions` "ignore" hook (already used elsewhere in the codebase) over adding new per-item exception handling to the pagination loop, since it required no change to shared iteration logic.

Checked for a duplicate: PR [#72929](https://github.com/PostHog/posthog/pull/72929) touches the same `fanout.py`/`test_fanout.py` files and coincidentally adds a similar 404-ignore action for `issue_hashes`, but only when its warehouse-parent-reuse feature flag is active (off by default) — the reported failure occurs on the current, flag-off "api" parent path, which that PR leaves unchanged. Worth a heads-up for whoever rebases second, given the file overlap.

Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*