### PR TITLE
chore(ci): fall back to the master schema artifact when the cache is evicted

### DIFF
--- a/.depot/actions/fetch-master-schema/action.yml
+++ b/.depot/actions/fetch-master-schema/action.yml
@@ -1,0 +1,60 @@
+# Depot mirror of .github/actions/fetch-master-schema — keep in sync (see
+# .depot/workflows/ci-backend.yml header for the shadow conventions).
+name: Fetch master schema dump
+description: >
+    Fill the schema dump file from ci-backend.yml's migrated-schema artifact when
+    the Actions cache restore missed. The repo's 10 GB LRU cache pool routinely
+    evicts the few-MB schema dumps, so the artifact (90-day retention, separate
+    storage) is the reliable source. The artifact is resolved only through
+    successful master push runs of ci-backend.yml, never the repo-wide artifact
+    list. Never fails - on any error the file stays absent and the caller's
+    prime step falls back to a full migrate. Needs actions:read on the token.
+inputs:
+    path:
+        description: Destination file for the gzipped schema dump
+        required: false
+        default: schema.sql.gz
+    token:
+        description: GitHub token with actions:read
+        required: false
+        default: ${{ github.token }}
+runs:
+    using: composite
+    steps:
+        - name: Fetch schema artifact on cache miss
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.token }}
+              DEST: ${{ inputs.path }}
+          run: |
+              if [ -f "$DEST" ]; then
+                  echo "schema dump already present (cache hit); skipping artifact fetch"
+                  exit 0
+              fi
+              # Paths-filtered master pushes can succeed without producing the
+              # artifact, hence the scan over recent runs.
+              RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-backend.yml/runs?branch=master&event=push&status=success&per_page=10" \
+                  --jq '.workflow_runs[].id' || true)
+              ARTIFACT_ID=""
+              for RUN_ID in $RUN_IDS; do
+                  ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=migrated-schema" \
+                      --jq '[.artifacts[] | select(.expired | not)][0].id // empty' || true)
+                  if [ -n "$ARTIFACT_ID" ]; then
+                      echo "using migrated-schema artifact ${ARTIFACT_ID} from master run ${RUN_ID}"
+                      break
+                  fi
+              done
+              if [ -z "$ARTIFACT_ID" ]; then
+                  echo "::warning::no migrated-schema artifact in recent successful master ci-backend runs; falling back to full migrate"
+                  exit 0
+              fi
+              TMP_DIR=$(mktemp -d)
+              if ! { gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > "${TMP_DIR}/migrated-schema.zip" \
+                  && unzip -o -d "$TMP_DIR" "${TMP_DIR}/migrated-schema.zip" schema.sql.gz \
+                  && gunzip -t "${TMP_DIR}/schema.sql.gz" \
+                  && mv "${TMP_DIR}/schema.sql.gz" "$DEST"; }; then
+                  echo "::warning::migrated-schema artifact ${ARTIFACT_ID} unusable; falling back to full migrate"
+                  rm -f "$DEST"
+              fi
+              rm -rf "$TMP_DIR"
+              exit 0

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -156,6 +156,8 @@ env:
 permissions:
     contents: read
     pull-requests: read
+    # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+    actions: read
 jobs:
     # Sampling gate (full design in the file header). The `if` keeps the whole workflow
     # off when the percent is 0/unset; when >0 this job computes `sampled`, and `changes`
@@ -903,6 +905,9 @@ jobs:
                   key: ${{ needs.turbo-discover.outputs.schema_migrations_key || needs.turbo-discover.outputs.schema_cache_key }}
                   restore-keys: |
                       ${{ needs.turbo-discover.outputs.schema_cache_key }}
+            - name: Fetch master schema dump on cache miss
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: ./.depot/actions/fetch-master-schema
             - name: Prime test_posthog from cached schema
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
               if: ${{ github.event_name == 'pull_request' }}
@@ -1116,6 +1121,13 @@ jobs:
                   components: cargo
             - name: Install sqlx-cli
               uses: ./.depot/actions/setup-sqlx-cli
