### PR TITLE
chore(aio): remove rolled-out llm prompt feature flags

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5243,9 +5243,9 @@ snapshots:
     scenes-app-ai-observability-prompts--empty-state--light:
         hash: v1.k794b7964.83bb6355d1386b5957fb43acb45e48d351e3adea9c71f47a67eeedb0ce1949a1.T0OWcSem5zhD85QUMGVmdYHwJPtpYOZV3Epg8teUqlc
     scenes-app-ai-observability-prompts--prompts-list--dark:
-        hash: v1.k794b7964.d04f5f25d543c7427fbfc2678fd8ef2828cec6d8c0107162204bbae9ec6e1c14.N6Zj2RLZ108T1ZC1w2KCCoMD7oaqaWSYBi_tChhGISM
+        hash: v1.k794b7964.5cdaae6b72efa77261704903c3b14197bd4996f9db290718a4a585758aaa6cf2.xbF6ujFL2OI5SqKxuBM4wYp4MT4t2IC_HjI5-9mkT4c
     scenes-app-ai-observability-prompts--prompts-list--light:
-        hash: v1.k794b7964.ea1fb296e2c4af76ad01efe5b7586e81f952d99aa3d6b7c1ef8701fdb4df857e.R8uyP-ciWKpHZTSh-zBebLbb4LELerPi08MaAIyVuIo
+        hash: v1.k794b7964.f4a3e9e0c94c327fbf41ea4698bb4d9cb92b5112848b3ee7f31c57466f0075b2.MoyySImBvALTiYl2FHqO1UG4XLCdcaJJzoUG56t_7gI
     scenes-app-ai-observability-sentiment--bar-full-width--dark:
         hash: v1.k794b7964.c85f4138877bf5f706d5675ad8ebca39a87300e45359ba3f5325551815fb5885.E-9wb0W7JxbRPXtj3-swTXq2QVbMKq-BpfDn-PXxcfU
     scenes-app-ai-observability-sentiment--bar-full-width--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -352,8 +352,6 @@ export const FEATURE_FLAGS = {
     LLM_ANALYTICS_TAGS: 'llm-analytics-tags', // owner: #team-ai-observability
     LLM_ANALYTICS_TRACE_NAVIGATION: 'llm-analytics-trace-navigation', // owner: #team-ai-observability
     LLM_OBSERVABILITY_TRACE_SEARCH: 'llm-observability-trace-search', // owner: #team-ai-observability
-    LLM_PROMPT_CONFIG: 'llm-prompt-config', // owner: @jurajmajerik #team-ai-observability
-    LLM_PROMPT_LABELS: 'prompt-labels', // owner: @jurajmajerik #team-ai-observability
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
     LOGS_ANOMALIES: 'logs-anomalies', // owner: @jonmcwest #team-logs

--- a/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptScene.tsx
@@ -8,10 +8,8 @@ import { LemonButton, LemonTabs } from '@posthog/lemon-ui'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -64,14 +62,10 @@ export function LLMPromptScene(): JSX.Element {
         isPromptFormDirty,
     } = useValues(llmPromptLogic)
     const { searchParams } = useValues(router)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const labelsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_LABELS]
     const currentSearchParams = searchParams ?? {}
-    // A ?tab= pointing at a tab that is not rendered (e.g. history with the flag off)
-    // would leave LemonTabs with no matching content; fall back to overview instead.
-    const availableViewTabs = labelsEnabled
-        ? ['code', 'usage', 'experiments', 'history']
-        : ['code', 'usage', 'experiments']
+    // A ?tab= pointing at a tab that is not rendered would leave LemonTabs with no
+    // matching content; fall back to overview instead.
+    const availableViewTabs = ['code', 'usage', 'experiments', 'history']
     const activeViewTab = availableViewTabs.includes(searchParams?.tab) ? searchParams.tab : 'overview'
 
     const {
@@ -235,20 +229,16 @@ export function LLMPromptScene(): JSX.Element {
                                     label: 'Experiments',
                                     content: <PromptExperiments prompt={prompt} />,
                                 },
-                                ...(labelsEnabled
-                                    ? [
-                                          {
-                                              key: 'history',
-                                              label: 'History',
-                                              content: (
-                                                  <ActivityLog
-                                                      scope={[ActivityScope.LLM_PROMPT, ActivityScope.LLM_PROMPT_LABEL]}
-                                                      id={prompt.activity_item_id}
-                                                  />
-                                              ),
-                                          },
-                                      ]
-                                    : []),
+                                {
+                                    key: 'history',
+                                    label: 'History',
+                                    content: (
+                                        <ActivityLog
+                                            scope={[ActivityScope.LLM_PROMPT, ActivityScope.LLM_PROMPT_LABEL]}
+                                            id={prompt.activity_item_id}
+                                        />
+                                    ),
+                                },
                             ]}
                         />
                     ) : (

--- a/products/ai_observability/frontend/prompts/LLMPromptsScene.tsx
+++ b/products/ai_observability/frontend/prompts/LLMPromptsScene.tsx
@@ -7,11 +7,9 @@ import { Link } from '@posthog/lemon-ui'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { MemberSelect } from 'lib/components/MemberSelect'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -40,8 +38,6 @@ export function LLMPromptsScene(): JSX.Element {
     const { prompts, promptsLoading, sorting, pagination, filters, promptCountLabel, shouldShowEmptyState } =
         useValues(llmPromptsLogic)
     const { searchParams } = useValues(router)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const labelsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_LABELS]
     const promptUrl = (name: string): string =>
         combineUrl(urls.aiObservabilityPrompt(name), stripPromptSceneSearchParams(searchParams)).url
 
@@ -93,26 +89,22 @@ export function LLMPromptsScene(): JSX.Element {
                 return <span className="text-muted-alt">{prompt.version_count}</span>
             },
         },
