### PR TITLE
fix(projects): match ?search= as a phrase, not as split terms

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -13,7 +13,7 @@ from django.utils.dateparse import parse_datetime
 import structlog
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field, extend_schema_view
-from rest_framework import exceptions, filters, request, response, serializers, viewsets
+from rest_framework import exceptions, request, response, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import BasePermission, IsAuthenticated
 
@@ -53,6 +53,7 @@ from posthog.constants import AvailableFeature
 from posthog.decorators import disallow_if_impersonated
 from posthog.event_usage import report_user_action
 from posthog.exceptions import Conflict
+from posthog.filters import PhraseSearchFilter
 from posthog.geoip import get_geoip_properties
 from posthog.helpers.impersonation import is_impersonated
 from posthog.models import User
@@ -1358,7 +1359,7 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
     queryset = Project.objects.all().select_related("organization").prefetch_related("teams")
     lookup_field = "id"
     ordering = "-created_by"
-    filter_backends = [filters.SearchFilter]
+    filter_backends = [PhraseSearchFilter]
     search_fields = ["name"]
 
     def safely_get_queryset(self, queryset):

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -694,6 +694,16 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
             name="User Analytics",
             initiating_user=self.user,
         )
+        Project.objects.create_with_team(
+            organization=self.organization,
+            name="Acme Non-prod",
+            initiating_user=self.user,
+        )
+        Project.objects.create_with_team(
+            organization=self.organization,
+            name="Acme NON PROD Portal",
+            initiating_user=self.user,
+        )
 
         response = self.client.get("/api/projects/?search=Analytics")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -712,6 +722,12 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 0)
+
+        for query in ("NON%20PROD", "%22NON%20PROD%22"):
+            response = self.client.get(f"/api/projects/?search={query}")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            results = response.json()["results"]
+            self.assertEqual([r["name"] for r in results], ["Acme NON PROD Portal"])
 
     def test_read_only_api_key_cannot_update_project_config_fields(self):
         """API keys with only project:read scope should not be able to modify config fields via /api/projects/."""

