### PR TITLE
fix(marketing-analytics): target precompute flags at the project group

### DIFF
--- a/posthog/hogql/database/schema/marketing_costs_precomputed.py
+++ b/posthog/hogql/database/schema/marketing_costs_precomputed.py
@@ -7,6 +7,8 @@ from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.models import DateTimeDatabaseField, FieldOrTable, LazyTable, LazyTableToAdd
 from posthog.hogql.database.schema.marketing_costs_preaggregated import MarketingCostsPreaggregatedTable
 
+from products.marketing_analytics.backend.hogql_queries.flag_targeting import team_flag_target
+
 if TYPE_CHECKING:
     from posthog.models.team import Team
 
@@ -47,13 +49,13 @@ def costs_dedup_v2_enabled(team: "Team | None") -> bool:
     cached = getattr(team, _FLAG_CACHE_ATTR, None)
     if cached is not None:
         return cached
-    organization = team.organization
+    distinct_id, groups, group_properties = team_flag_target(team)
     enabled = bool(
         posthoganalytics.feature_enabled(
             COSTS_DEDUP_V2_FLAG,
-            str(team.uuid),
-            groups={"organization": str(organization.id)},
-            group_properties={"organization": {"id": str(organization.id)}},
+            distinct_id,
+            groups=groups,
+            group_properties=group_properties,
             only_evaluate_locally=True,
             send_feature_flag_events=False,
         )

--- a/products/marketing_analytics/backend/hogql_queries/flag_targeting.py
+++ b/products/marketing_analytics/backend/hogql_queries/flag_targeting.py
@@ -1,0 +1,31 @@
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from posthog.models.team import Team
+
+# Kept free of intra-product imports so both `marketing_analytics_config` and
+# `marketing_lazy_precompute` can use it without an import cycle.
+
+
+def team_flag_target(team: "Team") -> tuple[str, dict[str, str | int], dict[str, dict[str, Any]]]:
+    """`(distinct_id, groups, group_properties)` for a team-scoped marketing analytics rollout flag.
+
+    Conditions on these flags must be organization or project *group* conditions: the distinct
+    id is a team uuid with no person behind it, so a person or cohort condition is unresolvable
+    and the flag keeps whatever the release conditions say for everyone. Turning such a flag off
+    for a single user therefore has no effect on the query path at all.
+
+    The project group is what makes a single-project opt-out possible — with only the
+    organization group, the narrowest kill switch is the whole org.
+    """
+    return (
+        str(team.uuid),
+        {
+            "organization": str(team.organization_id),
+            "project": str(team.id),
+        },
+        {
+            "organization": {"id": str(team.organization_id)},
+            "project": {"id": str(team.id)},
+        },
+    )

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_config.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_config.py
@@ -33,6 +33,7 @@ from .constants import (
     TOTAL_REPORTED_CONVERSION_VALUE_FIELD,
     UNIFIED_CONVERSION_GOALS_CTE_ALIAS,
 )
+from .flag_targeting import team_flag_target
 
 logger = structlog.get_logger(__name__)
 
@@ -116,7 +117,8 @@ class MarketingAnalyticsConfig:
         flag ~6 times. The team model instance is shared across the runners of a query, so caching on it
         dedupes the evaluation to once per load without leaking across requests (a fresh team is loaded per
         request). The multi-touch flag is evaluated separately (see `_multi_touch_enabled`) so single-touch
-        modes never trigger its evaluation.
+        modes never trigger its evaluation. See `team_flag_target` for why conditions on these flags
+        have to be group conditions.
 
         Test authors: the cache lives on the team instance (`team._ma_precompute_flags`, and
         `team._ma_multi_touch_flag`). A test that reuses the same team across cases (e.g. class-level setup)
@@ -126,18 +128,17 @@ class MarketingAnalyticsConfig:
         cached = getattr(team, "_ma_precompute_flags", None)
         if cached is not None:
             return cached
-        groups = {"organization": str(team.organization.id)}
-        group_properties = {"organization": {"id": str(team.organization.id)}}
+        distinct_id, groups, group_properties = team_flag_target(team)
         flags = {
             "conversion": feature_enabled_or_false(
                 "marketing-analytics-precomputation",
-                str(team.uuid),
+                distinct_id,
                 groups=groups,
                 group_properties=group_properties,
             ),
             "costs": feature_enabled_or_false(
                 "marketing-analytics-costs-precomputation",
-                str(team.uuid),
+                distinct_id,
                 groups=groups,
                 group_properties=group_properties,
             ),
@@ -156,11 +157,12 @@ class MarketingAnalyticsConfig:
         cached = getattr(team, "_ma_multi_touch_flag", None)
         if cached is not None:
             return cached
+        distinct_id, groups, group_properties = team_flag_target(team)
         enabled = feature_enabled_or_false(
             "marketing-analytics-multi-touch-attribution",
-            str(team.uuid),
-            groups={"organization": str(team.organization.id)},
-            group_properties={"organization": {"id": str(team.organization.id)}},
+            distinct_id,
+            groups=groups,
+            group_properties=group_properties,
         )
         team._ma_multi_touch_flag = enabled  # type: ignore[attr-defined]
         return enabled

--- a/products/marketing_analytics/backend/hogql_queries/marketing_lazy_precompute.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_lazy_precompute.py
@@ -37,6 +37,7 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     ensure_precomputed,
 )
 from products.analytics_platform.backend.lazy_computation.stale_policy import resolve_stale_while_revalidate_seconds
+from products.marketing_analytics.backend.hogql_queries.flag_targeting import team_flag_target
 
 logger = structlog.get_logger(__name__)
 
@@ -107,11 +108,12 @@ def serve_stale_enabled(team: Team) -> bool:
     cached = getattr(team, "_ma_serve_stale_flag", None)
     if cached is not None:
         return cached
+    distinct_id, groups, group_properties = team_flag_target(team)
     enabled = feature_enabled_or_false(
         SERVE_STALE_FLAG,
-        str(team.uuid),
-        groups={"organization": str(team.organization.id)},
-        group_properties={"organization": {"id": str(team.organization.id)}},
+        distinct_id,
+        groups=groups,
+        group_properties=group_properties,
     )
     team._ma_serve_stale_flag = enabled  # type: ignore[attr-defined]
     return enabled

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_config.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_config.py
@@ -84,6 +84,24 @@ class TestMarketingAnalyticsConfig(BaseTest):
         assert config.attribution_mode == AttributionMode.FIRST_TOUCH
         assert self._multi_touch_flag_calls(mock_ff) == []
 
+    @patch(
+        "products.marketing_analytics.backend.hogql_queries.marketing_analytics_config.feature_enabled_or_false",
+        return_value=True,
+    )
+    def test_from_team_targets_flags_at_the_project_group(self, mock_ff):
+        # Without the project group, the narrowest way to opt a customer out of precompute is the
+        # whole organization, and a person-level override does nothing at all (the distinct id is a
+        # team uuid with no person behind it).
+        self._set_attribution_mode(AttributionMode.LINEAR)
+        MarketingAnalyticsConfig.from_team(self.team)
+
+        assert mock_ff.call_args_list, "expected the precompute and multi-touch flags to be evaluated"
+        for call in mock_ff.call_args_list:
+            assert call.args[1] == str(self.team.uuid)
+            assert call.kwargs["groups"]["project"] == str(self.team.id)
+            assert call.kwargs["groups"]["organization"] == str(self.team.organization_id)
+            assert call.kwargs["group_properties"]["project"] == {"id": str(self.team.id)}
+
     def test_is_multi_touch_property(self):
         config = MarketingAnalyticsConfig()
 

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py
@@ -307,6 +307,20 @@ class TestMarketingCostsPrecompute(ClickhouseTestMixin, BaseTest):
                 f"deduped row should carry the latest {label_column} '{post_value}', not the stale '{pre_value}'"
             )
 
