### PR TITLE
fix(flags): preserve falsy payloads (false, 0, null) for boolean flags

### DIFF
--- a/frontend/src/scenes/feature-flags/featureFlagLogic.ts
+++ b/frontend/src/scenes/feature-flags/featureFlagLogic.ts
@@ -529,7 +529,7 @@ export const indexToVariantKeyFeatureFlagPayloads = (flag: Partial<FeatureFlagTy
     }
     if (flag.filters && !flag.filters.multivariate) {
         let cleanedPayloadValue = {}
-        if (flag.filters.payloads?.['true']) {
+        if (flag.filters.payloads?.['true'] !== undefined) {
             cleanedPayloadValue = { true: flag.filters.payloads['true'] }
         }
         return {

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1990,7 +1990,7 @@ class FeatureFlagSerializer(
                 # explicitly set a new payload during the downgrade).
                 payloads = filters.get("payloads") or {}
                 true_val = payloads.get("true")
-                if not true_val or true_val == REDACTED_PAYLOAD_VALUE:
+                if true_val is None or true_val == REDACTED_PAYLOAD_VALUE:
                     payloads.pop("true", None)
                 filters["payloads"] = payloads
 
@@ -4354,7 +4354,7 @@ class FeatureFlagViewSet(
             payloads = feature_flag.filters.get("payloads", {})
             if should_count:
                 increment_request_count(self.team.pk, 1, FlagRequestType.REMOTE_CONFIG)
-            return Response(payloads.get("true") or None)
+            return Response(payloads.get("true"))
 
         # Note: This decryption step is protected by the feature_flag:read scope, so we can assume the
         # user has access to the flag. However get_decrypted_flag_payloads_protected will also check the authentication
@@ -4367,7 +4367,7 @@ class FeatureFlagViewSet(
         if should_count:
             increment_request_count(self.team.pk, 1, FlagRequestType.REMOTE_CONFIG)
 
-        return Response(decrypted_flag_payloads["true"] or None)
+        return Response(decrypted_flag_payloads.get("true"))
 
     @validated_request(
         query_serializer=ActivityQuerySerializer,


### PR DESCRIPTION
## Problem

Boolean feature flag payloads set to falsy values (`false`, `0`, `null`, `""`) were silently dropped in two places, producing incorrect behavior for any team using those payload values.

## Changes

**Frontend (`featureFlagLogic.ts` line 532)**

`indexToVariantKeyFeatureFlagPayloads` checked `if (flag.filters.payloads?.['true'])` — a truthiness check that evaluates to `false` for valid payloads like `false`, `0`, or `null`. The payload was replaced with `{}` on every flag load, cache hydration, and save operation.

Fix: `if (flag.filters.payloads?.['true'] !== undefined)` — preserves any explicitly configured payload regardless of its value.

**Backend (`feature_flag.py`, `/remote_config` endpoint, lines 4357 and 4370)**

`payloads.get("true") or None` returns `None` for any falsy value. SDKs calling `/remote_config` for a flag with payload `false` or `0` received `null` in the response body instead of the actual configured value.

Fix: `payloads.get("true")` — `None` is already the default for missing keys; present falsy values are returned as-is. Changed the encrypted path from `decrypted_flag_payloads["true"] or None` to `.get("true")` for consistency and to avoid a `KeyError` if `"true"` is absent.

**Backend (`feature_flag.py`, downgrade path, line 1993)**

`if not true_val or true_val == REDACTED_PAYLOAD_VALUE:` would drop a payload of `false` or `0` during the encrypted→plaintext downgrade path, treating a valid falsy payload as "missing or redacted".

Fix: `if true_val is None or true_val == REDACTED_PAYLOAD_VALUE:`.

## How did you test this code?

Automated: no existing tests covered falsy payload values — the fix is straightforward truthiness→None-check substitution. Manual verification was not possible in this environment.

## 🤖 Agent context

Fully autonomous — no human directed this work; assigning to owning team to triage.

Root cause identified by static analysis: `JsonType` includes `boolean | number | null`, but all three guard sites used Python/JS truthiness checks rather than explicit `None`/`undefined` checks.