### PR TITLE
fix(data-imports): retry delta writes on a first-commit version race

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -115,6 +115,20 @@ def is_offset_overflow_compaction_error(error: BaseException) -> bool:
     return isinstance(error, deltalake.exceptions.DeltaError) and DELTA_OFFSET_OVERFLOW_ERROR_NEEDLE in str(error)
 
 
+# The optimistic-concurrency conflict checker raises this when the loser of a race to commit the
+# very next version can't read back the winner's just-committed log entry (delta-rs
+# `kernel/transaction/conflict_checker.rs`'s `WinningCommitSummary::try_new`) — most commonly two
+# writers racing to create the very first version of the same brand-new table, where the version in
+# the message is 0. Unlike `CommitFailedError` (mapped from `DeltaTableError::Transaction`), this
+# variant falls through delta-rs's Python binding as a plain `DeltaError` (see its `python/src/error.rs`
+# catch-all), so callers need to recognize it by message to retry it the same way as a commit conflict.
+DELTA_INVALID_VERSION_RACE_NEEDLE = "Invalid table version:"
+
+
+def is_invalid_version_race(error: BaseException) -> bool:
+    return type(error) is deltalake.exceptions.DeltaError and DELTA_INVALID_VERSION_RACE_NEEDLE in str(error)
+
+
 def is_transient_maintenance_error(error: BaseException) -> bool:
     """Infra blips seen during delta maintenance that aren't a maintenance bug.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/ops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/ops.py
@@ -8,6 +8,8 @@ import deltalake
 import deltalake.exceptions
 from structlog.types import FilteringBoundLogger
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import is_invalid_version_race
+
 T = TypeVar("T")
 
 
@@ -45,16 +47,20 @@ async def execute_with_conflict_retry(
     operation_name: str,
     logger: FilteringBoundLogger,
 ) -> T:
-    """Run a Delta operation that commits (merge, optimize.compact, vacuum, ...), refreshing the
-    table and re-running it on a commit conflict.
+    """Run a Delta operation that commits (merge, overwrite, append, optimize.compact, vacuum, ...),
+    refreshing the table and re-running it on a commit conflict.
 
-    See DELTA_MERGE_CONFLICT_RETRIES for why this can't rely on delta-rs's own retry budget.
+    See DELTA_MERGE_CONFLICT_RETRIES for why this can't rely on delta-rs's own retry budget. Also
+    retries `is_invalid_version_race` — the same race surfacing as a plain `DeltaError` rather than
+    `CommitFailedError` because delta-rs's Python binding doesn't give that variant its own class.
     """
     attempt = 0
     while True:
         try:
             return await asyncio.to_thread(operation_fn)
-        except deltalake.exceptions.CommitFailedError:
+        except deltalake.exceptions.DeltaError as e:
+            if not isinstance(e, deltalake.exceptions.CommitFailedError) and not is_invalid_version_race(e):
+                raise
             if attempt >= DELTA_MERGE_CONFLICT_RETRIES:
                 raise
             attempt += 1

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
     TransientObjectStoreError,
+    is_invalid_version_race,
     is_offset_overflow_compaction_error,
     is_transient_delta_maintenance_error,
     is_transient_maintenance_error,
@@ -155,6 +156,37 @@ class TestIsTransientMaintenanceError:
     )
     def test_classifies_transient_errors(self, _name: str, error: Exception, expected: bool):
         assert is_transient_maintenance_error(error) is expected
