### PR TITLE
fix(warehouse-sources): stop terminalize unit tests tripping the db blocker

### DIFF
--- a/posthog/temporal/tests/warehouse_sources_queue_partition_management/test_activities.py
+++ b/posthog/temporal/tests/warehouse_sources_queue_partition_management/test_activities.py
@@ -393,6 +393,9 @@ class _StrandedQueryConn:
 @contextmanager
 def _patched_terminalize_collaborators():
     with (
+        # These tests run without the django_db mark, but close_old_connections probes any
+        # connection a neighboring test left initialized, tripping pytest-django's DB blocker.
+        patch("django.db.close_old_connections"),
         patch("products.warehouse_sources.backend.facade.pipelines.BatchQueue") as batch_queue,
         patch("products.warehouse_sources.backend.facade.pipelines.mark_job_failed_if_not_terminal") as mark_failed,
         patch("products.warehouse_sources.backend.facade.pipelines.release_v3_pipeline_lock") as release_lock,


### PR DESCRIPTION
## Problem

Temporal Django test shard 7 fails on master and on every PR that merges current master, blocking merges repo-wide. The failing test is `test_terminalize_fails_each_stranded_run_and_releases_its_lock` ([failing master run](https://github.com/PostHog/posthog/actions/runs/31165466339)).

- The activity under test calls Django's `close_old_connections()`.
- The test has no `django_db` mark, so pytest-django blocks DB access.
- `close_old_connections()` probes any connection an earlier `django_db` test in the shard left initialized, and the blocker raises `RuntimeError: Database access not allowed`.
- The failure is ordering-dependent: recent commits reshuffled the shard so a DB test now runs first, making it deterministic.

## Changes

- Patch `django.db.close_old_connections` in `_patched_terminalize_collaborators`, next to the other patched collaborators, so the terminalize unit tests stay DB-free regardless of test order.

## How did you test this code?

- Reproduced locally: a minimal `django_db` test followed by the failing test in one pytest process fails with the exact CI traceback, every time.
- With the fix, 20/20 runs pass under those same repro conditions, and the surrounding file passes with the polluter present.
- Not run: the full Temporal shard, which needs CI's service matrix.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Agent-authored while babysitting an unrelated PR whose CI hit this failure. Skills invoked: /fixing-flaky-tests, /writing-pr-descriptions. Considered marking the tests `django_db` instead, but they are pure unit tests with a fake queue connection; requiring a database to silence a cleanup probe would be heavier than patching the probe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*