### PR TITLE
fix(data-imports): tolerate a missing S3 job folder on first materialization

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -163,6 +163,24 @@ class TestPrepareS3FilesForQuerying:
                     delete_existing=False,
                 )
 
+    async def test_tolerates_job_folder_missing_on_first_materialization(self):
+        # A brand new table/model has no prior content in S3, so listing the job folder to
+        # find old timestamped query folders to clean up raises FileNotFoundError (s3fs's
+        # `_ls` behavior for a prefix with zero objects under it). That's an expected first-run
+        # state, not a failure - regresses the crash this caused on first materialization.
+        s3 = _fake_s3(_ls=AsyncMock(side_effect=FileNotFoundError("job")))
+
+        with patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)):
+            await prepare_s3_files_for_querying(
+                folder_path="job",
+                table_name="my_table",
+                file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                delete_existing=True,
+                use_timestamped_folders=True,
+            )
+
+        s3._cp_file.assert_awaited_once()
+
 
 @parameterized.expand(
     [

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -139,7 +139,12 @@ async def prepare_s3_files_for_querying(
                     rf"(?:^|.+/){re.escape(normalized_table_name)}\_\_query\_(\d+)(?:_[0-9a-f]{{8}})?\/?$"
                 )
 
-                all_files = await s3._ls(s3_folder_for_job, detail=True)
+                try:
+                    all_files = await s3._ls(s3_folder_for_job, detail=True)
+                except FileNotFoundError:
+                    # First materialization for this table/model: the job folder has no
+                    # prior content in S3 yet, so there's nothing to clean up.
+                    all_files = []
                 all_file_values = all_files.values() if isinstance(all_files, dict) else all_files
                 directories = [f["Key"] for f in all_file_values if f["type"] == "directory"]
 


### PR DESCRIPTION
## Problem

The first materialization of a data-modeling saved query crashes with `FileNotFoundError` instead of completing. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd745-63d0-7df1-ae11-430fc9a83071).

The shared S3 file-preparation step used by both data-modeling materialization and warehouse source syncs lists the job's S3 folder to find old timestamped query folders to delete. On a brand new table or model, nothing has been written to that folder yet, so `s3fs`'s `_ls` raises `FileNotFoundError` for a prefix with zero objects under it. That's an expected first-run state, not a bug in the data being synced.

## Changes

- `prepare_s3_files_for_querying` now catches `FileNotFoundError` from the job-folder listing and treats it as "no existing folders to clean up", the same outcome the function already produces via `s3._exists()` for the non-timestamped-folder path.
- No behavior change once the job folder has prior content (the common case after the first run).

## How did you test this code?

Added `test_tolerates_job_folder_missing_on_first_materialization` to `test_util.py`, which mocks `s3._ls` to raise `FileNotFoundError` and asserts the copy still proceeds. Confirmed it fails without the fix and passes with it. Ran the full `test_util.py` file (15 tests) and `ruff check`/`ruff format --check`/`mypy` on the changed file locally, all clean.

Not run: an end-to-end Temporal workflow test against real S3, since this fix is scoped to the listing helper's exception handling.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via PostHog error tracking (Claude Code), which surfaced the `FileNotFoundError` issue linked above. Investigated the stack trace, traced the call path from `prepare_queryable_table_activity` into the shared `data_imports/util.py` helper, and confirmed with a local read of the installed `s3fs` source that `_ls` raises `FileNotFoundError` for a prefix with no objects. Searched open PRs (human-authored and the maintainer's own) for a duplicate fix; found none.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.