### PR TITLE
fix(desktop): open artifact tabs in Pi tasks

### DIFF
--- a/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.test.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.test.tsx
@@ -1,0 +1,86 @@
+import type { Task } from "@posthog/shared/domain-types";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { Tab } from "../../panels/panelTypes";
+import { TabContentRenderer } from "./TabContentRenderer";
+
+vi.mock("../../autoresearch/AutoresearchPanel", () => ({
+  AutoresearchPanel: (): null => null,
+}));
+vi.mock("../../code-editor/components/CodeEditorPanel", () => ({
+  CodeEditorPanel: (): null => null,
+}));
+vi.mock("../../code-review/components/LazyReviewPages", () => ({
+  LazyCloudReviewPage: (): null => null,
+  LazyReviewPage: (): null => null,
+}));
+vi.mock("../../sessions/components/ArtifactPreview", () => ({
+  ArtifactPreview: (): null => null,
+}));
+vi.mock("../../workspace/useWorkspace", () => ({
+  useIsWorkspaceCloudRun: () => false,
+}));
+vi.mock("./ActionPanel", () => ({ ActionPanel: (): null => null }));
+vi.mock("./CanvasInstructionsTab", () => ({
+  CanvasInstructionsTab: (): null => null,
+}));
+vi.mock("./ChangesPanel", () => ({ ChangesPanel: (): null => null }));
+vi.mock("./ChannelContextTab", () => ({
+  ChannelContextTab: (): null => null,
+}));
+vi.mock("./FileTreePanel", () => ({ FileTreePanel: (): null => null }));
+vi.mock("./TaskShellPanel", () => ({ TaskShellPanel: (): null => null }));
+
+vi.mock("../../pi-sessions/PiSessionView", () => ({
+  PiSessionView: ({
+    taskId,
+    taskRunId,
+  }: {
+    taskId: string;
+    taskRunId?: string;
+  }): ReactElement => (
+    <div data-testid="pi-session">
+      {taskId}:{taskRunId}
+    </div>
+  ),
+}));
+
+vi.mock("./TaskLogsPanel", () => ({
+  TaskLogsPanel: (): ReactElement => <div data-testid="acp-session" />,
+}));
+
+const logsTab: Tab = {
+  id: "logs",
+  label: "Chat",
+  data: { type: "logs" },
+};
+
+function task(runtime: "pi" | "acp"): Task {
+  return {
+    id: "task-1",
+    runtime,
+    latest_run: { id: "run-1" },
+  } as Task;
+}
+
+describe("TabContentRenderer", () => {
+  it.each([
+    { runtime: "pi" as const, expected: "pi-session", absent: "acp-session" },
+    { runtime: "acp" as const, expected: "acp-session", absent: "pi-session" },
+  ])(
+    "renders the $runtime chat inside the panel",
+    ({ runtime, expected, absent }) => {
+      render(
+        <TabContentRenderer
+          tab={logsTab}
+          taskId="task-1"
+          task={task(runtime)}
+        />,
+      );
+
+      expect(screen.getByTestId(expected)).toBeInTheDocument();
+      expect(screen.queryByTestId(absent)).not.toBeInTheDocument();
+    },
+  );
+});

--- a/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TabContentRenderer.tsx
@@ -6,6 +6,7 @@ import {
   LazyReviewPage as ReviewPage,
 } from "../../code-review/components/LazyReviewPages";
 import type { Tab } from "../../panels/panelTypes";
+import { PiSessionView } from "../../pi-sessions/PiSessionView";
 import { ArtifactPreview } from "../../sessions/components/ArtifactPreview";
 import { useIsWorkspaceCloudRun } from "../../workspace/useWorkspace";
 import { ActionPanel } from "./ActionPanel";
@@ -27,12 +28,22 @@ export function TabContentRenderer({
   taskId,
   task,
 }: TabContentRendererProps) {
-  const isCloud = useIsWorkspaceCloudRun(taskId);
+  const isCloud =
+    useIsWorkspaceCloudRun(taskId) || task.latest_run?.environment === "cloud";
   const { data } = tab;
 
   switch (data.type) {
     case "logs":
-      return <TaskLogsPanel taskId={taskId} task={task} />;
+      return task.runtime === "pi" ? (
+        <PiSessionView
+          key={taskId}
+          taskId={taskId}
+          taskRunId={task.latest_run?.id}
+          isCloud={isCloud}
+        />
+      ) : (
+        <TaskLogsPanel taskId={taskId} task={task} />
+      );
 
     case "terminal":
       return (

--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -25,7 +25,6 @@ import { SHORTCUTS } from "../../command/keyboard-shortcuts";
 import { useRepoFileWatcher } from "../../file-watcher/useRepoFileWatcher";
 import { clearGitReviewQueries } from "../../git-interaction/gitCacheKeys";
 import { PanelLayout } from "../../panels/components/PanelLayout";
-import { PiSessionView } from "../../pi-sessions/PiSessionView";
 import { MIN_CHAT_WIDTH } from "../../sessions/constants";
 import { useArchivingTasksStore } from "../../sidebar/archivingTasksStore";
 import { ArchiveRunningTaskDialog } from "../../sidebar/components/ArchiveRunningTaskDialog";
@@ -70,7 +69,6 @@ export function TaskDetail({
     (state) => state.sessions[taskId]?.status?.isStreaming ?? false,
   );
   const runtime = task.runtime === "pi" ? "pi" : "acp";
-  const selectedTaskRunId = task.latest_run?.id;
 
   const effectiveRepoPath = useCwd(taskId);
 
@@ -321,15 +319,7 @@ export function TaskDetail({
     <Box data-task-detail-id={taskId} height="100%" ref={containerRef}>
       <Flex height="100%">
         <Box className={`min-w-0 flex-1 ${isExpanded ? "hidden" : ""}`}>
-          {runtime === "pi" && (
-            <PiSessionView
-              key={taskId}
-              taskId={taskId}
-              taskRunId={selectedTaskRunId}
-              isCloud={isCloud}
-            />
-          )}
-          {runtime === "acp" && <PanelLayout taskId={taskId} task={task} />}
+          <PanelLayout taskId={taskId} task={task} />
         </Box>
 
         {isReviewOpen && !isExpanded && (


### PR DESCRIPTION
## Problem

People using Pi tasks cannot open generated artifacts in a tab, while downloads still work.

The preview action writes to the panel store, but Pi tasks did not mount the panel layout that renders those tabs.

## Changes

- Pi tasks now render chat through the shared panel layout, so artifact previews open beside Chat.
- The Chat tab selects the Pi or ACP session renderer from the task runtime.
- No screenshot: this restores the existing task-tab surface and adds no new visual design.

## How did you test this code?

- `pnpm --dir products/desktop --filter @posthog/ui exec vitest run src/features/panels/panelLayoutStore.test.ts src/features/task-detail/components/TabContentRenderer.test.tsx`
- `pnpm --dir products/desktop --filter @posthog/ui typecheck`
- The new runtime cases catch Pi chat bypassing the panel that owns artifact tabs.
- Not run: `hogli ci:preflight`; the active environment has a stale, non-importable hogli package.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This fixes internal desktop behavior without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code. Invoked `/writing-tests` and `/writing-pr-descriptions`.

The test data is invented and contains no session-derived material.
