### PR TITLE
feat(cymbal): add metric for event release resolution source

### DIFF
--- a/rust/cymbal/src/core/metric_consts.rs
+++ b/rust/cymbal/src/core/metric_consts.rs
@@ -25,6 +25,9 @@ pub const FRAME_DB_MISSES: &str = "cymbal_frame_db_misses";
 pub const FRAME_NOT_RESOLVED: &str = "cymbal_frame_not_resolved";
 pub const RELEASE_ID_CACHE_HITS: &str = "cymbal_release_id_cache_hits";
 pub const RELEASE_ID_CACHE_MISSES: &str = "cymbal_release_id_cache_misses";
+// Which source produced an event's release, labeled by `source`:
+// "release_id" / "mobile_hash" / "symbol_set" / "none".
+pub const EVENT_RELEASE_RESOLUTION: &str = "cymbal_event_release_resolution";
 // Client-expanded native inline groups, labeled by outcome: "replaced" when the
 // server expansion of the group's address superseded the client frames, "kept"
 // when resolution failed and the client expansion passed through.

--- a/rust/cymbal/src/modes/processing/stages/resolution/event_release.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/event_release.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use crate::{
     error::UnhandledError,
     frames::releases::{mobile_release_hash_id, ReleaseRecord},
-    metric_consts::{ANCILLARY_CACHE, EVENT_RELEASE_RESOLVER_OPERATOR},
+    metric_consts::{ANCILLARY_CACHE, EVENT_RELEASE_RESOLUTION, EVENT_RELEASE_RESOLVER_OPERATOR},
     stages::{pipeline::HandledError, resolution::ResolutionStage},
     types::{
         exception_event::{ExceptionEvent, Parsed},
@@ -158,15 +158,19 @@ async fn select_release(
         .and_then(Value::as_str)
         .and_then(|id| Uuid::parse_str(id).ok());
 
-    let record = if let Some(release_id) = release_id {
-        cache.for_id(pool, release_id, team_id).await?
+    let (record, source) = if let Some(release_id) = release_id {
+        (cache.for_id(pool, release_id, team_id).await?, "release_id")
     } else if let Some(hash_id) = mobile_release_hash_from_props(props) {
-        cache.for_hash(pool, &hash_id, team_id).await?
+        (
+            cache.for_hash(pool, &hash_id, team_id).await?,
+            "mobile_hash",
+        )
     } else {
-        None
+        (None, "none")
     };
 
     if let Some(record) = record {
+        record_release_source(source);
         return Ok(Some(record));
     }
 
@@ -176,7 +180,17 @@ async fn select_release(
     for id in symbol_set_release_ids {
         candidates.extend(cache.for_id(pool, *id, team_id).await?);
     }
-    Ok(ReleaseRecord::latest(candidates))
+    let record = ReleaseRecord::latest(candidates);
+    record_release_source(if record.is_some() {
+        "symbol_set"
+    } else {
+        "none"
+    });
+    Ok(record)
+}
+
+fn record_release_source(source: &'static str) {
+    metrics::counter!(EVENT_RELEASE_RESOLUTION, "source" => source).increment(1);
 }
 
 /// Rebuild the release `hash_id` from a mobile event's app metadata. Returns `None` for events that


### PR DESCRIPTION
## Problem

Error tracking attaches a release to each exception event during ingestion, but operators cannot see which source provides it, or how many events end up without one.
The resolver walks three sources in order (`$release_id`, the mobile app-metadata hash, releases bound to the symbol sets resolution used), and only cache hit/miss counters exist around the lookups today.

## Changes

- New counter `cymbal_event_release_resolution` with a `source` label: `release_id`, `mobile_hash`, `symbol_set`, or `none`.
- The resolver increments it exactly once per event, so the sum across sources equals events processed.
- The label reflects the source that actually produced the record. A `$release_id` pointing at a deleted release counts under the fallback that filled the gap.

## How did you test this code?

- `cargo clippy -p cymbal --all-targets` passes locally.
- The existing `event_release` tests pass locally against Postgres, including the sqlx test covering the fallback ordering.
- No new tests: selection behavior is unchanged, and the change only adds counter increments.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, the metric is internal observability.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /writing-code-comments, /writing-pr-descriptions.
I (actually Claude) emit the metric at the single selection point in `select_release` rather than at the cache lookups, so each event counts once and the label reflects the winning source rather than the attempted path.