--- a/posthog/api/test/test_project.py
+++ b/posthog/api/test/test_project.py
@@ -667,7 +667,7 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         response = self.client.post(f"/api/projects/{self.project.id}/generate_conversations_public_token/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_project_name_search_filter(self):
+    def _create_searchable_projects(self) -> None:
         self.organization.available_product_features = [
             {
                 "key": AvailableFeature.ORGANIZATIONS_PROJECTS,
@@ -679,55 +679,37 @@ class TestProjectAPI(team_api_test_factory()):  # type: ignore
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
 
-        Project.objects.create_with_team(
-            organization=self.organization,
-            name="Analytics Dashboard",
-            initiating_user=self.user,
-        )
-        Project.objects.create_with_team(
-            organization=self.organization,
-            name="Revenue Tracker",
-            initiating_user=self.user,
-        )
-        Project.objects.create_with_team(
-            organization=self.organization,
-            name="User Analytics",
-            initiating_user=self.user,
-        )
-        Project.objects.create_with_team(
-            organization=self.organization,
-            name="Acme Non-prod",
-            initiating_user=self.user,
-        )
-        Project.objects.create_with_team(
-            organization=self.organization,
-            name="Acme NON PROD Portal",
-            initiating_user=self.user,
-        )
+        for name in [
+            "Analytics Dashboard",
+            "Revenue Tracker",
+            "User Analytics",
+            "Acme Non-prod",
+            "Acme NON PROD Portal",
+        ]:
+            Project.objects.create_with_team(
+                organization=self.organization,
+                name=name,
+                initiating_user=self.user,
+            )
 
-        response = self.client.get("/api/projects/?search=Analytics")
+    @parameterized.expand(
+        [
+            ("term_matching_several", "Analytics", {"Analytics Dashboard", "User Analytics"}),
+            ("term_matching_one", "Revenue", {"Revenue Tracker"}),
+            ("term_matching_none", "nonexistent", set()),
+            # The space is part of the value, so "Acme Non-prod" must not come back
+            ("phrase_keeps_its_space", "NON%20PROD", {"Acme NON PROD Portal"}),
+            # Quotes carry no meaning, so they only match a name that contains them
+            ("quotes_match_literally", "%22NON%20PROD%22", set()),
+        ]
+    )
+    def test_project_name_search_filter(self, _name: str, query: str, expected_names: set[str]) -> None:
+        self._create_searchable_projects()
+
+        response = self.client.get(f"/api/projects/?search={query}")
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json()["results"]
-        self.assertEqual(len(results), 2)
-        names = {r["name"] for r in results}
-        self.assertEqual(names, {"Analytics Dashboard", "User Analytics"})
-
-        response = self.client.get("/api/projects/?search=Revenue")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json()["results"]
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0]["name"], "Revenue Tracker")
-
-        response = self.client.get("/api/projects/?search=nonexistent")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        results = response.json()["results"]
-        self.assertEqual(len(results), 0)
-
-        for query in ("NON%20PROD", "%22NON%20PROD%22"):
-            response = self.client.get(f"/api/projects/?search={query}")
-            self.assertEqual(response.status_code, status.HTTP_200_OK)
-            results = response.json()["results"]
-            self.assertEqual([r["name"] for r in results], ["Acme NON PROD Portal"])
+        self.assertEqual({result["name"] for result in response.json()["results"]}, expected_names)
 
     def test_read_only_api_key_cannot_update_project_config_fields(self):
         """API keys with only project:read scope should not be able to modify config fields via /api/projects/."""

--- a/posthog/filters.py
+++ b/posthog/filters.py
@@ -11,6 +11,20 @@ from rest_framework.views import APIView
 _MT = TypeVar("_MT", bound=models.Model)
 
 
+class PhraseSearchFilter(filters.SearchFilter):
+    """Matches `?search=` as one literal substring instead of splitting it into independent terms.
+
+    DRF's SearchFilter ANDs the whitespace-separated parts, so `NON PROD` also matches `Non-prod`.
+    """
+
+    def get_search_terms(self, request: Request) -> list[str]:
+        term = request.query_params.get(self.search_param, "").replace("\x00", "").strip()
+        # Quoting the value was the workaround for the splitting behavior, so keep honoring it
+        if len(term) >= 2 and term[0] == term[-1] and term[0] in ('"', "'"):
+            term = term[1:-1].strip()
+        return [term] if term else []
+
+
 class TermSearchFilterBackend(filters.BaseFilterBackend):
     """
     Allows fuzzy searching based on the pg_trgm extension.

--- a/posthog/filters.py
+++ b/posthog/filters.py
@@ -19,9 +19,6 @@ class PhraseSearchFilter(filters.SearchFilter):
 
     def get_search_terms(self, request: Request) -> list[str]:
         term = request.query_params.get(self.search_param, "").replace("\x00", "").strip()
-        # Quoting the value was the workaround for the splitting behavior, so keep honoring it
-        if len(term) >= 2 and term[0] == term[-1] and term[0] in ('"', "'"):
-            term = term[1:-1].strip()
         return [term] if term else []
 
 


### PR DESCRIPTION
## Problem

Someone searching `/api/projects/?search=NON PROD` gets back every project whose name contains both "non" and "prod" anywhere, including `Non-prod`. That makes an API lookup of a project by its exact name unreliable whenever the name contains a space.

The endpoint used DRF's stock `SearchFilter`, which splits the value on whitespace and ANDs the parts as separate `icontains` clauses. The in-app project switcher does the opposite: it matches the whole typed string as one substring. The two surfaces disagreed on the same query.

Wrapping the value in quotes worked around it, but only if you already knew the splitting happens.

## Changes

- `/api/projects/?search=` now matches the whole value as one case-insensitive substring, so `NON PROD` no longer matches `Non-prod`.
- New `PhraseSearchFilter` in `posthog/filters.py` overrides only `get_search_terms`, so DRF still supplies the `icontains` lookup and the OpenAPI parameter.
- The filter has no syntax at all. Quotes are matched literally, so a caller still sending the old `?search="NON PROD"` workaround now gets nothing back and has to drop the quotes.
- I subclassed `SearchFilter` rather than writing a `BaseFilterBackend`. A fresh backend would drop the `search` query parameter from the generated OpenAPI schema, and the frontend types and MCP tools are generated from it.

`ProjectViewSet` is the only viewset changed, which covers both routes it backs: `/api/projects/` and `/api/organizations/{id}/projects/`. `TermSearchFilterBackend`, which event and property definitions use, keeps its splitting behavior.

No caller in this repo sends `search` to either route today. The frontend project switcher filters an already-fetched list in memory, and the MCP `projects-get` tool takes no search input. The generated `organizationsProjectsList` client types a `search` param but has no call sites.

## How did you test this code?

`test_project_name_search_filter` is now parameterized, keeping its three original cases and adding two.

- `?search=NON PROD` returns only `Acme NON PROD Portal`, not `Acme Non-prod`. That is the regression this PR fixes and no existing test covered it.
- `?search="NON PROD"` returns nothing. This one guards the quote handling: if someone reintroduces quote stripping, the case comes back non-empty and fails.

I ran these against a local Postgres. I did not run any other suite, and I did not exercise the endpoint by hand.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I am the PostHog Slack app (Claude Code). The request came from a Slack thread where the mismatch between API search and in-app switcher search surfaced on a support ticket. I invoked `/writing-tests` and `/writing-pr-descriptions`.

The main decision was scope. Making the API split terms like a fuzzy search and making it match a phrase are both defensible, so I matched the in-app switcher, which is what the reporter expected.

The first version also stripped one pair of wrapping quotes, to keep the old workaround alive. Greptile flagged that a project named with literal quote characters would then be unfindable, which is the same over-matching this PR sets out to remove. I dropped the stripping rather than special-case it: a contains filter with no syntax is the predictable thing, and the workaround exists only because of the bug being fixed here. Greptile also asked for `parameterized.expand` on the new test cases, which I applied.

Nothing in this PR carries material from the agent session. The test fixture names are invented.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08UM214Z50/p1786097781327299?thread_ts=1786097781.327299&cid=C08UM214Z50)*


