### PR TITLE
feat(slack_app): remove workspace ai preference from home tab

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -79,7 +79,6 @@ from products.slack_app.backend.services.integration_resolver import (
 )
 from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
-    ACTION_EDIT_WORKSPACE,
     ACTION_RESET_PERSONAL,
     ACTION_RESET_PROJECT_PERSONAL,
     ACTION_SET_PROJECT_PERSONAL,
@@ -91,7 +90,6 @@ from products.slack_app.backend.services.slack_app_home import (
     ACTION_TASKS_REFRESH,
     ACTION_UNLINK_ACCOUNT,
     EDIT_MODAL_PERSONAL_CALLBACK_ID,
-    EDIT_MODAL_WORKSPACE_CALLBACK_ID,
     MODAL_ACTION_MODEL,
     MODAL_ACTION_RUNTIME_ADAPTER,
     handle_ai_preferences_block_action as _handle_ai_preferences_block_action,
@@ -3040,7 +3038,6 @@ def _extract_context_token(payload: dict) -> str:
 _AI_PREFERENCES_ACTION_IDS = frozenset(
     {
         ACTION_EDIT_PERSONAL,
-        ACTION_EDIT_WORKSPACE,
         ACTION_RESET_PERSONAL,
         ACTION_RESET_PROJECT_PERSONAL,
         ACTION_SET_PROJECT_PERSONAL,
@@ -3055,7 +3052,7 @@ _AI_PREFERENCES_ACTION_IDS = frozenset(
         MODAL_ACTION_MODEL,
     }
 )
-_AI_PREFERENCES_CALLBACK_IDS = frozenset({EDIT_MODAL_PERSONAL_CALLBACK_ID, EDIT_MODAL_WORKSPACE_CALLBACK_ID})
+_AI_PREFERENCES_CALLBACK_IDS = frozenset({EDIT_MODAL_PERSONAL_CALLBACK_ID})
 
 
 def _is_ai_preferences_interactivity(payload: dict, payload_type: str) -> bool:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta
-from typing import Any, Literal
+from typing import Any
 
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, JsonResponse
@@ -70,7 +70,6 @@ logger = structlog.get_logger(__name__)
 HOME_CALLBACK_ID = "slack_app_home"
 
 ACTION_EDIT_PERSONAL = "slack_app_home:edit_personal"
-ACTION_EDIT_WORKSPACE = "slack_app_home:edit_workspace"
 ACTION_RESET_PERSONAL = "slack_app_home:reset_personal"
 ACTION_UNLINK_ACCOUNT = "slack_app_home:unlink_account"
 ACTION_SET_PROJECT_PERSONAL = "slack_app_home:set_project_personal"
@@ -110,7 +109,6 @@ TASKS_STATUS_OPTIONS: tuple[tuple[str, str], ...] = (
 )
 
 EDIT_MODAL_PERSONAL_CALLBACK_ID = "slack_app_ai_prefs:personal"
-EDIT_MODAL_WORKSPACE_CALLBACK_ID = "slack_app_ai_prefs:workspace"
 
 MODAL_ACTION_RUNTIME_ADAPTER = "ai_prefs:runtime_adapter"
 MODAL_ACTION_MODEL = "ai_prefs:model"
@@ -119,8 +117,6 @@ MODAL_ACTION_REASONING_EFFORT = "ai_prefs:reasoning_effort"
 MODAL_BLOCK_RUNTIME_ADAPTER = "block_runtime_adapter"
 MODAL_BLOCK_MODEL = "block_model"
 MODAL_BLOCK_REASONING_EFFORT = "block_reasoning_effort"
-
-EditScope = Literal["personal", "workspace"]
 
 
 @dataclass(frozen=True)
@@ -180,10 +176,11 @@ def _runtime_adapter_options() -> tuple[tuple[str, str], ...]:
 
 @dataclass(frozen=True)
 class PreferenceSource:
-    """Which row contributed the effective `(runtime_adapter, model)` pair.
+    """Whether the user's own row contributed the effective `(runtime_adapter,
+    model)` pair.
 
-    Used to render the "Source: …" line on the active-model card so the
-    precedence (personal → workspace → unset) is visible at a glance.
+    Used to render the "Source: …" line on the active-model card so it's clear
+    at a glance whether the running model is a personal pick.
     """
 
     label: str
@@ -193,18 +190,11 @@ class PreferenceSource:
         return cls(label="Your personal override")
 
     @classmethod
-    def workspace(cls) -> PreferenceSource:
-        return cls(label="Workspace default")
-
-    @classmethod
     def unset(cls) -> PreferenceSource:
         return cls(label="System default")
 
 
-def resolve_source(
-    user_row: SlackSettings | None,
-    workspace_row: SlackSettings | None,
-) -> PreferenceSource:
+def resolve_source(user_row: SlackSettings | None) -> PreferenceSource:
     """Return where the effective pair came from.
 
     Mirrors the same atomic-pair rule the resolver uses: a row only "sources"
@@ -212,8 +202,6 @@ def resolve_source(
     """
     if user_row and user_row.runtime_adapter and user_row.model:
         return PreferenceSource.personal()
-    if workspace_row and workspace_row.runtime_adapter and workspace_row.model:
-        return PreferenceSource.workspace()
     return PreferenceSource.unset()
 
 
@@ -333,7 +321,6 @@ def render_home_view(
     *,
     effective: AIPreferences,
     user_row: SlackSettings | None,
-    workspace_row: SlackSettings | None,
     is_admin: bool,
     account_state: AccountState | None = None,
     project_state: ProjectState | None = None,
@@ -342,7 +329,7 @@ def render_home_view(
 ) -> dict:
     """Render the Block Kit payload for `views.publish` on the App Home tab."""
 
-    source = resolve_source(user_row, workspace_row)
+    source = resolve_source(user_row)
     blocks: list[dict] = []
 
     blocks.extend(_header_blocks())
@@ -361,12 +348,12 @@ def render_home_view(
         blocks.extend(_project_section_blocks(project_state, is_admin=is_admin))
 
     # Section 3 — AI model settings: which model handles those mentions.
-    # Headline shows the effective triple (and its source); personal /
-    # workspace controls underneath mirror the project routing layout.
+    # Headline shows the effective triple (and its source), with the personal
+    # picker underneath. Purely a per-user preference — there's no workspace-wide
+    # model default to inherit from.
     blocks.append({"type": "divider"})
     blocks.extend(_active_model_blocks(effective, source))
     blocks.extend(_personal_section_blocks(user_row))
-    blocks.extend(_workspace_section_blocks(workspace_row, is_admin=is_admin))
 
     # Section 4 — account linking: shown before Tasks so the connect
     # prompt is visible while the Tasks list is still empty. Flag-gated.
@@ -473,8 +460,7 @@ def _active_model_blocks(effective: AIPreferences, source: PreferenceSource) -> 
                 "text": {
                     "type": "mrkdwn",
                     "text": (
-                        f"Defaulting to {format_model_id(SLACK_DEFAULT_MODEL)}. "
-                        "Pick personal or workspace settings to override."
+                        f"Defaulting to {format_model_id(SLACK_DEFAULT_MODEL)}. Pick your own settings to override."
                     ),
                 },
             },
@@ -633,7 +619,7 @@ def _personal_section_blocks(user_row: SlackSettings | None) -> list[dict]:
     """Personal AI override sub-card. Always editable by the user themselves."""
 
     has_override = bool(user_row and user_row.runtime_adapter and user_row.model)
-    summary = _row_summary(user_row) if has_override else "_No personal override — inheriting the workspace default._"
+    summary = _row_summary(user_row) if has_override else "_No personal override — using PostHog's default._"
 
     actions: list[dict] = [
         {
@@ -648,12 +634,12 @@ def _personal_section_blocks(user_row: SlackSettings | None) -> list[dict]:
                 "type": "button",
                 "action_id": ACTION_RESET_PERSONAL,
                 "style": "danger",
-                "text": {"type": "plain_text", "text": "Reset to workspace default", "emoji": True},
+                "text": {"type": "plain_text", "text": "Reset to default", "emoji": True},
                 "confirm": {
                     "title": {"type": "plain_text", "text": "Clear your override?"},
                     "text": {
                         "type": "mrkdwn",
-                        "text": "You'll inherit the workspace default until you set new personal preferences.",
+                        "text": "You'll go back to PostHog's default until you set new personal preferences.",
                     },
                     "confirm": {"type": "plain_text", "text": "Reset"},
                     "deny": {"type": "plain_text", "text": "Cancel"},
@@ -666,39 +652,6 @@ def _personal_section_blocks(user_row: SlackSettings | None) -> list[dict]:
         {"type": "section", "text": {"type": "mrkdwn", "text": summary}},
         {"type": "actions", "elements": actions},
     ]
-
-
-def _workspace_section_blocks(
-    workspace_row: SlackSettings | None,
-    *,
-    is_admin: bool,
-) -> list[dict]:
-    """Workspace AI default sub-card — admin-only; non-admins don't see it."""
-
-    if not is_admin:
-        return []
-
-    has_default = bool(workspace_row and workspace_row.runtime_adapter and workspace_row.model)
-    summary = (
-        _row_summary(workspace_row)
-        if has_default
-        else "_No workspace default set — falls back to PostHog's system default._"
-    )
-    blocks: list[dict] = [
-        _subsection_label("Workspace default"),
-        {"type": "section", "text": {"type": "mrkdwn", "text": summary}},
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "action_id": ACTION_EDIT_WORKSPACE,
-                    "text": {"type": "plain_text", "text": "Edit workspace default", "emoji": True},
-                }
-            ],
-        },
-    ]
-    return blocks
 
 
 def _footer_blocks() -> list[dict]:
@@ -1127,11 +1080,10 @@ def _row_summary(row: SlackSettings | None) -> str:
 
 def render_edit_modal(
     *,
-    scope: EditScope,
     current: AIPreferences,
     supported_efforts: list[str] | None = None,
 ) -> dict:
-    """Build the Block Kit modal payload for personal or workspace editing.
+    """Build the Block Kit modal payload for editing your personal preferences.
 
     `supported_efforts` lets the caller pre-compute which efforts are valid for
     the currently selected model (using
@@ -1139,11 +1091,6 @@ def render_edit_modal(
     When `None`, the effort block is omitted entirely; the modal re-renders via
     `block_actions` on runtime_adapter / model change to fill it in.
     """
-
-    callback_id = EDIT_MODAL_PERSONAL_CALLBACK_ID if scope == "personal" else EDIT_MODAL_WORKSPACE_CALLBACK_ID
-    # Slack caps modal titles at 24 characters; longer ones get rejected with
-    # `invalid_arguments` on `views.open`.
-    title = "Personal AI preferences" if scope == "personal" else "Workspace AI preferences"
 
     runtime_pairs = _runtime_adapter_options()
     runtime_options = [
@@ -1226,11 +1173,7 @@ def render_edit_modal(
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": (
-                        "Pick the runtime and model that should handle PostHog Slack requests for you."
-                        if scope == "personal"
-                        else "Set the default runtime and model for everyone in this Slack workspace."
-                    ),
+                    "text": "Pick the runtime and model that should handle PostHog Slack requests for you.",
                 }
             ],
         },
@@ -1243,8 +1186,10 @@ def render_edit_modal(
 
     return {
         "type": "modal",
-        "callback_id": callback_id,
-        "title": {"type": "plain_text", "text": title, "emoji": True},
+        "callback_id": EDIT_MODAL_PERSONAL_CALLBACK_ID,
+        # Slack caps modal titles at 24 characters; longer ones get rejected
+        # with `invalid_arguments` on `views.open`.
+        "title": {"type": "plain_text", "text": "Personal AI preferences", "emoji": True},
         "submit": {"type": "plain_text", "text": "Save"},
         "close": {"type": "plain_text", "text": "Cancel"},
         "blocks": blocks,
@@ -1309,7 +1254,7 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
         return
 
     effective = resolve_ai_preferences(integration, slack_user_id)
-    user_row, workspace_row = _load_rows(integration, slack_user_id)
+    user_row = _load_user_row(integration, slack_user_id)
 
     slack = SlackIntegration(integration)
     is_admin = _is_admin(slack, integration, slack_user_id)
@@ -1322,7 +1267,6 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     view = render_home_view(
         effective=effective,
         user_row=user_row,
-        workspace_row=workspace_row,
         is_admin=is_admin,
         account_state=account_state,
         project_state=project_state,
@@ -1366,15 +1310,7 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
         _republish_home(integration, slack_user_id, view_state=state)
 
     if action_id == ACTION_EDIT_PERSONAL and trigger_id:
-        _open_edit_modal(integration, slack_user_id, scope="personal", trigger_id=trigger_id)
-        return HttpResponse(status=200)
-
-    if action_id == ACTION_EDIT_WORKSPACE and trigger_id:
-        slack = SlackIntegration(integration)
-        if not _is_admin(slack, integration, slack_user_id):
-            _post_ephemeral_admin_only(slack, payload)
-            return HttpResponse(status=200)
-        _open_edit_modal(integration, slack_user_id, scope="workspace", trigger_id=trigger_id)
+        _open_edit_modal(integration, slack_user_id, trigger_id=trigger_id)
         return HttpResponse(status=200)
 
     if action_id == ACTION_RESET_PERSONAL:
@@ -1444,11 +1380,10 @@ def handle_ai_preferences_block_action(payload: dict, action: dict) -> HttpRespo
 
 
 def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonResponse:
-    """Handle the Save click on the personal or workspace edit modal."""
+    """Handle the Save click on the personal edit modal."""
 
     view = payload.get("view", {})
-    callback_id = view.get("callback_id")
-    if callback_id not in (EDIT_MODAL_PERSONAL_CALLBACK_ID, EDIT_MODAL_WORKSPACE_CALLBACK_ID):
+    if view.get("callback_id") != EDIT_MODAL_PERSONAL_CALLBACK_ID:
         return HttpResponse(status=200)
 
     slack_team_id = (payload.get("team") or {}).get("id", "")
@@ -1468,25 +1403,13 @@ def handle_app_home_view_submission(payload: dict) -> HttpResponse | JsonRespons
     except ValidationError as exc:
         return _modal_error_response(_first_validation_message(exc))
 
-    if callback_id == EDIT_MODAL_PERSONAL_CALLBACK_ID:
-        _write_row(
-            integration,
-            slack_user_id=slack_user_id,
-            runtime_adapter=runtime_adapter,
-            model=model,
-            reasoning_effort=reasoning_effort,
-        )
-    else:
-        slack = SlackIntegration(integration)
-        if not _is_admin(slack, integration, slack_user_id):
-            return _modal_error_response("Only Slack workspace admins can change the workspace default.")
-        _write_row(
-            integration,
-            slack_user_id=None,
-            runtime_adapter=runtime_adapter,
-            model=model,
-            reasoning_effort=reasoning_effort,
-        )
+    _write_row(
+        integration,
+        slack_user_id=slack_user_id,
+        runtime_adapter=runtime_adapter,
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
 
     _republish_home(integration, slack_user_id)
     return JsonResponse({"response_action": "clear"})
@@ -1507,16 +1430,11 @@ def _get_slack_integration(slack_team_id: str) -> Integration | None:
     )
 
 
-def _load_rows(integration: Integration, slack_user_id: str) -> tuple[SlackSettings | None, SlackSettings | None]:
-    user_row = SlackSettings.objects.filter(
+def _load_user_row(integration: Integration, slack_user_id: str) -> SlackSettings | None:
+    return SlackSettings.objects.filter(
         slack_workspace_id=integration.integration_id,
         slack_user_id=slack_user_id,
     ).first()
-    workspace_row = SlackSettings.objects.filter(
-        slack_workspace_id=integration.integration_id,
-        slack_user_id__isnull=True,
-    ).first()
-    return user_row, workspace_row
 
 
 def _row_to_settings(row: SlackSettings | None) -> AIPreferences:
@@ -1541,9 +1459,8 @@ def _is_admin(slack: SlackIntegration, integration: Integration, slack_user_id: 
         return False
 
 
-def _open_edit_modal(integration: Integration, slack_user_id: str, *, scope: EditScope, trigger_id: str) -> None:
-    user_row, workspace_row = _load_rows(integration, slack_user_id)
-    current = _row_to_settings(user_row if scope == "personal" else workspace_row)
+def _open_edit_modal(integration: Integration, slack_user_id: str, *, trigger_id: str) -> None:
+    current = _row_to_settings(_load_user_row(integration, slack_user_id))
     supported = _supported_efforts(current.runtime_adapter, current.model)
     slack = SlackIntegration(integration)
 
@@ -1554,16 +1471,12 @@ def _open_edit_modal(integration: Integration, slack_user_id: str, *, scope: Edi
     if not _runtime_adapter_options():
         view = _render_unavailable_modal()
     else:
-        view = render_edit_modal(scope=scope, current=current, supported_efforts=supported)
+        view = render_edit_modal(current=current, supported_efforts=supported)
 
     try:
         slack.client.views_open(trigger_id=trigger_id, view=view)
     except Exception:
-        logger.exception(
-            "slack_app_home_open_modal_failed",
-            slack_user_id=slack_user_id,
-            scope=scope,
-        )
+        logger.exception("slack_app_home_open_modal_failed", slack_user_id=slack_user_id)
 
 
 def _render_unavailable_modal() -> dict:
@@ -1593,16 +1506,14 @@ def _update_modal_after_input_change(payload: dict) -> HttpResponse:
     """
 
     view = payload.get("view", {})
-    callback_id = view.get("callback_id")
-    if callback_id not in (EDIT_MODAL_PERSONAL_CALLBACK_ID, EDIT_MODAL_WORKSPACE_CALLBACK_ID):
+    if view.get("callback_id") != EDIT_MODAL_PERSONAL_CALLBACK_ID:
         return HttpResponse(status=200)
 
     runtime_adapter, model, reasoning_effort = parse_modal_submission(view)
     current = AIPreferences(runtime_adapter=runtime_adapter, model=model, reasoning_effort=reasoning_effort)
     supported = _supported_efforts(runtime_adapter, model)
 
-    scope: EditScope = "personal" if callback_id == EDIT_MODAL_PERSONAL_CALLBACK_ID else "workspace"
-    updated_view = render_edit_modal(scope=scope, current=current, supported_efforts=supported)
+    updated_view = render_edit_modal(current=current, supported_efforts=supported)
 
     slack_team_id = (payload.get("team") or {}).get("id", "")
     integration = _get_slack_integration(slack_team_id)
@@ -1628,7 +1539,7 @@ def _supported_efforts(runtime_adapter: str | None, model: str | None) -> list[s
 def _write_row(
     integration: Integration,
     *,
-    slack_user_id: str | None,
+    slack_user_id: str,
     runtime_adapter: str | None,
     model: str | None,
     reasoning_effort: str | None,
@@ -1679,7 +1590,7 @@ def _republish_home(
     view_state: HomeViewState | None = None,
 ) -> None:
     view_state = view_state or HomeViewState()
-    user_row, workspace_row = _load_rows(integration, slack_user_id)
+    user_row = _load_user_row(integration, slack_user_id)
     effective = resolve_ai_preferences(integration, slack_user_id)
     slack = SlackIntegration(integration)
     is_admin = _is_admin(slack, integration, slack_user_id)
@@ -1704,7 +1615,6 @@ def _republish_home(
     view = render_home_view(
         effective=effective,
         user_row=user_row,
-        workspace_row=workspace_row,
         is_admin=is_admin,
         account_state=account_state,
         project_state=project_state,

--- a/products/slack_app/backend/services/slack_settings.py
+++ b/products/slack_app/backend/services/slack_settings.py
@@ -6,16 +6,13 @@ Key names mirror the task-run request serializer
 (`products/tasks/backend/presentation/serializers.py`) so the resolver output
 can be handed to the task layer with zero translation.
 
-Resolution: whole-triple swap, not field-by-field merge. If the user row
-carries the atomic `(runtime_adapter, model)` pair, the user's entire
-preference object takes over (including its absent `reasoning_effort`);
-otherwise we fall back wholesale to the workspace default. A field-by-field
-merge would blend mismatched configurations — for example, surfacing a
-workspace `reasoning_effort` of `low` alongside the user's non-thinking
-model — which is never what the user picked. `reasoning_effort` is still
-dropped if the resolved model doesn't support it, so a stale effort from
-a previous model choice can't silently stick. Unset keys stay `None` so the
-task layer applies its own defaults rather than duplicating them here.
+Resolution: AI preferences are a personal setting. Only the user's own row
+counts, and only when it carries the atomic `(runtime_adapter, model)` pair —
+a half-set row reads as "no preference" rather than half-applying.
+`reasoning_effort` is dropped if the resolved model doesn't support it, so a
+stale effort from a previous model choice can't silently stick. Unset keys
+stay `None` so the task layer applies its own defaults rather than
+duplicating them here.
 
 Gated by the `slack-app-home` feature flag: when off the resolver returns
 the empty object, preserving pre-Home-tab behaviour for workspaces that
@@ -26,8 +23,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-
-from django.db.models import Q
 
 from products.slack_app.backend.feature_flags import is_slack_app_home_enabled
 from products.slack_app.backend.services.model_catalogue import filter_unsupported_effort
@@ -59,53 +54,38 @@ _EMPTY = AIPreferences()
 def resolve_ai_preferences(integration: Integration, slack_user_id: str | None) -> AIPreferences:
     """Resolve the effective AI preferences for a Slack user in a workspace.
 
-    Whole-triple swap: if the user row carries the atomic `(runtime_adapter,
-    model)` pair, the user's preference object wins outright; otherwise the
-    workspace row wins outright. We never blend the two. `reasoning_effort`
-    is dropped if the resolved model doesn't support it.
+    Only the user's own row counts, and only when it carries the atomic
+    `(runtime_adapter, model)` pair. `reasoning_effort` is dropped if the
+    resolved model doesn't support it.
     """
 
-    if not is_slack_app_home_enabled(integration):
+    if not slack_user_id or not is_slack_app_home_enabled(integration):
         return _EMPTY
 
     from products.slack_app.backend.models import SlackSettings
 
-    slack_workspace_id = integration.integration_id
-    # SQL `IN (..., NULL)` does not match NULL rows, so the workspace-wide row
-    # (slack_user_id IS NULL) needs its own arm in the filter.
-    user_row_filter = Q(slack_user_id=slack_user_id) if slack_user_id else Q(pk__in=[])
-    rows = list(
+    row = (
         SlackSettings.objects.filter(
-            Q(slack_workspace_id=slack_workspace_id) & (Q(slack_user_id__isnull=True) | user_row_filter)
-        ).values("slack_user_id", "ai_preferences")
+            slack_workspace_id=integration.integration_id,
+            slack_user_id=slack_user_id,
+        )
+        .values("ai_preferences")
+        .first()
     )
-    # Pulled into local dicts so mypy can give them a definite type — the
-    # JSONField returns `Any | None` per row, and a `next(...) or {}` expression
-    # ends up as a wider union mypy refuses to narrow.
-    user_prefs: dict[str, Any] = {}
-    workspace_prefs: dict[str, Any] = {}
-    for r in rows:
-        payload = r["ai_preferences"] or {}
-        if r["slack_user_id"] is None:
-            workspace_prefs = payload
-        elif slack_user_id is not None and r["slack_user_id"] == slack_user_id:
-            user_prefs = payload
+    # Pulled into a local dict so mypy can give it a definite type — the
+    # JSONField reads back as `Any | None`.
+    prefs: dict[str, Any] = (row["ai_preferences"] if row else None) or {}
 
     # `validate_ai_preferences` enforces that `runtime_adapter` and `model` are
-    # set together, so the presence of either one is a faithful signal that
-    # this row has been explicitly configured. Pick the whole triple from
-    # whichever row sourced the pair.
-    if user_prefs.get("runtime_adapter") and user_prefs.get("model"):
-        chosen = user_prefs
-    elif workspace_prefs.get("runtime_adapter") and workspace_prefs.get("model"):
-        chosen = workspace_prefs
-    else:
-        chosen = {}
+    # set together, so a row missing either half was never explicitly
+    # configured and contributes nothing.
+    runtime_adapter = prefs.get("runtime_adapter") or None
+    model = prefs.get("model") or None
+    if not runtime_adapter or not model:
+        return _EMPTY
 
-    runtime_adapter = chosen.get("runtime_adapter") or None
-    model = chosen.get("model") or None
-    reasoning_effort = chosen.get("reasoning_effort") or None
-    if runtime_adapter and model and reasoning_effort:
+    reasoning_effort = prefs.get("reasoning_effort") or None
+    if reasoning_effort:
         reasoning_effort = filter_unsupported_effort(runtime_adapter, model, reasoning_effort)
 
     return AIPreferences(

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -25,11 +25,9 @@ from posthog.models.team.team import Team
 from products.slack_app.backend.models import SlackSettings
 from products.slack_app.backend.services.slack_app_home import (
     ACTION_EDIT_PERSONAL,
-    ACTION_EDIT_WORKSPACE,
     ACTION_RESET_PERSONAL,
     ACTION_RESET_PROJECT_PERSONAL,
     EDIT_MODAL_PERSONAL_CALLBACK_ID,
-    EDIT_MODAL_WORKSPACE_CALLBACK_ID,
     MODAL_ACTION_MODEL,
     MODAL_ACTION_REASONING_EFFORT,
     MODAL_ACTION_RUNTIME_ADAPTER,
@@ -93,15 +91,6 @@ def admin_user():
     with patch(
         "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
         return_value=True,
-    ):
-        yield
-
-
-@pytest.fixture
-def non_admin_user():
-    with patch(
-        "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
-        return_value=False,
     ):
         yield
 
@@ -344,35 +333,24 @@ def _view_submission_payload(
 
 
 class TestRenderHomeView:
-    def test_empty_state_renders_buttons_and_no_reset(self):
+    @pytest.mark.parametrize("is_admin", [False, True])
+    def test_empty_state_renders_buttons_and_no_reset(self, is_admin):
         view = render_home_view(
             effective=AIPreferences(),
             user_row=None,
-            workspace_row=None,
-            is_admin=False,
+            is_admin=is_admin,
         )
         assert view["type"] == "home"
         ids = _action_ids(view)
-        # Personal edit always present; reset hidden when no override; non-admin
-        # doesn't see the workspace edit button.
+        # Personal edit always present; reset hidden when no override. Admins get
+        # no extra model control — the model is purely a personal preference.
         assert ACTION_EDIT_PERSONAL in ids
         assert ACTION_RESET_PERSONAL not in ids
-        assert ACTION_EDIT_WORKSPACE not in ids
-
-    def test_admin_sees_workspace_edit_button(self):
-        view = render_home_view(
-            effective=AIPreferences(),
-            user_row=None,
-            workspace_row=None,
-            is_admin=True,
-        )
-        assert ACTION_EDIT_WORKSPACE in _action_ids(view)
 
     def test_personal_override_renders_reset_button(self):
         view = render_home_view(
             effective=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
             user_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
-            workspace_row=None,
             is_admin=False,
         )
         assert ACTION_RESET_PERSONAL in _action_ids(view)
@@ -380,29 +358,21 @@ class TestRenderHomeView:
     def test_active_model_summary_mentions_model_label(self):
         view = render_home_view(
             effective=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
-            user_row=None,
-            workspace_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
+            user_row=_make_row(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
             is_admin=True,
         )
         text_blob = " ".join(block["text"]["text"] for block in view["blocks"] if block.get("type") == "section")
         # Friendly label rather than raw model id; source attribution visible.
         assert "Claude Opus 4.7" in text_blob
-        assert "Workspace default" in _all_text(view)
+        assert "Your personal override" in _all_text(view)
 
     def test_source_resolution_is_atomic(self):
-        # User has only `reasoning_effort` set (no pair). Source should fall
-        # through to the workspace's complete pair.
+        # A user row missing half the pair isn't a real override.
+        assert resolve_source(_make_row(reasoning_effort="medium")) == PreferenceSource.unset()
+        assert resolve_source(None) == PreferenceSource.unset()
         assert (
-            resolve_source(
-                _make_row(reasoning_effort="medium"),
-                _make_row(runtime_adapter="claude", model="claude-opus-4-7"),
-            )
-            == PreferenceSource.workspace()
+            resolve_source(_make_row(runtime_adapter="claude", model="claude-opus-4-7")) == PreferenceSource.personal()
         )
-
-    def test_source_unset_when_neither_row_has_pair(self):
-        assert resolve_source(None, None) == PreferenceSource.unset()
-        assert resolve_source(_make_row(reasoning_effort="high"), None) == PreferenceSource.unset()
 
 
 class TestTasksCard:
@@ -410,7 +380,6 @@ class TestTasksCard:
         base = {
             "effective": AIPreferences(),
             "user_row": None,
-            "workspace_row": None,
             "is_admin": False,
         }
         base.update(overrides)
@@ -630,33 +599,22 @@ class TestTasksCard:
 
 
 class TestRenderEditModal:
-    @pytest.mark.parametrize(
-        "scope,callback_id",
-        [
-            ("personal", EDIT_MODAL_PERSONAL_CALLBACK_ID),
-            ("workspace", EDIT_MODAL_WORKSPACE_CALLBACK_ID),
-        ],
-    )
-    def test_callback_id_matches_scope(self, scope, callback_id):
-        view = render_edit_modal(scope=scope, current=AIPreferences())
-        assert view["callback_id"] == callback_id
-
     def test_no_runtime_means_no_model_or_effort_blocks(self):
-        view = render_edit_modal(scope="personal", current=AIPreferences())
+        view = render_edit_modal(current=AIPreferences())
         ids = _block_ids(view)
         assert MODAL_BLOCK_RUNTIME_ADAPTER in ids
         assert MODAL_BLOCK_MODEL not in ids
         assert MODAL_BLOCK_REASONING_EFFORT not in ids
 
     def test_runtime_picked_unlocks_model_block(self):
-        view = render_edit_modal(scope="personal", current=AIPreferences(runtime_adapter="claude"))
+        view = render_edit_modal(current=AIPreferences(runtime_adapter="claude"))
         ids = _block_ids(view)
         assert MODAL_BLOCK_MODEL in ids
         # Effort block needs both the model and a non-empty supported list.
         assert MODAL_BLOCK_REASONING_EFFORT not in ids
 
     def test_model_options_match_runtime(self):
-        view = render_edit_modal(scope="personal", current=AIPreferences(runtime_adapter="codex"))
+        view = render_edit_modal(current=AIPreferences(runtime_adapter="codex"))
         model_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_MODEL)
         option_values = [o["value"] for o in model_block["element"]["options"]]
         # Codex models only — assert via prefix to stay resilient as the facade
@@ -666,7 +624,6 @@ class TestRenderEditModal:
 
     def test_effort_block_renders_only_when_supported_efforts_provided(self):
         view = render_edit_modal(
-            scope="personal",
             current=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7"),
             supported_efforts=["low", "medium", "high"],
         )
@@ -677,7 +634,6 @@ class TestRenderEditModal:
 
     def test_initial_options_reflect_current_values(self):
         view = render_edit_modal(
-            scope="workspace",
             current=AIPreferences(
                 runtime_adapter="claude",
                 model="claude-opus-4-7",
@@ -693,7 +649,7 @@ class TestRenderEditModal:
         assert effort_block["element"]["initial_option"]["value"] == "high"
 
     def test_dispatch_action_set_on_runtime_and_model(self):
-        view = render_edit_modal(scope="personal", current=AIPreferences(runtime_adapter="claude"))
+        view = render_edit_modal(current=AIPreferences(runtime_adapter="claude"))
         runtime_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_RUNTIME_ADAPTER)
         model_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_MODEL)
         # dispatch_action triggers a block_actions payload so the modal can
@@ -753,29 +709,6 @@ class TestEditPersonalAction:
         assert mock_slack_client.views_open.called
         view = mock_slack_client.views_open.call_args.kwargs["view"]
         assert view["callback_id"] == EDIT_MODAL_PERSONAL_CALLBACK_ID
-
-
-class TestEditWorkspaceAdminGate:
-    def test_admin_opens_modal(self, slack_integration, mock_slack_client, flag_on, admin_user):
-        payload = _block_action_payload(
-            action_id=ACTION_EDIT_WORKSPACE,
-            slack_user_id="U001",
-            trigger_id="trig.2",
-        )
-        handle_ai_preferences_block_action(payload, payload["actions"][0])
-        assert mock_slack_client.views_open.called
-
-    def test_non_admin_blocked(self, slack_integration, mock_slack_client, flag_on, non_admin_user):
-        payload = _block_action_payload(
-            action_id=ACTION_EDIT_WORKSPACE,
-            slack_user_id="U001",
-            trigger_id="trig.3",
-            channel="C1",
-        )
-        handle_ai_preferences_block_action(payload, payload["actions"][0])
-        # Non-admin gets an ephemeral notice rather than the modal.
-        assert not mock_slack_client.views_open.called
-        assert mock_slack_client.chat_postEphemeral.called or mock_slack_client.chat_postMessage.called
 
 
 class TestResetPersonal:
@@ -895,16 +828,17 @@ class TestPersonalSubmit:
         assert not SlackSettings.objects.filter(slack_user_id="U001").exists()
 
 
-class TestWorkspaceSubmitAdminGate:
-    def test_non_admin_blocked(self, slack_integration, mock_slack_client, flag_on, non_admin_user):
+class TestRetiredWorkspaceModal:
+    def test_stale_workspace_submission_is_ignored(self, slack_integration, mock_slack_client, flag_on, admin_user):
+        # A workspace modal opened before this callback id was retired can still
+        # be submitted afterwards. It must not write a workspace-wide row.
         payload = _view_submission_payload(
-            callback_id=EDIT_MODAL_WORKSPACE_CALLBACK_ID,
-            slack_user_id="U_NONADMIN",
+            callback_id="slack_app_ai_prefs:workspace",
+            slack_user_id="U001",
             runtime_adapter="claude",
             model="claude-opus-4-7",
             effort="high",
         )
         response = handle_app_home_view_submission(payload)
-        body = json.loads(response.content)
-        assert body["response_action"] == "errors"
-        assert not SlackSettings.objects.filter(slack_user_id__isnull=True).exists()
+        assert response.status_code == 200
+        assert not SlackSettings.objects.exists()

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -150,7 +150,6 @@ def _render(state: StatsState | None) -> dict:
     return render_home_view(
         effective=AIPreferences(),
         user_row=None,
-        workspace_row=None,
         is_admin=True,
         stats_state=state,
     )

--- a/products/slack_app/backend/tests/services/test_slack_settings.py
+++ b/products/slack_app/backend/tests/services/test_slack_settings.py
@@ -146,8 +146,8 @@ class TestResolveAIPreferences:
             pytest.param(
                 None,
                 {"runtime_adapter": "claude", "model": "claude-opus-4-7", "effort": "high"},
-                AIPreferences(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
-                id="workspace-only-applies",
+                AIPreferences(),
+                id="workspace-row-is-ignored",
             ),
             pytest.param(
                 {"runtime_adapter": "codex", "model": "gpt-5.5", "effort": "high"},
@@ -159,7 +159,7 @@ class TestResolveAIPreferences:
                 {"runtime_adapter": "claude", "model": "claude-opus-4-7", "effort": "high"},
                 {"runtime_adapter": "codex", "model": "gpt-5.5", "effort": "low"},
                 AIPreferences(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high"),
-                id="user-overrides-workspace",
+                id="user-wins-over-lingering-workspace-row",
             ),
         ],
     )
@@ -189,11 +189,10 @@ class TestResolveAIPreferences:
             )
         assert resolve_ai_preferences(integration, "U001") == expected
 
-    def test_user_row_with_no_pair_yields_workspace_triple_intact(self, slack_setup, flag_on):
+    def test_user_row_with_no_pair_reads_as_no_preference(self, slack_setup, flag_on):
         """A user row without the atomic `(runtime_adapter, model)` pair is
-        treated as "no personal preference", so the workspace row wins
-        wholesale — including its own `reasoning_effort`. The user's
-        orphaned effort never leaks into the resolved triple."""
+        treated as "no personal preference" — the orphaned effort never leaks
+        into the resolved triple."""
         integration = slack_setup
         SlackSettings.objects.create(
             default_integration=integration,
@@ -204,42 +203,8 @@ class TestResolveAIPreferences:
             # it (direct writes, older data, schema drift).
             ai_preferences={"reasoning_effort": "medium"},
         )
-        SlackSettings.objects.create(
-            default_integration=integration,
-            slack_workspace_id="T_WS",
-            slack_user_id=None,
-            ai_preferences={"runtime_adapter": "claude", "model": "claude-opus-4-7", "reasoning_effort": "high"},
-        )
 
-        assert resolve_ai_preferences(integration, "U001") == AIPreferences(
-            runtime_adapter="claude",
-            model="claude-opus-4-7",
-            reasoning_effort="high",
-        )
-
-    def test_user_pair_without_effort_does_not_inherit_workspace_effort(self, slack_setup, flag_on):
-        """If the user explicitly picks a pair without a reasoning effort,
-        the resolver must not silently graft the workspace's effort onto
-        it. Whole-triple swap: user's absent effort stays absent."""
-        integration = slack_setup
-        SlackSettings.objects.create(
-            default_integration=integration,
-            slack_workspace_id="T_WS",
-            slack_user_id="U001",
-            ai_preferences={"runtime_adapter": "claude", "model": "claude-opus-4-7"},
-        )
-        SlackSettings.objects.create(
-            default_integration=integration,
-            slack_workspace_id="T_WS",
-            slack_user_id=None,
-            ai_preferences={"runtime_adapter": "claude", "model": "claude-opus-4-7", "reasoning_effort": "low"},
-        )
-
-        assert resolve_ai_preferences(integration, "U001") == AIPreferences(
-            runtime_adapter="claude",
-            model="claude-opus-4-7",
-            reasoning_effort=None,
-        )
+        assert resolve_ai_preferences(integration, "U001") == AIPreferences()
 
     def test_unsupported_effort_dropped_when_model_does_not_support_it(self, slack_setup, flag_on):
         """If a row stores an effort the resolved model can't honour (e.g.
@@ -264,7 +229,9 @@ class TestResolveAIPreferences:
         assert result.model == "claude-sonnet-4-6"
         assert result.reasoning_effort is None
 
-    def test_user_id_none_uses_workspace_row_only(self, slack_setup, flag_on):
+    def test_user_id_none_resolves_empty(self, slack_setup, flag_on):
+        # No Slack user to attribute the run to, so there's no preference to
+        # apply — the workspace row's AI fields are no longer consulted.
         integration = slack_setup
         SlackSettings.objects.create(
             default_integration=integration,
@@ -272,8 +239,7 @@ class TestResolveAIPreferences:
             slack_user_id=None,
             ai_preferences={"runtime_adapter": "claude", "model": "claude-opus-4-7", "reasoning_effort": "high"},
         )
-        result = resolve_ai_preferences(integration, None)
-        assert result == AIPreferences(runtime_adapter="claude", model="claude-opus-4-7", reasoning_effort="high")
+        assert resolve_ai_preferences(integration, None) == AIPreferences()
 
     def test_flag_off_returns_empty_even_with_rows_present(self, slack_setup, flag_off):
         integration = slack_setup


### PR DESCRIPTION
## Problem

A Slack workspace admin could set a workspace-wide default AI model from the Home tab, applying to everyone who mentions @PostHog. We're replacing it with a different mechanism.

Removing only the picker would strand existing workspace defaults: still in force, no way to see or change them. So the resolver fallback goes too.

## Changes

- The "🤖 AI model" card shows only "Your override" — the admin-only workspace subsection, its button, and its modal are gone.
- `resolve_ai_preferences` reads the calling user's row only, with no workspace fallback.
- Workspace rows keep their `ai_preferences` JSON, unread. No migration — the same row still holds the project-routing default, unchanged.
- A submission on the retired `slack_app_ai_prefs:workspace` callback id is ignored, so a modal opened before the deploy can't write after it.

## How did you test this code?

Automated only — I did not exercise the Home tab in a real Slack workspace. `products/slack_app/backend/tests`, `posthog/temporal/tests/ai/slack_app`, and repo-wide mypy pass locally.

The resolution table now asserts a workspace row is ignored and that a lingering one loses to a personal pick — the regression a leftover fallback would cause. `TestRetiredWorkspaceModal` covers the stale-modal window above. The rest are mechanical updates for the dropped `workspace_row` / `scope` parameters.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. No repo skills invoked.

The open decision was how deep to cut. UI-only was the smaller diff; the human driver chose to drop the resolver fallback for the reason in Problem. Clearing the stored JSON was rejected — inert once unread, and not worth a destructive migration while the replacement is still being designed.
