### PR TITLE
fix(desktop): re-authorize when a grant lacks a required scope

### DIFF
--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -444,6 +444,32 @@ describe("AuthService", () => {
     },
   );
 
+  // The prompt is a blocking dialog, so an install whose server cannot grant the scope must not
+  // reach it twice: the user would sign in, refresh, and be blocked again with no way forward.
+  it("retires the prompt once the user re-authenticates into a still-narrowed grant", async () => {
+    seedStoredSession({ selectedProjectId: 42 });
+    oauthFlow.refreshToken.mockResolvedValue(
+      mockTokenResponse({ scope: "insight:read" }),
+    );
+    oauthFlow.startFlow.mockResolvedValue(
+      mockTokenResponse({ scope: "insight:read" }),
+    );
+    stubAuthFetch();
+
+    await service.initialize();
+    expect(service.getState()).toMatchObject({ needsScopeReauth: true });
+
+    await service.login("us");
+    expect(service.getState()).toMatchObject({ needsScopeReauth: false });
+
+    await service.refreshAccessToken();
+
+    expect(service.getState()).toMatchObject({
+      status: "authenticated",
+      needsScopeReauth: false,
+    });
+  });
+
   it("restores an authenticated session by refreshing the stored refresh token", async () => {
     seedStoredSession({ selectedProjectId: 42 });
     oauthFlow.refreshToken.mockResolvedValue(

--- a/products/desktop/packages/core/src/auth/auth.test.ts
+++ b/products/desktop/packages/core/src/auth/auth.test.ts
@@ -82,6 +82,7 @@ function mockTokenResponse(
     refreshToken?: string | null;
     expiresIn?: number;
     scopedOrgs?: string[];
+    scope?: string;
   } = {},
 ) {
   const refreshToken =
@@ -95,7 +96,7 @@ function mockTokenResponse(
       ...(refreshToken ? { refresh_token: refreshToken } : {}),
       expires_in: overrides.expiresIn ?? 3600,
       token_type: "Bearer",
-      scope: "",
+      scope: overrides.scope ?? "",
       scoped_organizations: overrides.scopedOrgs ?? ["org-1"],
     },
   };
@@ -421,6 +422,27 @@ describe("AuthService", () => {
       sessionEndReason: null,
     });
   });
