### PR TITLE
fix(mysql): stop reporting thread-exhaustion errors as sync noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -537,6 +537,24 @@ def _is_transient_too_many_connections(e: BaseException) -> bool:
     return code == _TOO_MANY_CONNECTIONS_CODE
 
 
+# MySQL/MariaDB error 1135 (ER_CANT_CREATE_THREAD): the server accepted the TCP connection but the
+# OS refused to spawn the thread that would service it (`errno 11`, EAGAIN — "Resource temporarily
+# unavailable"). Like `_TOO_MANY_CONNECTIONS_CODE` above, this is a transient capacity condition on
+# the customer's database host (it's hit its process/thread ulimit, not out of memory), not a
+# misconfiguration — it clears as other connections close and free up OS threads — so a fresh
+# attempt after a short backoff usually succeeds. Kept out of `get_non_retryable_errors` (see
+# `MySQLSource.get_retryable_errors`).
+_CANT_CREATE_THREAD_CODE = 1135
+
+
+def _is_transient_cant_create_thread(e: BaseException) -> bool:
+    """Return True if the server couldn't spawn an OS thread to service the new connection."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    code = e.args[0] if e.args else None
+    return code == _CANT_CREATE_THREAD_CODE
+
+
 def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
     """Open a pymysql connection, retrying a transient drop or timeout on connect.
 
@@ -561,6 +579,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
                 or _is_transient_packet_sequence_error(e)
                 or _is_transient_vitess_dial_timeout(e)
                 or _is_transient_too_many_connections(e)
+                or _is_transient_cant_create_thread(e)
             ):
                 raise
             structlog.get_logger().warning(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -342,7 +342,11 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
         # "Too many connections" (MySQL error 1040) shares the same contract: `_connect_with_transient_retry`
         # retries it in-process too (see `_is_transient_too_many_connections`) — a slot frees the moment
         # another connection closes, mirroring the Postgres source's connection-limit handling.
-        return {"Lost connection to MySQL server during query", "Too many connections"}
+        #
+        # "Can't create a new thread" (MySQL error 1135) is the same class of transient host-capacity
+        # condition — the server hit its OS thread/process limit rather than `max_connections` — and is
+        # retried in-process the same way (see `_is_transient_cant_create_thread`).
+        return {"Lost connection to MySQL server during query", "Too many connections", "Can't create a new thread"}
 
     def reconcile_schema_metadata(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -25,6 +25,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     MySQLImplementation,
     _build_query,
     _is_bad_plan_error,
+    _is_transient_cant_create_thread,
     _is_transient_connect_broken_pipe,
     _is_transient_connect_dns_failure,
     _is_transient_connect_drop,
@@ -1213,6 +1214,33 @@ class TestIsTransientTooManyConnections:
         assert not _is_transient_too_many_connections(pymysql.err.InternalError(1040, "Too many connections"))
 
 
+class TestIsTransientCantCreateThread:
+    def test_matches_cant_create_thread(self):
+        assert _is_transient_cant_create_thread(
+            pymysql.err.OperationalError(
+                1135, 'Can\'t create a new thread (errno 11 "Resource temporarily unavailable")'
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            (2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)"),
+            (1040, "Too many connections"),
+        ],
+    )
+    def test_does_not_match_other_codes(self, code, message):
+        assert not _is_transient_cant_create_thread(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_cant_create_thread(pymysql.err.OperationalError())
+
+    def test_does_not_match_non_operational_error(self):
+        assert not _is_transient_cant_create_thread(
+            pymysql.err.InternalError(1135, 'Can\'t create a new thread (errno 11 "Resource temporarily unavailable")')
+        )
+
+
 class TestConnectTransientRetry:
     @pytest.mark.parametrize(
         "fail_count,expected_sleeps",
@@ -1369,6 +1397,26 @@ class TestConnectTransientRetry:
         mock_connect = mocker.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
             side_effect=[pymysql.err.OperationalError(1040, "Too many connections"), conn],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
+
+    def test_retries_cant_create_thread_then_succeeds(self, mocker):
+        sleep = mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        mock_connect = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[
+                pymysql.err.OperationalError(
+                    1135, 'Can\'t create a new thread (errno 11 "Resource temporarily unavailable")'
+                ),
+                conn,
+            ],
         )
 
         with MySQLImplementation().connect(_make_config()) as yielded:
@@ -2130,6 +2178,24 @@ class TestMySQLSourceNonRetryableErrors:
         non_retryable = source.get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert not is_non_retryable, f"Transient thread-exhaustion error should remain retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "OperationalError: (1135, 'Can't create a new thread (errno 11 \"Resource temporarily "
+            'unavailable"); if you are not out of available memory, you can consult the manual for '
+            "a possible OS-dependent bug')",
+            'Can\'t create a new thread (errno 11 "Resource temporarily unavailable")',
+        ],
+    )
+    def test_cant_create_new_thread_is_classified_retryable(self, source, error_msg):
+        # Already retried in-process at connect time (`_is_transient_cant_create_thread`); once
+        # exhausted it re-raises for Temporal to retry the whole activity. Without this
+        # classification `_handle_import_error` logs it at `exception` on every occurrence,
+        # flooding error tracking with a self-recovering host-capacity condition.
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Transient thread-exhaustion error should be classified retryable: {error_msg}"
 
     @pytest.mark.parametrize(
         "error_msg",


### PR DESCRIPTION
## Problem

A MySQL/MariaDB sync fails and gets reported to error tracking every time the server can't spawn an OS thread for a new connection, even though the sync recovers on its own once a slot frees up.

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fd986-ac58-7623-8f89-6d204d44cfb6): `OperationalError: (1135, "Can't create a new thread (errno 11 \"Resource temporarily unavailable\")")`, raised from `pymysql.connect` inside `_connect_with_transient_retry`.

## Changes

- Error 1135 signals the server hit its OS thread/process limit, the same transient host-capacity class as error 1040 ("Too many connections"), which this source already retries in-process and excludes from error tracking.
- 1135 had neither: it wasn't retried at connect time, and wasn't classified as retryable, so every occurrence escaped straight to error tracking.
- Added `_is_transient_cant_create_thread`, mirroring the existing `_is_transient_too_many_connections` predicate, to the connect-time retry loop.
- Added `"Can't create a new thread"` to `MySQLSource.get_retryable_errors()` as a backstop once the in-process retry budget is exhausted.

## How did you test this code?

Added `TestIsTransientCantCreateThread` (predicate unit tests), `test_retries_cant_create_thread_then_succeeds` (connect-retry integration test), and `test_cant_create_new_thread_is_classified_retryable` (retryable classification) — the same shapes as the existing coverage for the 1040 "Too many connections" case, which had no equivalent for 1135 before this change.

Ran the full MySQL source test suite locally: 274 passed. Not run: an end-to-end sync against a real MySQL server at its thread limit, since that requires live infrastructure.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, stack trace, affected events) to confirm the failure originates in `mysql.py`'s connect path, then read `mysql.py` and `source.py` to find the existing but incomplete pattern for the sibling "Too many connections" error. Searched for duplicate open PRs (human-authored and the maintainer's own) before opening this one — found a related but distinct bot-authored PR ([#79129](https://github.com/PostHog/posthog/pull/79129)) fixing a different MySQL error (Vitess reparent, 1105), not a duplicate. Invoked `/writing-tests` before adding test cases and `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*