### PR TITLE
fix(data-imports): stop retrying malformed JSONPath config in REST sources

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -8,6 +8,7 @@ from typing import Any, NoReturn, Optional
 from django.db import InterfaceError, OperationalError
 from django.db.models import Prefetch
 
+from jsonpath_ng.exceptions import JSONPathError
 from requests.exceptions import HTTPError
 from structlog.contextvars import bind_contextvars
 from structlog.typing import FilteringBoundLogger
@@ -400,6 +401,16 @@ async def _handle_import_error(
     # contract by type so every REST-based source stops immediately, rather than depending on each
     # source listing the message in get_non_retryable_errors.
     if isinstance(error, RESTClientNonRetryableError):
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
+
+    # The shared REST engine compiles data_selector/cursor_path/next_url_path/resolve-param fields
+    # as JSONPath at sync time (jsonpath_utils.compile_path), not at manifest-validation time. A
+    # malformed path is a fixed string, so parsing it fails identically on every retry regardless
+    # of source — classify it here by type (message text varies across jsonpath_ng's several parse-
+    # and lex-error shapes, so it can't be matched via get_non_retryable_errors).
+    if isinstance(error, JSONPathError):
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from django.db import InterfaceError, OperationalError
 
+from jsonpath_ng.exceptions import JsonPathParserError
 from parameterized import parameterized
 from requests.exceptions import HTTPError
 
@@ -421,6 +422,37 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
 
     # autospec enforces handle_non_retryable_error's real signature, so a call with the wrong
     # positional args (as this branch once had) fails here instead of only at runtime.
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", autospec=True) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
+    assert handle_mock.await_args.args[5] is error
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_jsonpath_error_routes_through_handler_without_source_opt_in():
+    # The shared REST engine compiles data_selector/cursor_path/resolve-param fields as JSONPath at
+    # sync time, not manifest-validation time — a malformed path (e.g. a typo'd data_selector) raises
+    # jsonpath_ng's JSONPathError deep in shared code. It's a fixed string, so it fails identically on
+    # every retry regardless of source. It must be non-retryable by type, since jsonpath_ng's error
+    # messages vary across parse/lex failure shapes and can't be matched via get_non_retryable_errors.
+    error = JsonPathParserError("Parse error at 1:0 near token . (.)")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
     with (
         mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
         mock.patch.object(module, "handle_non_retryable_error", autospec=True) as handle_mock,


### PR DESCRIPTION
## Problem

A REST-based data warehouse source (Custom, and any source built on the shared REST engine) with a malformed JSONPath in its manifest — `data_selector`, `cursor_path`, `next_url_path`, or a resolve param's field — only fails once a sync actually runs the request that uses it, because these fields are compiled lazily at sync time rather than validated at manifest-creation time.

The resulting `jsonpath_ng` parse error was treated as a fresh, unclassified failure: Temporal retried the sync to its full activity budget and a new error-tracking issue was reported on every attempt, even though the JSONPath string is fixed and every retry fails identically.

Surfaced by [this error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdb22-0552-7663-a353-e502f93169e4) (`JsonPathParserError: Parse error at 1:0 near token . (.)`), raised from the shared REST engine's `jsonpath_utils.compile_path` during a Custom source sync.

## Changes

- Classify `jsonpath_ng.exceptions.JSONPathError` as non-retryable by type in the shared in-activity error handler (`_handle_import_error`), alongside the existing type-based checks for other shared, deterministic failures (`RESTClientNonRetryableError`, `SchemaColumnTypeChangedException`).
- Message-substring matching (`get_non_retryable_errors`) isn't viable for this error: `jsonpath_ng` raises several distinct parse/lex failure messages with no stable common substring, so classifying by exception type is the reliable option.

## How did you test this code?

Added `test_jsonpath_error_routes_through_handler_without_source_opt_in`, mirroring the existing sibling tests for `RESTClientNonRetryableError`/`SchemaColumnTypeChangedException`. It asserts a `JsonPathParserError` routes through `handle_non_retryable_error` even when the source's own `get_non_retryable_errors` doesn't list it — the regression this PR fixes.

Ran locally (no DB, mocked dependencies):

```
pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py -k "jsonpath or non_retryable or schema_column or rest_client or http_404 or http_401 or shared_non_retryable"
8 passed
```

Also ran `ruff check`, `ruff format --check`, and `mypy` on the changed files — all clean. Not run: the DB-backed test in the same file (`TestGetModelsPrefetchesSource`), which fails in this sandbox for an unrelated reason (no local Postgres).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled event stack trace, and a HogQL query for the `warehouse_sources_*` context properties) to trace the failure to `products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/jsonpath_utils.py`, then read the shared REST engine to confirm every JSONPath-bearing manifest field is compiled lazily at sync time. Skills invoked: `/writing-tests` before adding the regression test, `/writing-pr-descriptions` before writing this body.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*