### PR TITLE
fix(data-imports): stop reporting queue Postgres startup recovery as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -917,6 +917,15 @@ class TestQueueOperationTimeouts:
         ("the database system is starting up", True),
         ("the database system is not yet accepting connections", True),
         (
+            # Verbatim from the reported error-tracking issue: the refusal arrives with a
+            # trailing DETAIL line, so the classifier must match on a substring of a
+            # multi-line message rather than the bare phrase.
+            'connection failed: connection to server at "172.18.0.8", port 5432 failed: '
+            "FATAL:  the database system is not yet accepting connections\n"
+            "DETAIL:  Consistent recovery state has not been yet reached.",
+            True,
+        ),
+        (
             'connection failed: connection to server at "10.0.0.5", port 5432 failed: '
             "FATAL:  the database system is in recovery mode",
             True,


### PR DESCRIPTION
## Problem

Data-import pods poll their internal batch queue over a pooled connection to the queue Postgres database. When that Postgres node restarts (a rollout or failover), it briefly refuses new connections while it replays WAL, and the poll loop's connection retry logic reports every one of those attempts to error tracking.

- [Reported issue](https://us.posthog.com/project/2/error_tracking/019fd90c-9c0e-7893-b6ac-507f49197fe8): `OperationalError` from `batch_consumer.py`'s `_connect`, with the message `FATAL: the database system is not yet accepting connections \ DETAIL: Consistent recovery state has not been yet reached.`
- The exception events carry no `warehouse_sources_*` schema/source context, because the failure happens in the shared poll loop's own connection to the queue database, before any batch is claimed — it isn't tied to a customer source or sync.
- The poll loop (`BatchConsumer.run`) already retries this with capped, jittered backoff and recovers on its own once Postgres finishes starting up. The only problem is that every attempt during that window still calls `capture_exception`, adding non-actionable noise.

## Changes

- Recognize the known Postgres FATAL startup/recovery messages (`starting up`, `not yet accepting connections`, `in recovery mode`) in the poll loop's `OperationalError` handler.
- Skip `capture_exception` only for those messages; log a warning instead. Retry, backoff, and poll-failure metrics are unchanged.
- Not a `NonRetryableErrors` change: this stays retryable, since it is a transient infrastructure condition the pod already tolerates without any lost work.

## How did you test this code?

- Added `test_queue_db_starting_up_is_not_reported` to `postgres_queue/test_consumer.py`, exercising the full poll loop with the exact reported error message and asserting `capture_exception` is not called while polling continues — mirrors the existing precedent test for a masked poll timeout in the same handler.
- Added parameterized `TestIsDbStartingUpError` cases covering all three recognized startup messages, plus a negative case confirming an unrelated connection error (e.g. a real outage) still reports.
- Ran `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py` (94 passed) and `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py` (same 3 pre-existing failures as on master, which need a live Postgres and are unrelated to this change).
- Ran `ruff check`/`ruff format --check` on the changed files and a repo-wide `mypy` pass; both clean.
- Not run: `hogli ci:preflight` (hogli isn't installed in this environment).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error-tracking noise reduction, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged the linked error-tracking issue via the PostHog MCP error-tracking tools, confirmed the failing frame and read the surrounding poll-loop code, then found and followed the existing precedent in this repo for suppressing a similarly transient, self-resolving `OperationalError` (both a masked-poll-timeout case in this same file's tests, and PR #79222's Redshift RPC-timeout suppression) before applying the same pattern here. Skills invoked: `/writing-tests` before adding test coverage, `/writing-pr-descriptions` for this body.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*