### PR TITLE
feat(desktop): show token and compute usage

### DIFF
--- a/products/desktop/packages/core/src/billing/usageDisplay.test.ts
+++ b/products/desktop/packages/core/src/billing/usageDisplay.test.ts
@@ -3,6 +3,7 @@ import type { UsageOutput } from "../usage/schemas";
 import {
   codeOrgSpendLimitUsd,
   codeUsageMeter,
+  desktopUsageComponents,
   formatResetTime,
   formatUsageBreakdown,
   formatUsdAmount,
@@ -209,6 +210,57 @@ describe("formatUsageBreakdown", () => {
     expect(formatUsageBreakdown({ includedUsd: 20, spendLimitUsd: 50 })).toBe(
       "$20 included + $50 org spend limit",
     );
+  });
+});
+
+describe("desktopUsageComponents", () => {
+  it("converts credits and large resource quantities for display", () => {
+    const usage: UsageOutput = {
+      ...makeUsage(),
+      ai_credits: {
+        exhausted: false,
+        used_usd: 15,
+        limit_usd: 20,
+        breakdown: {
+          token_credits: 1_234,
+          compute_credits: 266,
+          cpu_millicore_seconds: 9_876_543_210,
+          memory_mib_seconds: 7_654_321_098,
+        },
+      },
+    };
+
+    expect(desktopUsageComponents(usage)).toEqual({
+      tokenUsd: 12.34,
+      computeUsd: 2.66,
+      cpuCoreSeconds: 9_876_543.21,
+      memoryGibSeconds: 7_474_922.947265625,
+    });
+  });
+
+  it("distinguishes an absent breakdown, missing values, and explicit zero", () => {
+    expect(desktopUsageComponents(makeUsage())).toBeNull();
+    expect(
+      desktopUsageComponents({
+        ...makeUsage(),
+        ai_credits: {
+          exhausted: false,
+          used_usd: 0,
+          limit_usd: 20,
+          breakdown: {
+            token_credits: 0,
+            compute_credits: null,
+            cpu_millicore_seconds: 0,
+            memory_mib_seconds: null,
+          },
+        },
+      }),
+    ).toEqual({
+      tokenUsd: 0,
+      computeUsd: null,
+      cpuCoreSeconds: 0,
+      memoryGibSeconds: null,
+    });
   });
 });
 

--- a/products/desktop/packages/core/src/billing/usageDisplay.ts
+++ b/products/desktop/packages/core/src/billing/usageDisplay.ts
@@ -80,6 +80,41 @@ export function formatUsageBreakdown(breakdown: CodeUsageBreakdown): string {
   return `${formatUsdAmount(breakdown.includedUsd)} included + ${formatUsdAmount(breakdown.spendLimitUsd)} org spend limit`;
 }
 
