### PR TITLE
feat(data-warehouse): add search aliases for Postgres, MySQL, BigQuery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -339,7 +339,7 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.BIG_QUERY,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["bq", "gbq", "sql"],
+            keywords=["bq", "gbq", "sql", "gcp", "google cloud"],
             featured=True,
             iconPath="/static/services/bigquery.png",
             caption=(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -98,7 +98,7 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             name=SchemaExternalDataSourceType.MY_SQL,
             category=DataWarehouseSourceCategory.DATABASES,
             featured=True,
-            keywords=["sql", "mariadb"],
+            keywords=["sql", "mariadb", "rds", "aws rds", "amazon rds", "aurora"],
             caption="Enter your MySQL/MariaDB credentials to automatically pull your MySQL data into the PostHog Data warehouse.",
             iconPath="/static/services/mysql.png",
             docsUrl="https://posthog.com/docs/cdp/sources/mysql",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -226,7 +226,7 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
         return SourceConfig(
             name=SchemaExternalDataSourceType.POSTGRES,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["postgresql", "sql"],
+            keywords=["postgresql", "sql", "rds", "aws rds", "amazon rds", "aurora"],
             caption="Enter your Postgres credentials to automatically pull your Postgres data into the PostHog Data warehouse",
             iconPath="/static/services/postgres.png",
             docsUrl="https://posthog.com/docs/cdp/sources/postgres",


### PR DESCRIPTION
## Problem

Someone adding a data source who searches the new-source catalog by a hosting or platform name misses the connector that imports that data. Searching "rds" returns nothing, though Amazon RDS databases connect through the Postgres and MySQL sources. Searching "gcp" returns nothing, though BigQuery is a Google Cloud source.

- Sessions in the new-source flow show users typing platform names, hitting no results, and abandoning or requesting a source that already exists under another name.
- Catalog search matches each connector's `keywords` list, but these connectors lacked the platform terms.

## Changes

- Postgres and MySQL: add `rds`, `aws rds`, `amazon rds`, `aurora` — Amazon RDS and Aurora are managed Postgres and MySQL.
- BigQuery: add `gcp`, `google cloud`.
- Data-only change to each source's `keywords`; no sync, schema, or connection behavior changes.

No visible change beyond search results; there is no UI to screenshot.

## How did you test this code?

Not run: the app was not started in this environment. The change is a static edit to each `get_source_config().keywords` list, which the catalog's existing search already indexes.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (actually Claude) made this change while reviewing anonymized summaries of real new-source onboarding sessions for friction themes. The recurring theme was users searching connectors by an alternate name and finding nothing. The `keywords` mechanism already existed for exactly this, so the fix adds the missing terms rather than new code. I limited the aliases to cases where the mapping is unambiguous (Amazon RDS and Aurora are managed Postgres/MySQL; BigQuery is a Google Cloud product), backed by searches seen in the sessions. Skill invoked: `/writing-pr-descriptions`. No customer data, names, or session content is included in this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
