### PR TITLE
fix(data-imports): cap poll backoff exponent to avoid float overflow

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -44,6 +44,13 @@ SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 30.0
 # whole fleet hammer a degraded queue DB in lockstep.
 POLL_BACKOFF_MAX_SECONDS = 30.0
 
+# Ceiling on the backoff exponent. A prolonged queue-DB outage drives the failure
+# count into the thousands, and 2 ** (failures - 1) then overflows float when
+# multiplied by the interval, before min() can clamp to POLL_BACKOFF_MAX_SECONDS.
+# 2 ** 32 already dwarfs the cap for any real poll interval, so doubling past here
+# only risks the overflow without changing the (already saturated) result.
+POLL_BACKOFF_MAX_DOUBLINGS = 32
+
 # Per-poll fetch cap multiplier: fetch at most (free slots x this) batches so a poll
 # never leases far more groups than it can dispatch. Runs average ~2 batches per
 # group (batch 0 + final), so x3 gives headroom for multi-batch runs without
@@ -1077,7 +1084,8 @@ class BatchConsumer:
         gets exponentially less pressure and the fleet's retries desynchronize."""
         base = self._config.poll_interval_seconds
         failures = max(self._consecutive_poll_failures, 1)
-        backoff = min(base * 2 ** (failures - 1), POLL_BACKOFF_MAX_SECONDS)
+        exponent = min(failures - 1, POLL_BACKOFF_MAX_DOUBLINGS)
+        backoff = min(base * 2**exponent, POLL_BACKOFF_MAX_SECONDS)
         return backoff + random.uniform(0, base)
 
     def _report_health(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -879,6 +879,10 @@ class TestPollBackoff:
             assert consumer._poll_retry_delay() == 8.0
             consumer._consecutive_poll_failures = 20  # far past the cap
             assert consumer._poll_retry_delay() == 30.0  # POLL_BACKOFF_MAX_SECONDS
+            # A prolonged outage grows the count without bound; 2 ** (failures - 1) used
+            # to overflow float here and crash the consumer instead of returning the cap.
+            consumer._consecutive_poll_failures = 5000
+            assert consumer._poll_retry_delay() == 30.0
 
     def test_jitter_is_added_within_one_interval(self):
         consumer = _make_consumer(poll_interval_seconds=2.0)


### PR DESCRIPTION
## Problem

- The data-warehouse import batch consumer crashes after a prolonged queue-DB outage, instead of continuing to retry once the DB is reachable again.
- Each failed poll increments `_consecutive_poll_failures`; a long outage drives it into the thousands.
- The retry backoff computed `base * 2 ** (failures - 1)`. Once the exponent passed ~1024 the intermediate int exceeded float's range, so the multiply raised `OverflowError: int too large to convert to float` before `min()` could clamp it.
- The error surfaced in error tracking during an outage where DNS could not resolve the queue-DB host, so every poll failed and the count climbed: [issue 019fdb0a-5205-78f0-81d2-ca1a8c3a9cee](https://us.posthog.com/project/2/error_tracking/019fdb0a-5205-78f0-81d2-ca1a8c3a9cee). The `OverflowError` was chained onto the transient connection `OperationalError`.

## Changes

- Cap the backoff exponent at `POLL_BACKOFF_MAX_DOUBLINGS` (32) before the doubling, so the intermediate value can no longer overflow.
- The delay already saturates at `POLL_BACKOFF_MAX_SECONDS`, and `2 ** 32` dwarfs that cap for any real poll interval, so the returned delay is unchanged for every failure count. Only the crash goes away.
- The transient connection failure that triggers the retries stays retryable; this fixes only the arithmetic that crashed the retry loop.

> [!NOTE]
> Related open PRs (#79258, #79261, #79271) touch the same file to quiet transient queue-DB connection errors in error tracking. None change the backoff math, so this is a distinct fix; they may need a trivial rebase around the shared file.

## How did you test this code?

- Added a case to `TestPollBackoff.test_delay_grows_exponentially_and_caps` with a failure count of 5000. It returns the 30s cap; on the old code the same input raised `OverflowError`, which no existing case caught (the highest was 20, well below the overflow point).
- Ran `TestPollBackoff` locally: both cases pass.
- Not run: the database-backed and end-to-end suites — this change is a pure arithmetic fix with no DB interaction.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal retry behavior, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) triaged the error-tracking issue, traced the chained `OverflowError` to `_poll_retry_delay`, and confirmed the overflow reproduces on the old formula and is gone on the new one. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`. No customer data, credentials, or internal identifiers are included in the code, tests, or this description.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
