### PR TITLE
fix(admin): fire deletion-confirm dialog handlers from a nonce'd script, not inline onclick

### DIFF
--- a/posthog/admin/admins/project_admin.py
+++ b/posthog/admin/admins/project_admin.py
@@ -62,6 +62,7 @@ class ProjectAdmin(admin.ModelAdmin):
     def trigger_deletion_display(self, project: Project):
         if not project.pk:
             return "-"
+        request = getattr(self, "_current_request", None)
         # No csrf_token needed in the partial: the button posts the surrounding admin change
         # form (which carries the token) to the action URL via formaction.
         # nosemgrep: python.django.security.audit.avoid-mark-safe.avoid-mark-safe (admin-only, renders trusted template)
@@ -82,8 +83,14 @@ class ProjectAdmin(admin.ModelAdmin):
                         "is safe: PostHog won't start a duplicate workflow if one is still running."
                     ),
                 },
+                request=request,
             )
         )
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        # Store request for access in display methods (needed for the CSP nonce in templates).
+        self._current_request = request
+        return super().change_view(request, object_id, form_url, extra_context=extra_context)
 
     def get_urls(self):
         urls = super().get_urls()

--- a/posthog/admin/test_trigger_deletion_admin.py
+++ b/posthog/admin/test_trigger_deletion_admin.py
@@ -114,6 +114,20 @@ class TestOrganizationAdminTriggerDeletion(BaseTest):
         self.organization.refresh_from_db()
         self.assertTrue(self.organization.is_pending_deletion)
 
+    def test_trigger_deletion_display_has_no_inline_onclick_and_carries_csp_nonce(self):
+        # Admin pages serve a CSP with no unsafe-inline/unsafe-hashes on script-src, which
+        # silently drops inline onclick attributes. Guards against reintroducing one.
+        request = self.factory.get(f"/admin/posthog/organization/{self.organization.pk}/change/")
+        request.user = self.user
+        request.csp_nonce = "test-nonce-value"  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
+        _attach_messages(request)
+        self.admin._current_request = request
+
+        html = self.admin.trigger_deletion_display(self.organization)
+
+        self.assertNotIn("onclick=", html)
+        self.assertIn('nonce="test-nonce-value"', html)
+
 
 class TestProjectAdminTriggerDeletion(BaseTest):
     def setUp(self):
@@ -200,3 +214,17 @@ class TestProjectAdminTriggerDeletion(BaseTest):
         mock_start.assert_called_once()
         self.project.refresh_from_db()
         self.assertFalse(self.project.is_pending_deletion)
+
+    def test_trigger_deletion_display_has_no_inline_onclick_and_carries_csp_nonce(self):
+        # Admin pages serve a CSP with no unsafe-inline/unsafe-hashes on script-src, which
+        # silently drops inline onclick attributes. Guards against reintroducing one.
+        request = self.factory.get(f"/admin/posthog/project/{self.project.pk}/change/")
+        request.user = self.user
+        request.csp_nonce = "test-nonce-value"  # type: ignore[attr-defined]  # ty: ignore[invalid-assignment]
+        _attach_messages(request)
+        self.admin._current_request = request
+
+        html = self.admin.trigger_deletion_display(self.project)
+
+        self.assertNotIn("onclick=", html)
+        self.assertIn('nonce="test-nonce-value"', html)

--- a/posthog/templates/admin/deletion_button.html
+++ b/posthog/templates/admin/deletion_button.html
@@ -3,27 +3,42 @@ Danger-zone action button for admin change pages. Clicking the button opens a <d
 confirmation modal instead of submitting directly. The modal's submit button posts the
 surrounding admin form to action_url via formaction, not a <form> of its own, because a nested
 <form> here would be dropped by the browser (formnovalidate skips its field validation).
+Admin pages serve a CSP with no 'unsafe-inline'/'unsafe-hashes' on script-src, which silently
+drops inline onclick attributes (no console error a user would see, no fallback), so the
+open/cancel handlers live in the nonce'd <script> block below instead.
 Include from a readonly display method with action_url / button_label / confirm_message /
-notice in context.
+notice in context, and pass request=request to render_to_string so {{ request.csp_nonce }}
+resolves.
 {% endcomment %}
