### PR TITLE
fix(slack_app): resolve model names like "codex sol" in mentions

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/classifiers.py
+++ b/posthog/temporal/ai/slack_app/activities/classifiers.py
@@ -19,6 +19,7 @@ from products.slack_app.backend.facade.run_preferences import (
     ModelChoice,
     available_model_choices,
     find_model_choice,
+    group_by_runtime,
     is_slack_app_model_classifier_enabled,
 )
 from products.slack_app.backend.models import SlackThreadTaskMapping
@@ -345,10 +346,13 @@ def _model_override_response_format(choices: tuple[ModelChoice, ...]) -> Respons
 
 
 def _render_model_catalogue(choices: tuple[ModelChoice, ...]) -> str:
+    """The models on offer, as the runtime → models tree `group_by_runtime` defines."""
     lines = []
-    for choice in choices:
-        efforts = ", ".join(choice.supported_efforts) if choice.supported_efforts else "no effort setting"
-        lines.append(f"- {choice.model} — {choice.label} (efforts: {efforts})")
+    for group in group_by_runtime(choices):
+        lines.append(f"{group.label} runtime:")
+        for choice in group.choices:
+            efforts = ", ".join(choice.supported_efforts) if choice.supported_efforts else "no effort setting"
+            lines.append(f"- {choice.model} — {choice.label} (efforts: {efforts})")
     return "\n".join(lines)
 
 
