### PR TITLE
fix(slack_app): reject AI preferences that pair a model with the wrong runtime

### DIFF
--- a/products/slack_app/backend/services/model_catalogue.py
+++ b/products/slack_app/backend/services/model_catalogue.py
@@ -106,15 +106,10 @@ def runtime_adapter_for(model: str | None) -> str | None:
     deriving it is what keeps a `(runtime_adapter, model)` pair from ever disagreeing.
     `None` for a model the tasks product has no runtime for.
     """
-    from products.tasks.backend.facade.run_config import RuntimeAdapter, get_models_for_runtime_adapter  # noqa: PLC0415
+    from products.tasks.backend.facade.run_config import get_runtime_adapter_for_model  # noqa: PLC0415
 
-    if not model:
-        return None
-    normalized = model.strip().lower()
-    for adapter in RuntimeAdapter:
-        if any(known.lower() == normalized for known in get_models_for_runtime_adapter(adapter)):
-            return adapter.value
-    return None
+    adapter = get_runtime_adapter_for_model(model)
+    return adapter.value if adapter else None
 
 
 def filter_unsupported_effort(runtime_adapter: str | None, model: str | None, effort: str | None) -> str | None:

--- a/products/slack_app/backend/services/slack_app_home.py
+++ b/products/slack_app/backend/services/slack_app_home.py
@@ -115,6 +115,11 @@ MODAL_ACTION_MODEL = "ai_prefs:model"
 MODAL_ACTION_REASONING_EFFORT = "ai_prefs:reasoning_effort"
 
 MODAL_BLOCK_RUNTIME_ADAPTER = "block_runtime_adapter"
+# Prefixes, not literal block ids: Slack carries a block's state across `views.update`
+# whenever the `block_id` is unchanged, which is how a model picked under the previous
+# runtime used to survive a runtime switch and get submitted. Suffixing each dependent
+# block with what it depends on makes the re-rendered block a new one to Slack, so the
+# stale pick is dropped instead of hiding behind the fresh options. See `_scoped_block_id`.
 MODAL_BLOCK_MODEL = "block_model"
 MODAL_BLOCK_REASONING_EFFORT = "block_reasoning_effort"
 
@@ -1136,7 +1141,7 @@ def render_edit_modal(
                 model_element["initial_option"] = next(o for o in model_options if o["value"] == current.model)
             model_block = {
                 "type": "input",
-                "block_id": MODAL_BLOCK_MODEL,
+                "block_id": _scoped_block_id(MODAL_BLOCK_MODEL, current.runtime_adapter),
                 "label": {"type": "plain_text", "text": "Model"},
                 "dispatch_action": True,
                 "element": model_element,
@@ -1161,7 +1166,7 @@ def render_edit_modal(
             effort_element["initial_option"] = next(o for o in effort_options if o["value"] == current.reasoning_effort)
         effort_block = {
             "type": "input",
-            "block_id": MODAL_BLOCK_REASONING_EFFORT,
+            "block_id": _scoped_block_id(MODAL_BLOCK_REASONING_EFFORT, current.model),
             "label": {"type": "plain_text", "text": "Reasoning effort"},
             "optional": True,
             "element": effort_element,
@@ -1196,6 +1201,11 @@ def render_edit_modal(
     }
 
 
+def _scoped_block_id(prefix: str, depends_on: str | None) -> str:
+    """Block id for an input whose options are derived from another input's value."""
+    return f"{prefix}:{depends_on}" if depends_on else prefix
+
+
 def parse_modal_submission(view: dict) -> tuple[str | None, str | None, str | None]:
     """Pull `(runtime_adapter, model, reasoning_effort)` out of a Slack view_submission payload.
 
@@ -1211,12 +1221,14 @@ def parse_modal_submission(view: dict) -> tuple[str | None, str | None, str | No
     return runtime_adapter, model, reasoning_effort
 
 
-def _selected_value(state: dict, block_id: str, action_id: str) -> str | None:
-    block = state.get(block_id, {})
-    action = block.get(action_id, {})
-    selected = action.get("selected_option")
-    if isinstance(selected, dict):
-        return selected.get("value")
+def _selected_value(state: dict, block_prefix: str, action_id: str) -> str | None:
+    """Read a select's value out of view state, matching the scoped block id it was rendered under."""
+    for block_id, actions in state.items():
+        if block_id != block_prefix and not block_id.startswith(f"{block_prefix}:"):
+            continue
+        selected = (actions.get(action_id) or {}).get("selected_option")
+        if isinstance(selected, dict):
+            return selected.get("value")
     return None
 
 
