### PR TITLE
fix(workflows): export SES reputation gauges as mostrecent in multiprocess mode

### DIFF
--- a/products/workflows/backend/tasks/ses_account_reputation.py
+++ b/products/workflows/backend/tasks/ses_account_reputation.py
@@ -33,11 +33,16 @@ def poll_ses_account_reputation() -> None:
         (finding["scope"], finding["finding_type"], finding["impact"]) for finding in reputation["findings"]
     )
 
+    # multiprocess_mode="mostrecent" everywhere: the celery workers run prometheus_client in
+    # multiprocess mode, which re-exports these gauges on the pod's own /metrics regardless of
+    # the private registry. Without it, every worker process exposes its own copy frozen at the
+    # last value that pid set, and alerts evaluating those fossil series flap.
     with pushed_metrics_registry("ses_account_reputation") as registry:
         Gauge(
             "posthog_ses_account_enforcement_healthy",
             "1 while AWS SES reports the account EnforcementStatus as HEALTHY, 0 otherwise.",
             registry=registry,
+            multiprocess_mode="mostrecent",
         ).set(1 if reputation["enforcement_status"] == "HEALTHY" else 0)
 
         findings_gauge = Gauge(
@@ -45,6 +50,7 @@ def poll_ses_account_reputation() -> None:
             "Open AWS SES reputation findings (ListRecommendations), by referenced resource scope.",
             labelnames=["scope", "finding_type", "impact"],
             registry=registry,
+            multiprocess_mode="mostrecent",
         )
         for (scope, finding_type, impact), count in finding_counts.items():
             findings_gauge.labels(scope=scope, finding_type=finding_type, impact=impact).set(count)
@@ -53,4 +59,5 @@ def poll_ses_account_reputation() -> None:
             "posthog_ses_account_reputation_last_poll_timestamp_seconds",
             "Unix timestamp of the last successful SES account reputation poll.",
             registry=registry,
+            multiprocess_mode="mostrecent",
         ).set(time.time())


### PR DESCRIPTION
## Problem

The SES reputation poller's gauges leak per-process copies onto each celery worker pod's /metrics.

- prometheus_client's multiprocess mode stores every metric write in per-pid mmap files, regardless of the private registry the task pushes from.
- Each worker process therefore exposes its own copy of the gauges, frozen at the last value that pid set.
- The charts alerts evaluated those fossil series and `SesReputationPollerStaleWarning` flapped in both regions (fixed on the alert side in PostHog/charts#14065 by scoping to the pushgateway job).

## Changes

- The three gauges in `poll_ses_account_reputation` declare `multiprocess_mode="mostrecent"`, so the pod-side export collapses to a single series carrying the latest write instead of one stale series per pid.
- The pushgateway push path is unchanged.

## How did you test this code?

- Existing task tests cover the gauge values; `multiprocess_mode` only changes aggregation in multiprocess collection, which plain test registries don't exercise. Verified `mostrecent` is supported by the pinned prometheus_client (0.22.1).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written with Claude Code alongside PostHog/charts#14065; skills invoked: /writing-pr-descriptions. Root cause found from per-`pid` labels on the flapping alert's series.