+    @patch("posthog.hogql.database.schema.marketing_costs_precomputed.posthoganalytics.feature_enabled")
+    def test_costs_dedup_v2_flag_is_targeted_at_the_project_group(self, feature_enabled):
+        # This flag is the switch that stops a renamed campaign from double-counting its cost, so it has to
+        # be enableable for one affected project. With only the organization group it is all-or-nothing per
+        # org, and a person-level override is silently ignored (the distinct id is a team uuid).
+        from posthog.hogql.database.schema.marketing_costs_precomputed import costs_dedup_v2_enabled
+
+        feature_enabled.return_value = True
+        assert costs_dedup_v2_enabled(self.team) is True
+
+        assert feature_enabled.call_args.args[1] == str(self.team.uuid)
+        assert feature_enabled.call_args.kwargs["groups"]["project"] == str(self.team.id)
+        assert feature_enabled.call_args.kwargs["group_properties"]["project"] == {"id": str(self.team.id)}
+
     def test_one_unmaterializable_source_does_not_force_all_to_s3(self):
         # One source materializes, one can't. The result must read the native table for the materialized
         # source and keep only the other on the live S3 union — not fall back to S3 for everything.

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_lazy_precompute.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_lazy_precompute.py
@@ -94,6 +94,22 @@ class TestMarketingLazyPrecompute(BaseTest):
 
         assert flag_eval.call_count == 1
 