@@ -1499,19 +1511,18 @@ def _render_unavailable_modal() -> dict:
 def _update_modal_after_input_change(payload: dict) -> HttpResponse:
     """Re-render the modal in response to a runtime_adapter or model change.
 
-    Reads the in-flight state from `payload["view"]`, derives the new supported
-    efforts (changes when the model changes), and pushes the updated view via
-    `views.update`. Nothing is persisted here — the user still has to Save to
-    commit.
+    Reads the in-flight state from `payload["view"]`, drops whatever the change
+    invalidated, derives the efforts the surviving model supports, and pushes the
+    updated view via `views.update`. Nothing is persisted here — the user still has
+    to Save to commit.
     """
 
     view = payload.get("view", {})
     if view.get("callback_id") != EDIT_MODAL_PERSONAL_CALLBACK_ID:
         return HttpResponse(status=200)
 
-    runtime_adapter, model, reasoning_effort = parse_modal_submission(view)
-    current = AIPreferences(runtime_adapter=runtime_adapter, model=model, reasoning_effort=reasoning_effort)
-    supported = _supported_efforts(runtime_adapter, model)
+    current = _drop_invalidated_selections(*parse_modal_submission(view))
+    supported = _supported_efforts(current.runtime_adapter, current.model)
 
     updated_view = render_edit_modal(current=current, supported_efforts=supported)
 
@@ -1526,6 +1537,24 @@ def _update_modal_after_input_change(payload: dict) -> HttpResponse:
     except Exception:
         logger.exception("slack_app_home_modal_update_failed")
     return HttpResponse(status=200)
+
+
+def _drop_invalidated_selections(
+    runtime_adapter: str | None,
+    model: str | None,
+    reasoning_effort: str | None,
+) -> AIPreferences:
+    """Keep only the parts of an in-flight selection the current runtime still allows.
+
+    Switching runtime orphans the model picked under the old one, and that orphans the
+    effort. The scoped block ids stop Slack handing those back on the next interaction;
+    this stops the view we render from the same payload showing them in the meantime.
+    """
+    if model and model not in {value for value, _ in _models_for(runtime_adapter or "")}:
+        model = None
+    if reasoning_effort and reasoning_effort not in (_supported_efforts(runtime_adapter, model) or ()):
+        reasoning_effort = None
+    return AIPreferences(runtime_adapter=runtime_adapter, model=model, reasoning_effort=reasoning_effort)
 
 
 def _supported_efforts(runtime_adapter: str | None, model: str | None) -> list[str] | None:

