### PR TITLE
fix(desktop): keep transcript intact when steering mid-reply

### DIFF
--- a/products/desktop/packages/agent/src/acp-extensions.ts
+++ b/products/desktop/packages/agent/src/acp-extensions.ts
@@ -63,6 +63,9 @@ export const POSTHOG_NOTIFICATIONS = {
   /** Agent status update (thinking, working, etc.) */
   STATUS: "_posthog/status",
 
+  /** A steered user message was consumed by the live turn; streamed text after this belongs to the model's next reply */
+  STEER_APPLIED: "_posthog/steer_applied",
+
   /** Structured backend progress notification; events in the same turn group into one card on the client */
   PROGRESS: "_posthog/progress",
 

--- a/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/claude/claude-agent.ts
@@ -1247,6 +1247,13 @@ export class ClaudeAcpAgent extends BaseAcpAgent {
             // cancelled guard so a turn enqueued after a cancel still starts.
             if (message.type === "user" && "uuid" in message && message.uuid) {
               if (session.activeTurn?.pendingSteerUuids.delete(message.uuid)) {
+                // The steer lands between the assistant reply it interrupted
+                // and the reply it provokes; without this boundary a renderer
+                // cannot tell where one reply's text ends and the next begins.
+                await this.client.extNotification(
+                  POSTHOG_NOTIFICATIONS.STEER_APPLIED,
+                  { sessionId },
+                );
                 break;
               }
               const queued = session.turnQueue.find(

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -261,6 +261,8 @@ export class CodexAppServerAgent extends BaseAcpAgent {
   private lastAgentMessage = "";
   /** True between a contextCompaction item's start and its boundary (dedupes the boundary). */
   private compactionActive = false;
+  /** An accepted steer awaits its consumption boundary (`_posthog/steer_applied`). */
+  private steerAppliedPending = false;
   /** Maps the host's taskRunId to this session, replayed for cloud notifications. */
   private taskRunId?: string;
   /** Deployment environment; on "cloud" a non-danger sandbox would panic, so we skip the override. */
@@ -833,11 +835,10 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       }
       this.turns.onSteered(steerRes?.turnId);
       this.broadcastUserInput(params.prompt);
-      // codex injects the steer into the live turn synchronously, so the
-      // accept point is its consumption boundary for transcript rendering.
-      await this.client.extNotification(POSTHOG_NOTIFICATIONS.STEER_APPLIED, {
-        sessionId: params.sessionId,
-      });
+      // codex folds the steer into the running turn: the in-flight item keeps
+      // streaming and the injected input is only picked up afterward, so the
+      // next item start — not the accept — is the transcript boundary.
+      this.steerAppliedPending = true;
       return { stopReason: "end_turn", _meta: { steer: true } };
     }
     if ((params._meta as { steer?: unknown } | undefined)?.steer === true) {
@@ -1446,6 +1447,19 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       this.interruptQueuedGoalTurn(turnId);
     }
 
+    if (
+      method === APP_SERVER_NOTIFICATIONS.ITEM_STARTED &&
+      this.steerAppliedPending &&
+      this.sessionId
+    ) {
+      this.steerAppliedPending = false;
+      void this.client
+        .extNotification(POSTHOG_NOTIFICATIONS.STEER_APPLIED, {
+          sessionId: this.sessionId,
+        })
+        .catch(() => undefined);
+    }
+
     // codex auto-compaction surfaces as a contextCompaction item: item/started → in progress,
     // item/completed → boundary (codex emits no separate thread/compacted; that's a guarded
     // fallback). compactionActive dedupes to one boundary per compaction.
@@ -1484,6 +1498,7 @@ export class CodexAppServerAgent extends BaseAcpAgent {
 
     if (method === APP_SERVER_NOTIFICATIONS.TURN_COMPLETED) {
       this.commandOutputs.clear();
+      this.steerAppliedPending = false;
       const turn = (params as { turn?: { id?: string; status?: string } })
         ?.turn;
       if (turn?.id === this.nativeGoalTurnId) {

--- a/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
+++ b/products/desktop/packages/agent/src/adapters/codex-app-server/codex-app-server-agent.ts
@@ -833,6 +833,11 @@ export class CodexAppServerAgent extends BaseAcpAgent {
       }
       this.turns.onSteered(steerRes?.turnId);
       this.broadcastUserInput(params.prompt);
+      // codex injects the steer into the live turn synchronously, so the
+      // accept point is its consumption boundary for transcript rendering.
+      await this.client.extNotification(POSTHOG_NOTIFICATIONS.STEER_APPLIED, {
+        sessionId: params.sessionId,
+      });
       return { stopReason: "end_turn", _meta: { steer: true } };
     }
     if ((params._meta as { steer?: unknown } | undefined)?.steer === true) {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildAgentConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildAgentConversationItems.test.ts
@@ -383,4 +383,46 @@ describe("buildAgentConversationItems", () => {
       ),
     ).toHaveLength(1);
   });
+
+  it("completes the open turn when a steered user message arrives mid-run", () => {
+    const events: AgentConversationEvent[] = [
+      {
+        type: "user_message",
+        id: "user-1",
+        timestamp: 1,
+        content: [{ type: "text", text: "write a poem" }],
+      },
+      {
+        type: "assistant_message_chunk",
+        timestamp: 2,
+        content: { type: "text", text: "Roses are red." },
+      },
+      {
+        type: "user_message",
+        id: "user-2",
+        timestamp: 3,
+        content: [{ type: "text", text: "make it about errors" }],
+      },
+      {
+        type: "assistant_message_chunk",
+        timestamp: 4,
+        content: { type: "text", text: "Fetch failures bloom." },
+      },
+      { type: "turn_completed", timestamp: 5, stopReason: "stop" },
+    ];
+
+    const { items } = buildAgentConversationItems(events, null);
+
+    const textBlocks = items.filter(
+      (item) =>
+        item.type === "session_update" &&
+        item.update.sessionUpdate === "agent_message_chunk",
+    );
+    expect(textBlocks).toHaveLength(2);
+    // The pre-steer reply's turn ended when the steer was delivered, so its
+    // text must not keep rendering as streaming while the next reply runs.
+    for (const block of textBlocks) {
+      expect(block).toMatchObject({ turnContext: { turnComplete: true } });
+    }
+  });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -1062,6 +1062,26 @@ describe("buildConversationItems", () => {
       expect(lastTurnInfo?.isComplete).toBe(true);
     });
 
+    it("pins the steer bubble at the tail while the interrupted reply keeps streaming", () => {
+      const events = [
+        userPromptMsg(1000, 1, "write me a poem"),
+        agentMessageMsg(1001, "Roses are red, "),
+        steerPromptMsg(1002, 2, "what error are you hitting?"),
+        steerAckMsg(1003, 2),
+        agentMessageMsg(1004, "violets are blue."),
+      ];
+
+      const { items } = buildConversationItems(events, null);
+
+      // Mid-stream: the bubble is already visible, and the reply's later
+      // chunks land above it.
+      expect(summarize(items)).toEqual([
+        "user:write me a poem",
+        "Roses are red, violets are blue.",
+        "user:what error are you hitting?",
+      ]);
+    });
+
     it("renders an accepted steer at the turn's end when no consumption boundary arrives", () => {
       const events = [
         userPromptMsg(1000, 1, "write me a poem"),

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -75,14 +75,14 @@ function steerPromptMsg(ts: number, id: number, text: string): AcpMessage {
   };
 }
 
-function steerAckMsg(ts: number, id: number): AcpMessage {
+function steerAckMsg(ts: number, id: number, steered = true): AcpMessage {
   return {
     type: "acp_message",
     ts,
     message: {
       jsonrpc: "2.0",
       id,
-      result: { stopReason: "end_turn", _meta: { steer: true } },
+      result: { stopReason: "end_turn", _meta: { steer: steered } },
     },
   };
 }
@@ -1021,7 +1021,17 @@ describe("buildConversationItems", () => {
   });
 
   describe("mid-turn steering", () => {
-    it("keeps the streaming turn intact and separates the steered reply", () => {
+    function summarize(items: ConversationItem[]): string[] {
+      return items.map((item) =>
+        item.type === "session_update"
+          ? (item.update as { content: { text: string } }).content.text
+          : item.type === "user_message"
+            ? `user:${item.content}`
+            : item.type,
+      );
+    }
+
+    it("renders the steer after the interrupted reply and separates the steered reply", () => {
       const events = [
         userPromptMsg(1000, 1, "write me a poem"),
         agentMessageMsg(1001, "Roses are red, "),
@@ -1035,19 +1045,10 @@ describe("buildConversationItems", () => {
 
       const { items, lastTurnInfo } = buildConversationItems(events, null);
 
-      expect(
-        items.map((item) =>
-          item.type === "session_update"
-            ? (item.update as { content: { text: string } }).content.text
-            : item.type === "user_message"
-              ? `user:${item.content}`
-              : item.type,
-        ),
-      ).toEqual([
+      expect(summarize(items)).toEqual([
         "user:write me a poem",
-        "Roses are red, ",
+        "Roses are red, violets are blue.",
         "user:what error are you hitting?",
-        "violets are blue.",
         "The error was a fetch failure.",
       ]);
 
@@ -1059,6 +1060,47 @@ describe("buildConversationItems", () => {
       expect(new Set(contexts).size).toBe(1);
       expect(contexts[0].turnComplete).toBe(true);
       expect(lastTurnInfo?.isComplete).toBe(true);
+    });
+
+    it("renders an accepted steer at the turn's end when no consumption boundary arrives", () => {
+      const events = [
+        userPromptMsg(1000, 1, "write me a poem"),
+        agentMessageMsg(1001, "Roses are red, "),
+        steerPromptMsg(1002, 2, "what error are you hitting?"),
+        steerAckMsg(1003, 2),
+        agentMessageMsg(1004, "violets are blue."),
+        promptResponseMsg(1005, 1),
+      ];
+
+      const { items } = buildConversationItems(events, null);
+
+      expect(summarize(items)).toEqual([
+        "user:write me a poem",
+        "Roses are red, violets are blue.",
+        "user:what error are you hitting?",
+      ]);
+    });
+
+    it("drops a declined steer so its redelivery as a follow-up renders once", () => {
+      const events = [
+        userPromptMsg(1000, 1, "write me a poem"),
+        agentMessageMsg(1001, "Roses are red."),
+        steerPromptMsg(1002, 2, "what error are you hitting?"),
+        steerAckMsg(1003, 2, false),
+        promptResponseMsg(1004, 1),
+        userPromptMsg(1005, 3, "what error are you hitting?"),
+        agentMessageMsg(1006, "A fetch failure."),
+        promptResponseMsg(1007, 3),
+      ];
+
+      const { items } = buildConversationItems(events, null);
+
+      expect(summarize(items)).toEqual([
+        "user:write me a poem",
+        "Roses are red.",
+        "user:what error are you hitting?",
+        "A fetch failure.",
+      ]);
     });
 
     it("opens a normal turn for a steer that arrives with no active turn", () => {

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.test.ts
@@ -62,6 +62,43 @@ function promptResponseMsg(ts: number, id: number): AcpMessage {
   };
 }
 
+function steerPromptMsg(ts: number, id: number, text: string): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      method: "session/prompt",
+      params: { prompt: [{ type: "text", text }], _meta: { steer: true } },
+    },
+  };
+}
+
+function steerAckMsg(ts: number, id: number): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      id,
+      result: { stopReason: "end_turn", _meta: { steer: true } },
+    },
+  };
+}
+
+function steerAppliedMsg(ts: number): AcpMessage {
+  return {
+    type: "acp_message",
+    ts,
+    message: {
+      jsonrpc: "2.0",
+      method: "_posthog/steer_applied",
+      params: { sessionId: "session-1" },
+    },
+  };
+}
+
 function turnCompleteMsg(ts: number, stopReason = "end_turn"): AcpMessage {
   return {
     type: "acp_message",
@@ -980,6 +1017,65 @@ describe("buildConversationItems", () => {
 
       expect(lastTurnInfo?.isComplete).toBe(true);
       expect(lastTurnInfo?.durationMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe("mid-turn steering", () => {
+    it("keeps the streaming turn intact and separates the steered reply", () => {
+      const events = [
+        userPromptMsg(1000, 1, "write me a poem"),
+        agentMessageMsg(1001, "Roses are red, "),
+        steerPromptMsg(1002, 2, "what error are you hitting?"),
+        steerAckMsg(1003, 2),
+        agentMessageMsg(1004, "violets are blue."),
+        steerAppliedMsg(1005),
+        agentMessageMsg(1006, "The error was a fetch failure."),
+        promptResponseMsg(1007, 1),
+      ];
+
+      const { items, lastTurnInfo } = buildConversationItems(events, null);
+
+      expect(
+        items.map((item) =>
+          item.type === "session_update"
+            ? (item.update as { content: { text: string } }).content.text
+            : item.type === "user_message"
+              ? `user:${item.content}`
+              : item.type,
+        ),
+      ).toEqual([
+        "user:write me a poem",
+        "Roses are red, ",
+        "user:what error are you hitting?",
+        "violets are blue.",
+        "The error was a fetch failure.",
+      ]);
+
+      // All streamed text belongs to the one real turn, which only completes
+      // when the original prompt's response arrives.
+      const contexts = items.flatMap((item) =>
+        item.type === "session_update" ? [item.turnContext] : [],
+      );
+      expect(new Set(contexts).size).toBe(1);
+      expect(contexts[0].turnComplete).toBe(true);
+      expect(lastTurnInfo?.isComplete).toBe(true);
+    });
+
+    it("opens a normal turn for a steer that arrives with no active turn", () => {
+      const events = [
+        steerPromptMsg(1000, 3, "hello?"),
+        agentMessageMsg(1001, "Hi!"),
+        promptResponseMsg(1002, 3),
+      ];
+
+      const { items, lastTurnInfo } = buildConversationItems(events, null);
+
+      expect(items).toHaveLength(2);
+      expect(items[0]).toMatchObject({
+        type: "user_message",
+        content: "hello?",
+      });
+      expect(lastTurnInfo?.isComplete).toBe(true);
     });
   });
 });

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -141,11 +141,13 @@ export interface ItemBuilder {
   /** Runs that emitted `_posthog/run_started`; until then the setup card's
    *  "agent" step stays in_progress rather than completing at HTTP-boot time. */
   runStartedRunIds: Set<string>;
-  /** Steer bubbles waiting for their consumption point. A steer joins the
-   *  turn that is already streaming, so its bubble renders where the model
-   *  consumed it (`_posthog/steer_applied`) rather than cutting the streamed
-   *  reply at arrival time. Keyed by the steer's prompt id so a declined ack
-   *  can drop it before the backend redelivers the message as a follow-up. */
+  /** Steer bubbles not yet consumed by the model. A steer joins the turn
+   *  that is already streaming, so its bubble renders immediately but floats
+   *  at the turn's tail: the interrupted reply keeps streaming above it, and
+   *  the bubble settles in place when the model consumes the steer
+   *  (`_posthog/steer_applied`) or the turn ends. Keyed by the steer's
+   *  prompt id so a declined ack can withdraw the bubble before the backend
+   *  redelivers the message as a follow-up. */
   pendingSteers: Map<
     number | string,
     Extract<ConversationItem, { type: "user_message" }>
@@ -225,11 +227,17 @@ function markThoughtCompletionInItems(
   }
 }
 
+/** Items the streaming reply produces enter above any floating steer
+ *  bubbles, which stay pinned at the tail until the model consumes them. */
+function activeTailIndex(b: ItemBuilder): number {
+  return b.items.length - b.pendingSteers.size;
+}
+
 function pushItem(b: ItemBuilder, update: RenderItem, ts?: number) {
   const turn = b.currentTurn;
   if (!turn) return;
   turn.itemCount++;
-  b.items.push({
+  b.items.splice(activeTailIndex(b), 0, {
     type: "session_update",
     id: `${turn.id}-item-${b.nextId()}`,
     update,
@@ -455,7 +463,7 @@ export function finalizeBuilder(
   // state (local sessions). For cloud sessions isPromptPending is
   // null, meaning that the response hasn't streamed "in" yet
   if (isPromptPending === false) {
-    flushPendingSteers(b);
+    settlePendingSteers(b);
     for (const turn of b.pendingPrompts.values()) {
       turn.isComplete = true;
       turn.durationMs = 0;
@@ -500,27 +508,29 @@ function handlePromptRequest(
     return;
   }
 
-  // A steer joins the turn that is already streaming: keep that turn open,
-  // and hold the steer's bubble until the model consumes it
-  // (`_posthog/steer_applied`) or the turn ends, so the reply being streamed
-  // stays one block instead of splitting at the arrival point. The steer's
-  // prompt response is a synthetic ack handled by handleSteerAck, so it is
-  // not registered in pendingPrompts.
+  // A steer joins the turn that is already streaming: keep that turn open
+  // and pin the steer's bubble to the turn's tail. The interrupted reply
+  // keeps streaming above the bubble until the model consumes the steer
+  // (`_posthog/steer_applied`) or the turn ends; the steered reply then
+  // lands below it. The steer's prompt response is a synthetic ack handled
+  // by handleSteerAck, so it is not registered in pendingPrompts.
   const isSteer =
     (msg.params as { _meta?: { steer?: unknown } } | undefined)?._meta
       ?.steer === true;
   if (isSteer && b.currentTurn && !b.currentTurn.isComplete) {
-    b.pendingSteers.set(msg.id, {
+    const bubble: Extract<ConversationItem, { type: "user_message" }> = {
       type: "user_message",
       id: `turn-${ts}-${msg.id}-user`,
       content: userContent,
       timestamp: ts,
       attachments: userPrompt.attachments,
-    });
+    };
+    b.pendingSteers.set(msg.id, bubble);
+    b.items.push(bubble);
     return;
   }
 
-  flushPendingSteers(b);
+  settlePendingSteers(b);
 
   const turnId = `turn-${ts}-${msg.id}`;
   const toolCalls = new Map<string, ToolCall>();
@@ -607,33 +617,47 @@ function trailingInsertIndex(b: ItemBuilder): number {
   return insertIndex;
 }
 
-function insertNextPendingSteer(b: ItemBuilder): boolean {
-  const next = b.pendingSteers.entries().next();
+function settleOldestPendingSteer(b: ItemBuilder): boolean {
+  const next = b.pendingSteers.keys().next();
   if (next.done) return false;
-  const [promptId, item] = next.value;
-  b.pendingSteers.delete(promptId);
-  b.items.splice(trailingInsertIndex(b), 0, item);
+  b.pendingSteers.delete(next.value);
   return true;
 }
 
-function flushPendingSteers(b: ItemBuilder) {
-  while (insertNextPendingSteer(b)) {
-    // Drain in send order; each bubble lands at the current end of the turn.
-  }
+function settlePendingSteers(b: ItemBuilder) {
+  b.pendingSteers.clear();
 }
 
 /** A declined steer never reaches the model and the backend redelivers it as
- *  a normal follow-up, so keeping its bubble queued would render it twice. */
+ *  a normal follow-up, so leaving the bubble would render the message twice. */
+function withdrawFloatingSteer(
+  b: ItemBuilder,
+  promptId: number | string,
+  bubble: ConversationItem,
+) {
+  b.pendingSteers.delete(promptId);
+  const idx = b.items.indexOf(bubble);
+  if (idx === -1) return;
+  b.items.splice(idx, 1);
+  for (const entry of b.shellExecutes.values()) {
+    if (entry.index > idx) entry.index--;
+  }
+  for (const card of b.progressCards.values()) {
+    if (card.itemIndex > idx) card.itemIndex--;
+  }
+}
+
 function handleSteerAck(
   b: ItemBuilder,
   msg: { id: number | string; result?: unknown },
 ) {
-  if (!b.pendingSteers.has(msg.id)) return;
+  const bubble = b.pendingSteers.get(msg.id);
+  if (!bubble) return;
   const accepted =
     (msg.result as { _meta?: { steer?: unknown } } | undefined)?._meta
       ?.steer === true;
   if (!accepted) {
-    b.pendingSteers.delete(msg.id);
+    withdrawFloatingSteer(b, msg.id, bubble);
   }
 }
 
@@ -662,9 +686,9 @@ function completePromptTurn(
 ) {
   if (turn.isComplete) return;
 
-  // A steer whose consumption boundary never arrived still has to render;
-  // the turn ending is the last ordered place for it.
-  flushPendingSteers(b);
+  // A steer whose consumption boundary never arrived settles where it
+  // floats; the turn ending is its last ordered position.
+  settlePendingSteers(b);
 
   turn.isComplete = true;
   turn.durationMs += ts;
@@ -717,8 +741,9 @@ function handleNotification(
         cwd: params.cwd,
         result: params.result,
       };
-      b.shellExecutes.set(params.id, { item, index: b.items.length });
-      b.items.push(item);
+      const index = activeTailIndex(b);
+      b.shellExecutes.set(params.id, { item, index });
+      b.items.splice(index, 0, item);
     }
     return;
   }
@@ -747,7 +772,7 @@ function handleNotification(
   }
 
   if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.STEER_APPLIED)) {
-    if (!insertNextPendingSteer(b)) {
+    if (!settleOldestPendingSteer(b)) {
       b.pendingTextBlockBreak = true;
     }
     return;
@@ -896,7 +921,7 @@ function ensureProgressCardForGroup(
   const card: ProgressCardState = {
     steps: new Map(),
     renderItem,
-    itemIndex: b.items.length,
+    itemIndex: activeTailIndex(b),
     runId: colon >= 0 ? group.slice(colon + 1) : "",
   };
   b.progressCards.set(group, card);
@@ -1223,7 +1248,8 @@ function appendTextChunk(
 ) {
   if (update.content.type !== "text") return;
 
-  const lastItem = b.items[b.items.length - 1];
+  const tail = activeTailIndex(b);
+  const lastItem = b.items[tail - 1];
   if (
     !b.pendingTextBlockBreak &&
     lastItem?.type === "session_update" &&
@@ -1232,7 +1258,7 @@ function appendTextChunk(
     "content" in lastItem.update &&
     lastItem.update.content.type === "text"
   ) {
-    b.items[b.items.length - 1] = {
+    b.items[tail - 1] = {
       ...lastItem,
       update: {
         ...lastItem.update,

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -141,9 +141,19 @@ export interface ItemBuilder {
   /** Runs that emitted `_posthog/run_started`; until then the setup card's
    *  "agent" step stays in_progress rather than completing at HTTP-boot time. */
   runStartedRunIds: Set<string>;
-  /** Set when a steer was consumed mid-turn (`_posthog/steer_applied`): the
-   *  model's next reply is a new message, so the next top-level text chunk
-   *  opens a fresh block instead of concatenating onto the pre-steer text. */
+  /** Steer bubbles waiting for their consumption point. A steer joins the
+   *  turn that is already streaming, so its bubble renders where the model
+   *  consumed it (`_posthog/steer_applied`) rather than cutting the streamed
+   *  reply at arrival time. Keyed by the steer's prompt id so a declined ack
+   *  can drop it before the backend redelivers the message as a follow-up. */
+  pendingSteers: Map<
+    number | string,
+    Extract<ConversationItem, { type: "user_message" }>
+  >;
+  /** Set when `_posthog/steer_applied` arrives with no queued bubble (e.g. a
+   *  replayed log whose steer prompt was not captured): the model's next
+   *  reply is a new message, so the next top-level text chunk opens a fresh
+   *  block instead of concatenating onto the pre-steer text. */
   pendingTextBlockBreak: boolean;
 }
 
@@ -161,6 +171,7 @@ export function createItemBuilder(): ItemBuilder {
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
     runStartedRunIds: new Set(),
+    pendingSteers: new Map(),
     pendingTextBlockBreak: false,
   };
 }
@@ -284,8 +295,12 @@ export function processEvent(
     return;
   }
 
-  if (isJsonRpcResponse(msg) && b.pendingPrompts.has(msg.id)) {
-    handlePromptResponse(b, msg, event.ts);
+  if (isJsonRpcResponse(msg)) {
+    if (b.pendingPrompts.has(msg.id)) {
+      handlePromptResponse(b, msg, event.ts);
+      return;
+    }
+    handleSteerAck(b, msg);
   }
 }
 
@@ -440,6 +455,7 @@ export function finalizeBuilder(
   // state (local sessions). For cloud sessions isPromptPending is
   // null, meaning that the response hasn't streamed "in" yet
   if (isPromptPending === false) {
+    flushPendingSteers(b);
     for (const turn of b.pendingPrompts.values()) {
       turn.isComplete = true;
       turn.durationMs = 0;
@@ -484,16 +500,17 @@ function handlePromptRequest(
     return;
   }
 
-  // A steer joins the turn that is already streaming: render its bubble in
-  // place but keep the open turn and its context, so the response text that
-  // keeps arriving after it still belongs to that turn rather than a phantom
-  // new one. The steer's prompt response is a synthetic ack and must not
-  // complete the real turn, so it is not registered in pendingPrompts.
+  // A steer joins the turn that is already streaming: keep that turn open,
+  // and hold the steer's bubble until the model consumes it
+  // (`_posthog/steer_applied`) or the turn ends, so the reply being streamed
+  // stays one block instead of splitting at the arrival point. The steer's
+  // prompt response is a synthetic ack handled by handleSteerAck, so it is
+  // not registered in pendingPrompts.
   const isSteer =
     (msg.params as { _meta?: { steer?: unknown } } | undefined)?._meta
       ?.steer === true;
   if (isSteer && b.currentTurn && !b.currentTurn.isComplete) {
-    b.items.splice(trailingInsertIndex(b), 0, {
+    b.pendingSteers.set(msg.id, {
       type: "user_message",
       id: `turn-${ts}-${msg.id}-user`,
       content: userContent,
@@ -502,6 +519,8 @@ function handlePromptRequest(
     });
     return;
   }
+
+  flushPendingSteers(b);
 
   const turnId = `turn-${ts}-${msg.id}`;
   const toolCalls = new Map<string, ToolCall>();
@@ -588,6 +607,36 @@ function trailingInsertIndex(b: ItemBuilder): number {
   return insertIndex;
 }
 
+function insertNextPendingSteer(b: ItemBuilder): boolean {
+  const next = b.pendingSteers.entries().next();
+  if (next.done) return false;
+  const [promptId, item] = next.value;
+  b.pendingSteers.delete(promptId);
+  b.items.splice(trailingInsertIndex(b), 0, item);
+  return true;
+}
+
+function flushPendingSteers(b: ItemBuilder) {
+  while (insertNextPendingSteer(b)) {
+    // Drain in send order; each bubble lands at the current end of the turn.
+  }
+}
+
+/** A declined steer never reaches the model and the backend redelivers it as
+ *  a normal follow-up, so keeping its bubble queued would render it twice. */
+function handleSteerAck(
+  b: ItemBuilder,
+  msg: { id: number | string; result?: unknown },
+) {
+  if (!b.pendingSteers.has(msg.id)) return;
+  const accepted =
+    (msg.result as { _meta?: { steer?: unknown } } | undefined)?._meta
+      ?.steer === true;
+  if (!accepted) {
+    b.pendingSteers.delete(msg.id);
+  }
+}
+
 function handlePromptResponse(
   b: ItemBuilder,
   msg: { id: number; result?: unknown },
@@ -612,6 +661,10 @@ function completePromptTurn(
   result: { stopReason?: string; interruptReason?: string } = {},
 ) {
   if (turn.isComplete) return;
+
+  // A steer whose consumption boundary never arrived still has to render;
+  // the turn ending is the last ordered place for it.
+  flushPendingSteers(b);
 
   turn.isComplete = true;
   turn.durationMs += ts;
@@ -694,7 +747,9 @@ function handleNotification(
   }
 
   if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.STEER_APPLIED)) {
-    b.pendingTextBlockBreak = true;
+    if (!insertNextPendingSteer(b)) {
+      b.pendingTextBlockBreak = true;
+    }
     return;
   }
 

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -323,6 +323,14 @@ export function processAgentConversationEvent(
   event: AgentConversationEvent,
 ): void {
   if (event.type === "user_message") {
+    // Pi delivers a steered message only between assistant messages, so a
+    // user message arriving while a turn is still open means that turn's
+    // reply already ended; complete it so its text stops rendering as
+    // streaming. History translation inserts an explicit turn_completed at
+    // the same spot.
+    if (b.currentTurn && !b.currentTurn.isComplete) {
+      completePromptTurn(b, b.currentTurn, event.timestamp);
+    }
     handlePromptRequest(
       b,
       { id: event.id, params: { prompt: event.content } },

--- a/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
+++ b/products/desktop/packages/ui/src/features/sessions/components/buildConversationItems.ts
@@ -141,6 +141,10 @@ export interface ItemBuilder {
   /** Runs that emitted `_posthog/run_started`; until then the setup card's
    *  "agent" step stays in_progress rather than completing at HTTP-boot time. */
   runStartedRunIds: Set<string>;
+  /** Set when a steer was consumed mid-turn (`_posthog/steer_applied`): the
+   *  model's next reply is a new message, so the next top-level text chunk
+   *  opens a fresh block instead of concatenating onto the pre-steer text. */
+  pendingTextBlockBreak: boolean;
 }
 
 export function createItemBuilder(): ItemBuilder {
@@ -157,6 +161,7 @@ export function createItemBuilder(): ItemBuilder {
     lowestTouchedProgressIndex: Number.POSITIVE_INFINITY,
     completedToolCallCount: 0,
     runStartedRunIds: new Set(),
+    pendingTextBlockBreak: false,
   };
 }
 
@@ -471,6 +476,25 @@ function handlePromptRequest(
     return;
   }
 
+  // A steer joins the turn that is already streaming: render its bubble in
+  // place but keep the open turn and its context, so the response text that
+  // keeps arriving after it still belongs to that turn rather than a phantom
+  // new one. The steer's prompt response is a synthetic ack and must not
+  // complete the real turn, so it is not registered in pendingPrompts.
+  const isSteer =
+    (msg.params as { _meta?: { steer?: unknown } } | undefined)?._meta
+      ?.steer === true;
+  if (isSteer && b.currentTurn && !b.currentTurn.isComplete) {
+    b.items.splice(trailingInsertIndex(b), 0, {
+      type: "user_message",
+      id: `turn-${ts}-${msg.id}-user`,
+      content: userContent,
+      timestamp: ts,
+      attachments: userPrompt.attachments,
+    });
+    return;
+  }
+
   const turnId = `turn-${ts}-${msg.id}`;
   const toolCalls = new Map<string, ToolCall>();
   const gitAction = parseGitActionMessage(userContent);
@@ -484,32 +508,7 @@ function handlePromptRequest(
     turnComplete: false,
   };
 
-  // The orchestrator emits its setup progress ("Started agent") before the
-  // prompt it responds to is replayed onto the stream, so the card would sit
-  // above the user's message. Open the turn before any trailing progress cards
-  // so the transcript reads user message → setup → work.
-  let insertIndex = b.items.length;
-  while (insertIndex > 0) {
-    const prev = b.items[insertIndex - 1];
-    if (
-      prev.type === "session_update" &&
-      prev.update.sessionUpdate === "progress_group"
-    ) {
-      insertIndex--;
-    } else {
-      break;
-    }
-  }
-  if (insertIndex < b.items.length) {
-    for (const card of b.progressCards.values()) {
-      if (card.itemIndex >= insertIndex) card.itemIndex++;
-    }
-    // The shifted cards may live inside a turn the incremental builder already
-    // froze; flag the mutation so it falls back to a full rebuild.
-    if (insertIndex < b.lowestTouchedProgressIndex) {
-      b.lowestTouchedProgressIndex = insertIndex;
-    }
-  }
+  const insertIndex = trailingInsertIndex(b);
 
   b.currentTurnStartIndex = insertIndex;
   b.currentTurn = {
@@ -546,6 +545,39 @@ function handlePromptRequest(
       attachments: userPrompt.attachments,
     });
   }
+}
+
+/**
+ * Index at which a user-initiated item should enter the transcript. The
+ * orchestrator emits its setup progress ("Started agent") before the prompt it
+ * responds to is replayed onto the stream, so the card would sit above the
+ * user's message. Insert before any trailing progress cards so the transcript
+ * reads user message → setup → work.
+ */
+function trailingInsertIndex(b: ItemBuilder): number {
+  let insertIndex = b.items.length;
+  while (insertIndex > 0) {
+    const prev = b.items[insertIndex - 1];
+    if (
+      prev.type === "session_update" &&
+      prev.update.sessionUpdate === "progress_group"
+    ) {
+      insertIndex--;
+    } else {
+      break;
+    }
+  }
+  if (insertIndex < b.items.length) {
+    for (const card of b.progressCards.values()) {
+      if (card.itemIndex >= insertIndex) card.itemIndex++;
+    }
+    // The shifted cards may live inside a turn the incremental builder already
+    // froze; flag the mutation so it falls back to a full rebuild.
+    if (insertIndex < b.lowestTouchedProgressIndex) {
+      b.lowestTouchedProgressIndex = insertIndex;
+    }
+  }
+  return insertIndex;
 }
 
 function handlePromptResponse(
@@ -650,6 +682,11 @@ function handleNotification(
     completePromptTurn(b, b.currentTurn, ts, {
       stopReason: params?.stopReason,
     });
+    return;
+  }
+
+  if (isNotification(msg.method, POSTHOG_NOTIFICATIONS.STEER_APPLIED)) {
+    b.pendingTextBlockBreak = true;
     return;
   }
 
@@ -1125,6 +1162,7 @@ function appendTextChunk(
 
   const lastItem = b.items[b.items.length - 1];
   if (
+    !b.pendingTextBlockBreak &&
     lastItem?.type === "session_update" &&
     lastItem.turnContext === b.currentTurn?.context &&
     lastItem.update.sessionUpdate === update.sessionUpdate &&
@@ -1142,6 +1180,7 @@ function appendTextChunk(
       },
     };
   } else {
+    b.pendingTextBlockBreak = false;
     pushItem(b, { ...update, content: { ...update.content } }, ts);
   }
 }


### PR DESCRIPTION
## Problem

Sending a steer message while the agent is mid-reply corrupts the transcript for the person watching the task: the streaming reply splits at the steer, its tail re-attaches below their bubble, and the next reply concatenates onto that tail with no separator (`...instead.The upload...`).

- The transcript builder opens a new turn for every `session/prompt` request, including a steer that joins a turn still streaming.
- The rest of the interrupted reply then fails the same-turn merge check and lands in a new block under the steer's turn context.
- Assistant text chunks carry no message id, so the steered reply's first chunk merges into that tail with bare string concatenation.

The bug is timing-dependent: it reproduces only when the steer lands inside an actively streaming text block and the next reply opens with plain text.

## Changes

- The builder keeps the open turn when a steer arrives and pins the steer's bubble to the turn's tail: visible the moment it is sent, with the interrupted reply streaming above it, so the reply renders whole and the message never looks lost.
- The Claude adapter emits `_posthog/steer_applied` at the moment the steer enters the model conversation, and the codex adapter emits it at the next item start after its accept (codex only picks up injected input once the in-flight item finishes); that boundary settles the bubble so the steered reply lands below it.
- A renderer-only fix could not settle the bubble, because no existing event marks where the steer is consumed; that is why the adapters emit the boundary.
- Fallbacks: a declined steer withdraws its floating bubble before the backend redelivers it as a follow-up, and a missing boundary settles the bubble when the turn ends. Old transcripts still get the turn fix.
- The pi runtime already delivers steers between assistant messages and echoes them at that point, so pi cannot split or fuse replies; its echo now also completes the open turn instead of leaving the pre-steer reply rendering as streaming.

## How did you test this code?

- New renderer test replays the failing interleaving (prompt, chunks, steer request and ack, tail chunks, boundary, reply chunks, response). It fails on both regressions: turn clobbering and reply fusing.
- A second test guards the fallback where a steer arrives with no open turn.
- Ran the three conversation-builder vitest files in `@posthog/ui`, the `@posthog/ui` typecheck, the `@posthog/agent` build, and biome on the touched files.
- Rendered the real ConversationView in Storybook (headless Chromium) with the failing event sequence: master fuses the two replies into one block with no separator; this branch renders the interrupted reply whole, then the steer bubble, then the steered reply.
- Not run: a live steered cloud run end to end; this sandbox has no desktop app session.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (actually Claude, in a PostHog Code cloud task) authored this after the reporter reproduced the split live by steering during a streaming reply.
- Skills invoked: /writing-tests, /writing-code-comments, /writing-pr-descriptions.
- The session started as a diagnosis of the split; the fix scope grew from renderer-only to renderer plus adapter once the missing boundary event became clear.
- Committed data is invented; no session material beyond the bug's shape reaches the diff.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*




