### PR TITLE
chore(ci): prime the multinode smoke from the schema artifact

### DIFF
--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -25,15 +25,18 @@ permissions:
     contents: read
     # Pull the pinned hclexp image from ghcr for the live-schema convergence gate.
     packages: read
+    # Download the migrated-schema artifact produced by ci-backend.yml on master.
+    actions: read
 
 jobs:
     multinode-migration-smoke:
         name: Run ClickHouse migrations against per-cluster topology
         runs-on: ubuntu-24.04
-        # The job applies every Postgres and ClickHouse migration from scratch, so its
-        # runtime grows with the migration count: ~20 minutes in June 2026, past 25 by
-        # July, ~27 minutes as of this bump. Raise further if it keeps creeping up.
-        timeout-minutes: 30
+        # The common path primes Postgres from the master schema artifact (~2 min for
+        # the Postgres phase). The fallback applies every Django migration from
+        # scratch and grows with the migration count (~27 minutes in August 2026), so
+        # the timeout is sized for the fallback. Raise it if migrate keeps creeping up.
+        timeout-minutes: 40
         env:
             DEBUG: '1'
             MULTINODE_CLICKHOUSE: '1'
@@ -52,9 +55,9 @@ jobs:
             # posthog_asyncmigration / posthog_instancesetting. Skip it so the
             # smoke can run against a schema-only Postgres dump.
             SKIP_ASYNC_MIGRATIONS_SETUP: '1'
-            # If the "Restore Postgres schema cache" step below succeeds, this
-            # file exists and the smoke script primes Postgres from it instead
-            # of running a full `manage.py migrate`. Cache miss → file absent →
+            # If the "Fetch master schema dump" step below succeeds, this file
+            # exists and the smoke script primes Postgres from it instead of
+            # running a full `manage.py migrate`. No artifact → file absent →
             # script falls back to migrate automatically.
             PRIME_POSTGRES_FROM: schema.sql.gz
             # The chschema build used by the live-schema convergence gate is pinned in
@@ -62,21 +65,6 @@ jobs:
             HCLEXP_IMAGE: ${{ vars.HCLEXP_IMAGE }}
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-              with:
-                  # Needed for `git merge-base HEAD^2 origin/master` so we can key
-                  # the Postgres schema cache by the PR's merge base, matching
-                  # the producer in ci-backend.yml.
-                  fetch-depth: 1000
-                  filter: blob:none
-
-            - name: Fetch current PR base for schema cache key
-              if: github.event_name == 'pull_request'
-              env:
-                  BASE_REF: ${{ github.event.pull_request.base.ref }}
-              # actions/checkout only populates the synthetic PR merge ref; the
-              # base ref has to be fetched explicitly for `git merge-base` to
-              # resolve it.
-              run: git fetch --no-tags --depth=1000 --filter=blob:none origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
 
             - name: Add multinode hostnames to /etc/hosts
               run: |
@@ -97,34 +85,30 @@ jobs:
             - name: Install Python dependencies
               run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
 
-            - name: Compute Postgres schema cache key
-              id: schema-key
-              if: github.event_name == 'pull_request'
+            - name: Fetch master schema dump
               env:
-                  BASE_REF: ${{ github.event.pull_request.base.ref }}
+                  GH_TOKEN: ${{ github.token }}
               run: |
-                  # ci-backend.yml's "Validate migrations" job dumps the post-PR
-                  # schema and caches it keyed by master SHA. PR jobs key off the
-                  # merge base so they restore the dump produced by the commit
-                  # their branch diverged from.
-                  # fetch-depth: 1000 on checkout bounds how far back the
-                  # merge base can be found; older divergence yields an empty
-                  # result and the graceful fallback to `migrate` below.
-                  BASE_SHA=$(git merge-base HEAD^2 "origin/${BASE_REF}" 2>/dev/null || echo "")
-                  # Always emit a key so the restore runs; when the exact branch-point
-                  # SHA is unknown, the bare prefix lets restore-keys fall back to the
-                  # most recent cached master schema (any valid schema works — the smoke
-                  # only needs Postgres bootable, migrate_clickhouse doesn't touch it).
-                  echo "key=posthog-schema-master-${BASE_SHA}" >> "$GITHUB_OUTPUT"
-
-            - name: Restore Postgres schema cache
-              if: github.event_name == 'pull_request'
-              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-              with:
-                  path: schema.sql.gz
-                  key: ${{ steps.schema-key.outputs.key }}
-                  restore-keys: |
-                      posthog-schema-master-
+                  # ci-backend.yml's "Validate migrations" job uploads the post-migrate
+                  # schema as the migrated-schema artifact on every master push
+                  # (90-day retention). The Actions cache also holds it, but the repo's
+                  # 10 GB LRU pool evicts the dump within minutes, so the artifact is
+                  # the reliable source. Any recent master schema works — the smoke
+                  # only needs Postgres bootable, migrate_clickhouse doesn't touch it.
+                  # Any failure here degrades to the full-migrate fallback in the
+                  # smoke script (PRIME_POSTGRES_FROM stays absent).
+                  ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=migrated-schema&per_page=10" \
+                      --jq '[.artifacts[] | select(.expired | not)] | sort_by(.created_at) | reverse | .[0].id // empty' || true)
+                  if [ -z "$ARTIFACT_ID" ]; then
+                      echo "::warning::no migrated-schema artifact found; falling back to full migrate"
+                      exit 0
+                  fi
+                  if ! { gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > migrated-schema.zip \
+                      && unzip -o migrated-schema.zip schema.sql.gz \
+                      && gunzip -t schema.sql.gz; }; then
+                      echo "::warning::migrated-schema artifact ${ARTIFACT_ID} unusable; falling back to full migrate"
+                      rm -f schema.sql.gz
+                  fi
 
             - name: Log in to ghcr.io
               uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -95,12 +95,25 @@ jobs:
                   # 10 GB LRU pool evicts the dump within minutes, so the artifact is
                   # the reliable source. Any recent master schema works — the smoke
                   # only needs Postgres bootable, migrate_clickhouse doesn't touch it.
