### PR TITLE
fix(signup): trim and split full name so first_name is never blank

### DIFF
--- a/frontend/src/lib/utils/strings.test.ts
+++ b/frontend/src/lib/utils/strings.test.ts
@@ -5,6 +5,7 @@ import {
     identifierToHuman,
     midEllipsis,
     pluralize,
+    splitFullName,
     wordPluralize,
 } from 'lib/utils/strings'
 
@@ -105,6 +106,30 @@ describe('strings utils', () => {
         it('handles happy case', () => {
             expect(ensureStringIsNotBlank('happyboy')).toEqual('happyboy')
             expect(ensureStringIsNotBlank('  happy boy  ')).toEqual('  happy boy  ')
+        })
+    })
+
+    describe('splitFullName()', () => {
+        it('splits a simple two-part name', () => {
+            expect(splitFullName('John Smith')).toEqual({ first_name: 'John', last_name: 'Smith' })
+        })
+        it('returns no last name for a single name', () => {
+            expect(splitFullName('John')).toEqual({ first_name: 'John', last_name: undefined })
+        })
+        it('trims surrounding whitespace before splitting', () => {
+            expect(splitFullName(' John')).toEqual({ first_name: 'John', last_name: undefined })
+            expect(splitFullName('  John Smith  ')).toEqual({ first_name: 'John', last_name: 'Smith' })
+        })
+        it('collapses internal whitespace', () => {
+            expect(splitFullName('John  Smith')).toEqual({ first_name: 'John', last_name: 'Smith' })
+            expect(splitFullName('\tJohn\tSmith')).toEqual({ first_name: 'John', last_name: 'Smith' })
+        })
+        it('keeps multi-part surnames intact', () => {
+            expect(splitFullName('  Ada Van Der Berg ')).toEqual({ first_name: 'Ada', last_name: 'Van Der Berg' })
+        })
+        it('returns a blank first name for blank input', () => {
+            expect(splitFullName('')).toEqual({ first_name: '', last_name: undefined })
+            expect(splitFullName('   ')).toEqual({ first_name: '', last_name: undefined })
         })
     })
 })

--- a/frontend/src/lib/utils/strings.ts
+++ b/frontend/src/lib/utils/strings.ts
@@ -38,6 +38,12 @@ export function fullName(props?: { first_name?: string; last_name?: string }): s
     return `${props.first_name || ''} ${props.last_name || ''}`.trim()
 }
 
+/** Inverse of `fullName`: derive first/last name from a single full-name input. */
+export function splitFullName(name: string): { first_name: string; last_name: string | undefined } {
+    const parts = name.trim().split(/\s+/).filter(Boolean)
+    return { first_name: parts[0] ?? '', last_name: parts.length > 1 ? parts.slice(1).join(' ') : undefined }
+}
+
 // trimBothEnds=false is useful when the input is slugified as the user is typing to allow them hitting space and continue typing
 export function slugify(
     text: string,

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.test.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.test.ts
@@ -255,6 +255,9 @@ describe('signupLogic — name handling', () => {
 
         expect(logic.values.signupPanelOnboardingManualErrors.name).toBe('This field may not be blank.')
         expect(logic.values.signupPanelOnboardingManualErrors.generic).toBeUndefined()
+        // The display-level selector fields read from — the error must remain visible after the
+        // failed submit (a successful submit resets showErrors and would hide it)
+        expect(logic.values.signupPanelOnboardingErrors.name).toBe('This field may not be blank.')
         expect(logic.values.panel).toBe(2)
     })
 })

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.test.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.test.ts
@@ -141,3 +141,120 @@ describe('signupLogic — pending invite banner', () => {
         expect(logic.values.pendingInviteResent).toBe(false)
     })
 })
