### PR TITLE
fix(slack_app): route app_home_opened through the region gate

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1801,6 +1801,54 @@ def _route_assistant_event(
     )
 
 
+def _route_app_home_opened(
+    request: HttpRequest,
+    event: dict,
+    slack_team_id: str,
+    event_id: str | None,
+    *,
+    proxied: bool,
+    incoming_host: str,
+    other_domain: str,
+    can_defer: bool,
+) -> str:
+    """Publish the Home tab from the region that owns the workspace's integration.
+
+    Slack delivers every event to a single Request URL, so the receiving region is
+    not necessarily the one holding the row the view renders against. Without this
+    gate the publish is silently skipped for every workspace owned by the other
+    region.
+    """
+    slack_user_id = str(event.get("user") or "")
+    if not slack_user_id:
+        return ROUTE_HANDLED_LOCALLY
+
+    result = load_integrations(
+        slack_team_id=slack_team_id,
+        kinds=[SLACK_INTEGRATION_KIND],
+        slack_user_id=slack_user_id,
+    )
+    region_route = resolve_region_or_terminal_route(
+        request,
+        slack_team_id,
+        candidates_present=bool(result.candidates),
+        kinds=[SLACK_INTEGRATION_KIND],
+        proxied=proxied,
+        other_domain=other_domain,
+        incoming_host=incoming_host,
+        can_defer=can_defer,
+    )
+    if region_route is not None:
+        return region_route
+
+    integration = result.integration if result.integration in result.candidates else result.candidates[0]
+    try:
+        _handle_app_home_opened(event, slack_team_id, integration=integration)
+    except Exception:
+        logger.exception("slack_app_home_opened_failed", slack_team_id=slack_team_id, event_id=event_id)
+    return ROUTE_HANDLED_LOCALLY
+
+
 def _handle_app_uninstalled(request: HttpRequest, slack_team_id: str) -> str:
     """Drop the workspace's cached Slack profiles so a reinstall resolves users from
     fresh ``users.info`` data instead of emails cached under the previous install.
@@ -1850,15 +1898,20 @@ def route_posthog_code_event_to_relevant_region(
     if event_type == "app_uninstalled":
         return _handle_app_uninstalled(request, slack_team_id)
 
-    # App Home tab: published per-user when they open the Home tab. Always
-    # handled locally — `views.publish` just renders a snapshot of the user's
-    # AI preferences against the integration row, no cross-region state.
+    # App Home tab: published per-user when they open the Home tab. The view is
+    # rendered against the workspace's integration row, which only the owning
+    # region holds, so this takes the same region gate as every other surface.
     if event_type == "app_home_opened":
-        try:
-            _handle_app_home_opened(event, slack_team_id)
-        except Exception:
-            logger.exception("slack_app_home_opened_failed", slack_team_id=slack_team_id, event_id=event_id)
-        return ROUTE_HANDLED_LOCALLY
+        return _route_app_home_opened(
+            request,
+            event,
+            slack_team_id,
+            event_id,
+            proxied=proxied,
+            incoming_host=incoming_host,
+            other_domain=other_domain,
+            can_defer=can_defer_to_other_region,
+        )
 
     # Assistant surface: DMs to the app and agent-container events resolve the DMing user and run
     # against their project. A ``message`` is a DM iff ``channel_type == "im"`` — channel ``message``

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -1288,8 +1288,11 @@ def _selected_value(state: dict, block_id: str, action_id: str) -> str | None:
 # here.
 
 
-def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
+def handle_app_home_opened(event: dict, slack_team_id: str, *, integration: Integration) -> None:
     """Publish the Home tab for the user who just opened it.
