### PR TITLE
fix(desktop): use a loop glyph for the loops icon

### DIFF
--- a/products/desktop/packages/ui/src/primitives/LoopIcon.tsx
+++ b/products/desktop/packages/ui/src/primitives/LoopIcon.tsx
@@ -1,14 +1,5 @@
-import { ArrowClockwiseIcon, type IconProps } from "@phosphor-icons/react";
-import { cn } from "@posthog/quill";
+import { type IconProps, RepeatIcon } from "@phosphor-icons/react";
 
-export function LoopIcon({ className, ...props }: IconProps) {
-  return (
-    <ArrowClockwiseIcon
-      {...props}
-      className={cn(
-        "transition-transform duration-800 ease-[cubic-bezier(0.22,1,0.36,1)] motion-safe:group-hover:rotate-360 motion-safe:hover:rotate-360",
-        className,
-      )}
-    />
-  );
+export function LoopIcon(props: IconProps) {
+  return <RepeatIcon {...props} />;
 }


### PR DESCRIPTION
## Problem

- Someone opening PostHog desktop reads the Loops nav item as a reload button rather than a way into Loops.
- Loops drew phosphor's `ArrowClockwise`, the circular-arrow glyph the app already uses for its real refresh controls.
- The command menu lists "Create loop" next to "Refresh repositories", each with a near-identical icon.

## Changes

- `LoopIcon` now renders phosphor's [`Repeat`](https://phosphoricons.com/?q=repeat) glyph instead of `ArrowClockwise`.
- One file covers every surface: sidebar, canvas nav, command menu, loops list, loop detail header.
- I dropped the 360 degree hover spin, because a spinning icon reads as a refresh spinner.
- The spin only looked right because `ArrowClockwise` is rotationally symmetric. `Repeat` tumbles through its mid-rotation frames.

Left is the current icon, right is this PR. Note "Create loop" and "Refresh repositories" in the bottom panel.

![loops icon before and after](https://raw.githubusercontent.com/PostHog/pr-assets/8869ae5232693e46387cc3a603f29414937fc924/2026/08/e7f309dd-ad4e-41d5-b526-b5c415ce34b0.png)

> [!NOTE]
> I rendered that comparison from the installed `@phosphor-icons/react` path data, not from the running app. The loop names in it are invented.

## How did you test this code?

- I (Claude) ran `pnpm --filter @posthog/ui exec vitest run src/features/loops src/features/sidebar`, and the loops and sidebar suites pass.
- I added no tests. The change swaps one icon import, and no behavior branches on it.
- I compared both glyphs at 12, 16, 20 and 32 px, in regular and fill weights, including mid-rotation frames.
- Not run: a clean typecheck. Several workspace packages have no built `dist/` in my sandbox, so `@posthog/shared` and `@posthog/git` fail to resolve across many files. No error referenced `LoopIcon`.
- I did not open the desktop app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No user-facing copy or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) wrote this. Skills invoked: `/writing-pr-descriptions`.

I chose `Repeat` over `Infinity` and `Recycle` after rendering all three. `Infinity` fills into a solid blob at 12 px, and `Recycle` means something else.

Removing the hover animation is my call and was not part of the original ask, so push back if you want it. I can restore it or replace it with a non-rotational one.

Nothing in this PR came from a non-public source.

Unrelated tooling note: `hogli pr:upload-image` fails with HTTP 409 against PostHog/pr-assets, because that repo now requires verified signatures and the contents-API commit from a personal token is unsigned. I pushed the screenshot as a signed commit instead, and reported the bug through `hogli devex:feedback`.
