### PR TITLE
fix(dev): allow every git config file the sandbox's git actually reads

### DIFF
--- a/bin/dev-sandbox
+++ b/bin/dev-sandbox
@@ -222,7 +222,15 @@ _gitcfg_deny_ancestors() {
 _add_gitcfg() {
     local _p="$1" _resolved _dir
     [[ -n "$_p" ]] || return 0
-    _gitcfg_bad_literal "$_p" && return 0
+    # A path that cannot be written as an SBPL literal cannot be write-denied
+    # either, so nothing stops sandboxed code rewriting it into a chooser of paths.
+    # Taint rather than skip: returning quietly would leave the include directives
+    # this file declares trusted by the pass below, which is the whole capability
+    # the taint exists to withdraw. Unrenderable means untrusted, wherever it lives.
+    if _gitcfg_bad_literal "$_p"; then
+        _gitcfg_untrusted=1
+        return 0
+    fi
     # Canonicalize before the containment tests, not after. They are string prefix
     # matches, so a symlink or a `..` component walks straight past them — and git
     # reports the logical path it was given, never the resolved one, so the logical
@@ -362,6 +370,14 @@ if [[ -x "$_git_bin" ]]; then
                 continue
                 ;;
         esac
+        # An unrenderable declaring file is untrusted for the same reason as above,
+        # and its targets must not be collected on its say-so. The origin pass
+        # reaches it too (a file declaring an include has a key, so it is reported
+        # there), but this does not depend on that.
+        if _gitcfg_bad_literal "$_origin_path"; then
+            _gitcfg_untrusted=1
+            continue
+        fi
         _add_gitcfg "$(_gitcfg_include_path "$_origin_path" "${_keyval#*$'\n'}")"
     done < <("$_git_bin" config --global --includes --show-origin -z --get-regexp '^include(if\..*)?\.path$' 2>/dev/null)
 fi

--- a/bin/dev-sandbox
+++ b/bin/dev-sandbox
@@ -26,10 +26,10 @@ set -euo pipefail
 # privileges. The inherited $PATH is not trustworthy at that point: it keeps the
 # repo's own node_modules/.bin (see the PATH sanitizing near the end, which
 # deliberately preserves repo bins for the child), and sandboxed dependency code
-# can write there. A bare `sed`/`mktemp` would then resolve to a binary a previous
-# sandboxed run planted, and run unsandboxed as the developer. So pin PATH to the
-# system directories for this script's own use and hand the inherited one to the
-# child, which is the only consumer that needs it.
+# can write there. A bare `git`/`sed`/`mktemp` would then resolve to a binary a
+# previous sandboxed run planted, and run unsandboxed as the developer. So pin
+# PATH to the system directories for this script's own use and hand the inherited
+# one to the child, which is the only consumer that needs it.
 inherited_path="$PATH"
 PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
@@ -82,17 +82,287 @@ unrenderable_path() { # $1 = path
     return 1
 }
 
-# The base profile allows the git config files by literal path, but Seatbelt
-# matches physical paths — when one is a symlink (dotfile managers), the read of
-# its target is still denied and cargo/libgit2 fails hard ("failed to stat
-# ~/.gitconfig"). Resolve symlinked configs here and allow (read) + deny (write,
-# hooksPath/credential-helper escape) their targets in the rendered profile.
+# The base profile allows three git config files by literal path, but git reads
+# whatever an [include]/[includeIf] chain points at, and Seatbelt matches physical
+# paths so a symlinked config's target is denied too (dotfile managers). Either gap
+# makes libgit2 fail hard ("could not stat ..."), which takes down any cargo build with
+# a git dependency, and with it whichever service's prestart runs that build.
+#
+# So ask git which files it actually reads instead of guessing names, and allow
+# (read) + deny (write, hooksPath/credential-helper escape) each one plus its
+# canonical path. Paths outside $HOME are readable already, so only $HOME ones
+# matter here. Falls back to the three well-known names when git is unavailable.
+# A config path containing a tab or newline is skipped: the render below rejects
+# quotes and backslashes for the same reason, and neither survives an SBPL literal.
+#
+# Only the global scope is read. A config file's contents decide which paths the
+# profile allows, so any config file sandboxed code can write is a way out: a
+# dependency that appends `[include] path = ~/.aws/credentials` to the repo's
+# .git/config would have the next launch emit a read-allow for that file, and the
+# allow wins because SBPL is last-match-wins and this render appends after the base
+# profile's denies. The repo stays broadly writable inside the sandbox (build
+# output, caches), so a config file under it must not be trusted to name paths —
+# not even indirectly, by including a file that then points somewhere else. Global config
+# cannot be turned into such a chooser in the default layout: the base profile
+# write-denies ~/.gitconfig, ~/.gitconfig.local and ~/.config/git, and the render
+# write-denies every file found below, which extends that protection across the
+# include chain. So the moment discovery reaches a file under the repo — as a key's
+# origin, an include's resolved target, or an include directive's own declaring
+# file — the whole run is treated as tainted: every dynamically discovered path is
+# discarded and discovery falls back to the fixed, safe file list below, the same
+# as when git itself is unavailable. Paths are canonicalized before that test, since
+# git reports the logical path it was handed and a symlink or `..` would otherwise
+# carry a repo file past a plain prefix match.
+#
+# The repo is not the only writable place a chain can reach: the profile permits
+# writes outside $HOME too, so a fragment in /tmp is just as much a chooser and
+# taints the run the same way. Such a file also gets a write-deny, which outlives
+# the taint so it cannot be rewritten later, but a deny alone would still honor
+# whatever it says right now. The same deny covers a global config relocated by
+# GIT_CONFIG_GLOBAL or XDG_CONFIG_HOME even before that file exists.
+#
+# Tainting costs availability: a developer whose chain genuinely reaches outside
+# $HOME falls back to the three default names, so git inside the sandbox can fail
+# on a config it reads fine outside. That is the same trade the repo case already
+# makes, and it fails closed and loudly rather than quietly widening what the
+# sandbox may read.
+#
+# One limit is deliberate. An [includeIf] whose condition does not match is reported
+# by git as a declared path but never parsed, so include directives *inside* it stay
+# invisible and only that one file is allowed. Should the condition later match, git
+# would read a nested target the profile does not list and fail closed on it. Walking
+# those chains means parsing arbitrary config files here, in the part of this script
+# that decides what the sandbox may read, which is a poor trade against a fail-closed
+# reliability edge that a service restart re-resolves anyway.
 gitcfg_targets=()
-for _cfg in "$HOME/.gitconfig" "$HOME/.gitconfig.local" "$HOME/.config/git/config"; do
-    [[ -L "$_cfg" ]] || continue
-    _resolved="$(/usr/bin/readlink -f "$_cfg" 2>/dev/null || true)"
-    [[ -n "$_resolved" && "$_resolved" != "$_cfg" ]] && gitcfg_targets+=("$_resolved")
+gitcfg_dirs=()
+gitcfg_wdeny=()
+_push_gitcfg() {
+    local _t
+    for _t in ${gitcfg_targets[@]+"${gitcfg_targets[@]}"}; do
+        if [[ "$_t" == "$1" ]]; then return 0; fi
+    done
+    gitcfg_targets+=("$1")
+}
+_push_gitcfg_dir() {
+    local _t
+    for _t in ${gitcfg_dirs[@]+"${gitcfg_dirs[@]}"}; do
+        if [[ "$_t" == "$1" ]]; then return 0; fi
+    done
+    gitcfg_dirs+=("$1")
+}
+_push_gitcfg_wdeny_raw() {
+    local _t
+    [[ -n "$1" && "$1" == /* ]] || return 0
+    [[ "$1" == *$'\t'* || "$1" == *$'\n'* ]] && return 0
+    for _t in ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"}; do
+        if [[ "$_t" == "$1" ]]; then return 0; fi
+    done
+    gitcfg_wdeny+=("$1")
+    return 0 # never end on a test under `set -e`
+}
+# Deny both the logical path and its physical one. Seatbelt matches physical paths,
+# so a literal alone leaves the target writable through a symlinked ancestor — and
+# readlink -f still resolves that ancestor when the leaf does not exist yet, which
+# is exactly the case these denies exist to cover.
+_push_gitcfg_wdeny() {
+    local _p="$1" _c _dir
+    [[ -n "$_p" ]] || return 0
+    [[ "$_p" != /* ]] && _p="$PWD/$_p" # git takes a relative GIT_CONFIG_GLOBAL too
+    _push_gitcfg_wdeny_raw "$_p"
+    _c="$(/usr/bin/readlink -f "$_p" 2>/dev/null || true)"
+    if [[ -z "$_c" ]]; then
+        # macOS readlink -f fails outright when the leaf does not exist, which is
+        # the whole point of these denies. Canonicalize the directory instead and
+        # re-attach the name, so a symlinked ancestor still resolves.
+        _dir="$(cd "${_p%/*}" 2>/dev/null && pwd -P || true)"
+        [[ -n "$_dir" ]] && _c="$_dir/${_p##*/}"
+    fi
+    [[ -n "$_c" && "$_c" != "$_p" ]] && _push_gitcfg_wdeny_raw "$_c"
+    return 0
+}
+_add_gitcfg() {
+    local _p="$1" _resolved _dir
+    [[ -n "$_p" ]] || return 0
+    [[ "$_p" == *$'\t'* || "$_p" == *$'\n'* ]] && return 0
+    # Canonicalize before the repo test, not after. That test is a string prefix
+    # match, so a symlink or a `..` component walks straight past it — and git
+    # reports the logical path it was given, never the resolved one, so the logical
+    # form is what discovery sees.
+    _resolved="$(/usr/bin/readlink -f "$_p" 2>/dev/null || true)"
+    # A config inside the repo is already readable via the PROJECT/MAINREPO subpath
+    # allow, and the repo stays broadly writable inside the sandbox, so such a file
+    # is one sandboxed code can rewrite. Flag the whole run as tainted (checked once
+    # discovery finishes, below) rather than merely omitting this one entry: a
+    # rewritten include here could otherwise redirect discovery to an arbitrary
+    # $HOME file. Either form reaching the repo taints it.
+    case "$_p" in "$project"/* | "$mainrepo"/*) _gitcfg_untrusted=1; return 0 ;; esac
+    case "$_resolved" in "$project"/* | "$mainrepo"/*) _gitcfg_untrusted=1; return 0 ;; esac
+    # Outside $HOME the profile permits writes, so a fragment in /tmp or /opt is a
+    # file sandboxed code can rewrite into a chooser of paths, exactly like a
+    # repo-local one — and its current contents are already whatever the last run
+    # left there. So taint, same as the repo case. The write-deny goes on regardless
+    # (it survives the taint reset) so the file cannot be rewritten from here on; it
+    # is not enough on its own, which is why it does not replace the taint.
+    if [[ "$_p" != "$HOME"/* ]]; then
+        _push_gitcfg_wdeny "$_p"
+        [[ -n "$_resolved" && "$_resolved" != "$_p" ]] && _push_gitcfg_wdeny "$_resolved"
+        _gitcfg_untrusted=1
+        return 0
+    fi
+    _push_gitcfg "$_p"
+    # Resolution stops at a symlinked ancestor directory (~/.config -> ~/.dotfiles):
+    # the kernel reads that link node itself, and the literal allow for the file
+    # behind it does not cover that read. Grant metadata on each directory between
+    # $HOME and the config, which is all resolution needs and exposes no directory's
+    # contents, the same trade the ~/.local grant in the base profile makes. A
+    # canonical path has no symlinked component, so only this logical path needs it.
+    _dir="${_p%/*}"
+    while [[ "$_dir" == "$HOME"/* ]]; do
+        _push_gitcfg_dir "$_dir"
+        _dir="${_dir%/*}"
+    done
+    # Seatbelt matches physical paths, so also allow the config's canonical path
+    # (resolved above). The symlink git followed can be the config file itself or any
+    # ancestor directory (~/.config -> ~/.dotfiles/config leaves the file regular),
+    # which is why readlink -f canonicalizes the whole path rather than testing only
+    # the leaf with -L. A canonical path that landed in the repo already returned
+    # above, so what reaches here is outside it.
+    if [[ -n "$_resolved" && "$_resolved" != "$_p" ]]; then
+        _push_gitcfg "$_resolved"
+    fi
+    return 0 # never end on a test: `set -e` kills the wrapper when a called function returns non-zero
+}
+# Resolve an include.path value the way git does: ~/ against $HOME, anything
+# relative against the directory of the file that declared it. ~user/ resolves
+# against $HOME too, but only when user is whoever is running this script — that is
+# the only ~user/ shape that can ever land under $HOME, since _add_gitcfg rejects
+# anything else. A %(prefix) value is left alone, since the origin pass below
+# already covers a target like that once it holds a key.
+_gitcfg_include_path() {
+    local _origin="$1" _value="$2" _user
+    # shellcheck disable=SC2088 # the leading tilde is data read out of a config file, not a path this shell should expand
+    case "$_value" in
+        "~/"*) printf '%s/%s' "$HOME" "${_value#\~/}" ;;
+        "~"*/*)
+            _user="${_value#\~}"
+            _user="${_user%%/*}"
+            [[ -n "$_gitcfg_user" && "$_user" == "$_gitcfg_user" ]] && printf '%s/%s' "$HOME" "${_value#"~$_user/"}"
+            ;;
+        "~"* | "%("*) ;;
+        /*) printf '%s' "$_value" ;;
+        *) printf '%s/%s' "${_origin%/*}" "$_value" ;;
+    esac
+}
+_gitcfg_listed=0
+_gitcfg_untrusted=0
+_gitcfg_user="$(/usr/bin/id -un 2>/dev/null || true)"
+# Absolute paths rather than bare names. The pinned PATH above already prevents a
+# planted binary from being resolved here, but these two invocations are the ones
+# that read attacker-influenced data (config file contents), so they spell out the
+# system binary the same way /usr/bin/readlink and /usr/bin/shasum already do in
+# this file. /usr/bin/git is the Xcode CLT git on the macOS this script is gated to.
+_git_bin="/usr/bin/git"
+if [[ -x "$_git_bin" ]]; then
+    # -z is what makes the tab and newline rules above enforceable: it separates
+    # records with NUL and the key from its value with a newline, so neither can be
+    # confused with a character inside a path. The tab-delimited form truncates a path
+    # at its first tab and allows the truncated result instead of skipping it, and an
+    # includeIf condition may itself contain spaces ([includeIf "gitdir:~/my work/"]),
+    # which puts a space inside the key and defeats splitting on the first one.
+    #
+    # --includes defaults to off once a scope is named, so pass it explicitly or git
+    # reports ~/.gitconfig alone and the chain this block exists for goes unseen.
+    while IFS= read -r -d '' _origin && IFS= read -r -d '' _key; do
+        case "$_origin" in
+            file:*)
+                _gitcfg_listed=1
+                _add_gitcfg "${_origin#file:}"
+                ;;
+        esac
+    done < <("$_git_bin" config --global --includes --list --show-origin --name-only -z 2>/dev/null)
+    # An include target holding no config keys is the origin of no value, so the pass
+    # above never sees it, yet git stats it and dies ("unable to access") when the
+    # sandbox denies it. Collect the declared paths too. That also covers a target
+    # whose includeIf condition does not match where the service happens to start
+    # (conditions are evaluated against the launch directory even in the global scope,
+    # so the origin pass alone makes the allowed set depend on cwd), and it write-denies
+    # a target while it is still empty, which is exactly when it would otherwise be
+    # writable and able to name paths of its own.
+    while IFS= read -r -d '' _origin && IFS= read -r -d '' _keyval; do
+        case "$_origin" in file:*) ;; *) continue ;; esac
+        case "$_keyval" in *$'\n'*) ;; *) continue ;; esac
+        # The declaring file matters here, not just the target it names: a
+        # repo-local file can rewrite its own [include] to point anywhere under
+        # $HOME, and that target need not itself be under the repo for
+        # _add_gitcfg's own project/mainrepo check (above) to catch it. Canonicalize
+        # for the same reason _add_gitcfg does — git reports the logical path, so a
+        # symlink or `..` would otherwise slip a repo file past this prefix test.
+        _origin_path="${_origin#file:}"
+        _origin_real="$(/usr/bin/readlink -f "$_origin_path" 2>/dev/null || true)"
+        case "$_origin_path" in
+            "$project"/* | "$mainrepo"/*)
+                _gitcfg_untrusted=1
+                continue
+                ;;
+        esac
+        case "$_origin_real" in
+            "$project"/* | "$mainrepo"/*)
+                _gitcfg_untrusted=1
+                continue
+                ;;
+        esac
+        _add_gitcfg "$(_gitcfg_include_path "$_origin_path" "${_keyval#*$'\n'}")"
+    done < <("$_git_bin" config --global --includes --show-origin -z --get-regexp '^include(if\..*)?\.path$' 2>/dev/null)
+fi
+# Discovery can only report a relocated global config (GIT_CONFIG_GLOBAL, or
+# $XDG_CONFIG_HOME/git/config) once the file exists. Until then nothing write-denies
+# it, so sandboxed code can create one naming paths of its own and the next launch
+# reads it as trusted global config. Write-deny the effective path whether or not it
+# exists yet.
+if [[ -n "${GIT_CONFIG_GLOBAL:-}" ]]; then
+    _gitcfg_relocated="$GIT_CONFIG_GLOBAL"
+elif [[ -n "${XDG_CONFIG_HOME:-}" ]]; then
+    _gitcfg_relocated="$XDG_CONFIG_HOME/git/config"
+else
+    _gitcfg_relocated=""
+fi
+# A worktree's gitdir sits under the MAIN repo's .git/worktrees/, so the profile's
+# PROJECT-relative denies miss it while git reads its config just the same — and
+# config.worktree there is live whenever extensions.worktreeConfig is set. Deny both.
+if [[ -n "${gitdir:-}" ]]; then
+    _gitcfg_relocated_dir="$(cd "$gitdir" 2>/dev/null && pwd -P || true)"
+    if [[ -n "$_gitcfg_relocated_dir" ]]; then
+        _push_gitcfg_wdeny "$_gitcfg_relocated_dir/config"
+        _push_gitcfg_wdeny "$_gitcfg_relocated_dir/config.worktree"
+    fi
+fi
+# The profile's PROJECT/MAINREPO .git/config denies are logical literals, so a
+# checkout whose .git is a symlink leaves the physical file writable. Push both
+# repo roots' config pair through the canonicalizing deny above to cover that.
+for _r in "$project" "$mainrepo"; do
+    [[ -d "$_r/.git" ]] || continue
+    _push_gitcfg_wdeny "$_r/.git/config"
+    _push_gitcfg_wdeny "$_r/.git/config.worktree"
 done
+_push_gitcfg_wdeny "$_gitcfg_relocated"
+
+if [[ "$_gitcfg_untrusted" -eq 1 ]]; then
+    # Discovery touched a file sandboxed dependency code can write, so nothing it
+    # named can be trusted — the dynamic set above may already include a target
+    # that file chose. Discard the read-allows and fall back to the fixed, safe list
+    # below rather than salvaging whichever entries were not chosen by it.
+    # gitcfg_wdeny survives: a write-deny only ever removes access, so keeping the
+    # ones already found is strictly safer than dropping them.
+    gitcfg_targets=()
+    gitcfg_dirs=()
+    _gitcfg_listed=0
+fi
+if [[ "$_gitcfg_listed" -eq 0 ]]; then
+    for _cfg in "$HOME/.gitconfig" "$HOME/.gitconfig.local" "$HOME/.config/git/config"; do
+        _add_gitcfg "$_cfg"
+    done
+fi
 
 # The profile write-denies the repo's own git config by PROJECT/MAINREPO literal,
 # which reaches neither a worktree's real gitdir (it lives under the MAIN repo, at
@@ -105,7 +375,6 @@ done
 # then reads that directory's config AND hooks/, so rewriting it reaches the escape
 # the .git/hooks denies close off. It is not worktree-only: git honors a commondir
 # in any git dir, including a plain clone's.
-gitcfg_wdeny=()
 for _gd in "$mainrepo/.git" ${gitdir:+"$gitdir"}; do
     [[ -d "$_gd" ]] || continue
     _raw="$_gd"
@@ -120,7 +389,7 @@ for _gd in "$mainrepo/.git" ${gitdir:+"$gitdir"}; do
     gitcfg_wdeny+=("$_gd/config" "$_gd/config.worktree" "$_gd/commondir")
 done
 
-cache_key="$(printf '%s\0' "$project" "$mainrepo" "$HOME" "${SSH_AUTH_SOCK:-}" ${gitcfg_targets[@]+"${gitcfg_targets[@]}"} "--" ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"} | /usr/bin/shasum -a256 | cut -c1-16)"
+cache_key="$(printf '%s\0' "$project" "$mainrepo" "$HOME" "${SSH_AUTH_SOCK:-}" ${gitcfg_targets[@]+"${gitcfg_targets[@]}"} "--" ${gitcfg_dirs[@]+"${gitcfg_dirs[@]}"} "--" ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"} | /usr/bin/shasum -a256 | cut -c1-16)"
 rendered="$tmpdir/posthog-dev-sandbox-$cache_key.sb"
 stamp="$rendered.ok" # touched once the rendered profile passes the init preflight
 
@@ -154,7 +423,7 @@ render_profile() {
     # These paths carry the read-allows the stack needs, so unlike a single git-dir
     # deny they cannot be dropped individually — fail the render and run without a
     # sandbox, loudly, rather than emit a profile missing part of what it grants.
-    for _a in "${ancestors[@]}" "$rendered" "$stamp" ${gitcfg_targets[@]+"${gitcfg_targets[@]}"}; do
+    for _a in "${ancestors[@]}" "$rendered" "$stamp" ${gitcfg_targets[@]+"${gitcfg_targets[@]}"} ${gitcfg_dirs[@]+"${gitcfg_dirs[@]}"} ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"}; do
         if unrenderable_path "$_a"; then
             echo "⚠️  dev sandbox: path is unrenderable, running WITHOUT sandbox: $_a" >&2
             return 1
@@ -164,12 +433,21 @@ render_profile() {
     if {
         cat "$base_profile"
         emit_rule 'allow file-read*' "${ancestors[@]}"
-        # Physical targets of symlinked git configs (resolved above): readable like
-        # the configs themselves, write-denied for the same hooksPath escape reason.
+        # Every git config file under $HOME that git reads, plus each one's canonical
+        # path (collected above): readable like the three the base profile lists, and
+        # write-denied both for the hooksPath escape and to keep the include chain from
+        # being rewritten into one that names a path of its own.
         emit_rule 'allow file-read*' ${gitcfg_targets[@]+"${gitcfg_targets[@]}"}
         emit_rule 'deny file-write*' ${gitcfg_targets[@]+"${gitcfg_targets[@]}"}
-        # Physical git-dir config paths (collected above), which the profile's
-        # PROJECT/MAINREPO literals miss for a worktree or a symlinked .git.
+        # Metadata on every directory between $HOME and a config file, which is all
+        # symlink resolution needs and exposes no directory's contents.
+        emit_rule 'allow file-read-metadata' ${gitcfg_dirs[@]+"${gitcfg_dirs[@]}"}
+        # Physical git-dir config paths, which the profile's PROJECT/MAINREPO literals
+        # miss for a worktree or a symlinked .git, and a relocated global config,
+        # write-denied even while it does not exist so sandboxed code cannot create the
+        # file the next launch would trust. No read-allow: under $HOME the discovery
+        # above adds one once the file exists, and outside $HOME reads are permitted
+        # anyway.
         emit_rule 'deny file-write*' ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"}
         # Deny the SSH agent socket (path varies per agent: Secretive, 1Password,
         # launchd, gpg). Canonicalize its dir — Seatbelt matches the kernel's

--- a/bin/dev-sandbox
+++ b/bin/dev-sandbox
@@ -137,24 +137,54 @@ unrenderable_path() { # $1 = path
 gitcfg_targets=()
 gitcfg_dirs=()
 gitcfg_wdeny=()
+# A path that cannot be written as an SBPL literal. Tabs and newlines do not survive
+# one, and a quote or backslash would corrupt the profile. Every path below is
+# screened here on the way in, because these come out of config files sandboxed code
+# may control and render_profile answers the same characters by abandoning the render
+# — which runs the command with no sandbox at all. Dropping the entry keeps that
+# fail-open out of reach of anything a config file can say.
+_gitcfg_bad_literal() {
+    # shellcheck disable=SC1003 # '\' is a quoted literal backslash to match on, not an escape
+    case "$1" in
+        *$'\t'* | *$'\n'* | *'"'* | *'\'*) return 0 ;;
+    esac
+    return 1
+}
+# Canonical form of a path, including when the leaf does not exist: macOS readlink -f
+# fails outright in that case, so fall back to canonicalizing the directory and
+# re-attaching the name. Echoes nothing when even the directory cannot be resolved,
+# which means nothing can be read there yet either.
+_gitcfg_canon() {
+    local _p="$1" _c _dir
+    _c="$(/usr/bin/readlink -f "$_p" 2>/dev/null || true)"
+    if [[ -z "$_c" ]]; then
+        _dir="$(cd "${_p%/*}" 2>/dev/null && pwd -P || true)"
+        [[ -n "$_dir" ]] && _c="$_dir/${_p##*/}"
+    fi
+    printf '%s' "$_c"
+}
 _push_gitcfg() {
     local _t
+    _gitcfg_bad_literal "$1" && return 0
     for _t in ${gitcfg_targets[@]+"${gitcfg_targets[@]}"}; do
         if [[ "$_t" == "$1" ]]; then return 0; fi
     done
     gitcfg_targets+=("$1")
+    return 0
 }
 _push_gitcfg_dir() {
     local _t
+    _gitcfg_bad_literal "$1" && return 0
     for _t in ${gitcfg_dirs[@]+"${gitcfg_dirs[@]}"}; do
         if [[ "$_t" == "$1" ]]; then return 0; fi
     done
     gitcfg_dirs+=("$1")
+    return 0
 }
 _push_gitcfg_wdeny_raw() {
     local _t
     [[ -n "$1" && "$1" == /* ]] || return 0
-    [[ "$1" == *$'\t'* || "$1" == *$'\n'* ]] && return 0
+    _gitcfg_bad_literal "$1" && return 0
     for _t in ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"}; do
         if [[ "$_t" == "$1" ]]; then return 0; fi
     done
@@ -162,34 +192,42 @@ _push_gitcfg_wdeny_raw() {
     return 0 # never end on a test under `set -e`
 }
 # Deny both the logical path and its physical one. Seatbelt matches physical paths,
-# so a literal alone leaves the target writable through a symlinked ancestor — and
-# readlink -f still resolves that ancestor when the leaf does not exist yet, which
-# is exactly the case these denies exist to cover.
+# so a literal alone leaves the target writable through a symlinked ancestor.
 _push_gitcfg_wdeny() {
-    local _p="$1" _c _dir
+    local _p="$1" _c
     [[ -n "$_p" ]] || return 0
     [[ "$_p" != /* ]] && _p="$PWD/$_p" # git takes a relative GIT_CONFIG_GLOBAL too
     _push_gitcfg_wdeny_raw "$_p"
-    _c="$(/usr/bin/readlink -f "$_p" 2>/dev/null || true)"
-    if [[ -z "$_c" ]]; then
-        # macOS readlink -f fails outright when the leaf does not exist, which is
-        # the whole point of these denies. Canonicalize the directory instead and
-        # re-attach the name, so a symlinked ancestor still resolves.
-        _dir="$(cd "${_p%/*}" 2>/dev/null && pwd -P || true)"
-        [[ -n "$_dir" ]] && _c="$_dir/${_p##*/}"
-    fi
+    _c="$(_gitcfg_canon "$_p")"
     [[ -n "$_c" && "$_c" != "$_p" ]] && _push_gitcfg_wdeny_raw "$_c"
+    return 0
+}
+# Write-deny every directory between $HOME and a config file. The file itself is
+# already denied, but Seatbelt evaluates rename(2) against the source path only, so
+# any directory on the chain that stays writable lets sandboxed code move the whole
+# subtree aside and put its own there — ~/.gitconfig then resolves to a file the
+# attacker wrote, and that file's contents choose what the next launch allows.
+# Denying a directory node does not affect entries inside it, which are their own
+# paths; the base profile makes the same distinction for the .git node. Call this
+# with the logical path and the canonical one: a symlinked ancestor has to be denied
+# in both forms, since replacing the link and renaming its target are separate acts.
+_gitcfg_deny_ancestors() {
+    local _dir="${1%/*}"
+    while [[ "$_dir" == "$HOME"/* ]]; do
+        _push_gitcfg_wdeny_raw "$_dir"
+        _dir="${_dir%/*}"
+    done
     return 0
 }
 _add_gitcfg() {
     local _p="$1" _resolved _dir
     [[ -n "$_p" ]] || return 0
-    [[ "$_p" == *$'\t'* || "$_p" == *$'\n'* ]] && return 0
-    # Canonicalize before the repo test, not after. That test is a string prefix
-    # match, so a symlink or a `..` component walks straight past it — and git
+    _gitcfg_bad_literal "$_p" && return 0
+    # Canonicalize before the containment tests, not after. They are string prefix
+    # matches, so a symlink or a `..` component walks straight past them — and git
     # reports the logical path it was given, never the resolved one, so the logical
     # form is what discovery sees.
-    _resolved="$(/usr/bin/readlink -f "$_p" 2>/dev/null || true)"
+    _resolved="$(_gitcfg_canon "$_p")"
     # A config inside the repo is already readable via the PROJECT/MAINREPO subpath
     # allow, and the repo stays broadly writable inside the sandbox, so such a file
     # is one sandboxed code can rewrite. Flag the whole run as tainted (checked once
@@ -204,13 +242,25 @@ _add_gitcfg() {
     # left there. So taint, same as the repo case. The write-deny goes on regardless
     # (it survives the taint reset) so the file cannot be rewritten from here on; it
     # is not enough on its own, which is why it does not replace the taint.
-    if [[ "$_p" != "$HOME"/* ]]; then
+    #
+    # Judge containment on the canonical path as well. A config that sits outside
+    # $HOME can still be named by a path that looks inside it — ~/.gitconfig
+    # symlinked to /Volumes/Dotfiles/gitconfig, or a target spelled ~/../shared/cfg —
+    # and the logical test alone waves both through. An unresolvable path is not
+    # treated as outside: _gitcfg_canon only comes back empty when the directory does
+    # not exist either, so nothing can be read there, and tainting on it would punish
+    # the ordinary absent ~/.gitconfig.local.
+    if [[ "$_p" != "$HOME"/* ]] || { [[ -n "$_resolved" ]] && [[ "$_resolved" != "$HOME"/* ]]; }; then
         _push_gitcfg_wdeny "$_p"
         [[ -n "$_resolved" && "$_resolved" != "$_p" ]] && _push_gitcfg_wdeny "$_resolved"
         _gitcfg_untrusted=1
         return 0
     fi
     _push_gitcfg "$_p"
+    # Keep the directories on the way to this config from being swapped out from
+    # under it (see _gitcfg_deny_ancestors).
+    _gitcfg_deny_ancestors "$_p"
+    [[ -n "$_resolved" ]] && _gitcfg_deny_ancestors "$_resolved"
     # Resolution stops at a symlinked ancestor directory (~/.config -> ~/.dotfiles):
     # the kernel reads that link node itself, and the literal allow for the file
     # behind it does not cover that read. Grant metadata on each directory between
@@ -420,10 +470,14 @@ render_profile() {
         done
     done
     ancestors+=("$HOME")
-    # These paths carry the read-allows the stack needs, so unlike a single git-dir
-    # deny they cannot be dropped individually — fail the render and run without a
-    # sandbox, loudly, rather than emit a profile missing part of what it grants.
-    for _a in "${ancestors[@]}" "$rendered" "$stamp" ${gitcfg_targets[@]+"${gitcfg_targets[@]}"} ${gitcfg_dirs[@]+"${gitcfg_dirs[@]}"} ${gitcfg_wdeny[@]+"${gitcfg_wdeny[@]}"}; do
+    # Paths are emitted as SBPL string literals; a " or \ would corrupt the
+    # profile (quoted expansions match literally, dodging glob/escape ambiguity).
+    # Only paths derived from the repo root, $HOME and TMPDIR are checked here.
+    # Bailing out means running with no sandbox, so nothing a config file can name
+    # may reach this: the gitcfg lists are screened by _gitcfg_bad_literal as they
+    # are built and the git-dir denies by unrenderable_path, and both drop the
+    # offending entry instead of the whole profile.
+    for _a in "${ancestors[@]}" "$rendered" "$stamp"; do
         if unrenderable_path "$_a"; then
             echo "⚠️  dev sandbox: path is unrenderable, running WITHOUT sandbox: $_a" >&2
             return 1

--- a/bin/dev-sandbox-selftest
+++ b/bin/dev-sandbox-selftest
@@ -584,6 +584,73 @@ else
             pass "write blocked: config fragment outside \$HOME"
         fi
     fi
+    #     A directory on the way to a discovered config must not be swappable. The
+    #     config file itself is write-denied, but Seatbelt evaluates rename(2)
+    #     against the source path only, so a writable parent lets sandboxed code move
+    #     the real subtree aside and leave its own config in place — and that config
+    #     then chooses what the next launch allows. Two layouts: the dotfile-manager
+    #     one, and the XDG one, whose ~/.config the profile's ~/.config/git deny does
+    #     not reach (subpath matches downward only).
+    h="$gitcfg_root/dirswap"
+    mkdir -p "$h/dotfiles"
+    printf '[user]\n\tname = selftest\n' >"$h/dotfiles/gitconfig"
+    ln -s "$h/dotfiles/gitconfig" "$h/.gitconfig"
+    HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" 'true' >/dev/null 2>&1
+    if HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "mv '$h/dotfiles' '$h/dotfiles.bak'" >/dev/null 2>&1; then
+        die "a config's parent directory is renameable (subtree swap picks the next allowlist)"
+    else
+        pass "write blocked: directory on the way to a git config"
+    fi
+
+    h="$gitcfg_root/dirswap-xdg"
+    mkdir -p "$h/.config/git"
+    printf '[user]\n\tname = selftest\n' >"$h/.config/git/config"
+    HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" 'true' >/dev/null 2>&1
+    if HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "mv '$h/.config' '$h/.config.bak'" >/dev/null 2>&1; then
+        die "\$HOME/.config is renameable (the \$HOME/.config/git deny does not cover its parent)"
+    else
+        pass "write blocked: \$HOME/.config as a git config ancestor"
+    fi
+
+    #     A config logically under $HOME but physically outside it is writable by
+    #     sandboxed code, so its contents cannot choose paths. Git reports the logical
+    #     path, so the containment test has to run on the canonical one.
+    h="$gitcfg_root/outside-link"
+    mkdir -p "$h" "$gitcfg_root/elsewhere"
+    printf '[leak]\n\tmarker = GITCFG_LEAK_MARKER\n' >"$h/secret.cfg"
+    printf '[include]\n\tpath = %s/secret.cfg\n' "$h" >"$gitcfg_root/elsewhere/gitconfig"
+    ln -s "$gitcfg_root/elsewhere/gitconfig" "$h/.gitconfig"
+    leaked="$(HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "cat '$h/secret.cfg'" 2>&1)"
+    if [[ "$leaked" == *GITCFG_LEAK_MARKER* ]]; then
+        die "config physically outside \$HOME exposed a \$HOME file (sandbox escape)"
+    else
+        pass "config physically outside \$HOME cannot expose a \$HOME file"
+    fi
+
+    #     A path a config names can hold a quote, which no SBPL literal can express.
+    #     Dropping that entry is right; abandoning the render is not, since the
+    #     wrapper answers a failed render by running the command with no sandbox —
+    #     which would let a config file switch the sandbox off.
+    h="$gitcfg_root/quote"
+    mkdir -p "$h"
+    printf '[include]\n\tpath = "/private/tmp/a\\"b"\n' >"$h/.gitconfig"
+    # Not a config, so no discovery pass can allow it: it stays denied whenever the
+    # sandbox is genuinely on, which is what separates "ran" from "ran sandboxed".
+    printf 'GITCFG_LEAK_MARKER\n' >"$h/not-a-config"
+    if [[ "$(HOME="$h" git config --global --get include.path 2>/dev/null)" != *'"'* ]]; then
+        die "quote check setup is broken: git does not report a quote in the value"
+    else
+        out="$(HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" 'echo SANDBOXED' 2>&1)"
+        if [[ "$out" == *"running WITHOUT sandbox"* ]]; then
+            die "a quote in a config-named path disables the sandbox (fail-open)"
+        elif [[ "$out" != *SANDBOXED* ]]; then
+            die "quote-in-path case did not run (${out:-no output})"
+        elif HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "cat '$h/not-a-config'" 2>/dev/null | grep -q GITCFG_LEAK_MARKER; then
+            die "quote-in-path case ran but the sandbox is not enforcing"
+        else
+            pass "quote in a config-named path does not disable the sandbox"
+        fi
+    fi
     rm -rf "$gitcfg_root"
 fi
 

--- a/bin/dev-sandbox-selftest
+++ b/bin/dev-sandbox-selftest
@@ -181,6 +181,16 @@ check_write_blocked() {
     $SANDBOX "echo x > '$1'" >/dev/null 2>&1
     report_write_blocked $? "$2" || rm -f "$1"
 }
+# For files that really exist and must not be damaged by the probe: opens for
+# append and writes nothing, so Seatbelt still has to decide on write access while
+# a missing deny cannot corrupt the file.
+check_write_blocked_existing() {
+    if $SANDBOX ": >> '$1'" >/dev/null 2>&1; then
+        die "writable, should be blocked: $2"
+    else
+        pass "write blocked: $2"
+    fi
+}
 check_write_blocked "bin/.dev_sandbox_selftest_probe" "repo bin/"
 mkdir -p .git/hooks 2>/dev/null || true
 check_write_blocked ".git/hooks/.dev_sandbox_selftest_probe" ".git/hooks"
@@ -397,6 +407,307 @@ if [[ -f "$marker" ]]; then
 else
     pass "shebang ignores a PATH-planted bash"
 fi
+
+# 16. Every git config file git reads is allowed. Git exits 128 on a config file it
+#     cannot stat, so each case runs git INSIDE the sandbox against a synthetic $HOME
+#     holding one of the config layouts developers actually have. The synthetic homes
+#     keep the developer's real config out of it, and are canonicalized because
+#     Seatbelt matches physical paths (/var -> /private/var), and an uncanonicalized
+#     $HOME would leave the profile's own deny matching nothing, which makes every
+#     check below meaningless.
+if ! command -v git >/dev/null 2>&1; then
+    echo "  --   git absent, skipping git-config checks"
+elif ! $SANDBOX 'git --version >/dev/null' 2>/dev/null; then
+    # A git binary under $HOME is dropped from the sandboxed PATH on purpose (check 13),
+    # so these cases have nothing to run. The collector itself still works: it runs
+    # before the sandbox starts and uses the unsanitized PATH.
+    echo "  --   git not runnable inside the sandbox, skipping git-config checks"
+else
+    gitcfg_root="$(cd "$(mktemp -d)" && pwd -P)"
+    # Own TMPDIR: each synthetic $HOME renders its own profile, and those must stay
+    # out of the private TMPDIR check 12 exported, whose single profile is the one
+    # checks 12 and 13 glob for.
+    mkdir -p "$gitcfg_root/tmp"
+    gitcfg_case() {
+        local name="$1" home="$2" dir="${3:-$repo}" out
+        out="$(cd "$dir" && HOME="$home" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" 'git config --list >/dev/null && echo GITCFG_OK' 2>&1)"
+        if [[ "$out" == *GITCFG_OK* ]]; then
+            pass "git config readable in sandbox: $name"
+        else
+            die "git config unreadable in sandbox: $name (${out:-no output})"
+        fi
+    }
+
+    # A regular config file whose include target holds no config keys. Git stats an
+    # include target before parsing it, so a comment-only file has to be allowed even
+    # though it is the origin of no value and `git config --list` never names it.
+    # The plain file also guards the wrapper's own exit status: a config path that is
+    # already canonical must not leave a failing test as the last command of the
+    # collector, which `set -e` turns into a silent exit before anything runs.
+    h="$gitcfg_root/plain"
+    mkdir -p "$h"
+    printf '[include]\n\tpath = %s/none.cfg\n' "$h" >"$h/.gitconfig"
+    printf '# holds no config keys\n' >"$h/none.cfg"
+    gitcfg_case "include target with no keys" "$h"
+
+    # The two shapes a dotfile manager produces: the config file is itself a link, or
+    # a regular file sits under a linked directory. Seatbelt denies the physical read
+    # in both unless the canonical path is allowed too.
+    h="$gitcfg_root/linkfile"
+    mkdir -p "$h/dotfiles"
+    printf '[user]\n\tname = selftest\n' >"$h/dotfiles/gitconfig"
+    ln -s "$h/dotfiles/gitconfig" "$h/.gitconfig"
+    gitcfg_case "symlinked config file" "$h"
+
+    h="$gitcfg_root/linkdir"
+    mkdir -p "$h/dotfiles/git"
+    printf '[user]\n\tname = selftest\n' >"$h/dotfiles/git/config"
+    ln -s "$h/dotfiles" "$h/.config"
+    gitcfg_case "config behind a symlinked directory" "$h"
+
+    # An includeIf condition can contain spaces, which puts a space inside the config
+    # key rather than only between key and value. Collecting the declared path has to
+    # survive that, or the target goes unallowed and a fragment of the condition is
+    # allowed in its place. Runs from inside the matching repo so the condition fires.
+    h="$gitcfg_root/spacey"
+    mkdir -p "$h"
+    spacey_repo="$gitcfg_root/spacey repo" # outside the synthetic $HOME, which is unreadable
+    git init -q "$spacey_repo"
+    printf '[includeIf "gitdir:%s/"]\n\tpath = ~/spacey.cfg\n' "$spacey_repo" >"$h/.gitconfig"
+    printf '# holds no config keys\n' >"$h/spacey.cfg"
+    gitcfg_case "includeIf condition containing a space" "$h" "$spacey_repo"
+
+    # 17. Repo-local git config must not be able to choose what the profile allows,
+    #     even indirectly. A dependency can write inside the repo (cargo does, to
+    #     .git/config, when it updates a git dependency), so a repo-local file
+    #     reached FROM the global scope (via an [include] in it, the way a dotfile
+    #     manager would set one up) must not have ITS OWN [include] trusted either —
+    #     otherwise a dependency-rewritten include pointing at a credential file
+    #     would have the next launch emit a read-allow for it, and that allow beats
+    #     the base profile's deny (last match wins). The planted file has to be
+    #     reached from the *global* scope: sitting only in the repo's own local
+    #     config isn't equivalent, since --global never reads that.
+    h="$gitcfg_root/hostile"
+    mkdir -p "$h"
+    hostile_repo="$gitcfg_root/hostile-repo"
+    mkdir -p "$hostile_repo/bin"
+    git init -q "$hostile_repo"
+    cp "$repo/bin/dev-sandbox" "$hostile_repo/bin/dev-sandbox"
+    cp "$repo/bin/dev-sandbox.sb" "$hostile_repo/bin/dev-sandbox.sb"
+    printf '[leak]\n\tmarker = GITCFG_LEAK_MARKER\n' >"$h/secret.cfg"
+    printf '[include]\n\tpath = %s/secret.cfg\n' "$h" >"$hostile_repo/.git/fragment"
+    printf '[include]\n\tpath = %s/.git/fragment\n' "$hostile_repo" >"$h/.gitconfig"
+    # Without this the check passes for the wrong reason whenever the setup breaks,
+    # since a setup that never plants the include also never leaks the marker.
+    planted="$(cd "$hostile_repo" && HOME="$h" git config --global --includes --get leak.marker 2>/dev/null)"
+    if [[ "$planted" != GITCFG_LEAK_MARKER ]]; then
+        die "check 17 setup is broken: the planted [include] chain is not in effect"
+    fi
+    leaked="$(cd "$hostile_repo" && HOME="$h" TMPDIR="$gitcfg_root/tmp" ./bin/dev-sandbox "cat '$h/secret.cfg'" 2>&1)"
+    if [[ "$leaked" == *GITCFG_LEAK_MARKER* ]]; then
+        die "repo-local [include] exposed a \$HOME file via the global scope (sandbox escape)"
+    else
+        pass "repo-local [include] reached from global scope cannot expose a \$HOME file"
+    fi
+
+    #     The repo test is a string prefix match on the path git reports, and git
+    #     reports the logical path it was handed. So the same escape must stay closed
+    #     when the chain reaches the repo indirectly. Two shapes: a $HOME symlink
+    #     pointing into the repo, and a `..` component walking into it.
+    #     Each case plants the same payload, then differs only in how ~/.gitconfig
+    #     reaches the repo-side file. The copied wrapper makes $ind_repo its own
+    #     PROJECT, which is what the repo test keys on.
+    gitcfg_indirect_setup() {
+        ind_home="$gitcfg_root/indirect-$1"
+        ind_repo="$gitcfg_root/indirect-repo-$1"
+        mkdir -p "$ind_home" "$ind_repo/bin"
+        git init -q "$ind_repo"
+        cp "$repo/bin/dev-sandbox" "$ind_repo/bin/dev-sandbox"
+        cp "$repo/bin/dev-sandbox.sb" "$ind_repo/bin/dev-sandbox.sb"
+        chmod +x "$ind_repo/bin/dev-sandbox"
+        printf '[leak]\n\tmarker = GITCFG_LEAK_MARKER\n' >"$ind_home/secret.cfg"
+        printf '[include]\n\tpath = %s/secret.cfg\n' "$ind_home" >"$ind_repo/repo-side.cfg"
+    }
+    gitcfg_indirect_assert() {
+        local name="$1" out
+        # Guard against a setup that silently stopped reaching the payload, which
+        # would make the leak check pass for the wrong reason.
+        if [[ "$(cd "$ind_repo" && HOME="$ind_home" git config --global --includes --get leak.marker 2>/dev/null)" != GITCFG_LEAK_MARKER ]]; then
+            die "indirect-case setup is broken ($name): the chain does not reach the payload"
+            return
+        fi
+        out="$(cd "$ind_repo" && HOME="$ind_home" TMPDIR="$gitcfg_root/tmp" ./bin/dev-sandbox "cat '$ind_home/secret.cfg'" 2>&1)"
+        if [[ "$out" == *GITCFG_LEAK_MARKER* ]]; then
+            die "repo config reached via $name exposed a \$HOME file (sandbox escape)"
+        else
+            pass "repo config reached via $name cannot expose a \$HOME file"
+        fi
+    }
+    gitcfg_indirect_setup sym
+    ln -s "$ind_repo/repo-side.cfg" "$ind_home/link.cfg"
+    printf '[include]\n\tpath = %s/link.cfg\n' "$ind_home" >"$ind_home/.gitconfig"
+    gitcfg_indirect_assert "a \$HOME symlink"
+
+    # The .. has to start somewhere the repo test does not already match. Walking up
+    # out of $HOME into the sibling repo does that; a path spelled from $ind_repo
+    # would still begin with the project prefix and be caught without resolving.
+    gitcfg_indirect_setup dotdot
+    printf '[include]\n\tpath = %s/../%s/repo-side.cfg\n' "$ind_home" "${ind_repo##*/}" >"$ind_home/.gitconfig"
+    gitcfg_indirect_assert "a .. component"
+
+    #     A config fragment OUTSIDE $HOME is writable inside the sandbox by default,
+    #     so it is a chooser of paths just like a repo-local one. It must be
+    #     write-denied, or a dependency rewrites it to name a credential file and the
+    #     next launch read-allows whatever it named.
+    h="$gitcfg_root/outside"
+    mkdir -p "$h"
+    frag_dir="$gitcfg_root/frag" # outside the synthetic $HOME on purpose
+    mkdir -p "$frag_dir"
+    printf '[leak]\n\tmarker = GITCFG_LEAK_MARKER\n' >"$h/secret.cfg"
+    printf '[include]\n\tpath = %s/secret.cfg\n' "$h" >"$frag_dir/aliases.cfg"
+    printf '[include]\n\tpath = %s/aliases.cfg\n' "$frag_dir" >"$h/.gitconfig"
+    # $h is the synthetic HOME for this case, so "outside $HOME" means outside $h —
+    # which $frag_dir is by construction. Assert it, so the case cannot quietly
+    # become a no-op if the layout above ever changes.
+    if [[ "$frag_dir" == "$h"/* ]]; then
+        die "check setup is broken: the fragment is inside the synthetic \$HOME"
+    else
+        leaked="$(HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "cat '$h/secret.cfg'" 2>&1)"
+        if [[ "$leaked" == *GITCFG_LEAK_MARKER* ]]; then
+            die "fragment outside \$HOME exposed a \$HOME file (sandbox escape)"
+        else
+            pass "fragment outside \$HOME cannot expose a \$HOME file"
+        fi
+        if HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "echo x >> '$frag_dir/aliases.cfg'" >/dev/null 2>&1; then
+            die "config fragment outside \$HOME is writable (can be rewritten into a chooser)"
+        else
+            pass "write blocked: config fragment outside \$HOME"
+        fi
+    fi
+    rm -rf "$gitcfg_root"
+fi
+
+# 18. Nothing the wrapper runs before the sandbox starts may be resolved through the
+#     inherited $PATH. That phase has the developer's full privileges, and $PATH
+#     keeps the repo's node_modules/.bin (check 13 preserves repo bins on purpose),
+#     which sandboxed dependency code can write. So a binary planted there by a
+#     PREVIOUS sandboxed run would execute unsandboxed as the developer. Plant a
+#     fake for every command the pre-sandbox path uses and confirm none of them run.
+fake_bin_dir="$(mktemp -d)"
+fake_bin_marker="$fake_bin_dir/ran"
+for _c in git id sed mktemp cat mv rm touch cut uname dirname shasum readlink; do
+    # Resolve the real binary now, while PATH is still clean — /usr/bin for most,
+    # /bin for cat/mv/rm on macOS.
+    _real="$(command -v "$_c" 2>/dev/null)"
+    [[ -x "$_real" ]] || continue
+    # Fakes must stay functional: several of these run before the checks that would
+    # catch the hijack, so a fake that merely exits would break the wrapper and let
+    # the test pass for the wrong reason. Record the hijack, then exec the real one.
+    cat >"$fake_bin_dir/$_c" <<SCRIPT
+#!/bin/bash
+echo "$_c" >>"$fake_bin_marker"
+exec "$_real" "\$@"
+SCRIPT
+    chmod +x "$fake_bin_dir/$_c"
+done
+PATH="$fake_bin_dir:$PATH" $SANDBOX 'true' >/dev/null 2>&1
+if [[ -f "$fake_bin_marker" ]]; then
+    die "pre-sandbox phase ran \$PATH-resolved $(sort -u "$fake_bin_marker" | tr '\n' ' ')(planted binaries executed)"
+else
+    pass "pre-sandbox phase resolves no command through the inherited \$PATH"
+fi
+rm -rf "$fake_bin_dir"
+
+# 19. The repo's own .git/config is read-only inside the sandbox. It reaches the
+#     same escape as .git/hooks (check 11) by another route: core.hooksPath moves
+#     the hook directory elsewhere, and core.fsmonitor is a command git runs on
+#     ordinary read commands — both execute in the developer's terminal, outside
+#     Seatbelt. --git-common-dir resolves to the main repo's .git in a worktree,
+#     which is the file git actually reads there.
+gitcommon="$(git rev-parse --git-common-dir 2>/dev/null || true)"
+if [[ -n "$gitcommon" ]]; then
+    [[ "$gitcommon" != /* ]] && gitcommon="$repo/$gitcommon"
+    gitcommon="$(cd "$gitcommon" 2>/dev/null && pwd -P || true)"
+fi
+if [[ -n "$gitcommon" && -f "$gitcommon/config" ]]; then
+    check_write_blocked_existing "$gitcommon/config" "repo .git/config (core.hooksPath / core.fsmonitor escape)"
+else
+    echo "  --   repo .git/config not found, skipping"
+fi
+#     config.worktree is the same escape for a repo with extensions.worktreeConfig
+#     set, and a worktree's gitdir lives under the MAIN repo, outside PROJECT.
+gitprivate="$(git rev-parse --git-dir 2>/dev/null || true)"
+if [[ -n "$gitprivate" ]]; then
+    [[ "$gitprivate" != /* ]] && gitprivate="$repo/$gitprivate"
+    gitprivate="$(cd "$gitprivate" 2>/dev/null && pwd -P || true)"
+fi
+if [[ -n "$gitprivate" ]]; then
+    # Pick the probe by whether the file is real: the create-and-clean variant
+    # would truncate then delete an existing one.
+    if [[ -f "$gitprivate/config.worktree" ]]; then
+        check_write_blocked_existing "$gitprivate/config.worktree" "per-worktree config.worktree"
+    else
+        check_write_blocked "$gitprivate/config.worktree" "per-worktree config.worktree"
+    fi
+fi
+#     The .git node itself. In a worktree it is a file holding `gitdir: <path>`, so
+#     rewriting it repoints git at an attacker-controlled directory that brings its
+#     own config — the same escape, one level further out. Build a throwaway
+#     worktree rather than probing this checkout's own .git: appending to a
+#     directory fails on its own, so on a plain clone that probe would report
+#     "blocked" without the sandbox having anything to do with it.
+wt_root="$(cd "$(mktemp -d)" && pwd -P)"
+if git init -q "$wt_root/origin" 2>/dev/null &&
+    git -C "$wt_root/origin" -c user.email=t@example.com -c user.name=t -c commit.gpgsign=false \
+        commit -q --allow-empty -m init 2>/dev/null &&
+    git -C "$wt_root/origin" worktree add -q "$wt_root/wt" 2>/dev/null &&
+    [[ -f "$wt_root/wt/.git" ]]; then
+    mkdir -p "$wt_root/wt/bin"
+    cp "$repo/bin/dev-sandbox" "$wt_root/wt/bin/dev-sandbox"
+    cp "$repo/bin/dev-sandbox.sb" "$wt_root/wt/bin/dev-sandbox.sb"
+    chmod +x "$wt_root/wt/bin/dev-sandbox"
+    mkdir -p "$wt_root/tmp"
+    if (cd "$wt_root/wt" && TMPDIR="$wt_root/tmp" ./bin/dev-sandbox ": >> .git") >/dev/null 2>&1; then
+        die "worktree .git redirect file is writable (gitdir redirect escape)"
+    else
+        pass "write blocked: worktree .git redirect file"
+    fi
+else
+    echo "  --   could not build a throwaway worktree, skipping .git redirect check"
+fi
+git -C "$wt_root/origin" worktree prune 2>/dev/null || true
+rm -rf "$wt_root"
+
+# 20. A relocated global config is write-denied even while it does not exist.
+#     Otherwise a dependency creates the file git will read on the next launch,
+#     names an [include] of its own in it, and that launch emits a read-allow for
+#     whatever it named. The probe path sits in TMPDIR, outside $HOME, where the
+#     profile permits writes by default — so this only passes on the new deny.
+reloc_dir="$(cd "$(mktemp -d)" && pwd -P)"
+reloc_cfg="$reloc_dir/relocated-gitconfig" # deliberately never created
+if GIT_CONFIG_GLOBAL="$reloc_cfg" $SANDBOX "echo '[user]' > '$reloc_cfg'" >/dev/null 2>&1; then
+    die "absent relocated global config is creatable (next launch would trust it)"
+else
+    pass "absent relocated global config write blocked"
+fi
+#     Seatbelt matches physical paths, so denying only the logical one leaves the
+#     target writable behind a symlinked ancestor. readlink -f cannot resolve an
+#     absent leaf on macOS, which is exactly this case, so the deny canonicalizes
+#     the directory instead — assert against the physical path.
+mkdir -p "$reloc_dir/real"
+ln -s "$reloc_dir/real" "$reloc_dir/link"
+if GIT_CONFIG_GLOBAL="$reloc_dir/link/gitconfig" $SANDBOX "echo '[user]' > '$reloc_dir/real/gitconfig'" >/dev/null 2>&1; then
+    die "relocated global config creatable at its physical path (symlinked ancestor)"
+else
+    pass "relocated global config write blocked at its physical path"
+fi
+#     git accepts a relative GIT_CONFIG_GLOBAL, which an absolute-only guard skips.
+if (cd "$reloc_dir" && GIT_CONFIG_GLOBAL=relcfg "$repo/bin/dev-sandbox" "echo '[user]' > '$reloc_dir/relcfg'") >/dev/null 2>&1; then
+    die "relative relocated global config is creatable"
+else
+    pass "relative relocated global config write blocked"
+fi
+rm -rf "$reloc_dir"
 
 echo
 if [[ $fail -eq 0 ]]; then

--- a/bin/dev-sandbox-selftest
+++ b/bin/dev-sandbox-selftest
@@ -651,6 +651,26 @@ else
             pass "quote in a config-named path does not disable the sandbox"
         fi
     fi
+    #     A config whose own filename cannot be rendered as a literal cannot be
+    #     write-denied either, so it stays rewritable and must not be trusted to name
+    #     paths. Skipping it quietly is not enough: the declared-include pass would
+    #     still collect the clean $HOME targets it points at, which is exactly the
+    #     capability the taint withdraws.
+    h="$gitcfg_root/badname"
+    mkdir -p "$h" "$gitcfg_root/badfrag"
+    printf '[leak]\n\tmarker = GITCFG_LEAK_MARKER\n' >"$h/secret.cfg"
+    printf '[include]\n\tpath = %s/secret.cfg\n' "$h" >"$gitcfg_root/badfrag/a\"b.cfg"
+    printf '[include]\n\tpath = "%s/badfrag/a\\"b.cfg"\n' "$gitcfg_root" >"$h/.gitconfig"
+    if [[ "$(HOME="$h" git config --global --includes --get leak.marker 2>/dev/null)" != GITCFG_LEAK_MARKER ]]; then
+        die "unrenderable-origin setup is broken: the chain does not reach the payload"
+    else
+        leaked="$(HOME="$h" TMPDIR="$gitcfg_root/tmp" "$repo/bin/dev-sandbox" "cat '$h/secret.cfg'" 2>&1)"
+        if [[ "$leaked" == *GITCFG_LEAK_MARKER* ]]; then
+            die "a config with an unrenderable filename exposed a \$HOME file (taint bypass)"
+        else
+            pass "config with an unrenderable filename cannot expose a \$HOME file"
+        fi
+    fi
     rm -rf "$gitcfg_root"
 fi
 


### PR DESCRIPTION
## Problem

Anyone whose git config is split across `[include]` files cannot start the local dev stack. The `nodejs` and `ingestion` services restart-loop forever, roughly every 2 seconds, and never become ready.

`bin/dev-sandbox` allows three git config paths by name: `~/.gitconfig`, `~/.gitconfig.local`, and `~/.config/git/config`. Git reads whatever an `[include]` or `[includeIf]` chain points at, which is anything a dotfile manager decides to split out. Everything else under `$HOME` stays denied.

libgit2 fails hard on a config file it cannot stat, so a denied include kills any cargo build with a git dependency. That is the cyclotron build, which `prestart:dev` runs before the node services boot:

```
error: failed to load source for dependency `js-source-scopes`
Caused by:
  could not stat '/Users/haacked/.gitconfig.aliases': Operation not permitted; class=Os (2)
💥 Nodejs services crashed!
```

Those two services are the only ones wrapped in the sandbox, which is why the rest of the stack looks fine while event ingestion is dead.

## Changes

The wrapper asks git which config files it reads rather than guessing names.

- `git config --global --includes --list --show-origin` enumerates the set, following the include chain.
- A second pass collects declared `include.path` and `includeIf.*.path` values, which the origin pass cannot see.
- That covers a target holding no config keys, and a target whose `includeIf` condition does not match the directory a service starts in.
- Both passes read `-z` output, because an `includeIf` condition can contain a space that lands inside the config key.
- Every path under `$HOME` gets a read-allow plus its canonical path, since Seatbelt matches physical paths.
- Every path also gets a write-deny, against the `core.hooksPath` and `credential.helper` escape.
- Directories between `$HOME` and each config get `file-read-metadata`.
- Path resolution stops at a symlinked ancestor, which the allow for the file behind it does not cover.
- The path collector returns 0, so `set -e` cannot exit the wrapper when a config path is already canonical.
- The wrapper falls back to the three well-known names when git is not on PATH.

Only the global scope is read, and that is the security boundary rather than a scoping detail.

> [!NOTE]
> A config file's contents choose which paths the rendered profile allows.
> Enumerating every scope would hand that choice to repo-local `.git/config`, which stays writable inside the sandbox because cargo writes to it when it updates a git dependency.
> A dependency could add `[include] path = ~/.aws/credentials` and have the next launch emit a literal read-allow for that file.
> The injected allow wins, because SBPL is last-match-wins and the render appends after the base profile's denies.
> Global config cannot be used that way: the base profile denies writes to it, and the render denies writes to every file these two passes find.

## How did you test this code?

`bin/dev-sandbox-selftest` gains five checks.
I confirmed each one fails when I revert only the change it guards.

- A repo-local `[include]` naming a file under `$HOME` must not make that file readable.
- Four config layouts must stay readable inside the sandbox: an include target with no keys, a symlinked config file, a config behind a symlinked directory, and an `includeIf` condition containing a space.
- Each check builds a synthetic `$HOME` under its own `TMPDIR`, so it touches neither the developer's real config nor the shared profile cache.
- Reproduced the crash loop on a machine whose `~/.gitconfig` includes `~/.gitconfig.aliases` and `~/.gitconfig.posthog`, both symlinks into `~/.dotfiles`. Before: `could not stat` on every restart. After: cyclotron compiles and both services reach ready.
- Not re-run for this revision: the full stack boot. I compared the rendered allow list against `git config` output on the same machine instead, and confirmed git runs clean inside the sandbox.
- Not run: the Linux path, which returns early since `sandbox-exec` does not exist there.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None needed. The behavior it describes, dev-stack services running under a sandbox, is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this change. Phil directed the scope at each decision point.

- The global-scope restriction and the declared-include pass answer two ReviewHog findings on this PR. I reproduced both against the real sandbox before changing anything.
- I found the `set -e` exit while reproducing the first finding. It hid the credential read on this machine, because the planted file was a regular file while the developer's own config files are symlinks.
- A `code-reviewer-correctness` pass caught the tab-delimited parse breaking on an `includeIf` condition containing a space. Both passes read `-z` because of it.
- Skills invoked: `/address-pr-reviews`, `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- No customer material. The config paths quoted come from a local dev machine.
