### PR TITLE
perf(propdefs): connect the API pool lazily

### DIFF
--- a/rust/property-defs-rs/src/main.rs
+++ b/rust/property-defs-rs/src/main.rs
@@ -95,9 +95,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let consumer = SingleTopicConsumer::new(config.kafka.clone(), config.consumer.clone())?;
 
     // Dedicated PG conn pool for serving propdefs API queries only. The API is mounted but
-    // receives no production traffic today.
-    let options = PgPoolOptions::new().max_connections(config.max_pg_connections);
-    let api_pool = options.connect(&config.database_url).await?;
+    // receives no production traffic today, so connect lazily: `connect` would open a connection
+    // at startup and hold it idle for a surface nothing calls, and would also make boot depend on
+    // Postgres being reachable. The first request pays the connect cost instead.
+    let api_pool = PgPoolOptions::new()
+        .max_connections(config.max_pg_connections)
+        .connect_lazy(&config.database_url)?;
     let query_manager = QueryManager::new(api_pool).await?;
 
     let context = Arc::new(AppContext::new(&config, query_manager).await?);


### PR DESCRIPTION
## Problem

Every propdefs pod holds an idle Postgres connection for an HTTP API that serves no traffic, and refuses to boot if that database is unreachable.

Stacked on #79315, which corrects the comment on this pool. This PR changes its behavior.

- `main` builds a second pool for the `/api/v1/projects/:project_id/property_definitions` route, separate from the write pool in `AppContext`.
- `PoolOptions::connect` opens one connection eagerly to validate the DSN, and `min_connections` defaults to 0, so the pool then sits at that one connection.
- In prod-US and prod-EU the only HTTP paths propdefs serves are `/_liveness`, `/_readiness`, and `/metrics`. The API route receives nothing.

So the cost is one wasted connection per pod, and a startup dependency on Postgres for a surface nothing calls.

## Changes

- Swap `options.connect(...).await?` for `connect_lazy(...)`. No connection opens until a request arrives.
- `max_connections` is unchanged, so an API that does get traffic behaves as before, paying the connect cost on the first request.

The write pool in `AppContext::new` stays eager on purpose. Failing startup when the write database is unreachable is correct for a service whose whole job is writing.

I considered gating the route behind a new `ENABLE_API` flag instead. That wins the same connection back but adds config surface and needs its own rollout, and it disables the endpoint rather than deferring it.

> [!NOTE]
> `QueryManager::new` stores the pool and runs no query, so nothing between here and the first request forces a connection.

## How did you test this code?

No new tests. The change is a constructor swap on a code path with no test coverage today, and a test asserting "no connection was opened" would assert sqlx's behavior rather than ours.

Ran locally: `cargo clippy -p property-defs-rs --all-targets -- -D warnings` (clean) and `cargo test -p property-defs-rs` against the local dev Postgres (all suites pass).

Not checked: I did not run the service or watch a pod start with this change, so the connection drop is predicted from `min_connections: 0` and `connect_lazy`'s contract rather than observed. After deploy, the propdefs connection count in `pg_stat_activity` should fall by one per pod, and `/_readiness` should be unaffected because it is served by the lifecycle manager, not this pool.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) did this work. Skills invoked: `/writing-code-comments`, `/stacking-prs` for the stack mechanics, and `/writing-pr-descriptions` for this body.

This started from a wrong estimate. I first reported the pool as costing `MAX_PG_CONNECTIONS` connections per pod, which would have been 4 in production. Reading `sqlx-core`'s `PoolOptions` showed `min_connections` defaults to 0, so the real standing cost is one connection, with `max_connections` only a ceiling. The change is still worth making for the startup coupling, but the scale claim in the description is now the accurate one.

Public artifact: nothing here draws on anything outside this repository and its deployment config.