+                  # Resolve the artifact through successful master runs of
+                  # ci-backend.yml rather than the repo-wide artifact list, so only
+                  # that workflow's uploads are ever trusted. Paths-filtered master
+                  # pushes can succeed without producing the artifact, hence the scan.
                   # Any failure here degrades to the full-migrate fallback in the
                   # smoke script (PRIME_POSTGRES_FROM stays absent).
-                  ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=migrated-schema&per_page=10" \
-                      --jq '[.artifacts[] | select(.expired | not)] | sort_by(.created_at) | reverse | .[0].id // empty' || true)
+                  RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-backend.yml/runs?branch=master&event=push&status=success&per_page=10" \
+                      --jq '.workflow_runs[].id' || true)
+                  ARTIFACT_ID=""
+                  for RUN_ID in $RUN_IDS; do
+                      ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=migrated-schema" \
+                          --jq '[.artifacts[] | select(.expired | not)][0].id // empty' || true)
+                      if [ -n "$ARTIFACT_ID" ]; then
+                          echo "using migrated-schema artifact ${ARTIFACT_ID} from master run ${RUN_ID}"
+                          break
+                      fi
+                  done
                   if [ -z "$ARTIFACT_ID" ]; then
-                      echo "::warning::no migrated-schema artifact found; falling back to full migrate"
+                      echo "::warning::no migrated-schema artifact in recent successful master ci-backend runs; falling back to full migrate"
                       exit 0
                   fi
                   if ! { gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > migrated-schema.zip \

--- a/docker-compose.multinode-clickhouse.yml
+++ b/docker-compose.multinode-clickhouse.yml
@@ -36,6 +36,9 @@ services:
         extends:
             file: docker-compose.base.yml
             service: db
+        # Throwaway smoke database: durability off makes the full-migrate
+        # fallback several times faster.
+        command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off
         ports:
             - '5432:5432'
 

--- a/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
+++ b/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
@@ -165,7 +165,7 @@ export REDIS_URL="${REDIS_URL:-redis://localhost:6379}"
 export SECRET_KEY="${SECRET_KEY:-multinode-smoke-not-a-real-secret}"
 
 if [ -n "${PRIME_POSTGRES_FROM:-}" ] && [ -f "${PRIME_POSTGRES_FROM}" ]; then
-    # CI primes Postgres from a cached schema dump produced by the
+    # CI primes Postgres from the master schema dump produced by the
     # "Validate migrations" job in ci-backend.yml. Loading via psql is much
     # faster than running every Django migration from scratch. Pair this with
     # SKIP_ASYNC_MIGRATIONS_SETUP=1 because PostHogConfig.ready() otherwise
@@ -189,7 +189,9 @@ else
     # read path; CI does that and points PRIME_POSTGRES_FROM at a cached
     # schema dump so this branch is only taken on cache miss.
     echo "==> Running Django (Postgres) migrations..."
-    python manage.py migrate --noinput
+    # --skip-checks: the Django system check pass costs ~1 minute here and
+    # runs in its own CI job already.
+    python manage.py migrate --noinput --skip-checks
 fi
 
 SMOKE_STAGE="migrate_clickhouse"


### PR DESCRIPTION
## Problem

The multinode ClickHouse smoke spends ~27 of its ~30 minutes applying every Django migration, and that time grows with each migration ([measured run](https://github.com/PostHog/posthog/actions/runs/31174521990/job/92853464756)). A Postgres schema cache exists to skip this, but it misses every time: the repo's Actions cache pool sits at the 10 GB LRU cap (pnpm entries hold ~8.5 GB), so the few-MB schema dumps are evicted within minutes of every master save. Zero `posthog-schema-*` entries currently exist.

## Changes

- The smoke now downloads ci-backend's `migrated-schema` artifact (uploaded on every master push, 90-day retention) instead of restoring from the Actions cache. Artifacts do not compete with the cache pool, so the prime path becomes the common path: the Postgres phase drops from ~27 minutes to ~2.
- Any failure in the fetch degrades to the existing full-migrate fallback, including fork PRs and the no-artifact case.
- The merge-base computation, its 1000-deep checkout, and the cache-restore steps go away; the checkout is shallow again. Any recent master schema works, which the old restore-keys fallback already relied on.
- The smoke's Postgres runs with `fsync=off`, `synchronous_commit=off`, `full_page_writes=off`, and the migrate fallback adds `--skip-checks` - the fallback gets several times faster when it does run.
- The job timeout goes to 40 minutes, sized for the fallback path.

> [!NOTE]
> The backend, mcp, dagster, and e2e-playwright workflows share the same evicted-cache restore path and can migrate to the artifact in a follow-up, as can a cleanup job for the pnpm cache variants that own the pool.

## How did you test this code?

- The artifact lookup ran against the live API: it resolves a master `migrated-schema` artifact from today.
- `docker compose config` confirms the db command override merges.
- `bin/hogli lint:workflows` and actionlint pass.
- Not run end to end locally: the smoke needs the full multinode stack; the PR's own CI run exercises it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - CI-internal change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Skills: /gh-logs, /authoring-ci-workflows, /writing-pr-descriptions. Diagnosis: per-step timing of the linked run, then cache-pool listing via the API showed the 10 GB cap and zero surviving schema entries.