### PR TITLE
fix(mysql): stop reporting a Vitess reparent as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -349,7 +349,18 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         # "Can't create a new thread" (MySQL error 1135) is the same class of transient host-capacity
         # condition — the server hit its OS thread/process limit rather than `max_connections` — and is
         # retried in-process the same way (see `_is_transient_cant_create_thread`).
-        return {"Lost connection to MySQL server during query", "Too many connections", "Can't create a new thread"}
+        #
+        # A Vitess/PlanetScale shard mid-reparent (see `_is_transient_vitess_reparent`) shares the same
+        # contract too: `_retry_on_transient_tablet_unavailable` already retries it in-process during
+        # metadata discovery, but a reparent can outlast that bounded in-process budget, so match the
+        # stable phrase here as a backstop — Temporal's own activity retry lands on the newly promoted
+        # primary once the reparent completes.
+        return {
+            "Lost connection to MySQL server during query",
+            "Too many connections",
+            "Can't create a new thread",
+            "reparent operation in progress",
+        }
 
     def reconcile_schema_metadata(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2225,6 +2225,24 @@ class TestMySQLSourceNonRetryableErrors:
         is_retryable = any(pattern in error_msg for pattern in retryable)
         assert is_retryable, f"Too-many-connections error should be classified retryable: {error_msg}"
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "(1105, 'unknown: target: keyspace.-.primary: primary is not serving, "
+            "there may be a reparent operation in progress')",
+            "reparent operation in progress",
+        ],
+    )
+    def test_vitess_reparent_is_classified_retryable(self, source, error_msg):
+        # `_retry_on_transient_tablet_unavailable` already retries this in-process during metadata
+        # discovery, but a reparent can outlast that bounded budget; once exhausted it re-raises for
+        # Temporal to retry the whole activity. Without this classification `_handle_import_error`
+        # logs it at `exception` on every occurrence, flooding error tracking with a self-recovering
+        # Vitess/PlanetScale failover.
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Vitess reparent error should be classified retryable: {error_msg}"
+
 
 class TestMySQLSourceValidateCredentials:
     @pytest.fixture


### PR DESCRIPTION
## Problem

A MySQL/Vitess (PlanetScale) sync fails and gets reported to error tracking every time a shard reparents its primary, even though the sync recovers on its own once the reparent finishes.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd842-a955-7900-a89a-4a79bb38f502): `OperationalError: (1105, 'unknown: target: app.-.primary: primary is not serving, there may be a reparent operation in progress')`, raised from `get_primary_keys_for_table` during metadata discovery.

## Changes

- The metadata-discovery path already retries this exact condition in-process (`_retry_on_transient_tablet_unavailable` / `_is_transient_vitess_reparent`), but a reparent can outlast that bounded retry budget.
- Once the budget is exhausted the error escapes uncaught. Temporal's own activity retry recovers it fine once the new primary is promoted, but the escape wasn't classified as a known transient condition, so it was reported to error tracking on every occurrence.
- Added `"reparent operation in progress"` to `MySQLSource.get_retryable_errors()`, mirroring the existing entries for other self-recovering MySQL errors (`"Lost connection to MySQL server during query"`, `"Too many connections"`).

## How did you test this code?

Added `test_vitess_reparent_is_classified_retryable`, parametrized over the raw error string and the wrapped form, asserting the new phrase is picked up by `get_retryable_errors()` — the same shape as the existing tests for the other two retryable-error entries. Ran the full MySQL source test suite locally: 268 passed. Not run: an end-to-end sync against a real Vitess/PlanetScale reparent, since that requires live infrastructure.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, stack trace, affected events) to confirm the failure originates in `mysql.py`, then read the source to find the existing but incomplete Vitess-reparent retry handling. Searched for duplicate open PRs (human-authored and the maintainer's own) before opening this one — none found. Invoked `/writing-tests` before adding the test case and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*