### PR TITLE
fix(sentry): request a clamped window for the org stats summary

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -715,12 +715,16 @@ def _iter_organization_stats_summary_rows(
     organization_slug: str,
 ) -> Iterator[dict[str, Any]]:
     """Per-project event volume for the retention window, one row per project per category."""
+    # A relative statsPeriod of the full retention length lands on the retention boundary, which
+    # Sentry rejects with a 400. Send an explicit clamped window instead, matching the other stats
+    # endpoints (see organization_stats).
+    window = _retention_window()
     try:
         payload = _fetch_json(
             base_api_url,
             _endpoint_path("organization_stats_summary", organization_slug=organization_slug),
             headers,
-            {"field": "sum(quantity)", "statsPeriod": f"{SENTRY_RETENTION_DAYS}d"},
+            {"field": "sum(quantity)", "start": window.start, "end": window.end},
         )
     except HTTPError as exc:
         response = exc.response

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -1464,6 +1464,33 @@ class TestSentryCustomIteratorEndpoints:
         assert rows[0]["period_end"] == "2026-03-01T00:00:00Z"
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_stats_summary_requests_a_clamped_window_not_a_boundary_stats_period(self, mock_request) -> None:
+        # A relative statsPeriod of the full retention length lands on the retention boundary,
+        # which Sentry rejects with a 400 — the request must send an explicit clamped window.
+        seen_params: list[dict | None] = []
+
+        def side_effect(url, headers=None, params=None, timeout=None):
+            seen_params.append(params)
+            return _response({"start": "s", "end": "e", "projects": []})
+
+        mock_request.side_effect = side_effect
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="organization_stats_summary",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        list(cast(Any, resp.items()))
+
+        assert seen_params[0] is not None
+        assert "statsPeriod" not in seen_params[0]
+        assert seen_params[0]["start"] and seen_params[0]["end"]
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
     def test_stats_summary_skips_when_token_has_no_project_access(self, mock_request) -> None:
         # The requesting token's user can be a member of the org without being a
         # member of any project's team — Sentry 400s this specific endpoint rather


### PR DESCRIPTION
## Problem

- A Sentry data warehouse source stops syncing its per-project event volume table, and every run fails with a bare `HTTPError: 400 Client Error: Bad Request` that tells the user nothing.
- The organization stats summary request sends `statsPeriod=90d`, the full retention length. Sentry computes a window start from that relative period that lands on or just past the retention floor, and rejects it with a 400.
- This hit many teams at once because the period is hardcoded, so it reads as a product defect rather than one customer's setup.

## Changes

- The request now sends an explicit retention-clamped `start`/`end` window instead of a boundary `statsPeriod`.
- It reuses `_retention_window()`, the same helper the sibling stats endpoints (`organization_stats`, `sessions`, `project_stats`) already use, which clamp their start to `now - retention` and their end to `now`.
- Those sibling endpoints prove the endpoint family accepts `start`/`end`; the summary endpoint was the only retention-spanning one still sending a relative period.

## How did you test this code?

- Added `test_stats_summary_requests_a_clamped_window_not_a_boundary_stats_period`, which asserts the request no longer sends `statsPeriod` and does send a `start`/`end` window. It catches a revert to the boundary period that Sentry 400s for every org. No existing test asserted the request params for this endpoint.
- Ran the sentry source tests locally: the six `stats_summary` cases pass.
- Not run: no sync against a real Sentry org.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a day of `ExternalDataJob` sync failures. I (Claude) traced the `400` to the hardcoded `statsPeriod` in `_iter_organization_stats_summary_rows`, confirmed the sibling endpoints already send clamped `start`/`end`, and mirrored that. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
