### PR TITLE
fix(openrouter): retry 408 request timeouts instead of failing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/openrouter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/openrouter.py
@@ -61,7 +61,9 @@ def _build_url(path: str, params: Optional[dict[str, Any]] = None) -> str:
 def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
     response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
 
-    if response.status_code == 429 or response.status_code >= 500:
+    # 408 is a transient request timeout on OpenRouter's side; retry it like 429/5xx rather than
+    # letting it raise_for_status() into a fatal, non-retried HTTPError.
+    if response.status_code in (408, 429) or response.status_code >= 500:
         raise OpenRouterRetryableError(f"OpenRouter API error (retryable): status={response.status_code}, url={url}")
 
     if not response.ok:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/tests/test_openrouter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/tests/test_openrouter.py
@@ -47,7 +47,7 @@ class TestFetch:
         with mock.patch.object(openrouter._fetch.retry, "wait", return_value=0):  # type: ignore[attr-defined]
             yield
 
-    @pytest.mark.parametrize("status_code", [429, 500, 502, 503])
+    @pytest.mark.parametrize("status_code", [408, 429, 500, 502, 503])
     def test_retries_then_succeeds_on_transient_status(self, status_code):
         session = mock.Mock()
         session.get.side_effect = [_response(status_code), _response(200, {"data": []})]


### PR DESCRIPTION
## Problem

The OpenRouter warehouse source fails an entire sync on a single request timeout from OpenRouter's API, instead of retrying it. [Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdc25-4c80-7802-8fbc-4e07e28aec8a) shows `HTTPError: 408 Client Error: Request Timeout` from the `/activity` endpoint.

`_fetch` in `openrouter.py` only classifies HTTP 429 and 5xx as retryable. A 408 falls through to `raise_for_status()`, which raises a plain `HTTPError` that tenacity's in-process retry does not catch. The error propagates out of the sync and only gets picked up by Temporal's coarser, whole-activity retry.

## Changes

- Treat 408 as a retryable status alongside 429 and 5xx, so a request timeout backs off and retries in place instead of restarting the whole sync.
- This is the same fix already shipped for the Datadog source (`datadog.py`), applied here for the same failure shape.

## How did you test this code?

Extended the existing parametrized `test_retries_then_succeeds_on_transient_status` case to cover 408, alongside 429/500/502/503 — this is the regression that would have caught the bug, since 408 previously fell into the sibling `test_client_errors_raise` behavior.

Ran `products/warehouse_sources/backend/temporal/data_imports/sources/openrouter/tests/test_openrouter.py` locally: all 41 cases pass.
Ran `ruff check --fix` and `ruff format --check` on the touched files: clean.
Not run: the wider Temporal activity/pipeline integration tests, or a live call against OpenRouter's API.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing behavior or config changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a webhook-delivered error tracking alert. Investigated the issue and stack trace with the PostHog error-tracking MCP tools, then read `openrouter.py`/`source.py`/`settings.py` and the Stripe source's `get_non_retryable_errors` as a style reference.

An `Explore`-style research pass found that the Datadog source had already hit and fixed this exact bug shape (408 falling through the retryable-status check), which set the fix and test pattern mirrored here.

Skills invoked: `/writing-tests` before extending the test, `/writing-pr-descriptions` before writing this body.