### PR TITLE
fix(code): tell cloud agents that cron jobs die with the run

### DIFF
--- a/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.test.ts
@@ -975,6 +975,25 @@ describe("AgentService", () => {
       );
     });
   });
+
+  describe("system prompt scheduling", () => {
+    it("scopes cron and loop tools to the current run", () => {
+      const prompt = (
+        service as unknown as {
+          buildSystemPrompt: (
+            credentials: { apiHost: string; projectId: number },
+            taskId: string,
+          ) => { append: string };
+        }
+      ).buildSystemPrompt(
+        { apiHost: "https://app.posthog.com", projectId: 1 },
+        "task-1",
+      ).append;
+
+      expect(prompt).toContain("Cron and loop tools live only in this run");
+      expect(prompt).toContain("set it up as a Signals scout instead");
+    });
+  });
 });
 
 describe("buildAutoApproveOutcome", () => {

--- a/products/desktop/packages/workspace-server/src/services/agent/agent.ts
+++ b/products/desktop/packages/workspace-server/src/services/agent/agent.ts
@@ -662,7 +662,11 @@ Optimize for the fewest shell round trips.
 - Batch related commands into one Bash invocation using \`&&\` (e.g. \`npm run typecheck && npm run lint && npm test\`).
 - Emit all independent tool calls in the same response.
 - Read multiple files at once.
-- Never rerun a command solely to reproduce output you already have.`;
+- Never rerun a command solely to reproduce output you already have.
+
+## Scheduling
+Cron and loop tools live only in this run. Use them to finish the job in front of you, such as polling CI until a pull request goes green. Never use them for a standing commitment.
+If the user asks for something ongoing ("every hour until I say stop", "keep an eye on X"), set it up as a Signals scout instead, which outlives this run. The \`working-with-scouts\` skill covers how. If you cannot set up what they asked for, say so plainly rather than approximating it with a job that dies with this session.`;
 
     if (channelMode) {
       prompt += `


### PR DESCRIPTION
## Problem

Cloud agents get cron and loop tools that only live as long as the run. Nothing in the prompt says so. An agent can promise a user a recurring job that quietly stops when the session ends.

## Changes

Adds a Scheduling section to the system prompt every cloud run gets.

- Cron and loop stay fine for finishing the current job, like polling CI until a PR goes green.
- Anything ongoing routes to a Signals scout, which outlives the run.
- If the agent cannot set up what was asked, it says so instead of approximating it.

## How did you test this code?

Added one unit test asserting the clause reaches the built prompt, matching the two sibling tests that already guard prompt clauses. It catches a silent deletion during a refactor.

Ran in `products/desktop`: `vitest run src/services/agent/agent.test.ts` for `@posthog/workspace-server` (43 passed), that package's typecheck, and Biome on both files. No manual run of the app.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This is an internal agent prompt.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus 5) wrote this after we traced a run where an agent answered a request for a recurring update by scheduling a session-scoped cron job. The job fired, but its output had no delivery path and it would have died with the run.

The first draft removed the cron tools from cloud runs entirely. We rejected that: babysitting a PR until CI goes green is a real use for them. The line is a standing commitment, not the tool.

No repo skills were invoked. `/writing-pr-descriptions` was not loadable from the worktree, so this follows the conventions in CLAUDE.md and the PR template directly.
