### PR TITLE
feat(growth): derive a top-tier-recent-round enrichment signal

### DIFF
--- a/products/growth/backend/enrichment/fields.py
+++ b/products/growth/backend/enrichment/fields.py
@@ -42,6 +42,7 @@ class EnrichmentFields:
     investors: Optional[list[str]] = None
     is_yc_company: Optional[bool] = None
     is_ai_native: Optional[bool] = None
+    top_tier_recent_round: Optional[bool] = None
     work_email: Optional[bool] = None
 
     def to_dict(self) -> dict[str, Any]:

--- a/products/growth/backend/enrichment/top_tier_investors.py
+++ b/products/growth/backend/enrichment/top_tier_investors.py
@@ -1,0 +1,110 @@
+"""Curated top-tier VC list backing the `enrichment_top_tier_recent_round` signal.
+
+v0, hand-curated from the ICP owner's Aug 2026 sprint-planning definition of "top-tier"
+investor — an explicit product definition, not derived from any external ranking or
+dataset. Edit TOP_TIER_VCS (and `_ALIASES` for spelling/abbreviation variants) directly
+as that definition evolves; this module is the only source of truth for it.
+"""
+
+import re
+from functools import lru_cache
+
+TOP_TIER_VCS: frozenset[str] = frozenset(
+    {
+        "Sequoia Capital",
+        "Andreessen Horowitz",
+        "Benchmark",
+        "Accel",
+        "Founders Fund",
+        "Greylock",
+        "Lightspeed Venture Partners",
+        "Index Ventures",
+        "Kleiner Perkins",
+        "Bessemer Venture Partners",
+        "GV",
+        "Khosla Ventures",
+        "Thrive Capital",
+        "ICONIQ",
+        "Insight Partners",
+        "General Catalyst",
+        "Coatue",
+        "Tiger Global",
+        "Y Combinator",
+        "First Round Capital",
+        "Union Square Ventures",
+        "Redpoint",
+        "CRV",
+        "Battery Ventures",
+        "NEA",
+        "IVP",
+        "Menlo Ventures",
+        "Spark Capital",
+        "Felicis",
+        "Craft Ventures",
+        "Initialized Capital",
+        "Emergence Capital",
+        "Sapphire Ventures",
+        "Scale Venture Partners",
+        "Two Sigma Ventures",
+        "DST Global",
+        "SoftBank Vision Fund",
+        "Addition",
+        "Ribbit Capital",
+        "Paradigm",
+        "a16z crypto",
+        "8VC",
+        "Lux Capital",
+        "Obvious Ventures",
+        "Amplify Partners",
+        "Boldstart Ventures",
+        "Uncork Capital",
+        "Homebrew",
+        "Costanoa Ventures",
+        "Wing Venture Capital",
+    }
+)
+
+# Alternate spellings/abbreviations a provider might report, keyed pre-normalized (see
+# _normalize) and valued with the TOP_TIER_VCS entry they stand for. Only needed where the
+# two differ after normalization; exact matches need no entry.
+_ALIASES: dict[str, str] = {
+    "a16z": "Andreessen Horowitz",
+    "yc": "Y Combinator",
+    "google ventures": "GV",
+    "usv": "Union Square Ventures",
+    "new enterprise associates": "NEA",
+    "charles river ventures": "CRV",
+    "institutional venture partners": "IVP",
+    "kleiner perkins caufield byers": "Kleiner Perkins",
+    "insight venture partners": "Insight Partners",
+    "softbank": "SoftBank Vision Fund",
+    "first round": "First Round Capital",
+    "greylock partners": "Greylock",
+    "iconiq capital": "ICONIQ",
+    "coatue management": "Coatue",
+    "tiger global management": "Tiger Global",
+    "felicis ventures": "Felicis",
+    "wing vc": "Wing Venture Capital",
+    "scale vp": "Scale Venture Partners",
+    "emergence capital partners": "Emergence Capital",
+    "bessemer": "Bessemer Venture Partners",
+    "lightspeed": "Lightspeed Venture Partners",
+    "general catalyst partners": "General Catalyst",
+    "sequoia": "Sequoia Capital",
+}
+
+
+def _normalize(name: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^\w\s]", "", name.lower())).strip()
+
+
+@lru_cache(maxsize=1)
+def _normalized_names() -> frozenset[str]:
+    return frozenset({_normalize(name) for name in TOP_TIER_VCS} | set(_ALIASES.keys()))
+
+
+def is_top_tier_investor(name: str) -> bool:
+    """Case/punctuation-insensitive, alias-aware membership check against TOP_TIER_VCS."""
+    if not isinstance(name, str) or not name.strip():
+        return False
+    return _normalize(name) in _normalized_names()

