### PR TITLE
fix(dub): give personal-API-key users workspace-key guidance at connect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dub/dub.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dub/dub.py
@@ -288,6 +288,15 @@ def validate_credentials(api_key: str) -> tuple[bool, str | None]:
             return True, None
         if res.status_code == 401:
             return False, "Invalid Dub API key. Please check your key and try again."
-        return False, _error_message(res)
+        message = _error_message(res)
+        # A personal (user) Dub API key fails the workspace-scoped probe with Dub's raw
+        # "workspaceId" error, which talks about a missing query param and links its API-refactoring
+        # docs — noise in the wizard. Point the user at a workspace key, which the field asks for.
+        if "workspaceid" in message.lower():
+            return False, (
+                "This looks like a personal Dub API key. Create a workspace API key in your Dub "
+                "workspace under Settings > API Keys, then try again."
+            )
+        return False, message
     except Exception as e:
         return False, str(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dub/tests/test_dub.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dub/tests/test_dub.py
@@ -309,6 +309,29 @@ class TestCredentialValidation:
         assert valid is expected_valid
         assert (message is None) is expected_valid
 
+    def test_personal_key_gets_workspace_guidance_not_raw_dub_error(self) -> None:
+        # A personal (non-workspace) key fails with Dub's raw "workspaceId" copy about a missing
+        # query param — replace it with guidance to use a workspace key.
+        response = _make_http_response(
+            {
+                "error": {
+                    "code": "bad_request",
+                    "message": "Workspace ID not found. Did you forget to include a `workspaceId` query parameter?",
+                }
+            },
+            400,
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.dub.dub.make_tracked_session",
+            return_value=self._mock_session(response),
+        ):
+            valid, message = validate_credentials("dub_test")
+
+        assert valid is False
+        assert message is not None
+        assert "workspaceId" not in message
+        assert "workspace API key" in message
+
     def test_check_endpoint_access_surfaces_api_denial_message(self) -> None:
         response = _make_http_response(
             {"error": {"code": "forbidden", "message": "Requires a Business plan or higher."}}, 403


### PR DESCRIPTION
## Problem

Someone connecting a Dub source with a personal (non-workspace) API key saw Dub's raw API error echoed straight into the wizard: it talks about a missing `workspaceId` query parameter and links Dub's API-refactoring docs. In the source setup flow that's noise — it names an internal API concept the user never sees and gives no clear next step, even though the fix is simple: use a workspace API key, which is exactly what the field asks for.

## Changes

- At connect time, a Dub response carrying the workspace-scoping error now surfaces guidance to create a workspace API key (under Settings > API Keys) instead of Dub's raw developer-facing message.
- Other non-200/401 responses are unchanged.

## How did you test this code?

- Added a `validate_credentials` test that feeds the workspace-scoping error body and asserts the raw `workspaceId` copy is gone and the workspace-key guidance is shown.
- Ran the Dub source unit tests locally (`test_dub.py`); the credential-validation group passes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — the source field caption and `posthog.com/docs/cdp/sources/dub` already tell users to create a workspace API key.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while triaging data-warehouse source-creation failures: a third-party API error was leaking verbatim into a user-facing wizard. The failing input came from analytics on a customer's own connect attempt and is treated as sensitive — it does not appear in this PR; the test uses an invented request body and asserts on a stable substring.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
