### PR TITLE
feat(cdp): track whether $set reads could map to person properties

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -17,6 +17,7 @@ import { createAddLogFunction, sanitizeLogMessage } from '../utils'
 import { execHog } from '../utils/hog-exec'
 import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '../utils/hog-function-filtering'
 import { createInvocationResult } from '../utils/invocation-utils'
+import { bytecodePersonUpdatePropertyReads, trackPersonUpdatePropertyReads } from '../utils/person-update-properties'
 import { HogInputsService } from './hog-inputs.service'
 
 export interface HogExecutorConfig {
@@ -156,6 +157,17 @@ export class HogExecutorService {
         const addLog = createAddLogFunction(result.logs)
 
         try {
+            // Observation only. It cannot throw, and it sits inside the try so that even if that
+            // guarantee ever broke, the failure would surface as an invocation error rather than
+            // escaping `execute` uncaught.
+            trackPersonUpdatePropertyReads({
+                reads: bytecodePersonUpdatePropertyReads(invocation.hogFunction.bytecode),
+                source: 'hog',
+                functionType: invocation.hogFunction.type,
+                eventProperties: invocation.state.globals.event?.properties,
+                personProperties: invocation.state.globals.person?.properties,
+            })
+
             let globals: HogFunctionInvocationGlobalsWithInputs
             let execRes: ExecResult | undefined = undefined
 

--- a/nodejs/src/cdp/services/hog-inputs.service.ts
+++ b/nodejs/src/cdp/services/hog-inputs.service.ts
@@ -8,6 +8,7 @@ import { HogFunctionInvocationGlobals, HogFunctionInvocationGlobalsWithInputs, H
 import { EncryptedFields } from '../utils/encryption-utils'
 import { execHog } from '../utils/hog-exec'
 import { LiquidRenderer } from '../utils/liquid'
+import { inputsPersonUpdatePropertyReads, trackPersonUpdatePropertyReads } from '../utils/person-update-properties'
 import { getDevicePushSubscriptionToken } from '../utils/push-subscription-utils'
 import { IntegrationManagerService } from './managers/integration-manager.service'
 import { RecipientTokensService } from './messaging/recipient-tokens.service'
@@ -26,6 +27,14 @@ export class HogInputsService {
         globals: HogFunctionInvocationGlobals,
         additionalInputs?: Record<string, any>
     ): Promise<Record<string, any>> {
+        trackPersonUpdatePropertyReads({
+            reads: inputsPersonUpdatePropertyReads(hogFunction),
+            source: 'inputs',
+            functionType: hogFunction.type,
+            eventProperties: globals.event?.properties,
+            personProperties: globals.person?.properties,
+        })
+
         // TODO: Load the values from the integrationManager
         const newGlobals: HogFunctionInvocationGlobalsWithInputs = {
             ...globals,

--- a/nodejs/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/nodejs/src/cdp/services/legacy-plugin-executor.service.ts
@@ -19,6 +19,10 @@ import { CyclotronJobInvocationHogFunction, CyclotronJobInvocationResult } from 
 import { CDP_TEST_ID, createAddLogFunction, destinationE2eLagMsSummary, isLegacyPluginHogFunction } from '../utils'
 import { cdpTrackedFetch } from '../utils/cdp-fetch'
 import { createInvocationResult } from '../utils/invocation-utils'
+import {
+    LEGACY_PLUGIN_PERSON_UPDATE_PROPERTY_READS,
+    trackPersonUpdatePropertyReads,
+} from '../utils/person-update-properties'
 
 const pluginExecutionDuration = new Histogram({
     name: 'cdp_plugin_execution_duration_ms',
@@ -268,6 +272,15 @@ export class LegacyPluginExecutorService {
 
             const start = performance.now()
             const globals = invocation.state.globals
+
+            // A legacy plugin reads both payloads whole from JavaScript, so no bytecode names them.
+            trackPersonUpdatePropertyReads({
+                reads: LEGACY_PLUGIN_PERSON_UPDATE_PROPERTY_READS,
+                source: 'legacy_plugin',
+                functionType: invocation.hogFunction.type,
+                eventProperties: globals.event?.properties,
+                personProperties: globals.person?.properties,
+            })
 
             const event = {
                 distinct_id: globals.event.distinct_id,

--- a/nodejs/src/cdp/utils/hog-function-filtering.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.ts
@@ -18,6 +18,7 @@ import {
     MinimalAppMetric,
 } from '../types'
 import { execHog } from './hog-exec'
+import { bytecodePersonUpdatePropertyReads, trackPersonUpdatePropertyReads } from './person-update-properties'
 
 // Module-level constants for fixed regex patterns to avoid recompilation
 // These patterns are compiled once at module load and reused for all events
@@ -376,6 +377,14 @@ export async function filterFunctionInstrumented(options: {
             result.match = true
             return result
         }
+
+        trackPersonUpdatePropertyReads({
+            reads: bytecodePersonUpdatePropertyReads(filters?.bytecode),
+            source: 'filters',
+            functionType: type,
+            eventProperties: filterGlobals.properties,
+            personProperties: filterGlobals.person?.properties,
+        })
 
         // check whether we have a match with our pre-filter
         // Only run if we have event filters and NO action filters (as actions are pre-saved event filters)

--- a/nodejs/src/cdp/utils/person-update-properties.test.ts
+++ b/nodejs/src/cdp/utils/person-update-properties.test.ts
@@ -1,0 +1,222 @@
+import { register } from 'prom-client'
+
+import { compileHog } from '../templates/compiler'
+import {
+    PersonUpdatePropertyOutcome,
+    PersonUpdatePropertyRead,
+    bytecodePersonUpdatePropertyReads,
+    findPersonUpdatePropertyReads,
+    inputsPersonUpdatePropertyReads,
+    personUpdatePropertyReadOutcome,
+    trackPersonUpdatePropertyReads,
+} from './person-update-properties'
+
+describe('person update properties', () => {
+    const read = (path: string[]): PersonUpdatePropertyRead => ({ key: '$set', path })
+
+    describe('findPersonUpdatePropertyReads', () => {
+        // Compiled against the real compiler so a change to how it emits global chains surfaces
+        // here, rather than as a scanner that silently stops finding anything.
+        it.each<[string, string, PersonUpdatePropertyRead[]]>([
+            [
+                'a nested read off event properties',
+                'return event.properties.$set.email',
+                [{ key: '$set', path: ['email'] }],
+            ],
+            [
+                'a nested read off filter globals',
+                'return properties.$set_once.plan',
+                [{ key: '$set_once', path: ['plan'] }],
+            ],
+            [
+                'the whole path of a deeply nested read',
+                'return event.properties.$set.profile.name',
+                [{ key: '$set', path: ['profile', 'name'] }],
+            ],
+            ['a whole object read, with no path', 'return event.properties.$set', [{ key: '$set', path: [] }]],
+            [
+                'both keys in one program',
+                'return f(event.properties.$set.email, event.properties.$set_once.plan)',
+                [
+                    { key: '$set', path: ['email'] },
+                    { key: '$set_once', path: ['plan'] },
+                ],
+            ],
+            ['nothing for unrelated properties', 'return event.properties.$browser', []],
+            ['nothing for a $set key outside properties', 'return event.$set.email', []],
+            ['nothing for a person property of the same name', 'return person.properties.$set.email', []],
+            // Only globals compile to a single chain, so a read through a local is invisible here.
+            ['nothing for a read through a local variable', 'let p := event.properties\nreturn p.$set.email', []],
+        ])('finds %s', async (_name, hog, expected) => {
+            expect(findPersonUpdatePropertyReads(await compileHog(hog))).toEqual(expected)
+        })
+    })
+
+    describe('inputsPersonUpdatePropertyReads', () => {
+        it('finds reads nested inside a compiled input tree', async () => {
+            const hogFunction = {
+                inputs: {
+                    payload: {
+                        value: {},
+                        bytecode: { body: { email: await compileHog('return event.properties.$set.email') } },
+                    },
+                },
+                mappings: [
+                    {
+                        inputs: {
+                            plan: { value: '', bytecode: await compileHog('return event.properties.$set.plan') },
+                        },
+                    },
+                ],
+            } as any
+
+            expect(inputsPersonUpdatePropertyReads(hogFunction)).toEqual([
+                { key: '$set', path: ['email'] },
+                { key: '$set', path: ['plan'] },
+            ])
+        })
+
+        it('memoizes per function so every invocation does not rescan', async () => {
+            const hogFunction = {
+                inputs: { payload: { value: '', bytecode: await compileHog('return event.properties.$set.email') } },
+            } as any
+
+            expect(inputsPersonUpdatePropertyReads(hogFunction)).toBe(inputsPersonUpdatePropertyReads(hogFunction))
+        })
+    })
+
+    describe('bytecodePersonUpdatePropertyReads', () => {
+        it.each([[null], [undefined], ['not bytecode'], [{}]])('tolerates %p', (bytecode) => {
+            expect(bytecodePersonUpdatePropertyReads(bytecode)).toEqual([])
+        })
+    })
+
+    describe('personUpdatePropertyReadOutcome', () => {
+        it.each<[PersonUpdatePropertyOutcome, PersonUpdatePropertyRead, any, any]>([
+            ['mappable', read(['email']), { $set: { email: 'a@example.com' } }, { email: 'a@example.com' }],
+            ['value_differs', read(['email']), { $set: { email: 'a@example.com' } }, { email: 'b@example.com' }],
+            ['missing_on_person', read(['email']), { $set: { email: 'a@example.com' } }, { plan: 'paid' }],
+            ['absent_in_event', read(['email']), { $set: { plan: 'paid' } }, { email: 'a@example.com' }],
+            ['absent_in_event', read(['email']), {}, { email: 'a@example.com' }],
+            ['no_person', read(['email']), { $set: { email: 'a@example.com' } }, undefined],
+            ['whole_object', read([]), { $set: { email: 'a@example.com' } }, { email: 'a@example.com' }],
+            ['mappable', read(['profile']), { $set: { profile: { name: 'Ada' } } }, { profile: { name: 'Ada' } }],
+            ['value_differs', read(['profile']), { $set: { profile: { name: 'Ada' } } }, { profile: { name: 'Bo' } }],
+            // A falsy value the event really set is a value, not an absence.
+            ['mappable', read(['count']), { $set: { count: 0 } }, { count: 0 }],
+            ['mappable', read(['optedIn']), { $set: { optedIn: false } }, { optedIn: false }],
+        ])('reports %s', (expected, subject, eventProperties, personProperties) => {
+            expect(personUpdatePropertyReadOutcome(subject, eventProperties, personProperties)).toEqual(expected)
+        })
+
+        it('walks a nested path on both sides', () => {
+            expect(
+                personUpdatePropertyReadOutcome(
+                    read(['profile', 'name']),
+                    { $set: { profile: { name: 'Ada' } } },
+                    { profile: { name: 'Ada' } }
+                )
+            ).toEqual('mappable')
+        })
+    })
+
+    // This module runs inside the filter and executor paths, where a throw does not mean "tracking
+    // failed": during filtering it reads as "the event does not match", which would silently stop a
+    // destination firing. So no input may make an entry point throw.
+    describe('never throws', () => {
+        const hostile = () => {
+            const throwingGetter = {}
+            Object.defineProperty(throwingGetter, 'email', {
+                get: () => {
+                    throw new Error('property access exploded')
+                },
+                enumerable: true,
+            })
+
+            // Two distinct objects, so the comparison cannot short-circuit on identity and has to
+            // reach the serialization that a cycle breaks.
+            const circular = () => {
+                const value: Record<string, any> = { profile: {} }
+                value.profile.self = value
+                return value
+            }
+
+            return { throwingGetter, circular }
+        }
+
+        const errorCount = async (): Promise<number> => {
+            const metric = await register.getSingleMetric('cdp_person_update_property_error')?.get()
+            return (metric?.values ?? []).reduce((total, sample) => total + sample.value, 0)
+        }
+
+        it('survives a person property whose getter throws, and reports it', async () => {
+            const { throwingGetter } = hostile()
+            const before = await errorCount()
+
+            expect(() =>
+                trackPersonUpdatePropertyReads({
+                    reads: [read(['email'])],
+                    source: 'hog',
+                    functionType: 'destination',
+                    eventProperties: { $set: { email: 'a@example.com' } },
+                    personProperties: throwingGetter,
+                })
+            ).not.toThrow()
+
+            // Proves the guard caught something rather than the input being harmless, and that a
+            // failure is visible instead of silent.
+            expect(await errorCount()).toBeGreaterThan(before)
+        })
+
+        it('survives an event property whose getter throws', () => {
+            const { throwingGetter } = hostile()
+
+            expect(() =>
+                trackPersonUpdatePropertyReads({
+                    reads: [read(['email'])],
+                    source: 'filters',
+                    functionType: 'destination',
+                    eventProperties: { $set: throwingGetter },
+                    personProperties: { email: 'a@example.com' },
+                })
+            ).not.toThrow()
+        })
+
+        it('survives a circular value on both sides of the comparison', () => {
+            const { circular } = hostile()
+
+            expect(() =>
+                trackPersonUpdatePropertyReads({
+                    reads: [read(['profile'])],
+                    source: 'inputs',
+                    functionType: 'destination',
+                    eventProperties: { $set: circular() },
+                    personProperties: circular(),
+                })
+            ).not.toThrow()
+        })
+
+        it.each([
+            ['bytecode of the wrong shape', [1, 'GET_GLOBAL', {}, null, undefined, Symbol('x')]],
+            ['a chain length past the start of the program', [32, 'email', 1, 99]],
+            ['a chain length that is not a number', [32, 'email', 1, 'four']],
+        ])('survives %s', (_name, bytecode) => {
+            expect(() => findPersonUpdatePropertyReads(bytecode)).not.toThrow()
+        })
+
+        it('survives an input tree deeper than the walk allows', () => {
+            let deep: Record<string, any> = { bytecode: ['_H', 1] }
+            for (let level = 0; level < 500; level++) {
+                deep = { nested: deep }
+            }
+
+            expect(() => inputsPersonUpdatePropertyReads({ inputs: { payload: deep } } as any)).not.toThrow()
+        })
+
+        it('survives inputs that are not the shape it expects', () => {
+            expect(() =>
+                inputsPersonUpdatePropertyReads({ inputs: 'not an object', mappings: 'neither' } as any)
+            ).not.toThrow()
+        })
+    })
+})

--- a/nodejs/src/cdp/utils/person-update-properties.ts
+++ b/nodejs/src/cdp/utils/person-update-properties.ts
@@ -1,0 +1,312 @@
+import { Counter } from 'prom-client'
+
+import { operations } from '@posthog/hogvm'
+
+import { HogBytecode, HogFunctionType } from '../types'
+
+/**
+ * Stored events are losing the duplicated person update payload, so `properties.$set` and
+ * `properties.$set_once` will not be there to read. Hog functions read them from filters, from
+ * templated inputs and from function bodies, and we have no idea how much of that is load bearing.
+ *
+ * This measures it, and it measures the fix at the same time. For every read a function makes, it
+ * asks the question the migration turns on: could the event's person snapshot have served this
+ * value instead? So the counter reports both how often these reads happen and how many of them a
+ * polyfill would carry, before any polyfill exists.
+ *
+ * A read of `properties.$set.email` is mappable when the person snapshot holds the same value under
+ * `email`. A whole-object read of `properties.$set` is not mappable by key at all, because the
+ * snapshot is the person's whole state rather than the subset one event updated. `$set_once` is
+ * expected to disagree sometimes: the person keeps the value it was first given, not the one a
+ * later event attempted.
+ */
+export const PERSON_UPDATE_PROPERTY_KEYS = ['$set', '$set_once'] as const
+
+export type PersonUpdatePropertyKey = (typeof PERSON_UPDATE_PROPERTY_KEYS)[number]
+
+/** Where in a hog function the read comes from. */
+export type PersonUpdatePropertyReadSource = 'filters' | 'inputs' | 'hog' | 'legacy_plugin'
+
+export type PersonUpdatePropertyRead = {
+    key: PersonUpdatePropertyKey
+    /** The chain after the key. Empty for a whole-object read. */
+    path: string[]
+}
+
+/** Whether the person snapshot could have stood in for one read. */
+export type PersonUpdatePropertyOutcome =
+    /** The snapshot holds the same value. A polyfill would be transparent. */
+    | 'mappable'
+    /** The snapshot holds a different value. A polyfill would change what the function sees. */
+    | 'value_differs'
+    /** The event set this key but the snapshot does not have it. A polyfill would resolve nothing. */
+    | 'missing_on_person'
+    /** The event carried no such value, so the read already resolves to nothing. */
+    | 'absent_in_event'
+    /** The event has no person, so there is nothing to map onto. */
+    | 'no_person'
+    /** A whole-object read, which no per-key mapping covers. */
+    | 'whole_object'
+
+const personUpdatePropertyReads = new Counter({
+    name: 'cdp_person_update_property_read',
+    help: 'Reads of $set or $set_once from event properties, by whether the person snapshot could have served them',
+    labelNames: ['key', 'source', 'function_type', 'outcome'],
+})
+
+const personUpdatePropertyErrors = new Counter({
+    name: 'cdp_person_update_property_error',
+    help: 'Failures inside the $set / $set_once read tracking, which is observation-only and never fails an invocation',
+    labelNames: ['stage'],
+})
+
+/**
+ * Nothing in this module may throw.
+ *
+ * It is observation only, but it runs inside the filter and executor paths, where the surrounding
+ * error handling means very different things: a throw during filtering is read as "this event does
+ * not match", which would silently stop a destination firing, and a throw in the executor fails the
+ * invocation. Neither is an acceptable outcome for a counter, so every entry point returns a
+ * fallback and reports the failure through `cdp_person_update_property_error` instead.
+ */
+function guarded<T>(stage: string, fallback: T, fn: () => T): T {
+    try {
+        return fn()
+    } catch {
+        personUpdatePropertyErrors.inc({ stage })
+        return fallback
+    }
+}
+
+// Bounds the walk over a compiled input tree. Inputs come from parsed JSON so they cannot be
+// cyclic, but a cap keeps a pathological shape from exhausting the stack.
+const MAX_INPUT_DEPTH = 32
+
+// Read off the VM's own opcode table so the scanner cannot drift from the compiler.
+const OP_GET_GLOBAL = operations.indexOf('GET_GLOBAL')
+const OP_STRING = operations.indexOf('STRING')
+
+const UPDATE_PROPERTY_KEYS = new Set<string>(PERSON_UPDATE_PROPERTY_KEYS)
+
+// Globals whose `properties` are the event's own. Person and group properties have a `$set` of
+// their own meaning and are not part of the payload being removed.
+const EVENT_PROPERTY_ROOTS = new Set(['event', 'properties'])
+
+function isPersonUpdatePropertyKey(value: unknown): value is PersonUpdatePropertyKey {
+    return typeof value === 'string' && UPDATE_PROPERTY_KEYS.has(value)
+}
+
+/**
+ * Recover the field chain behind a `GET_GLOBAL` op. The compiler emits the chain as `STRING`/value
+ * pairs in reverse order directly ahead of the op, then the op and the chain length — so
+ * `event.properties.$set.email` compiles to one `GET_GLOBAL 4` rather than a run of `GET_PROPERTY`.
+ */
+function readGlobalChain(bytecode: HogBytecode, opIndex: number): string[] | null {
+    const chainLength = bytecode[opIndex + 1]
+    if (typeof chainLength !== 'number' || chainLength < 2) {
+        return null
+    }
+
+    const chain: string[] = []
+    for (let position = 0; position < chainLength; position++) {
+        const stringOpIndex = opIndex - 2 * (position + 1)
+        if (stringOpIndex < 0 || bytecode[stringOpIndex] !== OP_STRING) {
+            return null
+        }
+        // Array indexes come through the same opcode, e.g. `properties.$set[1]`.
+        const segment = bytecode[stringOpIndex + 1]
+        if (typeof segment !== 'string' && typeof segment !== 'number') {
+            return null
+        }
+        chain.push(String(segment))
+    }
+    return chain
+}
+
+/**
+ * Find the reads of `$set` / `$set_once` off an event's properties in one compiled chunk.
+ *
+ * Only globals compile to a single chain, so a body that assigns `let props := event.properties` and
+ * then reads `props.$set.email` becomes `GET_PROPERTY` hops and is not found here. Those reads are
+ * invisible to any static pass, which is worth knowing when reading the counter as a total.
+ */
+export function findPersonUpdatePropertyReads(bytecode: unknown): PersonUpdatePropertyRead[] {
+    if (!Array.isArray(bytecode)) {
+        return []
+    }
+    return guarded('find_reads', [], () => scanForPersonUpdatePropertyReads(bytecode))
+}
+
+function scanForPersonUpdatePropertyReads(bytecode: HogBytecode): PersonUpdatePropertyRead[] {
+    const reads: PersonUpdatePropertyRead[] = []
+
+    for (let index = 0; index < bytecode.length; index++) {
+        if (bytecode[index] !== OP_GET_GLOBAL) {
+            continue
+        }
+        const chain = readGlobalChain(bytecode, index)
+        if (!chain || !EVENT_PROPERTY_ROOTS.has(chain[0])) {
+            continue
+        }
+
+        // Destination globals are rooted at `event.properties`, filter globals at `properties`.
+        const keyIndex = chain.findIndex(
+            (segment, position) =>
+                position > 0 && chain[position - 1] === 'properties' && isPersonUpdatePropertyKey(segment)
+        )
+        if (keyIndex === -1) {
+            continue
+        }
+
+        reads.push({ key: chain[keyIndex] as PersonUpdatePropertyKey, path: chain.slice(keyIndex + 1) })
+    }
+
+    return dedupeReads(reads)
+}
+
+function dedupeReads(reads: PersonUpdatePropertyRead[]): PersonUpdatePropertyRead[] {
+    return [...new Map(reads.map((read) => [`${read.key}.${read.path.join('.')}`, read])).values()]
+}
+
+const readsByBytecode = new WeakMap<object, PersonUpdatePropertyRead[]>()
+
+/** The reads compiled into one chunk of bytecode — a filter, or a function body. */
+export function bytecodePersonUpdatePropertyReads(bytecode: unknown): PersonUpdatePropertyRead[] {
+    if (!Array.isArray(bytecode)) {
+        return []
+    }
+    let reads = readsByBytecode.get(bytecode)
+    if (!reads) {
+        reads = findPersonUpdatePropertyReads(bytecode)
+        readsByBytecode.set(bytecode, reads)
+    }
+    return reads
+}
+
+/** Compiled input values are trees of nested objects with bytecode arrays at the leaves. */
+function collectInputBytecode(value: unknown, found: HogBytecode[], depth = 0): void {
+    if (depth > MAX_INPUT_DEPTH) {
+        return
+    }
+    if (Array.isArray(value)) {
+        if (value[0] === '_h' || value[0] === '_H') {
+            found.push(value)
+            return
+        }
+        value.forEach((item) => collectInputBytecode(item, found, depth + 1))
+        return
+    }
+    if (typeof value === 'object' && value !== null) {
+        Object.values(value).forEach((item) => collectInputBytecode(item, found, depth + 1))
+    }
+}
+
+const readsByHogFunction = new WeakMap<HogFunctionType, PersonUpdatePropertyRead[]>()
+
+/** The reads compiled into one function's templated inputs, including its mappings' inputs. */
+export function inputsPersonUpdatePropertyReads(hogFunction: HogFunctionType): PersonUpdatePropertyRead[] {
+    const cached = readsByHogFunction.get(hogFunction)
+    if (cached) {
+        return cached
+    }
+
+    // A failure caches its empty result too, so a function whose config breaks the walk costs this
+    // once rather than on every invocation.
+    const reads = guarded('inputs_reads', [], () => {
+        const inputBytecode: HogBytecode[] = []
+        for (const inputs of [
+            hogFunction.inputs,
+            hogFunction.encrypted_inputs,
+            ...(hogFunction.mappings ?? []).map((mapping) => mapping.inputs),
+        ]) {
+            for (const input of Object.values(inputs ?? {})) {
+                collectInputBytecode(input?.bytecode, inputBytecode)
+            }
+        }
+        return dedupeReads(inputBytecode.flatMap((bytecode) => findPersonUpdatePropertyReads(bytecode)))
+    })
+    readsByHogFunction.set(hogFunction, reads)
+    return reads
+}
+
+/** A legacy plugin is handed both payloads whole, so it reads them on every invocation. */
+export const LEGACY_PLUGIN_PERSON_UPDATE_PROPERTY_READS: PersonUpdatePropertyRead[] = PERSON_UPDATE_PROPERTY_KEYS.map(
+    (key) => ({ key, path: [] })
+)
+
+function resolvePath(root: unknown, path: string[]): unknown {
+    let value = root
+    for (const segment of path) {
+        if (typeof value !== 'object' || value === null) {
+            return undefined
+        }
+        value = (value as Record<string, unknown>)[segment]
+    }
+    return value
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+    if (left === right) {
+        return true
+    }
+    if (typeof left !== 'object' || typeof right !== 'object' || left === null || right === null) {
+        return false
+    }
+    // Person and event properties come from parsed JSON, but a throwing getter or a cyclic value
+    // reaching here should read as "not the same" rather than take the invocation down.
+    return guarded('compare', false, () => JSON.stringify(left) === JSON.stringify(right))
+}
+
+/** The question the migration turns on: could this read have come off the person snapshot? */
+export function personUpdatePropertyReadOutcome(
+    read: PersonUpdatePropertyRead,
+    eventProperties: Record<string, any> | undefined,
+    personProperties: Record<string, any> | undefined
+): PersonUpdatePropertyOutcome {
+    if (read.path.length === 0) {
+        return 'whole_object'
+    }
+    const eventValue = resolvePath(eventProperties?.[read.key], read.path)
+    if (eventValue === undefined) {
+        return 'absent_in_event'
+    }
+    if (!personProperties) {
+        return 'no_person'
+    }
+    const personValue = resolvePath(personProperties, read.path)
+    if (personValue === undefined) {
+        return 'missing_on_person'
+    }
+    return sameValue(eventValue, personValue) ? 'mappable' : 'value_differs'
+}
+
+/**
+ * Count one surface's reads against the globals it ran with.
+ *
+ * Called per invocation, so it stays on the memoized read list and only walks the globals for the
+ * functions that actually reference these properties.
+ */
+export function trackPersonUpdatePropertyReads(options: {
+    reads: PersonUpdatePropertyRead[]
+    source: PersonUpdatePropertyReadSource
+    functionType: string
+    eventProperties: Record<string, any> | undefined
+    personProperties: Record<string, any> | undefined
+}): void {
+    const { reads, source, functionType, eventProperties, personProperties } = options
+    if (reads.length === 0) {
+        return
+    }
+
+    // Guarded per read, so one hostile property does not cost the other reads their count.
+    for (const read of reads) {
+        guarded('track', undefined, () => {
+            personUpdatePropertyReads.inc({
+                key: read.key,
+                source,
+                function_type: functionType,
+                outcome: personUpdatePropertyReadOutcome(read, eventProperties, personProperties),
+            })
+        })
+    }
+}


### PR DESCRIPTION
## Problem

Stored events are losing the duplicated person update payload, so `properties.$set` and `properties.$set_once` will stop resolving. Hog functions read them from filters, from templated inputs and from function bodies, and nobody knows how much of that is load bearing.

The plan is to map those reads onto the event's person snapshot. That only works where the snapshot actually holds the same value, and today there is no way to tell how often it does.

First of three PRs. The templates that reference these properties, and the polyfill itself, follow separately.

## Changes

This measures the reads and the fix at once. For every read a function makes, it asks the question the migration turns on: could the person snapshot have served this value instead?

- `cdp_person_update_property_read` counts each read, labelled by key, source, function type, and outcome.
- The outcome is the answer for that read against the globals it ran with: `mappable`, `value_differs`, `missing_on_person`, `absent_in_event`, `no_person`, or `whole_object`.
- So the same counter gives both numbers: how often these reads happen, and how many of them a polyfill would carry. `sum by (outcome)` is the readiness check.

Reads come out of compiled bytecode rather than source, so one pass covers filters, input templates and function bodies. The scanner recovers the full chain, which is what makes the per-key comparison possible — `properties.$set.profile.name` is checked against `person.properties.profile.name`.

Each source is counted where it resolves: bodies by the hog executor, inputs by the inputs service, filters by the filter runner. Native and Segment destinations resolve inputs but never run hog, so counting bodies alone would report zero for them. Legacy plugins read both payloads whole from JavaScript, where no bytecode names them, so they are counted at the plugin boundary.

Two outcomes are worth reading carefully rather than as failures:

- `value_differs` is expected for `$set_once`. The person keeps the value it was first given, not the one a later event attempted.
- `whole_object` marks a read of `properties.$set` itself. No per-key mapping covers it, because the snapshot is the person's whole state rather than the subset one event updated. This is the same boundary [#79128](https://github.com/PostHog/posthog/pull/79128) draws on the HogQL side.

Nothing here changes what a function sees. There is no polyfill in this PR and no flag.

### Nothing here can throw

This is observation only, but it runs inside the filter and executor paths, where the surrounding error handling means very different things. A throw during filtering is caught and read as "this event does not match", which would silently stop a destination firing with no signal that tracking caused it. A throw in the executor fails the invocation. Neither is an acceptable outcome for a counter.

So every entry point returns a fallback and reports the failure through `cdp_person_update_property_error{stage}` rather than propagating. Counting is guarded per read, so one hostile property does not cost the other reads their count. A failure to scan a function's inputs caches its empty result, so a function whose config breaks the walk costs that once rather than on every invocation. The walk over a compiled input tree is depth-capped.

The executor call also sits inside the existing try, so even if the no-throw guarantee were ever broken the failure would surface as an invocation error rather than escaping uncaught.

> [!NOTE]
> A read through a local variable (`let p := event.properties` then `p.$set.email`) compiles to `GET_PROPERTY` hops rather than one chain, so no static pass finds it. Read the counter as a floor, not a total.

## How did you test this code?

- `person-update-properties.test.ts` compiles real hog through the repo compiler. Those cases catch a compiler change to how global chains are emitted, which would otherwise turn the counter silently to zero — the failure mode that matters most for a PR whose only output is a number.
- The outcome cases cover the comparison logic, including the ones that are easy to get wrong: a falsy value the event really set (`0`, `false`) is a value and not an absence, and a nested object compares by shape.
- A case asserts the per-function read list is memoized, since this runs on every invocation.
- A `never throws` block feeds the entry points a person property whose getter throws, an event property whose getter throws, two distinct cyclic values, malformed bytecode, and an input tree deeper than the walk allows. One case also asserts the error counter moved, which proves the guard caught something rather than the input being harmless.
- I checked those cases fail without the guard: removing the `try` from the guard helper turns four of them red. The rest are held by explicit type checks, which they also lock in.
- Not run: node suites needing Redis or Kafka. This sandbox has neither, so `hog-inputs.service.test.ts`, `hog-executor.service.test.ts` and `legacy-plugin-executor.service.test.ts` failed to boot — they fail identically on `master`. CI covers them, and they are the ones that exercise the wiring rather than the logic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This adds a metric and changes no behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this. Skills invoked: `/writing-tests`, `/code-review`, `/writing-pr-descriptions`, `/running-ci-preflight`.

This started as one PR carrying tracking, template fixes and the polyfill together, and was split on request. Two findings from that work shaped what stayed here. A review pass showed the job queue serializes globals to JSON between consumer and worker, which matters for the polyfill but not for counting. A pass over the live function rows in both regions showed transformations dominate any raw count of functions mentioning these properties, and they are unaffected — they write the payload before storage — which is why the counter labels function type.

An earlier draft counted references without evaluating them, so it could say how often a read happened but not whether the mapping would have worked. Comparing against the globals is the point of this PR.

The no-throw work came from a direct question about whether this could break anything. Auditing the four call sites showed none of them were safe: the executor call sat outside its try, and the filter path would have converted any error into a non-match. That audit is what produced the guard and the `never throws` cases.

Nothing here came from a customer conversation or an internal thread; the fixtures use `example.com` and invented values.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