+
+
+class TestIsInvalidVersionRace:
+    @parameterized.expand(
+        [
+            # Two writers racing to commit the very first version of a brand-new table: the loser's
+            # conflict check can't read back the winner's just-committed version 0 log entry.
+            ("invalid_table_version_zero", deltalake.exceptions.DeltaError("Invalid table version: 0"), True),
+            # The same race losing at a later version, not just table creation.
+            ("invalid_table_version_nonzero", deltalake.exceptions.DeltaError("Invalid table version: 7"), True),
+            # A distinct delta-rs error variant (`VersionDowngrade`, not `InvalidVersion`) with its own
+            # message shape and a real bug to surface (a caller requesting an older version than
+            # loaded) — must not be swept up by this race classifier.
+            (
+                "downgrade_error_not_matched",
+                deltalake.exceptions.DeltaError("Cannot downgrade from version 5 to 2; use DeltaTable.load_version()"),
+                False,
+            ),
+            ("unrelated_delta_error", deltalake.exceptions.DeltaError("no protocol found in delta log"), False),
+            # `CommitFailedError` is a `DeltaError` subclass, but this classifier is deliberately exact-type
+            # only — that variant already has its own dedicated handling via `CommitFailedError`.
+            (
+                "commit_failed_error_not_matched",
+                deltalake.exceptions.CommitFailedError("Invalid table version: 0"),
+                False,
+            ),
+            ("wrong_exception_type", RuntimeError("Invalid table version: 0"), False),
+        ]
+    )
+    def test_classifies_invalid_version_race(self, _name: str, error: Exception, expected: bool):
+        assert is_invalid_version_race(error) is expected
 
 
 class TestIsOffsetOverflowCompactionError:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_ops.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_ops.py
@@ -45,7 +45,8 @@ class TestExecuteWithConflictRetry:
     commit outright, without spending any of its own internal retry budget (see the comment on
     DELTA_MERGE_CONFLICT_RETRIES). Regression coverage for the sync dying on the first such
     conflict instead of refreshing the table and re-running the operation, as the error's own
-    "must be rerun" message calls for. Shared by merges and `compact_table`'s optimize.compact."""
+    "must be rerun" message calls for. Shared by merges, overwrite/append writes, and
+    `compact_table`'s optimize.compact."""
 
     @pytest.mark.asyncio
     async def test_succeeds_without_retry(self):
@@ -73,6 +74,37 @@ class TestExecuteWithConflictRetry:
         assert result == {"num_output_rows": 1}
         assert operation_fn.call_count == 2
         table.update_incremental.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_invalid_version_race_then_succeeds(self):
+        # Two writers racing to commit the very first version of a brand-new table surface as a
+        # plain DeltaError, not CommitFailedError (delta-rs's Python binding only special-cases
+        # DeltaTableError::Transaction — see errors.py's is_invalid_version_race). Regression
+        # coverage for this race killing the sync instead of retrying like a normal commit conflict.
+        table = MagicMock()
+        operation_fn = MagicMock(
+            side_effect=[
+                deltalake.exceptions.DeltaError("Invalid table version: 0"),
+                {"num_output_rows": 1},
+            ]
+        )
+
+        result = await execute_with_conflict_retry(table, operation_fn, "op", make_logger())
+
+        assert result == {"num_output_rows": 1}
+        assert operation_fn.call_count == 2
+        table.update_incremental.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_delta_error_propagates_without_retry(self):
+        table = MagicMock()
+        operation_fn = MagicMock(side_effect=deltalake.exceptions.DeltaError("no protocol found in delta log"))
+
+        with pytest.raises(deltalake.exceptions.DeltaError):
+            await execute_with_conflict_retry(table, operation_fn, "op", make_logger())
+
+        operation_fn.assert_called_once()
+        table.update_incremental.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_gives_up_after_exhausting_retries(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/writer.py
@@ -473,27 +473,35 @@ class DeltaWriter:
                 )
 
             try:
