### PR TITLE
fix(custom): stop retrying a 404 from a custom source URL

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py
@@ -880,6 +880,10 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             # is entirely manifest-driven, so a 400 is deterministic: the same request recurs on
             # every retry. Stop retrying and point at the config the user can actually change.
             "400 Client Error": "The upstream API rejected the request with HTTP 400. Check the resource's path, query params, and — for an incremental sync — the cursor's date format in the manifest, then try again.",
+            # A configured URL or resource path that doesn't exist. The request shape is
+            # manifest-driven, so the 404 recurs on every retry — stop and point at the config.
+            # The message omits the URL, which carries the customer's hostname.
+            "404 Client Error": "The upstream API returned HTTP 404 Not Found. Check that the base URL and the resource's path in the manifest are correct and that the endpoint exists, then try again.",
             # A schema points to a resource the manifest no longer defines (renamed or removed
             # in an edit while the table's sync stayed scheduled). Permanent until the config is
             # fixed — match the stable suffix, not the variable resource name in the message.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -3011,7 +3011,9 @@ class TestCustomSourceHttpNonRetryableClassification(SimpleTestCase):
     def test_404_is_non_retryable_with_a_url_free_message(self):
         # A 404 on a manifest-configured URL is deterministic, so it must be classified
         # non-retryable to stop the loop, and its message must not echo the customer's hostname.
-        error = requests.HTTPError("404 Client Error: Not Found for url: https://host.example.com/export")
+        # Classification is a substring match on str(error), so the exception type doesn't matter;
+        # a plain Exception carries the realistic message without requests' typed constructor.
+        error = Exception("404 Client Error: Not Found for url: https://host.example.com/export")
         non_retryable = CustomSource().get_non_retryable_errors()
         assert _classify_non_retryable(error)
         matched = [message for key, message in non_retryable.items() if key in str(error)]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/custom/test_custom_source.py
@@ -3005,3 +3005,14 @@ class TestCustomSourceOAuth2NonRetryableClassification(SimpleTestCase):
         assert not ctx.exception.is_permanent
         assert OAUTH2_PERMANENT_ERROR_MARKER not in str(ctx.exception)
         assert not _classify_non_retryable(ctx.exception), str(ctx.exception)
+
+
+class TestCustomSourceHttpNonRetryableClassification(SimpleTestCase):
+    def test_404_is_non_retryable_with_a_url_free_message(self):
+        # A 404 on a manifest-configured URL is deterministic, so it must be classified
+        # non-retryable to stop the loop, and its message must not echo the customer's hostname.
+        error = requests.HTTPError("404 Client Error: Not Found for url: https://host.example.com/export")
+        non_retryable = CustomSource().get_non_retryable_errors()
+        assert _classify_non_retryable(error)
+        matched = [message for key, message in non_retryable.items() if key in str(error)]
+        assert matched and all(message is not None and "://" not in message for message in matched)


### PR DESCRIPTION
## Problem

- A custom REST source whose configured URL returns 404 keeps failing every scheduled run instead of stopping, and the stored error is the raw `HTTPError: 404 Client Error: Not Found for url: ...`, which echoes the customer's hostname back into a user-visible field.
- A 404 is deterministic: the request shape is manifest-driven, so the same URL 404s on every retry. It should stop and tell the user what to fix, like the source's existing 400, 401, and 403 handling.

## Changes

- The custom source now classifies `404 Client Error` as non-retryable, so the schema stops looping and the user gets an actionable message.
- The message names the config to check (base URL and resource path) and deliberately omits the URL, so the customer's hostname no longer leaks into the stored error.

## How did you test this code?

- Added `test_404_is_non_retryable_with_a_url_free_message`. It drives a realistic 404 error string through the same classification the pipeline uses and asserts the match, and that the mapped message contains no URL. It catches both removing the 404 entry and reintroducing a hostname into the copy. No existing test covered the 404 path.
- Ran the custom source tests locally for the new class; they pass.
- Not run: no sync against a real custom source.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a day of `ExternalDataJob` sync failures. I (Claude) confirmed the shared REST client raises a bare `HTTPError` for non-429 4xx and that the custom source's non-retryable map had entries for 400/401/403 but not 404, so a 404 fell through to the default retry path. Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
