### PR TITLE
feat(inbox): surface tool status on signal source cards

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6266,6 +6266,30 @@ snapshots:
         hash: v1.k794b7964.bd2bee28eee6668bfd9f1e5c00191e38189bc27ac734c8adf8ddc55da8381b1b.HFfADdkZDnQv2BGCHc-yzXZ4Z0Rpk-xn9cn7uRUXIyg
     scenes-app-inbox-scene--self-driving-paused--light:
         hash: v1.k794b7964.54f6835c7d4a343bd6c9efef4189805b8dc5ea3347380b5d772ce55abaad79be.P7Ramt_0TgHAl4YgBsBumQ1QVxkb2ds9GsTaxbNAKRQ
+    scenes-app-inbox-signalsourcespanel--armed-but-tools-off--dark:
+        hash: v1.k794b7964.742013ce30e15b5b5d38b2e6939a899e6258c960bc38075c26d1bda289f5787c.glB0VlAeBYIngG4lWoiyaqpDKgMVnBLtxdeelz4aSME
+    scenes-app-inbox-signalsourcespanel--armed-but-tools-off--light:
+        hash: v1.k794b7964.815db9957f9da19d00683803f633cb468a05e4f698f12629dc8d8c85328a42ec.Yu4wrqmDkHcq6TKV5LZRQ2NBcPhWgZfJd9Vt5V-gpsM
+    scenes-app-inbox-signalsourcespanel--arming-blocked--dark:
+        hash: v1.k794b7964.cd76b5e3e4039fdc0fee477acd65505cc85989515ba53bc518a963ae2a2b2561.WXyh2FRGYjY1C8aL_yAdZUVJfxW6sd5SarZ5DEZDxB8
+    scenes-app-inbox-signalsourcespanel--arming-blocked--light:
+        hash: v1.k794b7964.25a78443d646dc69f69a12c882582efd41f1077e70f646d60e7cea8b3610d123.xd0X2Sxk_vFxvhV6D0k7EDctaS61tJWGuCXUnolntAE
+    scenes-app-inbox-signalsourcespanel--everything-healthy--dark:
+        hash: v1.k794b7964.de69ec220490357be3de892de5eabfc06fce9066a980c95bef3ba2ec8e4d7afc.HXtbOMlXNcHBRJslE0Bumji-Ybi3hUiP7_pMvwaEXfo
+    scenes-app-inbox-signalsourcespanel--everything-healthy--light:
+        hash: v1.k794b7964.cfc383fae4c1881c8377972452337fbe070ea5c64541fa87d2e088427d5aa20e.oiktmtDX4MnFc2kQZz-G4huxMXKvsyjW8LjrEIAYO_A
+    scenes-app-inbox-signalsourcespanel--playground--dark:
+        hash: v1.k794b7964.fff26488df405308a15e62ec5e5f1d9098790376d5c7a2dbc74b56ac8f96db5a.FnxQMtSJHjd51i7554HmHV2VDtD3ZBPnmjyaiwGxB8I
+    scenes-app-inbox-signalsourcespanel--playground--light:
+        hash: v1.k794b7964.e25f6d4d0820cc887752340ef581de7c1b67a1b6ef6fa9f7c93fdd4c5edef745.SnJd3cxBet51gMFec3lV3Yn_mFx0JlOx9pQhz2EGFfw
+    scenes-app-inbox-signalsourcespanel--server-side-exceptions-only--dark:
+        hash: v1.k794b7964.fff26488df405308a15e62ec5e5f1d9098790376d5c7a2dbc74b56ac8f96db5a.uYyWUYz23ovTwNTH2rmp88Rd8rmoIUzKWWp1OtGUsLw
+    scenes-app-inbox-signalsourcespanel--server-side-exceptions-only--light:
+        hash: v1.k794b7964.e25f6d4d0820cc887752340ef581de7c1b67a1b6ef6fa9f7c93fdd4c5edef745.AC3irtXDuYfoIjonKcrKoQiKM5cAzu1jisccASmMTpc
+    scenes-app-inbox-signalsourcespanel--tools-on-no-data-yet--dark:
+        hash: v1.k794b7964.203c1d6405e68ace50911e4f13d6edefc48895799412a148d8387d63614d3b41.aMGf7ZpBR4o3DWCom6TuEO-UzwqsaMVKgEYGMmBMss8
+    scenes-app-inbox-signalsourcespanel--tools-on-no-data-yet--light:
+        hash: v1.k794b7964.f610c72ee19f4f36e47157651dcfa007374c85d2b5e851e36c20844e37ba0c69.GvM2ToDHue-jV7R5WRULAKUeHr4CLiLLbzxjgxzUCw4
     scenes-app-inbox-tabs--pull-requests--dark:
         hash: v1.k794b7964.474d8e744637e08afd4bb7540f0f5dafd6a79342c2f547188cb436b55f9ef8e7.PiyD1Zkhkot-_DKLU3W0T5uA7rvpTUTn5bKChCa3AV4
     scenes-app-inbox-tabs--pull-requests--light:

