### PR TITLE
fix(billing): stop recounting signals credits per org in quota cron

### DIFF
--- a/ee/billing/quota_limiting.py
+++ b/ee/billing/quota_limiting.py
@@ -1238,13 +1238,15 @@ def update_all_orgs_billing_quotas(
                     org.refresh_from_db(fields=["usage", "customer_trust_scores", "never_drop_data"])
                     refresh_total_seconds += time() - refresh_call_start
                     refresh_count += 1
-                    if (org.usage or {}).get(QuotaResource.SIGNALS_CREDITS.value):
-                        # The queries-phase snapshot predates any push-refresh that fired during
-                        # this run (`refresh_org_self_driving_quota` raises `todays_usage` the
-                        # moment a PR lands); writing the older snapshot back would unpause an
-                        # over-limit org until the next tick. Recount live instead — as a count
-                        # of the current window it also keeps legitimate decreases (day
-                        # rollover, refunds) intact.
+                    signals_usage = (org.usage or {}).get(QuotaResource.SIGNALS_CREDITS.value)
+                    if signals_usage and (signals_usage.get("todays_usage") or 0) > todays_report["signals_credits"]:
+                        # The queries-phase snapshot is authoritative except when the stored value
+                        # just read from the DB exceeds it — the one case where either a
+                        # push-refresh raise (`refresh_org_self_driving_quota`, a PR landing
+                        # mid-run) or a legitimate decrease (same-day refund, day rollover) is
+                        # hiding, and `_patch_todays_usage` has no monotonic guard to protect the
+                        # fresher value. A live recount resolves which it is; every other org
+                        # keeps the snapshot without a per-org query.
                         todays_report["signals_credits"] = get_self_driving_credits_used_in_period_for_org(
                             org_id, period_start, period_end
                         )

--- a/ee/billing/test/test_quota_limiting.py
+++ b/ee/billing/test/test_quota_limiting.py
@@ -2932,7 +2932,7 @@ class TestRefreshOrgSelfDrivingQuota(BaseTest):
         # The cron snapshots fleet usage before its org loop, so a push-refresh that fires while
         # the loop runs (a PR landing) writes a fresher, higher todays_usage than the snapshot.
         # Writing the snapshot back would unpause the over-limit org until the next tick; the
-        # cron must recount candidates live at decision time instead.
+        # cron must recount live when the stored value exceeds its snapshot.
         self._set_self_driving_usage(3000, todays_usage=1500)
         # Score must be in the frozen clock's future: candidate selection reads the zset
         # through `list_limited_team_attributes`, which drops expired entries.
@@ -2959,6 +2959,33 @@ class TestRefreshOrgSelfDrivingQuota(BaseTest):
         assert self.team.api_token in list_limited_team_attributes(
             QuotaResource.SIGNALS_CREDITS, QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY
         )
+
+    @patch("posthoganalytics.capture")
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    @freeze_time("2026-06-15T12:00:00Z")
+    def test_quota_cron_trusts_snapshot_without_per_org_recount(self, _feature_enabled, _capture) -> None:
+        # When the stored todays_usage doesn't exceed the fleet snapshot, nothing can be hiding
+        # behind it, so the cron must write the snapshot without the per-org signals query —
+        # recounting every candidate live is the query storm this branch exists to avoid.
+        self._set_self_driving_usage(3000, todays_usage=0)
+        replace_limited_team_tokens(
+            QuotaResource.SIGNALS_CREDITS,
+            {self.team.api_token: 1798761600},
+            QuotaLimitingCaches.QUOTA_LIMITER_CACHE_KEY,
+        )
+        with (
+            patch(
+                "ee.billing.quota_limiting.get_teams_with_signals_credits_used_in_period",
+                return_value=[(self.team.id, 100)],
+            ),
+            patch("ee.billing.quota_limiting.get_self_driving_credits_used_in_period_for_org") as live_mock,
+        ):
+            update_all_orgs_billing_quotas()
+
+        live_mock.assert_not_called()
+        self.organization.refresh_from_db()
+        assert self.organization.usage is not None
+        assert self.organization.usage["signals_credits"]["todays_usage"] == 100
 
     def test_refresh_is_a_noop_without_self_driving_usage(self) -> None:
         self.organization.usage = {"events": {"usage": 1, "todays_usage": 0, "limit": None}}


### PR DESCRIPTION
## Problem

- The main Postgres carries a constant load of five-table signals billing joins that almost all return nothing.
- The quota-limiting cron issues that join once per refresh-candidate org, on every run.
- Any resource makes an org a refresh candidate, so events or recordings usage pulls in orgs that never used signals.
- The signals gate only tests a dict for truthiness, and billing stamps a zero-usage signals dict on nearly every org.
- Each call heap-filters `output->>'pr_url'` after bitmap-scanning the tasks and task-runs tables.

## Changes

- The cron now trusts the fleet-wide snapshot it already computes once per run in its queries phase.
- It falls back to the per-org recount only when the stored `todays_usage` exceeds that snapshot.
- That comparison isolates the three cases where the snapshot can be stale: a mid-run PR, a same-day refund, and the UTC day rollover.
- The no-query branch writes a value at least as large as the stored one.
- It can therefore never lower `todays_usage`, which is the property the unconditional recount protected.
- Deleting the recount outright would let a stale snapshot unpause an over-limit org.
- A `max()` guard in `_patch_todays_usage` would instead block legitimate decreases such as refunds.
- Billing amounts do not change, because the daily usage report computes credits on a separate path.

> [!NOTE]
> Enforcement can now lag by one cron cycle in one case: signals usage rises mid-run and the best-effort push-refresh dispatch fails. The old code caught that within the same run.

## How did you test this code?

- I ran `ee/billing/test/test_quota_limiting.py` against a local dev stack.
- `test_quota_cron_recounts_live_instead_of_writing_its_stale_snapshot` passes unchanged, so the protection against writing a stale lower value still holds.
- I added `test_quota_cron_trusts_snapshot_without_per_org_recount`, which fails if anyone restores the unconditional recount.
- No existing test asserted that the per-org query is skipped.
- Not checked: production. The expected drop in call rate is an inference from the write paths, not a measurement.
- After deploy, watch this query's call rate in query monitoring; it should fall to near zero.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. This changes no user-facing behavior and no documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Georgiy asked me (Claude, via Claude Code) to explain why this query dominated our query monitoring, then to plan and implement a fix. Skills invoked: `/writing-tests` before adding the test, and `/writing-pr-descriptions` for this body.

I first proposed narrowing the refresh-candidate gate. While planning I found that the queries phase already computes the fleet-wide snapshot, which made the guarded fallback a smaller change than adding any new query. I then traced the three writers of `todays_usage` and confirmed they all derive from the same count, which is why the stored value converges to the snapshot and the fallback stays rare.

The diff carries nothing from the internal monitoring data and production logs that prompted it.