--- a/products/growth/backend/enrichment/transform.py
+++ b/products/growth/backend/enrichment/transform.py
@@ -4,10 +4,16 @@ Tag/YC/safe-cast heuristics are shared with the Salesforce enrichment transforms
 ee/billing/salesforce_enrichment/enrichment.py and imported from there rather than copied.
 """
 
+from datetime import date
 from typing import Any, Optional
+
+from django.utils import timezone
+
+from dateutil.relativedelta import relativedelta
 
 from products.growth.backend.enrichment.countries import country_name_to_iso_code
 from products.growth.backend.enrichment.fields import EnrichmentFields
+from products.growth.backend.enrichment.top_tier_investors import is_top_tier_investor
 
 from ee.billing.salesforce_enrichment.enrichment import _extract_primary_tag, _is_yc_funded, _safe_dict, _safe_list
 
@@ -38,20 +44,23 @@ def _funding_date(value: Any) -> Optional[str]:
     return None
 
 
+def _investor_name_strings(investors: Any) -> list[str]:
+    # Company entries carry `name`, Person (angel) entries carry `fullName`; keep both.
+    if not isinstance(investors, list):
+        return []
+    return [
+        name
+        for investor in investors
+        if isinstance(investor, dict) and isinstance(name := investor.get("name") or investor.get("fullName"), str)
+    ]
+
+
 # Bound the passthrough so the group property can't grow unboundedly for a heavily-funded company.
 MAX_INVESTORS = 25
 
 
 def _investor_names(investors: Any) -> Optional[list[str]]:
-    # Company entries carry `name`, Person (angel) entries carry `fullName`; keep both.
-    if not isinstance(investors, list):
-        return None
-    names = [
-        name
-        for investor in investors
-        if isinstance(investor, dict) and isinstance(name := investor.get("name") or investor.get("fullName"), str)
-    ]
-    return names[:MAX_INVESTORS] or None
+    return _investor_name_strings(investors)[:MAX_INVESTORS] or None
 
 
 # Harmonic's own tagsV2 taxonomy spells these out; match conservatively on the phrases
@@ -68,6 +77,23 @@ def _is_ai_native(tags_v2: list[Any]) -> Optional[bool]:
         if isinstance(display, str) and any(marker in display.lower() for marker in AI_NATIVE_TAG_MARKERS):
             return True
     return False
+
+
+# How recent "recent round" means for the top-tier signal.
+TOP_TIER_ROUND_WINDOW_MONTHS = 12
+
+
+def _is_top_tier_recent_round(last_round_date: Optional[str], investors: Any) -> Optional[bool]:
+    # None (not False) when there's no last-round date at all: absence of round data isn't
+    # evidence the round wasn't top-tier, and downstream needs to tell the two apart.
+    if last_round_date is None:
+        return None
+    is_recent = (
+        date.fromisoformat(last_round_date)
+        >= (timezone.now() - relativedelta(months=TOP_TIER_ROUND_WINDOW_MONTHS)).date()
+    )
+    has_top_tier_investor = any(is_top_tier_investor(name) for name in _investor_name_strings(investors))
+    return is_recent and has_top_tier_investor
 
 
 def transform_harmonic_company(company: Optional[dict[str, Any]]) -> Optional[EnrichmentFields]:
@@ -88,6 +114,8 @@ def transform_harmonic_company(company: Optional[dict[str, Any]]) -> Optional[En
         headcount = int(company["headcount"])
 
     tags_v2 = _safe_list(company.get("tagsV2"))
+    last_round_date = _funding_date(funding.get("lastFundingAt"))
+    investors = funding.get("investors")
 
     return EnrichmentFields(
         company_type=company.get("companyType"),
@@ -100,8 +128,9 @@ def transform_harmonic_company(company: Optional[dict[str, Any]]) -> Optional[En
         funding_stage=funding.get("fundingStage"),
         total_raised=_funding_amount(funding.get("fundingTotal")),
         last_round_size=_funding_amount(funding.get("lastFundingTotal")),
-        last_round_date=_funding_date(funding.get("lastFundingAt")),
-        investors=_investor_names(funding.get("investors")),
-        is_yc_company=_is_yc_funded(funding.get("investors")),
+        last_round_date=last_round_date,
+        investors=_investor_names(investors),
+        is_yc_company=_is_yc_funded(investors),
         is_ai_native=_is_ai_native(tags_v2),
+        top_tier_recent_round=_is_top_tier_recent_round(last_round_date, investors),
     )

--- a/products/growth/backend/tests/test_enrichment_top_tier_investors.py
+++ b/products/growth/backend/tests/test_enrichment_top_tier_investors.py
@@ -1,0 +1,37 @@
+from parameterized import parameterized
+
+from products.growth.backend.enrichment.top_tier_investors import (
+    _ALIASES,
+    TOP_TIER_VCS,
+    _normalize,
+    is_top_tier_investor,
+)
+
+
+@parameterized.expand(
+    [
+        ("canonical_exact", "Sequoia Capital", True),
+        ("canonical_case_insensitive", "sequoia capital", True),
+        ("canonical_trailing_punctuation", "General Catalyst.", True),
+        ("alias_a16z", "a16z", True),
+        ("alias_a16z_uppercase", "A16Z", True),
+        ("alias_yc", "YC", True),
+        ("not_top_tier", "Acme Ventures", False),
+        ("unrelated_substring_of_a_top_tier_name", "Capital", False),
+        ("empty_string", "", False),
+    ]
+)
+def test_is_top_tier_investor(_name, investor_name, expected):
+    assert is_top_tier_investor(investor_name) is expected
+
+
+def test_is_top_tier_investor_rejects_non_string_input():
+    assert is_top_tier_investor(None) is False  # type: ignore[arg-type]
+
+
+def test_every_alias_resolves_to_a_canonical_name():
+    canonical_normalized = {_normalize(name) for name in TOP_TIER_VCS}
+    for alias, canonical in _ALIASES.items():
+        assert _normalize(canonical) in canonical_normalized, (
+            f"alias {alias!r} points at {canonical!r}, not in TOP_TIER_VCS"
+        )

--- a/products/growth/backend/tests/test_enrichment_transform.py
+++ b/products/growth/backend/tests/test_enrichment_transform.py
@@ -1,3 +1,8 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from dateutil.relativedelta import relativedelta
 from parameterized import parameterized
 
 from products.growth.backend.enrichment.transform import MAX_INVESTORS, transform_harmonic_company
@@ -44,6 +49,7 @@ def test_transform_maps_all_registry_fields():
         "investors": ["Y Combinator"],
         "is_yc_company": True,
         # is_ai_native stays unset: tagsV2 is empty, which is absence of tag data
+        "top_tier_recent_round": False,  # Y Combinator is top-tier, but the 2024 round is >12mo old
     }
 
 
@@ -127,3 +133,56 @@ def test_partial_payload_leaves_missing_fields_unset():
     fields = transform_harmonic_company({"companyType": "ENTERPRISE"})
     assert fields is not None
     assert fields.to_dict() == {"company_type": "ENTERPRISE", "is_yc_company": False}
+
+
+def _funding_at(dt) -> str:
+    return dt.strftime("%Y-%m-%dT00:00:00Z")
+
+
+def test_top_tier_recent_round_true_within_window_with_top_tier_investor():
+    recent = _funding_at(timezone.now() - timedelta(days=30))
+    fields = transform_harmonic_company(
+        _company(funding={"lastFundingAt": recent, "investors": [{"name": "Sequoia Capital"}]})
+    )
+    assert fields is not None
+    assert fields.top_tier_recent_round is True
+
+
+def test_top_tier_recent_round_false_when_round_is_older_than_window():
+    old = _funding_at(timezone.now() - relativedelta(months=13))
+    fields = transform_harmonic_company(
+        _company(funding={"lastFundingAt": old, "investors": [{"name": "Sequoia Capital"}]})
+    )
+    assert fields is not None
+    assert fields.top_tier_recent_round is False
+
+
+def test_top_tier_recent_round_false_when_investors_are_not_top_tier():
+    recent = _funding_at(timezone.now() - timedelta(days=30))
+    fields = transform_harmonic_company(
+        _company(funding={"lastFundingAt": recent, "investors": [{"name": "Acme Ventures"}]})
+    )
+    assert fields is not None
+    assert fields.top_tier_recent_round is False
+
+
+def test_top_tier_recent_round_unset_when_no_funding_data():
+    fields = transform_harmonic_company(_company(funding={}))
+    assert fields is not None
+    assert fields.top_tier_recent_round is None
+    assert "top_tier_recent_round" not in fields.to_dict()
+
+
+@parameterized.expand(
+    [
+        ("canonical_name", "Andreessen Horowitz"),
+        ("common_alias", "a16z"),
+    ]
+)
+def test_top_tier_recent_round_matches_investor_via_alias(_name, investor_name):
+    recent = _funding_at(timezone.now() - timedelta(days=30))
+    fields = transform_harmonic_company(
+        _company(funding={"lastFundingAt": recent, "investors": [{"name": investor_name}]})
+    )
+    assert fields is not None
+    assert fields.top_tier_recent_round is True


### PR DESCRIPTION
## Problem

The ICP model needs a proxy for high-potential companies. The signal chosen for it: the company raised a round in the last 12 months and a top-tier investor participated. Enrichment payloads already carry the round date and investor list, but nothing derives this.

## Changes

- New `enrichment_top_tier_recent_round` boolean group property: true when the most recent funding round is under `TOP_TIER_ROUND_WINDOW_MONTHS` (12) old AND at least one investor matches the curated list.
- New `products/growth/backend/enrichment/top_tier_investors.py` holds the curated VC list (`TOP_TIER_VCS`, ~50 names) plus an alias map (a16z ↔ Andreessen Horowitz, YC ↔ Y Combinator, …) with case/punctuation-insensitive matching. This is a hand-curated v0 reflecting an explicit product definition from the ICP owner — versionable in code, edited directly as the definition evolves, with this module as the single source of truth.
- When no round data exists the property is not written at all, so consumers can distinguish "no data" from "not top-tier"; false only when a round is known and fails the criteria.
- The top-tier check reads the *uncapped* investor list (the stored `enrichment_investors` property stays capped at 25), so a qualifying investor past the cap isn't missed.

No migrations, no backfill command — a generic backfill command landing in a parallel PR re-derives this field over archived payloads.

## How did you test this code?

Automated only:
- Transform tests: recent round + top-tier investor → true; old round → false; recent round with non-listed investors → false; no funding data → property absent from the write; alias-based matching. Each is a case no existing test exercised (new field).
- List module tests include a self-check that every alias resolves to a real `TOP_TIER_VCS` entry.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built in a Claude Code session (implementation by a sub-agent, reviewed in-session; /pr-ready flow used). Note for reviewers: normalization strips case/punctuation but deliberately not corporate suffixes ("Inc" survives as a token) — exact-after-normalization matching keeps false positives out at the cost of missing exotic name variants; the alias map is the escape hatch.

## Merge order

Part of the enrichment field set. Land bottom-first: [#79061](https://github.com/PostHog/posthog/pull/79061) → [#79068](https://github.com/PostHog/posthog/pull/79068) (stacked) → [#79072](https://github.com/PostHog/posthog/pull/79072) (stacked) → then the master-based PRs [#79062](https://github.com/PostHog/posthog/pull/79062) and [#79063](https://github.com/PostHog/posthog/pull/79063) in either order (small additive conflicts in fields.py/transform.py/tests). [#79064](https://github.com/PostHog/posthog/pull/79064) is independent and can land any time.
