### PR TITLE
fix(propdefs): stop skewing write latency and label every batch outcome

### DIFF
--- a/rust/property-defs-rs/src/batch_ingestion.rs
+++ b/rust/property-defs-rs/src/batch_ingestion.rs
@@ -532,6 +532,11 @@ async fn write_event_properties_batch(
                                 "Dropped {removed} event property rows referencing missing {column}={value}"
                             );
                             if batch.is_empty() {
+                                metrics::counter!(
+                                    V2_EVENT_PROPS_BATCH_ATTEMPT,
+                                    &[("result", "emptied_fk")]
+                                )
+                                .increment(1);
                                 total_time.fin();
                                 return Ok(());
                             }
@@ -590,7 +595,6 @@ async fn write_property_definitions_batch(
     mut batch: PropertyDefinitionsBatch,
     pool: &PgPool,
 ) -> Result<(), sqlx::Error> {
-    let total_time = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_WRITE_TIME, &[]);
     let mut tries: u64 = 1;
     let mut fk_strips: u64 = 0;
 
@@ -601,9 +605,14 @@ async fn write_property_definitions_batch(
     #[allow(clippy::len_zero)]
     if batch.len() == 0 {
         batch.uncache_dropped(&cache);
-        total_time.fin();
+        metrics::counter!(V2_PROP_DEFS_BATCH_ATTEMPT, &[("result", "noop")]).increment(1);
         return Ok(());
     }
+
+    // Started only once there are rows to write. Opening it above the early return would record a
+    // near-zero sample for a batch that issues no SQL at all, which drags down a histogram whose
+    // whole purpose is characterizing Postgres write latency.
+    let total_time = common_metrics::timing_guard(V2_PROP_DEFS_BATCH_WRITE_TIME, &[]);
 
     loop {
         // what if we just ditch properties without a property_type set? why update on conflict at all?
@@ -686,6 +695,11 @@ async fn write_property_definitions_batch(
                             // entries remain, and here we mean "no writable rows left".
                             #[allow(clippy::len_zero)]
                             if batch.len() == 0 {
+                                metrics::counter!(
+                                    V2_PROP_DEFS_BATCH_ATTEMPT,
+                                    &[("result", "emptied_fk")]
+                                )
+                                .increment(1);
                                 total_time.fin();
                                 batch.uncache_dropped(&cache);
                                 return Ok(());
@@ -822,6 +836,11 @@ async fn write_event_definitions_batch(
                                 "Dropped {removed} event definition rows referencing missing {column}={value}"
                             );
                             if batch.is_empty() {
+                                metrics::counter!(
+                                    V2_EVENT_DEFS_BATCH_ATTEMPT,
+                                    &[("result", "emptied_fk")]
+                                )
+                                .increment(1);
                                 total_time.fin();
                                 return Ok(());
                             }

--- a/rust/property-defs-rs/src/group_type_resolver.rs
+++ b/rust/property-defs-rs/src/group_type_resolver.rs
@@ -24,6 +24,31 @@ use crate::{
 const METHOD: &str = "GetGroupTypeMappingsByTeamIds";
 const CLIENT: &str = "property-defs-rs";
 
+// Metric label for a gRPC status code, as a static string so the error path allocates nothing.
+// The values are the PascalCase variant names on purpose: the Node.js and Python personhog
+// clients emit the same `error_type` values, and these three metric names are shared with them.
+fn code_label(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "Ok",
+        Code::Cancelled => "Cancelled",
+        Code::Unknown => "Unknown",
+        Code::InvalidArgument => "InvalidArgument",
+        Code::DeadlineExceeded => "DeadlineExceeded",
+        Code::NotFound => "NotFound",
+        Code::AlreadyExists => "AlreadyExists",
+        Code::PermissionDenied => "PermissionDenied",
+        Code::ResourceExhausted => "ResourceExhausted",
+        Code::FailedPrecondition => "FailedPrecondition",
+        Code::Aborted => "Aborted",
+        Code::OutOfRange => "OutOfRange",
+        Code::Unimplemented => "Unimplemented",
+        Code::Internal => "Internal",
+        Code::Unavailable => "Unavailable",
+        Code::DataLoss => "DataLoss",
+        Code::Unauthenticated => "Unauthenticated",
+    }
+}
+
 fn is_retryable(code: Code) -> bool {
     matches!(
         code,
@@ -59,13 +84,13 @@ where
         match make_call().await {
             Ok(value) => return Ok(value),
             Err(status) => {
-                let error_type = format!("{:?}", status.code());
+                let error_type = code_label(status.code());
 
                 metrics::counter!(
                     PERSONHOG_ERRORS_TOTAL,
                     "method" => method,
                     "client" => client,
-                    "error_type" => error_type.clone(),
+                    "error_type" => error_type,
                 )
                 .increment(1);
 
@@ -216,8 +241,8 @@ impl GroupTypeResolver {
                 Err(e) => {
                     let error_type = e
                         .downcast_ref::<Status>()
-                        .map(|s| format!("{:?}", s.code()))
-                        .unwrap_or_else(|| "unknown".to_string());
+                        .map(|s| code_label(s.code()))
+                        .unwrap_or("unknown");
                     warn!(error = %e, error_type = %error_type, "personhog group type resolution failed");
                     metrics::counter!(PERSONHOG_RESOLVE_ERRORS).increment(1);
                     return Err(e);

--- a/rust/property-defs-rs/src/metrics_buckets.rs
+++ b/rust/property-defs-rs/src/metrics_buckets.rs
@@ -18,8 +18,8 @@
 use common_metrics::Matcher;
 
 use crate::metrics_consts::{
-    BATCH_ACQUIRE_TIME, V2_EVENT_DEFS_BATCH_WRITE_TIME, V2_EVENT_PROPS_BATCH_WRITE_TIME,
-    V2_PROP_DEFS_BATCH_WRITE_TIME,
+    BATCH_ACQUIRE_TIME, UPDATES_PER_EVENT, V2_EVENT_DEFS_BATCH_WRITE_TIME,
+    V2_EVENT_PROPS_BATCH_WRITE_TIME, V2_PROP_DEFS_BATCH_WRITE_TIME,
 };
 
 // Batch-acquire spans "the channel already had a full batch waiting" to "we sat here until
@@ -39,11 +39,23 @@ const BATCH_WRITE_BUCKETS_MS: &[f64] = &[
     1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1_000.0, 2_000.0, 5_000.0, 10_000.0, 30_000.0,
 ];
 
+// Updates per event is a count, not a duration, so the millisecond ladder does not fit it at all:
+// its 10 to 50 gap sits exactly where the mass lives, and typical events yield single digits.
+// This ladder resolves the common range and still reaches update_count_skip_threshold (10000 by
+// default), above which the event is skipped entirely.
+const UPDATES_PER_EVENT_BUCKETS: &[f64] = &[
+    1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 21.0, 34.0, 55.0, 100.0, 250.0, 1_000.0, 10_000.0,
+];
+
 pub fn bucket_overrides() -> Vec<(Matcher, &'static [f64])> {
     vec![
         (
             Matcher::Full(BATCH_ACQUIRE_TIME.to_string()),
             BATCH_ACQUIRE_BUCKETS_MS,
+        ),
+        (
+            Matcher::Full(UPDATES_PER_EVENT.to_string()),
+            UPDATES_PER_EVENT_BUCKETS,
         ),
         (
             Matcher::Full(V2_EVENT_DEFS_BATCH_WRITE_TIME.to_string()),


### PR DESCRIPTION
## Problem

Anyone reading propdefs write latency on the Propdefs dashboard is reading a number that is too low, and any success rate built from the batch-attempt counter is too pessimistic.

Third layer of the stack, on top of #79316. This one changes emitted metrics.

- `write_property_definitions_batch` opened its latency guard before the early return for a batch with no writable rows. That batch issues no SQL, so it recorded a near-zero sample into a histogram whose purpose is characterizing Postgres write latency.
- Only the property-definitions writer has that shape, so its latency was not comparable to the event-definitions and event-properties writers.
- Four early returns exited with no `result` label at all, so `sum by(result)` under-counted the batches that actually ran.
- `prop_defs_updates_per_event` records a count of updates onto the shared millisecond ladder. Its `10 -> 50` gap sits exactly where the mass lives, so no quantile over it means anything.
- The personhog error path builds a `String` per failed attempt and clones it into three counters, which `rust/CLAUDE.md` forbids for label values.

## Changes

- Move the latency guard below the no-writable-rows return, so a batch that issues no SQL records no sample. Reordering is enough; no suppression API is needed.
- Add `result="noop"` to that return, and `result="emptied_fk"` to the three returns where an FK strip emptied the batch.
- Add a count-shaped bucket override for `prop_defs_updates_per_event`, reaching `update_count_skip_threshold`.
- Replace the formatted `error_type` with `code_label`, a match returning `&'static str`. The values stay the PascalCase variant names, because the Node.js and Python personhog clients emit the same `error_type` values on these three shared metric names.

The three FK-strip returns keep recording latency, and that is deliberate: the INSERT ran, hit an FK violation, and the batch emptied while stripping rows. That is real Postgres time. Only the property-definitions return exits before the loop is ever entered.

> [!NOTE]
> `result` gains two new values. The three "Batch Writes by Result" panels use `sum by(result)`, so they pick these up with no dashboard change. Expect `propdefs_v2_propdefs_batch_ms` quantiles to rise once this deploys, because the zeros that were dragging them down are gone. That is the metric getting more accurate, not the writer getting slower.

## How did you test this code?

No new tests, and the reason is a limitation worth stating. The regression worth guarding is "a drops-only batch records no latency sample", but the writers run inside `tokio::spawn`, so `metrics::with_local_recorder` cannot see their emissions, and the shared `DebuggingRecorder` used in `tests/update_cache.rs` is global to the test binary while `#[sqlx::test]` cases run in parallel. A histogram-absence assertion against it would be racy. The input condition is already covered: `unresolved_group_pd_is_dropped_and_recorded_for_eviction` asserts a drops-only batch has `len() == 0` and is not `is_empty()`.

Ran locally: `cargo clippy -p property-defs-rs --all-targets -- -D warnings` (clean) and `cargo test -p property-defs-rs` against the local dev Postgres (all suites pass).

Verified before writing the diff: the dashboard references `prop_defs_updates_per_event_sum` and `_count` but never `_bucket`, so the bucket override changes no panel. `tonic::Code` has 17 variants, and `code_label` covers all of them, so the match is exhaustive without a catch-all.

Not checked: I did not deploy this or observe the corrected histogram in production.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) did this work. Skills invoked: `/writing-code-comments`, `/writing-tests` (which is what ruled out the racy metrics test above), `/stacking-prs`, and `/writing-pr-descriptions`.

I first proposed adding a `cancel()` method to `common-metrics`' `TimingGuard`, since `fin()` is an empty no-op and the sample is recorded in `Drop`. Reordering turned out to be sufficient here, and an audit of all 113 external `timing_guard` call sites found no case in this crate that needs suppression rather than reordering, so adding an unused API to a shared crate would have been its own piece of cruft.

That audit did find the same bug class in three other services, which are deliberately out of scope for this PR because they belong to other teams: `feature-flags` at `flag_matching.rs:2315`, where the `else` arm is `(None, false)` with no DB call yet still records a sample labeled `outcome="success"` on what looks like the majority of `/flags` traffic, and two wrappers in `personhog-identity` at `storage/postgres/mod.rs:47` and `:53` whose delegates return early on empty input. Worth passing to those teams.

Public artifact: nothing here draws on anything outside this repository and its deployment config.
