### PR TITLE
feat(conversations): give `support ticket send failed` real context

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -144,9 +144,12 @@ function messagePreviewProperties(message?: string): Record<string, any> {
 }
 
 // Deliberately a different event from the widget endpoint's own `support ticket send failed`, which
-// reports requests the server rejected. That one names the offending field but has no session and no
-// draft, so only an engineer can act on it. This one means the message never left the browser, so it
-// carries what the customer wrote and someone can follow up. Two audiences, so keep them apart.
+// reports requests the server rejected. Both carry session linkage now, so the split is about what
+// happened rather than how much context each one has: this one means the message never left the
+// browser, so it carries the draft the customer would otherwise have to retype. The server-side one
+// means the request arrived and was refused, so it carries the reason and the field-level error code
+// instead — a draft the server rejected is still sitting in the customer's textarea. Keep them
+// apart: the rates mean different things, and only this one is suppressed by ad blockers.
 export function captureSupportTicketBlocked({
     surface,
     reason,

--- a/products/conversations/backend/api/tests/test_widget.py
+++ b/products/conversations/backend/api/tests/test_widget.py
@@ -1,20 +1,32 @@
+import json
 import uuid
 
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.exceptions import ErrorDetail
 from rest_framework.test import APIClient
 
 from posthog.models.comment import Comment
+from posthog.rate_limit import WidgetUserBurstThrottle
 
 from products.conversations.backend.api.serializers import WidgetMessageSerializer
+from products.conversations.backend.api.widget_analytics import (
+    _bounded_keys,
+    _error_codes,
+    _first_code,
+    _trusted_replay_url,
+)
 from products.conversations.backend.models import SigningSecret, Ticket
 from products.conversations.backend.models.constants import ChannelDetail, Status
 from products.conversations.backend.services.identity import compute_identity_hash
+
+WIDGET_ANALYTICS_MODULE = "products.conversations.backend.api.widget_analytics"
 
 
 def _verification_counter(outcome: str, source: str) -> float:
@@ -1111,3 +1123,493 @@ class TestWidgetContextSanitization(SimpleTestCase):
 
         self.assertFalse(serializer.is_valid())
         self.assertIn(field, serializer.errors)
+
+
+class TestWidgetSendFailedAnalytics(BaseTest):
+    """`support ticket send failed` — every exit that returns without creating a message.
+
+    report_team_action is patched in widget_analytics rather than widget, so these exercise the real
+    property construction and leave `support ticket created` alone. Patching is mandatory, not just
+    convenient: settings.TEST disables posthoganalytics, so nothing is observable without it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # WidgetUserBurstThrottle and WidgetTeamThrottle are plain SimpleRateThrottles, so unlike
+        # BurstRateThrottle they stay live under test, against a LocMemCache no one resets.
+        cache.clear()
+
+        self.widget_token = "test_widget_token_sfa"
+        self.secret = "test_secret_key_for_hmac"
+        self.team.conversations_enabled = True
+        self.team.conversations_settings = {"widget_public_token": self.widget_token}
+        self.team.secret_api_token = self.secret
+        self.team.save()
+
+        self.widget_session_id = str(uuid.uuid4())
+        self.distinct_id = "user-123"
+        self.identity_hash = compute_identity_hash(self.distinct_id, self.secret)
+
+        self.client = APIClient()
+
+    def _get_headers(self):
+        return {"HTTP_X_CONVERSATIONS_TOKEN": self.widget_token}
+
+    def _post(self, payload, **extra):
+        """POST with the session auth fields already filled in, so cases state only what they vary."""
+        return self.client.post(
+            "/api/conversations/v1/widget/message",
+            {"widget_session_id": self.widget_session_id, "distinct_id": self.distinct_id, **payload},
+            **self._get_headers(),
+            **extra,
+        )
+
+    def _properties(self, mock_report):
+        self.assertEqual(mock_report.call_count, 1, f"expected exactly one event, got {mock_report.call_args_list}")
+        team, event, properties = mock_report.call_args.args
+        self.assertEqual(team, self.team)
+        self.assertEqual(event, "support ticket send failed")
+        return properties
+
+    def _create_ticket(self, **overrides):
+        return Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id=overrides.pop("widget_session_id", self.widget_session_id),
+            distinct_id=overrides.pop("distinct_id", self.distinct_id),
+            channel_source="widget",
+            **overrides,
+        )
+
+    # --- error_codes: the whole point of the change ---
+
+    @parameterized.expand(
+        [
+            ("empty", "", "blank"),
+            # CharField trims whitespace before validate_message sees it, so this is "blank" too
+            # rather than the custom validator's "invalid" — worth pinning, since the two look
+            # identical from the client's side.
+            ("whitespace_only", "   ", "blank"),
+            ("over_max_length", "x" * 10001, "max_length"),
+        ]
+    )
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_error_codes_say_why_a_field_was_rejected(self, _name, message, expected_code, mock_report):
+        # error_fields is ["message"] for all of these, so without error_codes they collapse into
+        # one indistinguishable bucket — different bugs reported identically.
+        response = self._post({"message": message})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["error_fields"], ["message"])
+        self.assertEqual(properties["error_codes"], {"message": expected_code})
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_missing_message_is_reported_as_required(self, mock_report):
+        response = self._post({})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["error_codes"], {"message": "required"})
+        self.assertFalse(properties["had_message"])
+        self.assertEqual(properties["message_length"], 0)
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_non_field_error_is_reported_with_its_code(self, mock_report):
+        # No auth fields at all, so WidgetAuthSerializer.validate() rejects it.
+        response = self.client.post("/api/conversations/v1/widget/message", {"message": "Hello"}, **self._get_headers())
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["error_fields"], ["non_field_errors"])
+        self.assertEqual(properties["error_codes"], {"non_field_errors": "invalid"})
+        self.assertEqual(properties["auth_mode"], "none")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_multiple_field_errors_are_all_reported(self, mock_report):
+        response = self._post({"message": "x" * 10001, "widget_session_id": "not-a-uuid"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["error_fields"], ["message", "widget_session_id"])
+        self.assertEqual(properties["error_codes"], {"message": "max_length", "widget_session_id": "invalid"})
+
+    # --- reason coverage: exits that used to report nothing ---
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_honeypot_reports_its_reason(self, mock_report):
+        response = self._post({"message": "I am a bot", "_hp": "filled_by_bot"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._properties(mock_report)["reason"], "honeypot")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_disallowed_origin_reports_the_domain_to_allowlist(self, mock_report):
+        self.team.conversations_settings = {
+            "widget_public_token": self.widget_token,
+            "widget_domains": ["allowed.example"],
+        }
+        self.team.save()
+
+        response = self._post({"message": "Hello"}, HTTP_ORIGIN="https://evil.example")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["reason"], "origin_not_allowed")
+        self.assertEqual(properties["origin_host"], "evil.example")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_hostless_origin_falls_back_to_referer(self, mock_report):
+        # A sandboxed iframe sends the literal "Origin: null", which is truthy but has no host.
+        # validate_origin already consults Referer, so the reported host has to as well.
+        self.team.conversations_settings = {
+            "widget_public_token": self.widget_token,
+            "widget_domains": ["allowed.example"],
+        }
+        self.team.save()
+
+        response = self._post(
+            {"message": "Hello"}, HTTP_ORIGIN="null", HTTP_REFERER="https://app.acme.example/settings"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self._properties(mock_report)["origin_host"], "app.acme.example")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_invalid_identity_hash_reports_verification_failed(self, mock_report):
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {"identity_distinct_id": self.distinct_id, "identity_hash": "0" * 64, "message": "Hello"},
+            **self._get_headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["reason"], "identity_verification_failed")
+        self.assertEqual(properties["auth_mode"], "identity")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_missing_signing_secret_reports_not_configured(self, mock_report):
+        # The 403 body is identical to a bad hash on purpose, so the two are only separable here.
+        self.team.secret_api_token = None
+        self.team.save()
+
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {"identity_distinct_id": self.distinct_id, "identity_hash": self.identity_hash, "message": "Hello"},
+            **self._get_headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self._properties(mock_report)["reason"], "identity_not_configured")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_unparseable_ticket_id_reports_its_reason_without_echoing_it(self, mock_report):
+        response = self._post({"message": "Hello", "ticket_id": "'; DROP TABLE--"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["reason"], "invalid_ticket_id")
+        # Free text from an unauthenticated caller is unbounded cardinality, and the reason
+        # already says it was garbage.
+        self.assertIsNone(properties["ticket_id"])
+        self.assertFalse(properties["is_new_ticket"])
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_someone_elses_ticket_reports_forbidden(self, mock_report):
+        ticket = self._create_ticket(widget_session_id=str(uuid.uuid4()), distinct_id="other-user")
+
+        response = self._post({"message": "Hello", "ticket_id": str(ticket.id)})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["reason"], "ticket_forbidden_session")
+        self.assertEqual(properties["ticket_id"], str(ticket.id))
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_identity_ownership_rejection_is_a_separate_reason(self, mock_report):
+        # An identified client sends widget_session_id too, so auth_mode reads "both" and can't
+        # tell the two ownership checks apart — hence separate reasons.
+        ticket = self._create_ticket(distinct_id="someone-else")
+
+        response = self._post(
+            {
+                "message": "Hello",
+                "ticket_id": str(ticket.id),
+                "identity_distinct_id": self.distinct_id,
+                "identity_hash": self.identity_hash,
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["reason"], "ticket_forbidden_identity")
+        self.assertEqual(properties["auth_mode"], "both")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_missing_ticket_reports_not_found(self, mock_report):
+        missing_id = str(uuid.uuid4())
+
+        response = self._post({"message": "Hello", "ticket_id": missing_id})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["reason"], "ticket_not_found")
+        self.assertEqual(properties["ticket_id"], missing_id)
+        self.assertFalse(properties["is_new_ticket"])
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_throttled_request_reports_rate_limited(self, mock_report):
+        # DRF raises Throttled from initial(), before post() runs, so throttled() is the only
+        # place a 429 is visible to analytics. `wait` is stubbed alongside `allow_request` because
+        # DRF calls it straight after, and SimpleRateThrottle.wait reads the `history` that only a
+        # real allow_request would have set.
+        with (
+            patch.object(WidgetUserBurstThrottle, "allow_request", return_value=False),
+            patch.object(WidgetUserBurstThrottle, "wait", return_value=1.0),
+        ):
+            response = self._post({"message": "Hello"})
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(self._properties(mock_report)["reason"], "rate_limited")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_repeated_throttling_reports_once_per_window(self, mock_report):
+        # SimpleRateThrottle.throttle_failure records nothing, so being over the limit is exactly
+        # the state in which requests arrive fastest. Without the dedupe, anyone holding a public
+        # widget token could drive unbounded event volume into PostHog's own project.
+        with (
+            patch.object(WidgetUserBurstThrottle, "allow_request", return_value=False),
+            patch.object(WidgetUserBurstThrottle, "wait", return_value=1.0),
+        ):
+            for _ in range(10):
+                response = self._post({"message": "Hello"})
+
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(mock_report.call_count, 1)
+
+    # --- the context that was missing ---
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_session_linkage_is_reported(self, mock_report):
+        response = self._post(
+            {
+                "message": "",
+                "session_id": "0199-session",
+                "session_context": {
+                    "current_url": "https://acme.example/insights/new?tab=trends",
+                    "session_replay_url": "https://us.posthog.com/replay/0199-session",
+                },
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["client_session_id"], "0199-session")
+        self.assertEqual(properties["client_distinct_id"], self.distinct_id)
+        self.assertEqual(properties["session_replay_url"], "https://us.posthog.com/replay/0199-session")
+        self.assertEqual(properties["current_url_host"], "acme.example")
+        self.assertEqual(properties["current_url_path"], "/insights/new")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_current_url_query_string_is_never_reported(self, mock_report):
+        # Customer URLs routinely carry reset tokens, emails and record ids. Splitting host from
+        # path also means no single property is URL-shaped, so PropertiesTable can't render an
+        # attacker-supplied value as a clickable link.
+        response = self._post(
+            {
+                "message": "",
+                "session_context": {"current_url": "https://acme.example/reset?token=abc123&email=jane@acme.example"},
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(properties["current_url_path"], "/reset")
+        self.assertNotIn("abc123", json.dumps(properties))
+        self.assertNotIn("jane@acme.example", json.dumps(properties))
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_reply_to_an_existing_ticket_is_distinguishable_from_first_contact(self, mock_report):
+        ticket = self._create_ticket()
+
+        response = self._post({"message": "", "ticket_id": str(ticket.id)})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertFalse(properties["is_new_ticket"])
+        self.assertEqual(properties["ticket_id"], str(ticket.id))
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_identity_distinct_id_is_reported_when_there_is_no_plain_one(self, mock_report):
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {"identity_distinct_id": self.distinct_id, "identity_hash": "0" * 64, "message": "Hello"},
+            **self._get_headers(),
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(self._properties(mock_report)["client_distinct_id"], self.distinct_id)
+
+    # --- what must never reach the event ---
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_message_content_is_never_reported(self, mock_report):
+        secret = "my card number is 4111111111111111"
+
+        response = self._post({"message": secret + " " * 10, "widget_session_id": "not-a-uuid"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertNotIn(secret, json.dumps(properties))
+        self.assertTrue(properties["had_message"])
+        self.assertEqual(properties["message_length"], len(secret) + 10)
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_trait_values_are_never_reported(self, mock_report):
+        response = self._post({"message": "", "traits": {"email": "customer@acme.example", "name": "Ada"}})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertTrue(properties["has_traits"])
+        self.assertNotIn("customer@acme.example", json.dumps(properties))
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_offsite_replay_url_is_dropped(self, mock_report):
+        # Staff read this event in a UI that renders URL properties as links, and the value comes
+        # from an unauthenticated caller.
+        response = self._post(
+            {
+                "message": "",
+                "session_context": {
+                    "session_replay_url": "https://evil.example/phish",
+                    "current_url": "https://acme.example/dashboard",
+                },
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertIsNone(properties["session_replay_url"])
+        self.assertEqual(properties["current_url_host"], "acme.example")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_oversized_values_are_truncated(self, mock_report):
+        response = self._post(
+            {
+                "message": "",
+                "distinct_id": "d" * 1000,
+                "session_context": {"current_url": "https://acme.example/" + "q" * 3000},
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        properties = self._properties(mock_report)
+        self.assertEqual(len(properties["current_url_path"]), 500)
+        # Matches the serializer's own max_length, so an id it would have accepted is never cut.
+        self.assertEqual(len(properties["client_distinct_id"]), 400)
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_control_characters_are_stripped(self, mock_report):
+        # These land in a console-and-browser UI that staff read.
+        response = self._post({"message": "", "distinct_id": "user\x00\x1b[31m-123"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(self._properties(mock_report)["client_distinct_id"], "user[31m-123")
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_payload_keys_are_bounded(self, mock_report):
+        junk = {f"k{i}" * 40: "v" for i in range(100)}
+
+        response = self._post({"message": "", **junk})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        payload_keys = self._properties(mock_report)["payload_keys"]
+        self.assertLessEqual(len(payload_keys), 25)
+        self.assertLessEqual(max(len(key) for key in payload_keys), 50)
+        # Sorted and deduped before slicing, so the same key set always yields the same value —
+        # slicing insertion order first would make it depend on how the client serialized the body.
+        self.assertEqual(payload_keys, sorted(set(payload_keys)))
+
+    # --- contracts ---
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.capture_exception")
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action", side_effect=Exception("analytics is down"))
+    def test_analytics_failure_does_not_change_the_response(self, _mock_report, mock_capture):
+        response = self._post({"message": ""})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("message", response.json()["details"])
+        self.assertEqual(mock_capture.call_count, 1)
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_successful_send_reports_no_failure(self, mock_report):
+        response = self._post({"message": "Hello"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_report.assert_not_called()
+
+    @patch(f"{WIDGET_ANALYTICS_MODULE}.report_team_action")
+    def test_unauthenticated_request_reports_nothing(self, mock_report):
+        response = self.client.post(
+            "/api/conversations/v1/widget/message",
+            {"message": "Hello"},
+            headers={"x-conversations-token": "invalid_token"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        # There is no team to attribute it to — a known blind spot, not an oversight.
+        mock_report.assert_not_called()
+
+
+class TestWidgetSendFailedExtraction(SimpleTestCase):
+    """Unit coverage for the extraction helpers, including shapes the view can't produce today."""
+
+    @parameterized.expand(
+        [
+            ("flat_list", {"message": [ErrorDetail("nope", code="blank")]}, {"message": "blank"}),
+            # DictField.run_child_validation nests one level. Unreachable until someone adds
+            # `child=` to traits or session_context, which must not silently drop the code then.
+            ("nested_dict", {"traits": {"email": [ErrorDetail("nope", code="null")]}}, {"traits": "null"}),
+            ("plain_string", {"message": "handed a bare string"}, {"message": "unknown"}),
+            ("empty_detail", {"message": []}, {}),
+            ("not_a_dict", "not a dict", {}),
+            ("none", None, {}),
+        ]
+    )
+    def test_error_codes_extraction(self, _name, errors, expected):
+        self.assertEqual(_error_codes(errors), expected)
+
+    def test_deeply_nested_detail_gives_up_rather_than_recursing(self):
+        detail = [[[[[ErrorDetail("nope", code="blank")]]]]]
+
+        self.assertIsNone(_first_code(detail))
+
+    @parameterized.expand(
+        [
+            ("app_host", "https://us.posthog.com/replay/abc", "https://us.posthog.com/replay/abc"),
+            ("bare_host", "https://posthog.com/replay/abc", "https://posthog.com/replay/abc"),
+            ("offsite", "https://evil.example/replay/abc", None),
+            # Suffix matching must not be fooled by a lookalike domain.
+            ("lookalike", "https://notposthog.com/replay/abc", None),
+            ("insecure", "http://us.posthog.com/replay/abc", None),
+            ("relative", "/replay/abc", None),
+            ("not_a_string", 12345, None),
+            ("empty", "", None),
+        ]
+    )
+    def test_trusted_replay_url(self, _name, value, expected):
+        self.assertEqual(_trusted_replay_url(value), expected)
+
+    def test_bounded_keys_does_not_depend_on_insertion_order(self):
+        keys = [f"key_{i}" for i in range(40)]
+
+        forwards = _bounded_keys(dict.fromkeys(keys, "v"), 25)
+        backwards = _bounded_keys(dict.fromkeys(reversed(keys), "v"), 25)
+
+        self.assertEqual(forwards, backwards)
+        self.assertEqual(len(forwards), 25)
+
+    def test_bounded_keys_dedupes_keys_that_truncate_to_the_same_prefix(self):
+        source = {"a" * 60 + "_x": "v", "a" * 60 + "_y": "v"}
+
+        self.assertEqual(_bounded_keys(source, 25), ["a" * 50])

--- a/products/conversations/backend/api/widget.py
+++ b/products/conversations/backend/api/widget.py
@@ -13,6 +13,7 @@ Anonymous users are controlled by widget_session_id. Verified users are controll
 
 import uuid
 import logging
+from typing import NoReturn
 
 from django.db.models import F, Q
 
@@ -38,6 +39,11 @@ from products.conversations.backend.api.serializers import (
     WidgetMessagesQuerySerializer,
     WidgetTicketsQuerySerializer,
     validate_origin,
+)
+from products.conversations.backend.api.widget_analytics import (
+    SendFailureReason,
+    report_widget_rate_limited,
+    report_widget_send_failed,
 )
 from products.conversations.backend.cache import (
     get_cached_messages,
@@ -155,53 +161,49 @@ class WidgetMessageView(APIView):
     permission_classes = [AllowAny]
     throttle_classes = [WidgetUserBurstThrottle, WidgetTeamThrottle]
 
+    def throttled(self, request: Request, wait: float) -> NoReturn:
+        """A throttled customer can't send a message at all, so it belongs in the failure series.
+
+        DRF raises Throttled from initial(), before post() runs, so this is the only place the 429
+        is visible. report_widget_rate_limited rather than the plain reporter because being over
+        the limit is exactly the state in which requests arrive fastest — it dedupes per window.
+        """
+        team = getattr(request, "auth", None)
+        if isinstance(team, Team):
+            report_widget_rate_limited(team, request)
+        super().throttled(request, wait)
+
     def post(self, request: Request) -> Response:
         """Handle incoming message from widget."""
 
         team: Team | None = request.auth  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         if not team:
+            # report_team_action needs a team, so this exit stays uninstrumented: a customer who
+            # rotated their widget token sees every send fail and we see nothing. A counter like
+            # IDENTITY_VERIFICATION_COUNTER is the right tool for it, not an event.
             return Response({"error": "Authentication required"}, status=status.HTTP_403_FORBIDDEN)
 
         # Check honeypot field (bots fill this)
         if request.data.get("_hp"):
+            # Runs before the origin check below, so an off-domain bot lands here rather than in
+            # `origin_not_allowed`. Filter this reason out when measuring real customer failures.
+            report_widget_send_failed(team, request, SendFailureReason.HONEYPOT)
             return Response({"error": "Invalid request"}, status=status.HTTP_400_BAD_REQUEST)
 
         # Validate origin
         if not validate_origin(request, team):
+            # A misconfigured widget_domains allowlist rejects every ticket a team sends, and the
+            # 403 is silent from their side — `origin_host` names the domain they need to add.
+            report_widget_send_failed(team, request, SendFailureReason.ORIGIN_NOT_ALLOWED)
             return Response({"error": "Origin not allowed"}, status=status.HTTP_403_FORBIDDEN)
 
         # Validate and extract data
         serializer = WidgetMessageSerializer(data=request.data)
         if not serializer.is_valid():
             logger.warning("Validation error in WidgetMessageView", extra={"errors": serializer.errors})
-            try:
-                # Track rejected submissions server-side so they're queryable even when the
-                # client-side event is blocked (ad blockers, network drops). Field names and
-                # value lengths only — never message content. An over-long auto-captured
-                # session_context value (e.g. current_url) is a known rejection cause.
-                # This endpoint is public and unauthenticated, so session_context is
-                # attacker-controlled: bound both the number of fields and the key length we
-                # record so a request stuffed with many keys can't inflate the event payload.
-                raw_session_context = request.data.get("session_context")
-                session_context_field_count = len(raw_session_context) if isinstance(raw_session_context, dict) else 0
-                session_context_field_lengths = {}
-                if isinstance(raw_session_context, dict):
-                    for key, value in list(raw_session_context.items())[:20]:
-                        if isinstance(key, str) and isinstance(value, str):
-                            session_context_field_lengths[key[:100]] = len(value)
-                report_team_action(
-                    team,
-                    "support ticket send failed",
-                    {
-                        "channel_source": "widget",
-                        "reason": "validation_error",
-                        "error_fields": sorted(serializer.errors.keys()),
-                        "session_context_field_count": session_context_field_count,
-                        "session_context_field_lengths": session_context_field_lengths,
-                    },
-                )
-            except Exception as e:
-                capture_exception(e)
+            # Track rejected submissions server-side so they're queryable even when the
+            # client-side event is blocked (ad blockers, network drops).
+            report_widget_send_failed(team, request, SendFailureReason.VALIDATION_ERROR, serializer=serializer)
             return Response(
                 {"error": "Invalid request data", "details": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
             )
@@ -209,6 +211,17 @@ class WidgetMessageView(APIView):
         try:
             verified_distinct_id = _verify_identity(serializer.validated_data, team)
         except IdentityVerificationFailed as e:
+            # The response is deliberately identical for both (see IdentityVerificationNotConfigured),
+            # so if analytics can't separate them the distinction exists nowhere: "not configured" is
+            # the team's setup to fix, "verification failed" is a client signing bug or an attack.
+            report_widget_send_failed(
+                team,
+                request,
+                SendFailureReason.IDENTITY_NOT_CONFIGURED
+                if isinstance(e, IdentityVerificationNotConfigured)
+                else SendFailureReason.IDENTITY_VERIFICATION_FAILED,
+                serializer=serializer,
+            )
             return Response({"error": e.public_error}, status=status.HTTP_403_FORBIDDEN)
 
         if verified_distinct_id is not None:
@@ -219,6 +232,9 @@ class WidgetMessageView(APIView):
             widget_session_id = str(serializer.validated_data["widget_session_id"])
             distinct_id = serializer.validated_data["distinct_id"]
         else:
+            # Unreachable while the serializer's validate() requires one auth mode or the other.
+            # Instrumented anyway: if it ever fires, that invariant has broken.
+            report_widget_send_failed(team, request, SendFailureReason.NO_AUTH_CONTEXT, serializer=serializer)
             return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
         message_content = serializer.validated_data["message"]
@@ -233,6 +249,7 @@ class WidgetMessageView(APIView):
             try:
                 ticket_id = str(serializers.UUIDField().to_internal_value(raw_ticket_id))
             except ValidationError:
+                report_widget_send_failed(team, request, SendFailureReason.INVALID_TICKET_ID, serializer=serializer)
                 return Response({"error": "Invalid ticket_id format"}, status=status.HTTP_400_BAD_REQUEST)
 
         # Find or create ticket
@@ -241,13 +258,22 @@ class WidgetMessageView(APIView):
             try:
                 ticket = Ticket.objects.get(id=ticket_id, team=team)
 
+                # The two ownership checks get their own reasons. An identified client sends both
+                # widget_session_id and the identity fields, so auth_mode reads "both" here and
+                # can't say which check rejected — and they mean different things.
                 if verified_distinct_id is not None:
                     allowed_ids = get_person_distinct_ids(team.id, verified_distinct_id)
                     if ticket.distinct_id not in allowed_ids:
+                        report_widget_send_failed(
+                            team, request, SendFailureReason.TICKET_FORBIDDEN_IDENTITY, serializer=serializer
+                        )
                         return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
                 else:
                     # CRITICAL: Verify ticket belongs to this widget_session_id (NOT distinct_id)
                     if ticket.widget_session_id != widget_session_id:
+                        report_widget_send_failed(
+                            team, request, SendFailureReason.TICKET_FORBIDDEN_SESSION, serializer=serializer
+                        )
                         return Response({"error": "Forbidden"}, status=status.HTTP_403_FORBIDDEN)
 
                 # Only HMAC-verified requests may (re)bind a ticket's distinct_id.
@@ -285,6 +311,7 @@ class WidgetMessageView(APIView):
                 ticket.refresh_from_db()
 
             except Ticket.DoesNotExist:
+                report_widget_send_failed(team, request, SendFailureReason.TICKET_NOT_FOUND, serializer=serializer)
                 return Response({"error": "Ticket not found"}, status=status.HTTP_404_NOT_FOUND)
         else:
             # No ticket_id provided - always create a new ticket

--- a/products/conversations/backend/api/widget_analytics.py
+++ b/products/conversations/backend/api/widget_analytics.py
@@ -1,0 +1,336 @@
+"""Server-side analytics for widget submissions that never became a ticket.
+
+`support ticket send blocked` (frontend, supportLogic.ts) covers messages that never left the
+browser. This covers the other half: requests that reached us and were refused. They are
+complementary rather than redundant — an ad blocker suppresses the client event and neither one
+survives a network drop, and only the server knows which field it rejected and why.
+
+This event lands in PostHog's own project (posthoganalytics is keyed to it in posthog/apps.py),
+not the customer's. That rules out reserved property names: `$session_id`, `$current_url` and
+`distinct_id` describe a session and a person that live in the *customer's* project, so attaching
+them here would manufacture phantom sessions and persons in ours, and a `distinct_id` property
+would shadow the event's real one. Everything client-supplied is therefore prefixed `client_` or
+named plainly.
+
+WidgetMessageView is AllowAny and most of these exits happen before validation, so treat every
+value read here as attacker-controlled: type-check it, truncate it, and bound how many entries can
+be recorded.
+"""
+
+import re
+import uuid
+from enum import StrEnum
+from typing import Any
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.core.cache import cache
+
+from rest_framework.request import Request
+from rest_framework.serializers import Serializer
+
+from posthog.api.utils import parse_domain
+from posthog.event_usage import report_team_action
+from posthog.exceptions_capture import capture_exception
+from posthog.models import Team
+
+SEND_FAILED_EVENT = "support ticket send failed"
+
+
+class SendFailureReason(StrEnum):
+    """One constant per exit from WidgetMessageView.post that returns without a message.
+
+    An enum rather than bare strings so adding an exit without a reason is visibly wrong, and so a
+    typo at a call site fails at import rather than silently splitting a series. The values are the
+    breakdown key on the event, so renaming one breaks continuity.
+    """
+
+    HONEYPOT = "honeypot"
+    ORIGIN_NOT_ALLOWED = "origin_not_allowed"
+    VALIDATION_ERROR = "validation_error"
+    IDENTITY_VERIFICATION_FAILED = "identity_verification_failed"
+    IDENTITY_NOT_CONFIGURED = "identity_not_configured"
+    NO_AUTH_CONTEXT = "no_auth_context"
+    INVALID_TICKET_ID = "invalid_ticket_id"
+    # Two exits, not one: an identity-mode rejection is a person-merge problem and a session-mode
+    # rejection is a localStorage problem. auth_mode can't separate them, because the widget sends
+    # both sets of fields once a user is identified.
+    TICKET_FORBIDDEN_IDENTITY = "ticket_forbidden_identity"
+    TICKET_FORBIDDEN_SESSION = "ticket_forbidden_session"
+    TICKET_NOT_FOUND = "ticket_not_found"
+    RATE_LIMITED = "rate_limited"
+
+
+# Caps on what reaches the event, not on what the request may contain. The body is already bounded
+# by DATA_UPLOAD_MAX_MEMORY_SIZE; these bound the *analytics* payload so a stuffed request can't
+# inflate it.
+_MAX_ID_LENGTH = 400  # matches WidgetMessageSerializer.distinct_id, so a valid id is never cut
+_MAX_SESSION_ID_LENGTH = 64  # matches WidgetMessageSerializer.session_id
+_MAX_URL_LENGTH = 500
+_MAX_HOST_LENGTH = 100
+_MAX_KEY_LENGTH = 50
+_MAX_PAYLOAD_KEYS = 25
+_MAX_ERROR_FIELDS = 25
+_MAX_ERROR_DEPTH = 3
+
+# One rate_limited event per team per window. DRF's SimpleRateThrottle.throttle_failure records
+# nothing, so the throttle bounds *allowed* requests, not denied ones — without this, a client stuck
+# in a retry loop emits an event per rejected request rather than one per problem.
+_RATE_LIMITED_REPORT_TTL_SECONDS = 60
+
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _bounded_str(value: Any, max_length: int) -> str | None:
+    """Genuine non-empty strings only, stripped of control characters and truncated.
+
+    Deliberately does not coerce: a client sending `{"session_id": {...}}` is a bug worth seeing as
+    a missing value, not worth serialising an arbitrary object into an event property. Control
+    characters are dropped for the same reason sanitize_header_value drops them — these land in a
+    console-and-browser UI that staff read.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    return _CONTROL_CHARACTERS.sub("", value)[:max_length] or None
+
+
+def _host(url: Any) -> str | None:
+    """Hostname only. urlparse raises ValueError on a malformed IPv6 authority."""
+    if not isinstance(url, str):
+        return None
+    try:
+        hostname = parse_domain(url)
+    except ValueError:
+        return None
+    return hostname[:_MAX_HOST_LENGTH].lower() if hostname else None
+
+
+def _url_path(url: Any) -> str | None:
+    """The path, without host, query or fragment.
+
+    Recorded instead of the full URL. `current_url` is client-supplied on an unauthenticated
+    endpoint and PropertiesTable renders any URL-shaped property value as a clickable link, so
+    storing a whole URL would reopen the hole _trusted_replay_url exists to close. Dropping the
+    query string also keeps reset tokens, emails and record ids — routinely in a customer's URLs —
+    out of PostHog's own project. Host is reported separately, so "which page" survives intact.
+    """
+    if not isinstance(url, str):
+        return None
+    try:
+        return _bounded_str(urlparse(url).path, _MAX_URL_LENGTH)
+    except ValueError:
+        return None
+
+
+def _trusted_replay_url(value: Any) -> str | None:
+    """A replay link is recorded only when it points at PostHog.
+
+    The URL is client-supplied on an unauthenticated endpoint, and the event it lands in is read by
+    PostHog staff in our own project, where the UI renders URL properties as clickable links.
+    Without this check anyone holding a public widget token could plant an arbitrary link in front
+    of an engineer. It costs nothing: a real replay URL is always on a PostHog host.
+    """
+    url = _bounded_str(value, _MAX_URL_LENGTH)
+    if url is None:
+        return None
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    if parsed.scheme != "https":
+        return None
+    hostname = (parsed.hostname or "").lower()
+    if hostname == "posthog.com" or hostname.endswith(".posthog.com") or hostname == _host(settings.SITE_URL):
+        return url
+    return None
+
+
+def _ticket_uuid(value: Any) -> str | None:
+    """Only a parseable UUID.
+
+    An unparseable ticket_id is attacker-controlled free text, so recording it verbatim would be
+    unbounded cardinality — and `reason=invalid_ticket_id` already says it was garbage.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        return str(uuid.UUID(value))
+    except ValueError:
+        return None
+
+
+def _first_code(detail: Any, depth: int = 0) -> str | None:
+    """First DRF error `code` inside a possibly-nested error detail.
+
+    `serializer.errors` is field -> list[ErrorDetail], and ErrorDetail is a str subclass carrying
+    `.code`. Two shapes deviate: non-field errors land under "non_field_errors" with the same list
+    shape, and a nested DictField or child serializer yields field -> {inner_key: [ErrorDetail]}.
+    The nested shape doesn't happen for WidgetMessageSerializer today — its DictFields use the
+    default unvalidated child, which cannot fail — but it will the day someone adds `child=`, and
+    this must not start dropping codes or raising then.
+
+    Depth-bounded, because this runs on an error path where a second failure would mask the first.
+    """
+    if depth > _MAX_ERROR_DEPTH:
+        return None
+    if isinstance(detail, list | tuple):
+        for item in detail:
+            code = _first_code(item, depth + 1)
+            if code:
+                return code
+        return None
+    if isinstance(detail, dict):
+        for item in detail.values():
+            code = _first_code(item, depth + 1)
+            if code:
+                return code
+        return None
+    code = getattr(detail, "code", None)
+    if isinstance(code, str):
+        return code[:_MAX_KEY_LENGTH]
+    # A plain str can appear if a validator was handed one directly. "unknown" beats a missing key:
+    # a breakdown showing "unknown" is a bug report, a missing key is invisible.
+    return "unknown" if isinstance(detail, str) else None
+
+
+def _error_codes(errors: Any) -> dict[str, str]:
+    """field -> the code that rejected it, e.g. {"message": "max_length"}.
+
+    Codes rather than messages: DRF's codes are a small closed vocabulary ("required", "blank",
+    "max_length", "invalid", "null", "not_a_dict"), so they break down cleanly, while messages are
+    prose that gets reworded and would put a sentence into a property value.
+
+    One code per field, because a field almost always fails one check first and a flat string map
+    stays readable in HogQL without unnesting.
+    """
+    codes: dict[str, str] = {}
+    if not isinstance(errors, dict):
+        return codes
+    for field, detail in list(errors.items())[:_MAX_ERROR_FIELDS]:
+        if not isinstance(field, str):
+            continue
+        code = _first_code(detail)
+        if code:
+            codes[field[:_MAX_KEY_LENGTH]] = code
+    return codes
+
+
+def _bounded_keys(source: Any, limit: int) -> list[str]:
+    """Sorted, truncated, deduplicated string keys — a bound on cardinality, not a faithful copy.
+
+    Sorts and dedupes before slicing, so the result depends on the key set rather than on the order
+    the JSON parser happened to see it in. Slicing first would make the same logical payload
+    produce different values across requests, and would leave duplicates behind when two long keys
+    truncate to the same prefix.
+    """
+    if not isinstance(source, dict):
+        return []
+    return sorted({key[:_MAX_KEY_LENGTH] for key in source if isinstance(key, str)})[:limit]
+
+
+def _auth_mode(data: dict) -> str:
+    """Which access-control path the client attempted. Four values, so it breaks down."""
+    has_identity = bool(data.get("identity_distinct_id")) and bool(data.get("identity_hash"))
+    has_session = bool(data.get("widget_session_id"))
+    if has_identity and has_session:
+        return "both"
+    if has_identity:
+        return "identity"
+    if has_session:
+        return "widget_session"
+    return "none"
+
+
+def report_widget_send_failed(
+    team: Team,
+    request: Request,
+    reason: SendFailureReason,
+    *,
+    serializer: Serializer | None = None,
+) -> None:
+    """Record a widget message that was rejected, with enough context to act on it.
+
+    Never raises. Every call site is already returning an error to the customer; losing the
+    analytics must not turn a 400 into a 500.
+
+    `serializer` is optional because the earliest exits happen before or during validation. When it
+    is passed and validated cleanly, its `validated_data` is preferred over the raw body: the
+    serializer has already type-checked and truncated those fields, so the recorded values match
+    what a successful request would have stored. When it failed, only the raw body is available and
+    every read is defended. Callers must have called `is_valid()` first — `.errors` and
+    `.validated_data` assert on that.
+    """
+    try:
+        # request.data is a list or a str for a non-object JSON body, where `.get` would raise.
+        raw = request.data if isinstance(request.data, dict) else {}
+        errors = serializer.errors if serializer is not None else {}
+        validated = serializer.validated_data if serializer is not None and not errors else {}
+        source = validated or raw
+
+        session_context = source.get("session_context")
+        if not isinstance(session_context, dict):
+            session_context = {}
+        current_url = session_context.get("current_url")
+
+        raw_ticket_id = raw.get("ticket_id")
+        message = source.get("message")
+
+        report_team_action(
+            team,
+            SEND_FAILED_EVENT,
+            {
+                "channel_source": "widget",
+                "reason": str(reason),
+                "error_fields": _bounded_keys(errors, _MAX_ERROR_FIELDS),
+                "error_codes": _error_codes(errors),
+                # Length, never content — but "was there a draft at all" separates a customer who
+                # lost words from a bot probing the endpoint.
+                "had_message": bool(_bounded_str(message, 1)),
+                "message_length": len(message) if isinstance(message, str) else 0,
+                "auth_mode": _auth_mode(source),
+                "is_new_ticket": not raw_ticket_id,
+                "ticket_id": _ticket_uuid(raw_ticket_id),
+                "client_session_id": _bounded_str(source.get("session_id"), _MAX_SESSION_ID_LENGTH),
+                "client_distinct_id": _bounded_str(
+                    source.get("distinct_id") or source.get("identity_distinct_id"), _MAX_ID_LENGTH
+                ),
+                "session_replay_url": _trusted_replay_url(session_context.get("session_replay_url")),
+                # Split rather than stored whole — see _url_path.
+                "current_url_host": _host(current_url),
+                "current_url_path": _url_path(current_url),
+                # Presence only. Trait values are the customer's own name and email.
+                "has_traits": bool(source.get("traits")),
+                # Browser-attested, so this is the domain a team actually has to allowlist. Falls
+                # back per-header rather than on the raw string: a sandboxed iframe sends the
+                # literal "Origin: null", which is truthy but has no host.
+                "origin_host": _host(request.headers.get("Origin")) or _host(request.headers.get("Referer")),
+                "payload_shape": type(request.data).__name__[:_MAX_KEY_LENGTH],
+                "payload_keys": _bounded_keys(raw, _MAX_PAYLOAD_KEYS),
+            },
+        )
+    except Exception as e:
+        capture_exception(e)
+
+
+def report_widget_rate_limited(team: Team, request: Request) -> None:
+    """Record a throttled send, at most once per team per window.
+
+    Needs its own entry point because the throttle offers no backpressure here: DRF's
+    SimpleRateThrottle only writes to the cache on success, so once a caller is over the limit
+    every further request is a fresh denial. Reporting each one would let anyone holding a public
+    widget token drive unbounded event volume into PostHog's own project. One event per window says
+    the same thing — this team is hitting the limit — at a bounded cost.
+
+    cache.add is the dedupe: it sets the key only when absent, so the first caller in the window
+    reports and the rest are no-ops.
+    """
+    try:
+        if not cache.add(
+            f"conversations/send-failed-rate-limited/{team.id}", True, timeout=_RATE_LIMITED_REPORT_TTL_SECONDS
+        ):
+            return
+    except Exception as e:
+        # A cache outage must not silently turn the dedupe off, so fail closed and report nothing.
+        capture_exception(e)
+        return
+    report_widget_send_failed(team, request, SendFailureReason.RATE_LIMITED)


### PR DESCRIPTION
## Problem

`support ticket send failed` was attributed to the team UUID with five shape-only
properties, so a failure told you a field name and nothing else — no person, no
session, no ticket, and no reason beyond `validation_error`.

Live data in project 2 showed the cost: the dominant signal was
`error_fields = ["message"]`, which collapses `blank`, `max_length` and `required`
into one indistinguishable bucket. It also fired at only **one of the ten ways** a
widget send can fail — a misconfigured `widget_domains` allowlist 403s every ticket
a team sends, and that was completely invisible.

## Changes

- New `products/conversations/backend/api/widget_analytics.py`: a
  `report_widget_send_failed` helper and a `SendFailureReason` enum, called from
  every exit in `WidgetMessageView.post` that returns without creating a message,
  plus a `throttled()` override for the 429.
- New properties: `error_codes` (per-field DRF error code), session linkage
  (`client_session_id`, `session_replay_url`, `current_url_host`/`_path`),
  `client_distinct_id`, `is_new_ticket`/`ticket_id`, `auth_mode`, `origin_host`.
- Dropped `session_context_field_count`/`_lengths`, near-dead since
  `_sanitize_context` started truncating instead of raising. No saved insight
  references them.
- `error_fields` keeps its exact semantics, so existing history stays comparable.

## Safety

The endpoint is `AllowAny`, so every value is treated as attacker-controlled:
type-checked, control-character-stripped, truncated, and bounded in count.

URLs are split into host and path so **no property is URL-shaped** —
`PropertiesTable` renders URL-valued properties as clickable `<Link>`s, and the
value comes from an unauthenticated caller. Dropping the query string also keeps
reset tokens and emails out of PostHog's own project. Message content and trait
values are never recorded, only presence and length.

Rate-limit reporting dedupes per team per minute: DRF's
`SimpleRateThrottle.throttle_failure` records nothing, so being over the limit is
exactly the state in which requests arrive fastest.

## Reviewer notes

- **`client_distinct_id` may be an email** when customers call
  `posthog.identify('jane@acme.com')`, which sits awkwardly beside the rule that
  suppresses trait values for that reason. Deliberate, but worth a second opinion.
- **Honeypot ordering:** the `_hp` check runs *before* origin validation, so
  off-domain bots land in `honeypot`, not `origin_not_allowed`. Default internal
  insights to `reason NOT IN ('honeypot', 'rate_limited')`.
- **Pre-existing, not fixed here:** a non-object JSON body 500s in
  `posthog/rate_limit.py:1065` (`request.data.get(...)` unguarded) before the view
  runs.
- Filter `$lib = 'posthog-python'` on any insight — legacy `$lib = web` rows share
  this event name until pre-rename bundles age out.

## Testing

`products/conversations/backend/api/tests/test_widget.py` had zero coverage of this
event; it now has 47 cases across `TestWidgetSendFailedAnalytics` and
`TestWidgetSendFailedExtraction`. 112 pass locally.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*