-                await asyncio.to_thread(
-                    _write_deltalake,
+                await execute_with_conflict_retry(
                     delta_table,
-                    data,
-                    partition_by=PARTITION_KEY if use_partitioning else None,
-                    mode=mode,
-                    schema_mode=schema_mode,
-                    commit_properties=commit_properties,
+                    lambda: _write_deltalake(
+                        delta_table,
+                        data,
+                        partition_by=PARTITION_KEY if use_partitioning else None,
+                        mode=mode,
+                        schema_mode=schema_mode,
+                        commit_properties=commit_properties,
+                    ),
+                    "write: overwrite",
+                    self._logger,
                 )
             except deltalake.exceptions.SchemaMismatchError as e:
                 await self._logger.adebug("SchemaMismatchError: attempting to overwrite schema instead", exc_info=e)
                 capture_exception(e)
 
-                await asyncio.to_thread(
-                    _write_deltalake,
+                await execute_with_conflict_retry(
                     delta_table,
-                    data,
-                    partition_by=None,
-                    mode=mode,
-                    schema_mode="overwrite",
-                    commit_properties=commit_properties,
+                    lambda: _write_deltalake(
+                        delta_table,
+                        data,
+                        partition_by=None,
+                        mode=mode,
+                        schema_mode="overwrite",
+                        commit_properties=commit_properties,
+                    ),
+                    "write: overwrite (schema retry)",
+                    self._logger,
                 )
         elif write_type == "append":
             if delta_table is None:
@@ -518,14 +526,18 @@ class DeltaWriter:
 
             await self._logger.adebug(f"write: write_type = append")
 
-            await asyncio.to_thread(
-                _write_deltalake,
+            await execute_with_conflict_retry(
                 delta_table,
-                data,
-                partition_by=PARTITION_KEY if use_partitioning else None,
-                mode="append",
-                schema_mode="merge",
-                commit_properties=commit_properties,
+                lambda: _write_deltalake(
+                    delta_table,
+                    data,
+                    partition_by=PARTITION_KEY if use_partitioning else None,
+                    mode="append",
+                    schema_mode="merge",
+                    commit_properties=commit_properties,
+                ),
+                "write: append",
+                self._logger,
             )
 
         delta_table = await self._table.get_delta_table()


### PR DESCRIPTION
## Problem

A data warehouse full-refresh or first-incremental sync can abort with an unhandled error when two writers race to write the same brand-new Delta table. Seen live in PostHog error tracking: https://us.posthog.com/project/2/error_tracking/019fdb3f-3bcc-7ea3-8ba7-b9d711d83791.

- The loser of the race hits delta-rs's optimistic-concurrency conflict checker, which cannot read back the winner's just-committed log entry and raises `DeltaError: Invalid table version: 0`.
- This pipeline already retries the equivalent `CommitFailedError` conflict for merges, vacuum, and compaction, but the full-refresh and append write paths had no retry at all, and this specific error isn't a `CommitFailedError` in the first place.
- delta-rs's Python binding only maps one Rust error variant (`DeltaTableError::Transaction`) to `CommitFailedError`; this one falls through as the generic `DeltaError`, so the existing retry helper didn't recognize it.

## Changes

- `execute_with_conflict_retry` now also retries a `DeltaError` matching this signature, refreshing the table before re-running the write, same as it already does for `CommitFailedError`.
- Added `is_invalid_version_race` in `errors.py`, matched by exact exception type plus message prefix so it can't swallow other `DeltaError` subclasses or unrelated messages.
- Wired `execute_with_conflict_retry` around the full-refresh overwrite (including its schema-mismatch fallback) and append write paths in `DeltaWriter.write()`, which previously called `write_deltalake` directly with no conflict handling.

## How did you test this code?

- Added `TestIsInvalidVersionRace` in `test_delta_errors.py`: matches `Invalid table version: N`, rejects the unrelated `VersionDowngrade` message shape, rejects `CommitFailedError` (already handled separately), and rejects unrelated `DeltaError`/exception types.
- Added two cases to `TestExecuteWithConflictRetry` in `test_ops.py`: retries and succeeds on this `DeltaError` signature; a different `DeltaError` still propagates without retry.
- Ran `delta/test/test_ops.py`, `delta/test/test_delta_errors.py`, `delta/test/test_writer.py` (126 cases) and `uv run mypy` repo-wide; both clean.
- Not run: `delta/test/test_table.py` in the same directory, which needs the dev-stack object storage service unavailable here (pre-existing, unrelated to this change).
- The CI coverage report flags `writer.py:493` (the retry call inside the schema-mismatch fallback) as uncovered. That fallback branch was already untested before this PR — the same 12 lines are missed on `master` at their pre-change line numbers — so this isn't a gap the change introduces.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (stack trace, sampled event properties) to trace the failure to `_write_deltalake` in `writer.py`, then read delta-rs's Rust source (`errors.rs`, `conflict_checker.rs`, `python/src/error.rs` via the GitHub API) to confirm the `InvalidVersion` variant and why it isn't a `CommitFailedError`. Invoked `/writing-tests` before adding test coverage and `/writing-pr-descriptions` before writing this body. Searched open PRs for a duplicate fix; none found (one open PR from the maintainer, #78901, fixes a different Delta write bug — decimal scale reconciliation).
