### PR TITLE
fix(data-warehouse): surface SSH tunnel failures as user errors in direct SQL queries

### DIFF
--- a/posthog/hogql/direct_sql/clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/clickhouse_adapter.py
@@ -6,6 +6,7 @@ import sqlparse
 from opentelemetry import trace
 from sqlparse import tokens as sqlparse_tokens
 from sqlparse.sql import TokenList
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.direct_query_metrics import DIRECT_QUERY_ROW_CAP_EXCEEDED_TOTAL, observe_direct_query
@@ -301,7 +302,7 @@ class ClickHouseAdapter:
                     rows, column_names, column_types = _fetch_capped_clickhouse_rows(
                         client, request.sql, request.values or None, statement_timeout_seconds
                     )
-        except (ClickHouseError, OSError, ExposedHogQLError) as error:
+        except (ClickHouseError, OSError, BaseSSHTunnelForwarderError, ExposedHogQLError) as error:
             span.set_attribute("error_type", error.__class__.__name__)
             if request.debug:
                 return DirectQueryResult(

--- a/posthog/hogql/direct_sql/mysql_adapter.py
+++ b/posthog/hogql/direct_sql/mysql_adapter.py
@@ -6,6 +6,7 @@ from opentelemetry import trace
 from pymysql.constants import FIELD_TYPE as MYSQL_FIELD_TYPE
 from sqlparse import tokens as sqlparse_tokens
 from sqlparse.sql import Statement
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.direct_sql.adapter import DirectQueryRequest, DirectQueryResult
@@ -176,7 +177,7 @@ class MySQLAdapter:
                         )
                         results = cursor.fetchall()
                         description = cursor.description or []
-        except (pymysql.MySQLError, ExposedHogQLError) as error:
+        except (pymysql.MySQLError, BaseSSHTunnelForwarderError, ExposedHogQLError) as error:
             span.set_attribute("error_type", error.__class__.__name__)
             if request.debug:
                 return DirectQueryResult(results=[], types=[], print_columns=[], error=mysql_error_to_message(error))

--- a/posthog/hogql/direct_sql/postgres_adapter.py
+++ b/posthog/hogql/direct_sql/postgres_adapter.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, TypedDict, cast
 import psycopg
 from opentelemetry import trace
 from psycopg.types.datetime import DateLoader
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.direct_sql.adapter import DirectQueryRequest, DirectQueryResult
@@ -302,7 +303,7 @@ class PostgresAdapter:
                             # successful, empty result instead of surfacing a spurious error.
                             description = cursor.description or []
                             results = cursor.fetchall() if description else []
-        except (psycopg.Error, ExposedHogQLError) as error:
+        except (psycopg.Error, BaseSSHTunnelForwarderError, ExposedHogQLError) as error:
             span.set_attribute("error_type", error.__class__.__name__)
             if request.debug:
                 return DirectQueryResult(results=[], types=[], print_columns=[], error=postgres_error_to_message(error))

--- a/posthog/hogql/direct_sql/redshift_adapter.py
+++ b/posthog/hogql/direct_sql/redshift_adapter.py
@@ -4,6 +4,7 @@ import psycopg
 import sqlparse
 from opentelemetry import trace
 from sqlparse import tokens as sqlparse_tokens
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql.constants import HogQLDialect
 from posthog.hogql.direct_query_metrics import DIRECT_QUERY_ROW_CAP_EXCEEDED_TOTAL, observe_direct_query
@@ -162,7 +163,7 @@ class RedshiftAdapter:
                         # as an empty result instead of raising on fetch, mirroring Postgres.
                         description = cursor.description or []
                         results = _fetch_capped_redshift_rows(cursor) if description else []
-        except (psycopg.Error, ExposedHogQLError) as error:
+        except (psycopg.Error, BaseSSHTunnelForwarderError, ExposedHogQLError) as error:
             span.set_attribute("error_type", error.__class__.__name__)
             if request.debug:
                 return DirectQueryResult(results=[], types=[], print_columns=[], error=postgres_error_to_message(error))

--- a/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
+++ b/posthog/hogql/direct_sql/test/test_clickhouse_adapter.py
@@ -6,18 +6,23 @@ from unittest.mock import MagicMock, patch
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
+from sshtunnel import BaseSSHTunnelForwarderError
 
+from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.direct_clickhouse_table import DirectClickHouseTable
 from posthog.hogql.database.models import StringDatabaseField, TableNode
+from posthog.hogql.direct_sql.adapter import DirectQueryRequest
 from posthog.hogql.direct_sql.clickhouse_adapter import (
+    ClickHouseAdapter,
     _fetch_capped_clickhouse_rows,
     ensure_read_only_raw_clickhouse_statement,
 )
 from posthog.hogql.errors import ExposedHogQLError, QueryError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer.utils import prepare_and_print_ast
