### PR TITLE
feat(stamphog): credit commits approved elsewhere in a PR's stack

### DIFF
--- a/.github/workflows/pr-approval-agent.yml
+++ b/.github/workflows/pr-approval-agent.yml
@@ -246,8 +246,9 @@ jobs:
     # classifies the new commits since the last bot approval, dismiss only
     # runs when the delta is non-trivial. Trivial deltas (test/docs/lockfile
     # /generated paths and clean merges from the base branch) retain the
-    # prior approval — a comment on the PR records the reason. The stamphog
-    # label stays sticky across pushes; the review job's existing
+    # prior approval, as do commits whose content stamphog already approved on
+    # another PR in the same stack — a comment on the PR records the reason.
+    # The stamphog label stays sticky across pushes; the review job's existing
     # non-APPROVED label-strip is the auto-loop's escape hatch.
     decide-delta:
         if: >-
@@ -258,7 +259,10 @@ jobs:
             && github.event.pull_request.user.login != 'posthog-bot'
             && contains(github.event.pull_request.labels.*.name, 'stamphog')
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        # Headroom for the stack walk, which adds a few API calls and a ref
+        # fetch per layer when a commit needs crediting. The cap costs nothing
+        # unless a run hangs; runners bill actual minutes.
+        timeout-minutes: 10
         outputs:
             dismiss_approval: ${{ steps.decide.outputs.dismiss_approval }}
             run_review: ${{ steps.decide.outputs.run_review }}
@@ -311,7 +315,11 @@ jobs:
             # no_prior_approval (nothing to retain) or empty_delta (HEAD
             # didn't move, comment would be noise).
             - name: Note retained approval
-              if: contains(fromJSON('["trivial_paths", "merge_only", "mixed_trivial"]'), steps.decide.outputs.reason)
+              if: >-
+                  contains(
+                    fromJSON('["trivial_paths", "merge_only", "mixed_trivial", "approved_elsewhere", "rewritten_but_approved"]'),
+                    steps.decide.outputs.reason
+                  )
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   PR: ${{ github.event.pull_request.number }}
@@ -319,7 +327,7 @@ jobs:
                   REASON: ${{ steps.decide.outputs.reason }}
               run: |
                   gh pr comment "$PR" --repo "$REPO" \
-                    --body "Retaining stamphog approval — delta since last review classified as \`$REASON\`."
+                    --body "Retaining stamphog approval — this push classified as \`$REASON\`."
 
     # hogli-lint: not-a-required-gate — branches on decide-delta's result to decide
     # whether to dismiss a stale approval; it emits no required status check.

--- a/tools/pr-approval-agent/README.md
+++ b/tools/pr-approval-agent/README.md
@@ -145,6 +145,64 @@ An approval is posted once, as the Stamphog app (`stamphog[bot]`), carrying the 
 This identity was confirmed to satisfy branch protection, so the earlier bodyless `github-actions[bot]` fallback approval has been dropped and every stamphog action now runs under the app token.
 Every other verdict (REFUSED, ESCALATE, WAIT, ERROR) goes into a single sticky comment that is updated in place on each run, with a counter of how many verdicts the comment has carried (failure notes append without bumping it) — repeated refusals don't stack up as separate review comments on the PR.
 
+## Pushes after an approval
+
+The master ruleset sets `dismiss_stale_reviews_on_push=false` and `require_last_push_approval=false`, so GitHub leaves a stamphog approval in place when new commits arrive.
+Stamphog dismisses it itself, on `synchronize`, unless the push clears one of the bars below.
+`dismiss_check.py` decides; `stack_credit.py` answers the cross-PR half of the question.
+
+A push retains the approval when:
+
+| Reason                   | What it means                                                                                                                    |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `trivial_paths`          | Every new commit touches only test, docs, lockfile, snapshot, or generated-artifact paths                                        |
+| `merge_only`             | Every new commit is a clean merge from the base branch, with no manual conflict edits                                            |
+| `mixed_trivial`          | A mix of the two above                                                                                                           |
+| `approved_elsewhere`     | Every new commit's content was already approved on another PR in this stack                                                      |
+| `rewritten_but_approved` | History was rewritten, and every commit the PR now contains is trivial or already approved, including at least one of the latter |
+| `empty_delta`            | HEAD did not move                                                                                                                |
+
+Everything else dismisses and re-reviews automatically.
+The label stays on across all of this, so retention and re-review both happen without anyone touching the PR.
+
+### Stack credit
+
+Stamphog's approval state is per-PR.
+Without credit, folding a reviewed stack back into one PR reads as a pile of unreviewed work landing on the surviving PR, and costs a re-stamp that reviews nothing new.
+
+Credit closes that gap in the two forms a fold produces.
+
+A rebase or squash rewrites SHAs, so ordinary commits are matched by **content**.
+A commit's key is its `git diff-tree --raw` output: every touched path with its pre-image blob OID, post-image blob OID, file modes, and change status.
+Two commits match only when they turn byte-identical inputs into byte-identical outputs, which is stricter than `git patch-id` and reads no blobs, so it stays cheap in the workflow's blobless clone.
+
+Merging a layer in instead produces a single merge commit, which has no diff of its own to key on.
+Those are judged by their non-first parents: a merge is trusted when every parent it pulls in is reachable from the base branch (the ordinary "merged master in" case) or from a **stack tip** that carries its own approval.
+Manual conflict-resolution edits still dismiss, whichever branch the merge came from.
+
+Four rules keep it from becoming a laundering path:
+
+- **Layer scopes chain.** Layer N's scope is `approved(N-1)..approved(N)`, so no commit is ever credited by a layer that did not review it. Asking GitHub what a PR contains would over-credit, because `/pulls/{n}/commits` reports scope against the PR's _current_ base.
+- **The chain must hold.** A layer's approved commit has to descend from the layer below's approved commit. A broken chain grants that layer nothing.
+- **Retargeting voids an approval.** Changing a PR's base widens what its diff covers without re-recording the approval, so an approval from before a `base_ref_changed` event grants no credit.
+- **Same author, same repo.** Anyone can open a PR against someone else's branch on a public repo, so only the PR author's own same-repo layers join the chain.
+
+Anything that fails, times out, or does not fit these rules withholds credit and dismisses, which is the behavior that predates this feature.
+
+> [!NOTE]
+> The stack walk reads the PR timeline, which lives under `/issues/` and needs **`issues: read`** on the Stamphog app alongside its pull-requests permission.
+> Without it every stack lookup fails closed and credit silently never applies — the job log carries a `[stack_credit] timeline lookup failed` line when that is what is happening.
+
+### Fold shapes
+
+| Fold                                                           | Outcome                                                                   |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Merge the upper layers into the bottom PR                      | Retained. Each merge's second parent is an approved layer tip             |
+| Rebase the whole stack onto the bottom PR and force-push       | Retained, as long as each layer replays onto identical content            |
+| Rebase onto a newer base that changed a file the stack touches | Dismissed. The pre-image differs, so the content is not what was approved |
+| Squash the layers into one commit                              | Dismissed. The squashed commit matches no single approved commit          |
+| Retarget the top layer to master and drop the ones below       | Dismissed. Retargeting voids the top layer's approval                     |
+
 ## Tiers
 
 ### T0 — deterministic
@@ -247,6 +305,8 @@ The GitHub Action uploads this as a build artifact with 30-day retention.
 - `gates.py` — deterministic classification and deny-list logic
 - `github.py` — GitHub data fetching via `gh` CLI
 - `reviewer.py` — Claude Agent SDK reviewer (showstoppers prompt)
