### PR TITLE
fix(desktop): archive tasks from focused editors

### DIFF
--- a/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
+++ b/products/desktop/packages/ui/src/features/task-detail/components/TaskDetail.tsx
@@ -117,7 +117,11 @@ export function TaskDetail({
       }
       void runArchive().catch(() => undefined);
     },
-    { scopes: ["taskDetail"] },
+    {
+      scopes: ["taskDetail"],
+      enableOnContentEditable: true,
+      enableOnFormTags: true,
+    },
     [task, taskId, taskSession, runtime, isPiGenerating, runArchive],
   );
 


### PR DESCRIPTION
## Problem

- Task users could press the archive shortcut while focused on text input and see no action.
- The task-detail handler ignored focused inputs and rich-text editors.

## Changes

- The archive shortcut now works when an input or editor has focus.
- No visual change.

## How did you test this code?

- The desktop UI test suite completed without test failures.
- The full desktop production build completed after restoring workspace dependencies.
- Formatting passed for the changed file.
- Package typecheck remains blocked by existing errors in billing, canvas, loops, and chat-thread files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

- None. This fixes existing shortcut behavior without changing a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code for a user-reported archive shortcut failure.
- Skills invoked: `/writing-tests` and `/writing-pr-descriptions`.
- Extended the existing global shortcut behavior to focused task editors.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*