### PR TITLE
feat(cdp): polyfill $set reads for functions created before a cutoff

### DIFF
--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -17,7 +17,13 @@ import { createAddLogFunction, sanitizeLogMessage } from '../utils'
 import { execHog } from '../utils/hog-exec'
 import { convertToHogFunctionFilterGlobal, filterFunctionInstrumented } from '../utils/hog-function-filtering'
 import { createInvocationResult } from '../utils/invocation-utils'
-import { bytecodePersonUpdatePropertyReads, trackPersonUpdatePropertyReads } from '../utils/person-update-properties'
+import type { PersonUpdatePropertyRead } from '../utils/person-update-properties'
+import {
+    bytecodePersonUpdatePropertyReads,
+    personUpdatePropertyPolyfillMode,
+    polyfilledEventProperties,
+    trackPersonUpdatePropertyReads,
+} from '../utils/person-update-properties'
 import { HogInputsService } from './hog-inputs.service'
 
 export interface HogExecutorConfig {
@@ -138,6 +144,37 @@ export class HogExecutorService {
         return merged
     }
 
+    /**
+     * Count the reads this surface makes and, where the polyfill is on, fill them in.
+     *
+     * Mutating the invocation's own globals is safe: each invocation carries its own copy, and the
+     * inputs the function reads are resolved from these globals further down.
+     */
+    private applyPolyfill(
+        invocation: CyclotronJobInvocationHogFunction,
+        reads: PersonUpdatePropertyRead[],
+        source: 'hog'
+    ): void {
+        const globals = invocation.state.globals
+        trackPersonUpdatePropertyReads({
+            reads,
+            source,
+            functionType: invocation.hogFunction.type,
+            eventProperties: globals.event?.properties,
+            personProperties: globals.person?.properties,
+        })
+
+        const polyfilled = polyfilledEventProperties({
+            mode: personUpdatePropertyPolyfillMode(invocation.hogFunction),
+            reads,
+            eventProperties: globals.event?.properties,
+            personProperties: globals.person?.properties,
+        })
+        if (polyfilled) {
+            globals.event = { ...globals.event, properties: polyfilled }
+        }
+    }
+
     @instrumented({ key: 'hog-executor.execute', sendException: false })
     async execute(
         invocation: CyclotronJobInvocationHogFunction,
@@ -157,16 +194,9 @@ export class HogExecutorService {
         const addLog = createAddLogFunction(result.logs)
 
         try {
-            // Observation only. It cannot throw, and it sits inside the try so that even if that
-            // guarantee ever broke, the failure would surface as an invocation error rather than
-            // escaping `execute` uncaught.
-            trackPersonUpdatePropertyReads({
-                reads: bytecodePersonUpdatePropertyReads(invocation.hogFunction.bytecode),
-                source: 'hog',
-                functionType: invocation.hogFunction.type,
-                eventProperties: invocation.state.globals.event?.properties,
-                personProperties: invocation.state.globals.person?.properties,
-            })
+            // Sits inside the try so that a failure here surfaces as an invocation error rather
+            // than escaping `execute` uncaught. The tracking half cannot throw either way.
+            this.applyPolyfill(invocation, bytecodePersonUpdatePropertyReads(invocation.hogFunction.bytecode), 'hog')
 
             let globals: HogFunctionInvocationGlobalsWithInputs
             let execRes: ExecResult | undefined = undefined

--- a/nodejs/src/cdp/services/hog-inputs.service.ts
+++ b/nodejs/src/cdp/services/hog-inputs.service.ts
@@ -8,7 +8,12 @@ import { HogFunctionInvocationGlobals, HogFunctionInvocationGlobalsWithInputs, H
 import { EncryptedFields } from '../utils/encryption-utils'
 import { execHog } from '../utils/hog-exec'
 import { LiquidRenderer } from '../utils/liquid'
-import { inputsPersonUpdatePropertyReads, trackPersonUpdatePropertyReads } from '../utils/person-update-properties'
+import {
+    inputsPersonUpdatePropertyReads,
+    personUpdatePropertyPolyfillMode,
+    polyfilledEventProperties,
+    trackPersonUpdatePropertyReads,
+} from '../utils/person-update-properties'
 import { getDevicePushSubscriptionToken } from '../utils/push-subscription-utils'
 import { IntegrationManagerService } from './managers/integration-manager.service'
 import { RecipientTokensService } from './messaging/recipient-tokens.service'
@@ -27,10 +32,17 @@ export class HogInputsService {
         globals: HogFunctionInvocationGlobals,
         additionalInputs?: Record<string, any>
     ): Promise<Record<string, any>> {
+        const reads = inputsPersonUpdatePropertyReads(hogFunction)
         trackPersonUpdatePropertyReads({
-            reads: inputsPersonUpdatePropertyReads(hogFunction),
+            reads,
             source: 'inputs',
             functionType: hogFunction.type,
+            eventProperties: globals.event?.properties,
+            personProperties: globals.person?.properties,
+        })
+        const polyfilled = polyfilledEventProperties({
+            mode: personUpdatePropertyPolyfillMode(hogFunction),
+            reads,
             eventProperties: globals.event?.properties,
             personProperties: globals.person?.properties,
         })
@@ -38,6 +50,7 @@ export class HogInputsService {
         // TODO: Load the values from the integrationManager
         const newGlobals: HogFunctionInvocationGlobalsWithInputs = {
             ...globals,
+            ...(polyfilled ? { event: { ...globals.event, properties: polyfilled } } : {}),
             inputs: {},
         }
         const inputs: HogFunctionType['inputs'] = {

--- a/nodejs/src/cdp/services/legacy-plugin-executor.service.ts
+++ b/nodejs/src/cdp/services/legacy-plugin-executor.service.ts
@@ -21,6 +21,8 @@ import { cdpTrackedFetch } from '../utils/cdp-fetch'
 import { createInvocationResult } from '../utils/invocation-utils'
 import {
     LEGACY_PLUGIN_PERSON_UPDATE_PROPERTY_READS,
+    personUpdatePropertyPolyfillMode,
+    resolveLegacyPluginPersonUpdatePayload,
     trackPersonUpdatePropertyReads,
 } from '../utils/person-update-properties'
 
@@ -282,6 +284,15 @@ export class LegacyPluginExecutorService {
                 personProperties: globals.person?.properties,
             })
 
+            const polyfillMode = personUpdatePropertyPolyfillMode(invocation.hogFunction)
+            const legacyPayload = (key: '$set' | '$set_once') =>
+                resolveLegacyPluginPersonUpdatePayload(
+                    polyfillMode,
+                    key,
+                    globals.event.properties,
+                    globals.person?.properties
+                )
+
             const event = {
                 distinct_id: globals.event.distinct_id,
                 ip: globals.event.properties.$ip,
@@ -289,8 +300,8 @@ export class LegacyPluginExecutorService {
                 event: globals.event.event,
                 properties: globals.event.properties,
                 timestamp: globals.event.timestamp,
-                $set: globals.event.properties.$set,
-                $set_once: globals.event.properties.$set_once,
+                $set: legacyPayload('$set'),
+                $set_once: legacyPayload('$set_once'),
                 uuid: globals.event.uuid,
             }
 

--- a/nodejs/src/cdp/utils/hog-function-filtering.ts
+++ b/nodejs/src/cdp/utils/hog-function-filtering.ts
@@ -18,7 +18,12 @@ import {
     MinimalAppMetric,
 } from '../types'
 import { execHog } from './hog-exec'
-import { bytecodePersonUpdatePropertyReads, trackPersonUpdatePropertyReads } from './person-update-properties'
+import {
+    bytecodePersonUpdatePropertyReads,
+    personUpdatePropertyPolyfillMode,
+    polyfilledEventProperties,
+    trackPersonUpdatePropertyReads,
+} from './person-update-properties'
 
 // Module-level constants for fixed regex patterns to avoid recompilation
 // These patterns are compiled once at module load and reused for all events
@@ -327,6 +332,25 @@ export function convertToHogFunctionFilterGlobal(
     return response
 }
 
+/**
+ * Swap in one field without touching the rest. Copying descriptors rather than spreading keeps the
+ * lazily-computed `elements_chain_*` accessors as accessors, so they are neither evaluated here nor
+ * dropped for being non-enumerable.
+ */
+function withEventProperties(
+    filterGlobals: HogFunctionFilterGlobals,
+    properties: Record<string, any>
+): HogFunctionFilterGlobals {
+    const derived = Object.defineProperties({}, Object.getOwnPropertyDescriptors(filterGlobals))
+    Object.defineProperty(derived, 'properties', {
+        value: properties,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+    })
+    return derived as HogFunctionFilterGlobals
+}
+
 const HOG_FILTERING_TIMEOUT_MS = 100
 
 function preFilterResult(filters: HogFunctionType['filters'], filterGlobals: HogFunctionFilterGlobals): boolean {
@@ -354,7 +378,8 @@ export async function filterFunctionInstrumented(options: {
     /** Optional filters to use instead of those on the function */
     filters: HogFunctionType['filters']
 }): Promise<HogFilterResult> {
-    const { fn, filters, filterGlobals } = options
+    const { fn, filters } = options
+    let { filterGlobals } = options
     const type = 'type' in fn ? fn.type : 'hogflow'
     const fnKind = 'type' in fn ? 'HogFunction' : 'HogFlow'
     const logs: LogEntry[] = []
@@ -378,13 +403,25 @@ export async function filterFunctionInstrumented(options: {
             return result
         }
 
+        const reads = bytecodePersonUpdatePropertyReads(filters?.bytecode)
         trackPersonUpdatePropertyReads({
-            reads: bytecodePersonUpdatePropertyReads(filters?.bytecode),
+            reads,
             source: 'filters',
             functionType: type,
             eventProperties: filterGlobals.properties,
             personProperties: filterGlobals.person?.properties,
         })
+        // One filter globals object is shared across every function matching this event, so a
+        // per-function view has to be derived rather than written back onto it.
+        const polyfilled = polyfilledEventProperties({
+            mode: personUpdatePropertyPolyfillMode(fn),
+            reads,
+            eventProperties: filterGlobals.properties,
+            personProperties: filterGlobals.person?.properties,
+        })
+        if (polyfilled) {
+            filterGlobals = withEventProperties(filterGlobals, polyfilled)
+        }
 
         // check whether we have a match with our pre-filter
         // Only run if we have event filters and NO action filters (as actions are pre-saved event filters)

--- a/nodejs/src/cdp/utils/person-update-properties.test.ts
+++ b/nodejs/src/cdp/utils/person-update-properties.test.ts
@@ -7,7 +7,10 @@ import {
     bytecodePersonUpdatePropertyReads,
     findPersonUpdatePropertyReads,
     inputsPersonUpdatePropertyReads,
+    personUpdatePropertyPolyfillMode,
     personUpdatePropertyReadOutcome,
+    polyfilledEventProperties,
+    resolveLegacyPluginPersonUpdatePayload,
     trackPersonUpdatePropertyReads,
 } from './person-update-properties'
 
@@ -117,6 +120,185 @@ describe('person update properties', () => {
                     { profile: { name: 'Ada' } }
                 )
             ).toEqual('mappable')
+        })
+    })
+
+    describe('personUpdatePropertyPolyfillMode', () => {
+        beforeEach(() => {
+            process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE = '2026-06-01'
+        })
+
+        afterEach(() => {
+            delete process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE
+            delete process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_EXCLUDED_TEAMS
+        })
+
+        it.each([
+            ['map', '2026-01-01T00:00:00Z'],
+            ['hide', '2026-06-01T00:00:00Z'],
+            ['hide', '2026-09-01T00:00:00Z'],
+        ])('is %s for a function created at %s', (expected, created_at) => {
+            expect(personUpdatePropertyPolyfillMode({ team_id: 1, created_at })).toEqual(expected)
+        })
+
+        it('is off until a cutoff is configured', () => {
+            delete process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE
+
+            expect(personUpdatePropertyPolyfillMode({ team_id: 1, created_at: '2026-01-01T00:00:00Z' })).toEqual('off')
+        })
+
+        it('is off for an excluded team', () => {
+            process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_EXCLUDED_TEAMS = ' 2, 7 '
+
+            expect(personUpdatePropertyPolyfillMode({ team_id: 7, created_at: '2026-01-01T00:00:00Z' })).toEqual('off')
+            expect(personUpdatePropertyPolyfillMode({ team_id: 3, created_at: '2026-01-01T00:00:00Z' })).toEqual('map')
+        })
+
+        it.each([['not a date'], ['']])('is off for an unusable cutoff of %p', (before) => {
+            process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE = before
+
+            expect(personUpdatePropertyPolyfillMode({ team_id: 1, created_at: '2026-01-01T00:00:00Z' })).toEqual('off')
+        })
+
+        it('is off for a hog flow, which has no creation date', () => {
+            expect(personUpdatePropertyPolyfillMode({ team_id: 1 })).toEqual('off')
+        })
+    })
+
+    describe('polyfilledEventProperties', () => {
+        it('fills in only the paths the function reads', () => {
+            const properties = polyfilledEventProperties({
+                mode: 'map',
+                reads: [read(['email'])],
+                eventProperties: { $browser: 'Chrome' },
+                personProperties: { email: 'someone@example.com', plan: 'paid' },
+            })
+
+            expect(properties).toEqual({ $browser: 'Chrome', $set: { email: 'someone@example.com' } })
+        })
+
+        it('fills a nested path without dropping its siblings', () => {
+            const properties = polyfilledEventProperties({
+                mode: 'map',
+                reads: [read(['profile', 'name'])],
+                eventProperties: { $set: { profile: { id: 7 } } },
+                personProperties: { profile: { name: 'Ada', email: 'ada@example.com' } },
+            })
+
+            expect(properties!.$set).toEqual({ profile: { id: 7, name: 'Ada' } })
+        })
+
+        it('leaves the key absent when nothing can be filled', () => {
+            expect(
+                polyfilledEventProperties({
+                    mode: 'map',
+                    reads: [read(['email'])],
+                    eventProperties: { $browser: 'Chrome' },
+                    personProperties: { plan: 'paid' },
+                })
+            ).toBeUndefined()
+        })
+
+        it('keeps the value the event already carries', () => {
+            expect(
+                polyfilledEventProperties({
+                    mode: 'map',
+                    reads: [read(['email'])],
+                    eventProperties: { $set: { email: 'from-event@example.com' } },
+                    personProperties: { email: 'from-person@example.com' },
+                })
+            ).toBeUndefined()
+        })
+
+        it('does not answer a whole object read', () => {
+            expect(
+                polyfilledEventProperties({
+                    mode: 'map',
+                    reads: [read([])],
+                    eventProperties: { $browser: 'Chrome' },
+                    personProperties: { email: 'someone@example.com' },
+                })
+            ).toBeUndefined()
+        })
+
+        it('removes both keys for a function created after the cutoff', () => {
+            expect(
+                polyfilledEventProperties({
+                    mode: 'hide',
+                    reads: [read(['email'])],
+                    eventProperties: {
+                        $browser: 'Chrome',
+                        $set: { email: 'a@example.com' },
+                        $set_once: { plan: 'paid' },
+                    },
+                    personProperties: { email: 'a@example.com' },
+                })
+            ).toEqual({ $browser: 'Chrome' })
+        })
+
+        it('does not copy the event when there is nothing to hide', () => {
+            expect(
+                polyfilledEventProperties({
+                    mode: 'hide',
+                    reads: [],
+                    eventProperties: { $browser: 'Chrome' },
+                    personProperties: {},
+                })
+            ).toBeUndefined()
+        })
+
+        it('leaves the event alone when off', () => {
+            expect(
+                polyfilledEventProperties({
+                    mode: 'off',
+                    reads: [read(['email'])],
+                    eventProperties: { $set: { email: 'a@example.com' } },
+                    personProperties: { email: 'a@example.com' },
+                })
+            ).toBeUndefined()
+        })
+
+        it('does not mutate the event properties it was given', () => {
+            const eventProperties = { $set: { plan: 'paid' } }
+
+            polyfilledEventProperties({
+                mode: 'map',
+                reads: [read(['email'])],
+                eventProperties,
+                personProperties: { email: 'someone@example.com' },
+            })
+
+            expect(eventProperties).toEqual({ $set: { plan: 'paid' } })
+        })
+    })
+
+    describe('resolveLegacyPluginPersonUpdatePayload', () => {
+        it('gives a mapped plugin an enumerable copy of the person snapshot', () => {
+            const payload = resolveLegacyPluginPersonUpdatePayload('map', '$set', {}, { email: 'a@example.com' })
+
+            expect(Object.keys(payload!)).toEqual(['email'])
+        })
+
+        it.each([['map'], ['off']] as const)('prefers the payload the event carries when %s', (mode) => {
+            expect(
+                resolveLegacyPluginPersonUpdatePayload(
+                    mode,
+                    '$set',
+                    { $set: { email: 'from-event@example.com' } },
+                    { email: 'from-person@example.com' }
+                )
+            ).toEqual({ email: 'from-event@example.com' })
+        })
+
+        it('resolves nothing when hidden, even though the event carries it', () => {
+            expect(
+                resolveLegacyPluginPersonUpdatePayload(
+                    'hide',
+                    '$set',
+                    { $set: { email: 'a@example.com' } },
+                    { email: 'a@example.com' }
+                )
+            ).toBeUndefined()
         })
     })
 

--- a/nodejs/src/cdp/utils/person-update-properties.ts
+++ b/nodejs/src/cdp/utils/person-update-properties.ts
@@ -310,3 +310,165 @@ export function trackPersonUpdatePropertyReads(options: {
         })
     }
 }
+
+/**
+ * The polyfill. Off unless `CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE` is set to a date.
+ *
+ * Functions created before that date keep working: the reads they make are filled in from the
+ * person snapshot. Functions created on or after it never see these properties at all, even while
+ * stored events still carry them, so the deprecation is real for anything new rather than a grace
+ * period that never ends. `CDP_PERSON_UPDATE_PROPERTY_POLYFILL_EXCLUDED_TEAMS` opts a team out of
+ * both behaviours.
+ */
+export type PersonUpdatePropertyPolyfillMode =
+    /** Fill in the reads this function makes from the person snapshot. */
+    | 'map'
+    /** Resolve nothing, whatever the stored event carries. */
+    | 'hide'
+    /** Leave the event exactly as it arrived. */
+    | 'off'
+
+let excludedTeamsSource: string | undefined
+let excludedTeams = new Set<number>()
+
+function isExcludedTeam(teamId: number): boolean {
+    const source = process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_EXCLUDED_TEAMS ?? ''
+    if (source !== excludedTeamsSource) {
+        excludedTeamsSource = source
+        excludedTeams = new Set(
+            source
+                .split(',')
+                .map((id) => parseInt(id.trim(), 10))
+                .filter((id) => !isNaN(id))
+        )
+    }
+    return excludedTeams.has(teamId)
+}
+
+/**
+ * A hog flow carries no creation date, so the date rule cannot classify one and it is left alone.
+ * Its filters are still counted.
+ */
+export function personUpdatePropertyPolyfillMode(fn: {
+    team_id: number
+    created_at?: string
+}): PersonUpdatePropertyPolyfillMode {
+    // 'off' is the fallback for anything unexpected, so a failure leaves the event as it arrived.
+    return guarded('polyfill_mode', 'off', () => {
+        const before = process.env.CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE
+        if (!before || !fn.created_at || isExcludedTeam(fn.team_id)) {
+            return 'off'
+        }
+        const cutoff = Date.parse(before)
+        const createdAt = Date.parse(fn.created_at)
+        if (isNaN(cutoff) || isNaN(createdAt)) {
+            return 'off'
+        }
+        return createdAt < cutoff ? 'map' : 'hide'
+    })
+}
+
+function setPath(root: Record<string, any>, path: string[], value: unknown): void {
+    let target = root
+    for (const segment of path.slice(0, -1)) {
+        const next = target[segment]
+        target[segment] = typeof next === 'object' && next !== null ? { ...next } : {}
+        target = target[segment]
+    }
+    target[path[path.length - 1]] = value
+}
+
+/**
+ * Build the event properties one function should run against, or nothing when they are unchanged.
+ *
+ * A `map` fills in only the paths the function reads, so a function that reads
+ * `properties.$set.email` gets that one key and nothing else. Substituting the whole snapshot would
+ * hand it every property the person has, which is not what the event updated. Filling nothing
+ * leaves the key absent rather than present and empty, so a filter on whether it is set still reads
+ * the way it will once storage drops the payload.
+ */
+export function polyfilledEventProperties(options: {
+    mode: PersonUpdatePropertyPolyfillMode
+    reads: PersonUpdatePropertyRead[]
+    eventProperties: Record<string, any> | undefined
+    personProperties: Record<string, any> | undefined
+}): Record<string, any> | undefined {
+    const { mode, reads, eventProperties, personProperties } = options
+    if (mode === 'off' || typeof eventProperties !== 'object' || eventProperties === null) {
+        return undefined
+    }
+    // Returning nothing leaves the event as it arrived, which is the safe outcome for a failure.
+    return guarded('polyfill', undefined, () =>
+        buildPolyfilledEventProperties(mode, reads, eventProperties, personProperties)
+    )
+}
+
+function buildPolyfilledEventProperties(
+    mode: PersonUpdatePropertyPolyfillMode,
+    reads: PersonUpdatePropertyRead[],
+    eventProperties: Record<string, any>,
+    personProperties: Record<string, any> | undefined
+): Record<string, any> | undefined {
+    if (mode === 'hide') {
+        const present = PERSON_UPDATE_PROPERTY_KEYS.filter((key) =>
+            Object.prototype.hasOwnProperty.call(eventProperties, key)
+        )
+        if (present.length === 0) {
+            return undefined
+        }
+        const hidden = { ...eventProperties }
+        present.forEach((key) => delete hidden[key])
+        return hidden
+    }
+
+    if (reads.length === 0 || !personProperties) {
+        return undefined
+    }
+
+    let mapped: Record<string, any> | undefined
+    for (const read of reads) {
+        if (read.path.length === 0) {
+            // A whole-object read has no per-key answer, so it keeps whatever the event carried.
+            continue
+        }
+        if (resolvePath(eventProperties[read.key], read.path) !== undefined) {
+            continue
+        }
+        const personValue = resolvePath(personProperties, read.path)
+        if (personValue === undefined) {
+            continue
+        }
+        mapped ??= { ...eventProperties }
+        const payload = mapped[read.key]
+        mapped[read.key] = typeof payload === 'object' && payload !== null ? { ...payload } : {}
+        setPath(mapped[read.key], read.path, personValue)
+    }
+    return mapped
+}
+
+/**
+ * Resolve one payload for a legacy plugin, which reads it whole from JavaScript.
+ *
+ * There is no per-key answer to give a consumer that enumerates the object, so a mapped plugin gets
+ * the person snapshot itself. That is broader than the subset one event updated, and it is the only
+ * substitute that works for a plugin syncing traits. A copy goes over so a plugin mutating it does
+ * not reach the snapshot the rest of the invocation reads.
+ */
+export function resolveLegacyPluginPersonUpdatePayload(
+    mode: PersonUpdatePropertyPolyfillMode,
+    key: PersonUpdatePropertyKey,
+    eventProperties: Record<string, any> | undefined,
+    personProperties: Record<string, any> | undefined
+): Record<string, any> | undefined {
+    // Falling back to the raw payload keeps a failure from changing what the plugin receives.
+    return guarded('legacy_payload', eventProperties?.[key], () => {
+        if (mode === 'hide') {
+            return undefined
+        }
+        const raw = eventProperties?.[key]
+        if (raw !== undefined || mode === 'off' || !personProperties) {
+            return raw
+        }
+        return { ...personProperties }
+    })
+}


### PR DESCRIPTION
## Problem

Once stored events stop carrying `properties.$set` and `properties.$set_once`, every hog function that reads them starts resolving nothing. Filters stop matching, templated inputs render empty, and nothing surfaces an error.

Third of three PRs. [#79415](https://github.com/PostHog/posthog/pull/79415) added the tracking that says how many of those reads are recoverable; [#79447](https://github.com/PostHog/posthog/pull/79447) fixed the templates that read these properties. This carries the functions people already built.

## Changes

A function's reads are filled in from the event's person snapshot. The scope is its creation date:

- Created before `CDP_PERSON_UPDATE_PROPERTY_POLYFILL_BEFORE`: reads are filled in, so the function keeps working.
- Created on or after it: reads resolve to nothing, even while stored events still carry the payload. New functions never depend on these properties, so the deprecation actually ends rather than becoming permanent.
- `CDP_PERSON_UPDATE_PROPERTY_POLYFILL_EXCLUDED_TEAMS` takes a team out of both behaviors.

With no date configured, nothing changes. That variable is the switch as well as the boundary.

**Only the paths a function reads get filled.** A function reading `properties.$set.email` gets that one key. This is the part worth reviewing: the obvious implementation substitutes the whole person snapshot for `$set`, which hands the function every property the person has rather than what the event updated, and makes `$set` always present. Present-but-empty is worse than absent, because a filter on whether the property is set flips for every event that never carried an update. Filling per read keeps the key absent when there is nothing to fill.

The read list comes from the tracking pass in the first PR, so this costs nothing for the functions that do not reference these properties, which is nearly all of them.

Two surfaces need care:

- One filter globals object is shared across every function matching an event, so the per-function view is derived rather than written back. Copying descriptors rather than spreading keeps the lazy `elements_chain_*` accessors as accessors.
- Legacy plugins read the payload whole from JavaScript, so there is no per-key answer to give them. A mapped plugin gets a copy of the snapshot; a hidden one gets nothing.

Hog flows carry no creation date, so the date rule cannot classify one and they are left alone. Their filters are still counted.

Every entry point here falls back to leaving the event exactly as it arrived, on the same guard the tracking PR uses. A failure in the polyfill cannot change what a function receives: an unclassifiable function reads as `off`, a failed fill returns the event unchanged, and a failed legacy payload falls back to whatever the event carried.

> [!NOTE]
> The `$set_once` values a polyfill returns are the ones the person retained, which can differ from what a given event attempted. The `value_differs` counter from the first PR is how to size that before turning this on.

## How did you test this code?

- The mode cases cover the boundary in both directions, an excluded team, an unparseable date, and a hog flow with no date. Getting the comparison backwards would silently polyfill exactly the functions meant to be cut off.
- The fill cases cover what a reviewer should not take on trust: a nested path fills without dropping its siblings, a value the event already carries wins, a whole-object read gets no answer, nothing-to-fill returns the event unchanged rather than an empty key, and the input properties are not mutated.
- Not run: node suites needing Redis or Kafka. This sandbox has neither, so `hog-inputs.service.test.ts`, `hog-executor.service.test.ts` and `legacy-plugin-executor.service.test.ts` failed to boot — they fail identically on `master`. CI covers them, and they are the ones that exercise the wiring rather than the logic.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. Both variables are operational and documented where they are read.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this. Skills invoked: `/writing-tests`, `/code-review`, `/writing-pr-descriptions`.

Stacked on [#79415](https://github.com/PostHog/posthog/pull/79415); review that one first.

An earlier single-PR version of this work installed accessors on `event.properties` that returned the whole person snapshot. A review pass found two problems with that: the job queue serializes globals to JSON between consumer and worker, which erased the accessors before the body ran, and the substituted key was always present, which flips filters on whether the property is set. Splitting the work exposed the better approach, because the tracking PR already has to recover the exact read paths, and filling those paths avoids both problems.

Nothing here came from a customer conversation or an internal thread; the fixtures use `example.com` and invented values.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
