### PR TITLE
fix(propdefs): rename two metrics that describe the wrong thing

### DIFF
--- a/rust/property-defs-rs/src/lib.rs
+++ b/rust/property-defs-rs/src/lib.rs
@@ -5,10 +5,10 @@ use batch_ingestion::process_batch;
 use common_kafka::kafka_consumer::{RecvErr, SingleTopicConsumer};
 use config::Config;
 use metrics_consts::{
-    BATCH_ACQUIRE_TIME, CACHE_CONSUMED, CACHE_LEN, COMPACTED_UPDATES, DUPLICATES_IN_BATCH,
-    EMPTY_EVENTS, EVENTS_RECEIVED, EVENT_PARSE_ERROR, FORCED_SMALL_BATCH, RECV_DEQUEUED,
-    SKIPPED_DUE_TO_TEAM_FILTER, UPDATES_FILTERED_BY_CACHE, UPDATES_PER_EVENT, UPDATES_SEEN,
-    UPDATE_PRODUCER_OFFSET, WORKER_BLOCKED,
+    BATCH_ACQUIRE_TIME, CACHE_FILL_RATIO, CACHE_LEN, COMPACTED_UPDATES, DUPLICATES_IN_BATCH,
+    EMPTY_EVENTS, EVENTS_RECEIVED, EVENT_PARSE_ERROR, FORCED_SMALL_BATCH, OFFSET_STORE_FAILURES,
+    RECV_DEQUEUED, SKIPPED_DUE_TO_TEAM_FILTER, UPDATES_FILTERED_BY_CACHE, UPDATES_PER_EVENT,
+    UPDATES_SEEN, WORKER_BLOCKED,
 };
 use types::{Event, Update};
 