-<button type="button"
-        class="button"
-        style="background: #ba2121; color: #fff;"
-        onclick="this.nextElementSibling.showModal()">
-    {{ button_label }}
-</button>
-<dialog style="max-width: 32em; padding: 16px; border: 1px solid #ba2121; border-radius: 4px;">
-    <p>{{ confirm_message }}</p>
-    <p class="help" style="color: #ba2121;">{{ notice }}</p>
-    <div style="display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px;">
-        <button type="button" onclick="this.closest('dialog').close()">Cancel</button>
-        <button type="submit"
-                formaction="{{ action_url }}"
-                formmethod="post"
-                formnovalidate
-                class="button"
-                style="background: #ba2121; color: #fff;">
-            Confirm deletion
-        </button>
-    </div>
-</dialog>
+<div class="deletion-button-widget">
+    <button type="button" class="button deletion-trigger-button" style="background: #ba2121; color: #fff;">
+        {{ button_label }}
+    </button>
+    <dialog class="deletion-confirm-dialog" style="max-width: 32em; padding: 16px; border: 1px solid #ba2121; border-radius: 4px;">
+        <p>{{ confirm_message }}</p>
+        <p class="help" style="color: #ba2121;">{{ notice }}</p>
+        <div style="display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px;">
+            <button type="button" class="deletion-cancel-button">Cancel</button>
+            <button type="submit"
+                    formaction="{{ action_url }}"
+                    formmethod="post"
+                    formnovalidate
+                    class="button"
+                    style="background: #ba2121; color: #fff;">
+                Confirm deletion
+            </button>
+        </div>
+    </dialog>
+</div>
+<script nonce="{{ request.csp_nonce }}">
+(function () {
+    var widget = document.currentScript.previousElementSibling;
+    var dialog = widget.querySelector(".deletion-confirm-dialog");
+    widget.querySelector(".deletion-trigger-button").addEventListener("click", function () {
+        dialog.showModal();
+    });
+    widget.querySelector(".deletion-cancel-button").addEventListener("click", function () {
+        dialog.close();
+    });
+})();
+</script>


### PR DESCRIPTION
## Problem

Staff can no longer trigger a deletion from the org or project admin danger zone: clicking "Trigger deletion" does nothing. #78768 added a confirmation `<dialog>` wired up with inline `onclick` attributes, but every `/admin/` page serves a CSP with no `unsafe-inline`/`unsafe-hashes` on `script-src` (`posthog/middleware.py`), which drops inline event handlers with no visible error for a staff user - only a console message.

The old button was `type="submit"` with `formaction`, so a blocked `onclick` still let the click submit the form. The new button is `type="button"`, whose only path to doing anything is that blocked `onclick`. So the click is a no-op: no dialog, no request, nothing.

## Changes

- Move the dialog's open/cancel handlers into a `<script nonce="{{ request.csp_nonce }}">` block with `addEventListener`, matching the existing pattern in `posthog/templates/admin/radar_bypass.html`.
- Thread `request` into `render_to_string` in `ProjectAdmin.trigger_deletion_display` (it was missing entirely) so the nonce resolves; `OrganizationAdmin` already passed it.
- Add a `change_view` override on `ProjectAdmin` to cache `self._current_request`, mirroring the existing pattern already on `OrganizationAdmin`.

## How did you test this code?

- Reproduced the break live: created a throwaway local project, set `is_pending_deletion=True`, drove `/admin/` with Playwright MCP on master + #78768. Console showed `Executing inline event handler violates the following Content Security Policy directive 'script-src'... The action has been blocked.`, no dialog opened, zero requests to the trigger-deletion endpoint.
- Reran the same steps against this fix: dialog opens, no console error, "Confirm deletion" submits and returns "Started deletion workflow for project ... (33)."
- Added one test per admin (`test_trigger_deletion_display_has_no_inline_onclick_and_carries_csp_nonce`) asserting the rendered button has no `onclick=` and the script tag carries the request's nonce - guards against reintroducing an inline handler, which no existing test caught since they only call `trigger_deletion_view` directly and never render the template.
- Ran `mypy --version && uv run mypy --cache-fine-grained .`: success, no issues in 17847 files.
- Not run: full Playwright suite, or `hogli ci:preflight` beyond the pre-push hook (see below).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal admin tooling only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated at Yasen's direction after retriggering a batch of stuck project/org deletions in prod surfaced doubt about whether #78768's admin fix actually works. Reproduced the break locally with Playwright MCP against the running dev stack before writing any fix, then wrote the fix from the CSP error message and the codebase's existing nonce'd-script pattern rather than guessing.

Skills invoked: `/writing-tests` before adding the two new tests, `/writing-pr-descriptions` before this body.