+    @mock.patch(f"{_MODULE}.ensure_precomputed")
+    @mock.patch(f"{_MODULE}.feature_enabled_or_false")
+    def test_flag_is_targeted_at_the_project_group(self, flag_eval, mock_ensure):
+        # The kill switch has to be flippable for one project. With only the organization group it is
+        # all-or-nothing per org, and a person-level override is silently ignored (the distinct id is a
+        # team uuid with no person behind it).
+        del self.team._ma_serve_stale_flag  # type: ignore[attr-defined]
+        flag_eval.return_value = True
+        mock_ensure.return_value = LazyComputationResult(ready=True, job_ids=[])
+
+        marketing_ensure_precomputed(team=self.team, ttl_seconds={"default": 3600}, table=None)
+
+        assert flag_eval.call_args.args[1] == str(self.team.uuid)
+        assert flag_eval.call_args.kwargs["groups"]["project"] == str(self.team.id)
+        assert flag_eval.call_args.kwargs["group_properties"]["project"] == {"id": str(self.team.id)}
+
     @mock.patch(_DELAY)
     def test_handle_stale_served_tags_read_and_debounces_same_shape(self, delay):
         # A dashboard renders several tiles off one query shape and they go stale together. Each stale


### PR DESCRIPTION
## Problem

Team-scoped marketing analytics flags are evaluated with `distinct_id = str(team.uuid)` and **only** an `organization` group. Two things fall out of that:

1. There is no person behind a team uuid, so a person-level release condition or override is unresolvable. Turning one of these flags off (or on) "for a user" cannot affect the query path at all.
2. With only the organization group, the narrowest available kill switch is the entire org. There is no way to change the behaviour for a single project.

This bit us on a real report. A customer had costs coming back doubled through the MCP/API path. The switch that fixes that class of doubling — `marketing-analytics-costs-dedup-v2`, which folds renamable display labels into the dedup view's `argMax` so a renamed campaign stops splitting its cell — could not be enabled for just their project. Meanwhile the console's cost chart tile gates on the *logged-in user's* flag (`costsPrecomputeEnabled` in `marketingAnalyticsTilesLogic.ts`), so per-user overrides visibly change the console while every API and MCP caller keeps reading the precompute untouched. That divergence is what made this look already-fixed from the console.

Web analytics already passes both groups (`products/web_analytics/backend/hogql_queries/first_pageview_flag.py`), and its docstring spells out the group-conditions-only constraint. Marketing analytics didn't.

## Changes

