### PR TITLE
chore(api): exploratory throttling spike (closed, superseded)

### DIFF
--- a/posthog/api/query.py
+++ b/posthog/api/query.py
@@ -66,6 +66,8 @@ from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
     HogQLQueryThrottle,
+    QueryProjectBurstThrottle,
+    QueryProjectSustainedThrottle,
 )
 from posthog.rbac.user_access_control import UserAccessControlError
 from posthog.schema_migrations.upgrade import upgrade
@@ -187,7 +189,21 @@ class QueryViewSet(QueryCoalescingMixin, TeamAndOrgViewSetMixin, PydanticModelMi
         kind = query.get("kind") if isinstance(query, dict) else None
         return _QUERY_KIND_SCOPES.get(kind) if isinstance(kind, str) else None
 
+    # Actions left out of the project's query volume ceiling. Cancelling and the async auth
+    # pre-check stay available so a project that has hit the ceiling can still stop the queries it
+    # already started, and draft_sql runs no query and is already throttled per user. Anything else,
+    # including any action added later, counts.
+    ACTIONS_OUTSIDE_QUERY_VOLUME_CAP = ("destroy", "check_auth_for_async", "draft_sql")
+
     def get_throttles(self):
+        return [*self._per_credential_throttles(), *self._project_volume_throttles()]
+
+    def _project_volume_throttles(self):
+        if self.action in self.ACTIONS_OUTSIDE_QUERY_VOLUME_CAP:
+            return []
+        return [QueryProjectBurstThrottle(), QueryProjectSustainedThrottle()]
+
+    def _per_credential_throttles(self):
         if self.action == "draft_sql":
             return [AIBurstRateThrottle(), AISustainedRateThrottle()]
         if self.action == "get_query_log":

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -196,7 +196,7 @@ class PersonalApiKeyRateThrottle(SimpleRateThrottle):
             if team_id is not None and self.scope == HogQLQueryThrottle.scope:
                 self.load_team_rate_limit(team_id)
 
-            request_would_be_allowed = SimpleRateThrottle.allow_request(self, request, view)
+            request_would_be_allowed = self._request_would_be_allowed(request, view)
             if request_would_be_allowed:
                 return True
 
@@ -237,6 +237,11 @@ class PersonalApiKeyRateThrottle(SimpleRateThrottle):
         except Exception as e:
             capture_exception(e)
             return True
+
+    def _request_would_be_allowed(self, request: "Request", view: "APIView") -> bool:
+        """Whether the bucket still has room. Split out of `_allow_request_internal` so a subclass
+        can swap the counting mechanism while keeping the allow-list, metrics and error handling."""
+        return SimpleRateThrottle.allow_request(self, request, view)
 
     def allow_request(self, request, view):
         # Only rate limit authenticated requests made with a personal API key
@@ -523,6 +528,52 @@ class _TeamBucketRateThrottle(PersonalApiKeyOrUserRateThrottle):
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
+class _FixedWindowTeamBucketRateThrottle(_TeamBucketRateThrottle):
+    """A project-wide bucket counted as a single integer per window, for ceilings in the tens of
+    thousands.
+
+    SimpleRateThrottle keeps one timestamp per request in the window and rewrites the whole list on
+    every request, so a ceiling that high would move hundreds of kilobytes through the cache per
+    request. This keeps a counter instead, so the cache traffic per request stays constant however
+    high the ceiling goes.
+
+    Two tradeoffs, both acceptable for a ceiling meant to catch runaway volume rather than to pace a
+    caller precisely: the window is fixed rather than sliding, so a caller straddling a boundary can
+    send up to twice the rate before being cut off, and the increment is not atomic on every cache
+    backend, so concurrent requests can undercount.
+    """
+
+    window_ends_at: float | None = None
+
+    def _request_would_be_allowed(self, request: "Request", view: "APIView") -> bool:
+        if self.num_requests is None or self.duration is None:
+            return True
+
+        duration = int(self.duration)
+        window_start = int(time.time() // duration * duration)
+        self.window_ends_at = window_start + duration
+        bucket = f"{self.get_cache_key(request, view)}:{window_start}"
+
+        # add() is a no-op when the key exists, so the window's first request seeds the counter with
+        # its TTL and every later one only increments.
+        if self.cache.add(bucket, 1, duration + 1):
+            return True
+        try:
+            count = self.cache.incr(bucket)
+        except ValueError:
+            # Expired between the add and the incr, so this request opens a new window.
+            self.cache.set(bucket, 1, duration + 1)
+            return True
+        return count <= self.num_requests
+
+    def wait(self) -> float | None:
+        """Seconds until the window resets. Overridden because the parent derives Retry-After from
+        the timestamp history this class doesn't keep."""
+        if self.window_ends_at is None:
+            return None
+        return max(self.window_ends_at - time.time(), 0)
+
+
 # The heatmap page pre-flight makes one outbound fetch of a caller-supplied page per uncached probe,
 # holding a web worker for as long as that page takes to answer, so its budget is about worker
 # occupancy rather than about protecting our own datastores. A legitimate caller needs one probe per
@@ -713,6 +764,29 @@ class APIQueriesBurstThrottle(PersonalApiKeyRateThrottle):
 class APIQueriesSustainedThrottle(PersonalApiKeyRateThrottle):
     scope = "api_queries_sustained"
     rate = "2400/hour"
+
+
+# Every other throttle on /query is personal-API-key-only and keyed per credential, so a project
+# driving the endpoint from the app (session auth) or from many minted keys has no ceiling on the
+# ClickHouse load it can put on the cluster, and one project can take a large share of platform
+# query capacity. These two cap a project's total, counting every auth method and pooling all
+# credentials into one bucket. They stack with the per-credential throttles rather than replacing
+# them: those keep one key from starving a project's other callers, these bound the project.
+#
+# The rates are deliberately a ceiling on runaway volume, not a budget the app should ever feel: the
+# app itself is the biggest legitimate caller, one request per insight loaded plus polls on async
+# ones, so a large project with many concurrent users has to fit comfortably underneath. Both are
+# env-overridable so a region can ratchet them down against observed `rate_limit_exceeded` volume
+# without a code change, and a project can be exempted at runtime through the
+# RATE_LIMITING_ALLOW_LIST_TEAMS instance setting.
+class QueryProjectBurstThrottle(_FixedWindowTeamBucketRateThrottle):
+    scope = "query_project_burst"
+    rate = settings.QUERY_PROJECT_BURST_THROTTLE_RATE
+
+
+class QueryProjectSustainedThrottle(_FixedWindowTeamBucketRateThrottle):
+    scope = "query_project_sustained"
+    rate = settings.QUERY_PROJECT_SUSTAINED_THROTTLE_RATE
 
 
 class AIObservabilityTextReprBurstThrottle(PersonalApiKeyRateThrottle):

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -471,6 +471,14 @@ WHITENOISE_MAX_AGE = get_from_env("WHITENOISE_MAX_AGE", 3600, type_cast=int)
 # non-prod (e.g. dev deploy smoke-tests) can raise it without weakening the prod default.
 SIGNUP_IP_THROTTLE_RATE = get_from_env("SIGNUP_IP_THROTTLE_RATE", "5/day")
 
+# Project-wide ceilings on /query volume, counting every auth method (see
+# posthog.rate_limit.QueryProjectBurstThrottle). Sized so no single project can take a large share
+# of platform query capacity, while leaving the app's own session-authenticated traffic well below
+# the limit. Overridable per-env so a region can ratchet them down against observed
+# `rate_limit_exceeded` volume without a code change.
+QUERY_PROJECT_BURST_THROTTLE_RATE = get_from_env("QUERY_PROJECT_BURST_THROTTLE_RATE", "3000/minute")
+QUERY_PROJECT_SUSTAINED_THROTTLE_RATE = get_from_env("QUERY_PROJECT_SUSTAINED_THROTTLE_RATE", "60000/hour")
+
 # Email domains whose signups are created already-verified (skipping the email round-trip), so
 # non-prod deploy smoke-tests can sign up and act immediately. Empty by default — prod verifies
 # every signup.

--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -918,3 +918,77 @@ class TestProjectSecretApiKeyTeamRateThrottle(APIBaseTest):
 
     def test_cache_key_is_keyed_per_team(self):
         self.assertIn("psak-team:7", _PSAKTeamThrottleForTest().get_cache_key(self._psak_request(team_id=7), Mock()))
+
+
+# The query API's other throttles only count personal-API-key requests, and count them per
+# credential, so before these the app's own session-authenticated traffic had no ceiling at all.
+class TestQueryProjectVolumeThrottle(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.personal_api_key = generate_random_token_personal()
+        PersonalAPIKey.objects.create(
+            label="X",
+            user=self.user,
+            secure_value=hash_key_value(self.personal_api_key),
+            scopes=["*"],
+        )
+
+    def tearDown(self):
+        super().tearDown()
+        cache.clear()
+
+    def _run_query(self, **kwargs):
+        # An unknown query kind is rejected before anything is executed, and throttles are checked
+        # before that, so this exercises the ceiling without running a query.
+        return self.client.post(
+            f"/api/environments/{self.team.id}/query/", {"query": {"kind": "NotARealQueryKind"}}, **kwargs
+        )
+
+    def _poll_query(self, **kwargs):
+        return self.client.get(f"/api/environments/{self.team.id}/query/nonexistent-query-id/", **kwargs)
+
+    @parameterized.expand([("running", "_run_query"), ("polling", "_poll_query")])
+    @patch("posthog.rate_limit.QueryProjectBurstThrottle.rate", new="2/minute")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_session_authenticated_requests_are_capped_per_project(
+        self, _name: str, request_method: str, _rate_limit_enabled: Mock
+    ) -> None:
+        send = getattr(self, request_method)
+
+        for _ in range(2):
+            self.assertNotEqual(send().status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+        response = send()
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertLessEqual(int(response.headers["Retry-After"]), 60)
+
+    @patch("posthog.rate_limit.QueryProjectBurstThrottle.rate", new="2/minute")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_all_credentials_share_one_project_bucket(self, _rate_limit_enabled: Mock) -> None:
+        for _ in range(2):
+            self._run_query()
+
+        response = self._run_query(headers={"authorization": f"Bearer {self.personal_api_key}"})
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    @patch("posthog.rate_limit.QueryProjectBurstThrottle.rate", new="2/minute")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_cap_lifts_once_the_window_passes(self, _rate_limit_enabled: Mock) -> None:
+        with freeze_time("2024-01-01 12:00:00") as frozen_time:
+            for _ in range(2):
+                self._run_query()
+            self.assertEqual(self._run_query().status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+            frozen_time.tick(delta=timedelta(seconds=61))
+            self.assertNotEqual(self._run_query().status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    @patch("posthog.rate_limit.QueryProjectBurstThrottle.rate", new="2/minute")
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    def test_cancelling_a_query_is_not_capped(self, _rate_limit_enabled: Mock) -> None:
+        # A project that has hit the ceiling still has to be able to stop the queries it started.
+        for _ in range(3):
+            self._run_query()
+
+        response = self.client.delete(f"/api/environments/{self.team.id}/query/nonexistent-query-id/")
+        self.assertNotEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)


### PR DESCRIPTION
Closed and superseded. This was an exploratory spike that isn't the right fix for its originating issue and won't be merged; follow-up will be refiled separately with fresh context.