### PR TITLE
feat(eng-analytics): add CI diagnosis eval suite

### DIFF
--- a/products/engineering_analytics/evals/__init__.py
+++ b/products/engineering_analytics/evals/__init__.py
@@ -1,0 +1,1 @@
+"""CI-diagnosis eval suites for the engineering_analytics product."""

--- a/products/engineering_analytics/evals/cases.py
+++ b/products/engineering_analytics/evals/cases.py
@@ -1,0 +1,201 @@
+"""Real CI failures with a verified diagnosis, as eval fixtures.
+
+Every case is a failure that actually happened in `PostHog/posthog` and whose root cause
+was later confirmed — by the fix that merged, or by an engineer in the thread correcting a
+first, wrong answer. `evidence` is what a triager sees before investigating: the failing
+job, the error, and the surrounding context. Nothing downstream of the diagnosis is in it.
+
+Two things the ground truth encodes that a plausible-sounding answer will miss:
+
+`attribution` is the question people actually ask ("is this my fault?"), and the answer is
+not always "not you" — `mcp_char_budget` is the author's own doing. A grader that only ever
+rewards exoneration would score well on a bot that always says "master is broken".
+
+`decoy` is the loudest wrong answer: the error text a shallow read lands on. `jest_jsdom`
+fails visibly at a tooltip assertion whose cause is a ReferenceError several frames earlier,
+and `self_hosted_runner_disconnect` prints a module-resolution error 52 times per job in
+passing and failing jobs alike. Confusing symptom with cause is the failure mode this suite
+exists to catch, so it is scored separately from whether the diagnosis reads well.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+# Who owns the failure. The eval asks for exactly one, because a triage answer that hedges
+# across two is not actionable.
+Attribution = Literal[
+    "pr_caused",  # the PR under discussion introduced it
+    "trunk_broken",  # master is red; every concurrent PR sees it
+    "flaky",  # same commit both passes and fails
+    "infrastructure",  # runner, network, or registry — not the repo's code
+]
+
+
+@dataclass(frozen=True, kw_only=True)
+class CIDiagnosisCase:
+    """One CI failure and the diagnosis a good triager should reach."""
+
+    name: str
+    evidence: str
+    attribution: Attribution
+    root_cause: str
+    """The mechanism, in one or two sentences. Judged semantically, not by string match."""
+    decoy: list[str] = field(default_factory=list)
+    """Substrings that name the symptom rather than the cause. Present in the root cause of a
+    shallow answer, absent from a correct one."""
+    source: str = ""
+
+
+CASES: list[CIDiagnosisCase] = [
+    CIDiagnosisCase(
+        name="chdb_mock_target_moved",
+        attribution="trunk_broken",
+        evidence="""Two warehouse tests are failing across several different open PRs, and re-running does not clear them:
+
+```
+@posthog/products-data-warehouse:backend:test: FAILED backend/models/test/test_table.py::TestTable::test_chdb_introspection_escapes_single_quotes_in_placeholders_0_get_columns - Exception: Could not get columns
+@posthog/products-data-warehouse:backend:test: FAILED backend/models/test/test_table.py::TestTable::test_chdb_introspection_escapes_single_quotes_in_placeholders_1_get_count - Exception: Could not get columns
+```
+
+The test patches `chdb.query`. The production code in `products/warehouse_sources/backend/models/table.py` calls `run_chdb_query()`, which shells out to chdb in a subprocess via `subprocess.run` and returns `process.stdout`. Two engineers report the same two tests blocking unrelated PRs.""",
+        root_cause=(
+            "The test mocks `chdb.query`, but the code under test was refactored to call "
+            "`run_chdb_query()`, which runs chdb in a subprocess. The patch never intercepts the "
+            "real call, so the subprocess runs for real, fails to reach storage, and the code "
+            "falls through to its ClickHouse path."
+        ),
+        decoy=["could not get columns", "clickhouse is down", "s3 is flaky"],
+        source="#flakey-tests 2026-07-07; fix merged as PostHog/posthog#68855",
+    ),
+    CIDiagnosisCase(
+        name="jest_jsdom_performance_now",
+        attribution="flaky",
+        evidence="""`packages/quill/packages/charts/src/charts/PieChart/PieChart.test.tsx` fails intermittently in Frontend CI. The reported failure:
+
+```
+● PieChart › hover & tooltip › switches the tooltip to the other slice when the cursor moves
+
+    tooltip not yet rendered
+
+    <body>
+      <div>
+        <div style="...">Something went wrong rendering this chart</div>
+      </div>
+    </body>
+
+      at waitForTooltip (../packages/quill/packages/charts/src/testing/tooltip.ts:92:23)
+```
+
+Earlier in the same job's console output:
+
+```
+Error: Uncaught [ReferenceError: performance is not defined]
+    at tick (/home/runner/.../src/core/hooks/useHoverAnimation.ts:...)
+```
+
+`useHoverAnimation` drives the hover fade-in and calls `performance.now()` on mouse move. The test helper `setupSyncRaf()` mocks `requestAnimationFrame` to run synchronously. The chart is wrapped in an error boundary that renders "Something went wrong rendering this chart".""",
+        root_cause=(
+            "`useHoverAnimation` calls `performance.now()`, which is not always defined in the "
+            "jsdom environment. The ReferenceError is caught by the chart's error boundary, so the "
+            "chart never renders and no tooltip ever appears. The tooltip assertion is the "
+            "downstream symptom; `setupSyncRaf()` mocks rAF but does not guarantee `performance`."
+        ),
+        decoy=["tooltip not yet rendered", "tooltip timing", "waitfor timeout", "animation timing"],
+        source="#flakey-tests 2026-06-25; fix merged as PostHog/posthog#65972",
+    ),
+    CIDiagnosisCase(
+        name="mcp_char_budget",
+        attribution="pr_caused",
+        evidence="""A PR adding alerts MCP tools (`products/alerts/mcp/tools.yaml`, `services/mcp/src/tools/generated/alerts.ts`) has a failing MCP CI job. The author says it is unrelated to their changes.
+
+```
+tests/unit/execute-sql-description.test.ts > formatExecuteSqlDescription > keeps data-catalog discovery within its character budget
+
+AssertionError: expected 1444 to be less than 1200
+```
+
+The job log also prints:
+
+```
+MCP unit test artifacts are out of date. Run 'pnpm --filter=@posthog/mcp run test -u' and commit the result.
+```
+
+The same job is green on master.""",
+        root_cause=(
+            "The PR's new alerts MCP tools expand the data catalog that feeds the execute-sql "
+            "description, pushing it from under the asserted 1200-character budget to 1444. The "
+            "budget assertion is doing its job. Master is green because master lacks these tools."
+        ),
+        decoy=["out of date", "snapshot", "artifacts", "unrelated", "master is broken", "flaky"],
+        source="#flakey-tests 2026-07-17, PostHog/posthog#71705",
+    ),
+    CIDiagnosisCase(
+        name="receivers_baseline_not_updated",
+        attribution="trunk_broken",
+        evidence="""`test_setup_receivers_match_baseline` is failing in Django Core shard 19/19. The failure names three signal receivers that are registered at runtime but absent from the baseline file:
+
+```
+post_delete:products.ai_observability.backend.models.llm_prompt.invalidate_llm_prompt_label_cache
+post_save:products.ai_observability.backend.models.llm_prompt.invalidate_llm_prompt_label_cache
+post_save:products.early_access_features.backend.signals.create_waitlist_survey_on_concept_stage
+```
+
+The same shard is failing on every recent master commit. Re-running the job on the PR does not help. The PR under discussion touches MCP tool definitions only.""",
+        root_cause=(
+            "New Django signal receivers were merged to master without regenerating the checked-in "
+            "receivers baseline, so the baseline-comparison test fails for everyone. It needs a "
+            "baseline regeneration committed to master (`UPDATE_SETUP_RECEIVERS_BASELINE=1`); "
+            "re-running a PR cannot fix it."
+        ),
+        decoy=["flaky", "shard", "sharding", "rerun", "your pr"],
+        source="#flakey-tests 2026-07-17, PostHog/posthog#71705 thread",
+    ),
+    CIDiagnosisCase(
+        name="mcp_property_definition_post",
+        attribution="flaky",
+        evidence="""The MCP CI integration job failed and passed on re-run 32 times in the last 7 days, always on the same test.
+
+`services/mcp/tests/tools/projects.integration.test.ts` has a `beforeAll` for the `property-definition-update tool` block that looks for the `$browser` property definition and, when it is missing, tries to create it with `POST /api/projects/{id}/property_definitions/`.
+
+`PropertyDefinitionViewSet` in `posthog/taxonomy/property_definition_api.py` composes List/Retrieve/Update/Destroy and has no `CreateModelMixin`. The failed attempt is annotated `This action does not support personal API key access`.
+
+The CI workflow pre-seeds `EventDefinition` rows for `$pageview`, `$pageleave`, `$autocapture` and `$screen`, but seeds no `PropertyDefinition` rows. `vitest.integration.config.mts` sets `retry: 1`.""",
+        root_cause=(
+            "The test's `beforeAll` depends on whether generated demo data happened to produce a "
+            "`$browser` property definition that run. Its fallback POST can never succeed because "
+            "the viewset has no create action, and `retry: 1` does not help because a throwing "
+            "`beforeAll` is not retried. Nothing seeds `PropertyDefinition` rows, so the "
+            "precondition is left to chance."
+        ),
+        decoy=["403", "permissions", "api key scope", "auth"],
+        source="Signals report 2026-08-03, PostHog/posthog#76476",
+    ),
+    CIDiagnosisCase(
+        name="self_hosted_runner_disconnect",
+        attribution="infrastructure",
+        evidence="""Jobs on self-hosted runners are failing. The logs contain a long parade of module-resolution warnings around dynamic imports in a `codeowners.ts` script:
+
+```
+ERR_MODULE_NOT_FOUND  Cannot find module '.../codeowners.ts'
+```
+
+Counting occurrences across the window: the warning appears exactly 52 times per job, in passing jobs and failing jobs alike. In the source, those imports sit inside a try/catch and the handler calls `console.log`.
+
+Every failed job in the window carries the annotation:
+
+```
+The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection.
+```
+
+The failing jobs ran for 15 to 20 minutes before disconnecting. Passing jobs on the same runners completed normally.""",
+        root_cause=(
+            "The self-hosted runners lose communication with GitHub mid-job, which fails the job. "
+            "The module-resolution warnings are caught and logged, appear identically in passing "
+            "jobs, and do not affect exit status — they are noise, not the cause."
+        ),
+        decoy=["err_module_not_found", "module not found", "dynamic import", "codeowners", "import path"],
+        source="Mendral published post-mortem, 'How do we know if our agent is right?'",
+    ),
+]

--- a/products/engineering_analytics/evals/eval_ci_diagnosis.py
+++ b/products/engineering_analytics/evals/eval_ci_diagnosis.py
@@ -1,0 +1,123 @@
+"""Can the bot diagnose a real CI failure?
+
+One model call per case against a failure that actually happened, scored on the four axes in
+`scorers.py`. No sandbox and no tools: this isolates diagnostic reasoning from investigation,
+so a regression here is a reasoning regression and not a flaky MCP call. A companion sandboxed
+suite that grades the investigation itself needs seeded `github_*` warehouse data and is not
+built yet.
+
+Run:
+    hogli evals ci_diagnosis
+    hogli evals ci_diagnosis --eval jest_jsdom_performance_now
+"""
+
+from __future__ import annotations
+
+import os
+import json
+from typing import Any
+
+import structlog
+from anthropic import AsyncAnthropic
+
+from products.engineering_analytics.evals.cases import CASES
+from products.engineering_analytics.evals.scorers import CIAttribution, CIEvidenceGate, CIRootCause, CISymptomNotCause
+from products.posthog_ai.eval_harness.config import BaseEvalCase
+from products.posthog_ai.eval_harness.harness.context import EvalContext
+from products.posthog_ai.eval_harness.harness.requirements import SuiteKind
+from products.posthog_ai.eval_harness.one_shot import OneShotPrivateEval
+
+logger = structlog.get_logger(__name__)
+
+SUITE_KIND = SuiteKind.ONE_SHOT
+
+MODEL = "claude-sonnet-5"
+
+# Structured output, so attribution and the evidence gate are scored by field rather than by
+# grepping prose. The framing matches how these arrive in #flakey-tests: someone pastes a
+# failing job and asks whose fault it is.
+_PROMPT = """You are triaging a CI failure for the PostHog monorepo. An engineer has pasted the
+evidence below and wants to know what is going on.
+
+Evidence:
+{evidence}
+
+Reply with ONLY a JSON object, no prose or code fences, with exactly these keys:
+
+{{
+  "attribution": one of "pr_caused" | "trunk_broken" | "flaky" | "infrastructure",
+  "root_cause": "the mechanism, in one or two sentences — why it fails, not what the error says",
+  "evidence": "the specific line, count, or observation from the input that supports it",
+  "location": "the file, function, or job the problem lives in",
+  "proposed_fix": "the narrowest change that would fix it"
+}}
+
+Rules:
+- Pick exactly one attribution. "pr_caused" means the PR under discussion introduced it;
+  "trunk_broken" means master is red and every concurrent PR sees it; "flaky" means the same
+  commit both passes and fails; "infrastructure" means runner, network, or registry.
+- The loudest error in a log is often not the cause. An error that appears in passing runs as
+  well as failing ones did not cause the failure.
+- Do not assume the engineer is blameless. Sometimes their PR really did break it.
+"""
+
+
+async def _diagnose(case: BaseEvalCase, ctx: EvalContext) -> dict[str, Any]:
+    """One model invocation; its parsed JSON becomes the scorer output.
+
+    Calls Anthropic directly rather than through `get_llm_client`: one-shot suites are the
+    one kind the harness does not boot a gateway for (`INFRA_BY_KIND`), which is why their
+    preflight requires `LLM_GATEWAY_ANTHROPIC_API_KEY` at all.
+    """
+    client = AsyncAnthropic(api_key=os.environ["LLM_GATEWAY_ANTHROPIC_API_KEY"])
+    response = await client.messages.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": case.prompt}],
+        max_tokens=1024,
+    )
+    content = "".join(block.text for block in response.content if block.type == "text").strip()
+    raw = content
+    if content.startswith("```"):
+        content = content.strip("`").removeprefix("json").strip()
+
+    try:
+        diagnosis = json.loads(content)
+    except json.JSONDecodeError:
+        # Scored as a miss on every axis rather than raised: a model that cannot hold the output
+        # contract is a real regression, and raising here would mark it an infra error and drop
+        # the case from the averages entirely.
+        logger.warning("ci_diagnosis_unparseable_output", case=case.name)
+        return {"diagnosis": None, "raw": raw, "last_message": raw}
+
+    if not isinstance(diagnosis, dict):
+        return {"diagnosis": None, "raw": raw, "last_message": raw}
+
+    return {
+        "diagnosis": diagnosis,
+        "raw": raw,
+        "last_message": f"{diagnosis.get('attribution')}: {diagnosis.get('root_cause')}",
+    }
+
+
+async def eval_ci_diagnosis(ctx: EvalContext) -> None:
+    cases = [
+        BaseEvalCase(
+            name=case.name,
+            prompt=_PROMPT.format(evidence=case.evidence),
+            expected={
+                "ci_attribution": {"attribution": case.attribution},
+                "ci_root_cause": {"root_cause": case.root_cause},
+                "ci_symptom_not_cause": {"decoys": case.decoy},
+            },
+            metadata={"source": case.source, "attribution": case.attribution},
+        )
+        for case in CASES
+    ]
+
+    await OneShotPrivateEval(
+        experiment_name="ci-diagnosis",
+        cases=cases,
+        scorers=[CIAttribution(), CISymptomNotCause(), CIEvidenceGate(), CIRootCause()],
+        task=_diagnose,
+        ctx=ctx,
+    )

--- a/products/engineering_analytics/evals/scorers.py
+++ b/products/engineering_analytics/evals/scorers.py
@@ -1,0 +1,170 @@
+"""Scorers for CI-diagnosis quality.
+
+Four independent axes, deliberately not collapsed into one number:
+
+`ci_attribution` is the answer to "is this my fault?" — one label, exact match, no judge.
+`ci_symptom_not_cause` catches the failure mode where the diagnosis reads well and names the
+loudest error rather than the mechanism. `ci_evidence_gate` checks the diagnosis is anchored
+to something checkable before it is allowed to sound confident. `ci_root_cause` is the only
+judged axis, because a mechanism can be stated many correct ways.
+
+Keeping them apart is the point. Mendral's published post-mortem found rejected fix PRs whose
+diagnoses were all correct — the teams just preferred a different fix — so a single blended
+score would have read as a quality regression that wasn't one. Diagnosis quality and fix
+acceptance are different measurements and must not be averaged into each other.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from products.posthog_ai.eval_harness.scorers import GRADED_ALIGNMENT_CHOICE_SCORES, JUDGE_MODEL, JudgedScorer
+from products.posthog_ai.eval_harness.scorers.contract import Score, Scorer
+
+# Every criterion is checkable against the case evidence alone, so the gate stays honest for a
+# diagnosis produced without tool access.
+EVIDENCE_CRITERIA = ("explains_why", "cites_evidence", "names_location", "proposes_fix")
+
+
+def _diagnosis(output: Any) -> dict[str, Any] | None:
+    if not isinstance(output, dict):
+        return None
+    diagnosis = output.get("diagnosis")
+    return diagnosis if isinstance(diagnosis, dict) else None
+
+
+class CIAttribution(Scorer):
+    """Did it place the blame correctly: the PR, trunk, a flake, or infrastructure?"""
+
+    def _name(self) -> str:
+        return "ci_attribution"
+
+    def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        spec = expected.get(self._name()) if isinstance(expected, dict) else None
+        if not isinstance(spec, dict) or not spec.get("attribution"):
+            return Score(name=self._name(), score=None, metadata={"reason": "not requested"})
+
+        diagnosis = _diagnosis(output)
+        if diagnosis is None:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "no diagnosis in output"})
+
+        actual = str(diagnosis.get("attribution", "")).strip().lower()
+        want = str(spec["attribution"]).strip().lower()
+        return Score(
+            name=self._name(),
+            score=1.0 if actual == want else 0.0,
+            metadata={"expected": want, "actual": actual or "(missing)"},
+        )
+
+
+class CISymptomNotCause(Scorer):
+    """Does the stated root cause name the mechanism, or the loudest error in the log?
+
+    Scored on the root-cause field only. A decoy string is legitimate when describing the
+    observed failure, so matching it elsewhere in the answer is not penalized.
+    """
+
+    def _name(self) -> str:
+        return "ci_symptom_not_cause"
+
+    def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        spec = expected.get(self._name()) if isinstance(expected, dict) else None
+        decoys = spec.get("decoys") if isinstance(spec, dict) else None
+        if not decoys:
+            return Score(name=self._name(), score=None, metadata={"reason": "no decoys for this case"})
+
+        diagnosis = _diagnosis(output)
+        if diagnosis is None:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "no diagnosis in output"})
+
+        root_cause = str(diagnosis.get("root_cause", "")).lower()
+        if not root_cause:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "empty root_cause"})
+
+        hits = [d for d in decoys if str(d).lower() in root_cause]
+        return Score(
+            name=self._name(),
+            score=0.0 if hits else 1.0,
+            metadata={"decoys_matched": hits, "checked": list(decoys)},
+        )
+
+
+class CIEvidenceGate(Scorer):
+    """Fraction of the evidence criteria the diagnosis actually satisfies.
+
+    Adapted from the five-criteria gate Mendral described, minus "link the fix to the commit
+    that introduced it": these cases carry no commit history, so requiring it would score every
+    answer down for a fact the input never contained.
+    """
+
+    def _name(self) -> str:
+        return "ci_evidence_gate"
+
+    def _run_eval_sync(self, output: Any, expected: Any = None, **kwargs: Any) -> Score:
+        diagnosis = _diagnosis(output)
+        if diagnosis is None:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "no diagnosis in output"})
+
+        met: dict[str, bool] = {}
+        # A mechanism, not a restatement of the error. Short strings are almost always the latter.
+        met["explains_why"] = len(str(diagnosis.get("root_cause", "")).split()) >= 12
+        met["cites_evidence"] = bool(str(diagnosis.get("evidence", "")).strip())
+        met["names_location"] = bool(str(diagnosis.get("location", "")).strip())
+        met["proposes_fix"] = bool(str(diagnosis.get("proposed_fix", "")).strip())
+
+        score = sum(met.values()) / len(EVIDENCE_CRITERIA)
+        return Score(name=self._name(), score=score, metadata={"criteria": met})
+
+
+_ROOT_CAUSE_PROMPT = """You are grading whether a CI-failure diagnosis identified the correct mechanism.
+
+The confirmed root cause (ground truth, established by the fix that later merged):
+{{expected}}
+
+The diagnosis under test:
+{{output}}
+
+Grade ONLY whether the diagnosis identifies the same underlying mechanism. Ignore wording,
+length, structure, and whether the proposed fix matches the one that shipped — a different but
+valid fix for the same mechanism is still a correct diagnosis.
+
+Naming the symptom, or a plausible cause that is not the actual one, is not correct however
+confidently it is stated.
+
+Choose one:
+(perfect) Same mechanism, with the specific detail that makes it actionable.
+(near_perfect) Same mechanism, slightly vague on detail.
+(slightly_off) Right area, mechanism partly wrong or incomplete.
+(somewhat_misaligned) Related to the real cause but would send a fixer down the wrong path.
+(strongly_misaligned) A different cause entirely, or the symptom restated as the cause.
+(useless) No mechanism identified.
+"""
+
+
+class CIRootCause(JudgedScorer):
+    """Graded judge: same mechanism as the confirmed root cause?"""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            name="ci_root_cause",
+            prompt_template=_ROOT_CAUSE_PROMPT,
+            choice_scores=GRADED_ALIGNMENT_CHOICE_SCORES,
+            model=JUDGE_MODEL,
+            max_completion_tokens=512,
+            **kwargs,
+        )
+
+    def _prepare(self, output: Any, expected: Any) -> dict[str, Any] | Score:
+        spec = expected.get(self._name()) if isinstance(expected, dict) else None
+        if not isinstance(spec, dict) or not isinstance(spec.get("root_cause"), str):
+            return Score(name=self._name(), score=None, metadata={"reason": "not requested"})
+
+        diagnosis = _diagnosis(output)
+        if diagnosis is None:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "no diagnosis in output"})
+
+        stated = str(diagnosis.get("root_cause", "")).strip()
+        if not stated:
+            return Score(name=self._name(), score=0.0, metadata={"reason": "empty root_cause"})
+
+        return {"output": stated, "expected": spec["root_cause"]}