+- `dismiss_check.py` — retain-or-dismiss decision for a push after an approval
+- `stack_credit.py` — content keys for commits already approved elsewhere in a PR's stack
 - `.github/workflows/pr-approval-agent.yml` — GitHub Action (label trigger)
 
 ## Empirical basis

--- a/tools/pr-approval-agent/conftest.py
+++ b/tools/pr-approval-agent/conftest.py
@@ -1,0 +1,52 @@
+"""Shared git scaffolding for the tests that exercise real repository history."""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "test",
+    "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "test",
+    "GIT_COMMITTER_EMAIL": "t@t",
+}
+
+
+def git(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, **_GIT_ENV}
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=check,
+    )
+
+
+def write(repo: Path, path: str, content: str = "x") -> None:
+    p = repo / path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+
+
+def commit(repo: Path, message: str) -> str:
+    git("add", "-A", cwd=repo)
+    git("commit", "-m", message, cwd=repo)
+    return git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+
+
+def head(repo: Path) -> str:
+    return git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Empty repo with one initial commit on master."""
+    git("init", "--initial-branch=master", cwd=tmp_path)
+    write(tmp_path, "README.md", "init")
+    commit(tmp_path, "init")
+    return tmp_path

--- a/tools/pr-approval-agent/dismiss_check.py
+++ b/tools/pr-approval-agent/dismiss_check.py
@@ -21,20 +21,36 @@ and `Decision.error` — together they cover every legitimate combination,
 and the impossible "dismiss the approval but skip re-review" case is
 unrepresentable.
 
-Anything ambiguous (force-push, mixed paths, fetch error, foreign-branch
-merge) falls through to `Decision.dismiss_and_review`. The bias is
-correctness, not retention.
+Anything ambiguous (mixed paths, fetch error, foreign-branch merge) falls
+through to `Decision.dismiss_and_review`. The bias is correctness, not
+retention.
+
+A commit can also clear the bar by carrying an approval from elsewhere in the
+PR's stack, which is what makes folding a reviewed stack back into one PR free
+of a re-stamp. `stack_credit` owns that lookup and the invariants behind it;
+this module only asks it whether a given commit's content was already approved.
+Rewritten history is the one case where credit changes the shape of the check
+rather than just the verdict: after a force-push there is no delta to walk, so
+every commit in the PR has to clear the bar on its own.
 """
 
 import os
 import sys
 import json
 import subprocess
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 
+import stack_credit
 from gates import is_trivial_at_dismiss_time
+from stack_credit import (
+    Approval,
+    change_key,
+    is_ancestor as _is_ancestor,
+    merge_base,
+)
 
 # Stamphog now approves only as stamphog[bot] (the app), carrying the review
 # body. github-actions[bot] is kept here so legacy bodyless approvals from
@@ -52,6 +68,8 @@ class Reason(StrEnum):
     TRIVIAL_PATHS = "trivial_paths"
     MERGE_ONLY = "merge_only"
     MIXED_TRIVIAL = "mixed_trivial"
+    APPROVED_ELSEWHERE = "approved_elsewhere"
+    REWRITTEN_BUT_APPROVED = "rewritten_but_approved"
     NON_TRIVIAL_DELTA = "non_trivial_delta"
     NON_LINEAR_HISTORY = "non_linear_history"
     EMPTY_DELTA = "empty_delta"
@@ -63,6 +81,7 @@ class CommitClass(StrEnum):
 
     MERGE = "merge"
     TRIVIAL = "trivial"
+    APPROVED_ELSEWHERE = "approved_elsewhere"
     NON_TRIVIAL = "non_trivial"
 
 
@@ -109,30 +128,8 @@ def _run(*args: str, cwd: Path | None = None) -> str:
     return subprocess.run(list(args), cwd=cwd, capture_output=True, text=True, timeout=30, check=True).stdout
 
 
-def _is_ancestor(ancestor: str, descendant: str, cwd: Path) -> bool:
-    """`git merge-base --is-ancestor`: rc 0=ancestor, 1=not ancestor, ≥2=error.
-
-    Errors fall through to False so callers treat the relation as
-    non-linear and dismiss + re-review (fail-closed). The stderr log
-    distinguishes a real force-push from a git plumbing failure.
-    """
-    result = subprocess.run(
-        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if result.returncode not in (0, 1):
-        print(
-            f"[dismiss_check] _is_ancestor git error rc={result.returncode}: {result.stderr.strip()}",
-            file=sys.stderr,
-        )
-    return result.returncode == 0
-
-
-def select_last_bot_approval(reviews: list[dict]) -> str | None:
-    """Pick the commit SHA of the most recent bot APPROVED review.
+def select_last_bot_approval(reviews: list[dict]) -> Approval | None:
+    """Pick the most recent bot APPROVED review.
 
     Pure function so the filter+sort behavior can be exercised without
     invoking `gh api`. Human reviews and non-APPROVED bot reviews are
@@ -142,26 +139,24 @@ def select_last_bot_approval(reviews: list[dict]) -> str | None:
         (r for r in reviews if r.get("user", {}).get("login") in BOT_LOGINS and r.get("state") == "APPROVED"),
         key=lambda r: r.get("submitted_at", ""),
     )
-    return bot_approvals[-1].get("commit_id") if bot_approvals else None
+    if not bot_approvals:
+        return None
+    latest = bot_approvals[-1]
+    commit_id = latest.get("commit_id")
+    if not commit_id:
+        return None
+    return Approval(sha=commit_id, submitted_at=latest.get("submitted_at", ""))
 
 
-def find_last_approved_sha(repo: str, pr_number: int) -> str | None:
-    """Commit SHA of the most recent Stamphog-bot APPROVED review."""
+def find_last_approval(repo: str, pr_number: int) -> Approval | None:
+    """Most recent Stamphog-bot APPROVED review on `pr_number`."""
     reviews = json.loads(_run("gh", "api", f"repos/{repo}/pulls/{pr_number}/reviews", "--paginate"))
     return select_last_bot_approval(reviews)
 
 
-def _is_clean_merge_from_base(sha: str, foreign_parents: list[str], cwd: Path, base_ref: str) -> bool:
-    """A merge is clean iff it added no manual conflict-resolution edits AND
-    every non-first parent is already reachable from `base_ref`.
-
-    Without the ancestry check, a clean merge from an arbitrary side branch
-    would be trusted as if it came from base.
-    """
-    cc = _run("git", "show", sha, "--diff-merges=cc", "--format=", "-p", cwd=cwd)
-    if cc.strip():
-        return False
-    return all(_is_ancestor(p, base_ref, cwd) for p in foreign_parents)
+def _has_conflict_resolution_edits(sha: str, cwd: Path) -> bool:
+    """Whether a merge commit carries edits beyond what merging its parents produced."""
+    return bool(_run("git", "show", sha, "--diff-merges=cc", "--format=", "-p", cwd=cwd).strip())
 
 
 def _first_parent_commits_between(from_sha: str, to_sha: str, cwd: Path) -> list[str]:
@@ -171,33 +166,127 @@ def _first_parent_commits_between(from_sha: str, to_sha: str, cwd: Path) -> list
     return output.splitlines()
 
 
