### PR TITLE
feat(posthog_ai): offer Codex models in the task composer

### DIFF
--- a/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.tsx
+++ b/products/posthog_ai/frontend/components/composer/ComposerModelEffortPickers.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 
 import { IconBrain, IconChevronDown } from '@posthog/icons'
 import {
@@ -8,14 +8,17 @@ import {
     DropdownMenuLabel,
     DropdownMenuRadioGroup,
     DropdownMenuRadioItem,
+    DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@posthog/quill-primitives'
 
 import {
     COMPOSER_MODELS,
+    type ComposerModelOption,
     getEffortLabel,
     getEffortsForModel,
     getModelLabel,
+    groupModelsByRuntimeAdapter,
 } from 'products/posthog_ai/frontend/utils/composerModels'
 import { ReasoningEffortEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
@@ -24,6 +27,8 @@ export interface ComposerModelEffortPickersProps {
     selectedEffort: ReasoningEffortEnumApi
     onModelChange: (model: string) => void
     onEffortChange: (effort: ReasoningEffortEnumApi) => void
+    /** Narrows the models on offer — a live run can only switch within the runtime it was launched on. */
+    models?: ComposerModelOption[]
 }
 
 /**
@@ -37,8 +42,10 @@ export function ComposerModelEffortPickers({
     selectedEffort,
     onModelChange,
     onEffortChange,
+    models = COMPOSER_MODELS,
 }: ComposerModelEffortPickersProps): JSX.Element {
     const effortOptions = getEffortsForModel(selectedModel)
+    const modelGroups = useMemo(() => groupModelsByRuntimeAdapter(models), [models])
     const [modelOpen, setModelOpen] = useState(false)
     const [effortOpen, setEffortOpen] = useState(false)
 
@@ -61,11 +68,17 @@ export function ComposerModelEffortPickers({
                             setModelOpen(false)
                         }}
                     >
-                        <DropdownMenuLabel>Model</DropdownMenuLabel>
-                        {COMPOSER_MODELS.map((option) => (
-                            <DropdownMenuRadioItem key={option.value} value={option.value}>
-                                {option.label}
-                            </DropdownMenuRadioItem>
+                        {/* Sectioned by harness, so it's clear which agent a model actually runs in. */}
+                        {modelGroups.map((group, index) => (
+                            <Fragment key={group.adapter}>
+                                {index > 0 && <DropdownMenuSeparator />}
+                                <DropdownMenuLabel>{group.label}</DropdownMenuLabel>
+                                {group.models.map((option) => (
+                                    <DropdownMenuRadioItem key={option.value} value={option.value}>
+                                        {option.label}
+                                    </DropdownMenuRadioItem>
+                                ))}
+                            </Fragment>
                         ))}
                     </DropdownMenuRadioGroup>
                 </DropdownMenuContent>

--- a/products/posthog_ai/frontend/logics/runInteractionLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runInteractionLogic.test.ts
@@ -261,8 +261,14 @@ describe('runInteractionLogic', () => {
         expect(logic.values.selectedMode).toBe('auto')
     })
 
-    it('seeds a fresh run with the picked permission mode when the run is terminal', async () => {
+    // The picker speaks Claude's mode vocabulary, but a Codex run is created with Codex's — the API
+    // rejects the wrong one, so the runtime and the mode have to be derived from the picked model together.
+    it.each([
+        ['claude-sonnet-5', 'claude', 'bypassPermissions'],
+        ['gpt-5.6-luna', 'codex', 'full-access'],
+    ])("launches a fresh terminal-run send on %s's runtime and mode", async (model, adapter, permissionMode) => {
         setStatus('completed')
+        logic.actions.setModel(model)
         logic.actions.setMode('bypassPermissions')
         logic.actions.setComposerFormValues({ draft: 'continue from here' })
 
@@ -273,7 +279,11 @@ describe('runInteractionLogic', () => {
         expect(tasksRunCreate).toHaveBeenCalledWith(
             '997',
             TASK_ID,
-            expect.objectContaining({ initial_permission_mode: 'bypassPermissions' })
+            expect.objectContaining({
+                runtime_adapter: adapter,
+                model,
+                initial_permission_mode: permissionMode,
+            })
         )
     })
 

--- a/products/posthog_ai/frontend/logics/runInteractionLogic.ts
+++ b/products/posthog_ai/frontend/logics/runInteractionLogic.ts
@@ -9,6 +9,7 @@ import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
 import {
     DEFAULT_COMPOSER_EFFORT,
     DEFAULT_COMPOSER_MODEL,
+    buildRuntimeSelection,
     resolveEffortForModel,
 } from 'products/posthog_ai/frontend/utils/composerModels'
 import {
@@ -18,9 +19,8 @@ import {
 } from 'products/posthog_ai/frontend/utils/composerModes'
 import { tasksRunCreate, tasksRunsCommandCreate } from 'products/tasks/frontend/generated/api'
 import {
-    ClaudeRuntimeAdapterEnumApi,
-    type ClaudeTaskRunCreateSchemaApi,
     type ReasoningEffortEnumApi,
+    type TaskRunCreateRequestSchemaApi,
 } from 'products/tasks/frontend/generated/api.schemas'
 
 import { type AttachedContextItem, attachedContextItemKey } from '../types/contextTypes'
@@ -729,13 +729,10 @@ export const runInteractionLogic = kea<runInteractionLogicType>([
                 try {
                     // Same endpoint as the "Run again" button, but seeded with the user's message and chained
                     // from the finished run so the new run continues the thread, and carrying the picked model /
-                    // reasoning effort (the resume schema can't, so we send the Claude create shape). The response
+                    // reasoning effort (the resume schema can't, so we send the create shape). The response
                     // carries the new run id as `latest_run`; the consumer-provided `onRunStarted` re-points to it.
-                    const createRequest: ClaudeTaskRunCreateSchemaApi = {
-                        runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
-                        model: values.selectedModel,
-                        reasoning_effort: values.selectedEffort,
-                        initial_permission_mode: values.selectedMode,
+                    const createRequest: TaskRunCreateRequestSchemaApi = {
+                        ...buildRuntimeSelection(values.selectedModel, values.selectedEffort, values.selectedMode),
                         resume_from_run_id: props.runId,
                         pending_user_message: wrapWithPosthogContext(content, pendingContext),
                     }

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { useMemo } from 'react'
 
 import { AIConsentPopoverWrapper } from 'scenes/settings/organization/AIConsentPopoverWrapper'
 import { userLogic } from 'scenes/userLogic'
@@ -9,6 +10,11 @@ import { Composer, QueuedMessageList } from 'products/posthog_ai/frontend/api/pr
 // surface is its primary content, so a second `lazy()` would only add a redundant chunk fetch + Suspense
 // flash. The inbox embeds keep the lazy `ReadonlyRunSurface`.
 import { RunSurface } from 'products/posthog_ai/frontend/api/runSurface'
+import {
+    COMPOSER_MODELS,
+    getModelsForRuntimeAdapter,
+    getRuntimeAdapterForModel,
+} from 'products/posthog_ai/frontend/utils/composerModels'
 import { cycleMode } from 'products/posthog_ai/frontend/utils/composerModes'
 
 import { AttachedContextBar } from '../../../components/composer/AttachedContextBar'
@@ -133,6 +139,13 @@ function LiveComposer({ logicProps }: { logicProps: RunInteractionLogicProps }):
 
     const draft = useDebouncedDraft(composerForm.draft, (value) => setComposerFormValues({ draft: value }))
 
+    // A running session is pinned to the harness it booted on — its agent ignores a model id from the other
+    // one. Once terminal the send launches a fresh run, so any model is fair game again.
+    const availableModels = useMemo(
+        () => (isTerminal ? COMPOSER_MODELS : getModelsForRuntimeAdapter(getRuntimeAdapterForModel(selectedModel))),
+        [isTerminal, selectedModel]
+    )
+
     return (
         <>
             {/* Inside the slot children: detaches while a pending approval replaces the composer. */}
@@ -174,6 +187,7 @@ function LiveComposer({ logicProps }: { logicProps: RunInteractionLogicProps }):
                             selectedEffort={selectedEffort}
                             onModelChange={setModel}
                             onEffortChange={setEffort}
+                            models={availableModels}
                         />
                     </Composer.Footer>
                 </Composer.Frame>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
@@ -107,6 +107,25 @@ describe('taskTrackerSceneLogic', () => {
         expect(router.values.location.pathname).toContain('/tasks/new-task')
     })
 
+    // The picker speaks Claude's mode vocabulary, but a Codex model has to launch on the codex runtime with
+    // Codex's — the API rejects the wrong pairing, so the runtime and the mode both follow the picked model.
+    it.each([
+        ['claude-sonnet-5', 'claude', 'bypassPermissions'],
+        ['gpt-5.6-terra', 'codex', 'full-access'],
+    ])("launches a new task on %s's runtime and mode", async (model, adapter, permissionMode) => {
+        logic.mount()
+        logic.actions.setNewTaskData({ description: 'do the thing', model, permissionMode: 'bypassPermissions' })
+        logic.actions.submitNewTask()
+
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(runBody).toMatchObject({
+            runtime_adapter: adapter,
+            model,
+            initial_permission_mode: permissionMode,
+        })
+    })
+
     // The seeded first message wraps the on-screen context, and the wrapped non-text refs must be marked
     // sent under the created task's id — otherwise the run's first follow-up (sent via
     // `runInteractionLogic`, which prunes against the task-scoped store) re-wraps the same refs.

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -10,7 +10,6 @@ import { aiConsentLogic } from 'scenes/settings/organization/aiConsentLogic'
 
 import { tasksCreate, tasksRunCreate } from 'products/tasks/frontend/generated/api'
 import {
-    ClaudeRuntimeAdapterEnumApi,
     OriginProductEnumApi,
     ReasoningEffortEnumApi,
     type TaskWriteApi,
@@ -30,7 +29,7 @@ import { toolStreamEventsLogic } from '../../logics/toolStreamEventsLogic'
 import type { AttachedContextItem } from '../../types/contextTypes'
 import type { RepositoryConfig, Task } from '../../types/taskTypes'
 import type { TaskListParams } from '../../types/taskTypes'
-import { DEFAULT_COMPOSER_EFFORT, DEFAULT_COMPOSER_MODEL, resolveEffortForModel } from '../../utils/composerModels'
+import { DEFAULT_COMPOSER_EFFORT, DEFAULT_COMPOSER_MODEL, buildRuntimeSelection } from '../../utils/composerModels'
 import { DEFAULT_COMPOSER_MODE, type PermissionMode } from '../../utils/composerModes'
 import { wrapWithPosthogContext } from '../../utils/posthogContextBlock'
 
@@ -506,13 +505,11 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
 
                 // Auto-run the task after creation; the detail scene shows the latest run by default. The
                 // run checks out the chosen branch (server falls back to the repo's default branch if unset)
-                // and launches with the picked model / reasoning effort (clamped to one the model supports).
+                // and launches on the runtime the picked model needs, with its effort / permission mode
+                // clamped to what that runtime accepts.
                 const runResponse = await tasksRunCreate(projectId, newTask.id, {
+                    ...buildRuntimeSelection(model, reasoningEffort, permissionMode),
                     branch: repositoryConfig.branch ?? null,
-                    runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
-                    model,
-                    reasoning_effort: resolveEffortForModel(reasoningEffort, model),
-                    initial_permission_mode: permissionMode,
                     // Interactive keeps the sandbox agent-server's event stream open across turns, so
                     // follow-up messages stream their reply over the same SSE (background runs seal the
                     // stream after the first turn). Interactive runs boot with the agent-server pulling

--- a/products/posthog_ai/frontend/utils/composerModels.test.ts
+++ b/products/posthog_ai/frontend/utils/composerModels.test.ts
@@ -1,0 +1,29 @@
+import { RuntimeAdapterEnumApi } from 'products/tasks/frontend/generated/api.schemas'
+
+import { type ComposerModelOption, groupModelsByRuntimeAdapter } from './composerModels'
+
+describe('composerModels', () => {
+    // New models get appended to COMPOSER_MODELS as they ship, so a Claude model can land after the Codex
+    // ones. Each harness must still render as one section — two "Claude Code" headers would read as two
+    // different harnesses.
+    it('groups models under one section per harness, in first-seen order', () => {
+        const models: ComposerModelOption[] = [
+            { value: 'claude-sonnet-5', label: 'Claude Sonnet 5', runtimeAdapter: RuntimeAdapterEnumApi.Claude },
+            { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', runtimeAdapter: RuntimeAdapterEnumApi.Codex },
+            { value: 'claude-opus-5', label: 'Claude Opus 5', runtimeAdapter: RuntimeAdapterEnumApi.Claude },
+        ]
+
+        expect(groupModelsByRuntimeAdapter(models)).toEqual([
+            {
+                adapter: RuntimeAdapterEnumApi.Claude,
+                label: 'Claude Code',
+                models: [models[0], models[2]],
+            },
+            {
+                adapter: RuntimeAdapterEnumApi.Codex,
+                label: 'Codex',
+                models: [models[1]],
+            },
+        ])
+    })
+})

--- a/products/posthog_ai/frontend/utils/composerModels.ts
+++ b/products/posthog_ai/frontend/utils/composerModels.ts
@@ -1,8 +1,27 @@
-import { ReasoningEffortEnumApi } from 'products/tasks/frontend/generated/api.schemas'
+import {
+    ClaudeRuntimeAdapterEnumApi,
+    type ClaudeTaskRunCreateSchemaApi,
+    CodexRuntimeAdapterEnumApi,
+    type CodexTaskRunCreateSchemaApi,
+    ReasoningEffortEnumApi,
+    RuntimeAdapterEnumApi,
+} from 'products/tasks/frontend/generated/api.schemas'
+
+import { type PermissionMode, toCodexPermissionMode } from './composerModes'
+
+export type ComposerRuntimeAdapter = (typeof RuntimeAdapterEnumApi)[keyof typeof RuntimeAdapterEnumApi]
+
+// The harness each runtime runs, named the way the desktop app names it.
+export const RUNTIME_ADAPTER_LABELS: Record<ComposerRuntimeAdapter, string> = {
+    [RuntimeAdapterEnumApi.Claude]: 'Claude Code',
+    [RuntimeAdapterEnumApi.Codex]: 'Codex',
+}
 
 export interface ComposerModelOption {
     value: string
     label: string
+    /** The runtime the model has to be launched on — the harness is picked from the model, not chosen separately. */
+    runtimeAdapter: ComposerRuntimeAdapter
 }
 
 export interface ComposerEffortOption {
@@ -10,12 +29,15 @@ export interface ComposerEffortOption {
     label: string
 }
 
-// Claude-only lineup — the task tracker always launches the `claude` runtime adapter, so Codex/GPT models are
-// intentionally absent. Add new Claude models here as they ship.
+// Mirrors the backend's tested catalogs (CLAUDE_REASONING_EFFORTS_BY_MODEL and CODEX_MODELS in
+// products/tasks/backend/temporal/process_task/utils.py). Add new models here as they ship.
 export const COMPOSER_MODELS: ComposerModelOption[] = [
-    { value: 'claude-sonnet-5', label: 'Claude Sonnet 5' },
-    { value: 'claude-opus-5', label: 'Claude Opus 5' },
-    { value: 'claude-opus-4-8', label: 'Claude Opus 4.8' },
+    { value: 'claude-sonnet-5', label: 'Claude Sonnet 5', runtimeAdapter: RuntimeAdapterEnumApi.Claude },
+    { value: 'claude-opus-5', label: 'Claude Opus 5', runtimeAdapter: RuntimeAdapterEnumApi.Claude },
+    { value: 'claude-opus-4-8', label: 'Claude Opus 4.8', runtimeAdapter: RuntimeAdapterEnumApi.Claude },
+    { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna', runtimeAdapter: RuntimeAdapterEnumApi.Codex },
+    { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra', runtimeAdapter: RuntimeAdapterEnumApi.Codex },
+    { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol', runtimeAdapter: RuntimeAdapterEnumApi.Codex },
 ]
 
 export const DEFAULT_COMPOSER_MODEL = 'claude-sonnet-5'
@@ -30,8 +52,9 @@ const EFFORT_LABELS: Record<ReasoningEffortEnumApi, string> = {
     [ReasoningEffortEnumApi.Ultracode]: 'Ultracode',
 }
 
-// Mirrors backend CLAUDE_REASONING_EFFORTS_BY_MODEL (products/tasks/backend/temporal/process_task/utils.py):
-// xhigh/max are only offered for models that support them.
+// Mirrors the backend's per-model effort sets (CLAUDE_REASONING_EFFORTS_BY_MODEL and
+// CODEX_MAX_REASONING_MODELS in products/tasks/backend/temporal/process_task/utils.py): xhigh/max/ultracode
+// are only offered for models that support them.
 const EFFORTS_BY_MODEL: Record<string, ReasoningEffortEnumApi[]> = {
     'claude-opus-4-8': [
         ReasoningEffortEnumApi.Low,
@@ -57,6 +80,27 @@ const EFFORTS_BY_MODEL: Record<string, ReasoningEffortEnumApi[]> = {
         ReasoningEffortEnumApi.Max,
         ReasoningEffortEnumApi.Ultracode,
     ],
+    'gpt-5.6-luna': [
+        ReasoningEffortEnumApi.Low,
+        ReasoningEffortEnumApi.Medium,
+        ReasoningEffortEnumApi.High,
+        ReasoningEffortEnumApi.Xhigh,
+        ReasoningEffortEnumApi.Max,
+    ],
+    'gpt-5.6-terra': [
+        ReasoningEffortEnumApi.Low,
+        ReasoningEffortEnumApi.Medium,
+        ReasoningEffortEnumApi.High,
+        ReasoningEffortEnumApi.Xhigh,
+        ReasoningEffortEnumApi.Max,
+    ],
+    'gpt-5.6-sol': [
+        ReasoningEffortEnumApi.Low,
+        ReasoningEffortEnumApi.Medium,
+        ReasoningEffortEnumApi.High,
+        ReasoningEffortEnumApi.Xhigh,
+        ReasoningEffortEnumApi.Max,
+    ],
 }
 
 const FALLBACK_EFFORTS: ReasoningEffortEnumApi[] = [
@@ -72,6 +116,68 @@ export function getEffortsForModel(model: string | null | undefined): ComposerEf
 
 export function getModelLabel(model: string | null | undefined): string {
     return COMPOSER_MODELS.find((option) => option.value === model)?.label ?? model ?? 'Model'
+}
+
+// An unknown model resolves to Claude — the historical default, and the runtime every run predating the
+// Codex lineup was launched on.
+export function getRuntimeAdapterForModel(model: string | null | undefined): ComposerRuntimeAdapter {
+    return COMPOSER_MODELS.find((option) => option.value === model)?.runtimeAdapter ?? RuntimeAdapterEnumApi.Claude
+}
+
+export function getModelsForRuntimeAdapter(adapter: ComposerRuntimeAdapter): ComposerModelOption[] {
+    return COMPOSER_MODELS.filter((option) => option.runtimeAdapter === adapter)
+}
+
+export interface ComposerModelGroup {
+    adapter: ComposerRuntimeAdapter
+    label: string
+    models: ComposerModelOption[]
+}
+
+/** Split a model list into per-harness sections for the picker, keeping the lineup's order. */
+export function groupModelsByRuntimeAdapter(models: ComposerModelOption[]): ComposerModelGroup[] {
+    const groups: ComposerModelGroup[] = []
+    for (const model of models) {
+        const group = groups.find((candidate) => candidate.adapter === model.runtimeAdapter)
+        if (group) {
+            group.models.push(model)
+        } else {
+            groups.push({
+                adapter: model.runtimeAdapter,
+                label: RUNTIME_ADAPTER_LABELS[model.runtimeAdapter],
+                models: [model],
+            })
+        }
+    }
+    return groups
+}
+
+/** The runtime half of a run-create request — the two adapters take different permission-mode vocabularies. */
+export type ComposerRuntimeSelection =
+    | Pick<ClaudeTaskRunCreateSchemaApi, 'runtime_adapter' | 'model' | 'reasoning_effort' | 'initial_permission_mode'>
+    | Pick<CodexTaskRunCreateSchemaApi, 'runtime_adapter' | 'model' | 'reasoning_effort' | 'initial_permission_mode'>
+
+/** Derive the runtime a run launches on from the picked model, clamping effort and mode to what it accepts. */
+export function buildRuntimeSelection(
+    model: string,
+    effort: string | null | undefined,
+    mode: PermissionMode
+): ComposerRuntimeSelection {
+    const reasoningEffort = resolveEffortForModel(effort, model)
+    if (getRuntimeAdapterForModel(model) === RuntimeAdapterEnumApi.Codex) {
+        return {
+            runtime_adapter: CodexRuntimeAdapterEnumApi.Codex,
+            model,
+            reasoning_effort: reasoningEffort,
+            initial_permission_mode: toCodexPermissionMode(mode),
+        }
+    }
+    return {
+        runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
+        model,
+        reasoning_effort: reasoningEffort,
+        initial_permission_mode: mode,
+    }
 }
 
 export function getEffortLabel(effort: string | null | undefined): string {

--- a/products/posthog_ai/frontend/utils/composerModes.ts
+++ b/products/posthog_ai/frontend/utils/composerModes.ts
@@ -1,4 +1,7 @@
-import { InitialPermissionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
+import {
+    CodexTaskRunCreateSchemaInitialPermissionModeEnumApi,
+    InitialPermissionModeEnumApi,
+} from 'products/tasks/frontend/generated/api.schemas'
 
 /** The permission modes exposed by the PostHog AI composer. */
 export type PermissionMode =
@@ -33,6 +36,21 @@ export const MODE_OPTIONS: ComposerModeOption[] = [
         description: 'Plans the work first. Nothing runs until you approve the plan.',
     },
 ]
+
+export type CodexPermissionMode =
+    (typeof CodexTaskRunCreateSchemaInitialPermissionModeEnumApi)[keyof typeof CodexTaskRunCreateSchemaInitialPermissionModeEnumApi]
+
+// The picker speaks Claude's mode vocabulary; a Codex run takes its own, and the API rejects the wrong
+// one. Same mapping the agent framework applies (`resolveCloudInitialPermissionMode` in @posthog/shared).
+const CODEX_MODE_BY_PERMISSION_MODE: Record<PermissionMode, CodexPermissionMode> = {
+    [InitialPermissionModeEnumApi.Auto]: CodexTaskRunCreateSchemaInitialPermissionModeEnumApi.Auto,
+    [InitialPermissionModeEnumApi.BypassPermissions]: CodexTaskRunCreateSchemaInitialPermissionModeEnumApi.FullAccess,
+    [InitialPermissionModeEnumApi.Plan]: CodexTaskRunCreateSchemaInitialPermissionModeEnumApi.Plan,
+}
+
+export function toCodexPermissionMode(mode: PermissionMode): CodexPermissionMode {
+    return CODEX_MODE_BY_PERMISSION_MODE[mode]
+}
 
 // Modes retired from the picker resolve to their closest current equivalent, so persisted
 // selections and runs started before the retirement keep resolving to a real option.


### PR DESCRIPTION
## Problem

Someone starting a task in PostHog AI can only run it on Claude. The picker lists three Claude models and nothing else, so Codex is unreachable from the product even though the run API and the sandbox agent both support it.

The picker also gave no indication of which agent a model runs in, which is the thing a person is really choosing between.

## Changes

> [!NOTE]
> The screenshot of the grouped picker is missing because `hogli pr:upload-image` returned HTTP 409 on four attempts, each with a distinct generated asset path. Reported to the devex team. The picker now reads: a "Claude Code" heading over Claude Sonnet 5, Claude Opus 5 and Claude Opus 4.8, then a separator, then a "Codex" heading over GPT-5.6 Luna, GPT-5.6 Terra and GPT-5.6 Sol.

- The picker offers GPT-5.6 Luna, Terra and Sol alongside the Claude models.
- Each section is headed by the harness that runs it, "Claude Code" or "Codex". Those are the names the desktop app already uses.
- The runtime adapter comes from the picked model rather than a hardcoded `claude`.
- A Codex run receives Codex's permission mode. The picker speaks Claude's vocabulary (`bypassPermissions`), the run API rejects it on a Codex run, and `full-access` is the equivalent. The agent framework maps the two the same way in `resolveCloudInitialPermissionMode`.
- The effort list per model mirrors the backend. The Codex models offer low through max, and no ultracode.
- While a run is live, the picker only offers models from that run's harness. A running session is pinned to the harness it booted on, and the Codex adapter drops a model id it does not recognize, so a cross-harness switch would look like it worked and do nothing. Once the run is terminal the send starts a fresh run, so the full list returns.

Starting a Codex run that resumes from a finished Claude run stays allowed. The agent server falls back to summary resume when it finds no matching native session state, so it degrades instead of breaking.

## How did you test this code?

I (actually Claude) drove the local dev app in a browser and opened the picker on the new task screen. The screenshot above is that session. Selecting GPT-5.6 Luna updated the trigger and switched the effort list to low through max with ultracode gone.

Not checked: no Codex run was launched end to end. The tests pin the request the frontend sends, not that a Codex sandbox boots from it.

Two parameterized tests cover the create paths, one per path, because a fix applied to only one would ship broken:

- `taskTrackerSceneLogic` covers the new task path.
- `runInteractionLogic` covers a terminal run's send, which starts a fresh run.

Both assert that a Codex model goes out as `runtime_adapter: codex` with `full-access`, and that Claude keeps its existing shape. Without this the run endpoint returns a 400.

One unit test covers the picker grouping. New models get appended to `COMPOSER_MODELS` as they ship, so a Claude model can land after the Codex ones, and each harness still has to render as one section.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael asked for Codex models in the PostHog AI new task picker, then for the sections to name the harness behind each group. I (Claude, in Claude Code) wrote the change.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

Two decisions worth flagging. The runtime adapter is derived from the model rather than exposed as its own control, because every model belongs to exactly one harness and a second picker would let a person build an invalid pair. The live-run filtering came out of reading the Codex adapter's `setOption`, which silently ignores a model id outside its allowed set.

The screenshot in Changes could not be attached: `hogli pr:upload-image` returned HTTP 409 on three attempts, each with a distinct generated asset path. Reported to the devex team. The image exists locally and can be dropped in by hand.

