### PR TITLE
fix(github): name the repository in the malformed-format error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -349,9 +349,12 @@ def validate_credentials(
     # before the request so the message names the fix.
     repo = repository.strip()
     if repo.count("/") != 1 or not all(repo.split("/")):
+        # Name the offending entry, like the 404 message below. Without it, two malformed repos both
+        # return this identical sentence and the caller joins them into one repeated string that names
+        # neither.
         return (
             False,
-            "Enter the repository as owner/repo (for example, posthog/posthog), not a full URL or just the owner name.",
+            f"'{repo}' isn't a valid repository. Enter it as owner/repo (for example, posthog/posthog), not a full URL or just the owner name.",
         )
 
     url = f"{GITHUB_BASE_URL}/repos/{repository}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_validate_credentials.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_validate_credentials.py
@@ -62,3 +62,6 @@ def test_malformed_repository_gets_format_guidance(repository):
     assert is_valid is False
     assert message is not None
     assert "owner/repo" in message
+    # Naming the offending entry keeps two malformed repos from collapsing into one repeated
+    # sentence when the source layer joins their failures.
+    assert repository.strip() in message


### PR DESCRIPTION
## Problem

Someone adding a GitHub source with more than one badly-formatted repository entry (a pasted URL, or just an owner with no repo) saw the same "enter it as owner/repo" sentence repeated back to back, joined by a semicolon, naming neither entry. The source layer joins each repository's validation failure with "; ", and the format-error message was a fixed string, so identical copies collapsed into one confusing line that gave no clue which entry was wrong.

## Changes

- The malformed-format error now names the offending entry (e.g. `'<value>' isn't a valid repository. Enter it as owner/repo ...`), matching the existing "not found or not accessible" message.
- Distinct bad entries now produce distinct, actionable messages instead of one repeated sentence.

## How did you test this code?

- Extended the malformed-repository test to assert the offending value appears in the message — the guard against two entries collapsing into one repeated sentence.
- Ran the GitHub validate-credentials and source-class tests locally; the relevant groups pass.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no docs quote this error string.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while triaging data-warehouse source-creation failures: one recorded failure was this message duplicated within a single line. The failing input came from analytics on a customer's own connect attempt and is treated as sensitive — it does not appear in this PR; the test uses invented, obviously-malformed repository values.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
