### PR TITLE
feat(desktop/inbox): add collapsible report detail sections

### DIFF
--- a/products/desktop/packages/ui/src/features/inbox/components/CollapsibleSection.test.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/CollapsibleSection.test.tsx
@@ -1,0 +1,91 @@
+import type { IconProps } from "@phosphor-icons/react";
+import { FileTextIcon } from "@phosphor-icons/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentType, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DetailSection } from "./DetailSection";
+import { RightColumnSection } from "./RightColumnSection";
+
+interface SectionProps {
+  Icon: ComponentType<IconProps>;
+  title: string;
+  rightSlot?: ReactNode;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+const sections: ReadonlyArray<[string, ComponentType<SectionProps>]> = [
+  ["DetailSection", DetailSection],
+  ["RightColumnSection", RightColumnSection],
+];
+
+describe("collapsible inbox detail sections", () => {
+  it.each(sections)(
+    "%s starts expanded, toggles its body, and leaves the right slot interactive",
+    async (_name, Section): Promise<void> => {
+      const user = userEvent.setup();
+      const onRightSlotClick = vi.fn();
+
+      render(
+        <Section
+          Icon={FileTextIcon}
+          title="Section title"
+          rightSlot={
+            <button type="button" onClick={onRightSlotClick}>
+              Section action
+            </button>
+          }
+        >
+          <div>Section body</div>
+        </Section>,
+      );
+
+      const toggle = screen.getByRole("button", { name: "Section title" });
+      const body = screen.getByText("Section body");
+      const controlledRegion = document.getElementById(
+        toggle.getAttribute("aria-controls") ?? "",
+      );
+
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+      expect(controlledRegion).toContainElement(body);
+      expect(body).toBeVisible();
+
+      await user.click(screen.getByRole("button", { name: "Section action" }));
+
+      expect(onRightSlotClick).toHaveBeenCalledOnce();
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+      expect(body).toBeVisible();
+
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByText("Section body")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Section action" }),
+      ).toBeVisible();
+
+      await user.click(toggle);
+
+      expect(toggle).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByText("Section body")).toBeVisible();
+    },
+  );
+
+  it.each(sections)(
+    "%s supports starting collapsed",
+    (_name, Section): void => {
+      render(
+        <Section Icon={FileTextIcon} title="Section title" defaultOpen={false}>
+          <div>Section body</div>
+        </Section>,
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Section title" }),
+      ).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByText("Section body")).not.toBeInTheDocument();
+    },
+  );
+});

--- a/products/desktop/packages/ui/src/features/inbox/components/DetailSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DetailSection.tsx
@@ -1,11 +1,17 @@
 import type { IconProps } from "@phosphor-icons/react";
-import { Flex, Text } from "@radix-ui/themes";
-import type { ComponentType, ReactNode } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Text,
+} from "@posthog/quill";
+import type { ComponentType, ReactElement, ReactNode } from "react";
 
 interface DetailSectionProps {
   Icon: ComponentType<IconProps>;
   title: string;
   rightSlot?: ReactNode;
+  defaultOpen?: boolean;
   children: ReactNode;
 }
 
