### PR TITLE
fix(tasks): raise pnpm fetch timeout for the local sandbox image

### DIFF
--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -6,10 +6,15 @@ FROM posthog-sandbox-base
 
 COPY local-workspace /local-workspace
 
+# The agent pulls a few ~100MB platform binaries (@openai/codex, the Claude agent SDK).
+# pnpm's 60s per-request default expires mid-download on a slow link, and the whole layer
+# is then lost to a timeout after ~9 minutes of work.
+ENV npm_config_fetch_timeout=600000
+
 RUN cd /local-workspace && \
-    pnpm install --filter @posthog/agent... --ignore-scripts --frozen-lockfile && \
+    pnpm install --filter @posthog/agent... --ignore-scripts --frozen-lockfile --config.fetchTimeout=600000 && \
     cd /local-workspace/packages/agent && \
     pnpm pack --pack-destination /tmp && \
     cd /scripts && \
-    pnpm install /tmp/posthog-agent-*.tgz --config.dangerouslyAllowAllBuilds=true && \
+    pnpm install /tmp/posthog-agent-*.tgz --config.dangerouslyAllowAllBuilds=true --config.fetchTimeout=600000 && \
     rm -rf /tmp/posthog-agent-*.tgz /local-workspace


### PR DESCRIPTION
## Problem

`Dockerfile.sandbox-local` fails to build on a slow link. The agent's dependencies include ~100MB platform binaries (`@openai/codex`, the Claude agent SDK), and pnpm's 60s per-request default expires mid-download:

```
[WARN] GET .../codex-0.144.0-linux-arm64.tgz error (23). Will retry in 1 minute. 1 retries left.
[23] The operation was aborted due to timeout
```

The install is one `RUN`, so each failure throws away ~9 minutes of work. It fails identically on retry.

## Changes

Raise the fetch timeout to 10 minutes — as an `ENV` so everything in the layer inherits it, and explicitly on both `pnpm install` calls.

Only affects the local-development image (`LOCAL_POSTHOG_CODE_MONOREPO_ROOT`), not the published sandbox base.

## How did you test this code?

Reproduced the failure twice against the unmodified Dockerfile, then rebuilt with the change. No automated tests — this is a build-time constant in a dev-only image.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Found while building the local sandbox image out of band for #78376.
