### PR TITLE
fix(signals): match repo-qualified schema names in inbox source setup

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3291,6 +3291,45 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 return
             }
 
+            // Webhook-sync tables produce no rows until the webhook is registered with the
+            // provider, and the required-tables flow never shows the webhook step (step 4) —
+            // register the webhook after creation and only report completion once it succeeds.
+            const registerRequiredWebhookAndComplete = async (sourceId: string): Promise<void> => {
+                let webhookResult: WebhookCreateResult
+                try {
+                    webhookResult = await api.externalDataSources.createWebhook(sourceId)
+                } catch (e: any) {
+                    posthog.captureException(e)
+                    webhookResult = {
+                        success: false,
+                        webhook_url: '',
+                        error: e.data?.message ?? e.message,
+                    }
+                }
+                actions.setWebhookResult(webhookResult)
+                if (!webhookResultHasNoPendingInputs(webhookResult)) {
+                    lemonToast.error(
+                        `We created the source but couldn't set up its webhook${
+                            webhookResult.error ? `: ${webhookResult.error}` : ''
+                        }. Connect again to retry, or finish webhook setup in the source settings.`
+                    )
+                    return
+                }
+                props.onComplete!()
+            }
+
+            // A required-tables run whose webhook registration failed left the source created —
+            // retry the webhook instead of creating a duplicate source.
+            if (values.requiredTables && props.onComplete && values.sourceId) {
+                if (values.hasWebhookSchemas) {
+                    await registerRequiredWebhookAndComplete(values.sourceId)
+                } else {
+                    props.onComplete()
+                }
+                actions.setIsLoading(false)
+                return
+            }
+
             try {
                 const { id } = await api.externalDataSources.create({
                     ...values.source,
@@ -3318,32 +3357,11 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
 
                 // When requiredTables is set (e.g. signals setup), skip step 4 and complete directly
                 if (values.requiredTables && props.onComplete) {
-                    // Webhook-sync tables produce no rows until the webhook is registered with the
-                    // provider, and this flow never shows the webhook step (step 4) — register the
-                    // webhook here and only report completion once it succeeds.
                     if (values.hasWebhookSchemas) {
-                        let webhookResult: WebhookCreateResult
-                        try {
-                            webhookResult = await api.externalDataSources.createWebhook(id)
-                        } catch (e: any) {
-                            posthog.captureException(e)
-                            webhookResult = {
-                                success: false,
-                                webhook_url: '',
-                                error: e.data?.message ?? e.message,
-                            }
-                        }
-                        actions.setWebhookResult(webhookResult)
-                        if (!webhookResultHasNoPendingInputs(webhookResult)) {
-                            lemonToast.error(
-                                `We created the source but couldn't set up its webhook${
-                                    webhookResult.error ? `: ${webhookResult.error}` : ''
-                                }. Finish webhook setup in the source settings, then enable the signal again.`
-                            )
-                            return
-                        }
+                        await registerRequiredWebhookAndComplete(id)
+                    } else {
+                        props.onComplete()
                     }
-                    props.onComplete()
                 } else if (values.hasWebhookSchemas) {
                     // Go to webhook setup step (4)
                     actions.onNext()

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3318,6 +3318,31 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
 
                 // When requiredTables is set (e.g. signals setup), skip step 4 and complete directly
                 if (values.requiredTables && props.onComplete) {
+                    // Webhook-sync tables produce no rows until the webhook is registered with the
+                    // provider, and this flow never shows the webhook step (step 4) — register the
+                    // webhook here and only report completion once it succeeds.
+                    if (values.hasWebhookSchemas) {
+                        let webhookResult: WebhookCreateResult
+                        try {
+                            webhookResult = await api.externalDataSources.createWebhook(id)
+                        } catch (e: any) {
+                            posthog.captureException(e)
+                            webhookResult = {
+                                success: false,
+                                webhook_url: '',
+                                error: e.data?.message ?? e.message,
+                            }
+                        }
+                        actions.setWebhookResult(webhookResult)
+                        if (!webhookResultHasNoPendingInputs(webhookResult)) {
+                            lemonToast.error(
+                                `We created the source but couldn't set up its webhook${
+                                    webhookResult.error ? `: ${webhookResult.error}` : ''
+                                }. Finish webhook setup in the source settings, then enable the signal again.`
+                            )
+                            return
+                        }
+                    }
                     props.onComplete()
                 } else if (values.hasWebhookSchemas) {
                     // Go to webhook setup step (4)
@@ -3500,6 +3525,12 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                         actions.setIsLoading(false)
                         return
                     }
+                    for (const schema of requiredSchemas) {
+                        schema.should_sync = true
+                    }
+                    // createSource reads hasWebhookSchemas off databaseSchema to decide whether the
+                    // new source still needs its webhook registered.
+                    actions.setDatabaseSchemas(requiredSchemas)
 
                     actions.updateSource({
                         payload: {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3476,17 +3476,30 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     // row per repo. Mirrors ensureRequiredTableSyncing in signalSourcesLogic.
                     const matchesRequiredTable = (tableName: string, requiredTable: string): boolean =>
                         tableName === requiredTable || tableName.endsWith(`.${requiredTable}`)
+                    // The payload below forces should_sync on, so a permission-errored row would
+                    // queue a guaranteed-403 sync. Treat it as unavailable instead.
+                    const requiredSchemas = schemas.filter(
+                        (schema) =>
+                            !schema.permission_error &&
+                            values.requiredTables!.some((table: string) => matchesRequiredTable(schema.table, table))
+                    )
                     const missingTables = values.requiredTables.filter(
-                        (table: string) => !schemas.some((schema) => matchesRequiredTable(schema.table, table))
+                        (table: string) => !requiredSchemas.some((schema) => matchesRequiredTable(schema.table, table))
                     )
                     if (missingTables.length > 0) {
-                        lemonToast.error(`Required tables not found in source: ${missingTables.join(', ')}`)
+                        const permissionError = schemas.find(
+                            (schema) =>
+                                schema.permission_error &&
+                                missingTables.some((table: string) => matchesRequiredTable(schema.table, table))
+                        )?.permission_error
+                        lemonToast.error(
+                            permissionError
+                                ? `Source credentials cannot read the tables this needs (${missingTables.join(', ')}): ${permissionError}. Grant the missing scope in your source provider and reconnect.`
+                                : `Required tables not found in source: ${missingTables.join(', ')}`
+                        )
                         actions.setIsLoading(false)
                         return
                     }
-                    const requiredSchemas = schemas.filter((schema) =>
-                        values.requiredTables!.some((table: string) => matchesRequiredTable(schema.table, table))
-                    )
 
                     actions.updateSource({
                         payload: {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3471,15 +3471,22 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                 // If required tables are specified (e.g. signals setup), skip the schema selection step
                 // entirely and create the source with only those tables, using their default sync settings
                 if (values.requiredTables) {
-                    const requiredSchemas = schemas.filter((schema) => values.requiredTables!.includes(schema.table))
-                    if (requiredSchemas.length !== values.requiredTables.length) {
-                        const missingTables = values.requiredTables.filter(
-                            (table: string) => !requiredSchemas.some((schema) => schema.table === table)
-                        )
+                    // Multi-repo sources qualify their schema names (`owner/repo.endpoint`), so a
+                    // required table matches by suffix as well as exactly, and can resolve to one
+                    // row per repo. Mirrors ensureRequiredTableSyncing in signalSourcesLogic.
+                    const matchesRequiredTable = (tableName: string, requiredTable: string): boolean =>
+                        tableName === requiredTable || tableName.endsWith(`.${requiredTable}`)
+                    const missingTables = values.requiredTables.filter(
+                        (table: string) => !schemas.some((schema) => matchesRequiredTable(schema.table, table))
+                    )
+                    if (missingTables.length > 0) {
                         lemonToast.error(`Required tables not found in source: ${missingTables.join(', ')}`)
                         actions.setIsLoading(false)
                         return
                     }
+                    const requiredSchemas = schemas.filter((schema) =>
+                        values.requiredTables!.some((table: string) => matchesRequiredTable(schema.table, table))
+                    )
 
                     actions.updateSource({
                         payload: {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -956,7 +956,10 @@ describe('sourceWizardLogic', () => {
             fields: [],
         } as SourceConfig
 
-        const apiSchema = (table: string): ExternalDataSourceSyncSchema =>
+        const apiSchema = (
+            table: string,
+            overrides: Partial<ExternalDataSourceSyncSchema> = {}
+        ): ExternalDataSourceSyncSchema =>
             ({
                 table,
                 label: null,
@@ -977,30 +980,37 @@ describe('sourceWizardLogic', () => {
                 detected_primary_keys: null,
                 permission_error: null,
                 cdc_available: false,
+                ...overrides,
             }) as ExternalDataSourceSyncSchema
 
-        afterEach(() => {
-            jest.restoreAllMocks()
-        })
-
-        it('matches a required table against every repo-qualified schema row', async () => {
-            // Multi-repo sources name their rows `owner/repo.endpoint`, so an exact-match lookup
-            // for `issues` finds nothing and the wizard bails before creating the source.
-            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
-                apiSchema('posthog/posthog.issues'),
-                apiSchema('posthog/posthog-js.issues'),
-                apiSchema('posthog/posthog.commits'),
-            ] as ExternalDataSourceSyncSchema[])
-            const create = jest
-                .spyOn(api.externalDataSources, 'create')
-                .mockResolvedValue({ id: 'source-1' } as Awaited<ReturnType<typeof api.externalDataSources.create>>)
-
+        const mountWizard = (): { logic: ReturnType<typeof sourceWizardLogic>; unmount: () => void } => {
             const logic = sourceWizardLogic({
                 availableSources: { Github: githubSource },
                 requiredTables: ['issues'],
                 onComplete: jest.fn(),
             })
-            const unmount = logic.mount()
+            return { logic, unmount: logic.mount() }
+        }
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('syncs every repo-qualified row the credentials can read', async () => {
+            // Multi-repo sources name their rows `owner/repo.endpoint`, so an exact-match lookup
+            // for `issues` finds nothing and the wizard bails before creating the source. The
+            // payload forces should_sync on, so an unreadable row must not reach it.
+            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
+                apiSchema('posthog/posthog.issues'),
+                apiSchema('posthog/posthog-js.issues'),
+                apiSchema('posthog/posthog.commits'),
+                apiSchema('posthog/private.issues', { permission_error: 'Requires the "Issues" permission' }),
+            ] as ExternalDataSourceSyncSchema[])
+            const create = jest
+                .spyOn(api.externalDataSources, 'create')
+                .mockResolvedValue({ id: 'source-1' } as Awaited<ReturnType<typeof api.externalDataSources.create>>)
+
+            const { logic, unmount } = mountWizard()
 
             try {
                 logic.actions.selectConnector(githubSource)
@@ -1016,18 +1026,21 @@ describe('sourceWizardLogic', () => {
             }
         })
 
-        it('does not create the source when a required table is genuinely absent', async () => {
-            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
-                apiSchema('posthog/posthog.commits'),
-            ] as ExternalDataSourceSyncSchema[])
+        // Both leave the required table unsatisfied, so neither may create a source that reports
+        // setup as complete: the first would sync nothing, the second would queue a 403 sync.
+        it.each([
+            ['the required table is absent', [apiSchema('posthog/posthog.commits')]],
+            [
+                'every matching row is unreadable',
+                [apiSchema('posthog/posthog.issues', { permission_error: 'Requires the "Issues" permission' })],
+            ],
+        ])('does not create the source when %s', async (_, discoveredSchemas) => {
+            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue(
+                discoveredSchemas as ExternalDataSourceSyncSchema[]
+            )
             const create = jest.spyOn(api.externalDataSources, 'create')
 
-            const logic = sourceWizardLogic({
-                availableSources: { Github: githubSource },
-                requiredTables: ['issues'],
-                onComplete: jest.fn(),
-            })
-            const unmount = logic.mount()
+            const { logic, unmount } = mountWizard()
 
             try {
                 logic.actions.selectConnector(githubSource)

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -946,4 +946,98 @@ describe('sourceWizardLogic', () => {
             }
         })
     })
+
+    // Signals setup passes requiredTables to skip the schema step and sync just those tables.
+    describe('requiredTables', () => {
+        const githubSource = {
+            name: 'Github',
+            iconPath: '',
+            caption: null,
+            fields: [],
+        } as SourceConfig
+
+        const apiSchema = (table: string): ExternalDataSourceSyncSchema =>
+            ({
+                table,
+                label: null,
+                rows: null,
+                should_sync: false,
+                sync_time_of_day: null,
+                incremental_field: null,
+                incremental_field_type: null,
+                sync_type: null,
+                incremental_fields: [],
+                incremental_available: false,
+                append_available: false,
+                supports_webhooks: false,
+                description: null,
+                should_sync_default: true,
+                primary_key_columns: null,
+                available_columns: [],
+                detected_primary_keys: null,
+                permission_error: null,
+                cdc_available: false,
+            }) as ExternalDataSourceSyncSchema
+
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        it('matches a required table against every repo-qualified schema row', async () => {
+            // Multi-repo sources name their rows `owner/repo.endpoint`, so an exact-match lookup
+            // for `issues` finds nothing and the wizard bails before creating the source.
+            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
+                apiSchema('posthog/posthog.issues'),
+                apiSchema('posthog/posthog-js.issues'),
+                apiSchema('posthog/posthog.commits'),
+            ] as ExternalDataSourceSyncSchema[])
+            const create = jest
+                .spyOn(api.externalDataSources, 'create')
+                .mockResolvedValue({ id: 'source-1' } as Awaited<ReturnType<typeof api.externalDataSources.create>>)
+
+            const logic = sourceWizardLogic({
+                availableSources: { Github: githubSource },
+                requiredTables: ['issues'],
+                onComplete: jest.fn(),
+            })
+            const unmount = logic.mount()
+
+            try {
+                logic.actions.selectConnector(githubSource)
+                await expectLogic(logic, () => logic.actions.getDatabaseSchemas()).toFinishAllListeners()
+
+                expect(create).toHaveBeenCalledTimes(1)
+                expect(create.mock.calls[0][0].payload?.schemas).toEqual([
+                    expect.objectContaining({ name: 'posthog/posthog.issues', should_sync: true }),
+                    expect.objectContaining({ name: 'posthog/posthog-js.issues', should_sync: true }),
+                ])
+            } finally {
+                unmount()
+            }
+        })
+
+        it('does not create the source when a required table is genuinely absent', async () => {
+            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
+                apiSchema('posthog/posthog.commits'),
+            ] as ExternalDataSourceSyncSchema[])
+            const create = jest.spyOn(api.externalDataSources, 'create')
+
+            const logic = sourceWizardLogic({
+                availableSources: { Github: githubSource },
+                requiredTables: ['issues'],
+                onComplete: jest.fn(),
+            })
+            const unmount = logic.mount()
+
+            try {
+                logic.actions.selectConnector(githubSource)
+                await expectLogic(logic, () => logic.actions.getDatabaseSchemas()).toFinishAllListeners()
+
+                expect(create).not.toHaveBeenCalled()
+                expect(logic.values.isLoading).toBe(false)
+            } finally {
+                unmount()
+            }
+        })
+    })
 })

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -1085,18 +1085,21 @@ describe('sourceWizardLogic', () => {
             }
         })
 
-        it('does not complete when webhook registration fails', async () => {
+        it('does not complete on webhook failure, and a resubmit retries the webhook without a duplicate source', async () => {
             jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
                 apiSchema('posthog/posthog.workflow_runs', { supports_webhooks: true }),
             ] as ExternalDataSourceSyncSchema[])
-            jest.spyOn(api.externalDataSources, 'create').mockResolvedValue({ id: 'source-1' } as Awaited<
-                ReturnType<typeof api.externalDataSources.create>
-            >)
-            jest.spyOn(api.externalDataSources, 'createWebhook').mockResolvedValue({
-                success: false,
-                webhook_url: '',
-                error: 'Token is missing webhook permissions',
-            })
+            const create = jest.spyOn(api.externalDataSources, 'create').mockResolvedValue({
+                id: 'source-1',
+            } as Awaited<ReturnType<typeof api.externalDataSources.create>>)
+            const createWebhook = jest
+                .spyOn(api.externalDataSources, 'createWebhook')
+                .mockResolvedValueOnce({
+                    success: false,
+                    webhook_url: '',
+                    error: 'Token is missing webhook permissions',
+                })
+                .mockResolvedValueOnce({ success: true, webhook_url: 'https://example.com/webhook' })
 
             const { logic, onComplete, unmount } = mountRequiredTablesWizard(['workflow_runs'])
 
@@ -1105,6 +1108,14 @@ describe('sourceWizardLogic', () => {
 
                 expect(onComplete).not.toHaveBeenCalled()
                 expect(logic.values.isLoading).toBe(false)
+
+                // The source exists now, so a second submit must retry the webhook, not create again.
+                await expectLogic(logic, () => logic.actions.createSource()).toFinishAllListeners()
+
+                expect(create).toHaveBeenCalledTimes(1)
+                expect(createWebhook).toHaveBeenCalledTimes(2)
+                expect(createWebhook).toHaveBeenLastCalledWith('source-1')
+                expect(onComplete).toHaveBeenCalled()
             } finally {
                 unmount()
             }

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceWizardLogic.test.ts
@@ -983,13 +983,18 @@ describe('sourceWizardLogic', () => {
                 ...overrides,
             }) as ExternalDataSourceSyncSchema
 
-        const mountWizard = (): { logic: ReturnType<typeof sourceWizardLogic>; unmount: () => void } => {
+        const mountRequiredTablesWizard = (
+            requiredTables: string[]
+        ): { logic: ReturnType<typeof sourceWizardLogic>; onComplete: jest.Mock; unmount: () => void } => {
+            const onComplete = jest.fn()
             const logic = sourceWizardLogic({
                 availableSources: { Github: githubSource },
-                requiredTables: ['issues'],
-                onComplete: jest.fn(),
+                requiredTables,
+                onComplete,
             })
-            return { logic, unmount: logic.mount() }
+            const unmount = logic.mount()
+            logic.actions.selectConnector(githubSource)
+            return { logic, onComplete, unmount }
         }
 
         afterEach(() => {
@@ -1009,11 +1014,11 @@ describe('sourceWizardLogic', () => {
             const create = jest
                 .spyOn(api.externalDataSources, 'create')
                 .mockResolvedValue({ id: 'source-1' } as Awaited<ReturnType<typeof api.externalDataSources.create>>)
+            const createWebhook = jest.spyOn(api.externalDataSources, 'createWebhook')
 
-            const { logic, unmount } = mountWizard()
+            const { logic, onComplete, unmount } = mountRequiredTablesWizard(['issues'])
 
             try {
-                logic.actions.selectConnector(githubSource)
                 await expectLogic(logic, () => logic.actions.getDatabaseSchemas()).toFinishAllListeners()
 
                 expect(create).toHaveBeenCalledTimes(1)
@@ -1021,6 +1026,9 @@ describe('sourceWizardLogic', () => {
                     expect.objectContaining({ name: 'posthog/posthog.issues', should_sync: true }),
                     expect.objectContaining({ name: 'posthog/posthog-js.issues', should_sync: true }),
                 ])
+                // Poll-synced tables need no webhook, so completion must not wait on one.
+                expect(createWebhook).not.toHaveBeenCalled()
+                expect(onComplete).toHaveBeenCalled()
             } finally {
                 unmount()
             }
@@ -1040,13 +1048,62 @@ describe('sourceWizardLogic', () => {
             )
             const create = jest.spyOn(api.externalDataSources, 'create')
 
-            const { logic, unmount } = mountWizard()
+            const { logic, unmount } = mountRequiredTablesWizard(['issues'])
 
             try {
-                logic.actions.selectConnector(githubSource)
                 await expectLogic(logic, () => logic.actions.getDatabaseSchemas()).toFinishAllListeners()
 
                 expect(create).not.toHaveBeenCalled()
+                expect(logic.values.isLoading).toBe(false)
+            } finally {
+                unmount()
+            }
+        })
+
+        it('registers the webhook before completing when a required table is webhook-synced', async () => {
+            // GitHub's workflow_runs/workflow_jobs are webhook-only: without registration the
+            // tables stay empty forever, while the signal reports itself as set up.
+            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
+                apiSchema('posthog/posthog.workflow_runs', { supports_webhooks: true }),
+            ] as ExternalDataSourceSyncSchema[])
+            jest.spyOn(api.externalDataSources, 'create').mockResolvedValue({ id: 'source-1' } as Awaited<
+                ReturnType<typeof api.externalDataSources.create>
+            >)
+            const createWebhook = jest
+                .spyOn(api.externalDataSources, 'createWebhook')
+                .mockResolvedValue({ success: true, webhook_url: 'https://example.com/webhook' })
+
+            const { logic, onComplete, unmount } = mountRequiredTablesWizard(['workflow_runs'])
+
+            try {
+                await expectLogic(logic, () => logic.actions.getDatabaseSchemas()).toFinishAllListeners()
+
+                expect(createWebhook).toHaveBeenCalledWith('source-1')
+                expect(onComplete).toHaveBeenCalled()
+            } finally {
+                unmount()
+            }
+        })
+
+        it('does not complete when webhook registration fails', async () => {
+            jest.spyOn(api.externalDataSources, 'database_schema').mockResolvedValue([
+                apiSchema('posthog/posthog.workflow_runs', { supports_webhooks: true }),
+            ] as ExternalDataSourceSyncSchema[])
+            jest.spyOn(api.externalDataSources, 'create').mockResolvedValue({ id: 'source-1' } as Awaited<
+                ReturnType<typeof api.externalDataSources.create>
+            >)
+            jest.spyOn(api.externalDataSources, 'createWebhook').mockResolvedValue({
+                success: false,
+                webhook_url: '',
+                error: 'Token is missing webhook permissions',
+            })
+
+            const { logic, onComplete, unmount } = mountRequiredTablesWizard(['workflow_runs'])
+
+            try {
+                await expectLogic(logic, () => logic.actions.getDatabaseSchemas()).toFinishAllListeners()
+
+                expect(onComplete).not.toHaveBeenCalled()
                 expect(logic.values.isLoading).toBe(false)
             } finally {
                 unmount()


### PR DESCRIPTION
## Problem

Connecting GitHub from the Signals inbox fails with the toast "Required tables not found in source: issues", so the source is never created and the signal cannot be enabled.

- The GitHub source names its schema rows `owner/repo.endpoint` for multi-repo connections; only a legacy single-repo source keeps the bare `issues` name ([`is_legacy_bare_repo`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py#L382-L385)).
- The wizard's `requiredTables` check compared `schema.table` exactly, so nothing matched the required `issues` and it returned before creating the source.
- The same check also required one schema per required table, which cannot hold once a required table resolves to one row per repo.
- The already-connected path in `signalSourcesLogic` handles the qualified names correctly, so only the first-time connect flow broke.

## Changes

- The inbox connect flow now creates the GitHub source and selects the `issues` row for every selected repository.
- `sourceWizardLogic` matches a required table by exact name or `.<table>` suffix, and reports missing tables from that match rather than from a count comparison.
- Rows carrying a `permission_error` are excluded from the match. The payload forces `should_sync: true`, so including them would queue a guaranteed-403 sync while Signals reported setup as complete.
- When only unreadable rows satisfy a required table, the toast now carries the permission reason and tells the user to reconnect, matching the wording `SchemaForm` already uses.
- The flow now registers the source's webhook after creation when a required table syncs by webhook, and reports completion only once registration succeeds. `workflow_runs` and `workflow_jobs` are webhook-only, so completing without one enabled CI signals over tables that stay empty forever.
- If webhook registration fails, the toast carries the error, points to the source settings, and the signal stays disabled. The inbox connect surface renders no wizard steps, so the registration happens in the logic rather than on the wizard's webhook step.
- Also affects the other GitHub-backed signal source, `engineering_analytics`, which requires `workflow_runs`, `pull_requests`, and `workflow_jobs`.
- No visible change beyond the toasts, so there is no screenshot to add.

## How did you test this code?

Added five kea logic tests in `tests/sourceWizardLogic.test.ts`:

- Repo-qualified rows satisfy a bare required table, and every readable repo's row is sent to `create`. This is the reported bug: the test fails against the old exact-match code with `create` never called.
- A parameterized pair asserts nothing is created when a required table is absent, or when every matching row carries a `permission_error`. The first guards the suffix match from swallowing a genuine miss; the second guards the force-sync payload from queuing a 403.
- A webhook-synced required table registers the webhook before `onComplete` fires, and a failed registration leaves `onComplete` uncalled. Both fail against the pre-fix code, which never called `createWebhook` and completed unconditionally.

Ran the file's Jest suite, the frontend lint, format, and typecheck, and `hogli ci:preflight --strict` (0 failures). Not tested manually against a real GitHub connection.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by the PostHog Slack app from a report that enabling GitHub in the inbox failed. Diagnosis started from the toast string and traced the naming mismatch between `get_schemas` and the wizard's required-table check.

The narrower alternative was to have the inbox pass repo-qualified table names. That was rejected because the inbox does not know which repositories the user is about to select, and because `ensureRequiredTableSyncing` already matches by suffix; putting the same rule in the wizard keeps the two connect paths consistent.

The permission-error exclusion and the webhook registration came from bot review feedback (Codex and ReviewHog). Both findings were verified against the backend before fixing: the web `create` endpoint never registers webhooks (only the MCP one-shot `setup` path does), and `_maybe_create_webhook` only runs on schema updates. Each review comment has an inline reply with the verification and the fixing commit.

Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`. The PR is unassigned because no GitHub handle for the reporter was verified in this session; the reporter should assign themselves as DRI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1786099697554119)*