+
+describe('signupLogic — name handling', () => {
+    let logic: ReturnType<typeof signupLogic.build>
+    let signupRequestBody: Record<string, any> | null
+
+    const advanceToOnboardingPanel = async (): Promise<void> => {
+        logic.actions.setSignupPanelEmailValue('email', 'test@example.com')
+        logic.actions.submitSignupPanelEmail()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.panel).toBe(1)
+        logic.actions.setSignupPanelAuthValue('password', 'Str0ng-Test-Pass!')
+        logic.actions.submitSignupPanelAuth()
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.panel).toBe(2)
+    }
+
+    beforeEach(() => {
+        signupRequestBody = null
+        useMocks({
+            post: {
+                '/api/signup/precheck': () => [200, { email_exists: false, pending_invite: null }],
+                // 400 rather than 201 so that the submit handler never assigns `location.href`,
+                // which jsdom does not implement. The request body is captured before the response.
+                '/api/signup/': async (info) => {
+                    signupRequestBody = await info.request.clone().json()
+                    return [400, { type: 'validation_error', code: 'error', detail: 'Mocked failure', attr: null }]
+                },
+            },
+        })
+        initKeaTests()
+        router.actions.push('/signup')
+        logic = signupLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+    })
+
+    it('trims and splits the name before building the signup payload', async () => {
+        await advanceToOnboardingPanel()
+        logic.actions.setSignupPanelOnboardingValues({
+            name: '  John van Der Berg ',
+            organization_name: 'Hogflix',
+            role_at_organization: 'engineer',
+            referral_source: '',
+            referral_source_ai_prompt: '',
+        })
+        logic.actions.submitSignupPanelOnboarding()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(signupRequestBody?.first_name).toBe('John')
+        expect(signupRequestBody?.last_name).toBe('van Der Berg')
+    })
+
+    it('omits a whitespace-only organization name so the backend applies its default', async () => {
+        await advanceToOnboardingPanel()
+        logic.actions.setSignupPanelOnboardingValues({
+            name: 'John Smith',
+            organization_name: '   ',
+            role_at_organization: 'engineer',
+            referral_source: '',
+            referral_source_ai_prompt: '',
+        })
+        logic.actions.submitSignupPanelOnboarding()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(signupRequestBody).not.toBeNull()
+        expect(signupRequestBody).not.toHaveProperty('organization_name')
+    })
+
+    it('fails client-side validation for a whitespace-only name without issuing the POST', async () => {
+        await advanceToOnboardingPanel()
+        logic.actions.setSignupPanelOnboardingValues({
+            name: '   ',
+            organization_name: 'Hogflix',
+            role_at_organization: 'engineer',
+            referral_source: '',
+            referral_source_ai_prompt: '',
+        })
+        logic.actions.submitSignupPanelOnboarding()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(signupRequestBody).toBeNull()
+        expect(logic.values.panel).toBe(2)
+    })
+
+    it('surfaces a first_name API error on the name field instead of the generic banner', async () => {
+        useMocks({
+            post: {
+                '/api/signup/': () => [
+                    400,
+                    {
+                        type: 'validation_error',
+                        code: 'blank',
+                        detail: 'This field may not be blank.',
+                        attr: 'first_name',
+                    },
+                ],
+            },
+        })
+        await advanceToOnboardingPanel()
+        logic.actions.setSignupPanelOnboardingValues({
+            name: 'John Smith',
+            organization_name: 'Hogflix',
+            role_at_organization: 'engineer',
+            referral_source: '',
+            referral_source_ai_prompt: '',
+        })
+        logic.actions.submitSignupPanelOnboarding()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(logic.values.signupPanelOnboardingManualErrors.name).toBe('This field may not be blank.')
+        expect(logic.values.signupPanelOnboardingManualErrors.generic).toBeUndefined()
+        expect(logic.values.panel).toBe(2)
+    })
+})

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.test.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.test.ts
@@ -165,7 +165,7 @@ describe('signupLogic — name handling', () => {
                 // 400 rather than 201 so that the submit handler never assigns `location.href`,
                 // which jsdom does not implement. The request body is captured before the response.
                 '/api/signup/': async (info) => {
-                    signupRequestBody = await info.request.clone().json()
+                    signupRequestBody = (await info.request.clone().json()) as Record<string, any>
                     return [400, { type: 'validation_error', code: 'error', detail: 'Mocked failure', attr: null }]
                 },
             },

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -11,6 +11,7 @@ import api from 'lib/api'
 import { ValidatedPasswordResult, validatePassword } from 'lib/components/PasswordStrength'
 import { CLOUD_HOSTNAMES, FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { splitFullName } from 'lib/utils/strings'
 import { getRelativeNextPath } from 'lib/utils/url'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { getPasskeyErrorMessage, isWebAuthnCancellation } from 'scenes/settings/user/passkeys/utils'
@@ -493,7 +494,7 @@ export const signupLogic = kea<signupLogicType>([
                 referral_source_ai_prompt: '',
             } as SignupPanelOnboardingForm,
             errors: ({ name, role_at_organization }) => ({
-                name: !name ? 'Please enter your name' : undefined,
+                name: !name?.trim() ? 'Please enter your name' : undefined,
                 role_at_organization: !role_at_organization ? 'Please select your role in the organization' : undefined,
             }),
             submit: async (payload, breakpoint) => {
@@ -503,9 +504,8 @@ export const signupLogic = kea<signupLogicType>([
 
                     const signupData: Record<string, any> = {
                         email: values.signupPanelEmail.email,
-                        first_name: payload.name.split(' ')[0],
-                        last_name: payload.name.split(' ')[1] || undefined,
-                        organization_name: payload.organization_name || undefined,
+                        ...splitFullName(payload.name),
+                        organization_name: payload.organization_name?.trim() || undefined,
                         role_at_organization: payload.role_at_organization,
                         referral_source: payload.referral_source,
                         referral_source_ai_prompt: payload.referral_source_ai_prompt,
@@ -524,7 +524,7 @@ export const signupLogic = kea<signupLogicType>([
 
                     const res = await api.create('api/signup/', signupData)
 
-                    if (!payload.organization_name) {
+                    if (!payload.organization_name?.trim()) {
                         posthog.capture('sign up organization name not provided')
                     }
 
@@ -555,6 +555,15 @@ export const signupLogic = kea<signupLogicType>([
                         const message = Array.isArray(emailError) ? String(emailError[0]) : String(emailError)
                         actions.setSignupPanelEmailManualErrors({ email: message })
                         actions.setPanel(0)
+                        return
+                    }
+
+                    // The `name` input is split into first_name/last_name for the API — surface
+                    // errors on those attributes next to the field the user actually sees.
+                    if (error.attr === 'first_name' || error.attr === 'last_name') {
+                        actions.setSignupPanelOnboardingManualErrors({
+                            name: String(error.detail || 'Please enter your name'),
+                        })
                         return
                     }
 

--- a/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
+++ b/frontend/src/scenes/authentication/signup/signupForm/signupLogic.ts
@@ -560,11 +560,13 @@ export const signupLogic = kea<signupLogicType>([
 
                     // The `name` input is split into first_name/last_name for the API — surface
                     // errors on those attributes next to the field the user actually sees.
+                    // Must throw (not return) so kea-forms marks the submit as failed and keeps
+                    // showing errors — on a successful submit it hides them again.
                     if (error.attr === 'first_name' || error.attr === 'last_name') {
                         actions.setSignupPanelOnboardingManualErrors({
                             name: String(error.detail || 'Please enter your name'),
                         })
-                        return
+                        throw e
                     }
 
                     if (error.code === 'throttled') {

--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -111,6 +111,31 @@ test.describe('Signup', () => {
         await expect(page).toHaveURL(/\/verify_email\/[a-zA-Z0-9_.-]*/)
     })
 
+    test('Trims surrounding whitespace in the name so first_name is never blank', async ({ page }) => {
+        let signupRequestBody: string | null = null
+
+        await page.route('/api/signup/', async (route) => {
+            signupRequestBody = route.request().postData()
+            await route.continue()
+        })
+
+        const email = `new_user+${Math.floor(Math.random() * 10000)}@posthog.com`
+        await startSignupFlow(page, email, VALID_PASSWORD)
+        // A leading space used to slip through client validation and produce first_name: ""
+        await page.locator('[data-attr=signup-name]').fill(' Alice Bob')
+        await expect(page.locator('[data-attr=signup-name]')).toHaveValue(' Alice Bob')
+        await page.locator('[data-attr=signup-role-at-organization]').click()
+        await page.locator('.Popover li').filter({ hasText: 'Engineering' }).click()
+        await expect(page.locator('[data-attr=signup-role-at-organization]')).toContainText('Engineering')
+        await page.locator('[data-attr=signup-submit]').click()
+
+        const parsedBody = JSON.parse(signupRequestBody!)
+        expect(parsedBody.first_name).toEqual('Alice')
+        expect(parsedBody.last_name).toEqual('Bob')
+
+        await expect(page).toHaveURL(/\/verify_email\/[a-zA-Z0-9_.-]*/)
+    })
+
     test('Can submit the signup form multiple times if there is a generic email set', async ({ page }) => {
         let signupRequestBody: string | null = null
         const email = `new_user+generic_error_test_${Math.floor(Math.random() * 10000)}@posthog.com`

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -537,6 +537,40 @@ class TestSignupAPI(APIBaseTest):
         self.assertEqual(Team.objects.count(), team_count)
         self.assertEqual(Organization.objects.count(), org_count)
 
+    def test_cant_sign_up_with_blank_first_name(self):
+        count: int = User.objects.count()
+        team_count: int = Team.objects.count()
+        org_count: int = Organization.objects.count()
+
+        for first_name in ["", "   "]:
+            response = self.client.post(
+                "/api/signup/",
+                {
+                    "first_name": first_name,
+                    "email": "invalid@posthog.com",
+                    "password": VALID_TEST_PASSWORD,
+                },
+            )
+            self.assertEqual(
+                response.status_code,
+                status.HTTP_400_BAD_REQUEST,
+                f"first_name {first_name!r} may not be blank",
+            )
+            self.assertEqual(
+                response.json(),
+                {
+                    "type": "validation_error",
+                    "code": "blank",
+                    "detail": "This field may not be blank.",
+                    "attr": "first_name",
+                },
+                f"first_name {first_name!r} may not be blank",
+            )
+
+        self.assertEqual(User.objects.count(), count)
+        self.assertEqual(Team.objects.count(), team_count)
+        self.assertEqual(Organization.objects.count(), org_count)
+
     def test_cant_sign_up_with_short_password(self):
         count: int = User.objects.count()
         team_count: int = Team.objects.count()


### PR DESCRIPTION
## Problem

Investigation from [this support ticket](https://us.posthog.com/project/2/support/tickets/66235?status=%5B%22open%22%2C%22new%22%5D&assignee=%5B%22role%3A01978cae-04df-0000-14ff-d550f7310f3b%22%2C%22unassigned%22%2C%22me%22%5D&tags=%5B%22support_sme_accounts_billing%22%5D&tags_exclude=%5B%22community%22%5D&order_by=sla_due_at). A leading space in the signup Name field passed client-side validation (`!name`) but was split into `first_name: ""`, which the API rejected, surfacing to the user as an opaque banner: "This field may not be blank. Contact us to resolve this." The same naive `split(' ')` also silently truncated multi-part surnames ("Ada Van Der Berg" saved as last name "Van"), and a whitespace-only organization name bypassed the backend default and created an organization literally named `""`. 

## Changes

- New `splitFullName` util (inverse of the existing `fullName`): trims, collapses internal whitespace, and keeps multi-part surnames intact. Used by the signup submit.
- The `name` validator is trim-aware, so whitespace-only names fail client-side without firing the request.
- Whitespace-only organization names are omitted from the payload so the backend default (`"<name>'s Organization"`) applies.
- API errors on `first_name`/`last_name` (e.g. "URLs are not allowed in this field.") now render inline under the Name field instead of falling into the generic banner. The handler throws after routing so kea-forms keeps the error visible — a successful submit resets `showErrors` and would hide it.

## How did you test this code?

Automated, all passing locally:

- `splitFullName` unit tests in `strings.test.ts`: leading/trailing/double/tab whitespace, single names, multi-part surnames, blank input.
- `signupLogic.test.ts`: captures the actual `POST /api/signup/` body and asserts the trimmed split; whitespace-only name never issues the POST; a `first_name` API error lands on the `name` field (asserted on the display-level `signupPanelOnboardingErrors` selector, not just manual-errors state) with no generic banner.
- New Playwright regression case: `' Alice Bob'` submits `first_name: 'Alice'`, `last_name: 'Bob'`.
- New backend test pinning the existing `blank` error contract for `""`/`"   "` first_name (previously only `required` and `null` were covered).

Manual, against a local instance:

- Leading spaces in name and organization, double space mid-name, multi-part surname, single name, and whitespace-only name all behave as expected; DB rows verified clean.
- `John www.foo.com` now shows "URLs are not allowed in this field." inline under the Name field (verified in a real browser — before the fix this failed silently).

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*