@@ -13,26 +19,31 @@ export function DetailSection({
   Icon,
   title,
   rightSlot,
+  defaultOpen = true,
   children,
-}: DetailSectionProps) {
+}: DetailSectionProps): ReactElement {
   return (
-    <Flex direction="column" gap="3">
-      <Flex
-        align="center"
-        justify="between"
-        gap="3"
-        className="min-w-0 cursor-default select-none"
-      >
-        <Flex align="center" gap="2" className="min-w-0">
-          <Icon size={15} weight="bold" className="shrink-0 text-gray-11" />
-          <Text className="truncate font-semibold text-[14px] text-gray-12 tracking-[-0.01em]">
+    <Collapsible
+      defaultOpen={defaultOpen}
+      variant="folder"
+      className="flex flex-col gap-3"
+    >
+      <div className="flex min-w-0 select-none items-center gap-3">
+        <CollapsibleTrigger className="min-w-0 flex-1 text-left">
+          <Icon weight="bold" aria-hidden />
+          <Text
+            render={<span />}
+            size="sm"
+            weight="semibold"
+            className="truncate tracking-[-0.01em]"
+          >
             {title}
           </Text>
-        </Flex>
-        <div className="h-px min-w-4 flex-1 bg-(--gray-5)" />
-        {rightSlot && <div className="shrink-0">{rightSlot}</div>}
-      </Flex>
-      <div>{children}</div>
-    </Flex>
+          <div className="h-px min-w-4 flex-1 bg-(--gray-5)" />
+        </CollapsibleTrigger>
+        {rightSlot != null && <div className="shrink-0">{rightSlot}</div>}
+      </div>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/DetailSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/DetailSection.tsx
@@ -30,7 +30,7 @@ export function DetailSection({
     >
       <div className="flex min-w-0 select-none items-center gap-3">
         <CollapsibleTrigger className="min-w-0 flex-1 text-left">
-          <Icon weight="bold" aria-hidden />
+          <Icon size={15} weight="bold" aria-hidden />
           <Text
             render={<span />}
             size="sm"

--- a/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/ReportDetail.tsx
@@ -58,12 +58,12 @@ function ReportDetailContent({ report }: { report: SignalReport }) {
         </>
       }
       summarySection={{ Icon: FileTextIcon, title: "Summary" }}
+      belowSummary={<ReportFeedbackFooter report={report} />}
       evidenceSection={{ Icon: MagnifyingGlassIcon, title: "Evidence" }}
     >
       <ReportTasksSection report={report} />
       <SuggestedReviewersSection report={report} />
       <ReportActivitySection reportId={report.id} />
-      <ReportFeedbackFooter report={report} />
     </InboxDetailFrame>
   );
 }

--- a/products/desktop/packages/ui/src/features/inbox/components/RightColumnSection.tsx
+++ b/products/desktop/packages/ui/src/features/inbox/components/RightColumnSection.tsx
@@ -1,11 +1,17 @@
 import type { IconProps } from "@phosphor-icons/react";
-import { Flex, Text } from "@radix-ui/themes";
-import type { ComponentType, ReactNode } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Text,
+} from "@posthog/quill";
+import type { ComponentType, ReactElement, ReactNode } from "react";
 
 interface RightColumnSectionProps {
   Icon: ComponentType<IconProps>;
   title: string;
   rightSlot?: ReactNode;
+  defaultOpen?: boolean;
   children: ReactNode;
 }
 
@@ -19,25 +25,31 @@ export function RightColumnSection({
   Icon,
   title,
   rightSlot,
+  defaultOpen = true,
   children,
-}: RightColumnSectionProps) {
+}: RightColumnSectionProps): ReactElement {
   return (
-    <Flex direction="column" gap="2">
-      <Flex
-        align="center"
-        justify="between"
-        gap="2"
-        className="cursor-default select-none text-gray-10"
-      >
-        <Flex align="center" gap="2">
-          <Icon size={12} className="shrink-0" />
-          <Text className="font-medium text-[11px] uppercase tracking-[0.06em]">
+    <Collapsible
+      defaultOpen={defaultOpen}
+      variant="folder"
+      className="flex flex-col gap-2"
+    >
+      <div className="flex select-none items-center gap-2 text-gray-10">
+        <CollapsibleTrigger className="min-w-0 flex-1 text-left">
+          <Icon className="shrink-0" aria-hidden />
+          <Text
+            render={<span />}
+            size="xxs"
+            variant="muted"
+            weight="medium"
+            className="uppercase tracking-[0.06em]"
+          >
             {title}
           </Text>
-        </Flex>
-        {rightSlot && <div className="shrink-0">{rightSlot}</div>}
-      </Flex>
-      <div>{children}</div>
-    </Flex>
+        </CollapsibleTrigger>
+        {rightSlot != null && <div className="shrink-0">{rightSlot}</div>}
+      </div>
+      <CollapsibleContent>{children}</CollapsibleContent>
+    </Collapsible>
   );
 }


### PR DESCRIPTION
## Problem

Desktop Inbox readers cannot fold completed report sections, so long Evidence and Activity logs crowd the report detail view.

The feedback prompt appears in the supporting column instead of following the summary.

Closes #78214

## Changes

- Make shared report sections collapsible and expanded by default.
- Expose expanded state on each section header and keep count or action slots outside the toggle.
- Move the report feedback prompt below the summary and outside its collapsed content.
- Cover default, collapsed, and reopened states for both shared section components.

**Screenshots**

<img width="1200" height="573" alt="image" src="https://github.com/user-attachments/assets/6446f952-6b7a-47f8-b60b-5a8d02d3322d" />

<img width="1200" height="573" alt="image" src="https://github.com/user-attachments/assets/956754cc-ad93-4e1f-8b6b-4ab24532352a" />


## How did you test this code?

- Ran the Desktop UI Vitest suite, lint, TypeScript check, and `hogli ci:preflight --strict`.
- Exercised Summary, Evidence, and Activity twice in Electron.
- Verified feedback and count slots remain visible while content is collapsed.
- No interaction-related page errors appeared.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

No documentation update. This changes an existing Desktop interaction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this change with T3 Code.

Skills invoked: `/posthog-desktop`, `/writing-tests`, `/qa-frontend`, `/run-posthog`, `agent-browser`, `/writing-user-facing-copy`, `/writing-pr-descriptions`, and the GitHub publish flow.