### PR TITLE
fix(replay): show session_ids scoping as an editable filter chip

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
+++ b/frontend/src/scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed.tsx
@@ -23,6 +23,7 @@ import {
     LemonButton,
     LemonDivider,
     LemonInput,
+    LemonInputSelect,
     LemonModal,
     LemonTab,
     LemonTabs,
@@ -32,6 +33,7 @@ import {
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { SettingsMenu } from 'lib/components/PanelSettings/PanelSettings'
+import { PropertyFilterButton } from 'lib/components/PropertyFilters/components/PropertyFilterButton'
 import { CategoryDropdown } from 'lib/components/TaxonomicFilter/CategoryDropdown'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
 import {
@@ -59,6 +61,7 @@ import { groupsModel } from '~/models/groupsModel'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
 import { NodeKind, RecordingsQuery } from '~/queries/schema/schema-general'
 import {
+    PropertyFilterType,
     PropertyOperator,
     RecordingUniversalFilters,
     SessionRecordingPlaylistType,
@@ -675,6 +678,49 @@ export function RecordingsUniversalFilterAddFilterPopover({
     )
 }
 
+const SessionIdsFilterChip = ({
+    sessionIds,
+    setFilters,
+}: {
+    sessionIds: string[]
+    setFilters: (filters: Partial<RecordingUniversalFilters>) => void
+}): JSX.Element => {
+    const [isEditPopoverVisible, setIsEditPopoverVisible] = useState(false)
+
+    return (
+        <Popover
+            visible={isEditPopoverVisible}
+            onClickOutside={() => setIsEditPopoverVisible(false)}
+            placement="bottom-start"
+            overlay={
+                <div className="p-2 w-100">
+                    <LemonInputSelect
+                        mode="multiple"
+                        allowCustomValues
+                        value={sessionIds}
+                        onChange={(ids) => setFilters({ session_ids: ids.length ? ids : undefined })}
+                        placeholder="Enter a session ID"
+                        data-attr="replay-filters-session-ids-input"
+                    />
+                </div>
+            }
+        >
+            <span data-attr="replay-filters-session-ids-tag">
+                <PropertyFilterButton
+                    item={{
+                        type: PropertyFilterType.Event,
+                        key: '$session_id',
+                        value: sessionIds,
+                        operator: PropertyOperator.Exact,
+                    }}
+                    onClick={() => setIsEditPopoverVisible(!isEditPopoverVisible)}
+                    onClose={() => setFilters({ session_ids: undefined })}
+                />
+            </span>
+        </Popover>
+    )
+}
+
 export const ReplayFiltersTab = ({
     filters,
     setFilters,
@@ -957,6 +1003,9 @@ export const ReplayFiltersTab = ({
                             size="small"
                         />
                         <RecordingsUniversalFilterGroup hideAddFilterButton={true} pinnedFilters={pinnedFilters} />
+                        {!!filters.session_ids?.length && (
+                            <SessionIdsFilterChip sessionIds={filters.session_ids} setFilters={setFilters} />
+                        )}
                     </div>
                 </div>
             </UniversalFilters>

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -819,6 +819,16 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 expect(logic.values.filters.session_ids).toBeUndefined()
                 expect(listSpy).toHaveBeenLastCalledWith(expect.objectContaining({ session_ids: undefined }))
             })
+
+            it('counts session_ids in totalFiltersCount so the badge and reset button reflect them', async () => {
+                await expectLogic(logic, () => {
+                    logic.actions.setFilters({ session_ids: ['s1', 's2'] })
+                }).toMatchValues({ totalFiltersCount: 1 })
+
+                await expectLogic(logic, () => {
+                    logic.actions.setFilters({ session_ids: undefined })
+                }).toMatchValues({ totalFiltersCount: 0 })
+            })
         })
 
         describe('deleting recordings', () => {

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -1818,7 +1818,8 @@ export const sessionRecordingsPlaylistLogic = kea<sessionRecordingsPlaylistLogic
                     (equal(filters.duration?.[0] ?? defaultFilters.duration[0], defaultFilters.duration[0]) ? 0 : 1) +
                     (filters.date_from === defaultFilters.date_from && filters.date_to === defaultFilters.date_to
                         ? 0
-                        : 1)
+                        : 1) +
+                    (filters.session_ids?.length ? 1 : 0)
                 )
             },
         ],


### PR DESCRIPTION
## Problem

- Opening the replay list from a link whose `filters` URL param carries `session_ids` (for example, a PostHog AI generated link) shows an empty or near-empty list with no visible reason.
- The scoping never appears in the filter UI: no chip, the filter badge reads 0, and "Reset filters" stays disabled because it keys off that count.
- The filter state persists per team, so the scoping follows the user into fresh tabs.
- Users spend time troubleshooting their other filters before finding the culprit in the URL.

## Changes

- The session ID scoping now renders as a standard property filter chip ("Session ID = ...") in the applied filters row.
- Clicking the chip opens a popover where users add or remove individual IDs; removing the last one clears the scoping.
- The chip's close button clears the whole scoping in one click.
- `totalFiltersCount` now counts the scoping, so the filter badge shows it and "Reset filters" becomes usable.

URLs like this http://localhost:8010/project/1/replay/home?filters=%7B%22session_ids%22%3A%5B%220198a000-0000-7000-8000-000000000001%22%5D%2C%22date_from%22%3A%22-7d%22%2C%22filter_group%22%3A%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%7B%22type%22%3A%22AND%22%2C%22values%22%3A%5B%5D%7D%5D%7D%2C%22duration%22%3A%5B%5D%7D
now show the session id in the UI so that you can easily remove them 
<img width="2342" height="822" alt="image" src="https://github.com/user-attachments/assets/ca919260-bed8-4d53-a1b0-00b8d6983f34" />




## How did you test this code?

- Added one logic test: `totalFiltersCount` goes 0 → 1 → 0 as `session_ids` is set and cleared. It catches a refactor that drops the scoping from the count, which recreates the invisible-filter trap; existing tests only cover the query and URL round-trip.
- I ran the `sessionRecordingsPlaylistLogic` jest suite and the frontend typecheck locally.
- Chip visibility and label were verified on a local dev stack against a crafted `filters` URL with invented session IDs; the final click-to-edit popover iteration was not separately re-verified.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Fable 5) authored the change with Christian directing and testing each iteration locally.
- Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-pr-descriptions.
- The chip went through three iterations on visual feedback: a LemonTag with a count, then a PropertyFilterButton pill, then the standard formatted label plus a click-to-edit popover.
- All session IDs used while testing and in this description are invented; no customer data from the session appears in the diff.
