### PR TITLE
fix(data-warehouse): make ElevenLabs invalid-key error actionable at connect time

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/elevenlabs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/elevenlabs.py
@@ -159,7 +159,11 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
     if status == 200:
         return True, None
     if status == 401:
-        return False, "Invalid ElevenLabs API key"
+        return (
+            False,
+            "Your ElevenLabs API key is invalid or has been revoked. Create a new key in your "
+            "ElevenLabs account settings, then try again.",
+        )
     if status == 403:
         if schema_name is None:
             return True, None


### PR DESCRIPTION
## Problem

Someone connecting ElevenLabs as a data warehouse source with a wrong or revoked API key saw only "Invalid ElevenLabs API key" and had no idea what to do next. Session replays of the new-source flow show users hitting this, retrying the same key, and abandoning the connection.

The sync-time path already handles the identical 401 with a clear, actionable message. The connect-time credential check did not, so the first place a person meets the error was the least helpful.

## Changes

- The connect-time 401 now reads: "Your ElevenLabs API key is invalid or has been revoked. Create a new key in your ElevenLabs account settings, then try again."
- Copy only. The 200/403/429/5xx branches and validation behavior are unchanged.

## How did you test this code?

- Ran the ElevenLabs source tests: `products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs.py` (the status-mapping test asserts the ok/not-ok result and does not pin the message string, so the copy change is covered without a change-detector assertion).
- Did not exercise a live ElevenLabs connection.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Surfaced from an automated review of data-warehouse new-source onboarding session summaries, which flagged repeated dead-ends on ElevenLabs credential failures. The fix reuses the wording the maintainer already wrote for the sync-time 401 so the two paths stay consistent. No skills were required beyond the repo copy/test guidance. No customer data or session content is included in this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
