### PR TITLE
fix(baserow): handle non-JSON table listing responses

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baserow/baserow.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baserow/baserow.py
@@ -221,7 +221,14 @@ def list_tables(base_url: Optional[str], database_token: str) -> list[dict[str, 
         f"{base}/api/database/tables/all-tables/", timeout=REQUEST_TIMEOUT_SECONDS
     )
     response.raise_for_status()
-    tables = response.json()
+    try:
+        tables = response.json()
+    except requests.exceptions.JSONDecodeError:
+        # A user-supplied host can answer 2xx (or a redirect the no-redirect session leaves
+        # unfollowed) with an empty or HTML body; surface a clear reason, not a raw decode error.
+        raise ValueError(
+            "Baserow returned an unexpected response when listing tables. Check that the instance URL points to your Baserow API."
+        )
     if not isinstance(tables, list):
         raise ValueError("Unexpected response from Baserow when listing tables")
     return tables

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baserow/tests/test_baserow.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baserow/tests/test_baserow.py
@@ -16,6 +16,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.baserow.ba
     _read_capped,
     baserow_rows_source,
     check_table_read_permission,
+    list_tables,
     normalize_base_url,
     resolve_table_id,
 )
@@ -179,6 +180,26 @@ class TestCheckTableReadPermission:
             reason = check_table_read_permission(None, "tok", 42)
 
         assert (reason is not None) is expects_reason
+
+
+class TestListTables:
+    @pytest.mark.parametrize(
+        ("status_code", "body"),
+        [
+            (302, b""),  # a redirect the no-redirect session leaves unfollowed: empty body
+            (200, b"<html>not the API</html>"),  # wrong URL / proxy returns an HTML page
+        ],
+    )
+    def test_non_json_response_raises_clear_error(self, status_code: int, body: bytes) -> None:
+        response = Response()
+        response.status_code = status_code
+        response._content = body
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.baserow.baserow._get_session"
+        ) as mock_session:
+            mock_session.return_value.get.return_value = response
+            with pytest.raises(ValueError, match="unexpected response"):
+                list_tables(None, "tok")
 
 
 def _streamed_response(chunks: list[bytes], status_code: int = 200) -> Response:


### PR DESCRIPTION
## Problem

- A user connecting a self-hosted Baserow source saw the table picker fail with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` instead of a message they could act on. ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdaaa-8172-7660-a473-f47539645566))
- The failure fired during schema discovery, when `list_tables` asks the instance for its tables.
- `list_tables` calls `response.json()` right after `raise_for_status()`.
- The Baserow session follows no redirects (an SSRF boundary). A 3xx with an empty body, or a 2xx HTML page from a wrong instance URL, passes `raise_for_status()` and then crashes `.json()`.

## Changes

- `list_tables` now catches the JSON decode failure and raises a clear `ValueError` telling the user to check that the instance URL points to their Baserow API.
- This mirrors the existing `if not isinstance(tables, list)` guard on the next line.
- The classification is a fixable bug, not a non-retryable one: an empty or HTML body can also come from a transient upstream gateway, so the sync path stays retryable rather than being added to `NonRetryableErrors`.

## How did you test this code?

- Added `TestListTables`, parameterized over a redirect with an empty body and a 200 HTML page. It catches a regression where `list_tables` stops guarding `.json()` and surfaces the raw `JSONDecodeError` again; no existing test exercised `list_tables`.
- The assertion matches on the new message, so it fails against the old opaque error even though `requests.exceptions.JSONDecodeError` subclasses `ValueError`.
- Ran the baserow source test file locally.
- Not run: the wider data-imports suites.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude, via PostHog Code) triaged the error-tracking issue, confirmed the in-app frame was `list_tables` in the baserow source, and traced the crash to the no-redirect session returning a non-JSON body. Invoked `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`. Considered adding the error to `NonRetryableErrors` but kept it retryable because a non-JSON body can be a transient upstream response; the primary occurrence path (schema discovery) is not retried anyway.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
