### PR TITLE
fix(mcp-analytics): pin the event name in the recurring report prompts

### DIFF
--- a/products/mcp_analytics/frontend/notifications/recurringReportDefinitions.ts
+++ b/products/mcp_analytics/frontend/notifications/recurringReportDefinitions.ts
@@ -15,6 +15,28 @@ export interface MCPRecurringReport {
     prompt: string
 }
 
+/**
+ * Prompts MUST backtick `$mcp_tool_call` and do it inside their first 120 characters. That is not
+ * style — it is the only deterministic way to pin the event. `_pinned_event_names` (ai_subscription/
+ * spec_generator.py) resolves an explicitly named event without asking an LLM, via two paths, and
+ * both are positional:
+ *   - quoted/backticked tokens, extracted by `_QUOTED_TOKEN_RE` from the whole prompt. Backtick the
+ *     BARE name: a wider span like `event = '$mcp_tool_call'` is captured verbatim, matches no
+ *     EventDefinition, and pins nothing.
+ *   - bare standalone tokens, matched against a haystack that `_normalize_event_token` truncates to
+ *     EVENT_NAME_MAX_LENGTH (120) — so a name mentioned later in the prompt is invisible to it.
+ * Miss both and event choice falls through to a probabilistic LLM pass over every event in the
+ * project's taxonomy, legacy names included. That is exactly how a report from this template came to
+ * query the unprefixed `mcp_tool_call` and announce that no agent intent was recorded, over
+ * instrumentation where 92% of calls carried one.
+ *
+ * The prose below is a second line of defence only. Deliberately does not backtick the legacy name:
+ * quoted extraction reads the full prompt, so backticking it would pin the wrong event.
+ */
+const EVENT_NAME_DISAMBIGUATION =
+    'If this project also has an older, unprefixed mcp_tool_call event, that one is legacy data ' +
+    'and carries no $mcp_* properties.'
+
 export const MCP_RECURRING_REPORTS: MCPRecurringReport[] = [
     {
         key: 'intent-roundup',
@@ -26,8 +48,9 @@ export const MCP_RECURRING_REPORTS: MCPRecurringReport[] = [
         // been emitted by any project, while $mcp_intent is set on ~88% of calls. "Couldn't do it"
         // is inferred from the error flag on the same call, which is a signal that actually exists.
         prompt: [
-            'Summarize what AI agents were trying to do with our MCP server this week,',
-            'using the $mcp_intent property on $mcp_tool_call events.',
+            'Summarize what AI agents were trying to do with our MCP server this week',
+            'using `$mcp_tool_call` events and their $mcp_intent property.',
+            EVENT_NAME_DISAMBIGUATION,
             'Group similar intents together and rank the groups by how often they came up,',
             'quoting one or two verbatim $mcp_intent examples per group.',
             'For each group, give the share of those calls that failed ($mcp_is_error) — an intent',
@@ -45,7 +68,8 @@ export const MCP_RECURRING_REPORTS: MCPRecurringReport[] = [
         frequency: 'weekly',
         title: 'MCP tool health',
         prompt: [
-            'Report on our MCP server’s health for the last week using $mcp_tool_call events.',
+            'Report on our MCP server’s health for the last week using `$mcp_tool_call` events.',
+            EVENT_NAME_DISAMBIGUATION,
             'Cover total calls, calls per tool (use $mcp_exec_tool_call_name when set, else $mcp_tool_name),',
             'the error rate from $mcp_is_error, the most common $mcp_error_type values with example',
             '$mcp_error_message text, and p95 of $mcp_duration_ms per tool.',


### PR DESCRIPTION
## Problem

A report generated from the `intent-roundup` template told its reader that **no** MCP tool call carried an agent intent, and recommended fixing instrumentation. **92.3% of calls carried one.**

The planner had queried the legacy unprefixed `mcp_tool_call` — still emitted by older `posthog-cli` builds, so it sits in project 2's taxonomy right next to the canonical `$mcp_tool_call`, which is the event the template already named.

## Why naming it wasn't enough

`_pinned_event_names` (`ai_subscription/spec_generator.py`) resolves an explicitly named event **without an LLM**. Both of its paths are positional, and the template missed both:

| Path | Why it missed |
|---|---|
| Quoted/backticked tokens (`_QUOTED_TOKEN_RE`) | template quoted nothing |
| Bare standalone token | haystack is truncated to `EVENT_NAME_MAX_LENGTH` (120) by `_normalize_event_token`; the template's `$mcp_tool_call` sits at **char 108**, so the token is cut mid-word |

Missing both, event choice falls through to a probabilistic LLM pass over every event in the taxonomy — legacy names included.

## Fix

Both prompts now backtick the **bare** `$mcp_tool_call` within the first 120 chars (char 80 and 59), firing both pins.

Backticking the bare name is load-bearing: a wider span like `` `event = '$mcp_tool_call'` `` is captured verbatim by the regex, matches no `EventDefinition`, and pins nothing. I tried exactly that first and it failed.

The prose sentence is a second line of defence only. It deliberately does **not** backtick the legacy name — quoted extraction reads the whole prompt, so that would pin the wrong event — and it's phrased conditionally, since this template ships to every customer and almost none have a legacy event.

## Testing

End to end against project 2, generating real reports from throwaway subscriptions. Ground truth for the window: **4,130,700** canonical vs **27,098** legacy calls.

| Prompt variant | Result |
|---|---|
| prose `$mcp_tool_call` (current) | ❌ wrong event |
| SQL predicate `event = '$mcp_tool_call'` | ❌ wrong event |
| **backticked bare name inside 120 chars** | ✅ **correct** |

The passing run surfaced a real agent workflow failing **2,187/2,187** calls that the broken version claimed didn't exist.

Also verified by computation: both prompts extract exactly `['$mcp_tool_call']` as their quoted token, the legacy name is *not* pinned, both are well under the 4000-char cap, and there are no join-seam spacing defects.

## Reviewer notes

- **`codex review` could not run** — the account hit its usage limit until Aug 8. I substituted an adversarial Claude review, which is what found the two P1s above (the backtick-span trap and the 120-char cliff). Flagging so the gate status is clear rather than implied.
- An earlier draft asserted "MCP analytics event names are always $-prefixed". That's **false** — `mcp project switched`, `mcp organization switched` and `mcp feedback submitted` are live, unprefixed, and not `ignored_in_assistant`. Wording now scoped to the tool-call event only.
- **Worth filing separately:** the 120-char haystack truncation silently disables the deterministic pin for *any* AI-report prompt naming its event later than char 120 — not just these templates. `EVENT_NAME_MAX_LENGTH` is a per-name cap being applied to a whole prompt.

Third of three PRs from one wrong report — #76854 (NULL rendered as `None`) and #76884 (boolean compared to `1`) fix the two amplifiers that made the wrong query read as a confident answer.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*