### PR TITLE
fix(data-warehouse): clarify the error shown when a database connection times out

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -97,7 +97,7 @@ ClickHouseErrors: dict[str, str] = {
     "nodename nor servname provided": "Could not resolve the ClickHouse host",
     "name or service not known": "Could not resolve the ClickHouse host",
     "connection refused": "Could not connect to ClickHouse on the given host/port",
-    "connection timed out": "Connection to ClickHouse timed out. Check that it's reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a server that can't be exposed publicly, use the SSH tunnel option.",
+    "connection timed out": "Connection to ClickHouse timed out. Check that your database is reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a database that can't be exposed publicly, use the SSH tunnel option.",
     # Must stay above the generic "ssl" entry, which would otherwise match first and send the
     # user to the wrong toggle. Verification runs against the configured ClickHouse host even
     # over an SSH tunnel (server_hostname), so a mismatch is real: the certificate doesn't

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -97,7 +97,7 @@ ClickHouseErrors: dict[str, str] = {
     "nodename nor servname provided": "Could not resolve the ClickHouse host",
     "name or service not known": "Could not resolve the ClickHouse host",
     "connection refused": "Could not connect to ClickHouse on the given host/port",
-    "connection timed out": "Connection to ClickHouse timed out. Does your database have our IP addresses allow-listed?",
+    "connection timed out": "Connection to ClickHouse timed out. Check that it's reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a server that can't be exposed publicly, use the SSH tunnel option.",
     # Must stay above the generic "ssl" entry, which would otherwise match first and send the
     # user to the wrong toggle. Verification runs against the configured ClickHouse host even
     # over an SSH tunnel (server_hostname), so a mismatch is real: the certificate doesn't

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -60,7 +60,10 @@ _VALIDATE_CONNECTION_HINTS: list[tuple[str, str]] = [
         "Connection refused",
         "Could not connect to the host on the port given. Check the host and port are correct and the MySQL server is accepting connections.",
     ),
-    ("timed out", "Connection timed out. Does your database have our IP addresses allowed?"),
+    (
+        "timed out",
+        "Connection timed out. Check that your database is reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a database that can't be exposed publicly, use the SSH tunnel option.",
+    ),
     (
         "No route to host",
         "Could not reach the host. Check the host is correct and that PostHog's IP addresses are allowed through your firewall.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2188,7 +2188,7 @@ class TestMySQLSourceValidateCredentials:
             ),
             (
                 pymysql.err.OperationalError(2003, "Can't connect to MySQL server on 'db.example.com' (timed out)"),
-                "Connection timed out. Does your database have our IP addresses allowed?",
+                "Connection timed out. Check that your database is reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a database that can't be exposed publicly, use the SSH tunnel option.",
             ),
             (
                 pymysql.err.OperationalError(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -137,7 +137,7 @@ PostgresErrors = {
     "No route to host": _HOST_UNREACHABLE_ERROR,
     "Is the server running on that host and accepting TCP/IP connections": "Could not connect to the host on the port given",
     'database "': "Database does not exist",
-    "timeout expired": "Connection timed out. Does your database have our IP addresses allowed?",
+    "timeout expired": "Connection timed out. Check that your database is reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a database that can't be exposed publicly, use the SSH tunnel option.",
     "the database system is starting up": "Your database is starting up or recovering. Wait a moment and try again.",
     "SSL/TLS connection is required": "SSL/TLS connection is required but your database does not support it. Please enable SSL/TLS on your PostgreSQL server.",
     "server does not support SSL, but SSL was required": "SSL/TLS connection is required but your database does not support it. Please enable SSL/TLS on your PostgreSQL server.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -45,7 +45,7 @@ RedshiftErrors = {
     "could not translate host name": "Could not connect to the host",
     "Is the server running on that host and accepting TCP/IP connections": "Could not connect to the host on the port given",
     'database "': "Database does not exist",
-    "timeout expired": "Connection timed out. Does your database have our IP addresses allowed?",
+    "timeout expired": "Connection timed out. Check that your database is reachable from the public internet and that PostHog's egress IP addresses are allowed through your firewall (see the docs). For a database that can't be exposed publicly, use the SSH tunnel option.",
     "SSL connection has been closed unexpectedly": "SSL connection error. Please check your SSL settings.",
     "server does not support SSL": "The server does not support SSL, which we require for Redshift. Please check the host and port point to your Redshift cluster.",
     "Connection refused": "Connection refused. Please check the host and port.",


### PR DESCRIPTION
## Problem

- A user connecting a self-managed SQL source (Postgres, Redshift, MySQL, ClickHouse) whose firewall drops PostHog hits a "connection timed out" error that asks "Does your database have our IP addresses allowed?" and stops there.
- The message is a question, not an instruction. It names no next step, no way to find PostHog's IP addresses, and no alternative for a database that can't be public.
- In a watched onboarding session a user hit this on a Postgres source, retried, dead-clicked, and abandoned the setup.

## Changes

- Rewrite the timeout error for all four sources to state the next action: make the database reachable from the public internet, allow PostHog's egress IP addresses through the firewall (see the docs), or use the SSH tunnel option for a database that can't be exposed publicly.
- The new wording matches the sibling error messages ("No route to host", host unreachable) and the host-field caption already present in each source.
- Copy-only. The messages are validation-time display strings; retry classification is untouched.

## How did you test this code?

- Updated and ran the existing MySQL mapping test (`test_known_connection_errors_are_not_captured`), 7 passed.
- Ran `ruff check` and `ruff format --check` over the touched files, clean.
- Not run: the full warehouse-sources suite, which needs backing services this sandbox lacks.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by an agent (Claude) from a review of Replay Vision onboarding-session summaries for the data-warehouse new-source flow. The recurring friction was a database connection timing out with no actionable guidance.
- Skills invoked: `/writing-user-facing-copy`, `/writing-pr-descriptions`.
- Scope was deliberately kept to the four sources sharing the vague rhetorical-question phrasing; MSSQL already states a firewall next step and was left unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
