### PR TITLE
fix(ai-observability): tint user bubbles in the session transcript

### DIFF
--- a/products/ai_observability/frontend/ConversationDisplay/TranscriptBubbleStream.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/TranscriptBubbleStream.tsx
@@ -255,6 +255,8 @@ export function TranscriptBubbleStream({
                         key={i}
                         type={item.message.role === 'user' ? 'human' : 'ai'}
                         wrapperClassName="max-w-[75%]"
+                        // Same user-message fill the Trace page uses, so the two sides don't blend together
+                        boxClassName={item.message.role === 'user' ? 'bg-fill-tertiary' : undefined}
                     >
                         {item.text && (
                             <LemonMarkdown className="whitespace-pre-wrap break-words">{item.text}</LemonMarkdown>


### PR DESCRIPTION
## Problem

In the AI observability session view, user messages (right) and assistant messages (left) render with the same bubble background, so the two sides blend together and the transcript is hard to read. Alignment was the only cue.

## Changes

User bubbles now get `bg-fill-tertiary`, the same fill the Trace page already applies to user messages in `ConversationMessagesDisplay`. Assistant bubbles keep `bg-surface-primary`.

The color is passed through `MessageTemplate`'s `boxClassName` rather than changed inside `MessageTemplate` itself — that component is shared with Max's thread and the task runner, which should keep their current look.

Token picked for consistency within AI observability. The other precedent in the codebase is `bg-accent-highlight-secondary` (user interviews transcript), which is a stronger, brand-tinted wash if reviewers want more separation.

## How did you test this code?

Not verified in a running app or Storybook — this environment had no installed frontend dependencies, so no render was captured. The change is a one-token swap on an existing Tailwind background token used elsewhere in the app.

No tests added: a snapshot of a background class would assert an implementation detail rather than a regression worth catching.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The request was to differentiate the two bubble colors and to reuse an existing PostHog color rather than invent one, so the session was mostly a search for the established token: two exploration passes over `products/ai_observability/frontend`, `products/posthog_ai/frontend`, `products/conversations`, `products/user_interviews`, and the quill chat primitives.

Finding: there is no repo-wide convention. `MessageTemplate` (the shared bubble) has role-based alignment but a single background; the Trace page's own message list is the only place in this product that colors by role. Reusing its user fill keeps the two AI observability surfaces consistent, which is why it won over the brand-tinted user-interviews token.

No repo skills were invoked — the diff adds no user-visible copy, no migration, and no API surface.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1786029663372799)*
