### PR TITLE
fix(data-imports): stop reporting transient queue DB startup errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -71,6 +71,27 @@ def _is_dns_resolution_transient_error(error: BaseException) -> bool:
     return _DNS_RESOLUTION_TRANSIENT_MARKER in str(error).lower()
 
 
+# Connect-time "server not ready" refusals: PostgreSQL rejects a new connection with SQLSTATE
+# 57P03 while it is still coming up (starting up, replaying WAL after a crash — "the database
+# system is in recovery mode" — or not yet at a consistent recovery point) or shutting down.
+# All are transient: the queue DB begins accepting connections again within seconds, so this is
+# a self-healing blip, not a bug to report. Mirrors the source-side `_is_server_starting_up_error`
+# in sources/postgres/postgres.py, for the queue DB connection itself.
+_SERVER_NOT_READY_ERROR_SUBSTRINGS = (
+    "the database system is starting up",
+    "the database system is not yet accepting connections",
+    "the database system is in recovery mode",
+    "the database system is shutting down",
+)
+
+
+def _is_server_not_ready_error(error: BaseException) -> bool:
+    if not isinstance(error, psycopg.OperationalError):
+        return False
+    message = " ".join(str(arg) for arg in error.args).lower()
+    return any(substring in message for substring in _SERVER_NOT_READY_ERROR_SUBSTRINGS)
+
+
 class OwnershipLostError(Exception):
     """Raised when the group lease for a (team_id, schema_id) is no longer held by this consumer."""
 
@@ -453,6 +474,8 @@ class BatchConsumer:
                         continue
                     if _is_dns_resolution_transient_error(e):
                         logger.warning(self._event("poll_failed_queue_db_dns_unavailable"), error=str(e))
+                    elif _is_server_not_ready_error(e):
+                        logger.warning(self._event("poll_failed_queue_db_starting_up"), error=str(e))
                     else:
                         logger.exception(self._event("poll_failed_queue_db_unreachable"))
                         capture_exception(e)
@@ -1048,6 +1071,8 @@ class BatchConsumer:
             except psycopg.OperationalError as e:
                 if _is_dns_resolution_transient_error(e):
                     logger.warning(self._event("recovery_sweep_dns_unavailable"), error=str(e))
+                elif _is_server_not_ready_error(e):
+                    logger.warning(self._event("recovery_sweep_db_starting_up"), error=str(e))
                 else:
                     logger.exception(self._event("recovery_sweep_error"))
                     capture_exception(e)
@@ -1070,6 +1095,8 @@ class BatchConsumer:
                 except psycopg.OperationalError as e:
                     if _is_dns_resolution_transient_error(e):
                         logger.warning(self._event("reconcile_sweep_dns_unavailable"), error=str(e))