+
+  it.each([
+    ["missing a required scope", "insight:read", true],
+    ["carrying the required scopes", "task:read task:write", false],
+    // A server that omits `scope` reports nothing, and must not be read as a narrowed grant.
+    ["reporting no scopes at all", "", false],
+  ] as const)(
+    "keeps the session but prompts to re-authenticate for a refreshed grant %s",
+    async (_case, scope, needsScopeReauth) => {
+      seedStoredSession({ selectedProjectId: 42 });
+      oauthFlow.refreshToken.mockResolvedValue(mockTokenResponse({ scope }));
+      stubAuthFetch();
+
+      await service.initialize();
+
+      expect(service.getState()).toMatchObject({
+        status: "authenticated",
+        needsScopeReauth,
+      });
+    },
+  );
 
   it("restores an authenticated session by refreshing the stored refresh token", async () => {
     seedStoredSession({ selectedProjectId: 42 });

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -6,6 +6,7 @@ import {
 import {
   type BackoffOptions,
   type CloudRegion,
+  findMissingRequiredScopes,
   getCloudUrlFromRegion,
   NotAuthenticatedError,
   OAUTH_SCOPE_VERSION,
@@ -91,6 +92,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   private session: InMemorySession | null = null;
   private initializePromise: Promise<void> | null = null;
   private refreshPromise: Promise<InMemorySession> | null = null;
+  // Required scopes the last refreshed grant did not carry. Drives the scope-reauth
+  // prompt for a stored grant that predates a scope the app now needs.
+  private missingRequiredScopes: string[] = [];
   private impersonationExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   // Serializes session-state commits so overlapping selections can't
   // interleave across async encryption (see commitSessionState).
@@ -644,6 +648,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       );
 
       if (result.success && result.data) {
+        this.recordRefreshedGrantScopes(result.data.scope);
         return await this.createSessionFromTokenResponse(result.data, {
           ...input,
           fallbackRefreshToken: input.refreshToken,
@@ -682,6 +687,25 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
     }
 
     throw new Error(lastError);
+  }
+  /**
+   * Note the required scopes a refreshed grant came back without, so the session surfaces the
+   * scope-reauth prompt instead of running on a token whose missing scope only shows up as a
+   * feature that appears not to exist.
+   *
+   * Checked on refresh only. The fresh interactive grant clears the flag unconditionally, which
+   * caps this at one prompt: if the server clamps the scope away again, the user is let in with a
+   * warning rather than bounced back through login forever. A login loop is worse than a missing
+   * scope, and shipping the scope list has broken login before (see shared/src/oauth.ts).
+   */
+  private recordRefreshedGrantScopes(grantedScope: string | undefined): void {
+    this.missingRequiredScopes = findMissingRequiredScopes(grantedScope);
+    if (this.missingRequiredScopes.length > 0) {
+      this.logger.warn(
+        "Refreshed grant is missing required scopes, prompting to re-authenticate",
+        { missingScopes: this.missingRequiredScopes },
+      );
+    }
   }
   private async createSessionFromTokenResponse(
     tokenResponse: AuthTokenResponse,
@@ -866,6 +890,16 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       throw new Error(result.error || fallbackError);
     }
 
+    // A fresh grant is the answer to the scope-reauth prompt, so it always clears the flag —
+    // even when the server clamped the scope away again. See recordRefreshedGrantScopes.
+    const stillMissing = findMissingRequiredScopes(result.data.scope);
+    if (stillMissing.length > 0) {
+      this.logger.warn("Fresh grant is still missing required scopes", {
+        missingScopes: stillMissing,
+      });
+    }
+    this.missingRequiredScopes = [];
+
     const session = await this.createSessionFromTokenResponse(result.data, {
       cloudRegion: region,
       selectedProjectId: this.state.currentProjectId,
@@ -895,7 +929,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       orgProjectsMap: session.orgProjectsMap,
       currentOrgId: session.currentOrgId,
       currentProjectId: session.currentProjectId,
-      needsScopeReauth: false,
+      needsScopeReauth: this.missingRequiredScopes.length > 0,
       sessionType: session.sessionType,
       sessionExpiresAt: session.accessTokenExpiresAt,
       sessionEndReason: null,

--- a/products/desktop/packages/core/src/auth/auth.ts
+++ b/products/desktop/packages/core/src/auth/auth.ts
@@ -95,6 +95,9 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
   // Required scopes the last refreshed grant did not carry. Drives the scope-reauth
   // prompt for a stored grant that predates a scope the app now needs.
   private missingRequiredScopes: string[] = [];
+  // Set once the user completes an interactive grant, which retires the scope-reauth prompt for
+  // the rest of the run whether or not the new grant carries the scopes.
+  private scopeReauthAnswered = false;
   private impersonationExpiryTimer: ReturnType<typeof setTimeout> | null = null;
   // Serializes session-state commits so overlapping selections can't
   // interleave across async encryption (see commitSessionState).
@@ -693,12 +696,16 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
    * scope-reauth prompt instead of running on a token whose missing scope only shows up as a
    * feature that appears not to exist.
    *
-   * Checked on refresh only. The fresh interactive grant clears the flag unconditionally, which
-   * caps this at one prompt: if the server clamps the scope away again, the user is let in with a
-   * warning rather than bounced back through login forever. A login loop is worse than a missing
-   * scope, and shipping the scope list has broken login before (see shared/src/oauth.ts).
+   * Checked on refresh only, and never again once the user has answered the prompt in this run.
+   * The prompt is a blocking dialog, so an install whose server cannot grant the scope must not
+   * be able to reach it twice: the user would sign in, refresh, and be blocked again with no way
+   * forward. A login loop is worse than a missing scope, and shipping the scope list has broken
+   * login before (see shared/src/oauth.ts).
    */
   private recordRefreshedGrantScopes(grantedScope: string | undefined): void {
+    if (this.scopeReauthAnswered) {
+      return;
+    }
     this.missingRequiredScopes = findMissingRequiredScopes(grantedScope);
     if (this.missingRequiredScopes.length > 0) {
       this.logger.warn(
@@ -890,8 +897,8 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       throw new Error(result.error || fallbackError);
     }
 
-    // A fresh grant is the answer to the scope-reauth prompt, so it always clears the flag —
-    // even when the server clamped the scope away again. See recordRefreshedGrantScopes.
+    // A fresh grant is the answer to the scope-reauth prompt, so it retires the prompt for this
+    // run even when the server clamped the scope away again. See recordRefreshedGrantScopes.
     const stillMissing = findMissingRequiredScopes(result.data.scope);
     if (stillMissing.length > 0) {
       this.logger.warn("Fresh grant is still missing required scopes", {
@@ -899,6 +906,7 @@ export class AuthService extends TypedEventEmitter<AuthServiceEvents> {
       });
     }
     this.missingRequiredScopes = [];
+    this.scopeReauthAnswered = true;
 
     const session = await this.createSessionFromTokenResponse(result.data, {
       cloudRegion: region,

--- a/products/desktop/packages/shared/src/index.ts
+++ b/products/desktop/packages/shared/src/index.ts
@@ -243,7 +243,9 @@ export {
   selectOptionDocsUrl,
 } from "./models";
 export {
+  findMissingRequiredScopes,
   getOauthClientIdFromRegion,
+  OAUTH_REQUIRED_SCOPES,
   OAUTH_SCOPE_VERSION,
   OAUTH_SCOPES,
   POSTHOG_DEV_CLIENT_ID,

--- a/products/desktop/packages/shared/src/oauth.test.ts
+++ b/products/desktop/packages/shared/src/oauth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { OAUTH_SCOPE_VERSION, OAUTH_SCOPES } from "./oauth";
+import {
+  findMissingRequiredScopes,
+  OAUTH_REQUIRED_SCOPES,
+  OAUTH_SCOPE_VERSION,
+  OAUTH_SCOPES,
+} from "./oauth";
 
 describe("OAUTH_SCOPES guard", () => {
   // Fingerprint instead of snapshotting the whole list: any add, removal, or reorder of
@@ -50,5 +55,32 @@ describe("OAUTH_SCOPES guard", () => {
         !/^[a-z_]+:(read|write)$/.test(scope),
     );
     expect(malformed).toEqual([]);
+  });
+});
+
+describe("findMissingRequiredScopes", () => {
+  it.each([
+    ["an absent scope string", undefined, []],
+    ["an empty scope string", "", []],
+    ["a wildcard grant", "*", []],
+    ["both halves granted", "task:read task:write insight:read", []],
+    ["the write half alone", "task:write", []],
+    ["the read half alone", "task:read", ["task:write"]],
+    [
+      "no task scopes at all",
+      "insight:read person:read",
+      ["task:read", "task:write"],
+    ],
+  ] as const)("resolves %s", (_case, granted, expected) => {
+    expect(findMissingRequiredScopes(granted)).toEqual(expected);
+  });
+
+  // A required scope the app never asks for would nag every install to re-authenticate over a
+  // grant the server was never going to widen.
+  it("only requires scopes the app actually requests", () => {
+    const unrequested = OAUTH_REQUIRED_SCOPES.filter(
+      (scope) => !OAUTH_SCOPES.includes(scope),
+    );
+    expect(unrequested).toEqual([]);
   });
 });

--- a/products/desktop/packages/shared/src/oauth.ts
+++ b/products/desktop/packages/shared/src/oauth.ts
@@ -246,6 +246,51 @@ export const OAUTH_SCOPES = [
 // v7: "*" replaced with the explicit list above.
 export const OAUTH_SCOPE_VERSION = 7;
 
+// Scopes checked against what the server actually granted, not just what we asked for.
+// OAUTH_SCOPE_VERSION only catches drift someone remembered to hand-bump; /oauth/authorize
+// narrows a request to the app's ceiling instead of failing it, and refresh never widens a
+// grant, so a session can run indefinitely on a token quietly missing a scope. The failure is
+// invisible: MCP filters its tool catalog by granted scope, so a surface gated on a scope the
+// token lacks looks like a feature that does not exist rather than a permission error.
+//
+// Deliberately a small subset of OAUTH_SCOPES. A scope that is legitimately ungrantable for
+// some installs must never appear here, or every one of those users gets prompted to
+// re-authenticate over a grant that is behaving correctly. That rules out privileged
+// llm_gateway:read, which depends on the per-app ceiling being seeded in the region.
+export const OAUTH_REQUIRED_SCOPES = ["task:read", "task:write"];
+
+/**
+ * Required scopes absent from a granted `scope` string (the space-separated set the token
+ * endpoint echoes back).
+ *
+ * Returns [] when the string is empty or absent: `scope` is optional on a token response, and a
+ * server that does not report its grant is telling us nothing. Reading that silence as "every
+ * scope is missing" would prompt working installs to re-authenticate.
+ *
+ * A `<object>:write` grant satisfies a `<object>:read` requirement, mirroring the server's own
+ * APIScopePermission check, so a token holding only the write half is not reported as missing
+ * access it in fact has.
+ */
+export function findMissingRequiredScopes(
+  grantedScope: string | undefined,
+): string[] {
+  if (!grantedScope) {
+    return [];
+  }
+  const granted = new Set(grantedScope.split(" ").filter(Boolean));
+  // The wildcard short-circuits scope checks server-side and grants everything.
+  if (granted.has("*")) {
+    return [];
+  }
+  return OAUTH_REQUIRED_SCOPES.filter(
+    (scope) =>
+      !granted.has(scope) &&
+      !(
+        scope.endsWith(":read") && granted.has(scope.replace(":read", ":write"))
+      ),
+  );
+}
+
 // Token refresh settings
 export const TOKEN_REFRESH_BUFFER_MS = 30 * 60 * 1000; // 30 minutes before expiry
 export const TOKEN_REFRESH_FORCE_MS = 60 * 1000; // Force refresh when <1 min to expiry, even with active sessions


### PR DESCRIPTION
## Problem

- A Desktop session can lose a whole feature surface with no error: the inbox MCP tools stop appearing, and nothing says why.
- `/oauth/authorize` narrows a request to the app's scope ceiling instead of failing it, and a refresh never widens a grant. A session then runs indefinitely on a token missing a scope.
- MCP filters its tool catalog by granted scope, so a surface gated on a missing scope reads as a feature that does not exist rather than a permission error.
- `OAUTH_SCOPE_VERSION` was the only defence, and it catches drift only when someone remembers to hand-bump it.
- Desktop already received the granted scope set on every token response and discarded it.

## Changes

- Desktop compares the scope set the server granted against the scopes the app requires, and raises the existing re-authentication prompt when one is missing.
- `findMissingRequiredScopes` treats a `<object>:write` grant as satisfying `<object>:read`, mirroring the server's own `APIScopePermission` check.
- An empty or absent `scope` on the token response reports nothing missing. A server that does not report its grant must not log working installs out.
- `OAUTH_REQUIRED_SCOPES` is a deliberately small subset of `OAUTH_SCOPES`. A scope that is legitimately ungrantable for some installs would prompt those users forever, which rules out privileged `llm_gateway:read`.
- The check runs on refresh only, and stops for the rest of the run once the user answers the prompt. The dialog is blocking, so reaching it twice would strand an install whose server cannot grant the scope.

> [!NOTE]
> Users holding a grant that predates a scope the app now needs will see the re-authentication prompt once on their next refresh.

## How did you test this code?

- New `findMissingRequiredScopes` cases catch two regressions: reading an absent `scope` as "everything missing", which would prompt every working install, and dropping the write-satisfies-read rule, which would flag a token that has the access.
- A new guard fails if `OAUTH_REQUIRED_SCOPES` names a scope the app never requests. That scope would nag every install over a grant the server was never going to widen.
- Three parameterized `AuthService` cases assert the prompt appears for a narrowed grant and stays hidden both for a full grant and for a scope-less response. No existing test exercised the granted scope set at all.
- A further `AuthService` case covers re-authenticating into a grant that is still narrowed, and asserts the next refresh does not reopen the prompt. It fails without the guard that retires the prompt.
- Ran the `@posthog/shared` suite and `packages/core/src/auth/auth.test.ts` locally, plus `biome check` and `tsc --noEmit` on both packages. CI reports the counts.
- Not verified: the Electron app itself. The prompt was not exercised in a running session, so the UI path rests on the state assertions above. Remaining `tsc` errors in `packages/core` come from unbuilt sibling packages and predate this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigated from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786032050422969?thread_ts=1786032050.422969&cid=C09SK2PAGKF) about inbox MCP tools missing in a Desktop session.
- The cloud task path was ruled out first: every server-minted scope preset in `posthog/temporal/oauth.py` already carries `task:read`, so only the desktop-driven grant could be short. That narrowed the fix to `packages/core/src/auth`.
- Two alternatives were rejected. Persisting the granted scopes would need a `workspace-server` schema migration, and the refresh response already carries them. Forcing a logout on drift risked the login loop the existing deploy-order comment warns about, so this reuses the non-destructive prompt.
- Skills invoked: `inbox-exploration`, `/writing-tests`, `/writing-pr-descriptions`.
- Assignee left unset deliberately: the person who directed this work has no GitHub handle verified in this session, and guessing one would tag an unrelated account.
- Public artifact: the diff, tests, and this description carry no material from the session that is not already public. Test fixtures use invented scope strings.