-def _classify_commit(sha: str, cwd: Path, base_ref: str) -> CommitClass:
+class StackCredit:
+    """Answers what this PR's stack has already had approved.
+
+    The stack walk behind `provider` costs several GitHub API calls and a ref
+    fetch per layer, and most pushes reach a verdict without it, so it runs at
+    most once and only once a commit has already failed the cheaper local
+    checks. A None provider disables credit entirely, which is what keeps
+    `evaluate_delta` callable as a pure git-only function.
+    """
+
+    def __init__(self, provider: Callable[[], stack_credit.Credit] | None) -> None:
+        self._provider = provider
+        self._credit: stack_credit.Credit | None = None
+
+    def _load(self) -> stack_credit.Credit:
+        if self._credit is None:
+            try:
+                self._credit = self._provider() if self._provider else stack_credit.Credit.none()
+            except Exception as exc:
+                # Granting no credit leaves the caller dismissing exactly as it
+                # did before credit existed, so a GitHub or git failure here is
+                # reported against the real delta reason rather than collapsing
+                # the whole decision into `error:<ExcName>`.
+                print(f"[dismiss_check] stack credit unavailable: {exc}", file=sys.stderr)
+                self._credit = stack_credit.Credit.none()
+        return self._credit
+
+    def covers(self, sha: str, cwd: Path) -> bool:
+        if self._provider is None:
+            return False
+        key = change_key(sha, cwd)
+        if key is None:
+            return False
+        return key in self._load().change_keys
+
+    def reaches_approved_tip(self, sha: str, cwd: Path) -> bool:
+        if self._provider is None:
+            return False
+        return any(_is_ancestor(sha, tip, cwd) for tip in self._load().approved_tips)
+
+
+def _classify_merge(sha: str, foreign_parents: list[str], cwd: Path, base_ref: str, credit: StackCredit) -> CommitClass:
+    """Classify a merge by where the content it pulls in came from.
+
+    A merge has no diff of its own to key on, so it is judged by its non-first
+    parents. Reachable from `base_ref` is the ordinary "merged master in" case.
+    Reachable from a stack tip is the fold: merging a layer into the PR below
+    produces exactly this shape, and that layer carries its own approval.
+    Anything else is an arbitrary side branch nobody reviewed.
+    """
+    if _has_conflict_resolution_edits(sha, cwd):
+        return CommitClass.NON_TRIVIAL
+    if all(_is_ancestor(p, base_ref, cwd) for p in foreign_parents):
+        return CommitClass.MERGE
+    if all(_is_ancestor(p, base_ref, cwd) or credit.reaches_approved_tip(p, cwd) for p in foreign_parents):
+        return CommitClass.APPROVED_ELSEWHERE
+    return CommitClass.NON_TRIVIAL
+
+
+def _classify_commit(sha: str, cwd: Path, base_ref: str, credit: StackCredit) -> CommitClass:
     parents = _run("git", "rev-list", "--parents", "-n", "1", sha, cwd=cwd).split()[1:]
     if len(parents) >= 2:
-        return (
-            CommitClass.MERGE if _is_clean_merge_from_base(sha, parents[1:], cwd, base_ref) else CommitClass.NON_TRIVIAL
-        )
+        return _classify_merge(sha, parents[1:], cwd, base_ref, credit)
     files = [f for f in _run("git", "diff-tree", "--no-commit-id", "--name-only", "-r", sha, cwd=cwd).splitlines() if f]
-    return CommitClass.TRIVIAL if all(is_trivial_at_dismiss_time(f) for f in files) else CommitClass.NON_TRIVIAL
+    if all(is_trivial_at_dismiss_time(f) for f in files):
+        return CommitClass.TRIVIAL
+    if credit.covers(sha, cwd):
+        return CommitClass.APPROVED_ELSEWHERE
+    return CommitClass.NON_TRIVIAL
 
 
-def evaluate_delta(last_approved_sha: str, head_sha: str, cwd: Path, base_ref: str = "origin/master") -> Decision:
+def _evaluate_rewritten(head_sha: str, cwd: Path, base_ref: str, credit: StackCredit) -> Decision:
+    """Decide a force-pushed branch, where there is no delta left to walk.
+
+    A rewrite invalidates the incremental question, so this asks the whole
+    question instead: every commit the PR now contains has to be trivial, a
+    clean merge from base, or content Stamphog already approved somewhere in
+    the stack. Requiring at least one approved commit is what separates a
+    rebase that preserved reviewed work from a force-push that replaced it with
+    an unrelated branch that happens to touch only trivial paths.
+    """
+    fork_point = merge_base(base_ref, head_sha, cwd)
+    if fork_point is None:
+        return Decision.dismiss_and_review(Reason.NON_LINEAR_HISTORY)
+
+    commits = _first_parent_commits_between(fork_point, head_sha, cwd)
+    if not commits:
+        return Decision.dismiss_and_review(Reason.NON_LINEAR_HISTORY)
+
+    classes = [_classify_commit(c, cwd, base_ref, credit) for c in commits]
+    if CommitClass.NON_TRIVIAL in classes or CommitClass.APPROVED_ELSEWHERE not in classes:
+        return Decision.dismiss_and_review(Reason.NON_LINEAR_HISTORY)
+    return Decision.retain(Reason.REWRITTEN_BUT_APPROVED)
+
+
+def evaluate_delta(
+    last_approved_sha: str,
+    head_sha: str,
+    cwd: Path,
+    base_ref: str = "origin/master",
+    credit_provider: Callable[[], stack_credit.Credit] | None = None,
+) -> Decision:
     """Classify the first-parent commit delta from `last_approved_sha` to `head_sha`.
 
     First-parent walking ensures a merge from base appears as a single
     node — without it, the second-parent's commits would surface
     individually and almost always classify as non-trivial.
     """
+    credit = StackCredit(credit_provider)
     if not _is_ancestor(last_approved_sha, head_sha, cwd):
-        return Decision.dismiss_and_review(Reason.NON_LINEAR_HISTORY)
+        return _evaluate_rewritten(head_sha, cwd, base_ref, credit)
 
     commits = _first_parent_commits_between(last_approved_sha, head_sha, cwd)
     if not commits:
         return Decision.retain(Reason.EMPTY_DELTA)
 
-    classes = [_classify_commit(c, cwd, base_ref) for c in commits]
+    classes = [_classify_commit(c, cwd, base_ref, credit) for c in commits]
     if CommitClass.NON_TRIVIAL in classes:
         return Decision.dismiss_and_review(Reason.NON_TRIVIAL_DELTA)
+    if CommitClass.APPROVED_ELSEWHERE in classes:
+        return Decision.retain(Reason.APPROVED_ELSEWHERE)
     if CommitClass.MERGE in classes and CommitClass.TRIVIAL in classes:
         return Decision.retain(Reason.MIXED_TRIVIAL)
     if CommitClass.MERGE in classes:
