### PR TITLE
fix(desktop): bound github reference lookups

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/git/service.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.test.ts
@@ -36,6 +36,40 @@ describe("GitService", () => {
     ).resolves.toEqual([]);
   });
 
+  it("bounds GitHub pull request lookups so editor chips do not load forever", async () => {
+    execGhMock.mockResolvedValue(
+      ghResult({
+        stdout: JSON.stringify({
+          number: 123,
+          title: "Fix pull request title resolution",
+          state: "OPEN",
+          url: "https://github.com/posthog/posthog/pull/123",
+          isDraft: false,
+        }),
+      }),
+    );
+
+    await expect(
+      new GitService().getGithubPullRequest("posthog", "posthog", 123),
+    ).resolves.toMatchObject({
+      number: 123,
+      title: "Fix pull request title resolution",
+    });
+
+    expect(execGhMock).toHaveBeenCalledWith(
+      [
+        "pr",
+        "view",
+        "123",
+        "--repo",
+        "posthog/posthog",
+        "--json",
+        "number,title,state,url,isDraft",
+      ],
+      { timeoutMs: 10_000 },
+    );
+  });
+
   it("returns changed files from a successful comparison", async () => {
     execGhMock
       .mockResolvedValueOnce(ghResult({ stdout: "main\n" }))

--- a/products/desktop/packages/workspace-server/src/services/git/service.ts
+++ b/products/desktop/packages/workspace-server/src/services/git/service.ts
@@ -94,6 +94,7 @@ import type {
 import { getPrInfoByUrlOutput, prConversationCommentSchema } from "./schemas";
 
 const FETCH_THROTTLE_MS = 30_000;
+const GITHUB_REF_LOOKUP_TIMEOUT_MS = 10_000;
 /** Max PRs per GraphQL request – stays well under GitHub's complexity ceiling. */
 const PR_DIFF_STATS_BATCH_CHUNK_SIZE = 25;
 
@@ -1958,7 +1959,9 @@ export class GitService extends TypedEventEmitter<GitCloneEvents> {
       kind === "pr"
         ? "number,title,state,url,isDraft"
         : "number,title,state,labels,url";
-    const result = await execGh([...args, "--json", jsonFields]);
+    const result = await execGh([...args, "--json", jsonFields], {
+      timeoutMs: GITHUB_REF_LOOKUP_TIMEOUT_MS,
+    });
     if (result.exitCode !== 0) return [];
 
     try {


### PR DESCRIPTION
## Problem

- Pasting a GitHub pull request into a task can leave its reference chip on `Loading…` indefinitely when the underlying `gh` request stalls.

## Changes

- Bound GitHub issue and pull request reference lookups to 10 seconds.
- Existing fallback now replaces a failed lookup with the reference number instead of leaving a loading chip.

## How did you test this code?

- Added a Git service regression test that fails if pull request metadata lookups lose their timeout.
- Ran the focused Git service suite and full desktop TypeScript check.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This is an internal timeout safeguard with no user-facing configuration or documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Produced with PostHog Code.
- Invoked `/writing-tests` to add targeted coverage for the stalled lookup regression.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
