### PR TITLE
fix(aio): gate white labelling behind the enterprise feature in feedback wizard

### DIFF
--- a/products/ai_observability/frontend/feedback-view/wizard/FeedbackSurveyWizard.tsx
+++ b/products/ai_observability/frontend/feedback-view/wizard/FeedbackSurveyWizard.tsx
@@ -5,10 +5,11 @@ import { IconArrowLeft, IconArrowRight, IconCheck, IconDocument } from '@posthog
 import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, LemonTabs, LemonTextArea } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { dayjs } from 'lib/dayjs'
 import { ColorInput } from 'scenes/surveys/wizard/ColorInput'
 
-import { Survey, SurveyAppearance } from '~/types'
+import { AvailableFeature, Survey, SurveyAppearance } from '~/types'
 
 import { getManualCaptureExample, getReactExample } from './codeExamples'
 import { FeedbackPreviewMock } from './FeedbackPreviewMock'
@@ -138,6 +139,7 @@ function ConfigureStep(): JSX.Element {
     } = useValues(feedbackSurveyWizardLogic)
     const { setStep, setSurveyName, setFollowUpEnabled, setFollowUpQuestion, updateAppearance, createSurvey } =
         useActions(feedbackSurveyWizardLogic)
+    const { guardAvailableFeature } = useValues(upgradeModalLogic)
 
     const [thumbState, setThumbState] = useState<'none' | 'up' | 'down'>('down')
 
@@ -225,7 +227,15 @@ function ConfigureStep(): JSX.Element {
                                     <LemonCheckbox
                                         label="Hide PostHog branding"
                                         checked={appearance.whiteLabel}
-                                        onChange={(checked) => updateAppearance({ whiteLabel: checked })}
+                                        onChange={(checked) => {
+                                            if (checked) {
+                                                guardAvailableFeature(AvailableFeature.WHITE_LABELLING, () =>
+                                                    updateAppearance({ whiteLabel: checked })
+                                                )
+                                            } else {
+                                                updateAppearance({ whiteLabel: checked })
+                                            }
+                                        }}
                                         size="small"
                                     />
                                 </div>


### PR DESCRIPTION
## Problem

A user on a plan without white labelling could open the AI observability feedback survey wizard, tick "Hide PostHog branding", and hit create — only to get a raw API error and no survey. There was no upgrade prompt and no way to tell the option was unavailable before submitting.

The backend rejects `appearance.whiteLabel: true` in `SurveySerializer.validate_appearance` unless the organization has `AvailableFeature.WHITE_LABELLING`. The wizard's checkbox wrote that field straight into the survey payload with no client-side check, so the entitlement was only enforced after the POST failed.

This has been surfacing continuously in error tracking as `Error: You need to upgrade to PostHog Enterprise to use white labelling`, thrown from `feedbackSurveyWizardLogic.createSurvey`. It affects a modest number of sessions, but every one is a dead end.

## Changes

Wrap the checkbox's `onChange` in `guardAvailableFeature(AvailableFeature.WHITE_LABELLING, ...)` when it is being enabled, so the upgrade modal opens instead of setting an unsubmittable value. Unchecking stays unguarded.

This is the same pattern the rest of the surveys product already uses — `frontend/src/scenes/surveys/wizard/steps/AppearanceStep.tsx` and `frontend/src/scenes/surveys/survey-appearance/SurveyCustomization.tsx` both guard this exact field. The AI observability wizard was the only place that copied the checkbox without the guard, so aligning it is preferable to inventing a new gating mechanism here.

## How did you test this code?

No manual testing — the agent could not run the app in this environment.

Automated checks actually run: `pnpm --filter=@posthog/frontend fix` (clean) and `pnpm --filter=@posthog/frontend typescript:check`. The typecheck reports no errors in the changed file; the errors it does report are pre-existing missing-module failures from the unbuilt `@posthog/quill` workspace across unrelated products.

No tests added. The behavior is a one-line entitlement guard on a checkbox handler, matching two existing call sites that are themselves untested — a new test here would assert the wiring of `guardAvailableFeature` rather than any regression the type system doesn't already catch.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — no user-facing documentation describes this checkbox.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from an error tracking alert via the PostHog Slack app, using the PostHog MCP tools to pull the issue, sample exception events, and resolved stack frames, then reading the code to find the missing guard. Skills invoked: `/investigating-error-issue`.

Worth knowing for review: the error had regrouped into a second error tracking issue with a new fingerprint, because a recent refactor added an `api-error.ts` frame to the stack. Both issues share the same root cause and this fix should close out both. The team default appearance (`defaultSurveyAppearance`) already sets `whiteLabel: false`, so the only way to reach the failing state was ticking the box — hence the guard on the toggle rather than a filter on the submitted payload.

The PR is unassigned because the requester's GitHub handle could not be verified from this session.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1786106641990959?thread_ts=1786106641.990959&cid=C0A006STKHR)*