--- a/products/slack_app/backend/services/slack_settings.py
+++ b/products/slack_app/backend/services/slack_settings.py
@@ -122,28 +122,20 @@ def validate_ai_preferences(
 
     Raises `django.core.exceptions.ValidationError` if the triple is internally
     inconsistent. Call this from the write path so half-set rows never reach
-    the DB.
+    the DB. The storage rule — both halves of the pair or neither — lives here;
+    whether the three values may be used together is the model catalogue's call.
     """
     from django.core.exceptions import ValidationError
 
-    from products.tasks.backend.facade.run_config import (
-        PUBLIC_REASONING_EFFORTS,
-        RuntimeAdapter,
-        get_reasoning_effort_error,
-    )
+    from products.tasks.backend.facade.run_config import PUBLIC_REASONING_EFFORTS, validate_model_selection
 
     if (runtime_adapter is None) != (model is None):
         raise ValidationError(
             "runtime_adapter and model must be set together — set both to override the default, or both to null to inherit."
         )
 
-    if runtime_adapter is not None:
-        valid_adapters = {a.value for a in RuntimeAdapter}
-        if runtime_adapter not in valid_adapters:
-            raise ValidationError(
-                f"Unknown runtime_adapter '{runtime_adapter}'. Valid: {', '.join(sorted(valid_adapters))}."
-            )
-
+    # The catalogue only judges an effort against a model, so an effort stored without a
+    # pair — legal, and inherited by whatever model resolves later — still needs a check.
     if reasoning_effort is not None:
         valid_efforts = {e.value for e in PUBLIC_REASONING_EFFORTS}
         if reasoning_effort not in valid_efforts:
@@ -151,9 +143,7 @@ def validate_ai_preferences(
                 f"Unknown reasoning_effort '{reasoning_effort}'. Valid: {', '.join(sorted(valid_efforts))}."
             )
 
-    error = get_reasoning_effort_error(runtime_adapter, model, reasoning_effort)
-    if error:
-        raise ValidationError(error)
+    validate_model_selection(runtime_adapter, model, reasoning_effort)
 
 
 __all__ = [

--- a/products/slack_app/backend/tests/services/test_slack_app_home.py
+++ b/products/slack_app/backend/tests/services/test_slack_app_home.py
@@ -18,6 +18,8 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.core.exceptions import ValidationError
+
 from posthog.models.integration import Integration
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -158,6 +160,17 @@ def _stub_picker_facade():
     def fake_get_models(adapter):
         return models_by_adapter.get(_adapter_value(adapter), ())
 
+    def fake_validate_selection(adapter, model, effort):
+        adapter_value = _adapter_value(adapter)
+        if adapter_value is not None and adapter_value not in models_by_adapter:
+            raise ValidationError(f"Unknown runtime_adapter '{adapter_value}'.")
+        owning = next((a for a, models in models_by_adapter.items() if model in models), None)
+        if adapter_value is not None and owning is not None and owning != adapter_value:
+            raise ValidationError(f"Model '{model}' runs on runtime_adapter '{owning}', not '{adapter_value}'.")
+        error = fake_get_error(adapter_value, model, effort)
+        if error:
+            raise ValidationError(error)
+
     facade_name = "products.tasks.backend.facade.run_config"
     # `Any` annotation so mypy accepts the stub-attribute assignments below —
     # the stdlib `ModuleType` rejects them outright, and ruff B010 reverts any
@@ -168,6 +181,7 @@ def _stub_picker_facade():
     fake.get_reasoning_effort_error = fake_get_error
     fake.get_provider_for_runtime_adapter = fake_get_provider
     fake.get_models_for_runtime_adapter = fake_get_models
+    fake.validate_model_selection = fake_validate_selection
     fake.PUBLIC_REASONING_EFFORTS = public_efforts
 
     @dataclass(frozen=True)
@@ -244,6 +258,16 @@ def _block_ids(view: dict) -> list[str]:
     return [b.get("block_id") for b in view["blocks"] if b.get("block_id")]
 
 
+def _find_block(view: dict, block_prefix: str) -> dict | None:
+    """The block rendered under `block_prefix` — matching the runtime/model suffix the
+    modal scopes its dependent blocks with."""
+    for block in view["blocks"]:
+        block_id = block.get("block_id") or ""
+        if block_id == block_prefix or block_id.startswith(f"{block_prefix}:"):
+            return block
+    return None
+
+
 def _all_text(view: dict) -> str:
     """Flatten all `text` fields for substring assertions."""
     out: list[str] = []
@@ -262,17 +286,25 @@ def _all_text(view: dict) -> str:
     return " ".join(out)
 
 
-def _build_submission(*, runtime_adapter=None, model=None, effort=None) -> dict:
+def _modal_state(*, runtime_adapter=None, model=None, effort=None) -> dict:
+    """View state as Slack sends it back — dependent blocks under the scoped ids the
+    modal rendered them with."""
     state: dict = {}
     if runtime_adapter:
         state[MODAL_BLOCK_RUNTIME_ADAPTER] = {
             MODAL_ACTION_RUNTIME_ADAPTER: {"selected_option": {"value": runtime_adapter}}
         }
     if model:
-        state[MODAL_BLOCK_MODEL] = {MODAL_ACTION_MODEL: {"selected_option": {"value": model}}}
+        state[f"{MODAL_BLOCK_MODEL}:{runtime_adapter}"] = {MODAL_ACTION_MODEL: {"selected_option": {"value": model}}}
     if effort:
-        state[MODAL_BLOCK_REASONING_EFFORT] = {MODAL_ACTION_REASONING_EFFORT: {"selected_option": {"value": effort}}}
-    return {"state": {"values": state}}
+        state[f"{MODAL_BLOCK_REASONING_EFFORT}:{model}"] = {
+            MODAL_ACTION_REASONING_EFFORT: {"selected_option": {"value": effort}}
+        }
+    return state
+
+
+def _build_submission(*, runtime_adapter=None, model=None, effort=None) -> dict:
+    return {"state": {"values": _modal_state(runtime_adapter=runtime_adapter, model=model, effort=effort)}}
 
 
 # ---------------------------------------------------------------------------
@@ -305,15 +337,7 @@ def _view_submission_payload(
     model: str | None,
     effort: str | None,
 ) -> dict:
-    state: dict = {}
-    if runtime_adapter:
-        state[MODAL_BLOCK_RUNTIME_ADAPTER] = {
-            MODAL_ACTION_RUNTIME_ADAPTER: {"selected_option": {"value": runtime_adapter}}
-        }
-    if model:
-        state[MODAL_BLOCK_MODEL] = {MODAL_ACTION_MODEL: {"selected_option": {"value": model}}}
-    if effort:
-        state[MODAL_BLOCK_REASONING_EFFORT] = {"ai_prefs:reasoning_effort": {"selected_option": {"value": effort}}}
+    state = _modal_state(runtime_adapter=runtime_adapter, model=model, effort=effort)
     return {
         "type": "view_submission",
         "team": {"id": SLACK_WORKSPACE_ID},
@@ -601,21 +625,31 @@ class TestTasksCard:
 class TestRenderEditModal:
     def test_no_runtime_means_no_model_or_effort_blocks(self):
         view = render_edit_modal(current=AIPreferences())
-        ids = _block_ids(view)
-        assert MODAL_BLOCK_RUNTIME_ADAPTER in ids
-        assert MODAL_BLOCK_MODEL not in ids
-        assert MODAL_BLOCK_REASONING_EFFORT not in ids
+        assert MODAL_BLOCK_RUNTIME_ADAPTER in _block_ids(view)
+        assert _find_block(view, MODAL_BLOCK_MODEL) is None
+        assert _find_block(view, MODAL_BLOCK_REASONING_EFFORT) is None
 
     def test_runtime_picked_unlocks_model_block(self):
         view = render_edit_modal(current=AIPreferences(runtime_adapter="claude"))
-        ids = _block_ids(view)
-        assert MODAL_BLOCK_MODEL in ids
+        assert _find_block(view, MODAL_BLOCK_MODEL) is not None
         # Effort block needs both the model and a non-empty supported list.
-        assert MODAL_BLOCK_REASONING_EFFORT not in ids
+        assert _find_block(view, MODAL_BLOCK_REASONING_EFFORT) is None
+
+    def test_model_block_id_is_scoped_to_the_runtime(self):
+        # Slack replays a block's state across `views.update` when the block_id is
+        # unchanged, so a model picked under the old runtime would survive a runtime
+        # switch and get submitted. A per-runtime id makes it a new block instead.
+        claude = render_edit_modal(current=AIPreferences(runtime_adapter="claude"))
+        codex = render_edit_modal(current=AIPreferences(runtime_adapter="codex"))
+        claude_block = _find_block(claude, MODAL_BLOCK_MODEL)
+        codex_block = _find_block(codex, MODAL_BLOCK_MODEL)
+        assert claude_block and codex_block
+        assert claude_block["block_id"] != codex_block["block_id"]
 
     def test_model_options_match_runtime(self):
         view = render_edit_modal(current=AIPreferences(runtime_adapter="codex"))
-        model_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_MODEL)
+        model_block = _find_block(view, MODAL_BLOCK_MODEL)
+        assert model_block
         option_values = [o["value"] for o in model_block["element"]["options"]]
         # Codex models only — assert via prefix to stay resilient as the facade
         # adds new Codex ids.
@@ -627,7 +661,8 @@ class TestRenderEditModal:
             current=AIPreferences(runtime_adapter="claude", model="claude-opus-4-7"),
             supported_efforts=["low", "medium", "high"],
         )
-        block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_REASONING_EFFORT)
+        block = _find_block(view, MODAL_BLOCK_REASONING_EFFORT)
+        assert block
         assert block["optional"] is True
         values = [o["value"] for o in block["element"]["options"]]
         assert values == ["low", "medium", "high"]
@@ -641,17 +676,19 @@ class TestRenderEditModal:
             ),
             supported_efforts=["low", "medium", "high"],
         )
-        runtime_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_RUNTIME_ADAPTER)
-        model_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_MODEL)
-        effort_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_REASONING_EFFORT)
+        runtime_block = _find_block(view, MODAL_BLOCK_RUNTIME_ADAPTER)
+        model_block = _find_block(view, MODAL_BLOCK_MODEL)
+        effort_block = _find_block(view, MODAL_BLOCK_REASONING_EFFORT)
+        assert runtime_block and model_block and effort_block
         assert runtime_block["element"]["initial_option"]["value"] == "claude"
         assert model_block["element"]["initial_option"]["value"] == "claude-opus-4-7"
         assert effort_block["element"]["initial_option"]["value"] == "high"
 
     def test_dispatch_action_set_on_runtime_and_model(self):
         view = render_edit_modal(current=AIPreferences(runtime_adapter="claude"))
-        runtime_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_RUNTIME_ADAPTER)
-        model_block = next(b for b in view["blocks"] if b.get("block_id") == MODAL_BLOCK_MODEL)
+        runtime_block = _find_block(view, MODAL_BLOCK_RUNTIME_ADAPTER)
+        model_block = _find_block(view, MODAL_BLOCK_MODEL)
+        assert runtime_block and model_block
         # dispatch_action triggers a block_actions payload so the modal can
         # re-render with downstream options matching the new selection.
         assert runtime_block["dispatch_action"] is True
@@ -826,6 +863,49 @@ class TestPersonalSubmit:
         assert MODAL_BLOCK_RUNTIME_ADAPTER in body["errors"]
         # Modal left open: no row written, no publish.
         assert not SlackSettings.objects.filter(slack_user_id="U001").exists()
+
+    def test_model_from_another_runtime_keeps_modal_open_with_error(
+        self, slack_integration, mock_slack_client, flag_on
+    ):
+        payload = _view_submission_payload(
+            callback_id=EDIT_MODAL_PERSONAL_CALLBACK_ID,
+            slack_user_id="U001",
+            runtime_adapter="claude",
+            model="gpt-5",
+            effort=None,
+        )
+        response = handle_app_home_view_submission(payload)
+        assert json.loads(response.content)["response_action"] == "errors"
+        assert not SlackSettings.objects.filter(slack_user_id="U001").exists()
+
+
+class TestModalRerender:
+    def test_switching_runtime_drops_the_other_runtime_model(self, slack_integration, mock_slack_client, flag_on):
+        # Runtime just flipped to Claude; Slack still reports the Codex model and its
+        # effort in view state. Both have to be gone from the re-rendered modal.
+        state = _modal_state(runtime_adapter="codex", model="gpt-5", effort="high")
+        state[MODAL_BLOCK_RUNTIME_ADAPTER] = {MODAL_ACTION_RUNTIME_ADAPTER: {"selected_option": {"value": "claude"}}}
+        payload: dict[str, Any] = {
+            "type": "block_actions",
+            "team": {"id": SLACK_WORKSPACE_ID},
+            "user": {"id": "U001"},
+            "actions": [{"action_id": MODAL_ACTION_RUNTIME_ADAPTER}],
+            "view": {
+                "id": "V1",
+                "hash": "H1",
+                "callback_id": EDIT_MODAL_PERSONAL_CALLBACK_ID,
+                "state": {"values": state},
+            },
+        }
+        handle_ai_preferences_block_action(payload, payload["actions"][0])
+
+        view = mock_slack_client.views_update.call_args.kwargs["view"]
+        model_block = _find_block(view, MODAL_BLOCK_MODEL)
+        assert model_block
+        # A block id Slack has no state for, and nothing preselected in it.
+        assert model_block["block_id"] == f"{MODAL_BLOCK_MODEL}:claude"
+        assert "initial_option" not in model_block["element"]
+        assert _find_block(view, MODAL_BLOCK_REASONING_EFFORT) is None
 
 
 class TestRetiredWorkspaceModal:

--- a/products/slack_app/backend/tests/services/test_slack_settings.py
+++ b/products/slack_app/backend/tests/services/test_slack_settings.py
@@ -86,6 +86,21 @@ def _stub_task_runtime_helpers():
             return None
         return f"Reasoning effort '{effort}' is not supported for {adapter}/{model}."
 
+    models_by_adapter = {
+        "claude": ("claude-opus-4-7", "claude-sonnet-4-6"),
+        "codex": ("gpt-5", "gpt-5.5"),
+    }
+
+    def fake_validate_selection(adapter, model, effort):
+        if adapter is not None and adapter not in models_by_adapter:
+            raise ValidationError(f"Unknown runtime_adapter '{adapter}'.")
+        owning = next((a for a, models in models_by_adapter.items() if model in models), None)
+        if adapter is not None and owning is not None and owning != adapter:
+            raise ValidationError(f"Model '{model}' runs on runtime_adapter '{owning}', not '{adapter}'.")
+        error = fake_get_error(adapter, model, effort)
+        if error:
+            raise ValidationError(error)
+
     class _Adapter:
         def __init__(self, value):
             self.value = value
@@ -119,6 +134,8 @@ def _stub_task_runtime_helpers():
     fake: Any = ModuleType(module_name)
     fake.get_supported_reasoning_efforts = fake_get_supported
     fake.get_reasoning_effort_error = fake_get_error
+    fake.get_models_for_runtime_adapter = lambda adapter: models_by_adapter.get(adapter, ())
+    fake.validate_model_selection = fake_validate_selection
     fake.RuntimeAdapter = _RuntimeAdapter()
     fake.PUBLIC_REASONING_EFFORTS = public_efforts
 
@@ -290,6 +307,12 @@ class TestValidateAIPreferences:
     def test_unknown_runtime_adapter_rejected(self):
         with pytest.raises(ValidationError, match="Unknown runtime_adapter"):
             validate_ai_preferences("nonsense", "claude-opus-4-7", None)
+
+    def test_model_from_another_runtime_rejected(self):
+        # The modal offers both runtimes' models, so nothing but this check stops a
+        # Claude + GPT pair from being written and handed to a run.
+        with pytest.raises(ValidationError, match="runs on runtime_adapter"):
+            validate_ai_preferences("claude", "gpt-5.5", None)
 
     def test_unknown_reasoning_effort_rejected(self):
         with pytest.raises(ValidationError, match="Unknown reasoning_effort"):

--- a/products/tasks/backend/facade/run_config.py
+++ b/products/tasks/backend/facade/run_config.py
@@ -34,8 +34,10 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_models_for_runtime_adapter,
     get_provider_for_runtime_adapter,
     get_reasoning_effort_error,
+    get_runtime_adapter_for_model,
     get_supported_reasoning_efforts,
     parse_run_state,
+    validate_model_selection,
 )
 
 TaskArtifactType = _TaskArtifact.ArtifactType
@@ -63,6 +65,8 @@ __all__ = [
     "get_models_for_runtime_adapter",
     "get_provider_for_runtime_adapter",
     "get_reasoning_effort_error",
+    "get_runtime_adapter_for_model",
     "get_supported_reasoning_efforts",
     "parse_run_state",
+    "validate_model_selection",
 ]

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -7,6 +7,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Optional
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import transaction
 
 from pydantic import BaseModel
@@ -282,6 +283,56 @@ def get_reasoning_effort_error(
         f"Reasoning effort '{effort_value}' is not supported for runtime_adapter "
         f"'{adapter_value}' and model '{model}'. Supported values: {supported_values}."
     )
+
+
+def get_runtime_adapter_for_model(model: str | None) -> RuntimeAdapter | None:
+    """Which runtime adapter serves `model`, per this catalogue.
+
+    The adapter is a property of the model rather than an independent choice, so
+    deriving it is what lets callers reject a `(runtime_adapter, model)` pair that
+    disagrees with itself. `None` when no adapter claims the model.
+    """
+    if not model:
+        return None
+
+    normalized = model.strip().lower()
+    for adapter in RuntimeAdapter:
+        if any(known.lower() == normalized for known in get_models_for_runtime_adapter(adapter)):
+            return adapter
+    return None
+
+
+def validate_model_selection(
+    runtime_adapter: RuntimeAdapter | str | None,
+    model: str | None,
+    reasoning_effort: ReasoningEffort | str | None,
+) -> None:
+    """Raise `ValidationError` unless these three may be used together.
+
+    The one place a picker or a write path can ask "is this selection legal?", so a
+    linked-dropdown UI and the API that persists its output can't disagree.
+
+    A model this catalogue serves under a different runtime is rejected outright. A model
+    no runtime claims is left alone — callers whose model list comes from elsewhere (the
+    LLM gateway, say) own that allowlist, and rejecting anything unrecognised here would
+    make every newly served model look invalid.
+    """
+    adapter_value = runtime_adapter.value if isinstance(runtime_adapter, RuntimeAdapter) else runtime_adapter
+
+    if adapter_value is not None and adapter_value not in {adapter.value for adapter in RuntimeAdapter}:
+        valid_adapters = ", ".join(sorted(adapter.value for adapter in RuntimeAdapter))
+        raise ValidationError(f"Unknown runtime_adapter '{adapter_value}'. Valid values: {valid_adapters}.")
+
+    owning_adapter = get_runtime_adapter_for_model(model)
+    if adapter_value is not None and owning_adapter is not None and owning_adapter.value != adapter_value:
+        raise ValidationError(
+            f"Model '{model}' runs on runtime_adapter '{owning_adapter.value}', not '{adapter_value}'. "
+            f"Models for '{adapter_value}': {', '.join(get_models_for_runtime_adapter(adapter_value))}."
+        )
+
+    effort_error = get_reasoning_effort_error(adapter_value, model, reasoning_effort)
+    if effort_error:
+        raise ValidationError(effort_error)
 
 
 def normalize_directory_resume_snapshot_mount_path(snapshot_mount_path: object) -> str | None:

--- a/products/tasks/backend/tests/test_model_selection.py
+++ b/products/tasks/backend/tests/test_model_selection.py
@@ -1,0 +1,53 @@
+import pytest
+
+from django.core.exceptions import ValidationError
+
+from products.tasks.backend.temporal.process_task.utils import (
+    RuntimeAdapter,
+    get_runtime_adapter_for_model,
+    validate_model_selection,
+)
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        ("claude-sonnet-5", RuntimeAdapter.CLAUDE),
+        ("CLAUDE-SONNET-5", RuntimeAdapter.CLAUDE),
+        ("gpt-5.6-sol", RuntimeAdapter.CODEX),
+        ("some-model-nobody-serves", None),
+        (None, None),
+    ],
+)
+def test_get_runtime_adapter_for_model(model: str | None, expected: RuntimeAdapter | None) -> None:
+    assert get_runtime_adapter_for_model(model) == expected
+
+
+@pytest.mark.parametrize(
+    "runtime_adapter,model,reasoning_effort",
+    [
+        pytest.param("claude", "claude-sonnet-5", "high", id="pair-with-supported-effort"),
+        pytest.param("codex", "gpt-5.6-sol", "max", id="codex-max-effort-model"),
+        pytest.param("claude", "claude-sonnet-5", None, id="pair-without-effort"),
+        pytest.param(None, None, None, id="nothing-selected"),
+        pytest.param("claude", "a-model-no-adapter-claims", None, id="model-outside-the-catalogue"),
+    ],
+)
+def test_valid_selections_pass(runtime_adapter, model, reasoning_effort) -> None:
+    validate_model_selection(runtime_adapter, model, reasoning_effort)
+
+
+@pytest.mark.parametrize(
+    "runtime_adapter,model,reasoning_effort,expected_message",
+    [
+        pytest.param("claude", "gpt-5.6-sol", None, "runs on runtime_adapter 'codex'", id="openai-model-under-claude"),
+        pytest.param(
+            "codex", "claude-sonnet-5", None, "runs on runtime_adapter 'claude'", id="anthropic-model-under-codex"
+        ),
+        pytest.param("bedrock", "claude-sonnet-5", None, "Unknown runtime_adapter", id="unknown-adapter"),
+        pytest.param("claude", "claude-sonnet-4-6", "max", "not supported", id="effort-above-what-model-offers"),
+    ],
+)
+def test_invalid_selections_raise(runtime_adapter, model, reasoning_effort, expected_message) -> None:
+    with pytest.raises(ValidationError, match=expected_message):
+        validate_model_selection(runtime_adapter, model, reasoning_effort)


### PR DESCRIPTION
## Problem

The Slack App Home AI preferences modal let you save Claude as the runtime with a GPT model — and every run for that user (or the whole workspace) then carried a pair that doesn't go together.

Two gaps: the write path never checked the model against the runtime, and Slack replays a block's state across `views.update` when the `block_id` is unchanged, so the model picked under the previous runtime survived the switch.

## Changes

- `validate_model_selection(runtime_adapter, model, reasoning_effort)` in the tasks model catalogue — one place to ask whether the three may be used together. Rejects a model the catalogue serves under a different runtime; leaves a model no runtime claims alone, so a newly gateway-served model isn't rejected on sight.
- `validate_ai_preferences` routes through it.
- The modal's dependent block ids are scoped to what they derive from (`block_model:claude`), so a re-render gives Slack a block it has no state for instead of one hiding a stale pick.

## How did you test this code?

Tested manually on local against the Slack App Home modal.

New tests: `test_model_selection.py` covers the catalogue validator; one case in `test_slack_settings.py` guards the Slack write path; `TestModalRerender` covers the state-replay half (both modal tests fail against the pre-fix renderer).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Opus 5). Skills invoked: `/writing-tests`.

Two calls worth a look. The validator lives in the tasks catalogue because that's where the runtime→model and model→effort tables already are. And it's deliberately not an exact-membership check: the picker builds its list from the live LLM gateway, so rejecting anything the catalogue hasn't learned about yet would break it silently.