+export interface DesktopUsageComponents {
+  tokenUsd: number | null;
+  computeUsd: number | null;
+  cpuCoreSeconds: number | null;
+  memoryGibSeconds: number | null;
+}
+
+export function desktopUsageComponents(
+  usage: UsageOutput | null | undefined,
+): DesktopUsageComponents | null {
+  const breakdown = usage?.ai_credits?.breakdown;
+  if (breakdown == null) return null;
+
+  return {
+    tokenUsd:
+      breakdown.token_credits == null ? null : breakdown.token_credits / 100,
+    computeUsd:
+      breakdown.compute_credits == null
+        ? null
+        : breakdown.compute_credits / 100,
+    cpuCoreSeconds:
+      breakdown.cpu_millicore_seconds == null
+        ? null
+        : breakdown.cpu_millicore_seconds / 1_000,
+    memoryGibSeconds:
+      breakdown.memory_mib_seconds == null
+        ? null
+        : breakdown.memory_mib_seconds / 1_024,
+  };
+}
+
+export function formatUsageQuantity(value: number, unit: string): string {
+  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 3 }).format(value)} ${unit}`;
+}
+
 export function isUsageExceeded(usage: UsageOutput): boolean {
   return (
     usage.is_rate_limited || usage.sustained.exceeded || usage.burst.exceeded

--- a/products/desktop/packages/core/src/llm-gateway/llm-gateway.test.ts
+++ b/products/desktop/packages/core/src/llm-gateway/llm-gateway.test.ts
@@ -397,6 +397,31 @@ describe("LlmGatewayService.fetchUsage", () => {
     expect(usage.ai_credits?.limit_usd).toBeNull();
   });
 
+  it("parses the optional Desktop component breakdown without rounding integers", async () => {
+    const breakdown = {
+      token_credits: 1_234,
+      compute_credits: 67,
+      cpu_millicore_seconds: 9_876_543_210,
+      memory_mib_seconds: 7_654_321_098,
+    };
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        ...USAGE_BODY,
+        ai_credits: {
+          exhausted: false,
+          used_usd: 13.01,
+          limit_usd: 20,
+          breakdown,
+        },
+      }),
+    );
+    const { service } = createService(fetchMock);
+
+    const usage = await service.fetchUsage();
+
+    expect(usage.ai_credits?.breakdown).toEqual(breakdown);
+  });
+
   it("feeds code_usage_subscribed into helper model routing", async () => {
     const fetchMock = vi
       .fn()

--- a/products/desktop/packages/core/src/usage/schemas.ts
+++ b/products/desktop/packages/core/src/usage/schemas.ts
@@ -16,6 +16,14 @@ export const usageOutput = z.object({
       exhausted: z.boolean(),
       used_usd: z.number().nullish(),
       limit_usd: z.number().nullish(),
+      breakdown: z
+        .object({
+          token_credits: z.number().nullish(),
+          compute_credits: z.number().nullish(),
+          cpu_millicore_seconds: z.number().nullish(),
+          memory_mib_seconds: z.number().nullish(),
+        })
+        .nullish(),
     })
     .optional(),
   is_rate_limited: z.boolean(),

--- a/products/desktop/packages/core/src/usage/usage-monitor.ts
+++ b/products/desktop/packages/core/src/usage/usage-monitor.ts
@@ -267,6 +267,14 @@ function isSameUsage(a: UsageOutput | null, b: UsageOutput): boolean {
     a.ai_credits?.exhausted === b.ai_credits?.exhausted &&
     a.ai_credits?.used_usd === b.ai_credits?.used_usd &&
     a.ai_credits?.limit_usd === b.ai_credits?.limit_usd &&
+    a.ai_credits?.breakdown?.token_credits ===
+      b.ai_credits?.breakdown?.token_credits &&
+    a.ai_credits?.breakdown?.compute_credits ===
+      b.ai_credits?.breakdown?.compute_credits &&
+    a.ai_credits?.breakdown?.cpu_millicore_seconds ===
+      b.ai_credits?.breakdown?.cpu_millicore_seconds &&
+    a.ai_credits?.breakdown?.memory_mib_seconds ===
+      b.ai_credits?.breakdown?.memory_mib_seconds &&
     isSameBucket(a.burst, b.burst) &&
     isSameBucket(a.sustained, b.sustained)
   );

--- a/products/desktop/packages/ui/src/features/billing/UsageMeter.stories.tsx
+++ b/products/desktop/packages/ui/src/features/billing/UsageMeter.stories.tsx
@@ -2,7 +2,7 @@ import { UsageMeter } from "@posthog/ui/features/billing/UsageMeter";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const meta: Meta<typeof UsageMeter> = {
-  title: "Billing/UsageMeter",
+  title: "Billing/Organization usage meter",
   component: UsageMeter,
   decorators: [
     (Story) => (
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof UsageMeter>;
 // segments — the $20 included allowance (green) and the $50 default spend
 // limit (accent) — with a dot legend naming each amount. Usage still inside
 // the included allowance only fills the green segment.
-export const SubscribedWithBreakdown: Story = {
+export const SubscribedWithAllowanceAndLimit: Story = {
   args: {
     label: "Usage this period",
     percent: 18,

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -1,7 +1,6 @@
 import type { UsageOutput } from "@posthog/core/usage/schemas";
 import { PlanUsageContent } from "@posthog/ui/features/settings/sections/PlanUsageSettings";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Flex, Text } from "@radix-ui/themes";
 
 const usage = {
   product: "posthog_code",
@@ -33,41 +32,6 @@ const usage = {
   billing_period_end: "2026-09-01T00:00:00.000Z",
 } satisfies UsageOutput;
 
-const PersonalSpendPreview = () => (
-  <Flex
-    direction="column"
-    gap="3"
-    pt="5"
-    className="border-(--gray-5) border-t"
-  >
-    <Flex direction="column" gap="1">
-      <Text className="font-bold text-base">Your spend</Text>
-      <Text className="text-(--gray-11) text-sm">
-        Near-real-time spend for your activity in the selected window. It may
-        differ from the delayed organization billing period above.
-      </Text>
-    </Flex>
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-      {[
-        ["Last 30 days", "$18.72"],
-        ["Today", "$1.08"],
-        ["Runs", "42"],
-      ].map(([label, value]) => (
-        <Flex
-          key={label}
-          direction="column"
-          gap="1"
-          p="3"
-          className="rounded-(--radius-3) bg-(--gray-a2)"
-        >
-          <Text className="text-(--gray-11) text-xs">{label}</Text>
-          <Text className="font-medium text-lg">{value}</Text>
-        </Flex>
-      ))}
-    </div>
-  </Flex>
-);
-
 const meta: Meta<typeof PlanUsageContent> = {
   title: "Billing/Plan and usage",
   component: PlanUsageContent,
@@ -84,7 +48,6 @@ const meta: Meta<typeof PlanUsageContent> = {
     billingUrl: "https://app.posthog.com/organization/billing",
     usage,
     usageLoading: false,
-    personalSpendAnalysis: <PersonalSpendPreview />,
   },
 };
 

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -1,0 +1,136 @@
+import type { UsageOutput } from "@posthog/core/usage/schemas";
+import { PlanUsageContent } from "@posthog/ui/features/settings/sections/PlanUsageSettings";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flex, Text } from "@radix-ui/themes";
+
+const usage = {
+  product: "posthog_code",
+  user_id: 1,
+  sustained: {
+    used_percent: 34,
+    reset_at: "2026-09-01T00:00:00.000Z",
+    exceeded: false,
+  },
+  burst: {
+    used_percent: 4,
+    reset_at: "2026-08-07T00:00:00.000Z",
+    exceeded: false,
+  },
+  ai_credits: {
+    exhausted: false,
+    used_usd: 23.8,
+    limit_usd: 70,
+    breakdown: {
+      token_credits: 1_840,
+      compute_credits: 540,
+      cpu_millicore_seconds: 12_450_000,
+      memory_mib_seconds: 31_457_280,
+    },
+  },
+  is_rate_limited: false,
+  is_pro: true,
+  code_usage_subscribed: true,
+  billing_period_end: "2026-09-01T00:00:00.000Z",
+} satisfies UsageOutput;
+
+const PersonalSpendPreview = () => (
+  <Flex
+    direction="column"
+    gap="3"
+    pt="5"
+    className="border-(--gray-5) border-t"
+  >
+    <Flex direction="column" gap="1">
+      <Text className="font-bold text-base">Your spend</Text>
+      <Text className="text-(--gray-11) text-sm">
+        Near-real-time spend for your activity in the selected window. It may
+        differ from the delayed organization billing period above.
+      </Text>
+    </Flex>
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {[
+        ["Last 30 days", "$18.72"],
+        ["Today", "$1.08"],
+        ["Runs", "42"],
+      ].map(([label, value]) => (
+        <Flex
+          key={label}
+          direction="column"
+          gap="1"
+          p="3"
+          className="rounded-(--radius-3) bg-(--gray-a2)"
+        >
+          <Text className="text-(--gray-11) text-xs">{label}</Text>
+          <Text className="font-medium text-lg">{value}</Text>
+        </Flex>
+      ))}
+    </div>
+  </Flex>
+);
+
+const meta: Meta<typeof PlanUsageContent> = {
+  title: "Settings/Plan and usage",
+  component: PlanUsageContent,
+  decorators: [
+    (Story) => (
+      <div className="mx-auto max-w-3xl p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    billingEnabled: true,
+    spendAnalysisEnabled: true,
+    billingUrl: "https://app.posthog.com/organization/billing",
+    usage,
+    usageLoading: false,
+    personalSpendAnalysis: <PersonalSpendPreview />,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PlanUsageContent>;
+
+export const OrganizationAndPersonalSpend: Story = {};
+
+export const BreakdownAwaitingData: Story = {
+  args: {
+    spendAnalysisEnabled: false,
+    usage: { ...usage, ai_credits: { ...usage.ai_credits, breakdown: null } },
+  },
+};
+
+export const ExplicitZeroUsage: Story = {
+  args: {
+    spendAnalysisEnabled: false,
+    usage: {
+      ...usage,
+      ai_credits: {
+        exhausted: false,
+        used_usd: 0,
+        limit_usd: 70,
+        breakdown: {
+          token_credits: 0,
+          compute_credits: 0,
+          cpu_millicore_seconds: 0,
+          memory_mib_seconds: 0,
+        },
+      },
+    },
+  },
+};
+
+export const OrganizationLimitReached: Story = {
+  args: {
+    spendAnalysisEnabled: false,
+    usage: {
+      ...usage,
+      ai_credits: { ...usage.ai_credits, exhausted: true, used_usd: 70 },
+      is_rate_limited: true,
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: { usage: null, usageLoading: true, spendAnalysisEnabled: false },
+};

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.stories.tsx
@@ -69,7 +69,7 @@ const PersonalSpendPreview = () => (
 );
 
 const meta: Meta<typeof PlanUsageContent> = {
-  title: "Settings/Plan and usage",
+  title: "Billing/Plan and usage",
   component: PlanUsageContent,
   decorators: [
     (Story) => (
@@ -91,7 +91,7 @@ const meta: Meta<typeof PlanUsageContent> = {
 export default meta;
 type Story = StoryObj<typeof PlanUsageContent>;
 
-export const OrganizationAndPersonalSpend: Story = {};
+export const WithComponentBreakdown: Story = {};
 
 export const BreakdownAwaitingData: Story = {
   args: {

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -1,5 +1,7 @@
 import {
   ArrowSquareOut,
+  CaretDown,
+  CaretRight,
   CreditCard,
   WarningCircle,
 } from "@phosphor-icons/react";
@@ -31,7 +33,7 @@ import { track } from "@posthog/ui/shell/analytics";
 import { getBillingUrl } from "@posthog/ui/utils/urls";
 import { Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
 import type { UsageOutput } from "@posthog/core/usage/schemas";
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 export function PlanUsageSettings() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
@@ -91,6 +93,8 @@ export function PlanUsageContent({
   const orgLimitReached = usage?.ai_credits?.exhausted === true;
   const meter = codeUsageMeter(usage);
   const components = desktopUsageComponents(usage);
+  const hasUsageMix =
+    components?.tokenUsd != null && components.computeUsd != null;
 
   const openBilling = () => {
     if (billingUrl) window.open(billingUrl, "_blank");
@@ -231,19 +235,7 @@ export function PlanUsageContent({
             )}
             {!usageLoading && (
               <Flex direction="column" gap="3">
-                {components ? (
-                  <UsageMix components={components} />
-                ) : (
-                  <Flex
-                    p="4"
-                    className="rounded-(--radius-3) border border-(--gray-5)"
-                  >
-                    <Text color="gray" className="text-sm">
-                      Detailed usage is awaiting data. Your combined usage and
-                      organization limit are still shown above.
-                    </Text>
-                  </Flex>
-                )}
+                {hasUsageMix && <UsageMix components={components} />}
                 <Text className="text-(--gray-9) text-[13px]">
                   Usage reporting may be delayed by 15–20 minutes.
                 </Text>
@@ -253,7 +245,11 @@ export function PlanUsageContent({
         </>
       )}
 
-      {spendAnalysisEnabled && personalSpendAnalysis}
+      {spendAnalysisEnabled && (
+        <PersonalSpendDisclosure>
+          {personalSpendAnalysis}
+        </PersonalSpendDisclosure>
+      )}
     </Flex>
   );
 }
@@ -263,11 +259,10 @@ function UsageMix({
 }: {
   components: NonNullable<ReturnType<typeof desktopUsageComponents>>;
 }) {
-  const tokenUsd = components.tokenUsd;
-  const computeUsd = components.computeUsd;
-  const hasCreditMix = tokenUsd != null && computeUsd != null;
-  const totalUsd = hasCreditMix ? tokenUsd + computeUsd : 0;
-  const tokenPercent = totalUsd > 0 ? ((tokenUsd ?? 0) / totalUsd) * 100 : 0;
+  const tokenUsd = components.tokenUsd ?? 0;
+  const computeUsd = components.computeUsd ?? 0;
+  const totalUsd = tokenUsd + computeUsd;
+  const tokenPercent = totalUsd > 0 ? (tokenUsd / totalUsd) * 100 : 0;
   const roundedTokenPercent = Math.round(tokenPercent);
   const computeDetails = [
     components.cpuCoreSeconds == null
@@ -285,52 +280,69 @@ function UsageMix({
       p="4"
       className="rounded-(--radius-3) bg-(--gray-a2)"
     >
-      <Flex align="center" justify="between">
-        <Text className="font-medium text-sm">Usage mix</Text>
-        <Text className="text-(--gray-11) text-xs">
-          Token vs. compute spend
-        </Text>
+      <Text className="font-medium text-sm">Usage mix</Text>
+      <div
+        role="img"
+        aria-label={`${roundedTokenPercent}% tokens and ${totalUsd > 0 ? 100 - roundedTokenPercent : 0}% cloud compute`}
+        className="flex h-3 w-full overflow-hidden rounded-full bg-(--gray-a4)"
+      >
+        {totalUsd > 0 && (
+          <>
+            <div
+              className="bg-(--purple-9)"
+              style={{ width: `${tokenPercent}%` }}
+            />
+            <div className="flex-1 bg-(--blue-9)" />
+          </>
+        )}
+      </div>
+      <Flex align="center" gap="5" wrap="wrap">
+        <MixLegend
+          color="bg-(--purple-9)"
+          label="Tokens"
+          percent={roundedTokenPercent}
+          value={formatUsdAmount(tokenUsd)}
+        />
+        <MixLegend
+          color="bg-(--blue-9)"
+          label="Cloud compute"
+          percent={totalUsd > 0 ? 100 - roundedTokenPercent : 0}
+          value={formatUsdAmount(computeUsd)}
+        />
       </Flex>
-      {hasCreditMix ? (
-        <>
-          <div
-            role="img"
-            aria-label={`${roundedTokenPercent}% tokens and ${totalUsd > 0 ? 100 - roundedTokenPercent : 0}% cloud compute`}
-            className="flex h-3 w-full overflow-hidden rounded-full bg-(--gray-a4)"
-          >
-            {totalUsd > 0 && (
-              <>
-                <div
-                  className="bg-(--purple-9)"
-                  style={{ width: `${tokenPercent}%` }}
-                />
-                <div className="flex-1 bg-(--blue-9)" />
-              </>
-            )}
-          </div>
-          <Flex align="center" gap="5" wrap="wrap">
-            <MixLegend
-              color="bg-(--purple-9)"
-              label="Tokens"
-              percent={roundedTokenPercent}
-              value={formatUsdAmount(tokenUsd)}
-            />
-            <MixLegend
-              color="bg-(--blue-9)"
-              label="Cloud compute"
-              percent={totalUsd > 0 ? 100 - roundedTokenPercent : 0}
-              value={formatUsdAmount(computeUsd)}
-            />
-          </Flex>
-        </>
-      ) : (
-        <Text className="text-(--gray-11) text-sm">
-          Token and compute proportions are awaiting data.
-        </Text>
-      )}
       <Text className="text-(--gray-9) text-xs">
         Compute resources: {computeDetails}
       </Text>
+    </Flex>
+  );
+}
+
+function PersonalSpendDisclosure({ children }: { children: ReactNode }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <Flex
+      direction="column"
+      className="overflow-hidden rounded-(--radius-3) border border-(--gray-5)"
+    >
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+        className="flex w-full items-center justify-between gap-4 p-4 text-left hover:bg-(--gray-a2) focus-visible:outline-2 focus-visible:outline-(--accent-8)"
+      >
+        <Flex direction="column" gap="1">
+          <Text className="font-medium text-sm">Your spend</Text>
+          <Text className="text-(--gray-11) text-xs">
+            Near-real-time analysis of your activity, separate from organization
+            billing.
+          </Text>
+        </Flex>
+        {expanded ? <CaretDown size={16} /> : <CaretRight size={16} />}
+      </button>
+      {expanded && children && (
+        <div className="border-(--gray-5) border-t p-4">{children}</div>
+      )}
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -13,6 +13,7 @@ import {
   formatUsdAmount,
   isCodeUsageFreeTier,
 } from "@posthog/core/billing/usageDisplay";
+import type { UsageOutput } from "@posthog/core/usage/schemas";
 import {
   Empty,
   EmptyDescription,
@@ -32,8 +33,7 @@ import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageVie
 import { track } from "@posthog/ui/shell/analytics";
 import { getBillingUrl } from "@posthog/ui/utils/urls";
 import { Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
-import type { UsageOutput } from "@posthog/core/usage/schemas";
-import { useEffect, useState, type ReactNode } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 export function PlanUsageSettings() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
@@ -329,7 +329,7 @@ function PersonalSpendDisclosure({ children }: { children: ReactNode }) {
         type="button"
         aria-expanded={expanded}
         onClick={() => setExpanded((value) => !value)}
-        className="flex w-full items-center justify-between gap-4 p-4 text-left hover:bg-(--gray-a2) focus-visible:outline-2 focus-visible:outline-(--accent-8)"
+        className="flex w-full items-center justify-between gap-4 p-4 text-left hover:bg-(--gray-a2) focus-visible:outline-(--accent-8) focus-visible:outline-2"
       >
         <Flex direction="column" gap="1">
           <Text className="font-medium text-sm">Your spend</Text>

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -5,7 +5,9 @@ import {
 } from "@phosphor-icons/react";
 import {
   codeUsageMeter,
+  desktopUsageComponents,
   formatResetTime,
+  formatUsageQuantity,
   formatUsdAmount,
   isCodeUsageFreeTier,
 } from "@posthog/core/billing/usageDisplay";
@@ -27,16 +29,7 @@ import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnal
 import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageViewed";
 import { track } from "@posthog/ui/shell/analytics";
 import { getBillingUrl } from "@posthog/ui/utils/urls";
-import {
-  Badge,
-  Box,
-  Button,
-  Callout,
-  Flex,
-  ScrollArea,
-  Spinner,
-  Text,
-} from "@radix-ui/themes";
+import { Badge, Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
 import { useEffect } from "react";
 
 export function PlanUsageSettings() {
@@ -69,6 +62,7 @@ export function PlanUsageSettings() {
   const subscribed = usage?.code_usage_subscribed === true;
   const orgLimitReached = usage?.ai_credits?.exhausted === true;
   const meter = codeUsageMeter(usage);
+  const components = desktopUsageComponents(usage);
 
   const openBilling = () => {
     if (billingUrl) window.open(billingUrl, "_blank");
@@ -91,150 +85,226 @@ export function PlanUsageSettings() {
   }
 
   return (
-    <ScrollArea className="h-full w-full">
-      <Box p="6" className="relative z-[1]">
-        <Flex direction="column" gap="5">
-          {billingEnabled && (
-            <>
-              {orgLimitReached && (
-                <Callout.Root color="red" size="1">
-                  <Callout.Icon>
-                    <WarningCircle size={16} />
-                  </Callout.Icon>
-                  <Callout.Text>
-                    <Flex direction="column" gap="2">
-                      <Text className="text-sm">
-                        Your organization has reached its usage limit for this
-                        billing period.
-                      </Text>
-                      <Button
-                        size="1"
-                        variant="outline"
-                        color="red"
-                        disabled={!billingUrl}
-                        onClick={openBilling}
-                        className="self-start"
-                      >
-                        Manage billing
-                        <ArrowSquareOut size={12} />
-                      </Button>
-                    </Flex>
-                  </Callout.Text>
-                </Callout.Root>
-              )}
+    <Flex direction="column" gap="5">
+      {billingEnabled && (
+        <>
+          {orgLimitReached && (
+            <Callout.Root color="red" size="1">
+              <Callout.Icon>
+                <WarningCircle size={16} />
+              </Callout.Icon>
+              <Callout.Text>
+                <Flex direction="column" gap="2">
+                  <Text className="text-sm">
+                    Your organization has reached its usage limit for this
+                    billing period.
+                  </Text>
+                  <Button
+                    size="1"
+                    variant="outline"
+                    color="red"
+                    disabled={!billingUrl}
+                    onClick={openBilling}
+                    className="self-start"
+                  >
+                    Manage billing
+                    <ArrowSquareOut size={12} />
+                  </Button>
+                </Flex>
+              </Callout.Text>
+            </Callout.Root>
+          )}
 
+          <Flex
+            direction="column"
+            gap="3"
+            p="4"
+            className="rounded-(--radius-3) border border-(--gray-5)"
+          >
+            <Flex align="center" justify="between">
+              <Flex direction="column" gap="1">
+                <Text className="font-bold text-base">
+                  {freeTier ? "Free tier" : "Usage-based billing"}
+                </Text>
+                <Text className="text-(--gray-11) text-sm">
+                  {freeTier
+                    ? "Your organization's first $20 of usage each month is included, with access to open models. Add a payment method to unlock premium models — you only pay for what you use."
+                    : "Your organization pays for usage at cost — no seats, no subscriptions. The first $20 each month is included."}
+                </Text>
+              </Flex>
+              {subscribed && (
+                <Badge variant="soft" color="green" radius="full">
+                  Active
+                </Badge>
+              )}
+            </Flex>
+            <Button
+              size="1"
+              variant={freeTier ? "solid" : "outline"}
+              disabled={!billingUrl}
+              onClick={() => {
+                if (freeTier) {
+                  track(ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED, {
+                    surface: "plan_page_card",
+                  });
+                }
+                openBilling();
+              }}
+              className="self-start"
+            >
+              {freeTier
+                ? "Add payment method"
+                : "Manage billing and spend limits"}
+              <ArrowSquareOut size={12} />
+            </Button>
+          </Flex>
+
+          <Flex direction="column" gap="3">
+            <Text className="font-medium text-(--gray-9) text-sm">
+              Organization usage
+            </Text>
+            {usageLoading ? (
               <Flex
-                direction="column"
-                gap="3"
+                align="center"
+                justify="center"
                 p="4"
                 className="rounded-(--radius-3) border border-(--gray-5)"
               >
-                <Flex align="center" justify="between">
-                  <Flex direction="column" gap="1">
-                    <Text className="font-bold text-base">
-                      {freeTier ? "Free tier" : "Usage-based billing"}
-                    </Text>
-                    <Text className="text-(--gray-11) text-sm">
-                      {freeTier
-                        ? "Your organization's first $20 of usage each month is included, with access to open models. Add a payment method to unlock premium models — you only pay for what you use."
-                        : "Your organization pays for usage at cost — no seats, no subscriptions. The first $20 each month is included."}
-                    </Text>
-                  </Flex>
-                  {subscribed && (
-                    <Badge variant="soft" color="green" radius="full">
-                      Active
-                    </Badge>
-                  )}
-                </Flex>
-                <Button
-                  size="1"
-                  variant={freeTier ? "solid" : "outline"}
-                  disabled={!billingUrl}
-                  onClick={() => {
-                    if (freeTier) {
-                      track(ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED, {
-                        surface: "plan_page_card",
-                      });
-                    }
-                    openBilling();
-                  }}
-                  className="self-start"
-                >
-                  {freeTier
-                    ? "Add payment method"
-                    : "Manage billing and spend limits"}
-                  <ArrowSquareOut size={12} />
-                </Button>
+                <Spinner size="2" />
               </Flex>
-
+            ) : meter.kind === "dollars" ? (
+              <UsageMeter
+                label={freeTier ? "Monthly free usage" : "Usage this period"}
+                percent={meter.percent}
+                valueLabel={`${formatUsdAmount(meter.usedUsd)} of ${formatUsdAmount(meter.limitUsd)}${freeTier ? " included" : ""}`}
+                detail={`${meter.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.resetAt, { label: "Billing period ends" })}`}
+                breakdown={
+                  meter.breakdown
+                    ? { ...meter.breakdown, usedUsd: meter.usedUsd }
+                    : undefined
+                }
+                color={meter.exceeded ? "red" : undefined}
+              />
+            ) : meter.kind === "bucket" ? (
+              <UsageMeter
+                label="Monthly free usage"
+                percent={meter.bucket.used_percent}
+                valueLabel={`${meter.bucket.used_percent.toFixed(2)}%`}
+                detail={`${meter.bucket.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.bucket.reset_at)}`}
+                color={meter.bucket.exceeded ? "red" : undefined}
+              />
+            ) : (
+              <Flex
+                align="center"
+                justify="between"
+                p="4"
+                className="rounded-(--radius-3) border border-(--gray-5)"
+              >
+                <Text color="gray" className="text-sm">
+                  {usage
+                    ? "Usage is billed to your organization. View detailed usage and spend in PostHog."
+                    : "Unable to load usage data"}
+                </Text>
+                {usage && (
+                  <Button
+                    size="1"
+                    variant="outline"
+                    disabled={!billingUrl}
+                    onClick={openBilling}
+                  >
+                    View usage
+                    <ArrowSquareOut size={12} />
+                  </Button>
+                )}
+              </Flex>
+            )}
+            {!usageLoading && (
               <Flex direction="column" gap="3">
                 <Text className="font-medium text-(--gray-9) text-sm">
-                  Organization usage
+                  Usage breakdown
                 </Text>
-                {usageLoading ? (
-                  <Flex
-                    align="center"
-                    justify="center"
-                    p="4"
-                    className="rounded-(--radius-3) border border-(--gray-5)"
-                  >
-                    <Spinner size="2" />
-                  </Flex>
-                ) : meter.kind === "dollars" ? (
-                  <UsageMeter
-                    label={
-                      freeTier ? "Monthly free usage" : "Usage this period"
-                    }
-                    percent={meter.percent}
-                    valueLabel={`${formatUsdAmount(meter.usedUsd)} of ${formatUsdAmount(meter.limitUsd)}${freeTier ? " included" : ""}`}
-                    detail={`${meter.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.resetAt, { label: "Billing period ends" })}`}
-                    breakdown={
-                      meter.breakdown
-                        ? { ...meter.breakdown, usedUsd: meter.usedUsd }
-                        : undefined
-                    }
-                    color={meter.exceeded ? "red" : undefined}
-                  />
-                ) : meter.kind === "bucket" ? (
-                  <UsageMeter
-                    label="Monthly free usage"
-                    percent={meter.bucket.used_percent}
-                    valueLabel={`${meter.bucket.used_percent.toFixed(2)}%`}
-                    detail={`${meter.bucket.exceeded ? "Limit exceeded. " : ""}${formatResetTime(meter.bucket.reset_at)}`}
-                    color={meter.bucket.exceeded ? "red" : undefined}
-                  />
+                {components ? (
+                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <UsageComponent
+                      label="Tokens"
+                      value={
+                        components.tokenUsd == null
+                          ? null
+                          : formatUsdAmount(components.tokenUsd)
+                      }
+                    />
+                    <UsageComponent
+                      label="Cloud compute"
+                      value={
+                        components.computeUsd == null
+                          ? null
+                          : formatUsdAmount(components.computeUsd)
+                      }
+                    />
+                    <UsageComponent
+                      label="CPU usage"
+                      value={
+                        components.cpuCoreSeconds == null
+                          ? null
+                          : formatUsageQuantity(
+                              components.cpuCoreSeconds,
+                              "core-seconds",
+                            )
+                      }
+                    />
+                    <UsageComponent
+                      label="Memory usage"
+                      value={
+                        components.memoryGibSeconds == null
+                          ? null
+                          : formatUsageQuantity(
+                              components.memoryGibSeconds,
+                              "GiB-seconds",
+                            )
+                      }
+                    />
+                  </div>
                 ) : (
                   <Flex
-                    align="center"
-                    justify="between"
                     p="4"
                     className="rounded-(--radius-3) border border-(--gray-5)"
                   >
                     <Text color="gray" className="text-sm">
-                      {usage
-                        ? "Usage is billed to your organization. View detailed usage and spend in PostHog."
-                        : "Unable to load usage data"}
+                      Detailed usage is awaiting data. Your combined usage and
+                      organization limit are still shown above.
                     </Text>
-                    {usage && (
-                      <Button
-                        size="1"
-                        variant="outline"
-                        disabled={!billingUrl}
-                        onClick={openBilling}
-                      >
-                        View usage
-                        <ArrowSquareOut size={12} />
-                      </Button>
-                    )}
                   </Flex>
                 )}
+                <Text className="text-(--gray-9) text-[13px]">
+                  Usage reporting may be delayed by 15–20 minutes.
+                </Text>
               </Flex>
-            </>
-          )}
+            )}
+          </Flex>
+        </>
+      )}
 
-          {spendAnalysisEnabled && <SpendAnalysisSection />}
-        </Flex>
-      </Box>
-    </ScrollArea>
+      {spendAnalysisEnabled && <SpendAnalysisSection />}
+    </Flex>
+  );
+}
+
+function UsageComponent({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) {
+  return (
+    <Flex
+      direction="column"
+      gap="1"
+      p="4"
+      className="rounded-(--radius-3) border border-(--gray-5)"
+    >
+      <Text className="text-(--gray-9) text-sm">{label}</Text>
+      <Text className="font-medium text-base">{value ?? "Unavailable"}</Text>
+    </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -29,8 +29,9 @@ import { useSpendAnalysisEnabled } from "@posthog/ui/features/usage/useSpendAnal
 import { useTrackUsageViewed } from "@posthog/ui/features/usage/useTrackUsageViewed";
 import { track } from "@posthog/ui/shell/analytics";
 import { getBillingUrl } from "@posthog/ui/utils/urls";
-import { Badge, Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
-import { useEffect } from "react";
+import { Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
+import type { UsageOutput } from "@posthog/core/usage/schemas";
+import { useEffect, type ReactNode } from "react";
 
 export function PlanUsageSettings() {
   const billingEnabled = useFeatureFlag(BILLING_FLAG);
@@ -57,9 +58,36 @@ export function PlanUsageSettings() {
     burstUsedPercent: usage?.burst.used_percent ?? null,
   });
 
-  // Tri-state: unknown (absent field) must render as subscribed, never free.
+  return (
+    <PlanUsageContent
+      billingEnabled={billingEnabled}
+      spendAnalysisEnabled={spendAnalysisEnabled}
+      billingUrl={billingUrl}
+      usage={usage}
+      usageLoading={usageLoading}
+      personalSpendAnalysis={<SpendAnalysisSection />}
+    />
+  );
+}
+
+interface PlanUsageContentProps {
+  billingEnabled: boolean;
+  spendAnalysisEnabled: boolean;
+  billingUrl: string | null | undefined;
+  usage: UsageOutput | null | undefined;
+  usageLoading: boolean;
+  personalSpendAnalysis?: ReactNode;
+}
+
+export function PlanUsageContent({
+  billingEnabled,
+  spendAnalysisEnabled,
+  billingUrl,
+  usage,
+  usageLoading,
+  personalSpendAnalysis,
+}: PlanUsageContentProps) {
   const freeTier = isCodeUsageFreeTier(usage);
-  const subscribed = usage?.code_usage_subscribed === true;
   const orgLimitReached = usage?.ai_credits?.exhausted === true;
   const meter = codeUsageMeter(usage);
   const components = desktopUsageComponents(usage);
@@ -117,52 +145,35 @@ export function PlanUsageSettings() {
 
           <Flex
             direction="column"
-            gap="3"
+            gap="4"
             p="4"
             className="rounded-(--radius-3) border border-(--gray-5)"
           >
-            <Flex align="center" justify="between">
+            <Flex align="start" justify="between" gap="4" wrap="wrap">
               <Flex direction="column" gap="1">
-                <Text className="font-bold text-base">
-                  {freeTier ? "Free tier" : "Usage-based billing"}
-                </Text>
+                <Text className="font-bold text-base">Organization usage</Text>
                 <Text className="text-(--gray-11) text-sm">
-                  {freeTier
-                    ? "Your organization's first $20 of usage each month is included, with access to open models. Add a payment method to unlock premium models — you only pay for what you use."
-                    : "Your organization pays for usage at cost — no seats, no subscriptions. The first $20 each month is included."}
+                  Combined token and cloud-compute spend counts toward your
+                  organization's shared allowance and limit.
                 </Text>
               </Flex>
-              {subscribed && (
-                <Badge variant="soft" color="green" radius="full">
-                  Active
-                </Badge>
-              )}
+              <Button
+                size="1"
+                variant={freeTier ? "solid" : "outline"}
+                disabled={!billingUrl}
+                onClick={() => {
+                  if (freeTier) {
+                    track(ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED, {
+                      surface: "plan_page_card",
+                    });
+                  }
+                  openBilling();
+                }}
+              >
+                {freeTier ? "Add payment method" : "Manage billing and limits"}
+                <ArrowSquareOut size={12} />
+              </Button>
             </Flex>
-            <Button
-              size="1"
-              variant={freeTier ? "solid" : "outline"}
-              disabled={!billingUrl}
-              onClick={() => {
-                if (freeTier) {
-                  track(ANALYTICS_EVENTS.UPGRADE_PROMPT_CLICKED, {
-                    surface: "plan_page_card",
-                  });
-                }
-                openBilling();
-              }}
-              className="self-start"
-            >
-              {freeTier
-                ? "Add payment method"
-                : "Manage billing and spend limits"}
-              <ArrowSquareOut size={12} />
-            </Button>
-          </Flex>
-
-          <Flex direction="column" gap="3">
-            <Text className="font-medium text-(--gray-9) text-sm">
-              Organization usage
-            </Text>
             {usageLoading ? (
               <Flex
                 align="center"
@@ -220,9 +231,7 @@ export function PlanUsageSettings() {
             )}
             {!usageLoading && (
               <Flex direction="column" gap="3">
-                <Text className="font-medium text-(--gray-9) text-sm">
-                  Usage breakdown
-                </Text>
+                <Text className="font-medium text-sm">What's included</Text>
                 {components ? (
                   <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <UsageComponent
@@ -284,7 +293,7 @@ export function PlanUsageSettings() {
         </>
       )}
 
-      {spendAnalysisEnabled && <SpendAnalysisSection />}
+      {spendAnalysisEnabled && personalSpendAnalysis}
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
+++ b/products/desktop/packages/ui/src/features/settings/sections/PlanUsageSettings.tsx
@@ -231,48 +231,8 @@ export function PlanUsageContent({
             )}
             {!usageLoading && (
               <Flex direction="column" gap="3">
-                <Text className="font-medium text-sm">What's included</Text>
                 {components ? (
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                    <UsageComponent
-                      label="Tokens"
-                      value={
-                        components.tokenUsd == null
-                          ? null
-                          : formatUsdAmount(components.tokenUsd)
-                      }
-                    />
-                    <UsageComponent
-                      label="Cloud compute"
-                      value={
-                        components.computeUsd == null
-                          ? null
-                          : formatUsdAmount(components.computeUsd)
-                      }
-                    />
-                    <UsageComponent
-                      label="CPU usage"
-                      value={
-                        components.cpuCoreSeconds == null
-                          ? null
-                          : formatUsageQuantity(
-                              components.cpuCoreSeconds,
-                              "core-seconds",
-                            )
-                      }
-                    />
-                    <UsageComponent
-                      label="Memory usage"
-                      value={
-                        components.memoryGibSeconds == null
-                          ? null
-                          : formatUsageQuantity(
-                              components.memoryGibSeconds,
-                              "GiB-seconds",
-                            )
-                      }
-                    />
-                  </div>
+                  <UsageMix components={components} />
                 ) : (
                   <Flex
                     p="4"
@@ -298,22 +258,101 @@ export function PlanUsageContent({
   );
 }
 
-function UsageComponent({
-  label,
-  value,
+function UsageMix({
+  components,
 }: {
-  label: string;
-  value: string | null;
+  components: NonNullable<ReturnType<typeof desktopUsageComponents>>;
 }) {
+  const tokenUsd = components.tokenUsd;
+  const computeUsd = components.computeUsd;
+  const hasCreditMix = tokenUsd != null && computeUsd != null;
+  const totalUsd = hasCreditMix ? tokenUsd + computeUsd : 0;
+  const tokenPercent = totalUsd > 0 ? ((tokenUsd ?? 0) / totalUsd) * 100 : 0;
+  const roundedTokenPercent = Math.round(tokenPercent);
+  const computeDetails = [
+    components.cpuCoreSeconds == null
+      ? "CPU unavailable"
+      : formatUsageQuantity(components.cpuCoreSeconds, "core-seconds"),
+    components.memoryGibSeconds == null
+      ? "Memory unavailable"
+      : formatUsageQuantity(components.memoryGibSeconds, "GiB-seconds"),
+  ].join(" · ");
+
   return (
     <Flex
       direction="column"
-      gap="1"
+      gap="3"
       p="4"
-      className="rounded-(--radius-3) border border-(--gray-5)"
+      className="rounded-(--radius-3) bg-(--gray-a2)"
     >
-      <Text className="text-(--gray-9) text-sm">{label}</Text>
-      <Text className="font-medium text-base">{value ?? "Unavailable"}</Text>
+      <Flex align="center" justify="between">
+        <Text className="font-medium text-sm">Usage mix</Text>
+        <Text className="text-(--gray-11) text-xs">
+          Token vs. compute spend
+        </Text>
+      </Flex>
+      {hasCreditMix ? (
+        <>
+          <div
+            role="img"
+            aria-label={`${roundedTokenPercent}% tokens and ${totalUsd > 0 ? 100 - roundedTokenPercent : 0}% cloud compute`}
+            className="flex h-3 w-full overflow-hidden rounded-full bg-(--gray-a4)"
+          >
+            {totalUsd > 0 && (
+              <>
+                <div
+                  className="bg-(--purple-9)"
+                  style={{ width: `${tokenPercent}%` }}
+                />
+                <div className="flex-1 bg-(--blue-9)" />
+              </>
+            )}
+          </div>
+          <Flex align="center" gap="5" wrap="wrap">
+            <MixLegend
+              color="bg-(--purple-9)"
+              label="Tokens"
+              percent={roundedTokenPercent}
+              value={formatUsdAmount(tokenUsd)}
+            />
+            <MixLegend
+              color="bg-(--blue-9)"
+              label="Cloud compute"
+              percent={totalUsd > 0 ? 100 - roundedTokenPercent : 0}
+              value={formatUsdAmount(computeUsd)}
+            />
+          </Flex>
+        </>
+      ) : (
+        <Text className="text-(--gray-11) text-sm">
+          Token and compute proportions are awaiting data.
+        </Text>
+      )}
+      <Text className="text-(--gray-9) text-xs">
+        Compute resources: {computeDetails}
+      </Text>
+    </Flex>
+  );
+}
+
+function MixLegend({
+  color,
+  label,
+  percent,
+  value,
+}: {
+  color: string;
+  label: string;
+  percent: number;
+  value: string;
+}) {
+  return (
+    <Flex align="center" gap="2">
+      <span className={`size-2 rounded-full ${color}`} />
+      <Text className="text-sm">
+        <strong>{percent}%</strong> {label}
+        <span className="text-(--gray-9)"> · {value}</span>
+      </Text>
     </Flex>
   );
 }

--- a/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -35,20 +35,8 @@ export function SpendAnalysisSection() {
   }, [data]);
 
   return (
-    <Flex
-      direction="column"
-      gap="3"
-      pt="5"
-      className="border-(--gray-5) border-t"
-    >
-      <Flex align="end" justify="between" gap="3" wrap="wrap">
-        <Flex direction="column" gap="1">
-          <Text className="font-bold text-base">Your spend</Text>
-          <Text className="text-(--gray-11) text-sm">
-            Near-real-time spend for your activity in the selected window. It
-            may differ from the delayed organization billing period above.
-          </Text>
-        </Flex>
+    <Flex direction="column" gap="3">
+      <Flex justify="end">
         <Flex align="center" gap="4">
           <WindowSelector value={spendWindow} onChange={setSpendWindow} />
           <Button

--- a/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
+++ b/products/desktop/packages/ui/src/features/usage/components/SpendAnalysisSection.tsx
@@ -35,11 +35,20 @@ export function SpendAnalysisSection() {
   }, [data]);
 
   return (
-    <Flex direction="column" gap="3">
-      <Flex align="center" justify="between">
-        <Text className="font-medium text-(--gray-9) text-sm">
-          Personal spend analysis
-        </Text>
+    <Flex
+      direction="column"
+      gap="3"
+      pt="5"
+      className="border-(--gray-5) border-t"
+    >
+      <Flex align="end" justify="between" gap="3" wrap="wrap">
+        <Flex direction="column" gap="1">
+          <Text className="font-bold text-base">Your spend</Text>
+          <Text className="text-(--gray-11) text-sm">
+            Near-real-time spend for your activity in the selected window. It
+            may differ from the delayed organization billing period above.
+          </Text>
+        </Flex>
         <Flex align="center" gap="4">
           <WindowSelector value={spendWindow} onChange={setSpendWindow} />
           <Button


### PR DESCRIPTION
## Problem

PostHog Desktop users can see combined organization usage but cannot distinguish token spend from cloud-compute usage. The page also mixes organization billing with personal analysis without clearly explaining their different scope and freshness.

## Changes

![Screenshot 2026-08-06 at 3.27.24 PM.png](https://app.graphite.com/user-attachments/assets/51eb1bd7-db3e-4c1d-8096-61e4c258987d.png)

- Shows token and cloud-compute spend while keeping combined usage as the only authoritative meter and limit.
- Shows CPU core-seconds and memory GiB-seconds without prices or independent limits.
- Removes the redundant usage-based billing status card.
- Combines the organization meter and component breakdown into one billing surface.
- Separates near-real-time personal spend analysis from delayed organization billing.
- Treats a missing breakdown as awaiting data and preserves explicit zero values.
- Keeps existing exhaustion, upgrade, and Plan & Usage navigation behavior.
- Depends on [#76889](https://github.com/PostHog/posthog/pull/76889) for the optional gateway response field. It does not depend on compute enforcement.
- Adds Storybook states for standard, loading, unavailable, explicit-zero, and exhausted usage.

## How did you test this code?

- Ran focused usage-display tests covering conversion, missing values, explicit zero, and large integers.
- Ran gateway client tests covering the optional breakdown wire shape.
- Ran Desktop core and UI type checks.
- Built Storybook and reviewed the primary Plan & Usage story at desktop size.
- Did not manually test the packaged Electron application.

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation changes. The Plan & Usage surface explains scope, units, and freshness in context.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code using the local `/frontend-design` skill. The page now treats combined organization usage as the billing ledger and personal analysis as a separate near-real-time workspace.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)