### PR TITLE
fix(cdp): stop templates reading $set from event properties

### DIFF
--- a/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py
+++ b/posthog/cdp/templates/google_cloud_storage/template_google_cloud_storage.py
@@ -110,7 +110,7 @@ class TemplateGoogleCloudStorageMigrator(HogFunctionTemplateMigrator):
             "bucketName": {"value": bucketName},
             "payload": {
                 "value": "uuid,event,properties,elements,people_set,people_set_once,distinct_id,team_id,ip,site_url,timestamp\n"
-                + "{event.uuid},{event.event},{jsonStringify(event.properties)},{event.elements_chain},{jsonStringify(event.properties.$set)},{jsonStringify(event.properties.$set_once)},{event.distinct_id},,,,{event.timestamp}"
+                + "{event.uuid},{event.event},{jsonStringify(event.properties)},{event.elements_chain},{jsonStringify(person.properties)},,{event.distinct_id},,,,{event.timestamp}"
             },
             "filename": {
                 "value": "{toDate(event.timestamp)}/{replaceAll(replaceAll(replaceAll(toString(event.timestamp), '-', ''), ':', ''), 'T', '-')}-{event.uuid}.csv"

--- a/posthog/cdp/templates/google_cloud_storage/test_template_google_cloud_storage.py
+++ b/posthog/cdp/templates/google_cloud_storage/test_template_google_cloud_storage.py
@@ -43,7 +43,7 @@ class TestTemplateMigration(BaseTest):
             "bucketName": {"value": "BUCKET_NAME"},
             "payload": {
                 "value": "uuid,event,properties,elements,people_set,people_set_once,distinct_id,team_id,ip,site_url,timestamp\n"
-                + "{event.uuid},{event.event},{jsonStringify(event.properties)},{event.elements_chain},{jsonStringify(event.properties.$set)},{jsonStringify(event.properties.$set_once)},{event.distinct_id},,,,{event.timestamp}"
+                + "{event.uuid},{event.event},{jsonStringify(event.properties)},{event.elements_chain},{jsonStringify(person.properties)},,{event.distinct_id},,,,{event.timestamp}"
             },
             "filename": {
                 "value": "{toDate(event.timestamp)}/{replaceAll(replaceAll(replaceAll(toString(event.timestamp), '-', ''), ':', ''), 'T', '-')}-{event.uuid}.csv"
@@ -87,7 +87,7 @@ class TestTemplateMigration(BaseTest):
             "bucketName": {"value": "BUCKET_NAME"},
             "payload": {
                 "value": "uuid,event,properties,elements,people_set,people_set_once,distinct_id,team_id,ip,site_url,timestamp\n"
-                + "{event.uuid},{event.event},{jsonStringify(event.properties)},{event.elements_chain},{jsonStringify(event.properties.$set)},{jsonStringify(event.properties.$set_once)},{event.distinct_id},,,,{event.timestamp}"
+                + "{event.uuid},{event.event},{jsonStringify(event.properties)},{event.elements_chain},{jsonStringify(person.properties)},,{event.distinct_id},,,,{event.timestamp}"
             },
             "filename": {
                 "value": "{toDate(event.timestamp)}/{replaceAll(replaceAll(replaceAll(toString(event.timestamp), '-', ''), ':', ''), 'T', '-')}-{event.uuid}.csv"

--- a/posthog/cdp/templates/posthog/template_posthog.py
+++ b/posthog/cdp/templates/posthog/template_posthog.py
@@ -22,6 +22,14 @@ let include_all_properties := inputs.include_all_properties
 let propertyOverrides := inputs.properties
 let properties := include_all_properties ? event.properties : {}
 
+// Person properties used to ride along inside the event payload, so replication updated the
+// receiving project's persons as a side effect. They no longer do, so send them explicitly.
+// The whole snapshot goes over rather than one event's changes, which converges the receiving
+// person onto the same state and makes $set_once unnecessary.
+if (inputs.include_person_properties and not empty(person.properties)) {
+    properties['$set'] := person.properties
+}
+
 for (let key, value in propertyOverrides) {
     properties[key] := value
 }
@@ -68,6 +76,15 @@ fetch(f'{host}/e', {
             "required": True,
         },
         {
+            "key": "include_person_properties",
+            "type": "boolean",
+            "label": "Include person properties",
+            "description": "Replicate the person's properties so the receiving project updates its own persons. Turn this off to send events only.",
+            "default": True,
+            "secret": False,
+            "required": True,
+        },
+        {
             "key": "properties",
             "type": "dictionary",
             "label": "Property overrides",
@@ -99,6 +116,7 @@ class TemplatePostHogMigrator(HogFunctionTemplateMigrator):
             "host": {"value": host},
             "token": {"value": project_api_key},
             "include_all_properties": {"value": True},
+            "include_person_properties": {"value": True},
             "properties": {"value": {"$geoip_disable": True} if disable_geoip else {}},
         }
 

--- a/posthog/cdp/templates/posthog/test_template_posthog.py
+++ b/posthog/cdp/templates/posthog/test_template_posthog.py
@@ -38,6 +38,50 @@ class TestTemplatePosthog(BaseHogFunctionTemplateTest):
             },
         )
 
+    def test_function_replicates_person_properties(self):
+        self.run_function(
+            inputs={
+                "host": "https://us.i.posthog.com",
+                "token": "TOKEN",
+                "include_all_properties": False,
+                "include_person_properties": True,
+                "properties": {},
+            },
+            globals={"person": {"properties": {"email": "someone@example.com", "plan": "paid"}}},
+        )
+
+        assert self.get_mock_fetch_calls()[0][1]["body"]["properties"] == {
+            "$set": {"email": "someone@example.com", "plan": "paid"}
+        }
+
+    def test_function_can_skip_person_properties(self):
+        self.run_function(
+            inputs={
+                "host": "https://us.i.posthog.com",
+                "token": "TOKEN",
+                "include_all_properties": False,
+                "include_person_properties": False,
+                "properties": {},
+            },
+            globals={"person": {"properties": {"email": "someone@example.com"}}},
+        )
+
+        assert self.get_mock_fetch_calls()[0][1]["body"]["properties"] == {}
+
+    def test_property_overrides_win_over_person_properties(self):
+        self.run_function(
+            inputs={
+                "host": "https://us.i.posthog.com",
+                "token": "TOKEN",
+                "include_all_properties": False,
+                "include_person_properties": True,
+                "properties": {"$set": {"email": "override@example.com"}},
+            },
+            globals={"person": {"properties": {"email": "someone@example.com"}}},
+        )
+
+        assert self.get_mock_fetch_calls()[0][1]["body"]["properties"] == {"$set": {"email": "override@example.com"}}
+
     def test_function_doesnt_include_all_properties(self):
         self.run_function(
             inputs={
@@ -70,6 +114,7 @@ class TestTemplateMigration(BaseTest):
             "host": {"value": "us.i.example.com"},
             "token": {"value": "apikey"},
             "include_all_properties": {"value": True},
+            "include_person_properties": {"value": True},
             "properties": {"value": {}},
         }
 
@@ -82,6 +127,7 @@ class TestTemplateMigration(BaseTest):
             "host": {"value": "us.i.example.com"},
             "token": {"value": "apikey"},
             "include_all_properties": {"value": True},
+            "include_person_properties": {"value": True},
             "properties": {"value": {"$geoip_disable": True}},
         }
 
@@ -94,6 +140,7 @@ class TestTemplateMigration(BaseTest):
             "host": {"value": "us.i.example.com"},
             "token": {"value": "apikey"},
             "include_all_properties": {"value": True},
+            "include_person_properties": {"value": True},
             "properties": {"value": {}},
         }
 

--- a/posthog/cdp/templates/rudderstack/template_rudderstack.py
+++ b/posthog/cdp/templates/rudderstack/template_rudderstack.py
@@ -54,8 +54,8 @@ fun getPayload() {
 
     if (event.event in ('$identify', '$set')) {
         rudderPayload.type := 'identify'
-        if (not empty(event.properties.$set)) rudderPayload.context.trait := event.properties.$set
-        if (not empty(event.properties.$set)) rudderPayload.traits := event.properties.$set
+        if (not empty(person.properties)) rudderPayload.context.trait := person.properties
+        if (not empty(person.properties)) rudderPayload.traits := person.properties
     } else if (event.event == '$create_alias') {
         rudderPayload.type := 'alias'
         if (not empty(event.properties.alias)) rudderPayload.userId := event.properties.alias

--- a/posthog/cdp/templates/rudderstack/test_template_rudderstack.py
+++ b/posthog/cdp/templates/rudderstack/test_template_rudderstack.py
@@ -93,6 +93,19 @@ class TestTemplateRudderstack(BaseHogFunctionTemplateTest):
         res = self.get_mock_fetch_calls()[0]
         assert res[0] == "https://hosted.rudderlabs.com/v1/batch"
 
+    def test_identify_sends_person_properties_as_traits(self):
+        self.run_function(
+            inputs=self._inputs(),
+            globals={
+                "event": {"event": "$identify", "properties": {"$browser": "Chrome"}},
+                "person": {"properties": {"email": "someone@example.com", "plan": "paid"}},
+            },
+        )
+
+        payload = self.get_mock_fetch_calls()[0][1]["body"]["batch"][0]
+        assert payload["traits"] == {"email": "someone@example.com", "plan": "paid"}
+        assert payload["context"]["trait"] == {"email": "someone@example.com", "plan": "paid"}
+
     def test_automatic_action_mapping(self):
         for event_name, expected_action in [
             ("$identify", "identify"),


### PR DESCRIPTION
## Problem

Three shipped destination templates read `properties.$set` off the event. Stored events are losing that payload, so each one breaks quietly: RudderStack stops sending traits, Google Cloud Storage exports two empty CSV columns, and the PostHog replicator stops updating persons in the receiving project.

The replicator is the one that fails least visibly. It forwards `event.properties` wholesale, so today the payload rides along and the receiving project applies the same person updates as a side effect. Nothing in the template names it.

Second of three PRs. [#79415](https://github.com/PostHog/posthog/pull/79415) adds the usage tracking; the polyfill for functions that already exist follows separately.

## Changes

- RudderStack sends `person.properties` as `traits` and `context.trait` on identify events.
- Google Cloud Storage puts `person.properties` in the `people_set` column. `people_set_once` has no person-side counterpart, so it stays an empty column rather than repeating the same object. The column count does not change.
- The replicator sets `$set` from `person.properties` explicitly, with a comment saying why, behind a new **Include person properties** input that defaults to on.

The replicator sends the whole snapshot rather than one event's changes. That converges the receiving person onto the same state, which is what replication is for, and it is why there is no `$set_once` equivalent. Property overrides still win, so a function that already overrides `$set` keeps its own value.

> [!NOTE]
> Templates are ephemeral. A function that already exists keeps its own copy of the hog until someone pulls the update, so this fixes new functions and not the installed base. Migrating those is what the polyfill is for.

## How did you test this code?

- Compiled each edited template with `posthog.hogql.cli` and ran the bytecode through the TypeScript VM to check the payload it actually builds: RudderStack traits carry the person's properties, and the replicator emits `$set` when the new input is on, omits it when off, and lets an override win.
- Added Python template cases for the same three replicator paths and for the RudderStack traits mapping. No existing test asserted the traits mapping at all, so the reads could have been deleted without a failure.
- Existing replicator tests pass inputs without the new key, which reads as off, so they still assert the payload they always did.
- The Python template suites for all three templates pass locally against Postgres and ClickHouse in this sandbox (15 tests). Earlier attempts timed out during test-database migrations, so this took three tries to actually get a result.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The new input carries its own description in the template.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this. Skills invoked: `/writing-user-facing-copy` for the new input label and description, `/writing-tests`, `/writing-pr-descriptions`.

I found these three by scanning the repo and cross-checking against the live templates API, after a first pass that only looked at hog function bodies missed them. All three are whole-object reads, which is the shape a per-key mapping cannot cover, so they had to be fixed in the template rather than left to the polyfill.

I also checked the live function rows to size this. Almost every existing Google Cloud Storage function has already replaced the default payload, so that edit matters for new functions more than existing ones. RudderStack is the opposite. The counts stay out of this description on purpose.

Nothing here came from a customer conversation or an internal thread; the fixtures use `example.com` and invented values.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
