### PR TITLE
fix(experiments): strip generated SQL from MCP results tool responses

### DIFF
--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -762,6 +762,18 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+        response:
+            exclude:
+                - results.*.result.hogql
+                - results.*.result.clickhouse_sql
+                - results.*.result.cache_key
+                - results.*.result.is_cached
+                - results.*.result.cache_target_age
+                - results.*.result.next_allowed_client_refresh
+                - results.*.result.calculation_trigger
+                - results.*.result.query_status
+                - results.*.result.stats_version
+                - results.*.result.insight
     experiment-metrics-recalculation-retrieve:
         operation: experiments_metrics_recalculation_retrieve
         enabled: true
@@ -793,6 +805,18 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+        response:
+            exclude:
+                - results.*.result.hogql
+                - results.*.result.clickhouse_sql
+                - results.*.result.cache_key
+                - results.*.result.is_cached
+                - results.*.result.cache_target_age
+                - results.*.result.next_allowed_client_refresh
+                - results.*.result.calculation_trigger
+                - results.*.result.query_status
+                - results.*.result.stats_version
+                - results.*.result.insight
     experiment-pause:
         operation: experiments_pause_create
         enabled: true
@@ -1114,6 +1138,18 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+        response:
+            exclude:
+                - timeseries.*.hogql
+                - timeseries.*.clickhouse_sql
+                - timeseries.*.cache_key
+                - timeseries.*.is_cached
+                - timeseries.*.cache_target_age
+                - timeseries.*.next_allowed_client_refresh
+                - timeseries.*.calculation_trigger
+                - timeseries.*.query_status
+                - timeseries.*.stats_version
+                - timeseries.*.insight
         ui_app: experiment-results
     experiment-unarchive:
         operation: experiments_unarchive_create

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -1138,6 +1138,7 @@ tools:
         param_overrides:
             id:
                 cast: string-int
+        ui_app: experiment-results
         response:
             exclude:
                 - timeseries.*.hogql
@@ -1150,7 +1151,6 @@ tools:
                 - timeseries.*.query_status
                 - timeseries.*.stats_version
                 - timeseries.*.insight
-        ui_app: experiment-results
     experiment-unarchive:
         operation: experiments_unarchive_create
         enabled: true

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -52,7 +52,7 @@ import {
 import { withUiApp } from '@/resources/ui-apps'
 import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
 import { castStringToInt } from '@/tools/cast-helpers'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ExperimentActivitySchema = ExperimentsActivityRetrieveParams.omit({ project_id: true })
@@ -754,7 +754,19 @@ const experimentMetricsRecalculationLatestRetrieve = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/experiments/${encodeURIComponent(String(params.id))}/metrics_recalculation/latest/`,
         })
-        return await withPostHogUrl(context, result, `/experiments/${params.id}`)
+        const filtered = omitResponseFields(result, [
+            'results.*.result.hogql',
+            'results.*.result.clickhouse_sql',
+            'results.*.result.cache_key',
+            'results.*.result.is_cached',
+            'results.*.result.cache_target_age',
+            'results.*.result.next_allowed_client_refresh',
+            'results.*.result.calculation_trigger',
+            'results.*.result.query_status',
+            'results.*.result.stats_version',
+            'results.*.result.insight',
+        ]) as typeof result
+        return await withPostHogUrl(context, filtered, `/experiments/${params.id}`)
     },
 })
 
@@ -774,7 +786,19 @@ const experimentMetricsRecalculationRetrieve = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/experiments/${encodeURIComponent(String(params.id))}/metrics_recalculation/${encodeURIComponent(String(params.recalculation_id))}/`,
         })
-        return await withPostHogUrl(context, result, `/experiments/${params.id}`)
+        const filtered = omitResponseFields(result, [
+            'results.*.result.hogql',
+            'results.*.result.clickhouse_sql',
+            'results.*.result.cache_key',
+            'results.*.result.is_cached',
+            'results.*.result.cache_target_age',
+            'results.*.result.next_allowed_client_refresh',
+            'results.*.result.calculation_trigger',
+            'results.*.result.query_status',
+            'results.*.result.stats_version',
+            'results.*.result.insight',
+        ]) as typeof result
+        return await withPostHogUrl(context, filtered, `/experiments/${params.id}`)
     },
 })
 
@@ -1062,7 +1086,19 @@ const experimentTimeseriesResults = (): ToolBase<typeof ExperimentTimeseriesResu
                     metric_uuid: params.metric_uuid,
                 },
             })
-            return result
+            const filtered = omitResponseFields(result, [
+                'timeseries.*.hogql',
+                'timeseries.*.clickhouse_sql',
+                'timeseries.*.cache_key',
+                'timeseries.*.is_cached',
+                'timeseries.*.cache_target_age',
+                'timeseries.*.next_allowed_client_refresh',
+                'timeseries.*.calculation_trigger',
+                'timeseries.*.query_status',
+                'timeseries.*.stats_version',
+                'timeseries.*.insight',
+            ]) as typeof result
+            return filtered
         },
     })
 


### PR DESCRIPTION
## Problem

- An agent reading experiment results over MCP receives two full copies of generated ClickHouse SQL per metric, plus cache internals, on every call.
- On a real 14-day experiment the timeseries tool returned 130,727 characters. 79% of that is SQL and cache metadata the agent never uses.
- The results tools carry the same bloat per metric entry.

## Changes

- The three results tools now drop `hogql`, `clickhouse_sql`, and cache internals (`cache_key`, `is_cached`, `cache_target_age`, `next_allowed_client_refresh`, `calculation_trigger`, `query_status`, `stats_version`, `insight`) from each result entry.
- Tools: `experiment-metrics-recalculation-latest-retrieve`, `experiment-metrics-recalculation-retrieve`, `experiment-timeseries-results`.
- Implemented as `response.exclude` dot-paths in `products/experiments/mcp/tools.yaml`. The generated handlers apply `omitResponseFields`.
- Everything statistical survives: baseline, variant results, p-values, intervals, exposures, run status, freshness, errors.

> [!NOTE]
> This only affects MCP tool responses. The REST API payloads are unchanged.

## How did you test this code?

- I replayed the saved 130,727-character production response for experiment timeseries through the same `del()` paths: 27,885 characters remain (79% smaller).
- `pnpm --filter=@posthog/mcp run typecheck` passes and `hogli ci:preflight --fix` regenerated the handlers cleanly.
- Not run: a live MCP call with the trimmed handler, which needs the deployed server.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Written by Claude Code in a session directed by Juraj, as a follow-up to #79562 (results card rewiring). Independent of that PR; both touch adjacent lines of tools.yaml, so whichever lands second needs a trivial rebase.
- Skills invoked: implementing-mcp-ui-apps, writing-pr-descriptions.
- I kept `results.*.result.metric` and `query_metadata` in the response. `metric` carries the metric definition when populated, which agents and the results card can use for labeling.