-        ...(labelsEnabled
-            ? ([
-                  {
-                      title: 'Labels',
-                      key: 'labels',
-                      render: function renderLabels(_, prompt) {
-                          if (!prompt.all_labels?.length) {
-                              return <span className="text-muted-alt">–</span>
-                          }
-                          return (
-                              <div className="flex flex-wrap gap-1">
-                                  {prompt.all_labels.map((label) => (
-                                      <PromptLabelChip key={label.name} label={`${label.name}: v${label.version}`} />
-                                  ))}
-                              </div>
-                          )
-                      },
-                  },
-              ] as LemonTableColumns<LLMPrompt>)
-            : []),
+        {
+            title: 'Labels',
+            key: 'labels',
+            render: function renderLabels(_, prompt) {
+                if (!prompt.all_labels?.length) {
+                    return <span className="text-muted-alt">–</span>
+                }
+                return (
+                    <div className="flex flex-wrap gap-1">
+                        {prompt.all_labels.map((label) => (
+                            <PromptLabelChip key={label.name} label={`${label.name}: v${label.version}`} />
+                        ))}
+                    </div>
+                )
+            },
+        },
         atColumn('created_at', 'Latest version created') as LemonTableColumn<LLMPrompt, keyof LLMPrompt | undefined>,
         {
             width: 0,

--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -16,7 +16,6 @@ import {
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput'
@@ -25,7 +24,6 @@ import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { CodeEditor } from 'lib/monaco/CodeEditor'
 import { lazyWithRetry } from 'lib/utils/retryImport'
 import { teamLogic } from 'scenes/teamLogic'
@@ -79,15 +77,13 @@ export function PromptViewDetails(): JSX.Element {
     const { prompt, isRenderingMarkdown, isDiffVisible, canCompareVersions, compareVersionOptions } =
         useValues(llmPromptLogic)
     const { toggleMarkdownRendering, setCompareVersion } = useActions(llmPromptLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
     const markdownContainerRef = useRef<HTMLDivElement>(null)
 
     if (!prompt || !isPrompt(prompt)) {
         return <></>
     }
 
-    const configEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_CONFIG]
-    const configJson = configEnabled && prompt.config != null ? formatPromptConfig(prompt.config) : null
+    const configJson = prompt.config != null ? formatPromptConfig(prompt.config) : null
 
     const promptText = prompt.prompt
     const variableMatches = promptText.match(/\{\{([^}]+)\}\}/g)
@@ -176,8 +172,6 @@ export function PromptViewDetails(): JSX.Element {
 // version, freshness, and provenance.
 export function PromptHeaderMeta(): JSX.Element | null {
     const { prompt, promptLabels } = useValues(llmPromptLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const labelsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_LABELS]
 
     if (!isPrompt(prompt)) {
         return null
@@ -200,15 +194,13 @@ export function PromptHeaderMeta(): JSX.Element | null {
                     Historical
                 </LemonTag>
             )}
-            {labelsEnabled
-                ? promptLabels.map((label) => (
-                      <PromptLabelChip
-                          key={label.name}
-                          label={`${label.name} → v${label.version}`}
-                          data-attr={`llma-prompt-header-label-${label.name}`}
-                      />
-                  ))
-                : null}
+            {promptLabels.map((label) => (
+                <PromptLabelChip
+                    key={label.name}
+                    label={`${label.name} → v${label.version}`}
+                    data-attr={`llma-prompt-header-label-${label.name}`}
+                />
+            ))}
             {prompt.version_description ? (
                 <span className="italic" data-attr="llma-prompt-version-description">
                     “{prompt.version_description}”
@@ -238,9 +230,6 @@ export function PublishReviewModal(): JSX.Element | null {
     } = useValues(llmPromptLogic)
     const { promptLabels } = useValues(llmPromptLogic)
     const { closePublishReview, submitPromptForm, setVersionDescription } = useActions(llmPromptLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const labelsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_LABELS]
-    const showConfigChange = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_CONFIG] && isConfigChanged
 
     if (!isPrompt(prompt)) {
         return null
@@ -249,7 +238,7 @@ export function PublishReviewModal(): JSX.Element | null {
     const publishLabel = nextVersion ? `Publish v${nextVersion}` : 'Publish version'
     // Publishing no longer means shipping once labels are in use; say so at the moment it matters.
     const labelsNote =
-        labelsEnabled && promptLabels.length > 0
+        promptLabels.length > 0
             ? ` Publishing does not move labels: ${promptLabels
                   .map((label) => `${label.name} stays on v${label.version}`)
                   .join(', ')}.`
@@ -313,7 +302,7 @@ export function PublishReviewModal(): JSX.Element | null {
                         />
                     </Suspense>
                 </div>
-                {showConfigChange ? (
+                {isConfigChanged ? (
                     <div data-attr="llma-prompt-publish-review-config-diff">
                         <div className="mb-1 flex items-center gap-2">
                             <span className="text-sm font-semibold">Configuration</span>
@@ -367,7 +356,6 @@ function PromptDiffView(): JSX.Element {
     const { prompt, comparePrompt, comparePromptLoading, compareVersion, compareVersionOptions } =
         useValues(llmPromptLogic)
     const { setCompareVersion } = useActions(llmPromptLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
 
     if (!prompt || !isPrompt(prompt)) {
         return <></>
@@ -378,7 +366,7 @@ function PromptDiffView(): JSX.Element {
     const modified = prompt.prompt
     const originalConfig = formatPromptConfig(comparePrompt?.config)
     const modifiedConfig = formatPromptConfig(prompt.config)
-    const showConfigDiff = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_CONFIG] && !!(originalConfig || modifiedConfig)
+    const showConfigDiff = !!(originalConfig || modifiedConfig)
 
     return (
         <div className="mt-2 space-y-3" data-attr="llma-prompt-diff-view">
@@ -586,18 +574,14 @@ export function PromptCodeSnippets({ prompt }: { prompt: LLMPrompt }): JSX.Eleme
     const { snippetLanguage, promptLabels } = useValues(llmPromptLogic)
     const { setSnippetLanguage } = useActions(llmPromptLogic)
     const { currentTeam } = useValues(teamLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const labelsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_LABELS]
 
     const host = window.location.origin
     const projectApiKey = currentTeam?.api_token ?? '<project_api_key>'
     const variables = extractPromptVariables(prompt.prompt)
     // Teach the recommended pattern the moment it applies: once a label exists, fetch by it.
-    const snippetLabel = labelsEnabled
-        ? (promptLabels.find((label) => label.name === 'production') ?? promptLabels[0])?.name
-        : undefined
+    const snippetLabel = (promptLabels.find((label) => label.name === 'production') ?? promptLabels[0])?.name
     // Same principle for config: only show the usage line once this prompt has one.
-    const showConfig = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_CONFIG] && prompt.config != null
+    const showConfig = prompt.config != null
 
     return (
         <div className="mb-6" data-attr="llma-prompt-code-snippets">
@@ -849,11 +833,6 @@ export function PromptExperiments({ prompt }: { prompt: LLMPrompt }): JSX.Elemen
 function PromptConfigEditField(): JSX.Element | null {
     const { promptForm, isConfigEditorVisible } = useValues(llmPromptLogic)
     const { showConfigEditor, removeConfig } = useActions(llmPromptLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    if (!featureFlags[FEATURE_FLAGS.LLM_PROMPT_CONFIG]) {
-        return null
-    }
 
     if (!isConfigEditorVisible && !promptForm.config.trim()) {
         return (
@@ -1035,8 +1014,6 @@ export function PromptVersionSidebar({
 }): JSX.Element {
     const { compareVersion, labelsByVersion, labelPickerVersion } = useValues(llmPromptLogic)
     const { setCompareVersion, openLabelPicker, requestRemoveLabel } = useActions(llmPromptLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const labelsEnabled = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_LABELS]
 
     return (
         <aside className="w-full shrink-0 xl:sticky xl:top-4 xl:mt-3 xl:w-80">
@@ -1112,52 +1089,48 @@ export function PromptVersionSidebar({
                                 {versionPrompt.created_by?.email ? (
                                     <div className="mt-1 text-xs text-secondary">{versionPrompt.created_by.email}</div>
                                 ) : null}
-                                {labelsEnabled ? (
-                                    <div
-                                        className="mt-1.5 flex flex-wrap items-center gap-1"
-                                        // The card is a Link; label actions must not navigate. Capture-phase
-                                        // preventDefault runs before child handlers that stopPropagation
-                                        // (e.g. LemonTag's close button), which would otherwise let the
-                                        // anchor's native navigation through.
-                                        onClickCapture={(e) => e.preventDefault()}
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        {(labelsByVersion[versionPrompt.version] ?? []).map((label) => (
+                                <div
+                                    className="mt-1.5 flex flex-wrap items-center gap-1"
+                                    // The card is a Link; label actions must not navigate. Capture-phase
+                                    // preventDefault runs before child handlers that stopPropagation
+                                    // (e.g. LemonTag's close button), which would otherwise let the
+                                    // anchor's native navigation through.
+                                    onClickCapture={(e) => e.preventDefault()}
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    {(labelsByVersion[versionPrompt.version] ?? []).map((label) => (
+                                        <AccessControlAction
+                                            key={label.name}
+                                            resourceType={AccessControlResourceType.LlmAnalytics}
+                                            minAccessLevel={AccessControlLevel.Editor}
+                                        >
+                                            <PromptLabelChip
+                                                label={label.name}
+                                                onRemove={readOnly ? undefined : () => requestRemoveLabel(label.name)}
+                                                data-attr={`llma-prompt-label-${label.name}`}
+                                            />
+                                        </AccessControlAction>
+                                    ))}
+                                    {!readOnly &&
+                                        (labelPickerVersion === versionPrompt.version ? (
+                                            <PromptLabelPicker version={versionPrompt.version} />
+                                        ) : (
                                             <AccessControlAction
-                                                key={label.name}
                                                 resourceType={AccessControlResourceType.LlmAnalytics}
                                                 minAccessLevel={AccessControlLevel.Editor}
                                             >
-                                                <PromptLabelChip
-                                                    label={label.name}
-                                                    onRemove={
-                                                        readOnly ? undefined : () => requestRemoveLabel(label.name)
-                                                    }
-                                                    data-attr={`llma-prompt-label-${label.name}`}
-                                                />
+                                                <LemonButton
+                                                    size="xsmall"
+                                                    icon={<IconPlusSmall />}
+                                                    onClick={() => openLabelPicker(versionPrompt.version)}
+                                                    tooltip="Point a label at this version"
+                                                    data-attr={`llma-prompt-add-label-${versionPrompt.version}`}
+                                                >
+                                                    Add label
+                                                </LemonButton>
                                             </AccessControlAction>
                                         ))}
-                                        {!readOnly &&
-                                            (labelPickerVersion === versionPrompt.version ? (
-                                                <PromptLabelPicker version={versionPrompt.version} />
-                                            ) : (
-                                                <AccessControlAction
-                                                    resourceType={AccessControlResourceType.LlmAnalytics}
-                                                    minAccessLevel={AccessControlLevel.Editor}
-                                                >
-                                                    <LemonButton
-                                                        size="xsmall"
-                                                        icon={<IconPlusSmall />}
-                                                        onClick={() => openLabelPicker(versionPrompt.version)}
-                                                        tooltip="Point a label at this version"
-                                                        data-attr={`llma-prompt-add-label-${versionPrompt.version}`}
-                                                    >
-                                                        Add label
-                                                    </LemonButton>
-                                                </AccessControlAction>
-                                            ))}
-                                    </div>
-                                ) : null}
+                                </div>
                             </>
                         )
 


### PR DESCRIPTION
## Problem

The `prompt-labels` and `llm-prompt-config` flags are at 100% rollout, but 13 sites in the prompt scenes still check them.

## Changes

- Removed both flag checks from the prompt list, detail, and shared scene components. Labels, config, and the History tab now render unconditionally.
- Removed both entries from `FEATURE_FLAGS` in `constants.tsx`.

No visual change for users, since the flags were already on everywhere.

## How did you test this code?

Mechanical removal of always-true branches. Verified no references remain with a repo-wide grep. Not run locally: frontend typecheck and jest (light worktree without frontend node_modules); relying on CI for both.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Skills invoked: /wt, /writing-pr-descriptions. Follow-up: archive both flags in PostHog after this merges.