### PR TITLE
feat(auth): reject plus-addressed emails to stop duplicate signups

### DIFF
--- a/playwright/e2e/signup.spec.ts
+++ b/playwright/e2e/signup.spec.ts
@@ -67,7 +67,7 @@ test.describe('Signup', () => {
             await route.continue()
         })
 
-        const email = `new_user+${Math.floor(Math.random() * 10000)}@posthog.com`
+        const email = `new_user-${Math.floor(Math.random() * 10000)}@posthog.com`
         await startSignupFlow(page, email, VALID_PASSWORD)
         await page.locator('[data-attr=signup-name]').fill('Alice Bob')
         await expect(page.locator('[data-attr=signup-name]')).toHaveValue('Alice Bob')
@@ -88,7 +88,7 @@ test.describe('Signup', () => {
 
     test('Can submit the signup form multiple times if there is a generic email set', async ({ page }) => {
         let signupRequestBody: string | null = null
-        const email = `new_user+generic_error_test_${Math.floor(Math.random() * 10000)}@posthog.com`
+        const email = `new_user-generic_error_test_${Math.floor(Math.random() * 10000)}@posthog.com`
 
         await page.route('/api/signup/', async (route) => {
             signupRequestBody = route.request().postData()
@@ -122,7 +122,7 @@ test.describe('Signup', () => {
         await submitEmailAndExpectExistingAccount(page, email)
 
         // Update email to generic email and retry
-        const newEmail = `new_user+${Math.floor(Math.random() * 10000)}@posthog.com`
+        const newEmail = `new_user-${Math.floor(Math.random() * 10000)}@posthog.com`
         await startSignupFlow(page, newEmail, VALID_PASSWORD)
         await page.locator('[data-attr=signup-name]').fill('Alice Bob')
         await expect(page.locator('[data-attr=signup-name]')).toHaveValue('Alice Bob')
@@ -196,7 +196,7 @@ test.describe('Signup', () => {
         // Start signup with next parameter
         await page.goto('/signup?next=/custom_path')
 
-        const email = `new_user+${Math.floor(Math.random() * 10000)}@posthog.com`
+        const email = `new_user-${Math.floor(Math.random() * 10000)}@posthog.com`
         await startSignupFlow(page, email, VALID_PASSWORD)
         await page.locator('[data-attr=signup-name]').fill('Alice Bob')
         await expect(page.locator('[data-attr=signup-name]')).toHaveValue('Alice Bob')

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -18,7 +18,12 @@ from posthog.api.utils import action
 from posthog.constants import INVITE_DAYS_VALIDITY
 from posthog.email import is_email_available
 from posthog.event_usage import report_bulk_invited, report_team_member_invited
-from posthog.helpers.email_utils import EmailNormalizer, validate_display_name, validate_message_body
+from posthog.helpers.email_utils import (
+    EmailNormalizer,
+    reject_plus_addressed_email,
+    validate_display_name,
+    validate_message_body,
+)
 from posthog.models import OrganizationDomain, OrganizationInvite, OrganizationMembership
 from posthog.models.onboarding_delegation import (
     get_existing_pending_delegation_invite,
@@ -189,6 +194,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
 
     def validate_target_email(self, email: str):
         email = EmailNormalizer.normalize(email)
+        reject_plus_addressed_email(email)
         validate_invite_target_email_domain(self.context["get_organization"](), email)
         return email
 
@@ -373,7 +379,9 @@ class OrganizationInviteDelegateSerializer(serializers.Serializer):
     )
 
     def validate_target_email(self, email: str) -> str:
-        return EmailNormalizer.normalize(email)
+        email = EmailNormalizer.normalize(email)
+        reject_plus_addressed_email(email)
+        return email
 
     def validate_message(self, value: str | None) -> str | None:
         # Mirror the standard invite serializer's body validation so URLs / control chars

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -183,13 +183,15 @@ class SignupSerializer(serializers.Serializer):
 
             value = session_email
 
-        if not self.is_social_signup and not settings.DEMO:
-            reject_plus_addressed_email(value)
-            if EmailValidationHelper.user_exists_with_stripped_alias(value):
+        if not settings.DEMO:
+            if not self.is_social_signup:
+                reject_plus_addressed_email(value)
+                if EmailValidationHelper.user_exists_with_stripped_alias(value):
+                    raise serializers.ValidationError(
+                        "There is already an account with this email address.", code="unique"
+                    )
+            elif EmailValidationHelper.user_exists(value):
                 raise serializers.ValidationError("There is already an account with this email address.", code="unique")
-
-        if not settings.DEMO and EmailValidationHelper.user_exists(value):
-            raise serializers.ValidationError("There is already an account with this email address.", code="unique")
         return value
 
     def is_email_auto_verified(self):

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -32,7 +32,7 @@ from posthog.api.webauthn import (
 from posthog.email import is_email_available
 from posthog.event_usage import alias_invite_id, report_user_joined_organization, report_user_signed_up
 from posthog.exceptions_capture import capture_exception
-from posthog.helpers.email_utils import EmailValidationHelper, validate_display_name
+from posthog.helpers.email_utils import EmailValidationHelper, reject_plus_addressed_email, validate_display_name
 from posthog.helpers.verified_domain_enforcement import resolve_login_organization
 from posthog.models import InviteExpiredException, Organization, OrganizationDomain, OrganizationInvite, Team, User
 from posthog.models.organization_invite import INVITE_DAYS_VALIDITY
@@ -182,6 +182,11 @@ class SignupSerializer(serializers.Serializer):
                 )
 
             value = session_email
+
+        if not self.is_social_signup and not settings.DEMO:
+            reject_plus_addressed_email(value)
+            if EmailValidationHelper.user_exists_with_stripped_alias(value):
+                raise serializers.ValidationError("There is already an account with this email address.", code="unique")
 
         if not settings.DEMO and EmailValidationHelper.user_exists(value):
             raise serializers.ValidationError("There is already an account with this email address.", code="unique")

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -58,7 +58,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         for i in range(0, count):
             payload.append(
                 {
-                    "target_email": f"test+{random.randint(1000000, 9999999)}@posthog.com",
+                    "target_email": f"test-{random.randint(1000000, 9999999)}@posthog.com",
                     "first_name": NAME_SEEDS[i % len(NAME_SEEDS)],
                 }
             )
@@ -543,6 +543,15 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.json(), self.permission_denied_response())
 
+        self.assertEqual(OrganizationInvite.objects.count(), count)
+
+    def test_invite_creation_disallowed_with_plus_addressed_email(self):
+        count = OrganizationInvite.objects.count()
+        response = self.client.post(
+            "/api/organizations/@current/invites/", {"target_email": "newperson+alias@posthog.com"}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "plus_addressing_not_allowed")
         self.assertEqual(OrganizationInvite.objects.count(), count)
 
     @parameterized.expand(
@@ -1606,6 +1615,12 @@ class TestOnboardingDelegationInviteAPI(APIBaseTest):
         response = self.client.post(self._delegate_url(), {"target_email": "not-an-email"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_delegate_rejects_plus_addressed_email(self):
+        response = self.client.post(self._delegate_url(), {"target_email": "engineer+alias@example.com"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "plus_addressing_not_allowed")
+        self.assertFalse(OrganizationInvite.objects.filter(target_email="engineer+alias@example.com").exists())
+
     def test_delegate_rejects_self_delegation(self):
         response = self.client.post(self._delegate_url(), {"target_email": self.user.email})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -1840,7 +1855,7 @@ class TestOnboardingDelegationStateTransitionTable(APIBaseTest):
         self._assert_user_state(**expected)
 
     def _run_delegate_only(self) -> None:
-        self._last_delegate_email = f"engineer+{random.randint(100000, 999999)}@example.com"
+        self._last_delegate_email = f"engineer-{random.randint(100000, 999999)}@example.com"
         response = self.client.post(self._delegate_url(), {"target_email": self._last_delegate_email})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
 
@@ -1896,7 +1911,7 @@ class TestOrganizationInviteRateLimits(APIBaseTest):
         cache.clear()
 
     def _payload(self, count: int, seed: str = "burst") -> list[dict]:
-        return [{"target_email": f"test+{seed}_{i}@posthog.com"} for i in range(count)]
+        return [{"target_email": f"test-{seed}_{i}@posthog.com"} for i in range(count)]
 
     @patch("posthog.rate_limit.OrganizationInviteBurstThrottle.rate", new="3/hour")
     def test_burst_limit_rejects_single_invites_over_cap(self, _rate_limit_enabled_mock, _time_sensitive_mock):

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -330,7 +330,6 @@ class TestSignupAPI(APIBaseTest):
 
     @pytest.mark.skip_on_multitenancy
     def test_signup_disallowed_on_stripped_alias_collision(self):
-        """A plain-email signup is deflected when an existing user's plus-addressed email matches once stripped."""
         User.objects.create(email="jane+old@posthog.com", first_name="Jane")
 
         response = self.client.post(
@@ -354,7 +353,7 @@ class TestSignupAPI(APIBaseTest):
 
     @pytest.mark.skip_on_multitenancy
     def test_social_signup_allows_plus_addressed_email(self):
-        """Social signup is explicitly out of scope for the plus-addressing rules."""
+        # Social signup is deliberately out of scope for the plus-addressing rules.
         session = self.client.session
         session["backend"] = "google-oauth2"
         session["email"] = "social+alias@posthog.com"

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -308,6 +308,71 @@ class TestSignupAPI(APIBaseTest):
         self.assertEqual(existing_user.first_name, "Hoggy")
 
     @pytest.mark.skip_on_multitenancy
+    def test_signup_disallowed_with_plus_addressed_email(self):
+        response = self.client.post(
+            "/api/signup/",
+            {
+                "first_name": "John",
+                "email": "john+alias@posthog.com",
+                "password": VALID_TEST_PASSWORD,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            self.validation_error_response(
+                "Email addresses with a '+' aren't supported. Please use your primary email address.",
+                code="plus_addressing_not_allowed",
+                attr="email",
+            ),
+        )
+        self.assertEqual(User.objects.count(), 0)
+
+    @pytest.mark.skip_on_multitenancy
+    def test_signup_disallowed_on_stripped_alias_collision(self):
+        """A plain-email signup is deflected when an existing user's plus-addressed email matches once stripped."""
+        User.objects.create(email="jane+old@posthog.com", first_name="Jane")
+
+        response = self.client.post(
+            "/api/signup/",
+            {
+                "first_name": "John",
+                "email": "jane@posthog.com",
+                "password": VALID_TEST_PASSWORD,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            self.validation_error_response(
+                "There is already an account with this email address.",
+                code="unique",
+                attr="email",
+            ),
+        )
+        self.assertEqual(User.objects.count(), 1)
+
+    @pytest.mark.skip_on_multitenancy
+    def test_social_signup_allows_plus_addressed_email(self):
+        """Social signup is explicitly out of scope for the plus-addressing rules."""
+        session = self.client.session
+        session["backend"] = "google-oauth2"
+        session["email"] = "social+alias@posthog.com"
+        session["user_name"] = "Social User"
+        session.save()
+
+        response = self.client.post(
+            "/api/social_signup/",
+            {
+                "first_name": "Social",
+                "organization_name": "Social Org",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(User.objects.filter(email="social+alias@posthog.com").exists())
+
+    @pytest.mark.skip_on_multitenancy
     def test_signup_normalizes_email_to_lowercase(self):
         """Test that new signups normalize email addresses to lowercase."""
         unique_id = uuid.uuid4().hex[:8]

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -790,7 +790,7 @@ class TestUserAPI(APIBaseTest):
         assert self.user.pending_email is None
 
     def test_email_change_allowed_when_current_plus_addressed_email_is_unchanged(self):
-        """Grandfathers legacy plus-addressed accounts: resubmitting the current email unchanged must not be blocked."""
+        # Grandfathers legacy plus-addressed accounts, which can't edit their profile otherwise.
         self.user.email = "alpha+legacy@example.com"
         self.user.save()
 
@@ -800,6 +800,31 @@ class TestUserAPI(APIBaseTest):
         self.user.refresh_from_db()
         assert self.user.email == "alpha+legacy@example.com"
         assert self.user.first_name == "Newname"
+
+    def test_email_change_rejected_when_another_account_holds_the_aliased_form(self):
+        self.user.email = "alpha@example.com"
+        self.user.save()
+        User.objects.create(email="beta+old@example.com", first_name="Beta")
+
+        response = self.client.patch("/api/users/@me/", {"email": "beta@example.com"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "unique"
+        self.user.refresh_from_db()
+        assert self.user.email == "alpha@example.com"
+        assert self.user.pending_email is None
+
+    @patch("posthog.api.user.is_email_available", return_value=False)
+    def test_email_change_allowed_when_dropping_own_plus_alias(self, _mock_is_email_available):
+        # The collision check must skip the editor's own row, or a legacy alias holder can never clean it up.
+        self.user.email = "alpha+legacy@example.com"
+        self.user.save()
+
+        response = self.client.patch("/api/users/@me/", {"email": "alpha@example.com"})
+
+        assert response.status_code == status.HTTP_200_OK
+        self.user.refresh_from_db()
+        assert self.user.email == "alpha@example.com"
 
     @parameterized.expand(
         [

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -777,6 +777,30 @@ class TestUserAPI(APIBaseTest):
                 "beta@example.com",
             )
 
+    def test_email_change_rejected_when_new_email_is_plus_addressed(self):
+        self.user.email = "alpha@example.com"
+        self.user.save()
+
+        response = self.client.patch("/api/users/@me/", {"email": "alpha+alias@example.com"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["code"] == "plus_addressing_not_allowed"
+        self.user.refresh_from_db()
+        assert self.user.email == "alpha@example.com"
+        assert self.user.pending_email is None
+
+    def test_email_change_allowed_when_current_plus_addressed_email_is_unchanged(self):
+        """Grandfathers legacy plus-addressed accounts: resubmitting the current email unchanged must not be blocked."""
+        self.user.email = "alpha+legacy@example.com"
+        self.user.save()
+
+        response = self.client.patch("/api/users/@me/", {"email": "alpha+legacy@example.com", "first_name": "Newname"})
+
+        assert response.status_code == status.HTTP_200_OK
+        self.user.refresh_from_db()
+        assert self.user.email == "alpha+legacy@example.com"
+        assert self.user.first_name == "Newname"
+
     @parameterized.expand(
         [
             ("single_google", [("google-oauth2", "google-sub-1")]),

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -84,7 +84,7 @@ from posthog.event_usage import (
     report_user_verified_email,
 )
 from posthog.exceptions_capture import capture_exception
-from posthog.helpers.email_utils import EmailNormalizer, validate_display_name
+from posthog.helpers.email_utils import EmailNormalizer, reject_plus_addressed_email, validate_display_name
 from posthog.helpers.session_cache import SessionCache
 from posthog.helpers.two_factor_session import has_passkeys, set_two_factor_verified_in_session
 from posthog.helpers.verified_domain_enforcement import VERIFIED_DOMAIN_REQUIRED_ERROR, resolve_login_organization
@@ -379,6 +379,13 @@ class UserSerializer(serializers.ModelSerializer):
 
     def validate_last_name(self, value: str) -> str:
         return validate_display_name(value)
+
+    def validate_email(self, value: str) -> str:
+        if self.instance and value.lower() == self.instance.email.lower():
+            # Unchanged — don't re-validate a legacy '+' address on an unrelated profile edit.
+            return value
+        reject_plus_addressed_email(value)
+        return value
 
     def get_has_password(self, instance: User) -> bool:
         return bool(instance.password) and instance.has_usable_password()

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -84,7 +84,12 @@ from posthog.event_usage import (
     report_user_verified_email,
 )
 from posthog.exceptions_capture import capture_exception
-from posthog.helpers.email_utils import EmailNormalizer, reject_plus_addressed_email, validate_display_name
+from posthog.helpers.email_utils import (
+    EmailNormalizer,
+    EmailValidationHelper,
+    reject_plus_addressed_email,
+    validate_display_name,
+)
 from posthog.helpers.session_cache import SessionCache
 from posthog.helpers.two_factor_session import has_passkeys, set_two_factor_verified_in_session
 from posthog.helpers.verified_domain_enforcement import VERIFIED_DOMAIN_REQUIRED_ERROR, resolve_login_organization
@@ -385,6 +390,11 @@ class UserSerializer(serializers.ModelSerializer):
             # Unchanged — don't re-validate a legacy '+' address on an unrelated profile edit.
             return value
         reject_plus_addressed_email(value)
+        # Excluding the editor lets a legacy '+' account holder drop their own alias.
+        if EmailValidationHelper.user_exists_with_stripped_alias(
+            value, exclude_user_id=self.instance.pk if self.instance else None
+        ):
+            raise serializers.ValidationError("There is already an account with this email address.", code="unique")
         return value
 
     def get_has_password(self, instance: User) -> bool:

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -29,7 +29,6 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
-
 _URL_SCHEME_RE = re.compile(
     r"[a-z][a-z0-9+.\-]*://"
     r"|\b(?:javascript|data|vbscript|file|ftp|mailto|tel|sms):"
@@ -40,10 +39,10 @@ _BARE_DOMAIN_RE = re.compile(
     r"\b(?:[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]{2,24}\b",
     re.IGNORECASE,
 )
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f  ]")
-_NON_NEWLINE_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f  ]")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f\u0085\u2028\u2029]")
+_NON_NEWLINE_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f\u0085\u2028\u2029]")
 _BRACKET_RE = re.compile(r"[<>]")
-_INVISIBLE_CHAR_RE = re.compile(r"[​-‏‪-‮⁦-⁩﻿]")
+_INVISIBLE_CHAR_RE = re.compile(r"[\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]")
 
 _URL_ERROR = "URLs are not allowed in this field."
 _CONTROL_ERROR = "Line breaks and control characters are not allowed in this field."
@@ -55,7 +54,7 @@ def _check_shared(value: str) -> None:
     """
     Run the checks shared between display names and message bodies against an
     NFKC-normalized copy of `value`. Normalization folds fullwidth / compat
-    variants (e.g. `ｈｔｔｐ：／／` → `http://`) before regex matching.
+    variants (e.g. `ｈｔｔｐ：／／` \u2192 `http://`) before regex matching.
     """
     normalized = unicodedata.normalize("NFKC", value)
     if _INVISIBLE_CHAR_RE.search(normalized):
@@ -193,7 +192,6 @@ sanitize_message_body = partial(
     log_event="email_utils.message_body_sanitized",
     fallback="",
 )
-
 
 # Zero-width space inserted after `.` and `:` to break auto-link patterns.
 # We previously used `&#46;` / `&#58;` HTML entities, but Customer.io's

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -17,7 +17,7 @@ from urllib.parse import quote
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import MultipleObjectsReturned
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 
 import requests
 import structlog
@@ -40,10 +40,10 @@ _BARE_DOMAIN_RE = re.compile(
     r"\b(?:[a-z0-9](?:[a-z0-9\-]{0,61}[a-z0-9])?\.)+[a-z]{2,24}\b",
     re.IGNORECASE,
 )
-_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f\u0085\u2028\u2029]")
-_NON_NEWLINE_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f\u0085\u2028\u2029]")
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f  ]")
+_NON_NEWLINE_CONTROL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f  ]")
 _BRACKET_RE = re.compile(r"[<>]")
-_INVISIBLE_CHAR_RE = re.compile(r"[\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]")
+_INVISIBLE_CHAR_RE = re.compile(r"[​-‏‪-‮⁦-⁩﻿]")
 
 _URL_ERROR = "URLs are not allowed in this field."
 _CONTROL_ERROR = "Line breaks and control characters are not allowed in this field."
@@ -55,7 +55,7 @@ def _check_shared(value: str) -> None:
     """
     Run the checks shared between display names and message bodies against an
     NFKC-normalized copy of `value`. Normalization folds fullwidth / compat
-    variants (e.g. `ｈｔｔｐ：／／` \u2192 `http://`) before regex matching.
+    variants (e.g. `ｈｔｔｐ：／／` → `http://`) before regex matching.
     """
     normalized = unicodedata.normalize("NFKC", value)
     if _INVISIBLE_CHAR_RE.search(normalized):
@@ -247,6 +247,29 @@ class EmailNormalizer:
         return email.lower()
 
 
+def strip_email_alias(email: str) -> str:
+    """
+    Strip a Gmail-style '+suffix' from the local part of an email (e.g.
+    'someuser+alias@domain.com' -> 'someuser@domain.com'). Comparison-only —
+    never use this for the email that actually gets stored.
+    """
+    if not email:
+        return email
+    local, _, domain = email.rpartition("@")
+    local = local.split("+", 1)[0]
+    return f"{local}@{domain}"
+
+
+def reject_plus_addressed_email(value: str) -> None:
+    """Raise if the local part of `value` contains '+'."""
+    local = value.split("@", 1)[0]
+    if "+" in local:
+        raise serializers.ValidationError(
+            "Email addresses with a '+' aren't supported. Please use your primary email address.",
+            code="plus_addressing_not_allowed",
+        )
+
+
 class EmailLookupHandler:
     @staticmethod
     def get_user_by_email(email: str, is_active: Optional[bool] = True) -> Optional["User"]:
@@ -326,6 +349,19 @@ class EmailValidationHelper:
     @staticmethod
     def user_exists(email: str) -> bool:
         return EmailLookupHandler.get_user_by_email(email) is not None
+
+    @staticmethod
+    def user_exists_with_stripped_alias(email: str) -> bool:
+        """True if any existing active user's email, once its '+alias' is stripped, equals `email`."""
+        from posthog.models.user import User
+
+        stripped = strip_email_alias(email)
+        local, _, domain = stripped.rpartition("@")
+        return (
+            User.objects.filter(is_active=True)
+            .filter(Q(email__iexact=stripped) | (Q(email__istartswith=f"{local}+") & Q(email__iendswith=f"@{domain}")))
+            .exists()
+        )
 
 
 ESP_SUPPRESSION_CACHE_TTL_IN_SECONDS = 86400  # 1 day

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+
 _URL_SCHEME_RE = re.compile(
     r"[a-z][a-z0-9+.\-]*://"
     r"|\b(?:javascript|data|vbscript|file|ftp|mailto|tel|sms):"
@@ -192,6 +193,7 @@ sanitize_message_body = partial(
     log_event="email_utils.message_body_sanitized",
     fallback="",
 )
+
 
 # Zero-width space inserted after `.` and `:` to break auto-link patterns.
 # We previously used `&#46;` / `&#58;` HTML entities, but Customer.io's

--- a/posthog/helpers/email_utils.py
+++ b/posthog/helpers/email_utils.py
@@ -351,17 +351,21 @@ class EmailValidationHelper:
         return EmailLookupHandler.get_user_by_email(email) is not None
 
     @staticmethod
-    def user_exists_with_stripped_alias(email: str) -> bool:
-        """True if any existing active user's email, once its '+alias' is stripped, equals `email`."""
+    def user_exists_with_stripped_alias(email: str, exclude_user_id: Optional[int] = None) -> bool:
+        """
+        True if any existing active user's email, once its '+alias' is stripped, equals `email`.
+        `exclude_user_id` skips one account, so a user dropping their own '+alias' isn't blocked by themselves.
+        """
         from posthog.models.user import User
 
         stripped = strip_email_alias(email)
         local, _, domain = stripped.rpartition("@")
-        return (
-            User.objects.filter(is_active=True)
-            .filter(Q(email__iexact=stripped) | (Q(email__istartswith=f"{local}+") & Q(email__iendswith=f"@{domain}")))
-            .exists()
+        candidates = User.objects.filter(is_active=True).filter(
+            Q(email__iexact=stripped) | (Q(email__istartswith=f"{local}+") & Q(email__iendswith=f"@{domain}"))
         )
+        if exclude_user_id is not None:
+            candidates = candidates.exclude(pk=exclude_user_id)
+        return candidates.exists()
 
 
 ESP_SUPPRESSION_CACHE_TTL_IN_SECONDS = 86400  # 1 day

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -18,9 +18,11 @@ from posthog.helpers.email_utils import (
     ESPSuppressionReason,
     _get_esp_suppression_cache_key,
     check_esp_suppression,
+    reject_plus_addressed_email,
     sanitize_display_name,
     sanitize_email_string,
     sanitize_message_body,
+    strip_email_alias,
     validate_display_name,
     validate_message_body,
 )
@@ -93,6 +95,58 @@ class TestEmailValidationHelper(TestCase):
                 with self.subTest(email=email_variation):
                     result = EmailValidationHelper.user_exists(email_variation)
                     self.assertTrue(result)
+        finally:
+            user.delete()
+
+
+class TestStripEmailAlias(SimpleTestCase):
+    def test_strip_email_alias(self):
+        test_cases = [
+            ("someuser+someprefix@domain.com", "someuser@domain.com"),
+            ("someuser@domain.com", "someuser@domain.com"),
+            ("Someuser+Tag@Domain.com", "Someuser@Domain.com"),
+            ("a+b+c@domain.com", "a@domain.com"),
+            ("", ""),
+        ]
+
+        for input_email, expected in test_cases:
+            with self.subTest(input_email=input_email):
+                self.assertEqual(strip_email_alias(input_email), expected)
+
+
+class TestRejectPlusAddressedEmail(SimpleTestCase):
+    def test_rejects_plus_in_local_part(self):
+        with self.assertRaises(serializers.ValidationError) as ctx:
+            reject_plus_addressed_email("someuser+alias@domain.com")
+        self.assertEqual(ctx.exception.get_codes(), ["plus_addressing_not_allowed"])
+
+    def test_allows_email_without_plus(self):
+        # Should not raise.
+        reject_plus_addressed_email("someuser@domain.com")
+
+
+class TestUserExistsWithStrippedAlias(TestCase):
+    def test_no_match(self):
+        self.assertFalse(EmailValidationHelper.user_exists_with_stripped_alias("nobody@example.com"))
+
+    def test_matches_existing_plain_email(self):
+        user = User.objects.create_user(email="based@example.com", password=None, first_name="Base")
+        try:
+            self.assertTrue(EmailValidationHelper.user_exists_with_stripped_alias("based+new@example.com"))
+        finally:
+            user.delete()
+
+    def test_matches_existing_aliased_email(self):
+        user = User.objects.create_user(email="based+old@example.com", password=None, first_name="Base")
+        try:
+            self.assertTrue(EmailValidationHelper.user_exists_with_stripped_alias("based@example.com"))
+        finally:
+            user.delete()
+
+    def test_does_not_match_different_local_part(self):
+        user = User.objects.create_user(email="based@example.com", password=None, first_name="Base")
+        try:
+            self.assertFalse(EmailValidationHelper.user_exists_with_stripped_alias("basedxyz@example.com"))
         finally:
             user.delete()
 
@@ -356,18 +410,18 @@ class TestValidateDisplayName(SimpleTestCase):
             ("tab", "foo\tbar", "invalid_control_char"),
             ("null", "foo\x00bar", "invalid_control_char"),
             ("del", "foo\x7fbar", "invalid_control_char"),
-            ("line_separator", "foo\u2028bar", "invalid_control_char"),
-            ("paragraph_separator", "foo\u2029bar", "invalid_control_char"),
-            ("next_line", "foo\u0085bar", "invalid_control_char"),
+            ("line_separator", "foo bar", "invalid_control_char"),
+            ("paragraph_separator", "foo bar", "invalid_control_char"),
+            ("next_line", "foobar", "invalid_control_char"),
             ("www_embedded", "myname www.scam.io", "invalid_url"),
             ("javascript_scheme", "click javascript:alert(1)", "invalid_url"),
             ("data_scheme", "see data:text/html,x", "invalid_url"),
             ("vbscript_scheme", "run vbscript:msgbox", "invalid_url"),
-            ("fullwidth_url", "go \uff48\uff54\uff54\uff50\uff1a\uff0f\uff0fevil.com", "invalid_url"),
+            ("fullwidth_url", "go ｈｔｔｐ：／／evil.com", "invalid_url"),
             ("lt", "foo<bar", "invalid_bracket"),
             ("gt", "link > here", "invalid_bracket"),
-            ("zero_width", "foo\u200bbar", "invalid_invisible_char"),
-            ("rtl_override", "foo\u202ebar", "invalid_invisible_char"),
+            ("zero_width", "foo​bar", "invalid_invisible_char"),
+            ("rtl_override", "foo‮bar", "invalid_invisible_char"),
         ]
     )
     def test_rejects(self, _name: str, value: str, expected_code: str) -> None:
@@ -398,14 +452,14 @@ class TestValidateMessageBody(SimpleTestCase):
             ("www", "Visit www.scam.io", "invalid_url"),
             ("javascript_scheme", "click javascript:alert(1)", "invalid_url"),
             ("data_scheme", "see data:text/html,x", "invalid_url"),
-            ("fullwidth_url", "go \uff48\uff54\uff54\uff50\uff1a\uff0f\uff0fevil.com", "invalid_url"),
+            ("fullwidth_url", "go ｈｔｔｐ：／／evil.com", "invalid_url"),
             ("bracket", "hello <there>", "invalid_bracket"),
-            ("invisible", "foo\u200bbar", "invalid_invisible_char"),
-            ("rtl_override", "foo\u202ebar", "invalid_invisible_char"),
+            ("invisible", "foo​bar", "invalid_invisible_char"),
+            ("rtl_override", "foo‮bar", "invalid_invisible_char"),
             ("non_newline_control", "foo\x01bar", "invalid_control_char"),
             ("carriage_return", "foo\rbar", "invalid_control_char"),
             ("del", "foo\x7fbar", "invalid_control_char"),
-            ("line_separator", "foo\u2028bar", "invalid_control_char"),
+            ("line_separator", "foo bar", "invalid_control_char"),
         ]
     )
     def test_rejects(self, _name: str, value: str, expected_code: str) -> None:
@@ -430,7 +484,7 @@ class TestSanitizeDisplayName(SimpleTestCase):
         [
             ("plain", "Acme Inc", "Acme Inc"),
             ("strips_whitespace", "  Acme Inc  ", "Acme Inc"),
-            ("unicode_name", "\u00c9mile", "\u00c9mile"),
+            ("unicode_name", "Émile", "Émile"),
             # Bare-domain org names round-trip; the defang happens later in
             # `sanitize_email_properties` at render time.
             ("bare_domain", "acme.com", "acme.com"),
@@ -445,7 +499,7 @@ class TestSanitizeDisplayName(SimpleTestCase):
             ("www", "www.scam.io"),
             ("javascript_scheme", "javascript:alert(1)"),
             ("bracket", "<acme>"),
-            ("zero_width", "foo\u200bbar"),
+            ("zero_width", "foo​bar"),
             ("newline", "line1\nline2"),
         ]
     )

--- a/posthog/helpers/tests/test_email_utils.py
+++ b/posthog/helpers/tests/test_email_utils.py
@@ -410,18 +410,18 @@ class TestValidateDisplayName(SimpleTestCase):
             ("tab", "foo\tbar", "invalid_control_char"),
             ("null", "foo\x00bar", "invalid_control_char"),
             ("del", "foo\x7fbar", "invalid_control_char"),
-            ("line_separator", "foo bar", "invalid_control_char"),
-            ("paragraph_separator", "foo bar", "invalid_control_char"),
-            ("next_line", "foobar", "invalid_control_char"),
+            ("line_separator", "foo\u2028bar", "invalid_control_char"),
+            ("paragraph_separator", "foo\u2029bar", "invalid_control_char"),
+            ("next_line", "foo\u0085bar", "invalid_control_char"),
             ("www_embedded", "myname www.scam.io", "invalid_url"),
             ("javascript_scheme", "click javascript:alert(1)", "invalid_url"),
             ("data_scheme", "see data:text/html,x", "invalid_url"),
             ("vbscript_scheme", "run vbscript:msgbox", "invalid_url"),
-            ("fullwidth_url", "go ｈｔｔｐ：／／evil.com", "invalid_url"),
+            ("fullwidth_url", "go \uff48\uff54\uff54\uff50\uff1a\uff0f\uff0fevil.com", "invalid_url"),
             ("lt", "foo<bar", "invalid_bracket"),
             ("gt", "link > here", "invalid_bracket"),
-            ("zero_width", "foo​bar", "invalid_invisible_char"),
-            ("rtl_override", "foo‮bar", "invalid_invisible_char"),
+            ("zero_width", "foo\u200bbar", "invalid_invisible_char"),
+            ("rtl_override", "foo\u202ebar", "invalid_invisible_char"),
         ]
     )
     def test_rejects(self, _name: str, value: str, expected_code: str) -> None:
@@ -452,14 +452,14 @@ class TestValidateMessageBody(SimpleTestCase):
             ("www", "Visit www.scam.io", "invalid_url"),
             ("javascript_scheme", "click javascript:alert(1)", "invalid_url"),
             ("data_scheme", "see data:text/html,x", "invalid_url"),
-            ("fullwidth_url", "go ｈｔｔｐ：／／evil.com", "invalid_url"),
+            ("fullwidth_url", "go \uff48\uff54\uff54\uff50\uff1a\uff0f\uff0fevil.com", "invalid_url"),
             ("bracket", "hello <there>", "invalid_bracket"),
-            ("invisible", "foo​bar", "invalid_invisible_char"),
-            ("rtl_override", "foo‮bar", "invalid_invisible_char"),
+            ("invisible", "foo\u200bbar", "invalid_invisible_char"),
+            ("rtl_override", "foo\u202ebar", "invalid_invisible_char"),
             ("non_newline_control", "foo\x01bar", "invalid_control_char"),
             ("carriage_return", "foo\rbar", "invalid_control_char"),
             ("del", "foo\x7fbar", "invalid_control_char"),
-            ("line_separator", "foo bar", "invalid_control_char"),
+            ("line_separator", "foo\u2028bar", "invalid_control_char"),
         ]
     )
     def test_rejects(self, _name: str, value: str, expected_code: str) -> None:
@@ -484,7 +484,7 @@ class TestSanitizeDisplayName(SimpleTestCase):
         [
             ("plain", "Acme Inc", "Acme Inc"),
             ("strips_whitespace", "  Acme Inc  ", "Acme Inc"),
-            ("unicode_name", "Émile", "Émile"),
+            ("unicode_name", "\u00c9mile", "\u00c9mile"),
             # Bare-domain org names round-trip; the defang happens later in
             # `sanitize_email_properties` at render time.
             ("bare_domain", "acme.com", "acme.com"),
@@ -499,7 +499,7 @@ class TestSanitizeDisplayName(SimpleTestCase):
             ("www", "www.scam.io"),
             ("javascript_scheme", "javascript:alert(1)"),
             ("bracket", "<acme>"),
-            ("zero_width", "foo​bar"),
+            ("zero_width", "foo\u200bbar"),
             ("newline", "line1\nline2"),
         ]
     )


### PR DESCRIPTION
## Problem

Several users have signed up multiple times using Gmail-style `+alias` addresses (`jane+1@x.com`, `jane+2@x.com`), since most mail providers deliver every variant to the same inbox. This lets one person bypass per-person limits like free-tier signups and invite-based seat counts.

## Changes

- Reject signup when the email has a `+`, or when its plain form already matches an existing account
- Reject `+` addresses when creating an organization invite, regular or delegated
- Reject `+` addresses when changing an existing account's email, unless it's unchanged
- Leave social/SSO signup and JIT provisioning untouched — separate decision, not fixed here

> [!IMPORTANT]
> Invite-accept still allows `+` addresses by design: blocking it there would strand an existing `+`-alias account holder invited under their plain address, with no way to accept.

## How did you test this code?

- New unit and API tests cover alias stripping, signup rejection, invite rejection, and the email-change grandfather case
- Ran the four touched test files, mypy, ruff, and `ci:preflight`; did not run the full monorepo suite

Agent-authored; only the automated tests above were run.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Sonnet 5), using a subagent-driven-development workflow: a fresh implementer + reviewer subagent per task, plus a final whole-branch review, across a brainstormed spec and written plan
- Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/django-migrations` (checked, not needed — no schema change)
- Considered closing the invite-accept bypass the final review flagged, but rejected it: gating account creation there would strand a legitimate existing `+`-alias account holder invited under their plain address before they've logged in, since the invite is bound to a literal target email they can't change