### PR TITLE
fix(elevenlabs): treat a rejected key at connect as invalid, not transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/elevenlabs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/elevenlabs.py
@@ -164,6 +164,11 @@ def validate_credentials(api_key: str, schema_name: Optional[str] = None) -> tup
         if schema_name is None:
             return True, None
         return False, f"Your ElevenLabs API key is missing the permission required to sync `{schema_name}`."
+    # A 4xx other than the 401/403 above (a 400 is what users actually hit) is a deterministic client
+    # error: the key was rejected and retrying sends the same request, so treat it as an invalid key
+    # rather than a transient "try again". 429 is a rate limit and stays retryable below.
+    if 400 <= status < 500 and status != 429:
+        return False, "Invalid ElevenLabs API key"
     # A 429/5xx/unexpected status leaves the key unverified. Don't accept it — surface it so the user
     # can retry, rather than saving a source that only fails on its first sync.
     return False, f"Could not verify the ElevenLabs API key (status {status}). Please try again."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elevenlabs/tests/test_elevenlabs.py
@@ -237,6 +237,8 @@ class TestValidateCredentials:
         [
             ("valid", 200, None, True),
             ("bad_key", 401, None, False),
+            # A 400 (the status users actually hit) is a deterministic client error, not transient.
+            ("bad_request_at_create", 400, None, False),
             ("missing_scope_at_create", 403, None, True),
             ("missing_scope_at_schema", 403, "history", False),
             # An unverified key (transient 429/5xx) must not be saved as valid at create time.
@@ -249,6 +251,15 @@ class TestValidateCredentials:
         mts.return_value.get.return_value = mock.MagicMock(status_code=status)
         ok, _msg = validate_credentials("k", schema_name)
         assert ok is expected_ok
+
+    @mock.patch(SESSION_PATCH)
+    def test_client_error_reads_as_invalid_key_not_retry(self, mts) -> None:
+        # A 400 must not tell the user to "try again" — that only resolves for transient 429/5xx.
+        mts.return_value.get.return_value = mock.MagicMock(status_code=400)
+        ok, msg = validate_credentials("k")
+        assert ok is False
+        assert msg is not None
+        assert "try again" not in msg.lower()
 
     @mock.patch(SESSION_PATCH)
     def test_network_error_is_not_valid(self, mts) -> None:


### PR DESCRIPTION
## Problem

Someone connecting an ElevenLabs source whose key the API rejects with a client-error status (other than the 401/403 already handled) saw "Could not verify the ElevenLabs API key (status `<code>`). Please try again." A client error is deterministic — the same probe request fails the same way every time — so "try again" sends them in a loop instead of pointing at the key. This was the most common ElevenLabs connect failure.

## Changes

- At connect time, a client-error status other than 401/403 (a 400 is what users actually hit) now surfaces as an invalid-key error rather than a transient "please try again".
- 429 (rate limit) and 5xx stay retryable, so a genuine transient blip still tells the user to retry.

## How did you test this code?

- Added a parameterized `validate_credentials` case for a 400 at create time, and a case asserting the message does not tell the user to retry.
- Ran the ElevenLabs source unit tests locally (`test_elevenlabs.py`); the validate-credentials group passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing docs describe this error string.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triage of data-warehouse source-creation failures surfaced this ElevenLabs error as a misleading-message case: a deterministic client error was presented as a transient one. The failing input values came from analytics on customers' own connect attempts and are treated as sensitive — none appear in this PR; the test asserts a stable substring only.

Related in-flight PR: #79325 reworded the ElevenLabs 401 (invalid-key) message. It does not touch the client-error/"try again" path fixed here, so the two are complementary and land on different lines of the same function; they should be reconciled at review time.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