--- a/products/signals/frontend/inbox/components/config/AgentsRoster.tsx
+++ b/products/signals/frontend/inbox/components/config/AgentsRoster.tsx
@@ -10,6 +10,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import type { SyncStatusEnumApi } from 'products/engineering_analytics/frontend/generated/api.schemas'
 
 import { signalSourcesLogic } from '../../signalSourcesLogic'
+import type { SourceToolStatus } from '../../signalSourcesLogic'
 import { SignalSourceConfig, SignalSourceConfigStatus } from '../../types'
 import { getSourceProductMeta } from '../badges/sourceProductIcons'
 import { AGENT_ROSTER_GROUPS, AgentRosterDefinition, AgentRosterSource } from './agentRosterMeta'
@@ -61,14 +62,27 @@ function AgentIcon({ source }: { source: AgentRosterDefinition }): JSX.Element {
 interface AgentCardProps {
     agent: AgentRosterDefinition
     state: AgentSourceState
+    tool?: SourceToolStatus
+    enablingTool: boolean
     onToggle: (source: AgentRosterSource) => void
+    onEnableTool: (tool: SourceToolStatus) => void
 }
 
-const AgentCard = memo(function AgentCard({ agent, state, onToggle }: AgentCardProps): JSX.Element {
+const AgentCard = memo(function AgentCard({
+    agent,
+    state,
+    tool,
+    enablingTool,
+    onToggle,
+    onEnableTool,
+}: AgentCardProps): JSX.Element {
     const { armed, loading, requiresSetup, syncStatus } = state
     const status = resolveAgentStatus(armed, syncStatus)
     const statusTag = STATUS_TAG[status]
-    const isInteractive = !loading
+    const toolOff = !!tool && !tool.enabled
+    // An off tool blocks arming (the source would watch nothing), never disarming.
+    const armingBlocked = toolOff && !armed
+    const isInteractive = !loading && !armingBlocked
 
     const handleCardClick = useCallback(() => {
         if (!isInteractive) {
@@ -115,9 +129,15 @@ const AgentCard = memo(function AgentCard({ agent, state, onToggle }: AgentCardP
 
                 {/* eslint-disable-next-line react/no-unknown-property */}
                 <div className="flex flex-col items-end gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
-                    <LemonTag type={statusTag.type} size="small">
-                        {statusTag.label}
-                    </LemonTag>
+                    {toolOff ? (
+                        <LemonTag type="warning" size="small">
+                            Tool off
+                        </LemonTag>
+                    ) : (
+                        <LemonTag type={statusTag.type} size="small">
+                            {statusTag.label}
+                        </LemonTag>
+                    )}
                     {loading ? (
                         <Spinner className="text-lg" />
                     ) : requiresSetup ? (
@@ -128,11 +148,40 @@ const AgentCard = memo(function AgentCard({ agent, state, onToggle }: AgentCardP
                         <LemonSwitch
                             checked={armed}
                             onChange={() => onToggle(agent.source)}
+                            disabledReason={
+                                armingBlocked
+                                    ? `Turn on ${tool?.toolName} first. This source reads its data.`
+                                    : undefined
+                            }
                             aria-label={`Arm ${agent.label}`}
                         />
                     )}
                 </div>
             </div>
+
+            {toolOff && tool ? (
+                // eslint-disable-next-line react/no-unknown-property
+                <div className="flex items-center gap-2 mt-2 ml-11" onClick={(e) => e.stopPropagation()}>
+                    <span className="text-sm text-warning">
+                        {tool.toolName} is off, so this source has nothing to read.
+                    </span>
+                    {tool.enablement && (
+                        <LemonButton
+                            type="secondary"
+                            size="xsmall"
+                            loading={enablingTool}
+                            onClick={() => onEnableTool(tool)}
+                        >
+                            Turn it on
+                        </LemonButton>
+                    )}
+                </div>
+            ) : tool?.receivingData !== null && tool?.receivingData !== undefined ? (
+                <div className="flex items-center gap-1.5 mt-2 ml-11 text-xs text-muted">
+                    <span className={`size-1.5 rounded-full ${tool.receivingData ? 'bg-success' : 'bg-border-bold'}`} />
+                    {tool.receivingData ? 'Receiving data' : 'No data yet'}
+                </div>
+            ) : null}
 
             {armed && agent.source === 'session_replay' && status === 'syncing' && (
                 <div className="flex items-center gap-2 mt-2 ml-11">
@@ -170,6 +219,8 @@ export function AgentsRoster(): JSX.Element {
         isPgAnalyzeIssuesToggling,
         isHealthChecksToggling,
         isCiSignalsToggling,
+        toolStatusBySource,
+        enablingTool,
     } = useValues(signalSourcesLogic)
     const {
         toggleSessionAnalysis,
@@ -180,6 +231,7 @@ export function AgentsRoster(): JSX.Element {
         toggleAnomalyInvestigation,
         toggleHealthChecks,
         initiateDataWarehouseSourceToggle,
+        enableSourceTool,
     } = useActions(signalSourcesLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
@@ -338,7 +390,12 @@ export function AgentsRoster(): JSX.Element {
                                     key={agent.source}
                                     agent={agent}
                                     state={stateFor(agent.source)}
+                                    tool={toolStatusBySource[agent.source]}
+                                    enablingTool={
+                                        !!enablingTool && enablingTool === toolStatusBySource[agent.source]?.enablement
+                                    }
                                     onToggle={handleToggle}
+                                    onEnableTool={(tool) => tool.enablement && enableSourceTool(tool.enablement)}
                                 />
                             ))}
                     </div>

--- a/products/signals/frontend/inbox/components/config/SignalSourcesPanel.stories.tsx
+++ b/products/signals/frontend/inbox/components/config/SignalSourcesPanel.stories.tsx
@@ -1,0 +1,227 @@
+import { MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { useEffect } from 'react'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { useStorybookMocks } from '~/mocks/browser'
+
+import { ERROR_TRACKING_SIGNAL_SOURCE_TYPES } from '../../signalSourcesLogic'
+import { SignalSourceConfig, SignalSourceProduct, SignalSourceType } from '../../types'
+import { SignalSourcesPanel } from './SignalSourcesPanel'
+
+// Every axis the signal sources dialog renders from: which sources are armed
+// (SignalSourceConfig rows), which PostHog tools are on (team opt-ins), and which usage
+// events exist (event definitions). Each control drives one of the three mocks.
+interface PanelState {
+    // Armed sources
+    errorTrackingArmed: boolean
+    sessionReplayArmed: boolean
+    supportArmed: boolean
+    aiObservabilityArmed: boolean
+    productAnalyticsArmed: boolean
+    healthChecksArmed: boolean
+    // Tool enablement (team opt-ins)
+    exceptionAutocaptureOn: boolean
+    sessionRecordingOn: boolean
+    conversationsOn: boolean
+    // Usage (event definitions present)
+    hasExceptionEvents: boolean
+    hasAiEvents: boolean
+    hasAnalyticsEvents: boolean
+}
+
+function sourceConfig(
+    sourceProduct: SignalSourceProduct,
+    sourceType: SignalSourceType,
+    enabled: boolean
+): SignalSourceConfig {
+    return {
+        id: `${sourceProduct}_${sourceType}`,
+        source_product: sourceProduct,
+        source_type: sourceType,
+        enabled,
+        config: {},
+        created_at: '2024-03-20T00:00:00Z',
+        updated_at: '2024-03-20T00:00:00Z',
+        status: null,
+    }
+}
+
+function sourceConfigsFor(state: PanelState): SignalSourceConfig[] {
+    return [
+        ...ERROR_TRACKING_SIGNAL_SOURCE_TYPES.map((sourceType) =>
+            sourceConfig(SignalSourceProduct.ErrorTracking, sourceType, state.errorTrackingArmed)
+        ),
+        sourceConfig(
+            SignalSourceProduct.SessionReplay,
+            SignalSourceType.SessionAnalysisCluster,
+            state.sessionReplayArmed
+        ),
+        sourceConfig(SignalSourceProduct.Conversations, SignalSourceType.Ticket, state.supportArmed),
+        sourceConfig(SignalSourceProduct.LlmAnalytics, SignalSourceType.EvaluationReport, state.aiObservabilityArmed),
+        sourceConfig(SignalSourceProduct.Analytics, SignalSourceType.AnomalyInvestigation, state.productAnalyticsArmed),
+        sourceConfig(SignalSourceProduct.HealthChecks, SignalSourceType.HealthIssue, state.healthChecksArmed),
+    ]
+}
+
+function eventDefinitionsFor(state: PanelState): { name: string }[] {
+    const names = [
+        ...(state.hasExceptionEvents ? ['$exception'] : []),
+        ...(state.hasAiEvents ? ['$ai_generation', '$ai_trace'] : []),
+        ...(state.hasAnalyticsEvents ? ['$pageview', '$autocapture'] : []),
+    ]
+    return names.map((name) => ({ name }))
+}
+
+function PanelHarness(state: PanelState): JSX.Element {
+    useStorybookMocks({
+        get: {
+            '/api/environments/:team_id/': () => [
+                200,
+                {
+                    ...MOCK_DEFAULT_TEAM,
+                    autocapture_exceptions_opt_in: state.exceptionAutocaptureOn,
+                    session_recording_opt_in: state.sessionRecordingOn,
+                    conversations_enabled: state.conversationsOn,
+                },
+            ],
+            '/api/projects/:team_id/signals/source_configs/': () => [200, { results: sourceConfigsFor(state) }],
+            '/api/projects/:team_id/event_definitions/': () => [
+                200,
+                {
+                    count: eventDefinitionsFor(state).length,
+                    next: null,
+                    previous: null,
+                    results: eventDefinitionsFor(state),
+                },
+            ],
+            '/api/environments/:team_id/external_data_sources/': () => [
+                200,
+                { count: 0, next: null, previous: null, results: [] },
+            ],
+        },
+    })
+
+    // The panel loads on mount and the team is cached app-wide, so a control change has to
+    // both remount the panel (the `key`) and refetch the team against the updated mock.
+    const stateKey = JSON.stringify(state)
+    const { loadCurrentTeam } = teamLogic.actions
+    useEffect(() => {
+        loadCurrentTeam()
+    }, [stateKey, loadCurrentTeam])
+
+    return (
+        <div className="w-[760px] p-6 bg-surface-primary border rounded">
+            <SignalSourcesPanel key={stateKey} />
+        </div>
+    )
+}
+
+const meta: Meta<typeof PanelHarness> = {
+    title: 'Scenes-App/Inbox/SignalSourcesPanel',
+    component: PanelHarness,
+    parameters: {
+        layout: 'centered',
+        viewMode: 'story',
+        mockDate: '2024-03-20',
+    },
+    args: {
+        errorTrackingArmed: true,
+        sessionReplayArmed: true,
+        supportArmed: false,
+        aiObservabilityArmed: false,
+        productAnalyticsArmed: false,
+        healthChecksArmed: true,
+        exceptionAutocaptureOn: true,
+        sessionRecordingOn: true,
+        conversationsOn: false,
+        hasExceptionEvents: true,
+        hasAiEvents: false,
+        hasAnalyticsEvents: true,
+    },
+}
+export default meta
+
+type Story = StoryObj<typeof PanelHarness>
+
+/** Flip any control: armed sources, tool opt-ins, and which usage events exist. */
+export const Playground: Story = {}
+
+/** Sources armed while every tool is off: each PostHog card warns and offers "Turn it on". */
+export const ArmedButToolsOff: Story = {
+    args: {
+        errorTrackingArmed: true,
+        sessionReplayArmed: true,
+        supportArmed: true,
+        exceptionAutocaptureOn: false,
+        sessionRecordingOn: false,
+        conversationsOn: false,
+        hasExceptionEvents: false,
+        hasAiEvents: false,
+        hasAnalyticsEvents: false,
+    },
+}
+
+/** Nothing armed and every tool off: switches are disabled with the turn-on-the-tool reason. */
+export const ArmingBlocked: Story = {
+    args: {
+        errorTrackingArmed: false,
+        sessionReplayArmed: false,
+        supportArmed: false,
+        aiObservabilityArmed: false,
+        productAnalyticsArmed: false,
+        healthChecksArmed: false,
+        exceptionAutocaptureOn: false,
+        sessionRecordingOn: false,
+        conversationsOn: false,
+        hasExceptionEvents: false,
+        hasAiEvents: false,
+        hasAnalyticsEvents: false,
+    },
+}
+
+/** Every tool on and every source armed, with data flowing everywhere it can be measured. */
+export const EverythingHealthy: Story = {
+    args: {
+        errorTrackingArmed: true,
+        sessionReplayArmed: true,
+        supportArmed: true,
+        aiObservabilityArmed: true,
+        productAnalyticsArmed: true,
+        healthChecksArmed: true,
+        exceptionAutocaptureOn: true,
+        sessionRecordingOn: true,
+        conversationsOn: true,
+        hasExceptionEvents: true,
+        hasAiEvents: true,
+        hasAnalyticsEvents: true,
+    },
+}
+
+/** Tools on but no events yet: the usage lines read "No data yet". */
+export const ToolsOnNoDataYet: Story = {
+    args: {
+        errorTrackingArmed: true,
+        sessionReplayArmed: true,
+        supportArmed: true,
+        aiObservabilityArmed: true,
+        productAnalyticsArmed: true,
+        exceptionAutocaptureOn: true,
+        sessionRecordingOn: true,
+        conversationsOn: true,
+        hasExceptionEvents: false,
+        hasAiEvents: false,
+        hasAnalyticsEvents: false,
+    },
+}
+
+/** Exceptions flow from a server SDK while the autocapture opt-in is off: still counts as on. */
+export const ServerSideExceptionsOnly: Story = {
+    args: {
+        errorTrackingArmed: true,
+        exceptionAutocaptureOn: false,
+        hasExceptionEvents: true,
+    },
+}

--- a/products/signals/frontend/inbox/components/config/SignalSourcesPanel.tsx
+++ b/products/signals/frontend/inbox/components/config/SignalSourcesPanel.tsx
@@ -28,6 +28,7 @@ export function SignalSourcesPanel(): JSX.Element {
     const {
         loadSources,
         loadSourceConfigs,
+        loadToolDataEvents,
         closeSessionAnalysisSetup,
         closeDataSourceSetup,
         onDataSourceSetupComplete,
@@ -36,6 +37,7 @@ export function SignalSourcesPanel(): JSX.Element {
     useEffect(() => {
         loadSources()
         loadSourceConfigs()
+        loadToolDataEvents()
     }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
     if (dataSourceSetupSource !== null) {

--- a/products/signals/frontend/inbox/signalSourcesLogic.ts
+++ b/products/signals/frontend/inbox/signalSourcesLogic.ts
@@ -10,8 +10,15 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import type { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
+import { productEnablementCreate } from '~/generated/core/api'
 import { ExternalDataSourceType } from '~/queries/schema/schema-general'
-import { ExternalDataSource, ExternalDataSourceSchema, RecordingUniversalFilters } from '~/types'
+import {
+    ExternalDataSource,
+    ExternalDataSourceSchema,
+    RecordingUniversalFilters,
+    TeamPublicType,
+    TeamType,
+} from '~/types'
 
 import { sourcesDataLogic } from 'products/data_warehouse/frontend/shared/logics/sourcesDataLogic'
 import {
@@ -19,10 +26,28 @@ import {
     engineeringAnalyticsCiSignalsConfigUpdate,
 } from 'products/engineering_analytics/frontend/generated/api'
 import type { CISignalsConfigApi } from 'products/engineering_analytics/frontend/generated/api.schemas'
+import { eventDefinitionsList } from 'products/event_definitions/frontend/generated/api'
 import { SignalSourceProduct, SignalSourceType } from 'products/signals/frontend/inbox/types'
 
+import type { AgentRosterSource } from './components/config/agentRosterMeta'
 import { captureSignalSourceConnected, captureSignalSourceDisabled } from './inboxAnalytics'
 import { SignalSourceConfig, SignalSourceConfigStatus, ToggleSignalSourceParams } from './types'
+
+/** product_enablement recipe names for tools that back a signal source. */
+export type SourceToolEnablement = 'session_replay' | 'error_tracking' | 'conversations'
+
+/** The PostHog tool behind a signal source: whether it captures anything, and how to turn it on. */
+export interface SourceToolStatus {
+    toolName: string
+    enabled: boolean
+    /** The product_enablement recipe that turns the tool on, when one exists. */
+    enablement: SourceToolEnablement | null
+    /** Whether the tool's events exist in this project; null when there is no cheap event signal. */
+    receivingData: boolean | null
+}
+
+/** Event definitions probed to tell whether each source's tool is receiving data. */
+const TOOL_USAGE_EVENTS = ['$exception', '$ai_generation', '$ai_trace', '$pageview', '$autocapture']
 
 /** Matches Cymbal `EmitSignalRequest.source_type` + `products.signals.backend.api.emit_signal` checks. */
 export const ERROR_TRACKING_SIGNAL_SOURCE_TYPES: SignalSourceType[] = [
@@ -175,6 +200,7 @@ export interface signalSourcesLogicValues {
     featureFlags: FeatureFlagsSet // featureFlagLogic
     dataWarehouseSources: PaginatedResponse<ExternalDataSource> | null // sourcesDataLogic
     dataWarehouseSourcesLoading: boolean // sourcesDataLogic
+    currentTeam: TeamPublicType | TeamType | null // teamLogic
     anomalyInvestigationConfig: SignalSourceConfig | null
     ciSignalsConfig: CISignalsConfigApi | null
     ciSignalsConfigLoading: boolean
@@ -182,6 +208,7 @@ export interface signalSourcesLogicValues {
     conversationsConfig: SignalSourceConfig | null
     dataSourceSetupSource: WarehouseBackedSource | null
     enabledSourcesCount: number
+    enablingTool: SourceToolEnablement | null
     errorTrackingIsFullyEnabled: boolean
     evalReportsConfig: SignalSourceConfig | null
     githubIssuesConfig: SignalSourceConfig | null
@@ -207,6 +234,9 @@ export interface signalSourcesLogicValues {
     sourceConfigsLoading: boolean
     sourcesModalOpen: boolean
     togglingSourceKeys: Set<string>
+    toolDataEvents: Set<string> | null
+    toolDataEventsLoading: boolean
+    toolStatusBySource: Partial<Record<AgentRosterSource, SourceToolStatus>>
     zendeskTicketsConfig: SignalSourceConfig | null
 }
 
@@ -215,6 +245,7 @@ export interface signalSourcesLogicActions {
     loadSources: () => {
         value: true
     } // sourcesDataLogic
+    loadCurrentTeam: () => any // teamLogic
     clearSessionAnalysisFilters: () => {
         value: true
     }
@@ -229,6 +260,12 @@ export interface signalSourcesLogicActions {
     }
     completeDataWarehouseSourceToggle: (source: WarehouseBackedSource) => {
         source: WarehouseBackedSource
+    }
+    enableSourceTool: (enablement: SourceToolEnablement) => {
+        enablement: SourceToolEnablement
+    }
+    enableSourceToolComplete: () => {
+        value: true
     }
     initiateDataWarehouseSourceToggle: (source: WarehouseBackedSource) => {
         source: WarehouseBackedSource
@@ -261,6 +298,21 @@ export interface signalSourcesLogicActions {
         payload?: any
     ) => {
         sourceConfigs: SignalSourceConfig[]
+        payload?: any
+    }
+    loadToolDataEvents: () => any
+    loadToolDataEventsFailure: (
+        error: string,
+        errorObject?: any
+    ) => {
+        error: string
+        errorObject?: any
+    }
+    loadToolDataEventsSuccess: (
+        toolDataEvents: Set<string>,
+        payload?: any
+    ) => {
+        toolDataEvents: Set<string>
         payload?: any
     }
     onDataSourceSetupComplete: () => {
@@ -352,6 +404,10 @@ export interface signalSourcesLogicMeta {
         isEvalReportsToggling: (togglingSourceKeys: Set<string>) => boolean
         anomalyInvestigationConfig: (sourceConfigs: SignalSourceConfig[] | null) => SignalSourceConfig | null
         isAnomalyInvestigationToggling: (togglingSourceKeys: Set<string>) => boolean
+        toolStatusBySource: (
+            currentTeam: TeamPublicType | TeamType | null,
+            toolDataEvents: Set<string> | null
+        ) => Partial<Record<AgentRosterSource, SourceToolStatus>>
         errorTrackingIsFullyEnabled: (sourceConfigs: SignalSourceConfig[] | null) => boolean
         ciSignalsIsFullyEnabled: (ciSignalsConfig: CISignalsConfigApi | null) => boolean
         isCiSignalsToggling: (togglingSourceKeys: Set<string>) => boolean
@@ -377,8 +433,10 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
             ['dataWarehouseSources', 'dataWarehouseSourcesLoading'],
             featureFlagLogic,
             ['featureFlags'],
+            teamLogic,
+            ['currentTeam'],
         ],
-        actions: [sourcesDataLogic, ['loadSources']],
+        actions: [sourcesDataLogic, ['loadSources'], teamLogic, ['loadCurrentTeam']],
     })),
 
     actions({
@@ -405,6 +463,8 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
         toggleEvalReports: true,
         toggleConversations: true,
         toggleAnomalyInvestigation: true,
+        enableSourceTool: (enablement: SourceToolEnablement) => ({ enablement }),
+        enableSourceToolComplete: true,
         saveSessionAnalysisFilters: (filters: RecordingUniversalFilters) => ({ filters }),
         clearSessionAnalysisFilters: true,
     }),
@@ -424,6 +484,18 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
             {
                 loadCiSignalsConfig: async (): Promise<CISignalsConfigApi> =>
                     engineeringAnalyticsCiSignalsConfigRetrieve(String(teamLogic.values.currentTeamId)),
+            },
+        ],
+        toolDataEvents: [
+            null as Set<string> | null,
+            {
+                loadToolDataEvents: async (): Promise<Set<string>> => {
+                    const response = await eventDefinitionsList(String(teamLogic.values.currentTeamId), {
+                        names: TOOL_USAGE_EVENTS,
+                        limit: TOOL_USAGE_EVENTS.length,
+                    })
+                    return new Set(response.results.map(({ name }) => name))
+                },
             },
         ],
     }),
@@ -450,6 +522,13 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                 openDataSourceSetup: (_, { source }) => source,
                 closeDataSourceSetup: () => null,
                 closeSourcesModal: () => null,
+            },
+        ],
+        enablingTool: [
+            null as SourceToolEnablement | null,
+            {
+                enableSourceTool: (_, { enablement }) => enablement,
+                enableSourceToolComplete: () => null,
             },
         ],
         sourceConfigs: {
@@ -653,6 +732,52 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
             (s) => [s.togglingSourceKeys],
             (keys: Set<string>): boolean =>
                 keys.has(`${SignalSourceProduct.Analytics}_${SignalSourceType.AnomalyInvestigation}`),
+        ],
+        toolStatusBySource: [
+            (s) => [s.currentTeam, s.toolDataEvents],
+            (
+                currentTeam: TeamPublicType | TeamType | null,
+                toolDataEvents: Set<string> | null
+            ): Partial<Record<AgentRosterSource, SourceToolStatus>> => {
+                const team = currentTeam as TeamType | null
+                const has = (...events: string[]): boolean | null =>
+                    toolDataEvents ? events.some((event) => toolDataEvents.has(event)) : null
+                return {
+                    error_tracking: {
+                        toolName: 'Error tracking',
+                        // Server SDKs capture exceptions without the autocapture opt-in, so
+                        // flowing data counts as on.
+                        enabled: !!team?.autocapture_exceptions_opt_in || has('$exception') === true,
+                        enablement: 'error_tracking',
+                        receivingData: has('$exception'),
+                    },
+                    session_replay: {
+                        toolName: 'Session replay',
+                        enabled: !!team?.session_recording_opt_in,
+                        enablement: 'session_replay',
+                        // Recordings never produce event definitions, so there is no cheap signal.
+                        receivingData: null,
+                    },
+                    conversations: {
+                        toolName: 'Support',
+                        enabled: !!team?.conversations_enabled,
+                        enablement: 'conversations',
+                        receivingData: null,
+                    },
+                    llm_analytics: {
+                        toolName: 'AI observability',
+                        enabled: true,
+                        enablement: null,
+                        receivingData: has('$ai_generation', '$ai_trace'),
+                    },
+                    analytics: {
+                        toolName: 'Product analytics',
+                        enabled: true,
+                        enablement: null,
+                        receivingData: has('$pageview', '$autocapture'),
+                    },
+                }
+            },
         ],
         errorTrackingIsFullyEnabled: [
             (s) => [s.sourceConfigs],
@@ -1006,6 +1131,18 @@ export const signalSourcesLogic = kea<signalSourcesLogicType>([
                     sourceType: SignalSourceType.AnomalyInvestigation,
                     enabled: desiredEnabled,
                 })
+            },
+            enableSourceTool: async ({ enablement }) => {
+                try {
+                    await productEnablementCreate(String(teamLogic.values.currentTeamId), {
+                        products: [enablement],
+                    })
+                    // Refresh the cached team so the tool reads back as on.
+                    actions.loadCurrentTeam()
+                } catch (error: any) {
+                    lemonToast.error(error?.detail || error?.message || "Couldn't turn this on. Please try again.")
+                }
+                actions.enableSourceToolComplete()
             },
             setDataWarehouseSourceEnabled: ({ source, enabled }) => {
                 const { completion } = WAREHOUSE_SOURCE_SETUP[source]


### PR DESCRIPTION
## Problem

- A signal source can be armed while the PostHog tool behind it is off, so it watches nothing and the user cannot tell why the inbox stays empty.
- The source toggles only write `SignalSourceConfig` rows and never check the team's tool opt-ins (replay recording, exception autocapture, conversations).

Closes #79141

## Changes

- Each PostHog-data card in the Signal sources dialog now knows its tool's state, from the team row.
- A card whose tool is off shows a "Tool off" tag, an inline warning, and a "Turn it on" button that calls the `product_enablement` endpoint and refreshes the team.
- Arming is blocked while the tool is off (disabled switch with the reason); disarming stays allowed.
- Cards with a cheap usage signal show "Receiving data" or "No data yet", from one batched event-definition lookup (`$exception`, `$ai_generation`, `$ai_trace`, `$pageview`, `$autocapture`).
- Error tracking counts flowing `$exception` data as on even without the autocapture opt-in, because server SDKs capture exceptions without it.
- Session replay shows no usage line: recordings never produce event definitions, so there is no cheap signal.
- A story file covers the dialog's full state space: controls for armed sources, tool opt-ins, and usage events, plus presets for the notable combinations.

| Tool off states and usage lines | Blocked arming |
| --- | --- |
| ![tool off](https://raw.githubusercontent.com/PostHog/pr-assets/e12ff569565379767886e09d63c2fb4ff6205e78/2026/08/inbox-source-tool-status-off.jpg) | ![blocked](https://raw.githubusercontent.com/PostHog/pr-assets/e12ff569565379767886e09d63c2fb4ff6205e78/2026/08/inbox-source-tool-status-blocked.jpg) |

## How did you test this code?

- Verified in the running dev app: an armed source with its tool off shows the warning, "Turn it on" enabled the tool end to end (card flipped to Watching and the usage line appeared), and a disarmed source with its tool off has a disabled switch with the tooltip.
- Not run: no automated tests added; the change is display state plus one enablement call over existing logics, and the roster has no test harness to extend cheaply.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, the dialog behavior is self-describing and not separately documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code. Skills invoked: /writing-user-facing-copy, /writing-pr-descriptions.
- Validated the premise first: source toggles never touch team opt-ins, so the armed-but-dead state is real.
- Second layer of a stack: base is the Super Hog Powers tool status panel PR (#79251); the self-driving onboarding PR (#77849) stacks on top.