### PR DESCRIPTION
## Problem

- Nobody can tell whether the @PostHog bot diagnoses CI failures correctly, so every prompt or skill change lands unmeasured.
- Mendral ran this job for the monorepo until it was switched off on 2026-08-04. Nothing replaced its accuracy signal.
- The bot's autonomous loop has opened 22 fix PRs and merged 3. That reads as a diagnosis problem, but it is equally consistent with correct diagnoses and unwanted fixes. No measurement separates the two.

## Changes

- Adds a one-shot eval suite over 6 CI failures that really happened, each with a root cause later confirmed by the fix that merged.
- Scores four independent axes instead of one blended number: attribution, symptom-versus-cause, an evidence gate, and a judge on the mechanism.
- Excludes fix-merge rate as an accuracy metric on purpose. Rejected fixes often carry correct diagnoses, so blending the two would report a quality regression that did not happen.
- Runs no sandbox and no tools. A regression here is a reasoning regression, not a flaky tool call.
- Calls Anthropic directly. One-shot is the one suite kind the harness does not boot a gateway for, which is why its preflight requires `LLM_GATEWAY_ANTHROPIC_API_KEY`.

## How did you test this code?

- I (actually Claude) ran the suite end to end against all 6 cases. It executes, scores, and writes a transcript.
- `ci_symptom_not_cause` reports false positives today. It substring-matches the root cause, so a correct answer that names a decoy in order to dismiss it scores zero. Two of its three failures were this. A follow-up replaces the bare-noun decoys with full claim phrases.
- Not covered by CI: no check runs this suite, so nothing here guards it automatically.
- Not verified: results do not reach Braintrust, because `OneShotPrivateEval` sets `no_send_logs`. There is no cross-run history yet.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills invoked: `/writing-evals`, `/writing-pr-descriptions`.
- The suite could not run as first written. It called the LLM gateway with a product tag absent from the gateway's registry, which returns 403. I moved it to a direct Anthropic call, matching the harness contract for one-shot suites.
- Also removed `temperature`, which `claude-sonnet-5` rejects.
