### PR TITLE
feat(experiments): Log freeze and unfreeze exposure in History

### DIFF
--- a/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.test.tsx
@@ -65,6 +65,20 @@ describe('experimentActivityDescriber', () => {
         })
     })
 
+    describe('exposure freeze rows', () => {
+        it.each([
+            { activity: 'exposure_frozen', expectedFragment: 'froze exposure for', notExpected: 'unfroze' },
+            { activity: 'exposure_unfrozen', expectedFragment: 'unfroze exposure for', notExpected: 'unknown action' },
+        ])('$activity: "$expectedFragment experiment name"', ({ activity, expectedFragment, notExpected }) => {
+            const result = experimentActivityDescriber(baseLogItem({ activity }))
+            const text = textOf(result)
+            expect(text).toContain('Alice Adams')
+            expect(text).toContain(expectedFragment)
+            expect(text).toContain('Checkout funnel')
+            expect(text).not.toContain(notExpected)
+        })
+    })
+
     describe('metric reorder rows on the experiment scope', () => {
         it.each([
             {

--- a/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
+++ b/frontend/src/scenes/experiments/experimentActivityDescriber.tsx
@@ -265,6 +265,28 @@ export const experimentActivityDescriber = (logItem: ActivityLogItem): Humanized
                 ),
             }
         })
+        .with({ activity: 'exposure_frozen' }, ({ item_id, detail }) => {
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
+                        listParts={['froze exposure for']}
+                        suffix={nameOrLinkToExperiment(detail.name, item_id)}
+                    />
+                ),
+            }
+        })
+        .with({ activity: 'exposure_unfrozen' }, ({ item_id, detail }) => {
+            return {
+                description: (
+                    <SentenceList
+                        prefix={<strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong>}
+                        listParts={['unfroze exposure for']}
+                        suffix={nameOrLinkToExperiment(detail.name, item_id)}
+                    />
+                ),
+            }
+        })
         .with({ activity: 'updated' }, ({ item_id, detail: updateLogDetail }) => {
             /**
              * This is the catch all for all experiment updates

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -43,6 +43,8 @@ from posthog.exceptions import (
     ClickHouseQueryMemoryLimitExceeded,
     ClickHouseQueryTimeOut,
 )
+from posthog.models.activity_logging.activity_log import Detail, log_activity
+from posthog.models.activity_logging.model_activity import is_impersonated_session
 from posthog.models.activity_logging.utils import get_changed_fields_local
 from posthog.models.filters.filter import Filter
 from posthog.models.person.util import get_person_ids_and_uuids_by_uuids
@@ -2277,6 +2279,19 @@ class ExperimentService:
 
         # end_date intentionally left null — metrics keep flowing.
 
+        # The flag write above logs under the FeatureFlag scope only; without this entry the
+        # experiment's History tab shows nothing for the freeze.
+        log_activity(
+            organization_id=self.team.organization_id,
+            team_id=self.team.pk,
+            user=self.user,
+            was_impersonated=is_impersonated_session(request),
+            item_id=experiment.pk,
+            scope="Experiment",
+            activity="exposure_frozen",
+            detail=Detail(name=experiment.name),
+        )
+
         self._report_lifecycle_event(experiment, "experiment exposure frozen", request=request)
 
         # flag_save_ms includes the transaction commit, so it carries the on-commit flag cache
@@ -2534,6 +2549,17 @@ class ExperimentService:
         # Only after the flag no longer references them: soft-delete the now-orphaned snapshots.
         self._delete_orphaned_snapshot_cohorts(cohort_ids)
         cohort_cleanup_done_at = time.monotonic()
+
+        log_activity(
+            organization_id=self.team.organization_id,
+            team_id=self.team.pk,
+            user=self.user,
+            was_impersonated=is_impersonated_session(request),
+            item_id=experiment.pk,
+            scope="Experiment",
+            activity="exposure_unfrozen",
+            detail=Detail(name=experiment.name),
+        )
 
         self._report_lifecycle_event(experiment, "experiment exposure unfrozen", request=request)
 

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -3669,6 +3669,12 @@ class TestExperimentService(APIBaseTest):
         assert frozen.is_running is True
         assert frozen.is_exposure_frozen is True
 
+        # The freeze shows up in the experiment's History tab, not only under the flag's scope.
+        log = ActivityLog.objects.get(scope="Experiment", item_id=str(experiment.pk), activity="exposure_frozen")
+        assert log.user == self.user
+        assert log.detail is not None
+        assert log.detail["name"] == "Freeze Exposure"
+
     def test_freeze_exposure_multi_group_flag(self):
         experiment = self._create_running_experiment(name="Freeze Multi", feature_flag_key="freeze-multi-flag")
         flag = experiment.feature_flag
@@ -4186,6 +4192,12 @@ class TestExperimentService(APIBaseTest):
         # The snapshot cohort is soft-deleted, not left as clutter.
         cohort.refresh_from_db()
         assert cohort.deleted is True
+
+        # The unfreeze shows up in the experiment's History tab, not only under the flag's scope.
+        log = ActivityLog.objects.get(scope="Experiment", item_id=str(experiment.pk), activity="exposure_unfrozen")
+        assert log.user == self.user
+        assert log.detail is not None
+        assert log.detail["name"] == "Unfreeze Test"
 
     def test_unfreeze_exposure_keeps_user_edits_made_while_frozen(self) -> None:
         experiment = self._create_running_experiment(name="Unfreeze Edits", feature_flag_key="unfreeze-edits-flag")


### PR DESCRIPTION
## Problem

Freezing or unfreezing exposure leaves no trace in the experiment's History tab.

- Both actions only write the feature flag, so the activity lands under the flag's scope as opaque filter diffs.
- "Who froze this experiment, and when" cannot be answered from the experiment page.
- Launch, stop, and restore all appear there, so the missing freeze entries read as missing data.

## Changes

- The freeze and unfreeze service methods write an Experiment-scope activity entry after the flag write succeeds.
- The History tab renders the entries as "froze exposure for [experiment]" and "unfroze exposure for [experiment]", matching the existing lifecycle rows.

No screenshot: capturing the rendered entry needs a freeze performed against a running stack, which I did not do. The jest assertions below cover the rendered sentence text.

## How did you test this code?

- Extended the freeze and unfreeze happy-path service tests to assert the Experiment-scope activity row exists, with user attribution and the experiment name. Catches the entries silently disappearing again.
- Two jest rows assert the describer renders the new sentences instead of the "performed an unknown action" fallback. Catches a dropped or renamed matcher.
- Repo-wide mypy passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code in a worktree; second PR from an improvement scan of the Experiments history tab (first: #78789). Skills invoked: /wt, /writing-tests, /writing-user-facing-copy, /writing-code-comments, /writing-pr-descriptions. Kept scope to freeze/unfreeze; pause/resume have the same gap and can follow the same pattern in a later PR.
