### PR TITLE
chore(retention): test first-ever custom brackets east of utc

### DIFF
--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -7935,6 +7935,32 @@ class TestClickhouseRetentionGroupAggregation(
         day0_row = next(r for r in result if r["label"] == "Day 0")
         self.assertEqual([v["count"] for v in day0_row["values"]], [1, 1, 1])
 
+    def test_custom_brackets_first_ever_east_of_utc_timezone(self):
+        """The first-ever anchor must keep the same timezone type as legacy's aggregate, or brackets shift east of UTC"""
+        self.team.timezone = "Asia/Kolkata"
+        self.team.save()
+
+        _create_person(team_id=self.team.pk, distinct_ids=["person1"])
+        _create_events(self.team, [("person1", _date(0))], "$user_signed_up")
+        _create_events(self.team, [("person1", _date(1)), ("person1", _date(6))], "$pageview")
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_to": _date(10)},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 11,
+                    "retentionType": RETENTION_FIRST_EVER_OCCURRENCE,
+                    "targetEntity": {"id": "$user_signed_up", "type": TREND_FILTER_TYPE_EVENTS},
+                    "returningEntity": {"id": "$pageview", "type": "events"},
+                    "retentionCustomBrackets": [4, 5],  # Day 1-4, Day 5-9
+                },
+            }
+        )
+
+        day0_row = next(r for r in result if r["label"] == "Day 0")
+        self.assertEqual([v["count"] for v in day0_row["values"]], [1, 1, 1])
+
     def test_custom_brackets_with_minimum_occurrences(self):
         """Test custom brackets with minimum occurrences (counted per day within bracket)"""
         _create_person(team_id=self.team.pk, distinct_ids=["person1"])


### PR DESCRIPTION
## Problem

- The production legacy-vs-variant retention sweep flagged first-ever custom-bracket insights on east-of-UTC teams with the same one-bracket shift as first-time ones.
- [#79002](https://github.com/PostHog/posthog/pull/79002) fixed both, but its regression test covers first-time only.
- The first-ever anchor is a separate expression upstream of the shared `_anchored_start_event_timestamps_expr`. A refactor that splits it out would regress east-of-UTC bracket bucketing with no failing test.

## Changes

- One test: first-ever retention with custom brackets on an `Asia/Kolkata` team, asserting the next-day return stays in the first bracket. Mirrors the first-time test from #79002 with a distinct target entity, matching the insight shapes the sweep flagged.

## How did you test this code?

- The parity mixin runs the test through both query builders and asserts identical results, so the test fails whenever the variant loses the timezone pin.
- Ran locally three ways: passes on master, fails (variant comparison diverges) with the `toTimeZone` pin edited out of `_anchored_start_event_timestamps_expr`, passes again restored. The merged first-time test behaved identically in all three runs.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code, while investigating the remaining mismatches in the retention parity sweep ([#64819](https://github.com/PostHog/posthog/pull/64819)). The sweep's cell dumps showed the bracket shift on first-ever insights; #79002 (merged after the sweep pod's image was built) already fixes them, and this PR locks the first-ever combination.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