+from posthog.hogql.timings import HogQLTimings
 
 
 class TestDirectClickHouseTable(SimpleTestCase):
@@ -85,6 +90,34 @@ class TestDirectClickHouseTeamIdGuard(BaseTest):
         # Our own cluster would happily resolve `mydb.events` — printing it there must fail, not read it.
         with self.assertRaisesRegex(QueryError, "direct connection"):
             self._print(is_direct_query=False)
+
+
+class TestClickHouseAdapterExecute(BaseTest):
+    def test_execute_raises_exposed_error_when_ssh_tunnel_fails(self):
+        source = MagicMock()
+        source.id = "src"
+        clickhouse_source = MagicMock()
+        clickhouse_source.direct_query_client.side_effect = BaseSSHTunnelForwarderError(
+            "Could not establish session to SSH gateway"
+        )
+
+        adapter = ClickHouseAdapter()
+        request = DirectQueryRequest(
+            source=source,
+            team=self.team,
+            sql="SELECT 1",
+            values=None,
+            settings=HogQLGlobalSettings(),
+            timings=HogQLTimings(),
+            query_type="HogQLQuery",
+            debug=False,
+        )
+
+        with patch.object(adapter, "validate_source_config", return_value=(clickhouse_source, MagicMock())):
+            with self.assertRaises(ExposedHogQLError) as error:
+                adapter.execute(request)
+
+        self.assertEqual(str(error.exception), "Could not establish session to SSH gateway")
 
 
 class TestClickHouseReadOnlyGuard(SimpleTestCase):

--- a/posthog/hogql/test/test_direct_mysql_query.py
+++ b/posthog/hogql/test/test_direct_mysql_query.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pymysql
 from parameterized import parameterized
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql.direct_sql.mysql_adapter import mysql_error_to_message, mysql_field_type_to_clickhouse_type
 from posthog.hogql.errors import ExposedHogQLError, QueryError
@@ -424,6 +425,28 @@ class TestDirectMySQLQuery(APIBaseTest):
         self.assertEqual(executed_statements[1], "START TRANSACTION READ ONLY")
         self.assertEqual(response.results, [(1, "a@b.com")])
         self.assertEqual(response.types, [("id", "Int64"), ("email", "String")])
+
+    def test_execute_raises_exposed_error_when_ssh_tunnel_fails(self):
+        source = self._create_source()
+        self._create_table(source, "orders")
+
+        executor = HogQLQueryExecutor(
+            query="SELECT id FROM orders",
+            team=self.team,
+            connection_id=str(source.id),
+        )
+
+        implementation = MagicMock()
+        implementation.connect.side_effect = BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")
+
+        with patch(
+            "posthog.hogql.direct_sql.mysql_adapter.MySQLAdapter.validate_source_config",
+            return_value=(implementation, MagicMock()),
+        ):
+            with self.assertRaises(ExposedHogQLError) as error:
+                executor.execute()
+
+        self.assertEqual(str(error.exception), "Could not establish session to SSH gateway")
 
     def test_hogql_query_for_synced_source_prints_identical_sql_to_pure_direct(self):
         direct_source = self._create_source(prefix="direct")

--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 
 import psycopg
 from parameterized import parameterized
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings
@@ -1767,6 +1768,54 @@ class TestDirectPostgresQuery(APIBaseTest):
         executor.execute()
 
         self.assertEqual(mock_connect.call_args.kwargs["sslmode"], expected_sslmode)
