### PR TITLE
fix(mcp): stamp canonical error type on CLI tool-call events

### DIFF
--- a/services/mcp/src/cli/tool-call-properties.ts
+++ b/services/mcp/src/cli/tool-call-properties.ts
@@ -24,8 +24,10 @@ export function buildToolCallProperties(
         output_format: properties.output_format,
         ...(category ? { $mcp_tool_category: category } : {}),
         ...(description ? { $mcp_tool_description: description } : {}),
-        ...(properties.success ? {} : { error_class: errorClass(properties) }),
-        ...(properties.error_status !== undefined ? { error_status: properties.error_status } : {}),
+        ...(properties.success ? {} : { error_class: errorClass(properties), $mcp_error_type: errorType(properties) }),
+        ...(properties.error_status !== undefined
+            ? { error_status: properties.error_status, $mcp_error_status: properties.error_status }
+            : {}),
     }
 }
 
@@ -37,4 +39,28 @@ function errorClass(properties: ExecInnerCallProperties): 'validation_error' | '
         return 'api_error'
     }
     return 'error'
+}
+
+/**
+ * The hosted server's `$mcp_error_type` vocabulary, derived from the little the
+ * CLI records (a validation flag and an HTTP status) — without it, CLI failures
+ * land in the analytics tools' untyped bucket and can't be broken down by reason.
+ */
+function errorType(
+    properties: ExecInnerCallProperties
+): 'validation' | 'permission' | 'rate_limited' | 'api_4xx' | 'api_5xx' | 'internal' {
+    if (properties.validation_error) {
+        return 'validation'
+    }
+    const status = properties.error_status
+    if (status === undefined) {
+        return 'internal'
+    }
+    if (status === 401 || status === 403) {
+        return 'permission'
+    }
+    if (status === 429) {
+        return 'rate_limited'
+    }
+    return status >= 500 ? 'api_5xx' : 'api_4xx'
 }

--- a/services/mcp/tests/cli/tool-call-properties.test.ts
+++ b/services/mcp/tests/cli/tool-call-properties.test.ts
@@ -34,13 +34,40 @@ describe('buildToolCallProperties', () => {
             $mcp_is_error: true,
             output_format: 'text',
             error_class: 'error',
+            $mcp_error_type: 'internal',
             ...catalogMetadata('notebook-edit'),
         })
     })
 
+    // `$mcp_error_type`/`$mcp_error_status` mirror the hosted server's vocabulary so
+    // the MCP analytics failure tools can bucket CLI errors instead of showing them
+    // as typeless.
     it.each([
-        ['schema rejection', { validation_error: true }, { error_class: 'validation_error' }],
-        ['typed API failure', { error_status: 429 }, { error_class: 'api_error', error_status: 429 }],
+        [
+            'schema rejection',
+            { validation_error: true },
+            { error_class: 'validation_error', $mcp_error_type: 'validation' },
+        ],
+        [
+            'rate-limited API failure',
+            { error_status: 429 },
+            { error_class: 'api_error', error_status: 429, $mcp_error_type: 'rate_limited', $mcp_error_status: 429 },
+        ],
+        [
+            'permission API failure',
+            { error_status: 403 },
+            { error_class: 'api_error', error_status: 403, $mcp_error_type: 'permission', $mcp_error_status: 403 },
+        ],
+        [
+            'client API failure',
+            { error_status: 404 },
+            { error_class: 'api_error', error_status: 404, $mcp_error_type: 'api_4xx', $mcp_error_status: 404 },
+        ],
+        [
+            'server API failure',
+            { error_status: 502 },
+            { error_class: 'api_error', error_status: 502, $mcp_error_type: 'api_5xx', $mcp_error_status: 502 },
+        ],
     ])('classifies a %s without carrying the message', (_name, extra, expected) => {
         expect(buildToolCallProperties('feature-flag-get-all', { ...base, ...extra })).toEqual({
             tool_name: 'feature-flag-get-all',


### PR DESCRIPTION
## Problem

CLI-mode MCP tool failures show up as untyped in the MCP analytics failure tools: the events carry only `$mcp_is_error` plus a CLI-local `error_class`, never the canonical `$mcp_error_type` / `$mcp_error_status` the hosted server stamps. A recurring nightly `posthog-cli` failure burst on `query-web-vitals` (2–4/day for the past week) was unclassifiable because of this.

## Changes

- `buildToolCallProperties` now also stamps `$mcp_error_type` (hosted-server vocabulary: validation, permission, rate_limited, api_4xx, api_5xx, internal) and `$mcp_error_status`, derived from the validation flag and HTTP status the CLI already records.
- Stays value-free: no error message or input content is added, matching the CLI's privacy design.
- The legacy `error_class` / `error_status` keys are kept so existing dashboards don't break.

## How did you test this code?

- Extended the existing `toEqual`-pinned properties test with parameterized cases per status class (validation, 429, 403, 404, 502, untyped) — catches both a vocabulary drift from the hosted server and any reintroduction of value-carrying fields.
- Not verified against a live CLI session.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code) found the gap while monitoring the rollout of #78531: CLI failures landed in the failure tools' typeless bucket. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
