### PR TITLE
feat(desktop/spaces): give pinned sessions their own section

### DIFF
--- a/products/desktop/packages/core/src/canvas/channelItems.test.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.test.ts
@@ -72,6 +72,31 @@ describe("buildChannelItems", () => {
     expect(items.map((i) => i.key)).toEqual(["task:new", "canvas:old"]);
   });
 
+  it("orders a session by its last run, not by its record's own stamp", () => {
+    const items = build({
+      feedTasks: [
+        task({ id: "renamed", updated_at: new Date(5_000).toISOString() }),
+        task({
+          id: "running",
+          updated_at: new Date(1_000).toISOString(),
+          latest_run: { updated_at: new Date(9_000).toISOString() } as never,
+        }),
+      ],
+    });
+    expect(items.map((i) => i.key)).toEqual(["task:running", "task:renamed"]);
+  });
+
+  it("puts a pinned item above a more recent unpinned one", () => {
+    const items = build({
+      feedTasks: [
+        task({ id: "newer", updated_at: new Date(9_000).toISOString() }),
+        task({ id: "pinned", updated_at: new Date(1_000).toISOString() }),
+      ],
+      pinnedTaskIds: new Set(["pinned"]),
+    });
+    expect(items.map((i) => i.key)).toEqual(["task:pinned", "task:newer"]);
+  });
+
   it("drops archived tasks but keeps canvases", () => {
     const items = build({
       dashboards: [canvas()],

--- a/products/desktop/packages/core/src/canvas/channelItems.ts
+++ b/products/desktop/packages/core/src/canvas/channelItems.ts
@@ -10,6 +10,7 @@ export interface ChannelItemModel {
   kind: "task" | "canvas";
   id: string;
   title: string;
+  /** When this last did something. See `taskActivityTs` for a session's. */
   ts: number;
   pinned: boolean;
   rawStatus: TaskRunStatus | null;
@@ -42,6 +43,24 @@ function isOwnedBy(
   owner: ChannelItemOwner,
 ): boolean {
   return item.authorUuid != null && item.authorUuid === owner.uuid;
+}
+
+/**
+ * When a session last did something, which is what "recent" means to whoever is
+ * reading the list — not when its record was last written.
+ *
+ * A turn moves the run: the agent takes it to `in_progress` and back out again,
+ * and each of those saves the run. Nothing in that path touches the task row, so
+ * `task.updated_at` answers "when was the title or description last edited" and
+ * leaves a session that has been running all afternoon sitting below one that
+ * was renamed. The run's own stamp is the closest the list payload gets to the
+ * last turn; the task's still counts, because an edit is activity too.
+ */
+export function taskActivityTs(task: Task): number {
+  return Math.max(
+    Date.parse(task.updated_at) || 0,
+    task.latest_run ? Date.parse(task.latest_run.updated_at) || 0 : 0,
+  );
 }
 
 export function buildChannelItems({
@@ -81,7 +100,7 @@ export function buildChannelItems({
             kind: "task" as const,
             id: task.id,
             title: task.title || "Untitled task",
-            ts: Date.parse(task.updated_at) || 0,
+            ts: taskActivityTs(task),
             pinned: pinnedTaskIds.has(task.id),
             rawStatus: task.latest_run?.status ?? null,
             authorUser: task.created_by ?? null,
@@ -93,7 +112,14 @@ export function buildChannelItems({
         ],
   );
 
-  const all = [...canvasItems, ...taskItems].sort((a, b) => b.ts - a.ts);
+  // Pins first, then recency. A pin is a request not to lose the thing, and
+  // every surface that shows these cuts the list off somewhere — five rows in
+  // the sidebar's tree, `RECENTS_CAP` in a space's own list — so below the
+  // recency order a pinned session falls off the end of the one place it was
+  // pinned to stay.
+  const all = [...canvasItems, ...taskItems].sort(
+    (a, b) => Number(b.pinned) - Number(a.pinned) || b.ts - a.ts,
+  );
   return ownedBy ? all.filter((item) => isOwnedBy(item, ownedBy)) : all;
 }
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -80,7 +80,7 @@ describe("ChannelItemRow", () => {
     [
       // The run says in_progress, but nothing is streaming: a local run never
       // gets a terminal status written, and the cloud one holds in_progress past
-      // the agent. Live, but not moving — the still dot, not the spinner.
+      // the agent. Live, but not moving — the still dot, not the pulsing one.
       "a run claiming progress with nothing in flight",
       { taskRunStatus: "in_progress" as const },
       "Pending — no work in flight",
@@ -169,13 +169,24 @@ describe("ChannelItemRow", () => {
   });
 
   it("shows a task's badges instead of its timestamp", () => {
+    mocks.status = { workspaceMode: "worktree", prState: "merged" };
+
+    renderRow(item());
+
+    expect(screen.getByRole("img", { name: "Local" })).not.toBeNull();
+    expect(screen.getByRole("img", { name: "Merged" })).not.toBeNull();
+    expect(screen.queryByText(formatRelativeTimeShort(item().ts))).toBeNull();
+  });
+
+  it("leaves a cloud task's stack to what it produced", () => {
     mocks.status = { workspaceMode: "cloud", prState: "merged" };
 
     renderRow(item());
 
-    expect(screen.getByRole("img", { name: "Cloud" })).not.toBeNull();
+    // The cloud is where work runs by default, so it goes unmarked; only a
+    // workspace on this machine earns a glyph.
+    expect(screen.queryByRole("img", { name: "Local" })).toBeNull();
     expect(screen.getByRole("img", { name: "Merged" })).not.toBeNull();
-    expect(screen.queryByText(formatRelativeTimeShort(item().ts))).toBeNull();
   });
 
   it("renders a canvas like a quiet task with its glyph in the badge stack", () => {
@@ -194,19 +205,15 @@ describe("ChannelItemRow", () => {
     expect(screen.queryByText(formatRelativeTimeShort(item().ts))).toBeNull();
   });
 
-  it("marks a pinned row with the pin badge, alongside its status badges", () => {
-    mocks.status = { workspaceMode: "cloud" };
+  // Which section a pinned row lands in is the list's decision, not the row's.
+  // All the row owes is that a pin changes nothing about how it draws.
+  it("draws a pinned row exactly like any other", () => {
+    mocks.status = { workspaceMode: "local" };
 
     renderRow(item({ pinned: true }));
 
-    expect(screen.getByRole("img", { name: "Pinned" })).not.toBeNull();
-    expect(screen.getByRole("img", { name: "Cloud" })).not.toBeNull();
-  });
-
-  it("leaves an unpinned row without one", () => {
-    renderRow(item());
-
-    expect(screen.queryByRole("img", { name: "Pinned" })).toBeNull();
+    expect(screen.getByRole("img", { name: "All caught up" })).not.toBeNull();
+    expect(screen.getByRole("img", { name: "Local" })).not.toBeNull();
   });
 
   it("makes tasks draggable into the Command Center", () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.test.tsx
@@ -80,7 +80,7 @@ describe("ChannelItemRow", () => {
     [
       // The run says in_progress, but nothing is streaming: a local run never
       // gets a terminal status written, and the cloud one holds in_progress past
-      // the agent. Live, but not moving — the still dot, not the pulsing one.
+      // the agent. Live, but not moving — the still dot, not the spinner.
       "a run claiming progress with nothing in flight",
       { taskRunStatus: "in_progress" as const },
       "Pending — no work in flight",

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelItemRow.tsx
@@ -26,7 +26,6 @@ import { useChannelTaskStatus } from "@posthog/ui/features/canvas/hooks/useChann
 import { useIsCanvasPendingDelete } from "@posthog/ui/features/canvas/stores/pendingCanvasDeleteStore";
 import { InlineEditInput } from "@posthog/ui/features/sidebar/components/items/TaskItem";
 import {
-  PinnedBadge,
   TaskBadgeStack,
   TaskStatusDot,
   TaskStatusTooltips,
@@ -103,19 +102,12 @@ function RowBadge({ label, children }: { label: string; children: ReactNode }) {
 }
 
 /**
- * A canvas's trailing stack: the pin, then its template glyph. Same stack as a
- * task's badges — a pinned canvas reads the way a pinned task does.
+ * A canvas's trailing stack: its template glyph. Same stack as a task's badges —
+ * and like a task, a pinned canvas says so with the ring on its dot.
  */
-function CanvasBadgeStack({
-  item,
-  pinned,
-}: {
-  item: ChannelItemModel;
-  pinned?: boolean;
-}) {
+function CanvasBadgeStack({ item }: { item: ChannelItemModel }) {
   return (
     <AvatarGroup stacked reverse size="xs" className="shrink-0">
-      {pinned ? <PinnedBadge /> : null}
       <RowBadge label="Canvas">
         {/* Violet is the canvas colour everywhere else it appears — the
             artifacts list, the thread panel, the pinned menu — so the badge says
@@ -231,25 +223,16 @@ export function ChannelItemRow({
         endContent={
           <span className={TRAILING_CLASS}>
             {/* Badges take the timestamp's slot on a task row: the row's
-                      identity (pin, source, cloud, PR) is what you scan a task
-                      list for, and the relative age is still in the preview
-                      card. The pin joins whichever stack the row has, rather
-                      than standing beside it as a badge of its own. */}
+                      identity (source, local, PR) is what you scan a task list
+                      for, and the relative age is still in the preview card. */}
             {status ? (
-              <TaskBadgeStack status={status} pinned={item.pinned} />
+              <TaskBadgeStack status={status} />
             ) : item.kind === "canvas" ? (
-              <CanvasBadgeStack item={item} pinned={item.pinned} />
+              <CanvasBadgeStack item={item} />
             ) : (
-              <>
-                {item.pinned && (
-                  <AvatarGroup stacked reverse size="xs" className="shrink-0">
-                    <PinnedBadge />
-                  </AvatarGroup>
-                )}
-                <span className={TIMESTAMP_CLASS}>
-                  {formatRelativeTimeShort(item.ts)}
-                </span>
-              </>
+              <span className={TIMESTAMP_CLASS}>
+                {formatRelativeTimeShort(item.ts)}
+              </span>
             )}
           </span>
         }

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -230,14 +230,10 @@ describe("ChannelSidebar recents list", () => {
     expect(screen.queryByText("Today")).toBeNull();
   });
 
-  it("lists pins in the one session list, ahead of newer items", () => {
+  // Where a pin sorts is `buildChannelItems`' job, and its own tests cover it;
+  // what this list decides is that a pin gets no section of its own.
+  it("lists pins as rows in the one session list", () => {
     mocks.items = [
-      item({
-        key: "task:newer",
-        id: "newer",
-        title: "Filed this morning",
-        ts: new Date(2026, 6, 30, 9).getTime(),
-      }),
       item({
         key: "task:pinned",
         id: "pinned",
@@ -245,18 +241,20 @@ describe("ChannelSidebar recents list", () => {
         pinned: true,
         ts: new Date(2026, 6, 20, 9).getTime(),
       }),
+      item({
+        key: "task:newer",
+        id: "newer",
+        title: "Filed this morning",
+        ts: new Date(2026, 6, 30, 9).getTime(),
+      }),
     ];
 
     renderSidebar();
 
-    // No section of its own — a pin is a mark on a session, and the row's badge
-    // is what says so.
     expect(screen.queryByText("Pinned")).toBeNull();
     const titles = screen
       .getAllByText(/Kept at hand|Filed this morning/)
       .map((el) => el.textContent);
-    // Older, but pinned: it sorts above the newer row rather than risking the
-    // recents cap.
     expect(titles).toEqual(["Kept at hand", "Filed this morning"]);
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.test.tsx
@@ -230,31 +230,56 @@ describe("ChannelSidebar recents list", () => {
     expect(screen.queryByText("Today")).toBeNull();
   });
 
-  // Where a pin sorts is `buildChannelItems`' job, and its own tests cover it;
-  // what this list decides is that a pin gets no section of its own.
-  it("lists pins as rows in the one session list", () => {
-    mocks.items = [
-      item({
-        key: "task:pinned",
-        id: "pinned",
-        title: "Kept at hand",
-        pinned: true,
-        ts: new Date(2026, 6, 20, 9).getTime(),
-      }),
-      item({
-        key: "task:newer",
-        id: "newer",
-        title: "Filed this morning",
-        ts: new Date(2026, 6, 30, 9).getTime(),
-      }),
-    ];
+  describe("pins", () => {
+    const PINNED = item({
+      key: "task:pinned",
+      id: "pinned",
+      title: "Kept at hand",
+      pinned: true,
+      ts: new Date(2026, 6, 20, 9).getTime(),
+    });
+    const NEWER = item({
+      key: "task:newer",
+      id: "newer",
+      title: "Filed this morning",
+      ts: new Date(2026, 6, 30, 9).getTime(),
+    });
 
-    renderSidebar();
+    // Once a pin has a section, leaving it in the list below shows the same
+    // session twice in one pane.
+    it("lifts them into their own section, out of the list below", () => {
+      mocks.items = [PINNED, NEWER];
 
-    expect(screen.queryByText("Pinned")).toBeNull();
-    const titles = screen
-      .getAllByText(/Kept at hand|Filed this morning/)
-      .map((el) => el.textContent);
-    expect(titles).toEqual(["Kept at hand", "Filed this morning"]);
+      renderSidebar();
+
+      expect(screen.getByText("Pinned")).toBeTruthy();
+      expect(screen.getAllByText("Kept at hand")).toHaveLength(1);
+      const titles = screen
+        .getAllByText(/Kept at hand|Filed this morning/)
+        .map((el) => el.textContent);
+      expect(titles).toEqual(["Kept at hand", "Filed this morning"]);
+    });
+
+    it("has no section when nothing is pinned", () => {
+      mocks.items = [NEWER];
+
+      renderSidebar();
+
+      expect(screen.queryByText("Pinned")).toBeNull();
+    });
+
+    // A query that only a pin answers is still a query with an answer.
+    it("keeps the search narrowing both sections", async () => {
+      const user = userEvent.setup();
+      mocks.items = [PINNED, NEWER];
+
+      renderSidebar();
+      await user.click(screen.getByLabelText("Search"));
+      await user.type(screen.getByLabelText("Search sessions"), "Kept");
+
+      expect(screen.getByText("Kept at hand")).toBeTruthy();
+      expect(screen.queryByText("Filed this morning")).toBeNull();
+      expect(screen.queryByText("No matches")).toBeNull();
+    });
   });
 });

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -296,21 +296,18 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
   }, [pathname]);
 
   // One list, pins included — a pin is a mark on a session, not a different kind
-  // of thing, and the row's own badge says so. They sort to the top because a pin
-  // is a request not to lose the thing: below the recency order it would fall off
-  // the end of the cap.
-  const recentItems = useMemo(() => {
-    const matching = filterChannelItems(items, {
-      query,
-      createdBy,
-      status: statusFilter,
-      me,
-    });
-    return [
-      ...matching.filter((i) => i.pinned),
-      ...matching.filter((i) => !i.pinned),
-    ].slice(0, RECENTS_CAP);
-  }, [items, query, createdBy, statusFilter, me]);
+  // of thing, and the row's own badge says so. They lead it because
+  // `buildChannelItems` already sorts them there, and filtering keeps that order.
+  const recentItems = useMemo(
+    () =>
+      filterChannelItems(items, {
+        query,
+        createdBy,
+        status: statusFilter,
+        me,
+      }).slice(0, RECENTS_CAP),
+    [items, query, createdBy, statusFilter, me],
+  );
 
   const narrowed = filtersActive || searchOpen;
   const listState = listStateOf({

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelSidebar.tsx
@@ -89,7 +89,12 @@ function RecentSectionHeader({
   filtersActive: boolean;
 }) {
   return (
-    <>
+    // The header sticks, not the label inside it: a sticky element only travels
+    // within its own containing block, so a label stuck inside a one-row flex
+    // parent scrolls away with that row and never appears to stick at all. The
+    // search box comes along, because a header that leaves half of itself
+    // behind is worse than one that doesn't stick.
+    <div className="sticky top-0 z-10 bg-chrome">
       <div className="flex items-center gap-0.5">
         <div className="min-w-0 flex-1">
           <MenuLabel>Sessions</MenuLabel>
@@ -180,7 +185,7 @@ function RecentSectionHeader({
           />
         </div>
       )}
-    </>
+    </div>
   );
 }
 
@@ -295,19 +300,23 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
     return task ? `task:${task[1]}` : null;
   }, [pathname]);
 
-  // One list, pins included — a pin is a mark on a session, not a different kind
-  // of thing, and the row's own badge says so. They lead it because
-  // `buildChannelItems` already sorts them there, and filtering keeps that order.
-  const recentItems = useMemo(
-    () =>
-      filterChannelItems(items, {
-        query,
-        createdBy,
-        status: statusFilter,
-        me,
-      }).slice(0, RECENTS_CAP),
-    [items, query, createdBy, statusFilter, me],
-  );
+  // Pins get their own section, and leave the list below: a session you kept is
+  // one you come back to by name, and repeating it a few rows down under
+  // "Sessions" costs a row and says nothing new. The search and the filters
+  // still reach both — narrowing the pane and leaving a section of it unnarrowed
+  // would be the surprising half.
+  const [pinnedItems, recentItems] = useMemo(() => {
+    const matching = filterChannelItems(items, {
+      query,
+      createdBy,
+      status: statusFilter,
+      me,
+    });
+    return [
+      matching.filter((item) => item.pinned),
+      matching.filter((item) => !item.pinned).slice(0, RECENTS_CAP),
+    ];
+  }, [items, query, createdBy, statusFilter, me]);
 
   const narrowed = filtersActive || searchOpen;
   const listState = listStateOf({
@@ -465,6 +474,17 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
             </Empty>
           )}
 
+          {showRecent && pinnedItems.length > 0 && (
+            <>
+              {/* Deliberately not sticky: it scrolls off under the Sessions
+                  header, which is the one that has to stay. */}
+              <MenuLabel>Pinned</MenuLabel>
+              <div className="mb-2 flex flex-col gap-px">
+                {pinnedItems.map(taskRow)}
+              </div>
+            </>
+          )}
+
           {showRecent && (
             <>
               <RecentSectionHeader
@@ -482,11 +502,14 @@ export function ChannelSidebar({ channelId }: { channelId: string }) {
                 onStatusChange={setStatusFilter}
                 filtersActive={filtersActive}
               />
-              {recentItems.length > 0 ? (
+              {recentItems.length > 0 && (
                 <div className="flex flex-col gap-px">
                   {recentItems.map(taskRow)}
                 </div>
-              ) : (
+              )}
+              {/* Only when the query found nothing at all. A pin it did match is
+                  a match, however far up the pane it is drawn. */}
+              {recentItems.length === 0 && pinnedItems.length === 0 && (
                 <Empty className="border-0 py-6">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -16,6 +16,12 @@ const mocks = vi.hoisted(() => ({
     channel: string;
     updated_at: string;
   }[],
+  pinned: [] as {
+    id: string;
+    title: string;
+    channel: string;
+    updated_at: string;
+  }[],
   totals: {} as Record<string, number>,
   channelsLayout: true,
   navigate: vi.fn(),
@@ -70,6 +76,25 @@ vi.mock("@posthog/ui/features/canvas/hooks/useRecentSpaceTasks", () => ({
         ];
       }),
     ),
+}));
+vi.mock("@posthog/ui/features/canvas/hooks/usePinnedSpaceTasks", () => ({
+  usePinnedSpaceTasks: () =>
+    mocks.pinned.map((task) => ({
+      spaceId: task.channel,
+      item: {
+        key: `task:${task.id}`,
+        kind: "task",
+        id: task.id,
+        title: task.title,
+        ts: Date.parse(task.updated_at),
+        pinned: true,
+        rawStatus: null,
+        authorUser: null,
+        authorName: null,
+        authorUuid: null,
+        task: null,
+      },
+    })),
 }));
 vi.mock("@posthog/ui/features/canvas/hooks/useChannelTaskStatus", () => ({
   useChannelTaskStatus: () => null,
@@ -155,6 +180,7 @@ describe("ChannelsList", () => {
       highlightedValue: undefined,
     });
     mocks.totals = {};
+    mocks.pinned = [];
     useCurrentChannelStore.setState({ currentChannelId: null });
     mocks.tasks = [
       {
@@ -455,6 +481,51 @@ describe("ChannelsList", () => {
       await user.click(screen.getByLabelText("Expand design"));
 
       expect(screen.getByText("No sessions yet")).toBeTruthy();
+    });
+  });
+
+  describe("pinned sessions", () => {
+    const PIN = {
+      id: "task-new",
+      title: "Ship the tree",
+      channel: ENG.id,
+      updated_at: "2026-08-02T00:00:00Z",
+    };
+
+    it("has no section of its own until something is pinned", () => {
+      renderList();
+
+      expect(screen.queryByText("Pinned")).toBeNull();
+    });
+
+    // The same session is both a pin and a row under its space. Autocomplete
+    // maps a highlight index onto an option value, so the two rows have to be
+    // told apart or one keypress lands on both.
+    it("keeps a pinned session in its space's tree as well", async () => {
+      const user = userEvent.setup();
+      mocks.pinned = [PIN];
+      renderList();
+
+      await user.click(screen.getByLabelText("Expand engineering"));
+
+      expect(screen.getAllByText(PIN.title)).toHaveLength(2);
+    });
+
+    it("walks the pinned rows before the spaces", async () => {
+      const user = userEvent.setup();
+      mocks.pinned = [PIN];
+      renderList();
+
+      // The pinned row leads the list, so the first row the keyboard rests on
+      // is the pin rather than #me.
+      await user.click(screen.getByLabelText("Search spaces"));
+      await user.keyboard("{Enter}");
+
+      expect(mocks.navigate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: { channelId: ENG.id, taskId: PIN.id },
+        }),
+      );
     });
   });
 

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.test.tsx
@@ -55,6 +55,9 @@ vi.mock("@posthog/ui/features/canvas/hooks/useRecentSpaceTasks", () => ({
       spaceIds.map((spaceId) => {
         const items = mocks.tasks
           .filter((task) => task.channel === spaceId)
+          // The real hook drops a space's pinned sessions: they are drawn once,
+          // in the Pinned section above.
+          .filter((task) => !mocks.pinned.some((pin) => pin.id === task.id))
           .map((task) => ({
             key: `task:${task.id}`,
             kind: "task",
@@ -498,17 +501,14 @@ describe("ChannelsList", () => {
       expect(screen.queryByText("Pinned")).toBeNull();
     });
 
-    // The same session is both a pin and a row under its space. Autocomplete
-    // maps a highlight index onto an option value, so the two rows have to be
-    // told apart or one keypress lands on both.
-    it("keeps a pinned session in its space's tree as well", async () => {
+    it("draws a pinned session once, above its space's tree", async () => {
       const user = userEvent.setup();
       mocks.pinned = [PIN];
       renderList();
 
       await user.click(screen.getByLabelText("Expand engineering"));
 
-      expect(screen.getAllByText(PIN.title)).toHaveLength(2);
+      expect(screen.getAllByText(PIN.title)).toHaveLength(1);
     });
 
     it("walks the pinned rows before the spaces", async () => {

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -373,9 +373,8 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
   spaceId: string;
   asOption: boolean;
   /**
-   * What the keyboard calls this row. Defaults to the item's key, and the Pinned
-   * section overrides it: a pinned session is also a row under its own space, and
-   * two options sharing a value would map one highlight index onto both.
+   * What the keyboard calls this row. Defaults to the item's key; the Pinned
+   * section overrides it so a pin can't share a value with a space's row.
    */
   optionValue?: string;
   indent?: string;
@@ -1333,9 +1332,10 @@ const STARRED_SECTION_ID = "channels:starred";
 const CHANNELS_SECTION_ID = "channels:all";
 
 /**
- * What the keyboard calls a pinned row, kept clear of the same session's row
- * under its own space — the list shows both, and an Autocomplete option's value
- * is what a highlight index resolves to.
+ * What the keyboard calls a pinned row. Namespaced so it can never collide with
+ * the same session's row under its space while the two lists disagree about a
+ * pin mid-flight: an Autocomplete option's value is what a highlight index
+ * resolves to, and two rows sharing one would map a keypress onto both.
  */
 const pinnedValue = (taskKey: string) => `pinned:${taskKey}`;
 
@@ -1481,8 +1481,8 @@ export function ChannelsList() {
     [allChannels, expandedSpaceIds, treeOn],
   );
   const tasksBySpace = useRecentSpaceTasks(openSpaceIds);
-  // Pins lead the list, across every space. They stay in their space's own
-  // subtree as well: a pin is where a session is kept, not where it lives.
+  // Pins lead the list, across every space, and leave the subtree of the space
+  // they belong to — `useRecentSpaceTasks` drops them from a space's rows.
   const pinnedTasks = usePinnedSpaceTasks();
   // Pin / archive / command centre for every session row, built once here
   // rather than once per row.

--- a/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/ChannelsList.tsx
@@ -10,6 +10,7 @@ import {
   LinkIcon,
   PencilSimpleIcon,
   PlusIcon,
+  PushPinIcon,
   StarIcon,
   TrashIcon,
 } from "@phosphor-icons/react";
@@ -67,6 +68,7 @@ import {
 import { useChannelsLayout } from "@posthog/ui/features/canvas/hooks/useChannelsLayout";
 import { useChannelTaskStatus } from "@posthog/ui/features/canvas/hooks/useChannelTaskStatus";
 import { useCreateAndOpenDashboard } from "@posthog/ui/features/canvas/hooks/useDashboards";
+import { usePinnedSpaceTasks } from "@posthog/ui/features/canvas/hooks/usePinnedSpaceTasks";
 import {
   NO_TASKS,
   type SpaceTasks,
@@ -206,7 +208,10 @@ function SpaceRowSurface({
  */
 type SpaceTreeNode =
   | { kind: "space"; value: string; spaceId: string | undefined }
-  | { kind: "task"; value: string; spaceId: string; parentValue: string };
+  | { kind: "task"; value: string; spaceId: string; parentValue: string }
+  // A pinned session at the top of the list. It hangs off no space row, so ← has
+  // nothing to collapse and nowhere to move the highlight to.
+  | { kind: "pin"; value: string; spaceId: string };
 
 /** How long the pointer has to rest on a space before its sessions are warmed. */
 const SESSION_PREFETCH_DELAY_MS = 250;
@@ -361,10 +366,19 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
   item,
   spaceId,
   asOption,
+  optionValue = item.key,
+  indent = "pl-10",
 }: {
   item: ChannelItemModel;
   spaceId: string;
   asOption: boolean;
+  /**
+   * What the keyboard calls this row. Defaults to the item's key, and the Pinned
+   * section overrides it: a pinned session is also a row under its own space, and
+   * two options sharing a value would map one highlight index onto both.
+   */
+  optionValue?: string;
+  indent?: string;
 }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const openTask = useOpenSpaceTask();
@@ -376,7 +390,7 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
   // A boolean rather than the value itself, so a keypress re-renders only the
   // two rows whose answer changed.
   const isHighlighted = useSpaceTreeStore(
-    (s) => s.highlightedValue === item.key,
+    (s) => s.highlightedValue === optionValue,
   );
 
   // The tree only lists sessions, so this is always the task menu. Rename is
@@ -397,12 +411,12 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
   const row = (
     <SpaceRowSurface
       asOption={asOption}
-      optionValue={item.key}
+      optionValue={optionValue}
       data-selected={isActive || undefined}
       onClick={() => openTask(spaceId, item.id)}
       // A step in from its space's name, so the depth reads off that column
       // without a guide line to draw it.
-      className="pl-6"
+      className={indent}
     >
       {/* The dot belongs to the title, not to the row: its own tighter gap
           keeps them one mark rather than two columns. */}
@@ -419,7 +433,7 @@ const SpaceTaskRow = memo(function SpaceTaskRow({
       </span>
       {status && (
         <span className="ml-auto flex shrink-0 items-center gap-1">
-          <TaskBadgeStack status={status} pinned={item.pinned} />
+          <TaskBadgeStack status={status} />
         </span>
       )}
     </SpaceRowSurface>
@@ -480,7 +494,7 @@ function ViewAllRow({
       asOption={asOption}
       optionValue={viewAllValue(spaceId)}
       onClick={onOpenSpace}
-      className={cn("pl-6.5 text-[13px]", ROW_LABEL_TONE)}
+      className={cn("pl-10.5 text-[13px]", ROW_LABEL_TONE)}
     >
       {/* An empty slot the width of a session's status dot, so the label starts
           in the same column as the titles above it. */}
@@ -1314,8 +1328,16 @@ const PersonalChannelRow = memo(function PersonalChannelRow({
 // Collapse state is keyed per section in the shared sidebar store, so it
 // persists across navigation and restarts. Prefixed to stay clear of the Code
 // sidebar's folder sections, which key the same set by folder path.
+const PINNED_SECTION_ID = "channels:pinned";
 const STARRED_SECTION_ID = "channels:starred";
 const CHANNELS_SECTION_ID = "channels:all";
+
+/**
+ * What the keyboard calls a pinned row, kept clear of the same session's row
+ * under its own space — the list shows both, and an Autocomplete option's value
+ * is what a highlight index resolves to.
+ */
+const pinnedValue = (taskKey: string) => `pinned:${taskKey}`;
 
 // A collapsible sidebar group ("Starred" / "Channels"). Base UI directly rather
 // than quill's Collapsible: quill styles its trigger as a button (which fought
@@ -1459,6 +1481,9 @@ export function ChannelsList() {
     [allChannels, expandedSpaceIds, treeOn],
   );
   const tasksBySpace = useRecentSpaceTasks(openSpaceIds);
+  // Pins lead the list, across every space. They stay in their space's own
+  // subtree as well: a pin is where a session is kept, not where it lives.
+  const pinnedTasks = usePinnedSpaceTasks();
   // Pin / archive / command centre for every session row, built once here
   // rather than once per row.
   const spaceTaskActions = useSpaceTaskActions();
@@ -1513,6 +1538,15 @@ export function ChannelsList() {
         ),
       ]
     : [
+        ...(collapsedSections.has(PINNED_SECTION_ID)
+          ? []
+          : pinnedTasks.map(
+              ({ item, spaceId }): SpaceTreeNode => ({
+                kind: "pin",
+                value: pinnedValue(item.key),
+                spaceId,
+              }),
+            )),
         // "me" leads the starred section rather than floating above it: it is
         // the space you always keep, so it belongs with the ones you chose to
         // keep. Folding the section away takes it with them.
@@ -1589,6 +1623,9 @@ export function ChannelsList() {
     }
 
     if (!atStart) return;
+    // A pinned row is not inside the space it belongs to, so ← is not a request
+    // to close that space — it would fold away a section the row isn't in.
+    if (node.kind === "pin") return;
     if (node.kind === "task") {
       event.preventDefault();
       // Move first, while the children are still rendered — the highlight is an
@@ -1627,6 +1664,31 @@ export function ChannelsList() {
     </>
   ) : (
     <>
+      {/* Only when there is something in it: an empty Pinned heading is a
+          feature nobody asked for taking the top of the list. */}
+      {pinnedTasks.length > 0 && (
+        <ChannelGroup
+          sectionId={PINNED_SECTION_ID}
+          label="Pinned"
+          flat={channelsLayout}
+          keepMounted={!channelsLayout}
+          icon={<PushPinIcon size={14} />}
+        >
+          {pinnedTasks.map(({ item, spaceId }) => (
+            <SpaceTaskRow
+              key={item.key}
+              item={item}
+              spaceId={spaceId}
+              asOption={channelsLayout}
+              optionValue={pinnedValue(item.key)}
+              // Level with a space's name rather than a step in from it: these
+              // hang off the section, not off a space row above them.
+              indent="pl-4"
+            />
+          ))}
+        </ChannelGroup>
+      )}
+
       {/* Always rendered: "me" lives here, so the section is never empty. */}
       <ChannelGroup
         sectionId={STARRED_SECTION_ID}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/usePinnedSpaceTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/usePinnedSpaceTasks.ts
@@ -1,0 +1,70 @@
+import {
+  buildChannelItems,
+  type ChannelItemModel,
+} from "@posthog/core/canvas/channelItems";
+import type { Task } from "@posthog/shared/domain-types";
+import { useArchivedTaskIds } from "@posthog/ui/features/archive/useArchivedTaskIds";
+import { usePinnedTasks } from "@posthog/ui/features/sidebar/usePinnedTasks";
+import { taskDetailQuery } from "@posthog/ui/features/tasks/queries";
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { SPACE_QUERY_STALE_TIME_MS } from "./spaceQueryPolicy";
+
+/** A pinned session, with the space it belongs to. */
+export interface PinnedSpaceTask {
+  item: ChannelItemModel;
+  spaceId: string;
+}
+
+/**
+ * Module-level so `useQueries` can memoize on it — an inline combine is a new
+ * function every render, and every render would then rebuild the list.
+ */
+function combineTasks(queries: { data?: Task }[]): (Task | undefined)[] {
+  return queries.map((query) => query.data);
+}
+
+const NO_PINS: PinnedSpaceTask[] = [];
+
+/**
+ * Every pinned session, newest first, across all spaces.
+ *
+ * One query per pin, sharing the task detail cache: a pin is a session you keep
+ * going back to, so the row is usually warm before it is drawn, and opening one
+ * costs no fetch. That beats both alternatives — the full task list is ~630KB a
+ * poll, and the space feeds only cover spaces the tree has open.
+ *
+ * A pin outside the spaces (the Code app pins the same tasks) has nowhere to be
+ * opened here, so it is left out rather than drawn as a row that can't route.
+ */
+export function usePinnedSpaceTasks(): PinnedSpaceTask[] {
+  const { pinnedTaskIds } = usePinnedTasks();
+  const archivedTaskIds = useArchivedTaskIds();
+  // Sorted so the array only changes when the set of pins does.
+  const ids = useMemo(() => [...pinnedTaskIds].sort(), [pinnedTaskIds]);
+
+  const tasks = useQueries({
+    queries: ids.map((id) => ({
+      ...taskDetailQuery(id),
+      staleTime: SPACE_QUERY_STALE_TIME_MS,
+    })),
+    combine: combineTasks,
+  });
+
+  return useMemo(() => {
+    const loaded = tasks.filter((task): task is Task => task != null);
+    if (loaded.length === 0) return NO_PINS;
+    return buildChannelItems({
+      dashboards: [],
+      feedTasks: loaded,
+      archivedTaskIds,
+      pinnedTaskIds,
+      ownedBy: null,
+    }).flatMap((item) =>
+      item.task?.channel
+        ? [{ item, spaceId: item.task.channel }]
+        : // A pin whose task the API no longer places in a space.
+          [],
+    );
+  }, [tasks, archivedTaskIds, pinnedTaskIds]);
+}

--- a/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
+++ b/products/desktop/packages/ui/src/features/canvas/hooks/useRecentSpaceTasks.ts
@@ -141,13 +141,17 @@ export function useRecentSpaceTasks(
         pinnedTaskIds,
         ownedBy: null,
       });
+      // Pins lead the whole list in a section of their own, so a space's rows
+      // drop them: the same session again a few rows down under its space says
+      // nothing new, and it costs one of the five rows the space gets.
+      const unpinned = available.filter((item) => !item.pinned);
       // A page that came back short is the whole space, so the count is exact
       // once the archived ones are dropped. A full page falls back to the
       // server's total, which still counts anything archived in it.
       const built: SpaceTasks = {
-        items: available.slice(0, RECENT_TASKS_PER_SPACE),
+        items: unpinned.slice(0, RECENT_TASKS_PER_SPACE),
         total:
-          page.tasks.length < TREE_FETCH_LIMIT ? available.length : page.count,
+          page.tasks.length < TREE_FETCH_LIMIT ? unpinned.length : page.count,
       };
       cache.current.set(spaceId, {
         page,

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
@@ -15,12 +15,14 @@ import {
   TONE_ICON_VAR,
   taskBadges,
 } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
+import { DotRingSpinner } from "@posthog/ui/primitives/DotRingSpinner";
 import type { ReactElement, ReactNode } from "react";
 
-// One width for every state, working included: a dot that grew while it ran
-// would start its row's label further right than its neighbours', and the icon
-// column has to hold one width or the list stops looking like a list.
 const DOT_SIZE = 8;
+// Exactly the plain dot's box. Anything larger and a working row's label starts
+// further right than its neighbours' — the icon column has to hold one width or
+// the list stops looking like a list.
+const SPINNER_SIZE = DOT_SIZE;
 // Enough to still find the dot if you look for it, not enough to count as one of
 // the list's live rows.
 const FAINT_OPACITY = 0.4;
@@ -65,6 +67,22 @@ function RowTooltip({
  */
 export function TaskStatusDot({ dot }: { dot: TaskDot }) {
   const color = DOT_TONE_VAR[dot.tone];
+  if (dot.spinner) {
+    return (
+      <RowTooltip label={dot.label} side="right">
+        <span
+          aria-label={dot.label}
+          role="img"
+          className="flex shrink-0 items-center justify-center"
+          // The spinner draws its dots in `currentColor`, so the tone is set
+          // here rather than passed down.
+          style={{ color: TONE_ICON_VAR[dot.tone], width: SPINNER_SIZE }}
+        >
+          <DotRingSpinner size={SPINNER_SIZE} />
+        </span>
+      </RowTooltip>
+    );
+  }
   return (
     <RowTooltip label={dot.label} side="right">
       <span

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/TaskStatusDot.tsx
@@ -1,4 +1,3 @@
-import { PushPin } from "@phosphor-icons/react";
 import {
   Avatar,
   AvatarFallback,
@@ -16,14 +15,12 @@ import {
   TONE_ICON_VAR,
   taskBadges,
 } from "@posthog/ui/features/sidebar/components/items/taskStatusVocabulary";
-import { DotRingSpinner } from "@posthog/ui/primitives/DotRingSpinner";
 import type { ReactElement, ReactNode } from "react";
 
+// One width for every state, working included: a dot that grew while it ran
+// would start its row's label further right than its neighbours', and the icon
+// column has to hold one width or the list stops looking like a list.
 const DOT_SIZE = 8;
-// Exactly the plain dot's box. Anything larger and a working row's label starts
-// further right than its neighbours' — the icon column has to hold one width or
-// the list stops looking like a list.
-const SPINNER_SIZE = DOT_SIZE;
 // Enough to still find the dot if you look for it, not enough to count as one of
 // the list's live rows.
 const FAINT_OPACITY = 0.4;
@@ -59,27 +56,15 @@ function RowTooltip({
 
 /**
  * A task's state as a single dot: blue wants a decision, the brand yellow is
- * working or unread, grey is quiet. The trigger renders as a span because rows are
- * `<button>`s — a nested button would be invalid HTML.
+ * working or unread, grey is quiet. The trigger renders as a span because rows
+ * are `<button>`s — a nested button would be invalid HTML.
+ *
+ * The pin is not here. A mark on the dot has to compete with the state the dot
+ * is already reporting, and the two say unrelated things — a section of its own
+ * carries it instead.
  */
 export function TaskStatusDot({ dot }: { dot: TaskDot }) {
   const color = DOT_TONE_VAR[dot.tone];
-  if (dot.spinner) {
-    return (
-      <RowTooltip label={dot.label} side="right">
-        <span
-          aria-label={dot.label}
-          role="img"
-          className="flex shrink-0 items-center justify-center"
-          // The spinner draws its dots in `currentColor`, so the tone is set
-          // here rather than passed down.
-          style={{ color: TONE_ICON_VAR[dot.tone], width: SPINNER_SIZE }}
-        >
-          <DotRingSpinner size={SPINNER_SIZE} />
-        </span>
-      </RowTooltip>
-    );
-  }
   return (
     <RowTooltip label={dot.label} side="right">
       <span
@@ -106,45 +91,17 @@ export function TaskStatusDot({ dot }: { dot: TaskDot }) {
 }
 
 /**
- * The pin: this row was put here on purpose. Lives with the badges because it
- * belongs in their stack — pinned rows sit in the one list with everything else,
- * so the badge is what says a row is pinned.
+ * A task's identity as stacked avatars: source, local, and PR/branch — what came
+ * out of the row, in the order it was acquired. The pin isn't here: it says
+ * something about where the row sits rather than what it produced, and it rings
+ * the dot instead.
  *
- * Amber rather than the vocabulary's `--primary` yellow: primary means "there is
- * something here for you", and a pin is a shelf, not a claim on your attention.
+ * Often empty. A cloud task that opened no PR has nothing to say here, and the
+ * stack simply takes no room.
  */
-export function PinnedBadge() {
-  return (
-    <RowTooltip label="Pinned" side="top">
-      <Avatar
-        size="xs"
-        aria-label="Pinned"
-        role="img"
-        className="cursor-default"
-      >
-        <AvatarFallback className="bg-transparent">
-          <PushPin size={9} className="text-primary" />
-        </AvatarFallback>
-      </Avatar>
-    </RowTooltip>
-  );
-}
-
-/**
- * A task's identity as stacked avatars: the pin, then source, cloud, and
- * PR/branch. The pin goes first, which in a reversed stack puts it leftmost and
- * underneath — it says how the row got here, not what came out of it.
- */
-export function TaskBadgeStack({
-  status,
-  pinned,
-}: {
-  status: TaskStatusInput;
-  pinned?: boolean;
-}) {
+export function TaskBadgeStack({ status }: { status: TaskStatusInput }) {
   return (
     <AvatarGroup stacked reverse size="xs" className="shrink-0">
-      {pinned ? <PinnedBadge /> : null}
       {taskBadges(status).map(({ key, Icon, label, tone }) => (
         <RowTooltip key={key} label={label} side="top">
           {/* The tooltip names the badge on hover; `aria-label` is what names it

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -34,8 +34,7 @@ export type TaskStatusInput = TaskIconProps & {
  *     quiet hollow dot;
  *   - the **badges** on the right are identity — where it came from, whether it
  *     runs on this machine, and what came out of it. The PR badge carries its
- *     own colour,
- *     so PR state never needs to spend the dot.
+ *     own colour, so PR state never needs to spend the dot.
  *
  * That split is the whole point: a merged PR from Slack reads as "nothing owed"
  * (hollow dot) with a purple merge badge and a source badge, instead of
@@ -82,6 +81,12 @@ export interface TaskDot {
   /** Flashing = happening now, or wanting you now. */
   pulse: boolean;
   /**
+   * Draw as the braille dots spinner instead of one dot — still dot-shaped, so
+   * it stays in the dot column's vocabulary, but the motion is a *cycle* rather
+   * than a blink, which is the honest shape for "output is arriving".
+   */
+  spinner?: boolean;
+  /**
    * Draw the dot barely there. For states that are deliberately inert — the task
    * isn't idle waiting for you, it's been *put down* — so the row should read as
    * present but skippable rather than joining the quiet-but-live majority.
@@ -103,10 +108,10 @@ export interface TaskDot {
  *
  * A cloud run's queued is folded into working for the same reason. "Waiting on a
  * sandbox" and "a sandbox is writing code" are one fact to the reader, that it's
- * under way, so they share the pulse. Two states don't share it: a local run at
- * `queued`, whose persisted status nothing ever advances, and a run at
- * `in_progress` with nothing streaming. Both claims outlive the work, and a dot
- * that pulses forever is a lie about the machine.
+ * under way, so they share the spinner. Two states don't share it: a local run
+ * at `queued`, whose persisted status nothing ever advances, and a run at
+ * `in_progress` with nothing streaming. Both claims outlive the work, and a
+ * spinner that never stops is a lie about the machine.
  *
  * And a run that has already opened a PR is not working, whatever its status
  * says. The cloud workflow keeps the run `in_progress` while it babysits CI
@@ -114,8 +119,8 @@ export interface TaskDot {
  * enqueues the merge — so the run can claim to be working for hours after the
  * agent stopped. The PR is the deliverable; once it exists the badge carries the
  * story and the dot goes quiet. This beats a status that merely claims work, not
- * one that is visibly starting: a re-queued cloud run keeps its pulse even with
- * last run's PR still on the task.
+ * one that is visibly starting: a re-queued cloud run keeps its spinner even
+ * with last run's PR still on the task.
  */
 export function taskDot(props: TaskStatusInput): TaskDot {
   if (props.needsPermission) {
@@ -126,10 +131,10 @@ export function taskDot(props: TaskStatusInput): TaskDot {
       label: "Needs permission — blocked on you",
     };
   }
-  // Motion means something is moving on its own: a prompt in flight, or a cloud
-  // run still coming up. Cloud `queued` is a sandbox being claimed, and the
-  // backend leaves that state by itself, so the motion is bounded. A local run
-  // at `queued` is not a launch: nothing advances a local run's persisted
+  // Spinning means something is moving on its own: a prompt in flight, or a
+  // cloud run still coming up. Cloud `queued` is a sandbox being claimed, and
+  // the backend leaves that state by itself, so the motion is bounded. A local
+  // run at `queued` is not a launch: nothing advances a local run's persisted
   // status, so it can sit there for hours after the agent is done with it.
   const isStartingCloudRun =
     props.taskRunStatus === "queued" && props.workspaceMode === "cloud";
@@ -137,7 +142,8 @@ export function taskDot(props: TaskStatusInput): TaskDot {
     return {
       tone: "yellow",
       style: "solid",
-      pulse: true,
+      pulse: false,
+      spinner: true,
       label: props.isGenerating ? "Working" : "Starting",
     };
   }

--- a/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
+++ b/products/desktop/packages/ui/src/features/sidebar/components/items/taskStatusVocabulary.ts
@@ -1,6 +1,5 @@
 import {
   ArrowSquareIn,
-  Cloud,
   GitBranch,
   GitMerge,
   GitPullRequest,
@@ -33,8 +32,9 @@ export type TaskStatusInput = TaskIconProps & {
  *   - the **dot** on the left is attention and activity ONLY — is this blocked
  *     on me, working, or waiting to be read? Everything settled shares one
  *     quiet hollow dot;
- *   - the **badges** on the right are identity — where it came from, whether
- *     it's cloud, and what came out of it. The PR badge carries its own colour,
+ *   - the **badges** on the right are identity — where it came from, whether it
+ *     runs on this machine, and what came out of it. The PR badge carries its
+ *     own colour,
  *     so PR state never needs to spend the dot.
  *
  * That split is the whole point: a merged PR from Slack reads as "nothing owed"
@@ -82,12 +82,6 @@ export interface TaskDot {
   /** Flashing = happening now, or wanting you now. */
   pulse: boolean;
   /**
-   * Draw as the braille dots spinner instead of one dot — still dot-shaped, so
-   * it stays in the dot column's vocabulary, but the motion is a *cycle* rather
-   * than a blink, which is the honest shape for "output is arriving".
-   */
-  spinner?: boolean;
-  /**
    * Draw the dot barely there. For states that are deliberately inert — the task
    * isn't idle waiting for you, it's been *put down* — so the row should read as
    * present but skippable rather than joining the quiet-but-live majority.
@@ -109,10 +103,10 @@ export interface TaskDot {
  *
  * A cloud run's queued is folded into working for the same reason. "Waiting on a
  * sandbox" and "a sandbox is writing code" are one fact to the reader, that it's
- * under way, so they share the spinner. Two states don't share it: a local run
- * at `queued`, whose persisted status nothing ever advances, and a run at
- * `in_progress` with nothing streaming. Both claims outlive the work, and a
- * spinner that never stops is a lie about the machine.
+ * under way, so they share the pulse. Two states don't share it: a local run at
+ * `queued`, whose persisted status nothing ever advances, and a run at
+ * `in_progress` with nothing streaming. Both claims outlive the work, and a dot
+ * that pulses forever is a lie about the machine.
  *
  * And a run that has already opened a PR is not working, whatever its status
  * says. The cloud workflow keeps the run `in_progress` while it babysits CI
@@ -120,8 +114,8 @@ export interface TaskDot {
  * enqueues the merge — so the run can claim to be working for hours after the
  * agent stopped. The PR is the deliverable; once it exists the badge carries the
  * story and the dot goes quiet. This beats a status that merely claims work, not
- * one that is visibly starting: a re-queued cloud run keeps its spinner even
- * with last run's PR still on the task.
+ * one that is visibly starting: a re-queued cloud run keeps its pulse even with
+ * last run's PR still on the task.
  */
 export function taskDot(props: TaskStatusInput): TaskDot {
   if (props.needsPermission) {
@@ -132,10 +126,10 @@ export function taskDot(props: TaskStatusInput): TaskDot {
       label: "Needs permission — blocked on you",
     };
   }
-  // Spinning means something is moving on its own: a prompt in flight, or a
-  // cloud run still coming up. Cloud `queued` is a sandbox being claimed, and
-  // the backend leaves that state by itself, so the motion is bounded. A local
-  // run at `queued` is not a launch: nothing advances a local run's persisted
+  // Motion means something is moving on its own: a prompt in flight, or a cloud
+  // run still coming up. Cloud `queued` is a sandbox being claimed, and the
+  // backend leaves that state by itself, so the motion is bounded. A local run
+  // at `queued` is not a launch: nothing advances a local run's persisted
   // status, so it can sit there for hours after the agent is done with it.
   const isStartingCloudRun =
     props.taskRunStatus === "queued" && props.workspaceMode === "cloud";
@@ -143,8 +137,7 @@ export function taskDot(props: TaskStatusInput): TaskDot {
     return {
       tone: "yellow",
       style: "solid",
-      pulse: false,
-      spinner: true,
+      pulse: true,
       label: props.isGenerating ? "Working" : "Starting",
     };
   }
@@ -208,8 +201,14 @@ export interface TaskBadge {
 
 /**
  * Identity → badges, widest context first so the stack reads left-to-right as
- * "who asked, where it runs, what came out of it". Always returns at least one
- * badge: an empty slot where every other row has an avatar reads as a bug.
+ * "who asked, where it runs, what came out of it". A row with nothing to say
+ * gets no badges at all.
+ *
+ * Only local work is marked. The cloud is where work runs unless you asked
+ * otherwise, and a badge on the majority of rows is a badge nobody reads — it
+ * costs every row the space and tells the reader nothing they didn't assume. A
+ * task with a workspace on this machine is the exception worth a glyph, because
+ * it is the one that can't be picked up from another one.
  *
  * Origins deliberately share ONE glyph. Eight product marks at avatar size is a
  * vocabulary nobody learns — and the badge's job in a nav row is "this didn't
@@ -230,8 +229,8 @@ export function taskBadges(props: TaskStatusInput): TaskBadge[] {
       label: `Source: ${origin.label}`,
     });
   }
-  if (props.workspaceMode === "cloud") {
-    badges.push({ key: "cloud", Icon: Cloud, label: "Cloud" });
+  if (props.workspaceMode === "local" || props.workspaceMode === "worktree") {
+    badges.push({ key: "local", Icon: Laptop, label: "Local" });
   }
   if (props.prState === "merged") {
     badges.push({
@@ -277,9 +276,6 @@ export function taskBadges(props: TaskStatusInput): TaskBadge[] {
       label: "Has changes",
       tone: "yellow",
     });
-  }
-  if (badges.length === 0) {
-    badges.push({ key: "local", Icon: Laptop, label: "Local" });
   }
   return badges;
 }


### PR DESCRIPTION
## Problem

Someone browsing the spaces sidebar reads the same session twice: once as a pin at the top, once again a few rows down inside its space. The duplicate costs one of the five rows a space gets and says nothing new.

- Pinned sessions had no place of their own in the root list or in a space's pane.
- A session's row carried a cloud badge on almost every row, which nobody reads, and a separate spinner shape while it worked.
- A space's sessions sorted by record update time, so a session someone just replied to could sit below an idle one.

## Changes

- Pinned sessions lead the root list in a "Pinned" section, across every space, and get a section of their own inside a space.
- A pin leaves the list below it. `useRecentSpaceTasks` drops a space's pinned sessions, and the "View all" count follows.
- `usePinnedSpaceTasks` reads one task per pin off the task detail cache, so a pin is usually warm before it is drawn.
- Sessions order by their last turn rather than by record update time, with pins first.
- The cloud badge comes off the rows. Only a workspace on this machine is marked now.
- The working spinner becomes a pulse on the state dot, so a row keeps one dot shape and one width in every state.
- The space pane's "Sessions" header sticks while the pinned rows scroll under it.

A pinned row keeps its own Autocomplete option value (`pinned:<key>`) even though it no longer shares the list with a copy of itself. Two rows sharing a value map one keyboard highlight index onto both, and the two lists come from different queries, so they can disagree about a pin mid-flight.

No screenshot. The sidebar rows carry live internal session titles, and this repo's assets are public.

## How did you test this code?

- `ChannelsList.test.tsx` asserts a pinned session draws once when its space is expanded, and that the keyboard walks the pinned rows before the spaces. The regression: a pin rendered in both places, where one arrow keypress lands on two rows.
- `ChannelSidebar.test.tsx` covers the space pane's pinned section and that the search still narrows it.
- `channelItems.test.ts` covers the last-turn ordering.
- I ran the `@posthog/ui` canvas and sidebar suites and the `@posthog/core` canvas suite locally.
- Not run: the app itself against live data, and no manual pass in the running desktop app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5, in Claude Code) wrote the dedupe commit on top of three commits Adam and I had already made on this branch. Skills invoked: `/posthog-desktop`, `/writing-pr-descriptions`, plus the repo's writing-tests rule.

The earlier version kept a pin in its space's subtree on purpose, reading it as "kept, not moved". Adam called that a duplicate, so the filter moved into `useRecentSpaceTasks` rather than into the list component: the hook already caches per space, and filtering in the component would hand every space a new object whenever pins changed, which breaks the row memoization the tree depends on.

One local commit of unfinished pin drag-and-drop work was dropped from this branch before pushing, at Adam's request.