+
+    @override_settings(DEBUG=False, TEST=False)
+    @patch("products.warehouse_sources.backend.models.ssh_tunnel.SSHTunnelForwarder")
+    @patch("posthog.hogql.direct_sql.postgres_adapter.psycopg.connect")
+    def test_direct_postgres_ssh_tunnel_failure_raises_exposed_error(self, mock_connect, mock_tunnel_cls):
+        mock_tunnel_cls.return_value.__enter__.side_effect = BaseSSHTunnelForwarderError(
+            "Could not establish session to SSH gateway"
+        )
+
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="source_id",
+            connection_id="connection_id",
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type="Postgres",
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ph3",
+            job_inputs={
+                "host": "localhost",
+                "port": 5432,
+                "database": "postgres",
+                "user": "postgres",
+                "password": "postgres",
+                "schema": "ph3",
+                **self._SSH_TUNNEL_CONFIG,
+            },
+        )
+
+        DataWarehouseTable.objects.create(
+            name="posthog_dashboard",
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            url_pattern="direct://postgres",
+            columns={"id": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64", "valid": True}},
+        )
+
+        executor = HogQLQueryExecutor(
+            query="SELECT id FROM posthog_dashboard LIMIT 1",
+            team=self.team,
+            connection_id=str(source.id),
+        )
+
+        with self.assertRaises(ExposedHogQLError) as error:
+            executor.execute()
+
+        self.assertEqual(str(error.exception), "Could not establish session to SSH gateway")
+        mock_connect.assert_not_called()
 
     @override_settings(DEBUG=False, TEST=False, E2E_TESTING=True)
     @patch("posthog.hogql.direct_sql.postgres_adapter.psycopg.connect")

--- a/posthog/hogql/test/test_direct_redshift_query.py
+++ b/posthog/hogql/test/test_direct_redshift_query.py
@@ -6,6 +6,7 @@ from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
+from sshtunnel import BaseSSHTunnelForwarderError
 
 from posthog.hogql.direct_sql.redshift_adapter import RedshiftAdapter, ensure_read_only_raw_redshift_statement
 from posthog.hogql.errors import ExposedHogQLError, QueryError
@@ -172,6 +173,29 @@ class TestDirectRedshiftQuery(APIBaseTest):
                 with patch.object(HogQLQueryExecutor, "_capture_send_raw_query_translation_error"):
                     with self.assertRaisesRegex(ExposedHogQLError, "Add a LIMIT clause"):
                         executor.execute()
+
+    def test_execute_raises_exposed_error_when_ssh_tunnel_fails(self):
+        source = self._create_source()
+
+        executor = HogQLQueryExecutor(
+            query="SELECT id FROM orders",
+            team=self.team,
+            connection_id=str(source.id),
+            send_raw_query=True,
+        )
+
+        implementation = MagicMock()
+        implementation.connect.side_effect = BaseSSHTunnelForwarderError("Could not establish session to SSH gateway")
+
+        with patch(
+            "posthog.hogql.direct_sql.redshift_adapter.RedshiftAdapter.validate_source_config",
+            return_value=(implementation, MagicMock()),
+        ):
+            with patch.object(HogQLQueryExecutor, "_capture_send_raw_query_translation_error"):
+                with self.assertRaises(ExposedHogQLError) as error:
+                    executor.execute()
+
+        self.assertEqual(str(error.exception), "Could not establish session to SSH gateway")
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

A live query against an SSH-tunnelled Postgres, MySQL, Redshift, or ClickHouse source fails with a raw internal exception when the tunnel can't connect, instead of a clear message telling the user their SSH gateway is unreachable. [This error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdad8-ed13-7bb3-9a17-96b925f86ecd) shows one such failure, captured as an unclassified platform error rather than a user-facing connectivity problem.

## Changes

- Each direct-query adapter (`postgres_adapter.py`, `mysql_adapter.py`, `redshift_adapter.py`, `clickhouse_adapter.py`) opens an SSH tunnel before connecting, but only catches its own driver's error type plus `ExposedHogQLError`.
- `sshtunnel.BaseSSHTunnelForwarderError` fell through none of those, so a tunnel failure propagated as a bare exception. `query_runner.py` classifies unrecognized exceptions as platform failures, so this also polluted error tracking with what is really a user/upstream connectivity issue.
- Catch `BaseSSHTunnelForwarderError` alongside the existing driver errors in all four adapters and wrap it in `ExposedHogQLError`, matching how `psycopg.Error` / `pymysql.MySQLError` / `ClickHouseError` are already handled. Each adapter's existing message-formatting helper already falls back to `str(error)` for non-driver exceptions, so no other change was needed there.
- The scheduled Temporal sync pipeline already treats this same message as non-retryable (`Any_Source_Errors` in `external_data_job.py`); this PR only fixes the separate live-query code path, which had no such handling.

## How did you test this code?

- Added one regression test per adapter (Postgres, MySQL, Redshift, ClickHouse), each mocking the SSH tunnel to raise `BaseSSHTunnelForwarderError` and asserting the query now raises `ExposedHogQLError` with the tunnel's message instead of the raw exception. Existing coverage already asserts genuinely unexpected errors (e.g. a bare `RuntimeError`) still propagate uncaught, so the fix doesn't over-widen the except clause.
- Ran the full test files for all four adapters locally: `pytest posthog/hogql/test/test_direct_postgres_query.py posthog/hogql/test/test_direct_mysql_query.py posthog/hogql/test/test_direct_redshift_query.py posthog/hogql/direct_sql/test/test_clickhouse_adapter.py` — 219 passed.
- Ran `uv run mypy --cache-fine-grained .` repo-wide — clean.
- Ran `ruff check` and `ruff format --check` over the touched files — clean.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Authored by an agent (Claude) triaging a data-warehouse error tracking issue. The stack trace led to the direct SQL query adapters rather than the Temporal sync pipeline the issue was initially filed under.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Investigated whether this should instead be a non-retryable-error addition to the sync pipeline, but found the sync pipeline already treats this message as non-retryable; the actual gap was in the separate live direct-query path, which isn't a Temporal activity and has no retry policy to adjust — the fix is catching and translating the exception at the point it's thrown.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*