@@ -118,7 +118,7 @@ pub async fn update_consumer_loop(
         ];
         for (cap, label, len) in per_cache {
             let cap_f = cap as f64;
-            metrics::gauge!(CACHE_CONSUMED, &[("cache", label)]).set(if cap_f > 0.0 {
+            metrics::gauge!(CACHE_FILL_RATIO, &[("cache", label)]).set(if cap_f > 0.0 {
                 len as f64 / cap_f
             } else {
                 0.0
@@ -199,7 +199,7 @@ pub async fn update_producer_loop(
             match offset.store() {
                 Ok(_) => (),
                 Err(e) => {
-                    metrics::counter!(UPDATE_PRODUCER_OFFSET, &[("op", "store_fail")]).increment(1);
+                    metrics::counter!(OFFSET_STORE_FAILURES).increment(1);
                     // TODO: consumer json_recv() should expose the source partition ID too
                     error!("update_producer_loop: failed to store offset {curr_offset}, got: {e}");
                 }

--- a/rust/property-defs-rs/src/metrics_consts.rs
+++ b/rust/property-defs-rs/src/metrics_consts.rs
@@ -8,13 +8,26 @@ pub const UPDATES_FILTERED_BY_CACHE: &str = "prop_defs_filtered_by_cache";
 pub const EMPTY_EVENTS: &str = "prop_defs_empty_events";
 pub const EVENT_PARSE_ERROR: &str = "prop_defs_event_parse_error";
 pub const BATCH_ACQUIRE_TIME: &str = "prop_defs_batch_acquire_time_ms";
-pub const CACHE_CONSUMED: &str = "prop_defs_cache_space";
+// Fraction of a subcache's capacity currently occupied, 0.0 to 1.0. Not an absolute size:
+// CACHE_LEN carries that, and a threshold written against this one has to be a fraction.
+pub const CACHE_FILL_RATIO: &str = "prop_defs_cache_fill_ratio";
 pub const CACHE_LEN: &str = "prop_defs_cache_len";
 pub const CACHE_HITS: &str = "prop_defs_cache_hits";
 pub const CACHE_MISSES: &str = "prop_defs_cache_misses";
 pub const CACHE_EVICTIONS: &str = "prop_defs_cache_evictions";
 pub const UPDATES_CACHE: &str = "prop_defs_updates_cache";
-pub const UPDATE_PRODUCER_OFFSET: &str = "prop_defs_update_producer_offset";
+// Kafka offset stores that failed. The producer loop continues past a failure, so a later
+// successful store on the same partition supersedes it and nothing is redelivered. Redelivery
+// only follows a failure that a rebalance or restart interrupts before the next store lands.
+pub const OFFSET_STORE_FAILURES: &str = "prop_defs_offset_store_failures";
+
+// Outcomes of group-type resolution, labeled `action`:
+//   hit          local cache had the index
+//   miss         local cache did not, and personhog resolved it (a cache miss, not a failure)
+//   negative_hit a recent unresolvable lookup is still within its TTL, so we skipped personhog
+//   fail         personhog returned no mapping, and the definition is dropped
+// A hit rate must divide by the sum of all four. Dividing by hit + miss alone silently drops
+// both of the outcomes where a definition does not get written.
 pub const GROUP_TYPE_CACHE: &str = "prop_defs_group_type_cache";
 pub const RECV_DEQUEUED: &str = "prop_defs_recv_dequeued";
 pub const COMPACTED_UPDATES: &str = "prop_defs_compaction_dropped_updates";


### PR DESCRIPTION
## Problem

Two propdefs metrics are named for something other than what they measure, so an alert written against either one silently never fires.

Top layer of the stack, on top of #79318.

- `prop_defs_update_producer_offset` reads as a gauge of the producer's Kafka offset, which is what anyone building a lag panel would assume. It is a counter of offset stores that **failed**, carrying a single-valued `op="store_fail"` label.
- `prop_defs_cache_space` reads as an amount of space. It is a fill fraction between 0 and 1, so `> 1000` never fires. `prop_defs_cache_len` already carries the absolute size.

## Changes

- Rename to `prop_defs_offset_store_failures` and drop the `op` label, which only ever had one value.
- Rename to `prop_defs_cache_fill_ratio`, rename the `CACHE_CONSUMED` constant to match, and document the unit at the definition.
- Document the four `action` values on `prop_defs_group_type_cache`.

Companion dashboard change: PostHog/grafana-dashboards#358. It bridges both renames as `new or old` so the three affected panels stay populated across the rollout, rather than going empty for however long the deploy takes. Land this first, then that one; the `or` arms make the order safe either way.

### Group-type cache labels: documented, not renamed

I planned to rename `action="miss"` and reported that the natural `hit / (hit + miss)` expression overstates cache effectiveness. Checking the dashboard showed that claim was wrong: "Group Type Cache Hit Rate" divides by the sum of all four actions, which is correct. The trap is real but latent, for whoever next writes that expression, so this documents the values at the constant instead of spending a series discontinuity on it.

> [!WARNING]
> Both renames break series continuity. Neither metric is alerted on anywhere in PostHog/charts, and the only consumers are the three dashboard panels handled in the companion PR.

## How did you test this code?

No new tests. These are constant renames with no branching, and the compiler covers every use site.

Ran locally: `cargo clippy -p property-defs-rs --all-targets -- -D warnings` (clean) and `cargo test -p property-defs-rs` against the local dev Postgres (all suites pass).

Verified before renaming: `prop_defs_update_producer_offset` and `prop_defs_cache_space` appear in no vmalert rule in PostHog/charts, which references exactly one propdefs metric anywhere. Their only consumers are three panels on dashboard uid `fdzapgln4mh34b`. `prop_defs_update_producer_offset` currently has no series at all in prod-US, so almost no history is lost. `prop_defs_cache_space` carries only a `cache` label in production, which is what makes the `by(state)` grouping in the companion PR provably dead.

Not checked: I did not deploy this or watch the renamed series appear.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) did this work. Skills invoked: `/writing-code-comments`, `/writing-tests`, `/stacking-prs`, and `/writing-pr-descriptions`.

I originally skipped these renames, believing the dashboard existed only inside Grafana and so could not be updated atomically with the code. It is in git at PostHog/grafana-dashboards, synced bidirectionally, and editing it by PR is the established path. That is what made the renames worth doing, and it is also why the companion PR uses `or` arms rather than a hard cutover.

Because the sync is bidirectional, editing this dashboard in the Grafana UI between the two merges would conflict with the companion PR.

Public artifact: nothing here draws on anything outside this repository and its deployment config.