+
+    The caller resolves the integration through the shared region gate, so this
+    region owns the workspace by the time we get here.
 
     Gated by the slack-app-home flag — when off, the publish is skipped so
     installs without the manifest changes (and workspaces that haven't opted
@@ -1301,11 +1304,13 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     if not slack_user_id:
         return
 
-    integration = _get_slack_integration(slack_team_id)
-    if integration is None:
-        return
-
     if not is_slack_app_home_enabled(integration):
+        logger.info(
+            "slack_app_home_publish_skipped",
+            reason="flag_off",
+            slack_team_id=slack_team_id,
+            slack_user_id=slack_user_id,
+        )
         return
 
     effective = resolve_ai_preferences(integration, slack_user_id)
@@ -1334,6 +1339,12 @@ def handle_app_home_opened(event: dict, slack_team_id: str) -> None:
     except Exception:
         logger.exception(
             "slack_app_home_publish_failed",
+            slack_user_id=slack_user_id,
+            slack_team_id=slack_team_id,
+        )
+    else:
+        logger.info(
+            "slack_app_home_published",
             slack_user_id=slack_user_id,
             slack_team_id=slack_team_id,
         )

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -722,18 +722,14 @@ class TestParseModalSubmission:
 
 class TestHandleAppHomeOpened:
     def test_publishes_view_for_known_user(self, slack_integration, mock_slack_client, flag_on, admin_user):
-        handle_app_home_opened({"user": "U001"}, SLACK_WORKSPACE_ID)
+        handle_app_home_opened({"user": "U001"}, SLACK_WORKSPACE_ID, integration=slack_integration)
         assert mock_slack_client.views_publish.called
         kwargs = mock_slack_client.views_publish.call_args.kwargs
         assert kwargs["user_id"] == "U001"
         assert kwargs["view"]["type"] == "home"
 
     def test_noop_when_user_missing(self, slack_integration, mock_slack_client, flag_on):
-        handle_app_home_opened({}, SLACK_WORKSPACE_ID)
-        assert not mock_slack_client.views_publish.called
-
-    def test_noop_when_integration_missing(self, db, mock_slack_client, flag_on):
-        handle_app_home_opened({"user": "U001"}, "T_UNKNOWN")
+        handle_app_home_opened({}, SLACK_WORKSPACE_ID, integration=slack_integration)
         assert not mock_slack_client.views_publish.called
 
 

--- a/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home_stats.py
@@ -489,7 +489,7 @@ class TestStatsCardGating:
             "products.slack_app.backend.services.slack_app_home.is_slack_workspace_admin",
             return_value=is_admin,
         ):
-            handle_app_home_opened({"user": SLACK_USER}, WORKSPACE)
+            handle_app_home_opened({"user": SLACK_USER}, WORKSPACE, integration=slack_integration)
 
         view = mock_slack_client.views_publish.call_args.kwargs["view"]
         assert ("Workspace activity" in str(view)) is expected_visible