@@ -206,12 +295,23 @@ def evaluate_delta(last_approved_sha: str, head_sha: str, cwd: Path, base_ref: s
 
 
 def decide(repo: str, pr_number: int, head_sha: str, cwd: Path, base_ref: str = "origin/master") -> Decision:
-    last_approved_sha = find_last_approved_sha(repo, pr_number)
-    if last_approved_sha is None:
+    approval = find_last_approval(repo, pr_number)
+    if approval is None:
         return Decision.review_only(Reason.NO_PRIOR_APPROVAL)
+
+    def credit_provider() -> stack_credit.Credit:
+        return stack_credit.collect_credit(
+            repo=repo,
+            pr_number=pr_number,
+            own_approval=approval,
+            cwd=cwd,
+            base_ref=base_ref,
+            find_approval=find_last_approval,
+        )
+
     return replace(
-        evaluate_delta(last_approved_sha, head_sha, cwd, base_ref),
-        last_approved_sha=last_approved_sha,
+        evaluate_delta(approval.sha, head_sha, cwd, base_ref, credit_provider),
+        last_approved_sha=approval.sha,
     )
 
 

--- a/tools/pr-approval-agent/stack_credit.py
+++ b/tools/pr-approval-agent/stack_credit.py
@@ -1,0 +1,318 @@
+# ruff: noqa: T201
+"""Credit commits Stamphog already approved on another PR in the same stack.
+
+Stamphog's approval state is per-PR: it reads reviews for one PR number and
+nothing else. Folding a stack back into a single PR therefore looks like a pile
+of unreviewed work landing on the surviving PR, even though every commit was
+approved on the layer it came from, so the fold costs a re-stamp that reviews
+nothing new.
+
+This module rebuilds the lost context. It walks the stack rooted at a PR,
+collects the commits each layer's Stamphog approval actually covered, and
+reduces them to content keys the caller can match delta commits against.
+
+Two invariants keep the credit sound:
+
+Matching is by content, not by SHA, because folding rebases. A commit's key is
+its `git diff-tree --raw` output, which names every touched path along with the
+pre-image blob OID, the post-image blob OID, both file modes, and the change
+status. Two commits share a key only when they turn byte-identical inputs into
+byte-identical outputs, which is strictly stronger than `git patch-id` (that
+matches a hunk applied against different surrounding content). It also reads
+only tree objects, so it costs no blob downloads in the workflow's blobless
+clone.
+
+Layer scopes are derived by chaining approved SHAs rather than by asking GitHub
+what a PR contains. Layer N's scope is `approved(N-1)..approved(N)`, which
+partitions the stack so no commit is ever credited by a layer that did not
+review it. Asking the API instead would over-credit: `/pulls/{n}/commits`
+reports a PR's scope against its *current* base, so once the fold rewrites or
+retargets the branch below, a top layer's approval would appear to cover the
+whole stack.
+"""
+
+import sys
+import json
+import hashlib
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+# Bounds the stack walk. Each layer costs a PR listing, a timeline read, a
+# review read, and a fetch, inside a job with timeout-minutes: 5.
+MAX_STACK_DEPTH = 8
+
+# Backstop against crediting an unbounded history if a branch relationship is
+# not what this module assumes. A stack deep enough to exceed this is past the
+# point where folding is the interesting case.
+MAX_CREDITED_COMMITS = 500
+
+_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+
+@dataclass(frozen=True)
+class Approval:
+    """A Stamphog APPROVED review: the commit it was recorded against, and when.
+
+    `submitted_at` is only used to order the approval against base-ref changes,
+    so it carries GitHub's raw ISO-8601 string rather than a parsed datetime.
+    """
+
+    sha: str
+    submitted_at: str
+
+
+@dataclass(frozen=True)
+class Credit:
+    """What a PR's stack has already had approved, in the two forms callers need.
+
+    `change_keys` answers "was this commit's content approved?" and is what a
+    rewritten commit is matched against. `approved_tips` answers "was this
+    whole branch approved?", which is what a merge needs: folding by merging a
+    layer in produces one merge commit whose second parent is that layer's tip,
+    and a merge has no diff of its own to key on.
+    """
+
+    change_keys: frozenset[str]
+    approved_tips: tuple[str, ...]
+
+    @classmethod
+    def none(cls) -> "Credit":
+        return cls(change_keys=frozenset(), approved_tips=())
+
+
+def _run(*args: str, cwd: Path | None = None) -> str:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        check=True,
+    ).stdout
+
+
+def _succeeds(*args: str, cwd: Path | None = None) -> bool:
+    return (
+        subprocess.run(
+            list(args),
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+        ).returncode
+        == 0
+    )
+
+
+def _gh_json(*args: str) -> list | dict:
+    return json.loads(_run("gh", "api", *args))
+
+
+def is_ancestor(ancestor: str, descendant: str, cwd: Path) -> bool:
+    """`git merge-base --is-ancestor`: rc 0=ancestor, 1=not ancestor, >=2=error.
+
+    Errors fall through to False so callers treat the relation as non-linear
+    and dismiss, or withhold credit, rather than granting either. The stderr
+    log distinguishes a real force-push from a git plumbing failure.
+    """
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    if result.returncode not in (0, 1):
+        print(
+            f"[stack_credit] is_ancestor git error rc={result.returncode}: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+    return result.returncode == 0
+
+
+def change_key(sha: str, cwd: Path) -> str | None:
+    """Content key for a commit, or None when the commit cannot be credited.
+
+    Merge commits and empty commits both return None. `git diff-tree` prints
+    nothing for a merge unless asked to combine parents, so without this guard
+    every merge would hash to the digest of the empty string and match every
+    other merge, including a dirty one carrying manual conflict edits.
+
+    Rename detection is disabled because it is a whole-tree heuristic: the same
+    change can be reported as a rename in one history and as an add plus a
+    delete in another, which would break matching across the rewrite.
+    """
+    parents = _run("git", "rev-list", "--parents", "-n", "1", sha, cwd=cwd).split()[1:]
+    if len(parents) >= 2:
+        return None
+    raw = _run("git", "diff-tree", "--no-commit-id", "--raw", "-r", "--no-renames", sha, cwd=cwd)
+    lines = [line for line in raw.splitlines() if line]
+    if not lines:
+        return None
+    return hashlib.sha256("\n".join(lines).encode()).hexdigest()
+
+
+def _ensure_object(sha: str, pr_number: int, cwd: Path) -> bool:
+    """Make `sha` available locally, fetching the PR ref then the bare SHA.
+
+    The bare-SHA fetch is what reaches an approved commit that a force-push has
+    since orphaned, which is exactly the state a fold leaves behind.
+    """
+    if _succeeds("git", "cat-file", "-e", f"{sha}^{{commit}}", cwd=cwd):
+        return True
+    _succeeds("git", "fetch", "--filter=blob:none", "origin", f"pull/{pr_number}/head", cwd=cwd)
+    if _succeeds("git", "cat-file", "-e", f"{sha}^{{commit}}", cwd=cwd):
+        return True
+    _succeeds("git", "fetch", "--filter=blob:none", "origin", sha, cwd=cwd)
+    return _succeeds("git", "cat-file", "-e", f"{sha}^{{commit}}", cwd=cwd)
+
+
+def merge_base(a: str, b: str, cwd: Path) -> str | None:
+    result = subprocess.run(
+        ["git", "merge-base", a, b],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _first_parent(from_sha: str, to_sha: str, cwd: Path) -> list[str]:
+    return _run("git", "rev-list", "--first-parent", f"{from_sha}..{to_sha}", cwd=cwd).splitlines()
+
+
+def _base_ref_changed_since(repo: str, pr_number: int, submitted_at: str) -> bool:
+    """Whether the PR was retargeted after `submitted_at`.
+
+    Retargeting widens what a PR's diff covers without re-recording the
+    approval, so an approval from before the retarget no longer describes the
+    commits the PR now contains. Both timestamps are GitHub's UTC ISO-8601, so
+    a string comparison orders them correctly.
+
+    A failed lookup answers True, which withholds credit and leaves the caller
+    dismissing exactly as it did before this module existed. The timeline lives
+    under /issues/, so the Stamphog app needs issues:read on top of the
+    pull-requests permission its other calls use; without it this is the call
+    that fails, and the stderr log is what makes that diagnosable rather than
+    looking like a stack that never qualifies.
+    """
+    try:
+        events = _gh_json(f"repos/{repo}/issues/{pr_number}/timeline", "--paginate")
+    except (subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        print(f"[stack_credit] timeline lookup failed for #{pr_number}, withholding credit: {exc}", file=sys.stderr)
+        return True
+    return any(
+        event.get("event") == "base_ref_changed" and str(event.get("created_at", "")) > submitted_at
+        for event in events  # type: ignore[union-attr]
+    )
+
+
+def _child_prs(repo: str, base_branch: str, author: str) -> list[dict]:
+    """PRs stacked directly on `base_branch`: the next layer up.
+
+    Restricted to `author`'s own same-repo PRs. A stack is one person's, and on
+    a public repo anyone can open a PR against someone else's branch, so this
+    keeps a third party from introducing a layer into the chain.
+    """
+    prs = _gh_json(
+        f"repos/{repo}/pulls",
+        "-X",
+        "GET",
+        "-f",
+        "state=all",
+        "-f",
+        f"base={base_branch}",
+        "-f",
+        "per_page=100",
+    )
+    return [
+        pr
+        for pr in prs  # type: ignore[union-attr]
+        if pr.get("user", {}).get("login") == author and (pr.get("head", {}).get("repo") or {}).get("full_name") == repo
+    ]
+
+
+def _layer_scope(
+    repo: str,
+    pr_number: int,
+    approval: Approval,
+    previous_sha: str,
+    cwd: Path,
+) -> list[str] | None:
+    """Commits this layer's approval covered, or None when it grants no credit.
+
+    Requires the previous layer's approved commit to be an ancestor of this
+    one, which proves the layer was built on the exact content Stamphog signed
+    off below it. A broken chain means the stack is not the shape assumed here.
+    """
+    if not _ensure_object(approval.sha, pr_number, cwd):
+        return None
+    if not is_ancestor(previous_sha, approval.sha, cwd):
+        return None
+    if _base_ref_changed_since(repo, pr_number, approval.submitted_at):
+        return None
+    return _first_parent(previous_sha, approval.sha, cwd)
+
+
+def collect_credit(
+    repo: str,
+    pr_number: int,
+    own_approval: Approval,
+    cwd: Path,
+    base_ref: str,
+    find_approval: Callable[[str, int], Approval | None],
+) -> Credit:
+    """Everything this PR's stack has already had approved.
+
+    The root layer is the PR's own prior approval; each layer above it is a PR
+    the same author stacked on the layer below.
+    """
+    if not _ensure_object(own_approval.sha, pr_number, cwd):
+        return Credit.none()
+    if _base_ref_changed_since(repo, pr_number, own_approval.submitted_at):
+        return Credit.none()
+    root = merge_base(base_ref, own_approval.sha, cwd)
+    if root is None:
+        return Credit.none()
+
+    root_pr = _gh_json(f"repos/{repo}/pulls/{pr_number}")
+    author = root_pr.get("user", {}).get("login")  # type: ignore[union-attr]
+    head_ref = root_pr.get("head", {}).get("ref")  # type: ignore[union-attr]
+    if not author or not head_ref:
+        return Credit.none()
+
+    commits = list(_first_parent(root, own_approval.sha, cwd))
+    tips = [own_approval.sha]
+    frontier = [(head_ref, own_approval.sha)]
+    visited = {pr_number}
+
+    for _ in range(MAX_STACK_DEPTH):
+        next_frontier: list[tuple[str, str]] = []
+        for branch, previous_sha in frontier:
+            for child in _child_prs(repo, branch, author):
+                number = child["number"]
+                if number in visited:
+                    continue
+                visited.add(number)
+                approval = find_approval(repo, number)
+                if approval is None:
+                    continue
+                scope = _layer_scope(repo, number, approval, previous_sha, cwd)
+                if scope is None:
+                    continue
+                commits.extend(scope)
+                tips.append(approval.sha)
+                next_frontier.append((child["head"]["ref"], approval.sha))
+        if not next_frontier or len(commits) > MAX_CREDITED_COMMITS:
+            break
+        frontier = next_frontier
+
+    if len(commits) > MAX_CREDITED_COMMITS:
+        return Credit.none()
+
+    keys = {change_key(sha, cwd) for sha in commits}
+    keys.discard(None)
+    return Credit(change_keys=frozenset(keys), approved_tips=tuple(tips))  # type: ignore[arg-type]

--- a/tools/pr-approval-agent/test_dismiss_check.py
+++ b/tools/pr-approval-agent/test_dismiss_check.py
@@ -1,65 +1,32 @@
 """Tests for the Stamphog dismiss-decision logic."""
 
-import os
-import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
+import stack_credit
 import dismiss_check
 from dismiss_check import Decision, decide, evaluate_delta, select_last_bot_approval
 from gates import is_trivial_at_dismiss_time
+from stack_credit import Approval, Credit, change_key
 
-_GIT_ENV = {
-    "GIT_AUTHOR_NAME": "test",
-    "GIT_AUTHOR_EMAIL": "t@t",
-    "GIT_COMMITTER_NAME": "test",
-    "GIT_COMMITTER_EMAIL": "t@t",
-}
-
-
-def _git(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, **_GIT_ENV}
-    return subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=30,
-        check=check,
-    )
+from conftest import (
+    commit as _commit,
+    git as _git,
+    head as _head,
+    write as _write,
+)
 
 
-def _write(repo: Path, path: str, content: str = "x") -> None:
-    p = repo / path
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content)
-
-
-def _commit(repo: Path, message: str) -> str:
-    _git("add", "-A", cwd=repo)
-    _git("commit", "-m", message, cwd=repo)
-    return _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
-
-
-def _head(repo: Path) -> str:
-    return _git("rev-parse", "HEAD", cwd=repo).stdout.strip()
+def _approval(sha: str, submitted_at: str = "2026-01-01T00:00:00Z") -> Approval:
+    return Approval(sha=sha, submitted_at=submitted_at)
 
 
 def _assert_decision(d: Decision, *, dismiss: bool, review: bool, reason: str) -> None:
     assert d.dismiss_approval is dismiss
     assert d.run_review is review
     assert d.reason == reason
-
-
-@pytest.fixture
-def repo(tmp_path: Path) -> Path:
-    """Empty repo with one initial commit on master."""
-    _git("init", "--initial-branch=master", cwd=tmp_path)
-    _write(tmp_path, "README.md", "init")
-    _commit(tmp_path, "init")
-    return tmp_path
 
 
 # ── is_trivial_at_dismiss_time unit tests ────────────────────────
@@ -159,7 +126,7 @@ def test_is_ancestor_returns_false_when_not_ancestor(repo: Path) -> None:
 def test_is_ancestor_returns_false_on_git_error(repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
     bogus = "0" * 40
     assert dismiss_check._is_ancestor(bogus, _head(repo), repo) is False
-    assert "_is_ancestor git error" in capsys.readouterr().err
+    assert "is_ancestor git error" in capsys.readouterr().err
 
 
 # ── evaluate_delta scenarios ─────────────────────────────────────
@@ -358,6 +325,153 @@ def test_merge_from_non_base_branch_dismisses(repo: Path) -> None:
     )
 
 
+# ── stack credit ─────────────────────────────────────────────────
+
+
+def _credit_for(repo: Path, *shas: str, tips: tuple[str, ...] = ()) -> Callable[[], Credit]:
+    keys = {change_key(sha, repo) for sha in shas}
+    keys.discard(None)
+    return lambda: Credit(change_keys=frozenset(keys), approved_tips=tips)  # type: ignore[arg-type]
+
+
+def test_delta_carrying_stack_approved_content_retains(repo: Path) -> None:
+    _git("checkout", "-b", "layer", cwd=repo)
+    _write(repo, "docs/note.md", "note")
+    _commit(repo, "layer notes")
+    _write(repo, "frontend/src/foo.ts", "export const x = 1")
+    approved = _commit(repo, "layer work")
+
+    _git("checkout", "master", cwd=repo)
+    base = _head(repo)
+    _git("cherry-pick", approved, cwd=repo)
+
+    _assert_decision(
+        evaluate_delta(base, _head(repo), repo, "master", _credit_for(repo, approved)),
+        dismiss=False,
+        review=False,
+        reason="approved_elsewhere",
+    )
+
+
+def test_merge_of_an_approved_stack_layer_retains(repo: Path) -> None:
+    # Folding by merging a layer in leaves one merge commit, which has no diff
+    # of its own to match on. Its second parent is the layer tip.
+    _git("checkout", "-b", "feat", cwd=repo)
+    _write(repo, "frontend/src/feat.ts", "export const feat = 1")
+    feat_sha = _commit(repo, "feat")
+
+    _git("checkout", "-b", "layer", cwd=repo)
+    _write(repo, "frontend/src/layer.ts", "export const layer = 1")
+    layer_tip = _commit(repo, "layer work")
+
+    _git("checkout", "feat", cwd=repo)
+    _git("merge", "--no-ff", "layer", "-m", "fold layer in", cwd=repo)
+
+    _assert_decision(
+        evaluate_delta(feat_sha, _head(repo), repo, "master", _credit_for(repo, tips=(layer_tip,))),
+        dismiss=False,
+        review=False,
+        reason="approved_elsewhere",
+    )
+
+
+def test_delta_content_absent_from_stack_credit_dismisses(repo: Path) -> None:
+    _git("checkout", "-b", "layer", cwd=repo)
+    _write(repo, "frontend/src/approved.ts", "export const x = 1")
+    approved = _commit(repo, "layer work")
+
+    _git("checkout", "master", cwd=repo)
+    base = _head(repo)
+    _write(repo, "frontend/src/other.ts", "export const y = 2")
+    _commit(repo, "unrelated work")
+
+    _assert_decision(
+        evaluate_delta(base, _head(repo), repo, "master", _credit_for(repo, approved)),
+        dismiss=True,
+        review=True,
+        reason="non_trivial_delta",
+    )
+
+
+def test_rewritten_history_with_all_content_approved_retains(repo: Path) -> None:
+    _git("checkout", "-b", "feat", cwd=repo)
+    _write(repo, "frontend/src/foo.ts", "export const x = 1")
+    approved = _commit(repo, "feat")
+
+    _git("reset", "--hard", "master", cwd=repo)
+    _write(repo, "docs/note.md", "note")
+    _commit(repo, "notes")
+    _write(repo, "frontend/src/foo.ts", "export const x = 1")
+    _commit(repo, "feat replayed")
+
+    _assert_decision(
+        evaluate_delta(approved, _head(repo), repo, "master", _credit_for(repo, approved)),
+        dismiss=False,
+        review=False,
+        reason="rewritten_but_approved",
+    )
+
+
+def test_rewritten_history_with_one_uncredited_commit_dismisses(repo: Path) -> None:
+    _git("checkout", "-b", "feat", cwd=repo)
+    _write(repo, "frontend/src/foo.ts", "export const x = 1")
+    approved = _commit(repo, "feat")
+
+    _git("reset", "--hard", "master", cwd=repo)
+    _write(repo, "frontend/src/foo.ts", "export const x = 1")
+    _commit(repo, "feat replayed")
+    _write(repo, "frontend/src/smuggled.ts", "export const evil = 1")
+    _commit(repo, "smuggled in during the rewrite")
+
+    _assert_decision(
+        evaluate_delta(approved, _head(repo), repo, "master", _credit_for(repo, approved)),
+        dismiss=True,
+        review=True,
+        reason="non_linear_history",
+    )
+
+
+def test_rewritten_history_keeping_no_approved_commit_dismisses(repo: Path) -> None:
+    # A force-push that replaces every reviewed commit leaves nothing the prior
+    # approval spoke to, so trivial paths alone must not carry it over.
+    _git("checkout", "-b", "feat", cwd=repo)
+    _write(repo, "frontend/src/foo.ts", "export const x = 1")
+    approved = _commit(repo, "feat")
+
+    _git("reset", "--hard", "master", cwd=repo)
+    _write(repo, "docs/note.md", "note")
+    _commit(repo, "docs only")
+
+    _assert_decision(
+        evaluate_delta(approved, _head(repo), repo, "master", _credit_for(repo, approved)),
+        dismiss=True,
+        review=True,
+        reason="non_linear_history",
+    )
+
+
+def test_credit_provider_not_consulted_for_trivial_delta(repo: Path) -> None:
+    # The stack walk costs GitHub API calls and a fetch per layer inside a
+    # five-minute job, so a delta that classifies locally must never trigger it.
+    calls: list[int] = []
+
+    def provider() -> Credit:
+        calls.append(1)
+        return Credit.none()
+
+    base = _head(repo)
+    _write(repo, "tests/test_foo.py", "def test_foo(): pass")
+    _commit(repo, "test")
+
+    _assert_decision(
+        evaluate_delta(base, _head(repo), repo, "master", provider),
+        dismiss=False,
+        review=False,
+        reason="trivial_paths",
+    )
+    assert calls == []
+
+
 # ── decide() with mocked GitHub API ──────────────────────────────
 
 
@@ -366,7 +480,7 @@ def test_decide_no_prior_approval(monkeypatch: pytest.MonkeyPatch, repo: Path) -
     # when it is) and the agent hasn't approved — re-run the review on this
     # push so the first-run ERROR case (LLM backend down, label retained)
     # actually retries instead of staying labeled but stuck.
-    monkeypatch.setattr(dismiss_check, "find_last_approved_sha", lambda *_: None)
+    monkeypatch.setattr(dismiss_check, "find_last_approval", lambda *_: None)
     result = decide("PostHog/posthog", 1, _head(repo), repo)
     _assert_decision(result, dismiss=False, review=True, reason="no_prior_approval")
     assert result.last_approved_sha is None
@@ -377,7 +491,7 @@ def test_decide_returns_last_approved_sha(monkeypatch: pytest.MonkeyPatch, repo:
     _write(repo, "tests/test_foo.py", "def test_foo(): pass")
     _commit(repo, "test")
 
-    monkeypatch.setattr(dismiss_check, "find_last_approved_sha", lambda *_: base)
+    monkeypatch.setattr(dismiss_check, "find_last_approval", lambda *_: _approval(base))
     result = decide("PostHog/posthog", 1, _head(repo), repo)
     _assert_decision(result, dismiss=False, review=False, reason="trivial_paths")
     assert result.last_approved_sha == base
@@ -388,7 +502,8 @@ def test_decide_dismiss_path_includes_last_approved_sha(monkeypatch: pytest.Monk
     _write(repo, "frontend/src/foo.ts", "export const x = 1")
     _commit(repo, "prod")
 
-    monkeypatch.setattr(dismiss_check, "find_last_approved_sha", lambda *_: base)
+    monkeypatch.setattr(dismiss_check, "find_last_approval", lambda *_: _approval(base))
+    monkeypatch.setattr(stack_credit, "collect_credit", lambda **_: Credit.none())
     result = decide("PostHog/posthog", 1, _head(repo), repo)
     _assert_decision(result, dismiss=True, review=True, reason="non_trivial_delta")
     assert result.last_approved_sha == base
@@ -404,6 +519,11 @@ def _review(login: str, state: str, commit_id: str, submitted_at: str) -> dict:
         "commit_id": commit_id,
         "submitted_at": submitted_at,
     }
+
+
+def _approved_sha(reviews: list[dict]) -> str | None:
+    approval = select_last_bot_approval(reviews)
+    return approval.sha if approval else None
 
 
 def test_select_last_bot_approval_empty_list() -> None:
@@ -429,7 +549,7 @@ def test_select_last_bot_approval_picks_latest() -> None:
         _review("github-actions[bot]", "APPROVED", "sha-new", "2026-02-01T00:00:00Z"),
         _review("github-actions[bot]", "APPROVED", "sha-mid", "2026-01-15T00:00:00Z"),
     ]
-    assert select_last_bot_approval(reviews) == "sha-new"
+    assert _approved_sha(reviews) == "sha-new"
 
 
 def test_select_last_bot_approval_ignores_human_approvals() -> None:
@@ -437,7 +557,7 @@ def test_select_last_bot_approval_ignores_human_approvals() -> None:
         _review("github-actions[bot]", "APPROVED", "sha-bot", "2026-01-01T00:00:00Z"),
         _review("alice", "APPROVED", "sha-human", "2026-02-01T00:00:00Z"),
     ]