@@ -368,7 +372,11 @@ def classify_slack_app_model_override(
     prompt is built around that distinction, and the schema restricts the answer to an
     id from ``choices``.
 
-    Quality on that distinction is measured by the eval suite in
+    Its other job is resolving the shorthand people actually type onto an id. Nobody
+    writes ``gpt-5.6-sol``; they write "sol", or qualify it with the runtime or vendor
+    it belongs to ("codex sol"), or name a family and leave the version off ("opus").
+
+    Quality on both is measured by the eval suite in
     ``products/slack_app/evals/eval_model_classifier.py`` — the unit tests around this
     function cover parsing and validation, not whether the prompt reads a sentence right.
     """
@@ -379,15 +387,31 @@ def classify_slack_app_model_override(
         "Only these models can be selected — copy the id exactly as written:\n"
         f"{_render_model_catalogue(choices)}\n\n"
         "Name a model or effort only when the message instructs how to run this task:\n"
-        '  - "use fable for this one", "run this on opus 5", "do this with max effort".\n'
+        '  - "use fable for this one", "run this on opus 5", "do this with max effort", '
+        '"investigate this on high".\n'
         "  - The instruction can sit alongside the actual request: 'use sonnet and fix "
         "the flaky checkout test'.\n\n"
+        "Once — and only once — you have decided the message is such an instruction, "
+        "resolve its shorthand to an id from the list. Nobody types a model id:\n"
+        '  - A bare nickname is the model: "sol", "luna", "fable".\n'
+        "  - A runtime or vendor in front of it is only a qualifier, and the name beside "
+        'it is the answer: "codex sol" and "openai sol" are both the Sol id; "claude '
+        'opus" and "anthropic opus" are both an Opus id.\n'
+        '  - A family with no version means its newest listed member: "opus" is the '
+        "highest-numbered Opus in the list, not the first one you see. Read the versions "
+        "as decimals — 5 is newer than 4.8, not older.\n"
+        '  - A runtime or vendor standing alone names no model: "run this on codex", '
+        '"use anthropic" → null. A model id that happens to end in "codex" is a '
+        "different thing, and needs its version said out loud to be chosen.\n\n"
         "Answer with nulls when a model or effort is merely part of the subject "
         "matter — this is the common mistake, so check for it:\n"
         '  - "add claude-fable-5 to our model picker" (a code change that names a model).\n'
         '  - "why is gpt-5 slower than opus in our evals?" (a question about models).\n'
         '  - "the opus rollout broke the dashboard" (a topic).\n'
-        '  - "reasoning about this is hard" (the word, not a setting).\n\n'
+        '  - "reasoning about this is hard" (the word, not a setting).\n'
+        '  - "we tried sonnet on this last week and it kept timing out" (an account of a '
+        "run that already happened, not an instruction for this one — past tense is the "
+        "tell).\n\n"
         "Rules for the fields:\n"
         "  - model: an id from the list above, or null if the author named no model (or "
         "named one that isn't listed).\n"

--- a/posthog/temporal/tests/ai/slack_app/activities/__snapshots__/test_classify_slack_app_model_override.ambr
+++ b/posthog/temporal/tests/ai/slack_app/activities/__snapshots__/test_classify_slack_app_model_override.ambr
@@ -4,19 +4,28 @@
   You are routing a Slack message addressed to the PostHog agent. Decide whether the author asked for THIS task to run on a particular model or reasoning effort.
   
   Only these models can be selected — copy the id exactly as written:
+  Claude (Anthropic) runtime:
   - claude-opus-5 — Claude Opus 5 (efforts: low, medium, high, max)
   - claude-fable-5 — Claude Fable 5 (efforts: low, medium, high)
+  Codex (OpenAI) runtime:
   - gpt-5.6-sol — gpt-5.6-sol (efforts: low, medium, high, max)
   
   Name a model or effort only when the message instructs how to run this task:
-    - "use fable for this one", "run this on opus 5", "do this with max effort".
+    - "use fable for this one", "run this on opus 5", "do this with max effort", "investigate this on high".
     - The instruction can sit alongside the actual request: 'use sonnet and fix the flaky checkout test'.
+  
+  Once — and only once — you have decided the message is such an instruction, resolve its shorthand to an id from the list. Nobody types a model id:
+    - A bare nickname is the model: "sol", "luna", "fable".
+    - A runtime or vendor in front of it is only a qualifier, and the name beside it is the answer: "codex sol" and "openai sol" are both the Sol id; "claude opus" and "anthropic opus" are both an Opus id.
+    - A family with no version means its newest listed member: "opus" is the highest-numbered Opus in the list, not the first one you see. Read the versions as decimals — 5 is newer than 4.8, not older.
+    - A runtime or vendor standing alone names no model: "run this on codex", "use anthropic" → null. A model id that happens to end in "codex" is a different thing, and needs its version said out loud to be chosen.
   
   Answer with nulls when a model or effort is merely part of the subject matter — this is the common mistake, so check for it:
     - "add claude-fable-5 to our model picker" (a code change that names a model).
     - "why is gpt-5 slower than opus in our evals?" (a question about models).
     - "the opus rollout broke the dashboard" (a topic).
     - "reasoning about this is hard" (the word, not a setting).
+    - "we tried sonnet on this last week and it kept timing out" (an account of a run that already happened, not an instruction for this one — past tense is the tell).
   
   Rules for the fields:
     - model: an id from the list above, or null if the author named no model (or named one that isn't listed).

--- a/products/slack_app/backend/facade/run_preferences.py
+++ b/products/slack_app/backend/facade/run_preferences.py
@@ -7,13 +7,14 @@ catalogue those settings pick from and the precedence that resolves them for one
 """
 
 from products.slack_app.backend.feature_flags import is_slack_app_model_classifier_enabled
-from products.slack_app.backend.services.model_catalogue import ModelChoice, available_model_choices
+from products.slack_app.backend.services.model_catalogue import ModelChoice, available_model_choices, group_by_runtime
 from products.slack_app.backend.services.run_preferences import find_model_choice, resolve_run_preferences
 
 __all__ = [
     "ModelChoice",
     "available_model_choices",
     "find_model_choice",
+    "group_by_runtime",
     "is_slack_app_model_classifier_enabled",
     "resolve_run_preferences",
 ]

--- a/products/slack_app/backend/services/model_catalogue.py
+++ b/products/slack_app/backend/services/model_catalogue.py
@@ -72,6 +72,39 @@ class ModelChoice:
     supported_efforts: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class RuntimeGroup:
+    """The models one runtime drives, under the name that runtime goes by."""
+
+    runtime_adapter: str
+    label: str
+    choices: tuple[ModelChoice, ...]
+
+
+def group_by_runtime(choices: tuple[ModelChoice, ...]) -> tuple[RuntimeGroup, ...]:
+    """The catalogue as a runtime → models tree, in the order the catalogue gave.
+
+    Both consumers present the catalogue this way and neither should decide for itself
+    what a runtime is called: the App Home modal renders the tree as linked dropdowns,
+    and the model-override classifier renders it as the list of ids it may pick from.
+    The classifier needs the grouping to be visible rather than implied — people qualify
+    a model with the runtime it belongs to ("codex sol"), and a flat list gives that word
+    nothing to attach to, most sharply where a runtime name is also part of a model id
+    (`gpt-5.3-codex`). A runtime with no models simply doesn't appear.
+    """
+    by_adapter: dict[str, list[ModelChoice]] = {}
+    for choice in choices:
+        by_adapter.setdefault(choice.runtime_adapter, []).append(choice)
+    return tuple(
+        RuntimeGroup(
+            runtime_adapter=adapter,
+            label=label_for(adapter, RUNTIME_ADAPTER_DISPLAY_NAMES),
+            choices=tuple(grouped),
+        )
+        for adapter, grouped in by_adapter.items()
+    )
+
+
 def available_model_choices() -> tuple[ModelChoice, ...]:
     """Every model a Slack-triggered run may use.
 
@@ -182,10 +215,12 @@ __all__ = [
     "REASONING_EFFORT_DISPLAY_NAMES",
     "RUNTIME_ADAPTER_DISPLAY_NAMES",
     "ModelChoice",
+    "RuntimeGroup",
     "available_model_choices",
     "describe_run_model",
     "filter_unsupported_effort",
     "format_model_id",
+    "group_by_runtime",
     "label_for",
     "runtime_adapter_for",
 ]

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -38,6 +38,7 @@ from products.slack_app.backend.services.model_catalogue import (
     available_model_choices,
     describe_run_model,
     format_model_id,
+    group_by_runtime,
     label_for,
 )
 from products.slack_app.backend.services.run_preferences import SLACK_DEFAULT_MODEL
@@ -144,24 +145,25 @@ class PickerAdapter:
 
 
 def get_picker_choices() -> tuple[PickerAdapter, ...]:
-    """Group the model catalogue into the runtime → model → effort tree the modal's
-    linked dropdowns render. Adapters with no available models are omitted entirely."""
-    by_adapter: dict[str, list[PickerModel]] = {}
-    for choice in available_model_choices():
-        efforts = tuple(
-            PickerEffort(value=e, label=label_for(e, REASONING_EFFORT_DISPLAY_NAMES)) for e in choice.supported_efforts
-        )
-        by_adapter.setdefault(choice.runtime_adapter, []).append(
-            PickerModel(value=choice.model, label=choice.label, supported_efforts=efforts)
-        )
-
+    """Dress the catalogue's runtime → model tree in the effort labels the modal's linked
+    dropdowns render. Adapters with no available models are omitted entirely."""
     return tuple(
         PickerAdapter(
-            value=adapter_value,
-            label=label_for(adapter_value, RUNTIME_ADAPTER_DISPLAY_NAMES),
-            models=tuple(models),
+            value=group.runtime_adapter,
+            label=group.label,
+            models=tuple(
+                PickerModel(
+                    value=choice.model,
+                    label=choice.label,
+                    supported_efforts=tuple(
+                        PickerEffort(value=e, label=label_for(e, REASONING_EFFORT_DISPLAY_NAMES))
+                        for e in choice.supported_efforts
+                    ),
+                )
+                for choice in group.choices
+            ),
         )
-        for adapter_value, models in by_adapter.items()
+        for group in group_by_runtime(available_model_choices())
     )
 
 

--- a/products/slack_app/evals/eval_model_classifier.py
+++ b/products/slack_app/evals/eval_model_classifier.py
@@ -35,16 +35,39 @@ from products.slack_app.evals.model_classifier_scorers import EXPECTATION_KEY, M
 
 SUITE_KIND = SuiteKind.ONE_SHOT
 
-# Frozen rather than `available_model_choices()`: the live catalogue tracks whatever the
-# gateway currently serves, so scores would move when a model ships or is retired, for
-# reasons that have nothing to do with the prompt. Refresh deliberately, and expect the
-# baseline to step when you do.
+# A snapshot of `available_model_choices()` rather than a live call: the gateway's list
+# moves when a model ships or is retired, and scores that move with it can't be compared
+# across runs. Refresh deliberately, and expect the baseline to step when you do.
+#
+# It is a snapshot of the whole catalogue, not a tidy handful, because the classifier's
+# job gets harder as the list grows and it is the full list it faces in production. A
+# short list hides the two things that actually break it: several live versions of one
+# family, so "use opus" has to pick among them, and ids that contain a runtime name
+# (`gpt-5.3-codex`), so "codex sol" has to survive the collision between the word for a
+# runtime and the name of a model.
+_STANDARD: tuple[str, ...] = ("low", "medium", "high")
+_XHIGH: tuple[str, ...] = (*_STANDARD, "xhigh")
+_MAX: tuple[str, ...] = (*_XHIGH, "max")
+_ULTRACODE: tuple[str, ...] = (*_MAX, "ultracode")
 CHOICES: tuple[ModelChoice, ...] = (
-    ModelChoice("claude", "claude-opus-5", "Claude Opus 5", ("low", "medium", "high", "xhigh", "max")),
-    ModelChoice("claude", "claude-fable-5", "Claude Fable 5", ("low", "medium", "high", "xhigh", "max")),
-    ModelChoice("claude", "claude-sonnet-5", "Claude Sonnet 5", ("low", "medium", "high", "xhigh", "max")),
-    ModelChoice("codex", "gpt-5.6-luna", "GPT-5.6 Luna", ("low", "medium", "high", "xhigh", "max")),
-    ModelChoice("codex", "gpt-5.6-sol", "GPT-5.6 Sol", ("low", "medium", "high", "xhigh", "max")),
+    ModelChoice("claude", "claude-haiku-4-5", "Claude Haiku 4.5", ()),
+    ModelChoice("claude", "claude-sonnet-4-5", "Claude Sonnet 4.5", ()),
+    ModelChoice("claude", "claude-sonnet-5", "Claude Sonnet 5", _ULTRACODE),
+    ModelChoice("claude", "claude-sonnet-4-6", "Claude Sonnet 4.6", _STANDARD),
+    ModelChoice("claude", "claude-opus-4-5", "Claude Opus 4.5", _STANDARD),
+    ModelChoice("claude", "claude-opus-4-6", "Claude Opus 4.6", _MAX),
+    ModelChoice("claude", "claude-opus-4-7", "Claude Opus 4.7", _ULTRACODE),
+    ModelChoice("claude", "claude-fable-5", "Claude Fable 5", _ULTRACODE),
+    ModelChoice("claude", "claude-opus-5", "Claude Opus 5", _ULTRACODE),
+    ModelChoice("claude", "claude-opus-4-8", "Claude Opus 4.8", _ULTRACODE),
+    ModelChoice("codex", "gpt-5.2", "GPT-5.2", _STANDARD),
+    ModelChoice("codex", "gpt-5.6-sol", "GPT-5.6 Sol", _MAX),
+    ModelChoice("codex", "gpt-5.6-terra", "GPT-5.6 Terra", _MAX),
+    ModelChoice("codex", "gpt-5.6-luna", "GPT-5.6 Luna", _MAX),
+    ModelChoice("codex", "gpt-5.5", "GPT-5.5", _XHIGH),
+    ModelChoice("codex", "gpt-5.4", "GPT-5.4", _STANDARD),
+    ModelChoice("codex", "gpt-5.3-codex", "GPT-5.3 Codex", _STANDARD),
+    ModelChoice("codex", "gpt-5-mini", "GPT-5 Mini", _STANDARD),
 )
 
 
@@ -87,6 +110,58 @@ INSTRUCTION_CASES = [
             "@PostHog use fable for this one. The task: our model picker is missing gpt-5.6-sol, add it to the dropdown"
         ),
         expected=_asks(model="claude-fable-5"),
+    ),
+    # Verbatim from the thread that prompted this group. The runtime word in front of the
+    # nickname was enough to lose the model entirely — the run went to saved preferences
+    # while the effort was picked up, so the author got neither what they asked for nor a
+    # clean fallback.
+    BaseEvalCase(
+        name="runtime_qualified_model",
+        prompt="@PostHog can you investigate using codex sol on high",
+        expected=_asks(model="gpt-5.6-sol", reasoning_effort="high"),
+    ),
+    BaseEvalCase(
+        name="vendor_qualified_model",
+        prompt="@PostHog use openai luna and work out why the nightly export job stalls at 90%",
+        expected=_asks(model="gpt-5.6-luna"),
+    ),
+    # Two Opus versions are listed and the author named neither; the newest is what they
+    # mean by "opus".
+    BaseEvalCase(
+        name="unversioned_family",
+        prompt="@PostHog run this on opus — the cohort filter is silently dropping people",
+        expected=_asks(model="claude-opus-5"),
+    ),
+    BaseEvalCase(
+        name="effort_without_the_word_effort",
+        prompt="@PostHog dig into the flaky billing test on high, it fails maybe one run in five",
+        expected=_asks(reasoning_effort="high"),
+    ),
+    # The other side of `runtime_word_alone`. Teaching the classifier that "codex" names a
+    # runtime is one instruction away from teaching it that nothing containing "codex" is
+    # ever selectable, which would strand a listed model — and every null-answer case
+    # would still score green.
+    BaseEvalCase(
+        name="model_named_after_a_runtime",
+        prompt="@PostHog run this on gpt-5.3-codex — the retention query returns empty buckets",
+        expected=_asks(model="gpt-5.3-codex"),
+    ),
+]
+
+# Named a family without naming a model. Falling back to saved preferences is the answer:
+# there is no way to tell which member of the family the author wanted, and picking one
+# moves their run onto a model they never chose. These earn their own group because the
+# runtime words are also fragments of real ids, so the pull toward answering is real.
+UNDERSPECIFIED_CASES = [
+    BaseEvalCase(
+        name="runtime_word_alone",
+        prompt="@PostHog run this one on codex please — the webhook retry backoff looks wrong",
+        expected=_asks(),
+    ),
+    BaseEvalCase(
+        name="vendor_word_alone",
+        prompt="@PostHog use anthropic for this, the survey response export is truncating",
+        expected=_asks(),
     ),
 ]
 
@@ -134,6 +209,11 @@ SUBJECT_MATTER_CASES = [
         expected=_asks(),
     ),
     BaseEvalCase(
+        name="runtime_name_as_subject",
+        prompt="@PostHog our codex adapter drops the reasoning effort on retries, track down where it's lost",
+        expected=_asks(),
+    ),
+    BaseEvalCase(
         name="no_model_mentioned",
         prompt="@PostHog the checkout funnel drops 40% between steps 2 and 3, can you work out why",
         expected=_asks(),
@@ -165,7 +245,7 @@ async def eval_model_classifier(ctx: EvalContext) -> None:
 
     await OneShotPublicEval(
         experiment_name="slack-app-model-classifier",
-        cases=[*INSTRUCTION_CASES, *SUBJECT_MATTER_CASES],
+        cases=[*INSTRUCTION_CASES, *UNDERSPECIFIED_CASES, *SUBJECT_MATTER_CASES],
         scorers=[ModelOverrideMatch(), NoUnaskedOverride()],
         task=task,
         ctx=ctx,


### PR DESCRIPTION
## Problem

Asking the Slack app to `use codex sol on high` got the effort but not the model — the run quietly fell back to the author's saved default. Any `<runtime> <model>` phrasing lost the model the same way, and `use opus` picked an arbitrary one of the five listed Opus versions.

The catalogue was rendered to the classifier as a flat list of ids, so "codex", "claude", and "openai" had nothing to attach to. `gpt-5.3-codex` made it worse: "codex" reads as both a runtime and a model name.

## Changes

- Group the rendered catalogue by runtime. The App Home picker already built that tree, so it moved into `model_catalogue.group_by_runtime` and both consumers share it.
- Teach the prompt how people write model names: bare nickname, runtime- or vendor-qualified, family without a version, and a runtime word alone naming nothing.
- The shorthand rules only apply once the message is judged an instruction. Without that gate the classifier read "I ran this on opus yesterday" as one — the direction that silently moves someone's run.
- Widen the eval suite's frozen catalogue from five hand-picked models to the whole live list. At five models every new case here passes on master.

## How did you test this code?

Every eval case through the real classifier against the gateway, 5 repeats each, master vs this branch: **92/110 → 115/115**. Three cases go 0/5 → 5/5, including the reported phrasing verbatim; `past_tense_report` was already flaky at 2/5 and is now 5/5.

One harness run recorded the baseline: 23/23 cases, both scorers 100% — [experiment](https://www.braintrust.dev/app/PostHog/p/slack-app-model-classifier/experiments/vojtab%2Fslack-app-model-classifier-tuning-1786093975).

New cases cover both directions of the bug: a runtime or vendor word dropping the model, a family name resolving to an arbitrary version, "on high" as an effort request — and the inverse, where over-correcting into "nothing containing `codex` is selectable" would strand a listed model while every null-answer case still scored green.

Automated: slack_app temporal and backend suites, prompt snapshot, mypy, tach. Not verified: nothing was exercised through a real Slack workspace.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, plus a `/simplify` review pass. No repo skills invoked.

The first cut put the runtime grouping in the classifier; review found `get_picker_choices` already built the same tree, so it moved down into `model_catalogue` — which also let the facade drop two display-string re-exports it had briefly grown.

Considered and rejected: resolving nicknames in code after the classifier answers. The response schema pins `model` to an enum of live catalogue ids, so a bad id is impossible by construction; a free-string field plus a resolver would trade that for substring matching, which is exactly where `gpt-5.3-codex` versus "codex" is a judgement call rather than a rule.

Left undone: "newest in the family" is a prompt instruction rather than something the catalogue expresses. The gateway's `created` field looked like the deeper fix but is stubbed to the same constant for every model.
