### PR TITLE
feat(growth): stop conflating unknown Harmonic funding with none

### DIFF
--- a/ee/billing/salesforce_enrichment/constants.py
+++ b/ee/billing/salesforce_enrichment/constants.py
@@ -27,6 +27,8 @@ mutation($identifiers: CompanyEnrichmentIdentifiersInput!) {
             headcount
             description
             ownershipStatus
+            customerType
+            fundingAttributeNullStatus
             relatedCompanies {
                 acquiredBy {
                     companyUrn

--- a/products/growth/backend/enrichment/fields.py
+++ b/products/growth/backend/enrichment/fields.py
@@ -46,6 +46,8 @@ class EnrichmentFields:
     ownership_status: Optional[str] = None
     parent_company: Optional[str] = None
     parent_company_domain: Optional[str] = None
+    customer_type: Optional[str] = None
+    funding_status: Optional[str] = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return set (non-None) fields keyed by registry name."""

--- a/products/growth/backend/enrichment/transform.py
+++ b/products/growth/backend/enrichment/transform.py
@@ -38,6 +38,26 @@ def _funding_date(value: Any) -> Optional[str]:
     return None
 
 
+# Harmonic's catch-all when it has no real funding-stage signal, distinct from a company it has
+# genuinely confirmed raised nothing. ~83% of fetched stages are this shell with no round data
+# behind it (prod-checked Aug 2026), so passing it through as funding_stage reads as a real signal
+# to downstream consumers when it is actually an absence of one.
+_FUNDING_STAGE_UNKNOWN_PLACEHOLDER = "VENTURE_UNKNOWN"
+
+
+def _has_substantiating_round_data(funding: dict[str, Any]) -> bool:
+    total = funding.get("fundingTotal")
+    rounds = funding.get("numFundingRounds")
+    return (isinstance(total, (int, float)) and total > 0) or (isinstance(rounds, (int, float)) and rounds > 0)
+
+
+def _funding_stage(funding: dict[str, Any]) -> Optional[str]:
+    stage = funding.get("fundingStage")
+    if stage == _FUNDING_STAGE_UNKNOWN_PLACEHOLDER and not _has_substantiating_round_data(funding):
+        return None
+    return stage
+
+
 # Bound the passthrough so the group property can't grow unboundedly for a heavily-funded company.
 MAX_INVESTORS = 25
 
@@ -97,7 +117,7 @@ def transform_harmonic_company(company: Optional[dict[str, Any]]) -> Optional[En
         # ISO alpha-2 to match the format the icp_country group property already holds.
         country=country_name_to_iso_code(location.get("country")),
         founded_year=_founded_year(founding),
-        funding_stage=funding.get("fundingStage"),
+        funding_stage=_funding_stage(funding),
         total_raised=_funding_amount(funding.get("fundingTotal")),
         last_round_size=_funding_amount(funding.get("lastFundingTotal")),
         last_round_date=_funding_date(funding.get("lastFundingAt")),
@@ -105,4 +125,10 @@ def transform_harmonic_company(company: Optional[dict[str, Any]]) -> Optional[En
         is_yc_company=_is_yc_funded(funding.get("investors")),
         is_ai_native=_is_ai_native(tags_v2),
         ownership_status=company.get("ownershipStatus"),
+        customer_type=company.get("customerType"),
+        # Harmonic's own known-none-vs-unknown vocabulary for the funding data itself, passed
+        # through verbatim rather than re-derived, since fundingAttributeNullStatus already
+        # distinguishes what funding_stage's VENTURE_UNKNOWN placeholder conflates. A top-level
+        # Company field, not nested under funding, despite the name.
+        funding_status=company.get("fundingAttributeNullStatus"),
     )

--- a/products/growth/backend/tests/test_enrichment_transform.py
+++ b/products/growth/backend/tests/test_enrichment_transform.py
@@ -143,3 +143,48 @@ def test_ownership_status_unset_when_absent():
     fields = transform_harmonic_company(_company())
     assert fields is not None
     assert fields.ownership_status is None
+
+
+@parameterized.expand(
+    [
+        ("dropped_with_no_round_data", "VENTURE_UNKNOWN", {}, None),
+        ("kept_with_funding_total", "VENTURE_UNKNOWN", {"fundingTotal": 5000000}, "VENTURE_UNKNOWN"),
+        ("kept_with_funding_rounds", "VENTURE_UNKNOWN", {"numFundingRounds": 1}, "VENTURE_UNKNOWN"),
+        ("real_stage_kept_with_no_round_data", "SEED", {}, "SEED"),
+    ]
+)
+def test_venture_unknown_placeholder_filtered_only_without_round_data(_name, stage, funding_overrides, expected):
+    funding = {"fundingStage": stage, **funding_overrides}
+    fields = transform_harmonic_company(_company(funding=funding))
+    assert fields is not None
+    assert fields.funding_stage == expected
+
+
+def test_venture_unknown_placeholder_dropped_entirely_from_to_dict():
+    fields = transform_harmonic_company(_company(funding={"fundingStage": "VENTURE_UNKNOWN"}))
+    assert fields is not None
+    assert "funding_stage" not in fields.to_dict()
+
+
+def test_customer_type_is_mapped():
+    fields = transform_harmonic_company(_company(customerType="B2B"))
+    assert fields is not None
+    assert fields.customer_type == "B2B"
+
+
+def test_customer_type_unset_when_absent():
+    fields = transform_harmonic_company(_company())
+    assert fields is not None
+    assert fields.customer_type is None
+
+
+def test_funding_status_is_mapped_from_null_status():
+    fields = transform_harmonic_company(_company(fundingAttributeNullStatus="NULL_TRUE_ZERO"))
+    assert fields is not None
+    assert fields.funding_status == "NULL_TRUE_ZERO"
+
+
+def test_funding_status_unset_when_absent():
+    fields = transform_harmonic_company(_company())
+    assert fields is not None
+    assert fields.funding_status is None


### PR DESCRIPTION
> Stacked on #79061 (fetch Harmonic ownership status and parent company) — review only the top commit here.

## Problem

Harmonic returns `VENTURE_UNKNOWN` as a funding-stage placeholder when it has no real signal, not when it has confirmed a company raised nothing. We write it straight through as `enrichment_funding_stage`, so the large majority of written funding stages actually mean "we don't know" — indistinguishable from a genuine stage to any consumer doing data-completeness or confidence scoring.

## Changes

- Stop writing `enrichment_funding_stage` for `VENTURE_UNKNOWN` unless real round data (funding total or round count) backs it up. Every other stage passes through unchanged.
- Fetch two more fields on the existing query: `fundingAttributeNullStatus` — Harmonic's own known-none-vs-unknown signal for funding data, a **top-level Company field despite the name** (validated against the live API; the query passes GraphQL validation and the field resolves) — written verbatim as `enrichment_funding_status`; and `customerType`, written verbatim as `enrichment_customer_type`.
- Verbatim passthrough rather than a re-derived vocabulary for `enrichment_funding_status`: Harmonic's enum values for it aren't publicly documented, so relaying the raw value avoids inventing constants that might not match reality. Revisit once archived payloads show the real value set.
- The amended GraphQL query is shared with the Salesforce enrichment pipeline; the additions are purely additive and that pipeline's tests pass unchanged.

No schema changes — these ride the existing `enrichment_*` group-property mechanism and the raw payload archive.

## How did you test this code?

Automated plus one live probe:
- Parameterized transform tests: `VENTURE_UNKNOWN` with no round data → dropped; with funding total or round count → kept; real stages unaffected; mapped/unset coverage for both new fields.
- One live Harmonic API call with the amended query confirmed it validates and the new fields resolve (a funded company returns a real stage and a null `fundingAttributeNullStatus`, consistent with it being populated only when funding data is absent).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built in a Claude Code session (implementation by a sub-agent, reviewed in-session; /pr-ready flow used). Mid-build correction worth knowing: the field was initially placed inside the `funding` block per third-party docs; live API validation showed it is top-level, and both query and transform were fixed before this PR was opened.
