### PR TITLE
fix(signals): add the scout name prefix instead of requiring it

### DIFF
--- a/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.test.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.test.tsx
@@ -34,4 +34,24 @@ describe('ScoutCreateModal', () => {
         expect(await findByText('Connect a Slack workspace')).toBeTruthy()
         expect(await findByText('Tags')).toBeTruthy()
     })
+
+    it('renders the name prefix outside the field and previews the full skill name', async () => {
+        const { baseElement, findByText } = render(
+            <ScoutCreateModal
+                isOpen
+                onClose={jest.fn()}
+                initialValues={{
+                    name: 'signals-scout-ai-observability-daily-digest',
+                    description: 'Creates a daily AI observability digest.',
+                    body: 'Review AI observability and create one actionable digest.',
+                }}
+            />
+        )
+
+        expect(await findByText('signals-scout-')).toBeTruthy()
+        expect(await findByText('signals-scout-ai-observability-daily-digest')).toBeTruthy()
+        expect(baseElement.querySelector<HTMLInputElement>('[data-attr="scout-create-name"]')?.value).toBe(
+            'ai-observability-daily-digest'
+        )
+    })
 })

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.test.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.test.tsx
@@ -3,6 +3,8 @@ import { cleanup, render } from '@testing-library/react'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
+import { SKILL_NAME_MAX_LENGTH } from 'products/skills/frontend/skillConstants'
+
 import { ScoutCreateModal } from './ScoutCreateModal'
 
 describe('ScoutCreateModal', () => {
@@ -50,8 +52,11 @@ describe('ScoutCreateModal', () => {
 
         expect(await findByText('signals-scout-')).toBeTruthy()
         expect(await findByText('signals-scout-ai-observability-daily-digest')).toBeTruthy()
-        expect(baseElement.querySelector<HTMLInputElement>('[data-attr="scout-create-name"]')?.value).toBe(
-            'ai-observability-daily-digest'
-        )
+
+        const nameInput = baseElement.querySelector<HTMLInputElement>('[data-attr="scout-create-name"]')
+        expect(nameInput?.value).toBe('ai-observability-daily-digest')
+        // The browser truncates a paste before onChange strips the prefix, so a cap of
+        // SKILL_NAME_MAX_LENGTH - prefix would silently shorten a pasted full name.
+        expect(nameInput?.getAttribute('maxlength')).toBe(String(SKILL_NAME_MAX_LENGTH))
     })
 })

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.tsx
@@ -129,7 +129,10 @@ export function ScoutCreateModal({ isOpen, onClose, initialValues, onCreated }: 
                         {({ value, onChange }) => (
                             <LemonInput
                                 autoFocus
-                                maxLength={SKILL_NAME_MAX_LENGTH - SIGNALS_SCOUT_SKILL_PREFIX.length}
+                                // The browser enforces this before onChange strips the prefix, so capping at the
+                                // scope length would silently drop the tail of a pasted full name. The full-name
+                                // limit cannot truncate anything valid; an over-long scope fails validation instead.
+                                maxLength={SKILL_NAME_MAX_LENGTH}
                                 prefix={
                                     <span className="font-mono text-[11px] text-secondary">
                                         {SIGNALS_SCOUT_SKILL_PREFIX}

--- a/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.tsx
+++ b/products/signals/frontend/inbox/components/config/scouts/ScoutCreateModal.tsx
@@ -16,6 +16,7 @@ import { LemonField } from 'lib/lemon-ui/LemonField'
 import { teamLogic } from 'scenes/teamLogic'
 
 import type { SignalScoutCreateResponseApi } from 'products/signals/frontend/generated/api.schemas'
+import { SKILL_NAME_MAX_LENGTH } from 'products/skills/frontend/skillConstants'
 
 import {
     ScoutCreateInitialValues,
@@ -23,11 +24,13 @@ import {
     scoutCreateModalLogic,
 } from '../../../logics/scoutCreateModalLogic'
 import {
+    ensureScoutPrefix,
     getScoutScheduleMode,
     getScoutScheduleOptions,
     SCOUT_CUSTOM_CRON_SCHEDULE_MODE,
     SCOUT_DAILY_AT_SCHEDULE_MODE,
     SIGNALS_SCOUT_SKILL_PREFIX,
+    stripScoutPrefix,
 } from '../../../utils/scoutRunsWindow'
 import { MAX_SCOUT_TAGS, normalizeScoutTags } from '../../../utils/scoutTags'
 import { ScoutSlackDestination } from './ScoutSlackDestination'
@@ -111,18 +114,34 @@ export function ScoutCreateModal({ isOpen, onClose, initialValues, onCreated }: 
                         name="name"
                         label="Name"
                         help={
-                            <>
-                                Scout names start with{' '}
-                                <span className="font-mono text-[11px]">{SIGNALS_SCOUT_SKILL_PREFIX}</span>.
-                            </>
+                            scoutCreateForm.name.trim() ? (
+                                <>
+                                    Full name:{' '}
+                                    <span className="font-mono text-[11px]">
+                                        {ensureScoutPrefix(scoutCreateForm.name.trim())}
+                                    </span>
+                                </>
+                            ) : (
+                                'The prefix is added for you.'
+                            )
                         }
                     >
-                        <LemonInput
-                            autoFocus
-                            maxLength={64}
-                            placeholder="signals-scout-checkout-failures"
-                            data-attr="scout-create-name"
-                        />
+                        {({ value, onChange }) => (
+                            <LemonInput
+                                autoFocus
+                                maxLength={SKILL_NAME_MAX_LENGTH - SIGNALS_SCOUT_SKILL_PREFIX.length}
+                                prefix={
+                                    <span className="font-mono text-[11px] text-secondary">
+                                        {SIGNALS_SCOUT_SKILL_PREFIX}
+                                    </span>
+                                }
+                                placeholder="checkout-failures"
+                                value={value}
+                                // Pasting a full skill name is common, and the prefix is already rendered.
+                                onChange={(name) => onChange(stripScoutPrefix(name))}
+                                data-attr="scout-create-name"
+                            />
+                        )}
                     </LemonField>
 
                     <LemonField

--- a/products/signals/frontend/inbox/logics/scoutCreateModalLogic.test.ts
+++ b/products/signals/frontend/inbox/logics/scoutCreateModalLogic.test.ts
@@ -93,7 +93,7 @@ describe('scoutCreateModalLogic', () => {
         logic.mount()
 
         expect(logic.values.scoutCreateForm).toEqual({
-            name: 'signals-scout-checkout-failures',
+            name: 'checkout-failures',
             description: 'Investigates recurring checkout failures.',
             body: 'Inspect checkout failure signals and report meaningful regressions.',
             dailyTime: '09:00',
@@ -234,8 +234,47 @@ describe('scoutCreateModalLogic', () => {
         expect(logic.values.scoutCreateFormManualErrors).toEqual({
             name: 'A scout with this name already exists with different instructions.',
         })
-        expect(logic.values.scoutCreateForm).toMatchObject(initialValues)
+        expect(logic.values.scoutCreateForm).toMatchObject({ ...initialValues, name: 'checkout-failures' })
         expect(onCreated).not.toHaveBeenCalled()
         expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('adds the scout name prefix on submit', async () => {
+        mockSignalsScoutCreate.mockResolvedValue(CREATED_SCOUT)
+        logic = scoutCreateModalLogic({ logicKey: 'bare-name-scout', onClose, onCreated })
+        logic.mount()
+
+        logic.actions.setScoutCreateFormValues({
+            name: 'checkout-failures',
+            description: 'Investigates recurring checkout failures.',
+            body: 'Inspect checkout failure signals and report meaningful regressions.',
+        })
+        await expectLogic(logic, () => logic.actions.submitScoutCreateForm()).toFinishAllListeners()
+
+        expect(mockSignalsScoutCreate).toHaveBeenCalledWith(
+            String(MOCK_TEAM_ID),
+            expect.objectContaining({ name: 'signals-scout-checkout-failures' })
+        )
+    })
+
+    it.each([
+        ['an empty name', ''],
+        ['the prefix on its own', 'signals-scout-'],
+    ])('does not submit %s', async (_label, name) => {
+        mockSignalsScoutCreate.mockResolvedValue(CREATED_SCOUT)
+        logic = scoutCreateModalLogic({ logicKey: `nameless-scout-${name}`, onClose, onCreated })
+        logic.mount()
+
+        logic.actions.setScoutCreateFormValues({
+            name,
+            description: 'Investigates recurring checkout failures.',
+            body: 'Inspect checkout failure signals and report meaningful regressions.',
+        })
+        await expectLogic(logic).toMatchValues({
+            scoutCreateFormValidationErrors: expect.objectContaining({ name: 'Name is required' }),
+        })
+        await expectLogic(logic, () => logic.actions.submitScoutCreateForm()).toFinishAllListeners()
+
+        expect(mockSignalsScoutCreate).not.toHaveBeenCalled()
     })
 })

--- a/products/signals/frontend/inbox/logics/scoutCreateModalLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutCreateModalLogic.ts
@@ -18,9 +18,10 @@ import { SKILL_DESCRIPTION_MAX_LENGTH, validateSkillName } from 'products/skills
 import {
     dailyCronToTime,
     DEFAULT_SCOUT_DAILY_TIME,
+    ensureScoutPrefix,
     SCOUT_CUSTOM_CRON_SCHEDULE_MODE,
     SCOUT_DAILY_AT_SCHEDULE_MODE,
-    SIGNALS_SCOUT_SKILL_PREFIX,
+    stripScoutPrefix,
     timeToDailyCron,
 } from '../utils/scoutRunsWindow'
 import { MAX_SCOUT_TAG_LENGTH, MAX_SCOUT_TAGS, normalizeScoutTag } from '../utils/scoutTags'
@@ -47,7 +48,7 @@ export interface ScoutCreateModalLogicProps {
 }
 
 export const DEFAULT_SCOUT_CREATE_FORM_VALUES: ScoutCreateFormValues = {
-    name: SIGNALS_SCOUT_SKILL_PREFIX,
+    name: '',
     description: '',
     body: '',
     dailyTime: DEFAULT_SCOUT_DAILY_TIME,
@@ -68,6 +69,10 @@ export function getScoutCreateFormValues(initialValues?: ScoutCreateInitialValue
     return {
         ...DEFAULT_SCOUT_CREATE_FORM_VALUES,
         ...initialValues,
+        // The form field holds the part after `signals-scout-`, which the modal renders as an inert
+        // input prefix and `submit` puts back. Openers (deep links, product buttons) pass a full
+        // skill name, so strip it here to keep the field and the rendered prefix from doubling up.
+        name: stripScoutPrefix(initialValues?.name?.trim() ?? DEFAULT_SCOUT_CREATE_FORM_VALUES.name),
         config,
         dailyTime: dailyCronToTime(config.run_cron_schedule) ?? DEFAULT_SCOUT_DAILY_TIME,
     }
@@ -78,15 +83,12 @@ function isValidScoutDailyTime(dailyTime: string): boolean {
 }
 
 function scoutNameError(name: string): string | undefined {
-    const normalizedName = name.trim()
-    const validationError = validateSkillName(normalizedName)
-    if (validationError) {
-        return validationError
+    const scopeName = stripScoutPrefix(name.trim())
+    if (!scopeName) {
+        return 'Name is required'
     }
-    if (!normalizedName.startsWith(SIGNALS_SCOUT_SKILL_PREFIX)) {
-        return `Name must start with ${SIGNALS_SCOUT_SKILL_PREFIX}`
-    }
-    return undefined
+    // Validate the name the backend receives, so its 64-character cap and slug rules account for the prefix.
+    return validateSkillName(ensureScoutPrefix(scopeName))
 }
 
 function scoutTagsError(tags: string[]): string | undefined {
@@ -222,7 +224,7 @@ export const scoutCreateModalLogic: LogicWrapper<scoutCreateModalLogicType> = ke
 
                 try {
                     const scout = await signalsScoutCreate(String(values.currentTeamId), {
-                        name: formValues.name.trim(),
+                        name: ensureScoutPrefix(formValues.name.trim()),
                         description: formValues.description.trim(),
                         body: formValues.body.trim(),
                         config: formValues.config,

--- a/products/signals/frontend/inbox/logics/scoutCreateModalLogic.ts
+++ b/products/signals/frontend/inbox/logics/scoutCreateModalLogic.ts
@@ -13,7 +13,11 @@ import type {
     SignalScoutCreateApi,
     SignalScoutCreateResponseApi,
 } from 'products/signals/frontend/generated/api.schemas'
-import { SKILL_DESCRIPTION_MAX_LENGTH, validateSkillName } from 'products/skills/frontend/skillConstants'
+import {
+    SKILL_DESCRIPTION_MAX_LENGTH,
+    SKILL_NAME_MAX_LENGTH,
+    validateSkillName,
+} from 'products/skills/frontend/skillConstants'
 
 import {
     dailyCronToTime,
@@ -21,6 +25,7 @@ import {
     ensureScoutPrefix,
     SCOUT_CUSTOM_CRON_SCHEDULE_MODE,
     SCOUT_DAILY_AT_SCHEDULE_MODE,
+    SIGNALS_SCOUT_SKILL_PREFIX,
     stripScoutPrefix,
     timeToDailyCron,
 } from '../utils/scoutRunsWindow'
@@ -82,12 +87,20 @@ function isValidScoutDailyTime(dailyTime: string): boolean {
     return /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(dailyTime)
 }
 
+/** The field holds the part after the prefix, so its cap is what the prefix leaves of the skill-name limit. */
+export const MAX_SCOUT_SCOPE_LENGTH = SKILL_NAME_MAX_LENGTH - SIGNALS_SCOUT_SKILL_PREFIX.length
+
 function scoutNameError(name: string): string | undefined {
     const scopeName = stripScoutPrefix(name.trim())
     if (!scopeName) {
         return 'Name is required'
     }
-    // Validate the name the backend receives, so its 64-character cap and slug rules account for the prefix.
+    // Report the field's own limit. validateSkillName would name the full 64, which reads as
+    // wrong against a field showing 55 characters.
+    if (scopeName.length > MAX_SCOUT_SCOPE_LENGTH) {
+        return `Name must be ${MAX_SCOUT_SCOPE_LENGTH} characters or fewer`
+    }
+    // Validate the name the backend receives, so the slug rules account for the prefix.
     return validateSkillName(ensureScoutPrefix(scopeName))
 }
 

--- a/products/signals/frontend/inbox/utils/scoutRunsWindow.ts
+++ b/products/signals/frontend/inbox/utils/scoutRunsWindow.ts
@@ -65,6 +65,11 @@ export function stripScoutPrefix(skillName: string): string {
         : skillName
 }
 
+/** Add the fleet prefix unless it is already there. `apm` → `signals-scout-apm`. Idempotent. */
+export function ensureScoutPrefix(skillName: string): string {
+    return skillName.startsWith(SIGNALS_SCOUT_SKILL_PREFIX) ? skillName : `${SIGNALS_SCOUT_SKILL_PREFIX}${skillName}`
+}
+
 /** "signals-scout-error-tracking" → "Error tracking" */
 export function prettifyScoutSkillName(skillName: string): string {
     const cleaned = stripScoutPrefix(skillName).replace(/[-_]/g, ' ').trim()


### PR DESCRIPTION
## Problem

- Anyone creating a scout in the inbox met a disabled "Create scout" button until they typed `signals-scout-` into the name field themselves.
- The form prefilled the prefix, so clearing the field or retyping the name re-broke the button with "Name must start with signals-scout-".
- Every scout skill name carries that prefix, so the field asked the author to retype a constant.

Refs #57939

## Changes

- The name field now takes the scout's scope on its own, for example `checkout-failures`.
- `signals-scout-` renders as an inert prefix inside the input.
- The help text shows the full skill name the form will create.
- Submit adds the prefix through a new `ensureScoutPrefix` helper, so the API still receives `signals-scout-<scope>`.
- The field strips a pasted or prefilled prefix. That keeps existing openers working, including the `#createScout` deep link and the AI observability digest button, without double-prefixing.
- Name validation now runs against the prefixed name, so the 64-character cap and the slug rules account for the 14 characters the prefix costs. The input caps typing at 50 characters for the same reason.
- The backend still requires the prefix. This PR only stops the form from making a person satisfy it.

No screenshot: I could not run the app or Storybook in this sandbox, because the `@posthog/quill` workspace is unbuilt there. The visible change is a grey monospace `signals-scout-` inside the name input, plus help text reading `Full name: signals-scout-checkout-failures`.

> [!NOTE]
> Retiring the prefix as a hard requirement is a separate, larger change. It is scoped but not started, and nothing in this diff touches the six places that enforce it.

## How did you test this code?

Jest over `products/signals/frontend/inbox/` and `products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx`.

- New logic case: a bare name reaches the API prefixed. Catches the prefix being dropped on submit, which would send a name the backend rejects.
- New parameterized cases: an empty field and the prefix alone both block submit with "Name is required". Catches an empty scope reaching the API as a bare `signals-scout-`.
- New render case: the prefix renders outside the field, and the input holds only the scope. This is the only assertion that the prefix is shown rather than typed, so it is what catches the papercut returning.
- Updated the existing prefill assertions to expect the bare name in the form and the prefixed name at the API. That pair guards double-prefixing.

Not run: the app and Storybook, per the note above. Nothing backend, since this diff is frontend only. The repo-wide frontend typecheck fails on unrelated files in this sandbox for the same quill reason, so I checked that none of its errors name the files in this diff.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. The `signals-scout-` contract is unchanged for scout authors, and the docs describe the prefix rather than this form.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) wrote this after Andy asked for the papercut fix ahead of the larger prefix work. Skills invoked: `/working-with-scouts`, `/writing-user-facing-copy`, `/writing-code-comments`, `/writing-tests`, `/writing-pr-descriptions`. Tooling: the PostHog MCP for the scouts skills store, plus ripgrep and Jest locally.

The session began by mapping every place the prefix is enforced, since the underlying request is to retire it. That map is tracked outside this repo and shaped only the scope of this PR, which is deliberately the form alone.

One design choice worth a reviewer's attention: the form field now holds the scope rather than the full name. Keeping the full name would have left the inert prefix duplicating text the author can already see, so prefill strips the prefix and submit re-adds it.

Public artifact: nothing here carries material from the agent session. The originating thread is not quoted, and no customer or operational data appears in the diff or this description.
