### PR TITLE
fix(insights): preserve visualization settings on MCP updates

### DIFF
--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1484,9 +1484,15 @@ class MCPInsightSerializer(InsightSerializer):
     def validate_query(self, value: dict[str, Any] | None) -> dict[str, Any]:
         # Raw HogQL → DataVisualizationNode
         try:
-            return schema.DataVisualizationNode(source=schema.HogQLQuery.model_validate(value)).model_dump(
+            normalized_query = schema.DataVisualizationNode(source=schema.HogQLQuery.model_validate(value)).model_dump(
                 exclude_none=True, mode="json"
             )
+            # MCP updates send only the source query, so retain wrapper-only visualization settings.
+            if self.instance is not None and isinstance(self.instance.query, dict):
+                existing_query = self.instance.query
+                if existing_query.get("kind") == "DataVisualizationNode":
+                    return {**existing_query, **normalized_query}
+            return normalized_query
         except PydanticValidationError:
             pass
 

--- a/products/product_analytics/backend/api/test/test_insight_query.py
+++ b/products/product_analytics/backend/api/test/test_insight_query.py
@@ -376,3 +376,32 @@ class TestInsight(ClickhouseTestMixin, LicensedTestMixin, APIBaseTest, QueryMatc
         error_body = str(response.json())
         assert "This query can't be saved" in error_body
         assert "Traceback" not in error_body
+
+    def test_mcp_update_raw_hogql_preserves_visualization_settings(self) -> None:
+        insight = Insight.objects.create(
+            team=self.team,
+            created_by=self.user,
+            query={
+                "kind": "DataVisualizationNode",
+                "source": {"kind": "HogQLQuery", "query": "select event from events limit 1"},
+                "display": "ActionsTable",
+                "chartSettings": {"showValuesOnSeries": True},
+                "tableSettings": {"conditionalFormatting": []},
+            },
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/insights/{insight.id}/",
+            data={"query": {"kind": "HogQLQuery", "query": "select distinct_id from events limit 1"}},
+            content_type="application/json",
+            HTTP_X_POSTHOG_CLIENT="mcp",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert response.json()["query"] == {
+            "kind": "DataVisualizationNode",
+            "source": {"kind": "HogQLQuery", "query": "select distinct_id from events limit 1"},
+            "display": "ActionsTable",
+            "chartSettings": {"showValuesOnSeries": True},
+            "tableSettings": {"conditionalFormatting": []},
+        }


### PR DESCRIPTION
## Problem

MCP clients lose an insight's display, chart, and table settings when they update only its SQL source.

Closes #54870

## Changes

- Preserve existing `DataVisualizationNode` wrapper settings when an MCP update replaces its HogQL source.
- Keep create requests and non-visualization queries on the existing normalization path.

## How did you test this code?

- Local: `uv run pytest products/product_analytics/backend/api/test/test_insight_query.py -q --reuse-db -k mcp` against Postgres, Redis, and ClickHouse.
- Local: `uv run mypy --cache-fine-grained .`, Ruff, and `hogli ci:preflight --against upstream/master --fix`.
- Generated OpenAPI, frontend, and MCP artifacts; no tracked artifact changed.
- Manual testing: not run because this backend behavior is covered through the public API regression.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fixes server-side merge behavior without changing the API shape.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Codex used direct `gh`, the local PostHog test stack, and repository tooling.
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`, and `/running-ci-preflight`.
- The endpoint regression verifies MCP serializer selection, persisted wrapper settings, and the returned API representation.
- The public issue and repository sources were the only problem context. No private customer or support data was used.
