### PR TITLE
fix(data-imports): stop retrying checkout.com reports 401 auth failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/source.py
@@ -110,6 +110,12 @@ class CheckoutComSource(ResumableSource[CheckoutComSourceConfig, CheckoutComResu
             errors[f"403 Client Error: Forbidden for url: {host}/reports"] = (
                 "Checkout.com denied access to reports. Please check that your access key has the reports scope."
             )
+            # Unlike disputes, a freshly-minted token still gets 401 (not 403) from the
+            # reports endpoint when the access key lacks the reports scope, so a mid-sync
+            # re-mint (which handles a genuinely expired token elsewhere) never resolves it.
+            errors[f"401 Client Error: Unauthorized for url: {host}/reports"] = (
+                "Checkout.com denied access to reports. Please check that your access key has the reports scope."
+            )
             errors[f"403 Client Error: Forbidden for url: {host}/payments/search"] = (
                 "Checkout.com denied access to payments search. Please check that your access key has the payments scope."
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/checkout_com/tests/test_checkout_com_source.py
@@ -68,6 +68,10 @@ class TestCheckoutComSource:
             "403 Client Error: Forbidden for url: https://api.checkout.com/disputes?limit=250",
             "403 Client Error: Forbidden for url: https://api.checkout.com/reports?limit=100",
             "403 Client Error: Forbidden for url: https://api.sandbox.checkout.com/reports/rpt_1/files/file_1",
+            # A freshly-minted token still gets 401 (not 403) from reports when the access
+            # key lacks the reports scope, so a mid-sync re-mint never resolves it.
+            "401 Client Error: Unauthorized for url: https://api.checkout.com/reports?limit=100",
+            "401 Client Error: Unauthorized for url: https://api.sandbox.checkout.com/reports/rpt_1/files/file_1",
         ],
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error):


### PR DESCRIPTION
## Problem

A Checkout.com data warehouse sync with an access key that lacks the reports scope keeps retrying instead of stopping with a clear message. [Error tracking](https://us.posthog.com/project/2/error_tracking/019fd75c-4bd3-7cf2-8f1e-a14dd178476d) shows the same `401 Client Error: Unauthorized for url: https://api.checkout.com/reports` recurring across several retries with growing backoff, so a fresh token mint each attempt gets the same rejection.

The reports endpoint returns 401 for a missing scope, but `CheckoutComSource.get_non_retryable_errors` only mapped the equivalent 403 case to an actionable, non-retryable error.

## Changes

- Add a `/reports`-scoped 401 mapping to `get_non_retryable_errors`, reusing the same "check your reports scope" message as the existing 403 mapping.
- Scope the new mapping to the reports path only. The existing 401-on-`/disputes` case stays retryable, since that path assumes a mid-sync token re-mint can resolve a token that expired while a long sync was running.

## How did you test this code

- Added two parametrized cases to `test_non_retryable_errors_match_auth_failures` for the reports listing and file-download paths, and confirmed `test_non_retryable_errors_does_not_match_unrelated` still passes for the disputes case.
- Ran the full `test_checkout_com_source.py` suite locally: 32 passed.
- Not run: an end-to-end sync against Checkout.com's live API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking webhook by Claude Code. No skill invocation was required beyond reading the Stripe source's `get_non_retryable_errors` as a reference pattern, per repo instructions for this source's non-retryable error classification.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*