+                    elif _is_server_not_ready_error(e):
+                        logger.warning(self._event("reconcile_sweep_db_starting_up"), error=str(e))
                     else:
                         logger.exception(self._event("reconcile_sweep_error"))
                         capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -16,6 +16,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.batch_consumer import (
     OwnershipLostError,
     _is_dns_resolution_transient_error,
+    _is_server_not_ready_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.load.health import HealthState
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer import (
@@ -818,6 +819,122 @@ class TestQueueOperationTimeouts:
             await asyncio.wait_for(run_task, timeout=5.0)
 
         mock_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_poll_failure_does_not_report_queue_db_starting_up_error(self):
+        # Same self-healing "server not ready" refusal as above, but hit directly at
+        # connect/query time rather than wrapped by a cancelled poll timeout — the main
+        # poll loop's own OperationalError branch must apply the same classification.
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            poll_interval_seconds=0.01,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+
+        second_poll_started = asyncio.Event()
+        fetch_calls = 0
+
+        async def flaky_fetch(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls == 1:
+                raise psycopg.OperationalError(
+                    'connection failed: connection to server at "10.0.0.5", port 5432 failed: '
+                    "FATAL:  the database system is in recovery mode"
+                )
+            second_poll_started.set()
+            return []
+
+        with (
+            patch.object(
+                consumer, "_connect", new_callable=AsyncMock, side_effect=lambda **kwargs: _make_healthy_conn()
+            ),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_unprocessed_and_lock",
+                side_effect=flaky_fetch,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+            patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            await asyncio.wait_for(second_poll_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+        mock_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_recovery_loop_does_not_report_queue_db_starting_up_error(self):
+        # A queue-DB failover/restart can drop the recovery connection; reconnecting while the
+        # server is still coming back up raises this exact refusal. It self-heals within seconds
+        # (see `_is_server_not_ready_error`), so it must not be reported to error tracking.
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            recovery_interval_seconds=0.01,
+            reconcile_interval_seconds=0,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+        consumer._recovery_conn = _make_healthy_conn()
+
+        second_reconcile_started = asyncio.Event()
+        call_count = 0
+
+        async def flaky_reconcile() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise psycopg.OperationalError(
+                    'connection failed: connection to server at "10.0.0.5", port 5432 failed: '
+                    "FATAL:  the database system is in recovery mode"
+                )
+            second_reconcile_started.set()
+
+        with (
+            patch.object(consumer, "_recovery_sweep_with_timeout", new_callable=AsyncMock),
+            patch.object(consumer, "_reconcile_failed_runs", side_effect=flaky_reconcile),
+            patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            loop_task = asyncio.create_task(consumer._recovery_loop())
+            await asyncio.wait_for(second_reconcile_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(loop_task, timeout=5.0)
+
+        mock_capture.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    [
+        ("the database system is starting up", True),
+        ("the database system is not yet accepting connections", True),
+        (
+            'connection failed: connection to server at "10.0.0.5", port 5432 failed: '
+            "FATAL:  the database system is in recovery mode",
+            True,
+        ),
+        ("the database system is shutting down", True),
+        ("THE DATABASE SYSTEM IS IN RECOVERY MODE", True),  # case-insensitive
+        ("connection to server was lost during table metadata discovery", False),
+        ("Hot standby mode is disabled", False),
+    ],
+)
+def test_is_server_not_ready_error_classifies_operational_errors(message, expected):
+    assert _is_server_not_ready_error(psycopg.OperationalError(message)) is expected
+
+
+def test_is_server_not_ready_error_ignores_non_operational_errors():
+    # A generic exception carrying the same phrase must not be misclassified — the
+    # SQLSTATE 57P03 refusal only ever surfaces as psycopg.OperationalError.
+    assert _is_server_not_ready_error(RuntimeError("the database system is in recovery mode")) is False
 
 
 class TestPollFailureLiveness:


### PR DESCRIPTION
## Problem

- The data-imports batch consumer reports every Postgres "not ready yet" connection refusal to error tracking, even ones that resolve within seconds.
- [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd90e-b096-7fa0-86b2-3e1355b87857): `OperationalError: ... FATAL: the database system is in recovery mode`, raised from `_connect` in the batch consumer's recovery loop.
- The failing connection was to the queue database itself, not a customer's data source.
- A queue-DB restart or failover briefly refuses new connections, then accepts them again once recovery finishes.

## Changes

- `batch_consumer.py` now classifies four PostgreSQL connect-time refusals as self-healing: starting up, not yet accepting connections, in recovery mode, and shutting down (SQLSTATE 57P03).
- The consumer reconnects to the queue DB in three places: the poll loop, the recovery sweep, and the reconcile sweep.
- All three now log a warning and skip `capture_exception` for these refusals.
- Retry and backoff timing is unchanged.
- The customer-facing Postgres source connector already treats these four messages as transient.
- This PR applies the same rule to the queue DB's own connection in `batch_consumer.py`.

## How did you test this code?

- Added `test_is_server_not_ready_error_classifies_operational_errors`, parametrized over the four refusal messages and two non-matching cases.
- Added `test_poll_failure_does_not_report_queue_db_starting_up_error` and `test_recovery_loop_does_not_report_queue_db_starting_up_error`, asserting `capture_exception` is not called and polling/reconciling resumes once the queue DB recovers.
- Ran `postgres_queue/test_consumer.py` (99 passed) and the `duckgres` consumer suite (27 passed; 3 pre-existing errors need a live database and are unrelated to this change).
- Ran `ruff check --fix`, `ruff format`, and `mypy --cache-fine-grained` on the changed file, all clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog error tracking MCP tools (issue details, stack trace, sample event) to confirm the failure originates in `batch_consumer.py`'s recovery loop while reconnecting to the queue database.
- Read the customer-facing Postgres source connector (`sources/postgres/postgres.py`) and found it already treats this exact message as a transient "server not ready" condition; this PR brings the queue-DB connection paths in `batch_consumer.py` in line with that precedent.
- Searched for duplicate open PRs (human-authored and the maintainer's own) before opening this one — none addressed this specific code path.
- Skills invoked: `/investigating-error-issue`, `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*