### PR TITLE
feat(autoresearch): reduce TypeScript check overhead

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
         "schema:build:json": "ts-node ./bin/build-schema-json.mjs && oxfmt ./src/queries/schema.json && ts-node ./bin/build-validators.mjs && oxfmt ./src/queries/validators.js",
         "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/|packages/quill/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
         "jest": "pnpm build:products && jest",
-        "typescript:check": "tsgo --noEmit --pretty false && echo \"No errors reported by tsgo.\"",
+        "typescript:check": "tsgo --noEmit && echo \"No errors reported by tsgo.\"",
         "typescript:version": "tsgo --version",
         "lint": "cd .. && oxlint --quiet",
         "lint:fix": "cd .. && oxlint --fix --quiet",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
         "schema:build:json": "ts-node ./bin/build-schema-json.mjs && oxfmt ./src/queries/schema.json && ts-node ./bin/build-validators.mjs && oxfmt ./src/queries/validators.js",
         "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/|packages/quill/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
         "jest": "pnpm build:products && jest",
-        "typescript:check": "tsgo --noEmit && echo \"No errors reported by tsgo.\"",
+        "typescript:check": "tsgo --noEmit --pretty false && echo \"No errors reported by tsgo.\"",
         "typescript:version": "tsgo --version",
         "lint": "cd .. && oxlint --quiet",
         "lint:fix": "cd .. && oxlint --fix --quiet",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,3 +1,7 @@
 {
-    "extends": "../tsconfig.json"
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "declaration": false,
+        "sourceMap": false
+    }
 }


### PR DESCRIPTION
## Problem

- Frontend type checks configure output that a no-emit command never writes.
- **Why:** Developers run this command repeatedly during TypeScript work.

## Changes

- The check skips declaration and source-map output configuration.
- Type coverage, Jest wiring, diagnostic formatting, and failure behavior stay unchanged.

## How did you test this code?

- The full frontend type check completes successfully.
- A representative Jest suite runs through the unchanged Jest command.
- Original and updated compiler settings report identical semantic diagnostics for an invalid fixture.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- Not needed. This changes an internal compiler configuration.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Created with Autoresearch.
- Used the `hogli` and `writing-pr-descriptions` skills.
- Restored pretty diagnostics after review because its small timing difference did not justify changing developer output.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*