--- a/products/slack_app/backend/tests/test_app_home_routing.py
+++ b/products/slack_app/backend/tests/test_app_home_routing.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase
+
+from posthog.models.integration import Integration
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+
+from products.slack_app.backend.api import (
+    ROUTE_HANDLED_LOCALLY,
+    ROUTE_PROXIED,
+    route_posthog_code_event_to_relevant_region,
+)
+from products.slack_app.backend.services.slack_auth import write_auth_state_ok
+
+
+class TestAppHomeOpenedRegionRouting(TestCase):
+    SLACK_TEAM_ID = "T_HOME_ROUTING"
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+
+    def _create_local_integration(self) -> Integration:
+        organization = Organization.objects.create(name="Home Org")
+        team = Team.objects.create(organization=organization, name="Home Team")
+        integration = Integration.objects.create(
+            team=team,
+            kind="slack",
+            integration_id=self.SLACK_TEAM_ID,
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+        write_auth_state_ok(integration.id, bot_user_id=None)
+        return integration
+
+    def _route(self, host: str = "eu.posthog.com") -> str:
+        request = self.factory.post("/slack/event-callback/", HTTP_HOST=host)
+        return route_posthog_code_event_to_relevant_region(
+            request, {"type": "app_home_opened", "user": "U001"}, self.SLACK_TEAM_ID
+        )
+
+    @patch("products.slack_app.backend.api.get_instance_region", return_value="EU")
+    @patch("products.slack_app.backend.api._proxy_event_to_region", return_value=MagicMock())
+    @patch("products.slack_app.backend.api._handle_app_home_opened")
+    def test_forwards_to_other_region_when_workspace_is_not_local(
+        self, mock_publish: MagicMock, mock_proxy: MagicMock, _region: MagicMock
+    ) -> None:
+        # Slack posts every event to one Request URL, so the receiving region may not hold the
+        # integration row. Publishing locally here silently no-ops for the whole workspace.
+        assert self._route() == ROUTE_PROXIED
+        assert mock_proxy.called
+        assert not mock_publish.called
+
+    @patch("products.slack_app.backend.api.does_other_region_claim_workspace", return_value=False)
+    @patch("products.slack_app.backend.api.get_instance_region", return_value="EU")
+    @patch("products.slack_app.backend.api._proxy_event_to_region")
+    @patch("products.slack_app.backend.api._handle_app_home_opened")
+    def test_publishes_locally_when_workspace_is_local(
+        self, mock_publish: MagicMock, mock_proxy: MagicMock, _region: MagicMock, _claims: MagicMock
+    ) -> None:
+        integration = self._create_local_integration()
+
+        assert self._route() == ROUTE_HANDLED_LOCALLY
+        assert not mock_proxy.called
+        assert mock_publish.call_args.kwargs["integration"] == integration

--- a/products/slack_app/backend/tests/test_zz_app_home_routing.py
+++ b/products/slack_app/backend/tests/test_zz_app_home_routing.py
@@ -1,3 +1,15 @@
+"""Region routing for ``app_home_opened``.
+
+The ``zz_`` prefix keeps this file last in the package, and it has to stay: importing
+``backend.api`` pulls in ``posthog.temporal``, whose import runs ``configure_logger`` and
+installs Temporal's logger factory process-wide. Structlog binds loggers on first use, so
+every module that logs after that point is stuck with the swapped factory and its
+``caplog`` assertions go quiet — silently, since assertions that a log is *absent* still
+pass. Sorting last means the log-asserting suites (``test_get_slack_email_for_user``,
+``test_guess_repository``) have run before the swap. Same reasoning as
+``test_zz_resolve_slack_user_with_link_no_access.py``.
+"""
+
 from unittest.mock import MagicMock, patch
 
 from django.test import RequestFactory, TestCase


### PR DESCRIPTION
## Problem

The Slack App Home tab never publishes for workspaces owned by the region that didn't receive the event.

Slack posts every event to one Request URL, so the receiving region isn't necessarily the one holding the workspace's integration row. Every surface probes the other region and proxies — except `app_home_opened`, which returned `ROUTE_HANDLED_LOCALLY` before the gate and then looked the integration up locally:

```python
integration = _get_slack_integration(slack_team_id)   # local DB only
if integration is None:
    return                                            # silent, no log
```

For a workspace owned elsewhere that returns `None` and the handler bails three lines before the flag check. Blank tab, no log, and `slack-app-home` never even gets evaluated. Mentions, DMs and unfurls work for the same workspaces because they all take the proxy hop. Home tab interactivity is fine too — that endpoint has its own gate. Only the initial publish was missing one.

The Slack manifest is already correct (`home_tab_enabled: true`, `app_home_opened` subscribed). No flag or manifest change fixes this.

## Changes

- New `_route_app_home_opened` in `api.py`, mirroring `_route_assistant_event`: `load_integrations` → `resolve_region_or_terminal_route` → publish only when the gate returns `None`. Inherits the existing claims cache and US-precedence rules.
- `handle_app_home_opened` takes the resolved `integration` as a kwarg instead of re-querying, so the region decision and the publish can't disagree.
- Added `slack_app_home_publish_skipped` / `slack_app_home_published` logs — every early return here was silent, which is why this went unnoticed.

## How did you test this code?

Manually verified locally by me. Claude ran the automated side:

- New `test_app_home_routing.py`, 2 cases. First one is the regression: when the receiving region holds no row, the event must be forwarded rather than dropped — it fails on master. Second pins that a locally-owned workspace still publishes without a proxy hop. Nothing covered either before.
- `test_slack_app_home.py`, `test_slack_app_home_stats.py`, `test_slack_settings.py`: 99 passed.
- `ruff`, and repo-wide `mypy`: clean (17848 files).


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) investigated and wrote the patch, I directed it and verified the fix locally. Two wrong theories first: a missing Slack manifest change (killed by reading the manifest) and flag targeting (killed by replaying the server-side evaluation with group context, which returned `true`). The tell was that the flag had never been evaluated at all — which pointed at the router, where `app_home_opened` was the one branch skipping the region gate.

Considered giving `handle_app_home_opened` its own cross-region fallback lookup, rejected it: duplicating routing logic in one handler gets you two subtly different answers to the same question. No skills invoked. The test interaction above is the open item.