New `flag_targeting.team_flag_target(team)` returning `(distinct_id, groups, group_properties)` with both the organization **and** project groups, plus a docstring naming the trap. Used at every team-scoped marketing analytics flag evaluation:

| Flag | Call site |
| --- | --- |
| `marketing-analytics-precomputation` | `MarketingAnalyticsConfig._precompute_flags` |
| `marketing-analytics-costs-precomputation` | `MarketingAnalyticsConfig._precompute_flags` |
| `marketing-analytics-multi-touch-attribution` | `MarketingAnalyticsConfig._multi_touch_enabled` |
| `marketing-analytics-serve-stale` | `marketing_lazy_precompute.serve_stale_enabled` |
| `marketing-analytics-costs-dedup-v2` | `marketing_costs_precomputed.costs_dedup_v2_enabled` |

Behaviour is otherwise untouched: same per-team-instance caching, same fail-safe semantics. This only widens the targeting payload so a project group condition becomes evaluable.

The Dagster warmer goes through `from_team`, so the read path and the warmer still agree on what gets materialized.

> [!NOTE]
> No behaviour change for existing flag configurations. Flags targeted by organization group or by a global rollout keep evaluating exactly as before. The new capability is that a project group condition now works.

The dedup-v2 call site lives in `posthog/hogql/database/schema/`, so it imports the helper from `products/`. That direction is already established — `posthog/hogql_queries/query_runner.py` imports `first_pageview_flag` from `products/web_analytics` the same way — and `flag_targeting` is deliberately free of intra-product imports so it can't create a cycle.

## How did you test this code?

I (actually Claude) added three regression tests, each of which fails on master with a `KeyError: 'project'`:

- `test_marketing_analytics_config.py::test_from_team_targets_flags_at_the_project_group`
- `test_marketing_lazy_precompute.py::test_flag_is_targeted_at_the_project_group`
- `test_marketing_costs_precompute.py::test_costs_dedup_v2_flag_is_targeted_at_the_project_group`

Each asserts the flag call carries the project group in both `groups` and `group_properties`, and that the distinct id is still the team uuid.

Ran locally, all green:

```
pytest products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_config.py \
       products/marketing_analytics/backend/hogql_queries/test_marketing_lazy_precompute.py \
       products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py \
       products/marketing_analytics/dags/tests/test_marketing_precompute.py
64 passed
```

Also verified `costs_dedup_v2_enabled` still imports cleanly under Django setup (no import cycle from the new `posthog/hogql` → `products/` edge).

I have not exercised the end-to-end flag path against a real project. To verify after this ships: add a project group condition on `marketing-analytics-costs-dedup-v2` for the affected project and confirm the doubled costs collapse.

## Follow-ups (not in this PR)

- `costsPrecomputeEnabled` in `marketingAnalyticsTilesLogic.ts` decides with the user's flag while the server decides by team. That divergence is what makes the console look fixed while API/MCP callers are not. Worth its own PR.
- `marketing-analytics-costs-dedup-v2` is still opt-in. Given it fixes a systematic 2x, it's worth asking whether the legacy grouping should stay reachable at all once it's been on for a while.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation and implementation by Claude (PostHog Code) under my direction, starting from a customer report that marketing analytics costs coming back through the MCP tools were doubled after a flag had been changed. Claude traced the read path from the MCP tools through `MarketingAnalyticsBaseQueryRunner` to the flag evaluations and found the team-uuid distinct id with no project group, then compared against how web analytics targets the equivalent rollout flags. The `costs_dedup_v2` call site lives outside `products/marketing_analytics`, so it was missed on the first pass and added in the second commit once the doubling symptom pointed at it.

Considered and rejected for this PR: adding a `precompute_disabled` column on `MarketingAnalyticsConfig` as an explicit kill switch (a migration for something the flag system can already express once the project group is passed), and fixing the frontend/server gate divergence in the same change (separable, and the frontend one is cosmetic by comparison).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
