### PR TITLE
fix(desktop): keep thoughts outside tool groups

### DIFF
--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ChatThread.tsx
@@ -150,12 +150,6 @@ function isToolCallItem(item: ConversationItem): item is SessionUpdateItem {
   );
 }
 
-function isSessionUpdateItem(
-  item: ConversationItem,
-): item is SessionUpdateItem {
-  return item.type === "session_update";
-}
-
 /**
  * Session-updates that `SessionUpdateView` always renders as `null`. They produce no row, so they
  * must not break a contiguous tool run.
@@ -188,26 +182,6 @@ function isInvisibleItem(item: ConversationItem): boolean {
 }
 
 /**
- * A thought joins a tool run instead of breaking it, because between two calls it narrates the
- * stretch of work the run already stands for. The group's body still lists it in order. Prose to
- * the user (`agent_message_chunk`) does break a run, since that is addressed to the reader rather
- * than describing the work.
- */
-function isThoughtItem(item: ConversationItem): boolean {
-  return (
-    item.type === "session_update" &&
-    item.update.sessionUpdate === "agent_thought_chunk"
-  );
-}
-
-/**
- * Collapse each contiguous run of ≥2 tool-call updates into a single `ToolGroupItem`. A run is
- * broken by any *visible* non-tool, non-thought item (prose, status) so groups follow reading
- * order; invisible updates (see {@link INVISIBLE_UPDATES}) are transparent and don't split a run.
- * A lone tool call passes through untouched as a single marker, and so do the thoughts around it:
- * thoughts ride along a run, they never make one.
- */
-/**
  * Item arrays for settled runs, keyed on the run's (stable) first item.
  *
  * Grouping re-runs over the whole thread on every streamed chunk, so a completed run produces a
@@ -233,34 +207,31 @@ function stableRunItems(run: SessionUpdateItem[]): SessionUpdateItem[] {
   return run;
 }
 
-function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
+/**
+ * Collapse each contiguous run of ≥2 tool-call updates into a single `ToolGroupItem`. A visible
+ * non-tool item breaks the run so thoughts and prose keep their place in the conversation.
+ * Invisible updates remain transparent because they produce no row.
+ */
+export function groupToolRuns(items: ConversationItem[]): ThreadItem[] {
   const out: ThreadItem[] = [];
-  // The buffer holds the active run in order: tools, the thoughts between them, and any invisible
-  // items interleaved with either.
   let buffer: ConversationItem[] = [];
-  let toolCount = 0;
 
   const flush = () => {
-    if (toolCount >= 2) {
+    const tools = buffer.filter(isToolCallItem);
+    if (tools.length >= 2) {
       out.push({
         type: "tool_group",
-        // Keyed on the first tool call so the id survives thoughts appending around it.
-        id: buffer.filter(isToolCallItem)[0].id,
-        items: stableRunItems(buffer.filter(isSessionUpdateItem)),
+        id: tools[0].id,
+        items: stableRunItems(tools),
       });
     } else {
       out.push(...buffer);
     }
     buffer = [];
-    toolCount = 0;
   };
 
   for (const item of items) {
-    if (isToolCallItem(item)) {
-      buffer.push(item);
-      toolCount++;
-    } else if (isInvisibleItem(item) || isThoughtItem(item)) {
-      // Don't break the run; carry it along in order.
+    if (isToolCallItem(item) || isInvisibleItem(item)) {
       buffer.push(item);
     } else {
       flush();

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.test.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.test.tsx
@@ -36,27 +36,6 @@ function subagentItem(
   } as SessionUpdateItem;
 }
 
-function thoughtItem(
-  id: string,
-  options: { thoughtComplete: boolean; turnComplete?: boolean },
-): SessionUpdateItem {
-  return {
-    type: "session_update",
-    id,
-    update: {
-      sessionUpdate: "agent_thought_chunk",
-      content: { type: "text", text: "weighing the options" },
-    },
-    thoughtComplete: options.thoughtComplete,
-    turnContext: {
-      toolCalls: new Map(),
-      childItems: new Map(),
-      turnCancelled: false,
-      turnComplete: options.turnComplete ?? true,
-    },
-  } as SessionUpdateItem;
-}
-
 function renderGroup(items: SessionUpdateItem[]) {
   return render(
     <ServiceProvider container={new Container()}>
@@ -85,18 +64,6 @@ describe("ToolGroup", () => {
         subagentItem("spawn-2", running),
       ],
       expected: "Subagents",
-    },
-    {
-      name: "reads as thinking while a trailing thought streams",
-      items: [
-        subagentItem("spawn-1", running),
-        subagentItem("spawn-2", running),
-        thoughtItem("thought-1", {
-          thoughtComplete: false,
-          turnComplete: false,
-        }),
-      ],
-      expected: "Thinking…",
     },
   ])("$name", ({ items, expected }) => {
     renderGroup(items);

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/ToolGroup.tsx
@@ -17,11 +17,11 @@ import { iconForToolCall } from "../session-update/toolCallUtils";
 
 type SessionUpdateItem = Extract<ConversationItem, { type: "session_update" }>;
 
-/** A contiguous run of one assistant turn's work: ≥2 `tool_call` updates plus the thoughts between them. */
+/** A contiguous run of at least two `tool_call` updates. */
 export type ToolGroupItem = {
   type: "tool_group";
   id: string;
-  /** Everything in the run, in order — what the body lists and what the summary counts. */
+  /** Every tool call in the run, in order. */
   items: SessionUpdateItem[];
 };
 
@@ -87,15 +87,6 @@ function lastActiveTool(
   return undefined;
 }
 
-/** True while the run's last item is a thought still streaming — the agent is mid-reasoning. */
-function isThinking(items: SessionUpdateItem[]): boolean {
-  const last = items.at(-1);
-  return (
-    last?.update.sessionUpdate === "agent_thought_chunk" &&
-    last.thoughtComplete === false
-  );
-}
-
 /** Cross-fade between successive labels, so the row reads as one thing changing, not a new row. */
 const LABEL_MOTION = {
   initial: { opacity: 0 },
@@ -105,11 +96,8 @@ const LABEL_MOTION = {
 };
 
 /**
- * One row standing in for a whole stretch of work: the tool calls and the thoughts between them.
- *
- * While the run is live the row shows what is happening now, which is the current tool or
- * "Thinking…" while the agent reasons between calls. Once it settles the row shows what the run
- * did ("Ran 3 commands, read a file"). Opening it lists every step in order.
+ * One row standing in for a contiguous stretch of tool calls. While the run is live, the row
+ * shows the current tool. Once it settles, the row summarizes the completed work.
  */
 export const ToolGroup = memo(function ToolGroup({
   items,
@@ -131,11 +119,8 @@ export const ToolGroup = memo(function ToolGroup({
     () => items.filter((item) => item.update.sessionUpdate === "tool_call"),
     [items],
   );
-  const thinking = isThinking(items);
-  const isActive = tools.some(isToolActive) || thinking || mayStillGrow;
+  const isActive = tools.some(isToolActive) || mayStillGrow;
 
-  // Grouping only ever builds a run around ≥2 tool calls, but this component is exported, so a
-  // thought-only run has to resolve to no current tool rather than throw on `undefined`.
   const currentItem = lastActiveTool(tools) ?? tools.at(-1);
   const current = currentItem ? resolveTool(currentItem) : null;
   const currentName = currentItem ? friendlyName(toolKey(currentItem)) : null;
@@ -150,22 +135,17 @@ export const ToolGroup = memo(function ToolGroup({
     ? iconForToolCall(current.toolCall, current.toolName)
     : null;
 
-  // A run with no countable work (a lone streaming thought) keeps the live shape rather than
-  // falling back to summarize's "Worked". Cached once the turn completes because the walk is
-  // O(run) and the live turn re-renders every group on every streamed chunk.
+  // Cached once the turn completes because the walk is O(run) and the live turn re-renders every
+  // group on every streamed chunk.
   const summary = useMemo(
     () => summarizeMemo(items, items.at(-1)?.turnContext.turnComplete ?? false),
     [items],
   );
   const showSummary = !isActive && summary.hasCountableWork;
 
-  // Thinking gets its own key so a run that returns to the same tool after a thought still reads
-  // as a change rather than sitting static.
   const labelKey = showSummary
     ? `done:${summary.doneLabel}`
-    : thinking || !currentName
-      ? "thinking"
-      : `tool:${currentName}:${currentContext ?? ""}`;
+    : `tool:${currentName ?? "working"}:${currentContext ?? ""}`;
 
   return (
     <ChatMarker
@@ -212,8 +192,6 @@ export const ToolGroup = memo(function ToolGroup({
           >
             {showSummary ? (
               <span className="truncate">{summary.doneLabel}</span>
-            ) : thinking || !currentName ? (
-              <span className="shrink-0 font-medium">Thinking…</span>
             ) : (
               <>
                 <span className="shrink-0 font-medium">{currentName}</span>

--- a/products/desktop/packages/ui/src/features/sessions/components/chat-thread/groupToolRuns.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/chat-thread/groupToolRuns.test.ts
@@ -1,0 +1,70 @@
+import type { ConversationItem } from "@posthog/ui/features/sessions/components/buildConversationItems";
+import { describe, expect, it } from "vitest";
+import { groupToolRuns } from "./ChatThread";
+
+function turnContext() {
+  return {
+    toolCalls: new Map(),
+    childItems: new Map(),
+    turnCancelled: false,
+    turnComplete: true,
+  };
+}
+
+function toolItem(id: string): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    update: {
+      sessionUpdate: "tool_call",
+      toolCallId: id,
+      title: id,
+      kind: "read",
+      status: "completed",
+    },
+    turnContext: turnContext(),
+  } as ConversationItem;
+}
+
+function thoughtItem(id: string): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    update: {
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text: "Considering the next step" },
+    },
+    thoughtComplete: true,
+    turnContext: turnContext(),
+  } as ConversationItem;
+}
+
+describe("groupToolRuns", () => {
+  it("keeps thoughts outside adjacent tool groups", () => {
+    const grouped = groupToolRuns([
+      toolItem("read-1"),
+      toolItem("read-2"),
+      thoughtItem("thought-1"),
+      toolItem("read-3"),
+      toolItem("read-4"),
+    ]);
+
+    expect(grouped.map((item) => item.type)).toEqual([
+      "tool_group",
+      "session_update",
+      "tool_group",
+    ]);
+    expect(grouped[0]).toMatchObject({
+      type: "tool_group",
+      items: [{ id: "read-1" }, { id: "read-2" }],
+    });
+    expect(grouped[1]).toMatchObject({
+      type: "session_update",
+      id: "thought-1",
+    });
+    expect(grouped[2]).toMatchObject({
+      type: "tool_group",
+      items: [{ id: "read-3" }, { id: "read-4" }],
+    });
+  });
+});

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/buildThreadGroups.test.ts
@@ -32,6 +32,19 @@ function toolCallItem(
   } as unknown as ConversationItem;
 }
 
+function thoughtItem(id: string): ConversationItem {
+  return {
+    type: "session_update",
+    id,
+    update: {
+      sessionUpdate: "agent_thought_chunk",
+      content: { type: "text", text: "Considering the next step" },
+    },
+    thoughtComplete: true,
+    turnContext: turnContext(),
+  } as ConversationItem;
+}
+
 describe("buildThreadGroups MCP detection", () => {
   it("keeps a tool call with only the posthog meta channel standalone (codex adapters)", () => {
     const mcpItem = toolCallItem("t1", {
@@ -72,6 +85,27 @@ describe("buildThreadGroups MCP detection", () => {
     // Both folded items still map to the group's row for find-in-thread.
     expect(grouping.idToRowIndex.get("t1")).toBe(0);
     expect(grouping.idToRowIndex.get("t2")).toBe(0);
+  });
+
+  it("keeps thoughts outside adjacent tool groups", () => {
+    const grouping = buildThreadGroups(
+      [
+        toolCallItem("t1", undefined),
+        thoughtItem("thought-1"),
+        toolCallItem("t2", undefined),
+      ],
+      {},
+    );
+
+    expect(grouping.rows.map((row) => row.kind)).toEqual([
+      "tool_group",
+      "item",
+      "tool_group",
+    ]);
+    expect(grouping.rows[1]).toMatchObject({
+      kind: "item",
+      item: { id: "thought-1" },
+    });
   });
 
   it("counts only spawned agents as subagents", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/new-thread/conversationThreadConfig.ts
@@ -39,7 +39,10 @@ export const grouping = {
    * their own row regardless of collapse mode (e.g. the cloud setup / clone
    * progress card).
    */
-  alwaysVisibleUpdates: new Set<string>(["progress_group"]),
+  alwaysVisibleUpdates: new Set<string>([
+    "progress_group",
+    "agent_thought_chunk",
+  ]),
   /** Max distinct tool icons shown in a collapsed chip's icon strip. */
   maxIconsInChip: 10,
 } as const;


### PR DESCRIPTION
## Problem

Agent activity can hide several reasoning phases inside one large tool group, making long runs hard to scan.

## Changes

- Thoughts now render as standalone rows and split neighboring tool groups.
- The same rule applies to Pi, Claude, and Codex conversations.
- Tool groups now summarize only contiguous tool calls.

| Before | After |
| --- | --- |
| ![Thoughts nested inside one tool group](https://raw.githubusercontent.com/PostHog/pr-assets/4261843e9858dcb635c4fb5d8713fb35392a76b6/2026/08/f40c47aa-f4b8-4595-8fd4-d46250c074f0.png) | ![Thoughts shown between separate tool groups](https://raw.githubusercontent.com/PostHog/pr-assets/4261843e9858dcb635c4fb5d8713fb35392a76b6/2026/08/957ccdbd-5880-43ec-9ab4-bcc436e6d5bc.png) |

## How did you test this code?

- Added regression tests that fail if thoughts are folded between neighboring tool calls.
- Ran the full UI test suite and desktop typecheck.
- Verified the result in the live Electron app over CDP.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This only changes conversation rendering.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- OpenAI coding agent in Pi used repository tools and agent-browser. A public session link is unavailable.
- Skills: `/posthog-desktop`, `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`, `/code-review`, `/running-ci-preflight`, `/writing-pr-descriptions`, and `test-electron-app`.
- The implementation replaced an initial timestamp-based approach with a provider-neutral rule that keeps thoughts outside tool groups.
- The test fixtures and screenshots use local synthetic data and contain no customer data.
