### PR TITLE
fix(desktop): import the product tours skill

### DIFF
--- a/products/desktop/apps/code/vite-main-plugins.mts
+++ b/products/desktop/apps/code/vite-main-plugins.mts
@@ -357,7 +357,7 @@ async function findSkillsDirInExtract(
 
 /**
  * Downloads context-mill skills-mcp-resources.zip (a zip-of-zips), extracts
- * omnibus-* inner zips, strips the "omnibus-" prefix, and writes into targetDir.
+ * omnibus skills and selected standalone skills, and writes them into targetDir.
  * Returns true on success, false on failure (non-fatal).
  */
 async function downloadAndExtractContextMillSkills(
@@ -383,11 +383,17 @@ async function downloadAndExtractContextMillSkills(
 
       for (const [filename, content] of Object.entries(outerEntries)) {
         const base = filename.replace(/^.*\//, ""); // strip any directory prefix
-        if (!base.startsWith("omnibus-") || !base.endsWith(".zip")) continue;
+        if (!base.endsWith(".zip")) continue;
 
-        const strippedName = base
-          .replace(/^omnibus-/, "")
-          .replace(/\.zip$/, "");
+        const archiveName = base.replace(/\.zip$/, "");
+        if (
+          !archiveName.startsWith("omnibus-") &&
+          archiveName !== "creating-product-tours"
+        ) {
+          continue;
+        }
+
+        const strippedName = archiveName.replace(/^omnibus-/, "");
         const innerEntries = unzipSync(new Uint8Array(content));
         const destDir = join(targetDir, strippedName);
         await mkdir(destDir, { recursive: true });
@@ -480,7 +486,7 @@ export function copyPosthogPlugin(isDev: boolean): Plugin {
       if (!remoteSkillsFetched) {
         await downloadAndExtractSkills(destSkillsDir);
 
-        // 2b. Download and overlay context-mill omnibus skills (overrides same-named skills)
+        // 2b. Download and overlay selected context-mill skills (overrides same-named skills)
         await downloadAndExtractContextMillSkills(destSkillsDir);
         remoteSkillsFetched = true;
       }

--- a/products/desktop/apps/code/vite-main-plugins.mts
+++ b/products/desktop/apps/code/vite-main-plugins.mts
@@ -355,9 +355,29 @@ async function findSkillsDirInExtract(
   return null;
 }
 
+function getDesktopContextMillSkillFiles(
+  entries: Record<string, Uint8Array>,
+): Set<string> {
+  const manifestData = entries["manifest.json"];
+  if (!manifestData) return new Set();
+
+  try {
+    const manifest = JSON.parse(new TextDecoder().decode(manifestData)) as {
+      resources?: Array<{ desktop?: boolean; file?: string }>;
+    };
+    return new Set(
+      (manifest.resources ?? [])
+        .filter((resource) => resource.desktop && resource.file)
+        .map((resource) => resource.file as string),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 /**
  * Downloads context-mill skills-mcp-resources.zip (a zip-of-zips), extracts
- * omnibus skills and selected standalone skills, and writes them into targetDir.
+ * skills marked for desktop distribution, and writes them into targetDir.
  * Returns true on success, false on failure (non-fatal).
  */
 async function downloadAndExtractContextMillSkills(
@@ -378,6 +398,7 @@ async function downloadAndExtractContextMillSkills(
 
       const zipData = readFileSync(zipPath);
       const outerEntries = unzipSync(new Uint8Array(zipData));
+      const desktopSkillFiles = getDesktopContextMillSkillFiles(outerEntries);
 
       await mkdir(targetDir, { recursive: true });
 
@@ -387,8 +408,8 @@ async function downloadAndExtractContextMillSkills(
 
         const archiveName = base.replace(/\.zip$/, "");
         if (
-          !archiveName.startsWith("omnibus-") &&
-          archiveName !== "creating-product-tours"
+          !desktopSkillFiles.has(base) &&
+          !archiveName.startsWith("omnibus-")
         ) {
           continue;
         }

--- a/products/desktop/apps/code/vite.main.config.mts
+++ b/products/desktop/apps/code/vite.main.config.mts
@@ -331,7 +331,7 @@ async function findSkillsDirInExtract(
 
 /**
  * Downloads context-mill skills-mcp-resources.zip (a zip-of-zips), extracts
- * omnibus-* inner zips, strips the "omnibus-" prefix, and writes into targetDir.
+ * omnibus skills and selected standalone skills, and writes them into targetDir.
  * Returns true on success, false on failure (non-fatal).
  */
 async function downloadAndExtractContextMillSkills(
@@ -357,11 +357,17 @@ async function downloadAndExtractContextMillSkills(
 
       for (const [filename, content] of Object.entries(outerEntries)) {
         const base = filename.replace(/^.*\//, ""); // strip any directory prefix
-        if (!base.startsWith("omnibus-") || !base.endsWith(".zip")) continue;
+        if (!base.endsWith(".zip")) continue;
 
-        const strippedName = base
-          .replace(/^omnibus-/, "")
-          .replace(/\.zip$/, "");
+        const archiveName = base.replace(/\.zip$/, "");
+        if (
+          !archiveName.startsWith("omnibus-") &&
+          archiveName !== "creating-product-tours"
+        ) {
+          continue;
+        }
+
+        const strippedName = archiveName.replace(/^omnibus-/, "");
         const innerEntries = unzipSync(new Uint8Array(content));
         const destDir = join(targetDir, strippedName);
         await mkdir(destDir, { recursive: true });
@@ -454,7 +460,7 @@ function copyPosthogPlugin(isDev: boolean): Plugin {
       if (!remoteSkillsFetched) {
         await downloadAndExtractSkills(destSkillsDir);
 
-        // 2b. Download and overlay context-mill omnibus skills (overrides same-named skills)
+        // 2b. Download and overlay selected context-mill skills (overrides same-named skills)
         await downloadAndExtractContextMillSkills(destSkillsDir);
         remoteSkillsFetched = true;
       }

--- a/products/desktop/apps/code/vite.main.config.mts
+++ b/products/desktop/apps/code/vite.main.config.mts
@@ -329,9 +329,29 @@ async function findSkillsDirInExtract(
   return null;
 }
 
+function getDesktopContextMillSkillFiles(
+  entries: Record<string, Uint8Array>,
+): Set<string> {
+  const manifestData = entries["manifest.json"];
+  if (!manifestData) return new Set();
+
+  try {
+    const manifest = JSON.parse(new TextDecoder().decode(manifestData)) as {
+      resources?: Array<{ desktop?: boolean; file?: string }>;
+    };
+    return new Set(
+      (manifest.resources ?? [])
+        .filter((resource) => resource.desktop && resource.file)
+        .map((resource) => resource.file as string),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 /**
  * Downloads context-mill skills-mcp-resources.zip (a zip-of-zips), extracts
- * omnibus skills and selected standalone skills, and writes them into targetDir.
+ * skills marked for desktop distribution, and writes them into targetDir.
  * Returns true on success, false on failure (non-fatal).
  */
 async function downloadAndExtractContextMillSkills(
@@ -352,6 +372,7 @@ async function downloadAndExtractContextMillSkills(
 
       const zipData = readFileSync(zipPath);
       const outerEntries = unzipSync(new Uint8Array(zipData));
+      const desktopSkillFiles = getDesktopContextMillSkillFiles(outerEntries);
 
       await mkdir(targetDir, { recursive: true });
 
@@ -361,8 +382,8 @@ async function downloadAndExtractContextMillSkills(
 
         const archiveName = base.replace(/\.zip$/, "");
         if (
-          !archiveName.startsWith("omnibus-") &&
-          archiveName !== "creating-product-tours"
+          !desktopSkillFiles.has(base) &&
+          !archiveName.startsWith("omnibus-")
         ) {
           continue;
         }

--- a/products/desktop/packages/workspace-server/src/services/posthog-plugin/README.md
+++ b/products/desktop/packages/workspace-server/src/services/posthog-plugin/README.md
@@ -17,7 +17,7 @@ The plugin directory is assembled from three skill sources, merged in priority o
 | Source | Location | When used |
 |---|---|---|
 | **Shipped** | `plugins/posthog/skills/` | Always — committed to the repo |
-| **Remote** | GitHub releases `skills.zip` and selected context-mill skills | Downloaded at build time and every 30 min at runtime |
+| **Remote** | GitHub releases `skills.zip` and context-mill skills marked for desktop distribution | Downloaded at build time and every 30 min at runtime |
 | **Local dev** | `plugins/posthog/local-skills/` | Dev mode only — gitignored |
 
 A "skill name" is its directory name. If remote and shipped both have `query-data/`, the remote version wins. If local-dev also has `query-data/`, that wins over both.
@@ -27,7 +27,7 @@ A "skill name" is its directory name. If remote and shipped both have `query-dat
 `copyPosthogPlugin()` in `vite-main-plugins.mts` assembles the plugin during `writeBundle`:
 
 1. Copies allowed plugin entries into `.vite/build/plugins/posthog/`
-2. Downloads `skills.zip` plus context-mill omnibus and selected standalone skills, then overlays them into the build output
+2. Downloads `skills.zip` plus context-mill skills marked for desktop distribution, then overlays them into the build output
 3. In dev mode only: overlays `plugins/posthog/local-skills/` on top
 4. Download failure is non-fatal — build continues with shipped skills only
 
@@ -46,7 +46,7 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 
 **Every 30 minutes (`updateSkills`):**
 1. Downloads `skills.zip` and the context-mill resource bundle using `net.fetch` (Electron's network stack, respects proxy)
-2. Extracts the primary, omnibus, and selected standalone skills to a temp dir
+2. Extracts the primary skills and context-mill skills marked for desktop distribution to a temp dir
 3. Atomically swaps them into `{userData}/skills/`
 4. Re-assembles the runtime plugin dir
 5. On failure: logs a warning, keeps existing skills, retries next interval

--- a/products/desktop/packages/workspace-server/src/services/posthog-plugin/README.md
+++ b/products/desktop/packages/workspace-server/src/services/posthog-plugin/README.md
@@ -17,7 +17,7 @@ The plugin directory is assembled from three skill sources, merged in priority o
 | Source | Location | When used |
 |---|---|---|
 | **Shipped** | `plugins/posthog/skills/` | Always — committed to the repo |
-| **Remote** | GitHub releases `skills.zip` | Downloaded at build time and every 30 min at runtime |
+| **Remote** | GitHub releases `skills.zip` and selected context-mill skills | Downloaded at build time and every 30 min at runtime |
 | **Local dev** | `plugins/posthog/local-skills/` | Dev mode only — gitignored |
 
 A "skill name" is its directory name. If remote and shipped both have `query-data/`, the remote version wins. If local-dev also has `query-data/`, that wins over both.
@@ -27,7 +27,7 @@ A "skill name" is its directory name. If remote and shipped both have `query-dat
 `copyPosthogPlugin()` in `vite-main-plugins.mts` assembles the plugin during `writeBundle`:
 
 1. Copies allowed plugin entries into `.vite/build/plugins/posthog/`
-2. Downloads `skills.zip` via `curl`, extracts with `unzip`, overlays into the build output
+2. Downloads `skills.zip` plus context-mill omnibus and selected standalone skills, then overlays them into the build output
 3. In dev mode only: overlays `plugins/posthog/local-skills/` on top
 4. Download failure is non-fatal — build continues with shipped skills only
 
@@ -45,9 +45,9 @@ Vite watches `plugins/posthog/` (and `local-skills/` in dev) for hot-reload.
 5. Kicks off the first async download
 
 **Every 30 minutes (`updateSkills`):**
-1. Downloads `skills.zip` using `net.fetch` (Electron's network stack, respects proxy)
-2. Extracts to a temp dir via `unzip`
-3. Atomically swaps into `{userData}/skills/`
+1. Downloads `skills.zip` and the context-mill resource bundle using `net.fetch` (Electron's network stack, respects proxy)
+2. Extracts the primary, omnibus, and selected standalone skills to a temp dir
+3. Atomically swaps them into `{userData}/skills/`
 4. Re-assembles the runtime plugin dir
 5. On failure: logs a warning, keeps existing skills, retries next interval
 

--- a/products/desktop/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
@@ -122,6 +122,7 @@ function simulateExtractZip() {
         // Inner zip bytes are dummy — fflate.unzip is mocked below.
         vol.mkdirSync(extractDir, { recursive: true });
         vol.writeFileSync(`${extractDir}/omnibus-test-skill.zip`, "dummy");
+        vol.writeFileSync(`${extractDir}/creating-product-tours.zip`, "dummy");
         vol.writeFileSync(`${extractDir}/manifest.json`, "{}");
         // Non-omnibus zip should be ignored
         vol.writeFileSync(`${extractDir}/other-skill.zip`, "dummy");
@@ -373,18 +374,20 @@ describe("PosthogPluginService", () => {
       await first.catch(() => {});
     });
 
-    it("downloads and merges context-mill omnibus skills with prefix stripped", async () => {
+    it("downloads selected context-mill skills", async () => {
       setupBundledPlugin();
       simulateExtractZip();
 
       await service.updateSkills();
 
-      // Omnibus skill should exist with prefix stripped
       expect(vol.existsSync(`${RUNTIME_SKILLS_DIR}/test-skill/SKILL.md`)).toBe(
         true,
       );
+      expect(
+        vol.existsSync(`${RUNTIME_SKILLS_DIR}/creating-product-tours/SKILL.md`),
+      ).toBe(true);
+      expect(vol.existsSync(`${RUNTIME_SKILLS_DIR}/other-skill`)).toBe(false);
 
-      // SKILL.md should have "omnibus-" stripped from name field
       const content = vol.readFileSync(
         `${RUNTIME_SKILLS_DIR}/test-skill/SKILL.md`,
         "utf-8",

--- a/products/desktop/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
+++ b/products/desktop/packages/workspace-server/src/services/posthog-plugin/posthog-plugin.test.ts
@@ -122,8 +122,21 @@ function simulateExtractZip() {
         // Inner zip bytes are dummy — fflate.unzip is mocked below.
         vol.mkdirSync(extractDir, { recursive: true });
         vol.writeFileSync(`${extractDir}/omnibus-test-skill.zip`, "dummy");
-        vol.writeFileSync(`${extractDir}/creating-product-tours.zip`, "dummy");
-        vol.writeFileSync(`${extractDir}/manifest.json`, "{}");
+        vol.writeFileSync(
+          `${extractDir}/standalone-desktop-skill.zip`,
+          "dummy",
+        );
+        vol.writeFileSync(
+          `${extractDir}/manifest.json`,
+          JSON.stringify({
+            resources: [
+              {
+                file: "standalone-desktop-skill.zip",
+                desktop: true,
+              },
+            ],
+          }),
+        );
         // Non-omnibus zip should be ignored
         vol.writeFileSync(`${extractDir}/other-skill.zip`, "dummy");
       } else {
@@ -384,7 +397,9 @@ describe("PosthogPluginService", () => {
         true,
       );
       expect(
-        vol.existsSync(`${RUNTIME_SKILLS_DIR}/creating-product-tours/SKILL.md`),
+        vol.existsSync(
+          `${RUNTIME_SKILLS_DIR}/standalone-desktop-skill/SKILL.md`,
+        ),
       ).toBe(true);
       expect(vol.existsSync(`${RUNTIME_SKILLS_DIR}/other-skill`)).toBe(false);
 

--- a/products/desktop/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
+++ b/products/desktop/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
@@ -267,8 +267,8 @@ export class UpdateSkillsSaga extends Saga<
   }
 
   /**
-   * Downloads context-mill zip-of-zips, extracts omnibus-* inner zips,
-   * strips the "omnibus-" prefix, patches SKILL.md, and merges into destDir.
+   * Downloads context-mill zip-of-zips, extracts omnibus and selected standalone
+   * skills, strips the "omnibus-" prefix, and merges them into destDir.
    */
   private async downloadAndMergeContextMillSkills(
     url: string,
@@ -285,9 +285,17 @@ export class UpdateSkillsSaga extends Saga<
 
     const files = await readdir(extractDir);
     for (const file of files) {
-      if (!file.startsWith("omnibus-") || !file.endsWith(".zip")) continue;
+      if (!file.endsWith(".zip")) continue;
 
-      const strippedName = file.replace(/^omnibus-/, "").replace(/\.zip$/, "");
+      const archiveName = file.replace(/\.zip$/, "");
+      if (
+        !archiveName.startsWith("omnibus-") &&
+        archiveName !== "creating-product-tours"
+      ) {
+        continue;
+      }
+
+      const strippedName = archiveName.replace(/^omnibus-/, "");
       const innerZipPath = join(extractDir, file);
       const innerZipData = await readFile(innerZipPath);
       const innerEntries = await unzipAsync(new Uint8Array(innerZipData));

--- a/products/desktop/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
+++ b/products/desktop/packages/workspace-server/src/services/posthog-plugin/update-skills-saga.ts
@@ -51,6 +51,25 @@ export interface UpdateSkillsOutput {
   updated: boolean;
 }
 
+async function getDesktopContextMillSkillFiles(
+  extractDir: string,
+): Promise<Set<string>> {
+  try {
+    const manifest = JSON.parse(
+      await readFile(join(extractDir, "manifest.json"), "utf-8"),
+    ) as {
+      resources?: Array<{ desktop?: boolean; file?: string }>;
+    };
+    return new Set(
+      (manifest.resources ?? [])
+        .filter((resource) => resource.desktop && resource.file)
+        .map((resource) => resource.file as string),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 export class UpdateSkillsSaga extends Saga<
   UpdateSkillsInput,
   UpdateSkillsOutput
@@ -267,8 +286,8 @@ export class UpdateSkillsSaga extends Saga<
   }
 
   /**
-   * Downloads context-mill zip-of-zips, extracts omnibus and selected standalone
-   * skills, strips the "omnibus-" prefix, and merges them into destDir.
+   * Downloads context-mill zip-of-zips, extracts skills marked for desktop
+   * distribution, strips the "omnibus-" prefix, and merges them into destDir.
    */
   private async downloadAndMergeContextMillSkills(
     url: string,
@@ -284,14 +303,12 @@ export class UpdateSkillsSaga extends Saga<
     await extractZip(zipPath, extractDir);
 
     const files = await readdir(extractDir);
+    const desktopSkillFiles = await getDesktopContextMillSkillFiles(extractDir);
     for (const file of files) {
       if (!file.endsWith(".zip")) continue;
 
       const archiveName = file.replace(/\.zip$/, "");
-      if (
-        !archiveName.startsWith("omnibus-") &&
-        archiveName !== "creating-product-tours"
-      ) {
+      if (!desktopSkillFiles.has(file) && !archiveName.startsWith("omnibus-")) {
         continue;
       }
 

--- a/products/desktop/scripts/pull-skills.mjs
+++ b/products/desktop/scripts/pull-skills.mjs
@@ -32,6 +32,22 @@ const LOCAL_SKILLS_DIR = join(
   "local-skills",
 );
 
+function getDesktopContextMillSkillFiles(entries) {
+  const manifestData = entries["manifest.json"];
+  if (!manifestData) return new Set();
+
+  try {
+    const manifest = JSON.parse(new TextDecoder().decode(manifestData));
+    return new Set(
+      (manifest.resources ?? [])
+        .filter((resource) => resource.desktop && resource.file)
+        .map((resource) => resource.file),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
 const tempDir = join(tmpdir(), `posthog-code-pull-skills-${Date.now()}`);
 await mkdir(tempDir, { recursive: true });
 
@@ -109,16 +125,14 @@ try {
 
     const cmZipData = readFileSync(cmZipPath);
     const cmOuter = unzipSync(new Uint8Array(cmZipData));
+    const desktopSkillFiles = getDesktopContextMillSkillFiles(cmOuter);
 
     for (const [filename, content] of Object.entries(cmOuter)) {
       const base = filename.replace(/^.*\//, "");
       if (!base.endsWith(".zip")) continue;
 
       const archiveName = base.replace(/\.zip$/, "");
-      if (
-        !archiveName.startsWith("omnibus-") &&
-        archiveName !== "creating-product-tours"
-      ) {
+      if (!desktopSkillFiles.has(base) && !archiveName.startsWith("omnibus-")) {
         continue;
       }
 

--- a/products/desktop/scripts/pull-skills.mjs
+++ b/products/desktop/scripts/pull-skills.mjs
@@ -97,7 +97,7 @@ try {
   await rm(LOCAL_SKILLS_DIR, { recursive: true, force: true });
   await cp(skillsSource, LOCAL_SKILLS_DIR, { recursive: true });
 
-  // Download and merge context-mill omnibus skills (non-fatal)
+  // Download and merge selected context-mill skills (non-fatal)
   try {
     const cmZipPath = join(tempDir, "context-mill.zip");
     console.log("Downloading context-mill skills-mcp-resources.zip...");
@@ -112,9 +112,17 @@ try {
 
     for (const [filename, content] of Object.entries(cmOuter)) {
       const base = filename.replace(/^.*\//, "");
-      if (!base.startsWith("omnibus-") || !base.endsWith(".zip")) continue;
+      if (!base.endsWith(".zip")) continue;
 
-      const strippedName = base.replace(/^omnibus-/, "").replace(/\.zip$/, "");
+      const archiveName = base.replace(/\.zip$/, "");
+      if (
+        !archiveName.startsWith("omnibus-") &&
+        archiveName !== "creating-product-tours"
+      ) {
+        continue;
+      }
+
+      const strippedName = archiveName.replace(/^omnibus-/, "");
       const innerEntries = unzipSync(new Uint8Array(content));
       const destDir = join(LOCAL_SKILLS_DIR, strippedName);
       await mkdir(destDir, { recursive: true });
@@ -134,7 +142,7 @@ try {
         }
       }
     }
-    console.log("Context-mill omnibus skills merged into local-skills/");
+    console.log("Selected context-mill skills merged into local-skills/");
   } catch (err) {
     console.warn(
       "Failed to download context-mill skills (non-fatal):",


### PR DESCRIPTION
## Problem

PostHog Desktop downloads the context-mill resource bundle, but historically selected skills by the `omnibus-*` filename convention. Standalone skills intended for Desktop had no generic way to opt in.

## Changes

- select context-mill skills using `desktop: true` metadata from `manifest.json`
- keep `omnibus-*` support as a backward-compatible fallback for older bundles
- apply the manifest selection consistently at build time, runtime, and in the local `skills:pull` workflow
- cover a generic standalone Desktop skill in the runtime updater test
- update the plugin distribution documentation

There is no skill-name allowlist in Desktop. Future context-mill skills can opt in without a Desktop code change.

Companion context-mill PR: https://github.com/PostHog/context-mill/pull/330

## Testing

- `pnpm exec biome check` on changed source files
- `pnpm --filter @posthog/workspace-server typecheck`
- `pnpm --filter @posthog/workspace-server exec vitest run src/services/posthog-plugin/posthog-plugin.test.ts` — 30 tests pass
- `pnpm --filter code typecheck`