+            - name: Fetch master schema dump
+              # Must run before "Checkout master" switches the workspace tree: the
+              # local action resolves from the checked-out PR ref. The untracked
+              # dump survives the in-place checkout (clean: false), and an
+              # exact-key cache hit below overwrites it with an equivalent dump.
+              if: github.event_name != 'push'
+              uses: ./.depot/actions/fetch-master-schema
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1782,6 +1794,9 @@ jobs:
                   key: ${{ needs.turbo-discover.outputs.schema_migrations_key || needs.turbo-discover.outputs.schema_cache_key }}
                   restore-keys: |
                       ${{ needs.turbo-discover.outputs.schema_cache_key }}
+            - name: Fetch master schema dump on cache miss
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: ./.depot/actions/fetch-master-schema
             - name: Prime test_posthog from cached schema
               # No-op on cache miss; pytest --reuse-db falls back to a full migrate.
               if: ${{ github.event_name == 'pull_request' }}

--- a/.github/actions/fetch-master-schema/action.yml
+++ b/.github/actions/fetch-master-schema/action.yml
@@ -1,0 +1,58 @@
+name: Fetch master schema dump
+description: >
+    Fill the schema dump file from ci-backend.yml's migrated-schema artifact when
+    the Actions cache restore missed. The repo's 10 GB LRU cache pool routinely
+    evicts the few-MB schema dumps, so the artifact (90-day retention, separate
+    storage) is the reliable source. The artifact is resolved only through
+    successful master push runs of ci-backend.yml, never the repo-wide artifact
+    list. Never fails - on any error the file stays absent and the caller's
+    prime step falls back to a full migrate. Needs actions:read on the token.
+inputs:
+    path:
+        description: Destination file for the gzipped schema dump
+        required: false
+        default: schema.sql.gz
+    token:
+        description: GitHub token with actions:read
+        required: false
+        default: ${{ github.token }}
+runs:
+    using: composite
+    steps:
+        - name: Fetch schema artifact on cache miss
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.token }}
+              DEST: ${{ inputs.path }}
+          run: |
+              if [ -f "$DEST" ]; then
+                  echo "schema dump already present (cache hit); skipping artifact fetch"
+                  exit 0
+              fi
+              # Paths-filtered master pushes can succeed without producing the
+              # artifact, hence the scan over recent runs.
+              RUN_IDS=$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/ci-backend.yml/runs?branch=master&event=push&status=success&per_page=10" \
+                  --jq '.workflow_runs[].id' || true)
+              ARTIFACT_ID=""
+              for RUN_ID in $RUN_IDS; do
+                  ARTIFACT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts?name=migrated-schema" \
+                      --jq '[.artifacts[] | select(.expired | not)][0].id // empty' || true)
+                  if [ -n "$ARTIFACT_ID" ]; then
+                      echo "using migrated-schema artifact ${ARTIFACT_ID} from master run ${RUN_ID}"
+                      break
+                  fi
+              done
+              if [ -z "$ARTIFACT_ID" ]; then
+                  echo "::warning::no migrated-schema artifact in recent successful master ci-backend runs; falling back to full migrate"
+                  exit 0
+              fi
+              TMP_DIR=$(mktemp -d)
+              if ! { gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" > "${TMP_DIR}/migrated-schema.zip" \
+                  && unzip -o -d "$TMP_DIR" "${TMP_DIR}/migrated-schema.zip" schema.sql.gz \
+                  && gunzip -t "${TMP_DIR}/schema.sql.gz" \
+                  && mv "${TMP_DIR}/schema.sql.gz" "$DEST"; }; then
+                  echo "::warning::migrated-schema artifact ${ARTIFACT_ID} unusable; falling back to full migrate"
+                  rm -f "$DEST"
+              fi
+              rm -rf "$TMP_DIR"
+              exit 0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -1423,6 +1423,14 @@ jobs:
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
 
+            - name: Fetch master schema dump
+              # Must run before "Checkout master" switches the workspace tree: the
+              # local action resolves from the checked-out PR ref. The untracked
+              # dump survives the in-place checkout (clean: false), and an
+              # exact-key cache hit below overwrites it with an equivalent dump.
+              if: github.event_name != 'push'
+              uses: ./.github/actions/fetch-master-schema
+
             # First running migrations from master, to simulate the real-world scenario
             - name: Checkout master
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1464,12 +1472,6 @@ jobs:
               with:
                   path: schema.sql.gz
                   key: ${{ steps.master-schema-key.outputs.key }}
-
-            - name: Fetch master schema dump on cache miss
-              # The "Run migrations up to master" step below applies any gap between
-              # the artifact's schema and master, so freshest-available is correct.
-              if: github.event_name != 'push'
-              uses: ./.github/actions/fetch-master-schema
 
             - name: Wait for Docker services
               env:

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -76,6 +76,8 @@ env:
 permissions:
     contents: read
     pull-requests: write
+    # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+    actions: read
 
 jobs:
     # Job to decide if we should run backend ci
@@ -906,6 +908,10 @@ jobs:
                   restore-keys: |
                       ${{ needs.turbo-discover.outputs.schema_cache_key }}
 
+            - name: Fetch master schema dump on cache miss
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: ./.github/actions/fetch-master-schema
+
             - name: Prime test_posthog from cached schema
               # Treat cache problems as misses; db:restore-test-db recreates the DB after failure.
               if: ${{ github.event_name == 'pull_request' }}
@@ -1345,6 +1351,8 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
+            # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+            actions: read
 
         name: Validate migrations
         runs-on: depot-ubuntu-24.04
@@ -1456,6 +1464,12 @@ jobs:
               with:
                   path: schema.sql.gz
                   key: ${{ steps.master-schema-key.outputs.key }}
+
+            - name: Fetch master schema dump on cache miss
+              # The "Run migrations up to master" step below applies any gap between
+              # the artifact's schema and master, so freshest-available is correct.
+              if: github.event_name != 'push'
+              uses: ./.github/actions/fetch-master-schema
 
             - name: Wait for Docker services
               env:
@@ -2757,6 +2771,10 @@ jobs:
                   key: ${{ needs.turbo-discover.outputs.schema_migrations_key || needs.turbo-discover.outputs.schema_cache_key }}
                   restore-keys: |
                       ${{ needs.turbo-discover.outputs.schema_cache_key }}
+
+            - name: Fetch master schema dump on cache miss
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: ./.github/actions/fetch-master-schema
 
             - name: Prime test_posthog from cached schema
               # Treat cache problems as misses; db:restore-test-db recreates the DB after failure.

--- a/.github/workflows/ci-dagster.yml
+++ b/.github/workflows/ci-dagster.yml
@@ -13,6 +13,8 @@ concurrency:
 permissions:
     contents: read
     pull-requests: read
+    # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+    actions: read
 
 env:
     # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in ci-backend.yml, which saves these caches on master pushes.
@@ -393,6 +395,10 @@ jobs:
                   key: ${{ needs.changes.outputs.schema_migrations_key || needs.changes.outputs.schema_cache_key }}
                   restore-keys: |
                       ${{ needs.changes.outputs.schema_cache_key }}
+
+            - name: Fetch master schema dump on cache miss
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: ./.github/actions/fetch-master-schema
 
             - name: Prime test_posthog and posthog from cached schema (PR)
               # Primes both test_posthog (used by pytest --reuse-db) and the prod-style

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -24,6 +24,8 @@ on:
 
 permissions:
     contents: read
+    # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+    actions: read
 
 env:
     SECRET_KEY: '6b01eee4f945ca25045b5aab440b953461faf08693a9abbf1166dc7c6b9772da' # unsafe - for testing only
@@ -495,6 +497,8 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
+            # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+            actions: read
         outputs:
             vr_run_id: ${{ steps.vr-create.outputs.run_id }}
             # Wall-clock of the test step, for the CI-minutes-saved telemetry.
@@ -759,6 +763,10 @@ jobs:
                   key: ${{ needs.changes.outputs.schema_migrations_key || needs.changes.outputs.schema_cache_key }}
                   restore-keys: |
                       ${{ needs.changes.outputs.schema_cache_key }}
+
+            - name: Fetch master schema dump on cache miss
+              if: github.event_name == 'pull_request' || github.event_name == 'push'
+              uses: ./.github/actions/fetch-master-schema
 
             - name: Prime posthog_e2e_test from cached schema
               # Schema dump is from master's `posthog` db but schemas are db-name agnostic.

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -18,6 +18,8 @@ concurrency:
 permissions:
     contents: read
     pull-requests: read
+    # Read the migrated-schema artifact from master runs (fetch-master-schema action).
+    actions: read
 
 env:
     # Manual cache-bust knob. Keep in sync with SCHEMA_CACHE_EPOCH in ci-backend.yml, which saves these caches on master pushes.
@@ -514,6 +516,10 @@ jobs:
                   key: ${{ steps.schema-key.outputs.migrations_key || steps.schema-key.outputs.key }}
                   restore-keys: |
                       ${{ steps.schema-key.outputs.key }}
+
+            - name: Fetch master schema dump on cache miss
+              if: ${{ github.event_name == 'pull_request' }}
+              uses: ./.github/actions/fetch-master-schema
 
             - name: Prime posthog from cached schema
               # No-op on cache miss; manage.py migrate below falls back to a full migrate.


### PR DESCRIPTION
## Problem

Schema-cache restores are unreliable, and for one consumer deterministically broken. The multinode smoke restored only `posthog-schema-master-*` keys, which never match the one cache entry that stays warm (the content-keyed `posthog-schema-mig-*` entry every PR job touches), so it paid a ~27-minute full migrate on every run ([measured](https://github.com/PostHog/posthog/actions/runs/31174521990/job/92853464756); fixed by #79592). The other consumers restore the warm key first and usually hit, but the pool sits at the 10 GB LRU cap (pnpm entries hold ~8.5 GB) and the schema entries oscillate - a job that starts in an eviction window pays minutes of full migrations. At the moment of diagnosis, zero `posthog-schema-*` entries existed.

## Changes

- Adds a `fetch-master-schema` composite action: when the cache restore left `schema.sql.gz` absent, it downloads ci-backend's `migrated-schema` artifact (90-day retention, separate storage from the cache pool). It resolves the artifact only through successful master push runs of ci-backend.yml, never the repo-wide artifact list.
- Wires the composite after the cache restore in six jobs: ci-backend's turbo-tests, Validate migrations, and both Django shard families, plus ci-mcp, ci-dagster, and ci-e2e-playwright. Priming becomes deterministic; the cache stays as the cheap first try.
- In Validate migrations the fetch runs before the in-place `Checkout master` step: a local action must resolve from the PR ref's tree, and the untracked dump survives the checkout.
- Mirrors everything into the `.depot` shadow (workflow + a composite mirror under `.depot/actions/`), per the shadow-drift gate.
- The existing prime steps and their full-migrate fallbacks are untouched - any fetch failure leaves the file absent and behavior is exactly as today.
- Grants `actions: read` where needed, including the job-level permissions blocks that would otherwise mask the workflow-level grant.

> [!NOTE]
> This is tail-latency insurance for these jobs, not a happy-path speedup: measured cache-hit runs of Validate migrations were 213-237s before and 248s after (the artifact fetch itself is 4s). What it removes is the minutes-long full-migrate penalty whenever the cache oscillates. Priming from the newest master schema is safe in every wired job: each still runs migrate (or pytest's keepdb path) after priming, which applies any delta.

## How did you test this code?

- This PR's own CI: [Validate migrations passed](https://github.com/PostHog/posthog/actions/runs/31185754565) with the artifact path live - the log shows the artifact resolved from a master run and `Primed posthog DB from cached master schema`; total 4m08s.
- The Django/mcp/e2e matrices are skipped on this PR (workflow-only diff), so those sites are exercised by the first backend-touching PR after merge; their step wiring is identical to the two verified sites.
- `bin/hogli lint:workflows` passes; actionlint reports only pre-existing findings on untouched lines; shellcheck is clean on the composite's script.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - CI-internal change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5). Skills: /authoring-ci-workflows, /writing-pr-descriptions. Follow-up to #79592. Post-merge before/after measurement across consumers corrected the initial always-evicted diagnosis to the key-mismatch + oscillation story above; the pnpm cache-pool cleanup job remains open as a further follow-up.