### PR TITLE
chore(settings): remove debug information section from project settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       id: debug-info
       attributes:
           label: Debug info
-          value: "- [ ] PostHog Cloud, region and project ID: [please provide, you can find both at https://us.posthog.com/settings/project-details#variables or https://eu.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+          value: "- [ ] PostHog Cloud, region and project ID: [please provide, you can find both at https://app.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
           render: shell
 
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       id: debug-info
       attributes:
           label: Debug info
-          value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables or https://eu.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+          value: "- [ ] PostHog Cloud, region and project ID: [please provide, you can find both at https://us.posthog.com/settings/project-details#variables or https://eu.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
           render: shell
 
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
       id: debug-info
       attributes:
           label: Debug info
-          value: "- [ ] PostHog Cloud, Debug information: [please copy/paste from https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+          value: "- [ ] PostHog Cloud, region and project ID: [please provide, you can find both at https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
           render: shell
 
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
       id: debug-info
       attributes:
           label: Debug info
-          value: "- [ ] PostHog Cloud, region and project ID: [please provide, you can find both at https://us.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
+          value: "- [ ] PostHog Cloud, region and project ID: [please provide, you can find both at https://app.posthog.com/settings/project-details#variables]\n- [ ] PostHog Hobby self-hosted with `docker compose`, version/commit: [please provide]\n- [ ] PostHog self-hosted with Kubernetes (deprecated, see [`Sunsetting Kubernetes support`](https://posthog.com/blog/sunsetting-helm-support-posthog)), version/commit: [please provide]\n"
           render: shell
 
     - type: markdown

--- a/frontend/src/lib/components/Support/supportLogic.test.ts
+++ b/frontend/src/lib/components/Support/supportLogic.test.ts
@@ -3,11 +3,10 @@ import posthog from 'posthog-js'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { initKeaTests } from '~/test/init'
-import { OrganizationBasicType, Region, SidePanelTab, TeamPublicType } from '~/types'
+import { SidePanelTab } from '~/types'
 
 import {
     CONVERSATIONS_MESSAGE_MAX_LENGTH,
-    getPublicSupportSnippet,
     SUPPORT_MESSAGE_PREVIEW_MAX_LENGTH,
     SupportFormFields,
     supportLogic,
@@ -19,37 +18,6 @@ import * as SupportModal from './SupportModal'
 const openSupportModal = jest.spyOn(SupportModal, 'openSupportModal').mockImplementation(() => {})
 
 describe('supportLogic', () => {
-    describe('snippet helpers', () => {
-        const mockedGetReplayUrl = posthog.get_session_replay_url as jest.Mock
-        const organization = { id: 'org-1', name: 'Test org' } as OrganizationBasicType
-        const team = { id: 42 } as TeamPublicType
-
-        beforeEach(() => {
-            mockedGetReplayUrl.mockReset()
-        })
-
-        it('rewrites the session line to the internal golink for staff triage', () => {
-            // posthog-js returns a project-scoped path, not one rooted at the current origin's /replay/ —
-            // this shape is what regressed the naive origin-prefix replace this test used to assert on.
-            mockedGetReplayUrl.mockReturnValue(`${window.location.origin}/project/sTMFPsFhdP1Ssg/replay/abc?t=30`)
-            const snippet = getPublicSupportSnippet(Region.US, organization, team, false)
-            expect(snippet).toContain('Session: http://go/session/abc?t=30')
-            expect(snippet).not.toContain(`${window.location.origin}/project/`)
-        })
-
-        it('omits the session line when there is no recording', () => {
-            mockedGetReplayUrl.mockReturnValue(undefined)
-            const snippet = getPublicSupportSnippet(Region.US, organization, team, false)
-            expect(snippet).not.toContain('Session:')
-        })
-
-        it('marks the admin line as internal', () => {
-            mockedGetReplayUrl.mockReturnValue(undefined)
-            const snippet = getPublicSupportSnippet(Region.US, organization, team, false)
-            expect(snippet).toContain('Admin (internal): http://go/adminOrg')
-        })
-    })
-
     describe('openSupportForm modal vs side panel target', () => {
         let logic: ReturnType<typeof supportLogic.build>
 
@@ -190,7 +158,7 @@ describe('supportLogic', () => {
         // ticket that never got created. That needs the draft and a way back into the session.
         it('carries the draft and session context on a lost submit, so an alert is actionable', async () => {
             ;(posthog.get_session_id as jest.Mock).mockReturnValue('sess-1')
-            // Project-scoped path, the shape posthog-js actually returns — see the snippet tests
+            // Project-scoped path, the shape posthog-js actually returns
             ;(posthog.get_session_replay_url as jest.Mock).mockReturnValue(
                 `${window.location.origin}/project/sTMFPsFhdP1Ssg/replay/sess-1?t=30`
             )
@@ -206,7 +174,7 @@ describe('supportLogic', () => {
                 message_preview: 'Billing is broken',
                 message_truncated: false,
                 session_id: 'sess-1',
-                // Golinked for the same reason as the ticket snippet: staff-facing, not user-facing
+                // Golinked because this is staff-facing triage context, not user-facing
                 session_replay_url: 'http://go/session/sess-1?t=30',
             })
         })

--- a/frontend/src/lib/components/Support/supportLogic.test.ts
+++ b/frontend/src/lib/components/Support/supportLogic.test.ts
@@ -158,9 +158,9 @@ describe('supportLogic', () => {
         // ticket that never got created. That needs the draft and a way back into the session.
         it('carries the draft and session context on a lost submit, so an alert is actionable', async () => {
             ;(posthog.get_session_id as jest.Mock).mockReturnValue('sess-1')
-            // Project-scoped path, the shape posthog-js actually returns
+            // Resolved against ui_host, the shape posthog-js actually returns
             ;(posthog.get_session_replay_url as jest.Mock).mockReturnValue(
-                `${window.location.origin}/project/sTMFPsFhdP1Ssg/replay/sess-1?t=30`
+                'https://us.posthog.com/project/sTMFPsFhdP1Ssg/replay/sess-1?t=30'
             )
             conversationsMock(jest.fn().mockRejectedValue(new Error('network down')))
 
@@ -174,8 +174,7 @@ describe('supportLogic', () => {
                 message_preview: 'Billing is broken',
                 message_truncated: false,
                 session_id: 'sess-1',
-                // Golinked because this is staff-facing triage context, not user-facing
-                session_replay_url: 'http://go/session/sess-1?t=30',
+                session_replay_url: 'https://us.posthog.com/project/sTMFPsFhdP1Ssg/replay/sess-1?t=30',
             })
         })
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -15,20 +15,6 @@ import { parseExceptionEvent } from './exceptionUtils'
 import { openSupportModal } from './SupportModal'
 import { getSupportResponseTime } from './supportResponseTime'
 
-// The recording lives in PostHog's own telemetry project, which the reporting user is not a member
-// of, so this is for PostHog staff triaging the ticket or the alert — never the user. posthog-js
-// returns a project-scoped path (`/project/<token>/replay/<id>`), so pull the session id out of the
-// `/replay/` segment rather than assuming the URL starts with the current origin.
-function getSessionReplayGolink(): string | null {
-    const replayUrl = posthog.get_session_replay_url?.({ withTimestamp: true, timestampLookBack: 30 })
-    const match = replayUrl?.match(/\/replay\/([^/?#]+)([?#].*)?$/)
-    if (!match) {
-        return null
-    }
-    const [, sessionId, queryAndHash] = match
-    return `http://go/session/${sessionId}${queryAndHash ?? ''}`
-}
-
 const SUPPORT_TICKET_KIND_TO_TITLE: Record<SupportTicketKind, string> = {
     support: 'Contact support',
     feedback: 'Give feedback',
@@ -81,11 +67,12 @@ export const SUPPORT_WIDGET_UNAVAILABLE_MESSAGE =
     "We can't load the support chat, which is usually an ad blocker or a network policy."
 
 // `current_url` is explicit rather than autocapture's `$current_url`, so an alert template reading
-// these properties doesn't depend on autocapture staying enabled.
+// these properties doesn't depend on autocapture staying enabled. The recording lives in PostHog's
+// own telemetry project, so the replay link is for staff triaging the alert, never the reporter.
 function supportFailureContext(): Record<string, any> {
     return {
         session_id: posthog.get_session_id?.() ?? null,
-        session_replay_url: getSessionReplayGolink(),
+        session_replay_url: posthog.get_session_replay_url?.({ withTimestamp: true, timestampLookBack: 30 }) ?? null,
         current_url: window.location.href,
     }
 }

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -8,42 +8,12 @@ import { billingLogic } from 'scenes/billing/billingLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
-import {
-    BillingPlan,
-    BillingPlanType,
-    OrganizationBasicType,
-    Region,
-    SidePanelTab,
-    TeamPublicType,
-    UserType,
-} from '~/types'
+import { BillingPlan, BillingPlanType, SidePanelTab, UserType } from '~/types'
 
 import type { BillingType } from '../../../types'
 import { parseExceptionEvent } from './exceptionUtils'
 import { openSupportModal } from './SupportModal'
 import { getSupportResponseTime } from './supportResponseTime'
-
-export function getPublicSupportSnippet(
-    cloudRegion: Region | null | undefined,
-    currentOrganization: OrganizationBasicType | null,
-    currentTeam: TeamPublicType | null,
-    includeCurrentLocation = true
-): string {
-    if (!cloudRegion) {
-        // we don't call this without region being available, so we return some value so we can see errors in visual regression tests
-        return '🚫'
-    }
-    return (
-        (includeCurrentLocation ? getCurrentLocationLink() : '') +
-        getSessionReplayLink() +
-        `\nAdmin (internal): http://go/adminOrg${cloudRegion}/${currentOrganization?.id} (project ID ${currentTeam?.id})`
-    ).trimStart()
-}
-
-function getCurrentLocationLink(): string {
-    const cleanedCurrentUrl = window.location.href.replace(/panel=support[^&]*(&)?/, '').replace(/#$/, '')
-    return `\nLocation: ${cleanedCurrentUrl}`
-}
 
 // The recording lives in PostHog's own telemetry project, which the reporting user is not a member
 // of, so this is for PostHog staff triaging the ticket or the alert — never the user. posthog-js
@@ -57,11 +27,6 @@ function getSessionReplayGolink(): string | null {
     }
     const [, sessionId, queryAndHash] = match
     return `http://go/session/${sessionId}${queryAndHash ?? ''}`
-}
-
-function getSessionReplayLink(): string {
-    const golink = getSessionReplayGolink()
-    return golink ? `\nSession: ${golink}` : ''
 }
 
 const SUPPORT_TICKET_KIND_TO_TITLE: Record<SupportTicketKind, string> = {

--- a/frontend/src/scenes/settings/environment/TeamSettings.tsx
+++ b/frontend/src/scenes/settings/environment/TeamSettings.tsx
@@ -9,14 +9,12 @@ import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authoriz
 import { CodeSnippet } from 'lib/components/CodeSnippet'
 import { JSSnippet } from 'lib/components/JSSnippet'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
-import { getPublicSupportSnippet } from 'lib/components/Support/supportLogic'
 import { TeamMembershipLevel } from 'lib/constants'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { Link } from 'lib/lemon-ui/Link'
 import { userHasAccess } from 'lib/utils/accessControlUtils'
 import { debounce } from 'lib/utils/async'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
-import { organizationLogic } from 'scenes/organizationLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -70,46 +68,6 @@ export function WebSnippet(): JSX.Element {
         </div>
     ) : (
         <JSSnippet />
-    )
-}
-
-function DebugInfoPanel(): JSX.Element | null {
-    const { currentTeam, currentTeamLoading } = useValues(teamLogic)
-    const { currentOrganization, currentOrganizationLoading } = useValues(organizationLogic)
-    const { preflight, preflightLoading } = useValues(preflightLogic)
-
-    const region = preflight?.region
-    const anyLoading = preflightLoading || currentOrganizationLoading || currentTeamLoading
-    const hasRequiredInfo = region && currentOrganization && currentTeam
-
-    if (!hasRequiredInfo && !anyLoading) {
-        return null
-    }
-
-    if (inStorybookTestRunner() || inStorybook()) {
-        // this data changes e.g. when session id changes, so it flaps in visual regression tests
-        // so...
-        return null
-    }
-
-    return (
-        <div className="flex-1 max-w-full">
-            <h3 id="debug-info" className="min-w-[25rem]">
-                Debug information
-            </h3>
-            <p>
-                Include this snippet when creating an issue (feature request or bug report) on GitHub. The session and
-                admin links inside it are internal references the PostHog team uses to look into your report — they only
-                resolve for PostHog staff.
-            </p>
-            {anyLoading ? (
-                <LemonSkeleton repeat={2} active={true} />
-            ) : (
-                <CodeSnippet compact thing="debug info">
-                    {getPublicSupportSnippet(region, currentOrganization, currentTeam, false)}
-                </CodeSnippet>
-            )}
-        </div>
     )
 }
 
@@ -205,8 +163,6 @@ export function TeamVariables(): JSX.Element {
                     </div>
                 ) : null}
             </div>
-
-            <DebugInfoPanel />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Anyone opening project settings saw a "Debug information" panel offering a copyable snippet, but every link in it was an internal `go/` address that only resolves for PostHog staff on the VPN.

People copied that snippet into support tickets, so tickets arrived carrying links their reader often could not open — even though the equivalent public URL was already known.

Support staff can look up an org, project, or session themselves, so the panel was asking users to do work on our behalf and producing a worse result.

The same `go/` rewrite was also applied to the replay link on support failure telemetry, where it made the link unopenable for a responder not running Tailscale.

## Changes

- Removes the "Debug information" panel from the project token and ID settings section.
- Deletes `getPublicSupportSnippet` and its location/session line helpers, which the panel was the only caller of.
- Support failure events now carry the replay URL posthog-js returns instead of a `go/session/<id>` rewrite.

`get_session_replay_url` resolves against `ui_host`, which is already the public app host, so the rewrite bought nothing and cost VPN-free access. This matches what `urlChangeTracker` already sends on equivalent internal telemetry.

No other settings section, notice, or deep link referenced the panel, so nothing else changes. No `go/` links remain in the support code.

## How did you test this code?

Automated only — no manual UI check was performed in this environment.

- Ran `pnpm --filter=@posthog/frontend exec jest src/lib/components/Support/supportLogic.test.ts` — 14 passed.
- Ran the frontend TypeScript check; no errors in the touched files. Unrelated pre-existing failures remain in `products/tracing`, `products/workflows`, and `products/signals` from an unbuilt quill workspace.
- Removed the three tests that only exercised the deleted snippet helper. The failed-submission test still asserts the exact `session_replay_url` value, so a regression in the link format is still caught.
- Confirmed against telemetry that both support failure events fire and always populate `session_replay_url`, so the link is live rather than dead code. No saved insight consumes those events.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested in a Slack thread after support noticed tickets arriving with internal-only links pasted in from this panel. Written by the PostHog Slack app (Claude Code harness); no repo skills were invoked beyond reading the PR template.

The panel could have been kept with the internal links swapped for public URLs, but the discussion landed on deleting it: staff can resolve org, project, and session themselves, so the section gave users a chore rather than a capability.

The telemetry change came from a follow-up review question about whether the remaining internal link generation was still used. It is — but the `go/` form is not worth keeping, so the second commit removes the rewrite rather than the property.

No PR assignee is set because no GitHub handle for the requester was verified in this session.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1786096619100889?thread_ts=1786096619.100889&cid=C075D3C5HST)*