-    assert select_last_bot_approval(reviews) == "sha-bot"
+    assert _approved_sha(reviews) == "sha-bot"
 
 
 def test_select_last_bot_approval_ignores_bot_non_approval_states() -> None:
@@ -445,14 +565,14 @@ def test_select_last_bot_approval_ignores_bot_non_approval_states() -> None:
         _review("github-actions[bot]", "APPROVED", "sha-approved", "2026-01-01T00:00:00Z"),
         _review("github-actions[bot]", "CHANGES_REQUESTED", "sha-changes", "2026-02-01T00:00:00Z"),
     ]
-    assert select_last_bot_approval(reviews) == "sha-approved"
+    assert _approved_sha(reviews) == "sha-approved"
 
 
 def test_select_last_bot_approval_recognizes_app_identity() -> None:
     # The Stamphog app posts the body-carrying approval as stamphog[bot]; it
     # must count as a prior bot approval so dismiss-on-push can find its SHA.
     reviews = [_review("stamphog[bot]", "APPROVED", "sha-app", "2026-01-01T00:00:00Z")]
-    assert select_last_bot_approval(reviews) == "sha-app"
+    assert _approved_sha(reviews) == "sha-app"
 
 
 # ── main() error path ────────────────────────────────────────────

--- a/tools/pr-approval-agent/test_stack_credit.py
+++ b/tools/pr-approval-agent/test_stack_credit.py
@@ -1,0 +1,171 @@
+"""Tests for cross-PR approval credit."""
+
+from pathlib import Path
+
+import pytest
+
+import stack_credit
+from stack_credit import Approval, change_key, collect_credit
+
+from conftest import commit, git, head, write
+
+_REPO = "PostHog/posthog"
+_APPROVED_AT = "2026-01-01T00:00:00Z"
+
+
+# ── change_key ───────────────────────────────────────────────────
+
+
+def test_change_key_survives_replay_onto_a_different_parent(repo: Path) -> None:
+    git("checkout", "-b", "layer", cwd=repo)
+    write(repo, "frontend/src/foo.ts", "export const x = 1")
+    original = commit(repo, "layer work")
+
+    git("checkout", "master", cwd=repo)
+    write(repo, "docs/note.md", "note")
+    commit(repo, "unrelated")
+    write(repo, "frontend/src/foo.ts", "export const x = 1")
+    replayed = commit(repo, "layer work replayed")
+
+    assert original != replayed
+    assert change_key(original, repo) == change_key(replayed, repo)
+
+
+def test_change_key_differs_when_the_pre_image_differs(repo: Path) -> None:
+    write(repo, "frontend/src/foo.ts", "export const x = 1")
+    commit(repo, "starting point")
+    write(repo, "frontend/src/foo.ts", "export const x = 2")
+    from_v1 = commit(repo, "bump")
+
+    git("reset", "--hard", "HEAD~2", cwd=repo)
+    write(repo, "frontend/src/foo.ts", "export const x = 99")
+    commit(repo, "different starting point")
+    write(repo, "frontend/src/foo.ts", "export const x = 2")
+    from_v99 = commit(repo, "bump")
+
+    assert change_key(from_v1, repo) != change_key(from_v99, repo)
+
+
+@pytest.mark.parametrize("kind", ["merge", "empty"])
+def test_change_key_is_none_for_uncreditable_commits(repo: Path, kind: str) -> None:
+    if kind == "empty":
+        git("commit", "--allow-empty", "-m", "empty", cwd=repo)
+    else:
+        git("checkout", "-b", "side", cwd=repo)
+        write(repo, "side.ts", "side")
+        commit(repo, "side")
+        git("checkout", "master", cwd=repo)
+        write(repo, "main.ts", "main")
+        commit(repo, "main")
+        git("merge", "--no-ff", "side", "-m", "merge side", cwd=repo)
+
+    assert change_key(head(repo), repo) is None
+
+
+# ── stack walk ───────────────────────────────────────────────────
+
+
+def _pr(number: int, head_ref: str, base_ref: str, author: str = "alice") -> dict:
+    return {
+        "number": number,
+        "user": {"login": author},
+        "head": {"ref": head_ref, "repo": {"full_name": _REPO}},
+        "base": {"ref": base_ref},
+    }
+
+
+def _fake_gh(prs: dict[int, dict], timelines: dict[int, list[dict]]):
+    def _gh_json(*args: str) -> list | dict:
+        endpoint = args[0]
+        if endpoint.endswith("/timeline"):
+            return timelines.get(int(endpoint.split("/")[-2]), [])
+        if endpoint.endswith("/pulls"):
+            base = next(a.split("=", 1)[1] for a in args if a.startswith("base="))
+            return [pr for pr in prs.values() if pr["base"]["ref"] == base]
+        return prs[int(endpoint.rsplit("/", 1)[1])]
+
+    return _gh_json
+
+
+@pytest.fixture
+def stack(repo: Path) -> dict:
+    """Two-layer stack: PR 1 on master with a1, PR 2 on PR 1's branch with b1."""
+    git("checkout", "-b", "pr-a", cwd=repo)
+    write(repo, "frontend/src/a.ts", "export const a = 1")
+    a1 = commit(repo, "layer a")
+    git("checkout", "-b", "pr-b", cwd=repo)
+    write(repo, "frontend/src/b.ts", "export const b = 1")
+    b1 = commit(repo, "layer b")
+    return {
+        "a1": a1,
+        "b1": b1,
+        "prs": {1: _pr(1, "pr-a", "master"), 2: _pr(2, "pr-b", "pr-a")},
+    }
+
+
+def _collect(repo: Path, stack: dict, approvals: dict[int, str]) -> stack_credit.Credit:
+    return collect_credit(
+        repo=_REPO,
+        pr_number=1,
+        own_approval=Approval(sha=stack["a1"], submitted_at=_APPROVED_AT),
+        cwd=repo,
+        base_ref="master",
+        find_approval=lambda _repo, number: (
+            Approval(sha=approvals[number], submitted_at=_APPROVED_AT) if number in approvals else None
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(stack_credit, "_gh_json", lambda *_: pytest.fail("unstubbed gh api call"))
+
+
+def test_each_layer_contributes_its_own_commits(repo: Path, stack: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(stack_credit, "_gh_json", _fake_gh(stack["prs"], {}))
+    credit = _collect(repo, stack, {2: stack["b1"]})
+    assert credit.change_keys == {change_key(stack["a1"], repo), change_key(stack["b1"], repo)}
+    assert credit.approved_tips == (stack["a1"], stack["b1"])
+
+
+def test_layer_off_the_approved_chain_contributes_nothing(
+    repo: Path, stack: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # PR 2's approval points at a commit that never sat on top of PR 1's
+    # approved commit, so the stack is not the shape credit assumes.
+    git("checkout", "-b", "divergent", "master", cwd=repo)
+    write(repo, "frontend/src/c.ts", "export const c = 1")
+    divergent = commit(repo, "off-chain work")
+
+    monkeypatch.setattr(stack_credit, "_gh_json", _fake_gh(stack["prs"], {}))
+    credit = _collect(repo, stack, {2: divergent})
+    assert credit.change_keys == {change_key(stack["a1"], repo)}
+    assert credit.approved_tips == (stack["a1"],)
+
+
+def test_third_party_layer_is_ignored(repo: Path, stack: dict, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Anyone can open a PR against someone else's branch on a public repo.
+    stack["prs"][2]["user"]["login"] = "mallory"
+    monkeypatch.setattr(stack_credit, "_gh_json", _fake_gh(stack["prs"], {}))
+    credit = _collect(repo, stack, {2: stack["b1"]})
+    assert credit.change_keys == {change_key(stack["a1"], repo)}
+
+
+@pytest.mark.parametrize(
+    "retargeted_at,expected_credit",
+    [
+        ("2026-02-01T00:00:00Z", False),
+        ("2025-12-01T00:00:00Z", True),
+    ],
+)
+def test_retarget_after_the_approval_voids_credit(
+    repo: Path,
+    stack: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    retargeted_at: str,
+    expected_credit: bool,
+) -> None:
+    timelines = {1: [{"event": "base_ref_changed", "created_at": retargeted_at}]}
+    monkeypatch.setattr(stack_credit, "_gh_json", _fake_gh(stack["prs"], timelines))
+    credit = _collect(repo, stack, {})
+    assert bool(credit.change_keys) is expected_credit


### PR DESCRIPTION
## Problem

Folding a stack of stamphog-approved PRs back into one PR costs a fresh re-stamp, even though every commit was already approved.

- Stamphog reads reviews for one PR number, so it cannot see an approval that lives on another layer of the same stack.
- Folding also rewrites history, and a force-push leaves no delta to classify, so stamphog dismisses on ancestry alone.
- Stacking for reviewability is the documented path in AGENTS.md, so the tax lands on the people following it.

## Changes

Stamphog now retains its approval when every arriving commit was already approved on another PR in the same stack.

- `stack_credit.py` walks the stack rooted at a PR and collects what each layer's approval covered.
- A rebase or squash rewrites SHAs, so commits match by content, not by SHA.
- A commit's content key is its `git diff-tree --raw` output, naming each path with its pre-image blob OID, post-image blob OID, mode, and change status.
- That key is stricter than `git patch-id`, which matches a hunk applied against different surrounding content.
- It reads only tree objects, so it costs no blob downloads in the workflow's blobless clone.
- A merge commit has no diff of its own, so merges are judged by whether their non-first parents reach an approved layer tip.
- A force-pushed branch has no delta, so every commit the PR now contains has to clear the bar on its own.
- Two retain reasons join the existing three on the PR comment: `approved_elsewhere` and `rewritten_but_approved`.
- `decide-delta` goes from a 5 to a 10 minute timeout, for the extra API calls and the per-layer ref fetch.

### Why credit cannot launder an unreviewed commit

- Layer scopes chain approved SHAs. Layer N's scope is `approved(N-1)..approved(N)`.
- I rejected `/pulls/{n}/commits` for that. It reports scope against a PR's current base, so once a fold rewrites the branch below, a top layer's approval appears to cover the whole stack.
- A layer whose approved commit does not descend from the layer below gets no credit.
- An approval submitted before a `base_ref_changed` event gets no credit, because retargeting widens the diff without re-recording the approval.
- Only the PR author's own same-repo layers join the chain. Anyone can open a PR against someone else's branch on a public repo.
- Any failure or timeout withholds credit and dismisses, which is the behavior before this PR.

### Which folds qualify

| Fold | Result |
| --- | --- |
| Merge the upper layers into the bottom PR | Retained |
| Rebase the stack onto the bottom PR and force-push | Retained |
| Rebase onto a base that changed a file the stack touches | Dismissed |
| Squash the layers into one commit | Dismissed |
| Retarget the top layer to master and drop the ones below | Dismissed |

The last three dismiss because the content stamphog approved is no longer what the PR contains.

> [!WARNING]
> The stack walk reads the PR timeline, which lives under `/issues/`, so the Stamphog app needs `issues: read` alongside its pull-requests permission. I could not verify the app's current grants. Without that permission every lookup fails closed and credit never applies, and the job log carries a `[stack_credit] timeline lookup failed` line.

## How did you test this code?

Automated tests only. I did not exercise this against a real stack on GitHub, and I could not check the Stamphog app's permissions.

New tests, and the regression each catches:

- `change_key` survives a replay onto a different parent, and changes when the pre-image differs. The second guards credit transplanting into a context the approval never covered.
- `change_key` returns None for merges and empty commits. `git diff-tree` prints nothing for a merge, so without the guard every merge hashes to the empty digest and matches every other merge, including a dirty one.
- A layer whose approval sits off the chain contributes nothing, and neither does a third-party layer.
- A retarget after the approval voids credit. One before it does not.
- The rewritten-history path dismisses when one commit is uncredited, and when no commit carries an approval at all.
- The credit provider is never consulted for a trivial delta. Eager walking would add GitHub API calls to every push.

`tools/pr-approval-agent` is self-contained, so nothing else in the repo exercises this code.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

`tools/pr-approval-agent/README.md` gains a section on what happens to an approval after a push. The file documented the review pipeline but never the retention rules, so the existing reasons are written down here for the first time alongside the new ones.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote this, directed by @gantoine. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.

The session started as a question about why a fold demanded a re-stamp, on the assumption that a GitHub setting had changed. It had not. The repository-level `master` ruleset keeps `dismiss_stale_reviews_on_push=false` and `require_last_push_approval=false`, and its `pull_request` rule is byte-identical across every version GitHub still retains. The behavior comes from this tool, which is what turned the question into this PR.

The first implementation matched content only. That silently missed the most common fold, because merging a layer in produces a single merge commit with no diff to key on, so the approved-tip check was added afterwards. Shared git scaffolding for the tests moved into a new `conftest.py`.

Nothing in this PR carries material from the session that is not already public. Every fact came from this repository and from the GitHub API's own state on it.
