### PR TITLE
fix(cdp): suggest activity scopes in team activity trigger filters

### DIFF
--- a/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
+++ b/frontend/src/lib/components/PropertyFilters/PropertyFilters.tsx
@@ -21,6 +21,7 @@ import { AnyPropertyFilter, FilterLogicalOperator } from '~/types'
 import { FilterRow } from './components/FilterRow'
 import { OperatorValueSelectProps } from './components/OperatorValueSelect'
 import { propertyFilterLogic } from './propertyFilterLogic'
+import { PropertyFilterInternalProps } from './types'
 
 export interface PropertyFiltersProps {
     endpoint?: string | null
@@ -65,6 +66,7 @@ export interface PropertyFiltersProps {
      * (`TAXONOMIC_FILTER_MENU_REBUILD`).
      */
     triggerVariant?: 'button' | 'input'
+    staticValueOptions?: PropertyFilterInternalProps['staticValueOptions']
 }
 
 export function PropertyFilters({
@@ -104,6 +106,7 @@ export function PropertyFilters({
     operatorAllowlist,
     hogQLGlobals,
     triggerVariant = 'button',
+    staticValueOptions,
 }: PropertyFiltersProps): JSX.Element {
     const logicProps = { propertyFilters, onChange, pageKey, sendAllKeyUpdates }
     const { filters, filtersWithNew, filterIds, filterIdsWithNew } = useValues(propertyFilterLogic(logicProps))
@@ -175,6 +178,7 @@ export function PropertyFilters({
                                             operatorAllowlist={operatorAllowlist}
                                             hogQLGlobals={hogQLGlobals}
                                             triggerVariant={triggerVariant}
+                                            staticValueOptions={staticValueOptions}
                                         />
                                     )}
                                     errorMessage={errorMessages && errorMessages[index]}

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lib/utils/operators'
 import { RE2_DOCS_LINK, formatRE2Error } from 'lib/utils/regexp'
 
+import { PropValue } from '~/models/propertyDefinitionsModel'
 import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import {
     GroupTypeIndex,
@@ -147,6 +148,8 @@ export interface OperatorValueSelectProps {
      * Force single-select mode regardless of operator type
      * **/
     forceSingleSelect?: boolean
+    /** Statically known value suggestions, replacing API-fetched ones. See `PropertyValueProps.staticValues`. */
+    staticValues?: PropValue[]
 }
 
 interface OperatorSelectProps extends Omit<LemonSelectProps<any>, 'options'> {
@@ -202,6 +205,7 @@ export function OperatorValueSelect({
     startVisible,
     operatorAllowlist,
     forceSingleSelect,
+    staticValues,
 }: OperatorValueSelectProps): JSX.Element {
     const lookupKey = type === PropertyFilterType.DataWarehousePersonProperty ? 'id' : 'name'
     const propertyDefinition = propertyDefinitions.find((pd) => pd[lookupKey] === propertyKey)
@@ -436,6 +440,7 @@ export function OperatorValueSelect({
                             key={propertyKey}
                             propertyKey={propertyKey}
                             endpoint={endpoint}
+                            staticValues={staticValues}
                             operator={currentOperator || PropertyOperator.Exact}
                             placeholder={placeholder}
                             value={value}

--- a/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/OperatorValueSelect.tsx
@@ -149,7 +149,7 @@ export interface OperatorValueSelectProps {
      * **/
     forceSingleSelect?: boolean
     /** Statically known value suggestions, replacing API-fetched ones. See `PropertyValueProps.staticValues`. */
-    staticValues?: PropValue[]
+    staticValues?: PropValue[] | null
 }
 
 interface OperatorSelectProps extends Omit<LemonSelectProps<any>, 'options'> {

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.test.tsx
@@ -222,6 +222,33 @@ describe('PropertyValue', () => {
         expect(input).toHaveValue('7.8')
     })
 
+    it('renders static values without fetching from the API', async () => {
+        // Guards the staticValues escape hatch: consumers whose events are not in
+        // ClickHouse (e.g. internal events) must get their statically known values,
+        // not values of same-named properties fetched from the events table.
+        render(
+            <Provider>
+                <PropertyValue
+                    propertyKey="scope"
+                    type={PropertyFilterType.Event}
+                    operator={PropertyOperator.Exact}
+                    onSet={jest.fn()}
+                    value={[]}
+                    staticValues={[{ name: 'FeatureFlag' }, { name: 'Insight' }]}
+                />
+            </Provider>
+        )
+
+        userEvent.click(screen.getByRole('textbox'))
+
+        expect(await screen.findByText('FeatureFlag')).toBeInTheDocument()
+        expect(screen.getByText('Insight')).toBeInTheDocument()
+
+        // Flush the load debounce window to catch a stray fetch
+        await new Promise((r) => setTimeout(r, 350))
+        expect(loadPropertyValuesSpy).not.toHaveBeenCalled()
+    })
+
     it('renders a group `id` filter with the generic value editor, not the group-name picker', () => {
         // Reverting the editor swap for `id` is the regression fix: a group property
         // named `id` must keep its normal value input (GroupKeySelect, used only for

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -67,7 +67,7 @@ export interface PropertyValueProps {
      * which matters for properties whose values can't be sourced from the events table
      * (e.g. internal events, which are never ingested into ClickHouse).
      */
-    staticValues?: PropValue[]
+    staticValues?: PropValue[] | null
 }
 
 export function PropertyValue({
@@ -90,7 +90,7 @@ export function PropertyValue({
     forceSingleSelect = false,
     validationError = null,
     showInlineValidationErrors = false,
-    staticValues = undefined,
+    staticValues = null,
 }: PropertyValueProps): JSX.Element {
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)

--- a/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/PropertyValue.tsx
@@ -36,6 +36,7 @@ import { toString } from 'lib/utils/strings'
 import {
     PROPERTY_FILTER_TYPES_WITH_ALL_TIME_SUGGESTIONS,
     PROPERTY_FILTER_TYPES_WITH_TEMPORAL_SUGGESTIONS,
+    PropValue,
     propertyDefinitionsModel,
 } from '~/models/propertyDefinitionsModel'
 import { ErrorTrackingIssueAssignee } from '~/queries/schema/schema-general'
@@ -61,6 +62,12 @@ export interface PropertyValueProps {
     forceSingleSelect?: boolean
     validationError?: string | null
     showInlineValidationErrors?: boolean
+    /**
+     * Statically known value suggestions. When set, no values are fetched from the API,
+     * which matters for properties whose values can't be sourced from the events table
+     * (e.g. internal events, which are never ingested into ClickHouse).
+     */
+    staticValues?: PropValue[]
 }
 
 export function PropertyValue({
@@ -83,6 +90,7 @@ export function PropertyValue({
     forceSingleSelect = false,
     validationError = null,
     showInlineValidationErrors = false,
+    staticValues = undefined,
 }: PropertyValueProps): JSX.Element {
     const { formatPropertyValueForDisplay, describeProperty, options } = useValues(propertyDefinitionsModel)
     const { loadPropertyValues } = useActions(propertyDefinitionsModel)
@@ -136,8 +144,12 @@ export function PropertyValue({
     }>({ set: new Set(), orderedKeys: [] })
     const currentSearchInput = useRef<string>('')
 
+    const hasStaticValues = !!staticValues
     const load = useCallback(
         (newInput: string | undefined): void => {
+            if (hasStaticValues) {
+                return
+            }
             currentSearchInput.current = newInput || ''
             loadPropertyValues({
                 endpoint,
@@ -148,7 +160,7 @@ export function PropertyValue({
                 properties: [],
             })
         },
-        [loadPropertyValues, endpoint, propertyDefinitionType, propertyKey, eventNames]
+        [loadPropertyValues, endpoint, propertyDefinitionType, propertyKey, eventNames, hasStaticValues]
     )
 
     const setValue = (newValue: PropertyValueProps['value']): void => onSet(newValue)
@@ -224,6 +236,9 @@ export function PropertyValue({
 
     // show suggested values first, then any other available options that aren't in the suggested list
     const displayOptions = useMemo(() => {
+        if (staticValues) {
+            return staticValues
+        }
         const options = propertyOptions?.values || []
         if (initialSuggestedValues.set.size === 0) {
             return options
@@ -255,7 +270,7 @@ export function PropertyValue({
         }
 
         return [...suggestedOptions, ...otherOptions]
-    }, [propertyOptions?.values, initialSuggestedValues])
+    }, [propertyOptions?.values, initialSuggestedValues, staticValues])
 
     const onSearchTextChange = (newInput: string): void => {
         const trimmedInput = newInput.trim()
@@ -409,34 +424,40 @@ export function PropertyValue({
     // Disable comma splitting for user agent properties that contain commas in their values
     const isUserAgentProperty = ['$raw_user_agent', '$initial_raw_user_agent', '$user_agent'].includes(propertyKey)
 
-    const suggestionsLabel = PROPERTY_FILTER_TYPES_WITH_TEMPORAL_SUGGESTIONS.includes(type)
-        ? 'Suggested values (last 7 days)'
-        : PROPERTY_FILTER_TYPES_WITH_ALL_TIME_SUGGESTIONS.includes(type)
-          ? 'Suggested values'
-          : null
+    const suggestionsLabel = staticValues
+        ? staticValues.length > 0
+            ? 'Suggested values'
+            : null
+        : PROPERTY_FILTER_TYPES_WITH_TEMPORAL_SUGGESTIONS.includes(type)
+          ? 'Suggested values (last 7 days)'
+          : PROPERTY_FILTER_TYPES_WITH_ALL_TIME_SUGGESTIONS.includes(type)
+            ? 'Suggested values'
+            : null
     const refreshDisabledReason =
         propertyOptions?.status === 'loading' ? 'Loading values…' : isRefreshing ? 'Refreshing values…' : undefined
     const titleNode = suggestionsLabel ? (
         <span className="flex justify-between items-center gap-4">
             {suggestionsLabel}
-            <LemonButton
-                size="xsmall"
-                icon={<IconRefresh />}
-                tooltip="Refresh values"
-                disabledReason={refreshDisabledReason}
-                onClick={() =>
-                    loadPropertyValues({
-                        endpoint,
-                        type: propertyDefinitionType,
-                        newInput: currentSearchInput.current || undefined,
-                        propertyKey,
-                        eventNames,
-                        properties: [],
-                        refresh: 'force_blocking',
-                    })
-                }
-                noPadding
-            />
+            {!staticValues && (
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconRefresh />}
+                    tooltip="Refresh values"
+                    disabledReason={refreshDisabledReason}
+                    onClick={() =>
+                        loadPropertyValues({
+                            endpoint,
+                            type: propertyDefinitionType,
+                            newInput: currentSearchInput.current || undefined,
+                            propertyKey,
+                            eventNames,
+                            properties: [],
+                            refresh: 'force_blocking',
+                        })
+                    }
+                    noPadding
+                />
+            )}
         </span>
     ) : undefined
 
@@ -445,11 +466,11 @@ export function PropertyValue({
             <LemonInputSelect
                 className={inputClassName}
                 data-attr="prop-val"
-                loading={propertyOptions?.status === 'loading' || isRefreshing}
+                loading={!staticValues && (propertyOptions?.status === 'loading' || isRefreshing)}
                 value={formattedValues}
                 mode={isMultiSelect ? 'multiple' : 'single'}
                 singleValueAsSnack
-                allowCustomValues={propertyOptions?.allowCustomValues ?? true}
+                allowCustomValues={staticValues ? true : (propertyOptions?.allowCustomValues ?? true)}
                 inputTransform={
                     shouldRestrictToNumericInput
                         ? (input: string) => {

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -91,6 +91,7 @@ export function TaxonomicPropertyFilter({
     endpointFilters,
     hogQLGlobals,
     triggerVariant = 'button',
+    staticValueOptions,
 }: PropertyFilterInternalProps): JSX.Element {
     const generatedKey = useId()
     const pageKey = pageKeyInput || `filter-${generatedKey}`
@@ -216,6 +217,7 @@ export function TaxonomicPropertyFilter({
                       })}`
                     : filter?.key && activeTaxonomicGroup?.valuesEndpoint?.(filter.key)
             }
+            staticValues={typeof filter?.key === 'string' ? staticValueOptions?.(filter.key) : undefined}
             eventNames={eventNames}
             addRelativeDateTimeOptions={allowRelativeDateOptions}
             onChange={(newOperator, newValue) => {

--- a/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
+++ b/frontend/src/lib/components/PropertyFilters/components/TaxonomicPropertyFilter.tsx
@@ -217,7 +217,7 @@ export function TaxonomicPropertyFilter({
                       })}`
                     : filter?.key && activeTaxonomicGroup?.valuesEndpoint?.(filter.key)
             }
-            staticValues={typeof filter?.key === 'string' ? staticValueOptions?.(filter.key) : undefined}
+            staticValues={typeof filter?.key === 'string' ? (staticValueOptions?.(filter.key) ?? null) : null}
             eventNames={eventNames}
             addRelativeDateTimeOptions={allowRelativeDateOptions}
             onChange={(newOperator, newValue) => {

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -77,8 +77,8 @@ export interface PropertyFilterInternalProps {
     triggerVariant?: 'button' | 'input'
     /**
      * Statically known value suggestions per property key, replacing API-fetched ones.
-     * Return an empty array to disable suggestions for a key, or undefined to fall back
+     * Return an empty array to disable suggestions for a key, or null to fall back
      * to the default behavior. See `PropertyValueProps.staticValues`.
      */
-    staticValueOptions?: (propertyKey: string) => PropValue[] | undefined
+    staticValueOptions?: (propertyKey: string) => PropValue[] | null
 }

--- a/frontend/src/lib/components/PropertyFilters/types.ts
+++ b/frontend/src/lib/components/PropertyFilters/types.ts
@@ -10,6 +10,7 @@ import {
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
 
+import { PropValue } from '~/models/propertyDefinitionsModel'
 import { AnyDataNode, DatabaseSchemaField } from '~/queries/schema/schema-general'
 import { AnyPropertyFilter, FilterLogicalOperator, PropertyGroupFilter } from '~/types'
 
@@ -74,4 +75,10 @@ export interface PropertyFilterInternalProps {
      * (`TAXONOMIC_FILTER_MENU_REBUILD`).
      */
     triggerVariant?: 'button' | 'input'
+    /**
+     * Statically known value suggestions per property key, replacing API-fetched ones.
+     * Return an empty array to disable suggestions for a key, or undefined to fall back
+     * to the default behavior. See `PropertyValueProps.staticValues`.
+     */
+    staticValueOptions?: (propertyKey: string) => PropValue[] | undefined
 }

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.test.ts
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.test.ts
@@ -1,0 +1,20 @@
+import { getProductEventPropertyValues } from './HogFunctionFiltersInternal'
+
+describe('getProductEventPropertyValues', () => {
+    it('suggests all activity scopes for the activity-log scope property', () => {
+        const values = getProductEventPropertyValues('activity-log', 'scope')
+
+        expect(values).toEqual(expect.arrayContaining([{ name: 'FeatureFlag' }, { name: 'Insight' }]))
+    })
+
+    it.each([
+        // Keys without a statically known value set must suppress suggestions entirely,
+        // because the events-table fallback would surface values from unrelated analytics events
+        { contextId: 'activity-log' as const, propertyKey: 'detail.name', expected: [] },
+        // Non-internal contexts keep the default events-table suggestions
+        { contextId: 'error-tracking' as const, propertyKey: '$exception_types', expected: undefined },
+        { contextId: 'standard' as const, propertyKey: 'scope', expected: undefined },
+    ])('returns $expected for $propertyKey in the $contextId context', ({ contextId, propertyKey, expected }) => {
+        expect(getProductEventPropertyValues(contextId, propertyKey)).toEqual(expected)
+    })
+})

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.test.ts
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.test.ts
@@ -4,7 +4,11 @@ describe('getProductEventPropertyValues', () => {
     it('suggests all activity scopes for the activity-log scope property', () => {
         const values = getProductEventPropertyValues('activity-log', 'scope')
 
-        expect(values).toEqual(expect.arrayContaining([{ name: 'FeatureFlag' }, { name: 'Insight' }]))
+        // ExperimentHoldout only exists in the generated backend-sourced enum, so it
+        // catches a regression to the handwritten frontend ActivityScope enum
+        expect(values).toEqual(
+            expect.arrayContaining([{ name: 'FeatureFlag' }, { name: 'Insight' }, { name: 'ExperimentHoldout' }])
+        )
     })
 
     it.each([
@@ -12,8 +16,8 @@ describe('getProductEventPropertyValues', () => {
         // because the events-table fallback would surface values from unrelated analytics events
         { contextId: 'activity-log' as const, propertyKey: 'detail.name', expected: [] },
         // Non-internal contexts keep the default events-table suggestions
-        { contextId: 'error-tracking' as const, propertyKey: '$exception_types', expected: undefined },
-        { contextId: 'standard' as const, propertyKey: 'scope', expected: undefined },
+        { contextId: 'error-tracking' as const, propertyKey: '$exception_types', expected: null },
+        { contextId: 'standard' as const, propertyKey: 'scope', expected: null },
     ])('returns $expected for $propertyKey in the $contextId context', ({ contextId, propertyKey, expected }) => {
         expect(getProductEventPropertyValues(contextId, propertyKey)).toEqual(expected)
     })

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -129,6 +129,17 @@ export const getProductEventPropertyFilterOptions = (contextId: HogFunctionConfi
     return []
 }
 
+// Hoisted so repeated calls return stable references, keeping downstream memos idle.
+// The generated enum mirrors the backend ActivityScope literal, unlike the handwritten
+// frontend ActivityScope enum, which lags behind it.
+const ACTIVITY_LOG_SCOPE_VALUES: PropValue[] = Object.values(ActivityLogListScope)
+    .sort()
+    .map((name) => ({ name }))
+// The standard lifecycle activities. Scopes also log custom activities (e.g. 'exported'),
+// which can still be entered as custom values.
+const ACTIVITY_LOG_ACTIVITY_VALUES: PropValue[] = ['created', 'updated', 'deleted'].map((name) => ({ name }))
+const NO_SUGGESTED_VALUES: PropValue[] = []
+
 /**
  * Value suggestions for the property filters on the 'Trigger' field. Internal events are
  * never ingested into ClickHouse, so the default events-table suggestions would surface
@@ -144,17 +155,11 @@ export const getProductEventPropertyValues = (
     }
     switch (propertyKey) {
         case 'scope':
-            // The generated enum mirrors the backend ActivityScope literal, unlike the
-            // handwritten frontend ActivityScope enum, which lags behind it
-            return Object.values(ActivityLogListScope)
-                .sort()
-                .map((name) => ({ name }))
+            return ACTIVITY_LOG_SCOPE_VALUES
         case 'activity':
-            // The standard lifecycle activities. Scopes also log custom activities (e.g.
-            // 'exported'), which can still be entered as custom values.
-            return ['created', 'updated', 'deleted'].map((name) => ({ name }))
+            return ACTIVITY_LOG_ACTIVITY_VALUES
         default:
-            return []
+            return NO_SUGGESTED_VALUES
     }
 }
 

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -10,7 +10,9 @@ import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
 
 import { PropValue } from '~/models/propertyDefinitionsModel'
-import { ActivityScope, AnyPropertyFilter, CyclotronJobFiltersType, HogFunctionConfigurationContextId } from '~/types'
+import { AnyPropertyFilter, CyclotronJobFiltersType, HogFunctionConfigurationContextId } from '~/types'
+
+import { ActivityLogListScope } from 'products/platform_features/frontend/generated/api.schemas'
 
 import { hogFunctionConfigurationLogic } from '../configuration/hogFunctionConfigurationLogic'
 
@@ -136,13 +138,15 @@ export const getProductEventPropertyFilterOptions = (contextId: HogFunctionConfi
 export const getProductEventPropertyValues = (
     contextId: HogFunctionConfigurationContextId,
     propertyKey: string
-): PropValue[] | undefined => {
+): PropValue[] | null => {
     if (contextId !== 'activity-log') {
-        return undefined
+        return null
     }
     switch (propertyKey) {
         case 'scope':
-            return Object.values(ActivityScope)
+            // The generated enum mirrors the backend ActivityScope literal, unlike the
+            // handwritten frontend ActivityScope enum, which lags behind it
+            return Object.values(ActivityLogListScope)
                 .sort()
                 .map((name) => ({ name }))
         case 'activity':
@@ -188,7 +192,7 @@ export function HogFunctionFiltersInternal(): JSX.Element {
 
     const staticValueOptions = useMemo(
         () =>
-            (propertyKey: string): PropValue[] | undefined =>
+            (propertyKey: string): PropValue[] | null =>
                 getProductEventPropertyValues(contextId, propertyKey),
         [contextId]
     )

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -9,7 +9,8 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { Link } from 'lib/lemon-ui/Link'
 import { urls } from 'scenes/urls'
 
-import { AnyPropertyFilter, CyclotronJobFiltersType, HogFunctionConfigurationContextId } from '~/types'
+import { PropValue } from '~/models/propertyDefinitionsModel'
+import { ActivityScope, AnyPropertyFilter, CyclotronJobFiltersType, HogFunctionConfigurationContextId } from '~/types'
 
 import { hogFunctionConfigurationLogic } from '../configuration/hogFunctionConfigurationLogic'
 
@@ -126,6 +127,33 @@ export const getProductEventPropertyFilterOptions = (contextId: HogFunctionConfi
     return []
 }
 
+/**
+ * Value suggestions for the property filters on the 'Trigger' field. Internal events are
+ * never ingested into ClickHouse, so the default events-table suggestions would surface
+ * values of same-named properties from unrelated analytics events. Instead, offer the
+ * statically known values, and no suggestions (free text) for keys without a known value set.
+ */
+export const getProductEventPropertyValues = (
+    contextId: HogFunctionConfigurationContextId,
+    propertyKey: string
+): PropValue[] | undefined => {
+    if (contextId !== 'activity-log') {
+        return undefined
+    }
+    switch (propertyKey) {
+        case 'scope':
+            return Object.values(ActivityScope)
+                .sort()
+                .map((name) => ({ name }))
+        case 'activity':
+            // The standard lifecycle activities. Scopes also log custom activities (e.g.
+            // 'exported'), which can still be entered as custom values.
+            return ['created', 'updated', 'deleted'].map((name) => ({ name }))
+        default:
+            return []
+    }
+}
+
 const getSimpleFilterValue = (value?: CyclotronJobFiltersType): string | undefined => {
     return value?.events?.[0]?.id
 }
@@ -157,6 +185,13 @@ export function HogFunctionFiltersInternal(): JSX.Element {
     const { contextId } = useValues(hogFunctionConfigurationLogic)
 
     const options = useMemo(() => getProductEventFilterOptions(contextId), [contextId])
+
+    const staticValueOptions = useMemo(
+        () =>
+            (propertyKey: string): PropValue[] | undefined =>
+                getProductEventPropertyValues(contextId, propertyKey),
+        [contextId]
+    )
 
     const taxonomicGroupTypes = useMemo(() => {
         if (contextId === 'error-tracking') {
@@ -204,6 +239,7 @@ export function HogFunctionFiltersInternal(): JSX.Element {
                                 pageKey={`hog-function-internal-property-filters-${contextId}`}
                                 buttonSize="small"
                                 disablePopover
+                                staticValueOptions={staticValueOptions}
                             />
                         ) : null}
                     </>


### PR DESCRIPTION
## Problem

When configuring an internal destination like "HTTP Webhook on team activity", filtering the trigger on `scope` suggests values that never occur on team activity events, and real scopes like `FeatureFlag` are missing entirely.

- Internal events (`$activity_log_entry_created`) are produced straight to the CDP topic and are never ingested into ClickHouse.
- The value picker still queried `api/event/values`, so it surfaced values of same-named properties from unrelated analytics events.

## Changes

- The `scope` filter now suggests the known `ActivityScope` values, and `activity` suggests `created`/`updated`/`deleted`; both still accept custom values.
- Other activity-log keys stop fetching suggestions from the events table and fall back to free-text input.
- Mechanism: an optional `staticValueOptions` prop threaded `PropertyFilters` → `TaxonomicPropertyFilter` → `OperatorValueSelect` → `PropertyValue`; pickers that don't pass it are unchanged.

## How did you test this code?

- New Jest test: `PropertyValue` with `staticValues` renders them and never dispatches `loadPropertyValues`, catching the static path regressing to an API fetch.
- New Jest test: `getProductEventPropertyValues` keeps `FeatureFlag` in `scope` suggestions and returns `undefined` outside the activity-log context, so other contexts keep API suggestions.
- Both suites (including the pre-existing `PropertyValue` tests) pass locally; `oxlint`/`oxfmt` and `hogli ci:preflight --fix` are clean.
- Frontend typecheck introduces no new errors (pre-existing quill-related errors on master are unchanged).
- Not done: manual verification in a running app, so no screenshot of the fixed dropdown.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — behavior fix, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by PostHog Code (Claude Code) from a report that feature flags were missing from this screen's suggested values; diagnosed by confirming activity-log internal events never reach the events table the picker was querying.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- Considered a backend endpoint serving per-team scopes from the activity log instead; chose static enum suggestions because trigger config should offer scopes before any matching activity exists, and it avoids new API surface.
- The requester couldn't be resolved to a verified GitHub handle from this session, so the PR is left unassigned.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
