### PR TITLE
fix(logs): strip indexHint from hoisted batched alert predicates

### DIFF
--- a/products/logs/backend/alert_check_query.py
+++ b/products/logs/backend/alert_check_query.py
@@ -18,7 +18,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import HogQLGlobalSettings, LimitContext
 from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
-from posthog.hogql.visitor import clone_expr
+from posthog.hogql.visitor import CloningVisitor
 
 from posthog.clickhouse.client.connection import Workload
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
@@ -152,6 +152,24 @@ def build_alert_where_expr(
             ),
         ]
     )
+
+
+class _StripIndexHints(CloningVisitor):
+    """Return a copy of the expression with indexHint(...) calls replaced by true.
+
+    indexHint always evaluates to 1; it exists only so index analysis sees the
+    wrapped expression. See `BatchedAlertCheckQuery.__init__` for why the
+    hoisted predicate copies must not carry it.
+    """
+
+    def visit_call(self, node: ast.Call) -> ast.Expr:
+        if node.name == "indexHint":
+            return ast.Constant(value=True)
+        return super().visit_call(node)
+
+
+def _strip_index_hints(expr: ast.Expr) -> ast.Expr:
+    return _StripIndexHints().visit(expr)
 
 
 class AlertCheckQuery:
@@ -389,15 +407,19 @@ class BatchedAlertCheckQuery:
             },
         )
         if HOIST_BATCHED_ALERT_PREDICATES:
-            # clone_expr is required: the same expr instances sit inside the
-            # countIf select columns of the same query tree, and the resolver
-            # annotates nodes in place, so sharing one instance at two positions
-            # is an aliasing hazard.
-            hoisted = (
-                clone_expr(self._alert_where_exprs[0])
-                if len(self._alert_where_exprs) == 1
-                else ast.Or(exprs=[clone_expr(e) for e in self._alert_where_exprs])
-            )
+            # The hoisted copies must differ from the countIf copies in two ways.
+            # They must be fresh instances, because the resolver annotates nodes
+            # in place and sharing one instance at two positions in the query
+            # tree is an aliasing hazard. And they must not carry indexHint(...)
+            # wrappers: ClickHouse dedupes an expression that appears in both
+            # the WHERE clause and a countIf argument, and when that shared
+            # expression contains indexHint the filter step constant-folds one
+            # use but not the other and the query fails with ILLEGAL_COLUMN
+            # ("non constant in source stream but must be constant in result").
+            # Dropping the hint loses nothing here: the real predicate sits in
+            # the WHERE clause where the planner can use it directly.
+            hoisted_exprs = [_strip_index_hints(e) for e in self._alert_where_exprs]
+            hoisted = hoisted_exprs[0] if len(hoisted_exprs) == 1 else ast.Or(exprs=hoisted_exprs)
             self._outer_where = ast.And(exprs=[self._outer_where, hoisted])
 
     def execute_bucketed(self, interval_minutes: int, *, limit: int = 10_000) -> BatchedBucketedResult:

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -71,6 +71,7 @@ def _log_row(
     severity: str = "info",
     attributes: dict[str, str] | None = None,
     body: str = "",
+    resource_attributes: dict[str, str] | None = None,
 ) -> dict:
     return {
         "uuid": uuid,
@@ -80,7 +81,7 @@ def _log_row(
         "severity_text": severity,
         "severity_number": 9,
         "service_name": service,
-        "resource_attributes": {},
+        "resource_attributes": resource_attributes or {},
         "attributes_map_str": attributes or {},
     }
 
@@ -1791,7 +1792,9 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
             # the attribute leg.
             _log_row(cls.team.id, "hoist-target-4", "2026-02-03 10:04:40", cls.TARGET_SERVICE, severity="error"),
             # Rows with bodies for body-filter alerts, the only filter class
-            # whose predicate carries an indexHint(...).
+            # whose predicate carries an indexHint(...). The resource attribute
+            # feeds the log_attributes materialized view so resource-attribute
+            # filters resolve to a `resource_fingerprint IN (subquery)` set.
             _log_row(
                 cls.team.id,
                 "hoist-body-1",
@@ -1799,6 +1802,7 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
                 cls.TARGET_SERVICE,
                 severity="error",
                 body="task_crashed",
+                resource_attributes={"deployment.environment": "production"},
             ),
             _log_row(
                 cls.team.id,
@@ -1807,6 +1811,7 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
                 cls.TARGET_SERVICE,
                 severity="error",
                 body="nightly export failed: connection reset by peer",
+                resource_attributes={"deployment.environment": "production"},
             ),
             # Wrong severity: must be excluded by the severity leg.
             _log_row(
@@ -1816,6 +1821,7 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
                 cls.TARGET_SERVICE,
                 severity="info",
                 body="nightly export failed: retrying",
+                resource_attributes={"deployment.environment": "production"},
             ),
         ]
         sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
@@ -2115,6 +2121,37 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
         non_zero = [b for b in batched_bucketed.per_alert[str(alert.id)] if b.count > 0]
         assert non_zero == single_bucketed
 
+    @freeze_time("2026-02-03T10:05:00Z")
+    def test_body_and_resource_attribute_filter_matches_per_alert_path(self):
+        # The full failing shape: the body filter contributes the indexHint and
+        # the resource-attribute filter contributes a `resource_fingerprint IN
+        # (subquery)` prepared set. With both hoisted verbatim into the outer
+        # WHERE, ClickHouse plans the shared expression once, constant-folds
+        # its WHERE use but not its countIf use, and rejects the query with
+        # ILLEGAL_COLUMN. Body-only predicates survive on some ClickHouse
+        # versions; this combination does not.
+        filters = self._body_filters("icontains", "export failed")
+        filters["filterGroup"]["values"][0]["values"].append(
+            {
+                "key": "deployment.environment",
+                "value": "production",
+                "operator": "exact",
+                "type": "log_resource_attribute",
+            }
+        )
+        alert = self._make_alert(filters=filters)
+        date_from = self.NCA - dt.timedelta(minutes=15)
+
+        batched = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=date_from, date_to=self.NCA, projection_eligible=False
+        ).execute_rolling_checks(nca=self.NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+        single = AlertCheckQuery(
+            team=self.team, alert=alert, date_from=date_from, date_to=self.NCA
+        ).execute_rolling_checks(nca=self.NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+
+        assert batched.per_alert[str(alert.id)] == single
+        assert sum(b.count for b in single) == 1
+
     def test_hoisted_where_strips_index_hints(self):
         # The countIf copy keeps its indexHint; only the hoisted WHERE copy
         # drops it. If a refactor hoists the hint again, the equivalence tests
@@ -2129,6 +2166,53 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
         select_part, _, _ = sql.partition(" WHERE ")
         assert "indexHint(" in select_part
         assert "indexHint(" not in self._outer_where_sql(sql)
+
+
+# No fixture rows on purpose: the ILLEGAL_COLUMN plan failure needs the scan
+# to select zero parts, so the constant-folded filter column meets an empty
+# source stream. Seeded classes can never hit it; production hits it whenever
+# a shard has no matching parts for the check window.
+class TestBatchedQueryPredicateHoistingEmptyScan(ClickhouseTestMixin, APIBaseTest):
+    @freeze_time("2026-02-03T10:05:00Z")
+    @patch("products.logs.backend.alert_check_query.HOIST_BATCHED_ALERT_PREDICATES", True)
+    def test_body_and_resource_filter_with_no_matching_logs(self):
+        alert = LogsAlertConfiguration.objects.create(
+            team=self.team,
+            name="empty scan",
+            threshold_count=0,
+            threshold_operator="above",
+            window_minutes=5,
+            evaluation_periods=3,
+            filters={
+                "serviceNames": ["quiet_service"],
+                "severityLevels": ["error", "fatal"],
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "message", "value": "export failed", "operator": "icontains", "type": "log"},
+                                {
+                                    "key": "deployment.environment",
+                                    "value": "production",
+                                    "operator": "exact",
+                                    "type": "log_resource_attribute",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+        nca = datetime(2026, 2, 3, 10, 5, 0, tzinfo=UTC)
+        date_from = nca - dt.timedelta(minutes=15)
+
+        batched = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=date_from, date_to=nca, projection_eligible=False
+        ).execute_rolling_checks(nca=nca, window_minutes=5, cadence_minutes=5, period_count=3)
+
+        assert [b.count for b in batched.per_alert[str(alert.id)]] == [0, 0, 0]
 
 
 class TestFetchLiveLogsCheckpoint(APIBaseTest):

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -70,12 +70,13 @@ def _log_row(
     *,
     severity: str = "info",
     attributes: dict[str, str] | None = None,
+    body: str = "",
 ) -> dict:
     return {
         "uuid": uuid,
         "team_id": team_id,
         "timestamp": timestamp,
-        "body": "",
+        "body": body,
         "severity_text": severity,
         "severity_number": 9,
         "service_name": service,
@@ -1789,6 +1790,33 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
             # Same service and severity but no attribute: must be excluded by
             # the attribute leg.
             _log_row(cls.team.id, "hoist-target-4", "2026-02-03 10:04:40", cls.TARGET_SERVICE, severity="error"),
+            # Rows with bodies for body-filter alerts, the only filter class
+            # whose predicate carries an indexHint(...).
+            _log_row(
+                cls.team.id,
+                "hoist-body-1",
+                "2026-02-03 10:01:15",
+                cls.TARGET_SERVICE,
+                severity="error",
+                body="task_crashed",
+            ),
+            _log_row(
+                cls.team.id,
+                "hoist-body-2",
+                "2026-02-03 10:02:25",
+                cls.TARGET_SERVICE,
+                severity="error",
+                body="nightly export failed: connection reset by peer",
+            ),
+            # Wrong severity: must be excluded by the severity leg.
+            _log_row(
+                cls.team.id,
+                "hoist-body-3",
+                "2026-02-03 10:03:35",
+                cls.TARGET_SERVICE,
+                severity="info",
+                body="nightly export failed: retrying",
+            ),
         ]
         sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
 
@@ -2036,6 +2064,71 @@ class TestBatchedQueryPredicateHoisting(ClickhouseTestMixin, APIBaseTest):
         non_zero = [b for b in batched.per_alert[str(alert.id)] if b.count > 0]
         assert non_zero == single
         assert sum(b.count for b in single) == expected_total
+
+    def _body_filters(self, operator: str, value: str) -> dict:
+        return {
+            "serviceNames": [self.TARGET_SERVICE],
+            "severityLevels": ["error", "fatal"],
+            "filterGroup": {
+                "type": "AND",
+                "values": [
+                    {
+                        "type": "AND",
+                        "values": [{"key": "message", "value": value, "operator": operator, "type": "log"}],
+                    }
+                ],
+            },
+        }
+
+    @parameterized.expand(
+        [
+            ("exact", "exact", "task_crashed", 1),
+            ("icontains", "icontains", "export failed", 1),
+            ("regex", "regex", "connection reset|task_crashed", 2),
+        ]
+    )
+    @freeze_time("2026-02-03T10:05:00Z")
+    def test_body_filter_alert_matches_per_alert_path(self, _name: str, operator: str, value: str, expected: int):
+        # Body filters are the only predicates carrying an indexHint(...). With
+        # the hint hoisted into the outer WHERE alongside its countIf copy,
+        # ClickHouse dedupes the shared expression and rejects the query with
+        # ILLEGAL_COLUMN ("non constant in source stream but must be constant
+        # in result"), so every check for such an alert fails outright.
+        alert = self._make_alert(filters=self._body_filters(operator, value))
+        date_from = self.NCA - dt.timedelta(minutes=15)
+
+        batched_rolling = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=date_from, date_to=self.NCA, projection_eligible=False
+        ).execute_rolling_checks(nca=self.NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+        single_rolling = AlertCheckQuery(
+            team=self.team, alert=alert, date_from=date_from, date_to=self.NCA
+        ).execute_rolling_checks(nca=self.NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+        assert batched_rolling.per_alert[str(alert.id)] == single_rolling
+        assert sum(b.count for b in single_rolling) == expected
+
+        batched_bucketed = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=date_from, date_to=self.NCA, projection_eligible=False
+        ).execute_bucketed(interval_minutes=5)
+        single_bucketed = AlertCheckQuery(
+            team=self.team, alert=alert, date_from=date_from, date_to=self.NCA
+        ).execute_bucketed(interval_minutes=5)
+        non_zero = [b for b in batched_bucketed.per_alert[str(alert.id)] if b.count > 0]
+        assert non_zero == single_bucketed
+
+    def test_hoisted_where_strips_index_hints(self):
+        # The countIf copy keeps its indexHint; only the hoisted WHERE copy
+        # drops it. If a refactor hoists the hint again, the equivalence tests
+        # above only catch it on ClickHouse versions where the plan dedup
+        # triggers, so pin the SQL shape too.
+        alert = self._make_alert(filters=self._body_filters("icontains", "export failed"))
+        date_from = self.NCA - dt.timedelta(minutes=15)
+        query = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=date_from, date_to=self.NCA, projection_eligible=False
+        )
+        sql, _ = self._print_query(query._build_count_per_range_query(_rolling_check_ranges(self.NCA, 5, 5, 3)))
+        select_part, _, _ = sql.partition(" WHERE ")
+        assert "indexHint(" in select_part
+        assert "indexHint(" not in self._outer_where_sql(sql)
 
 
 class TestFetchLiveLogsCheckpoint(APIBaseTest):

--- a/products/logs/backend/test/test_alert_hoisting_sweep.py
+++ b/products/logs/backend/test/test_alert_hoisting_sweep.py
@@ -1,0 +1,413 @@
+# Sweeps the alert-filter config space through the hoisted batched query.
+#
+# Customers author these configs, so the input space is theirs, not ours:
+# hand-picked cases cover the shapes we thought of, and the ILLEGAL_COLUMN
+# incident came from a combination nobody picked (body filter + resource
+# attribute filter + a scan selecting zero parts). These sweeps enumerate the
+# space instead: every operator the filter builder supports (single leaves),
+# every pair and triple of expression *shapes* (indexHint, attribute map,
+# fingerprint IN/NOT IN subqueries, nested groups), each on both seeded data
+# and an empty scan. The property throughout is per-alert equivalence: the
+# batched hoisted query must return exactly what `AlertCheckQuery` returns,
+# and must not error where it doesn't.
+import os
+import json
+import random
+import datetime as dt
+import itertools
+from datetime import UTC, datetime
+
+import pytest
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import patch
+
+from parameterized import parameterized
+
+from posthog.clickhouse.client import sync_execute
+
+from products.logs.backend.alert_check_query import AlertCheckQuery, BatchedAlertCheckQuery
+from products.logs.backend.models import LogsAlertConfiguration
+from products.logs.backend.test.test_alert_check_query import _log_row
+
+NCA = datetime(2026, 3, 5, 10, 5, 0, tzinfo=UTC)
+DATE_FROM = NCA - dt.timedelta(minutes=15)
+
+SERVICE = "sweep_payments_api"
+OTHER_SERVICE = "sweep_background_jobs"
+
+BODY_NEEDLE = "export failed"
+BODY_EXACT = "task_crashed"
+ATTR_KEY = "job_kind"
+ATTR_VALUE = "usage-rollup"
+NUM_ATTR_KEY = "retry_count"
+RESOURCE_KEY = "deployment.environment"
+RESOURCE_VALUE = "production"
+
+
+def _leaf(key: str, operator: str, value, type_: str = "log") -> dict:
+    leaf: dict = {"key": key, "operator": operator, "type": type_}
+    if value is not None:
+        leaf["value"] = value
+    return leaf
+
+
+def _filters(*leaves: dict, services: list[str] | None = None, severities: list[str] | None = None) -> dict:
+    filters: dict = {}
+    if services is not None:
+        filters["serviceNames"] = services
+    if severities is not None:
+        filters["severityLevels"] = severities
+    if leaves:
+        filters["filterGroup"] = {"type": "AND", "values": [{"type": "AND", "values": list(leaves)}]}
+    return filters
+
+
+# Every operator surface the filter builder exposes, one leaf per case.
+# expect_matches pins the seeded sweep against vacuous all-zero equivalence.
+OPERATOR_CATALOG: list[tuple[str, dict, bool]] = [
+    ("body_exact", _leaf("message", "exact", BODY_EXACT), True),
+    ("body_exact_list", _leaf("message", "exact", [BODY_EXACT, "never_logged"]), True),
+    ("body_is_not", _leaf("message", "is_not", BODY_EXACT), True),
+    ("body_icontains", _leaf("message", "icontains", BODY_NEEDLE), True),
+    ("body_not_icontains", _leaf("message", "not_icontains", BODY_NEEDLE), True),
+    ("body_regex", _leaf("message", "regex", "export failed|task_crashed"), True),
+    ("body_not_regex", _leaf("message", "not_regex", "task_crashed"), True),
+    ("attr_exact", _leaf(ATTR_KEY, "exact", ATTR_VALUE, "log_attribute"), True),
+    ("attr_exact_list", _leaf(ATTR_KEY, "exact", [ATTR_VALUE, "never-set"], "log_attribute"), True),
+    ("attr_numeric_gt", _leaf(NUM_ATTR_KEY, "gt", "2", "log_attribute"), True),
+    ("attr_icontains", _leaf(ATTR_KEY, "icontains", "rollup", "log_attribute"), True),
+    ("attr_regex", _leaf(ATTR_KEY, "regex", "usage-.*", "log_attribute"), True),
+    ("attr_is_set", _leaf(ATTR_KEY, "is_set", None, "log_attribute"), True),
+    ("attr_is_not_set", _leaf(ATTR_KEY, "is_not_set", None, "log_attribute"), True),
+    ("resource_exact", _leaf(RESOURCE_KEY, "exact", RESOURCE_VALUE, "log_resource_attribute"), True),
+    ("resource_exact_list", _leaf(RESOURCE_KEY, "exact", [RESOURCE_VALUE], "log_resource_attribute"), True),
+    ("resource_is_not", _leaf(RESOURCE_KEY, "is_not", "staging", "log_resource_attribute"), True),
+    ("resource_icontains", _leaf(RESOURCE_KEY, "icontains", "prod", "log_resource_attribute"), True),
+    ("severity_level_leaf", _leaf("severity_level", "exact", ["error"]), True),
+    ("trace_id_exact", _leaf("trace_id", "exact", "0123456789abcdef0123456789abcdef"), False),
+    (
+        "nested_or_attr_group",
+        {
+            "type": "OR",
+            "values": [
+                _leaf(ATTR_KEY, "exact", ATTR_VALUE, "log_attribute"),
+                _leaf("logtag", "exact", "F", "log_attribute"),
+            ],
+        },
+        True,
+    ),
+]
+
+# Representatives of each distinct expression shape the builder can emit; the
+# interaction sweep crosses these. The incident was body_index_hint ×
+# resource_subquery_in on an empty scan — a pair, not a single leaf.
+SHAPE_CLASSES: dict[str, dict] = {
+    "body_index_hint": _leaf("message", "icontains", BODY_NEEDLE),
+    "attr_map": _leaf(ATTR_KEY, "exact", ATTR_VALUE, "log_attribute"),
+    "resource_subquery_in": _leaf(RESOURCE_KEY, "exact", RESOURCE_VALUE, "log_resource_attribute"),
+    "resource_subquery_not_in": _leaf(RESOURCE_KEY, "is_not", "staging", "log_resource_attribute"),
+    "nested_or_group": {
+        "type": "OR",
+        "values": [
+            _leaf(ATTR_KEY, "exact", ATTR_VALUE, "log_attribute"),
+            _leaf("logtag", "exact", "F", "log_attribute"),
+        ],
+    },
+}
+
+SHAPE_PAIRS = list(itertools.combinations(sorted(SHAPE_CLASSES), 2))
+SHAPE_TRIPLES = list(itertools.combinations(sorted(SHAPE_CLASSES), 3))
+
+
+def _make_alert(team, filters: dict, name: str) -> LogsAlertConfiguration:
+    return LogsAlertConfiguration.objects.create(
+        team=team,
+        name=name,
+        threshold_count=0,
+        threshold_operator="above",
+        window_minutes=5,
+        evaluation_periods=3,
+        filters=filters,
+    )
+
+
+class _HoistingSweepBase(ClickhouseTestMixin, APIBaseTest):
+    class Meta:
+        abstract = True
+
+    def setUp(self):
+        super().setUp()
+        patcher = patch("products.logs.backend.alert_check_query.HOIST_BATCHED_ALERT_PREDICATES", True)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _assert_batched_matches_per_alert(self, alerts: list[LogsAlertConfiguration]) -> dict[str, int]:
+        batched = BatchedAlertCheckQuery(
+            team=self.team, alerts=alerts, date_from=DATE_FROM, date_to=NCA, projection_eligible=False
+        ).execute_rolling_checks(nca=NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+
+        totals: dict[str, int] = {}
+        for alert in alerts:
+            single = AlertCheckQuery(
+                team=self.team, alert=alert, date_from=DATE_FROM, date_to=NCA
+            ).execute_rolling_checks(nca=NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+            assert batched.per_alert[str(alert.id)] == single, f"alert={alert.name}"
+            totals[alert.name] = sum(b.count for b in single)
+        return totals
+
+
+def _seed_sweep_rows(team_id: int) -> None:
+    prod = {RESOURCE_KEY: RESOURCE_VALUE}
+    staging = {RESOURCE_KEY: "staging"}
+    rows = [
+        _log_row(
+            team_id,
+            "sweep-1",
+            "2026-03-05 10:01:10",
+            SERVICE,
+            severity="error",
+            body=BODY_EXACT,
+            # The numeric value feeds the MATERIALIZED attributes_map_float
+            # column (derived from the str map), which the numeric-gt leaf reads.
+            attributes={f"{ATTR_KEY}__str": ATTR_VALUE, "logtag__str": "F", f"{NUM_ATTR_KEY}__str": "3"},
+            resource_attributes=prod,
+        ),
+        _log_row(
+            team_id,
+            "sweep-2",
+            "2026-03-05 10:02:20",
+            SERVICE,
+            severity="error",
+            body=f"nightly {BODY_NEEDLE}: connection reset",
+            attributes={f"{ATTR_KEY}__str": "cleanup"},
+            resource_attributes=prod,
+        ),
+        _log_row(
+            team_id,
+            "sweep-3",
+            "2026-03-05 10:03:30",
+            SERVICE,
+            severity="error",
+            body="routine heartbeat",
+            resource_attributes=staging,
+        ),
+        _log_row(
+            team_id,
+            "sweep-4",
+            "2026-03-05 10:04:40",
+            SERVICE,
+            severity="info",
+            body=f"{BODY_NEEDLE}: retrying",
+            attributes={f"{ATTR_KEY}__str": ATTR_VALUE},
+            resource_attributes=prod,
+        ),
+        _log_row(
+            team_id,
+            "sweep-5",
+            "2026-03-05 10:01:50",
+            OTHER_SERVICE,
+            severity="error",
+            body=BODY_EXACT,
+            attributes={f"{ATTR_KEY}__str": ATTR_VALUE},
+            resource_attributes=prod,
+        ),
+    ]
+    sync_execute("INSERT INTO logs FORMAT JSONEachRow\n" + "\n".join(json.dumps(r) for r in rows))
+
+
+class TestHoistedOperatorSweepSeeded(_HoistingSweepBase):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        _seed_sweep_rows(cls.team.id)
+
+    @parameterized.expand([(name, leaf, expect_matches) for name, leaf, expect_matches in OPERATOR_CATALOG])
+    def test_operator_leaf(self, _name: str, leaf: dict, expect_matches: bool):
+        alert = _make_alert(self.team, _filters(leaf, services=[SERVICE], severities=["error", "fatal"]), _name)
+        totals = self._assert_batched_matches_per_alert([alert])
+        if expect_matches:
+            assert totals[_name] > 0, f"vacuous case: {_name} matched nothing in the seeded window"
+
+        batched = BatchedAlertCheckQuery(
+            team=self.team, alerts=[alert], date_from=DATE_FROM, date_to=NCA, projection_eligible=False
+        ).execute_bucketed(interval_minutes=5)
+        single = AlertCheckQuery(team=self.team, alert=alert, date_from=DATE_FROM, date_to=NCA).execute_bucketed(
+            interval_minutes=5
+        )
+        non_zero = [b for b in batched.per_alert[str(alert.id)] if b.count > 0]
+        assert non_zero == single
+
+
+# No fixture rows anywhere in this class: the scan must select zero parts so
+# a constant-folded predicate column meets an empty source stream — the
+# trigger condition for the ILLEGAL_COLUMN plan failure.
+class TestHoistedOperatorSweepEmptyScan(_HoistingSweepBase):
+    @parameterized.expand([(name, leaf) for name, leaf, _ in OPERATOR_CATALOG])
+    def test_operator_leaf(self, _name: str, leaf: dict):
+        alert = _make_alert(self.team, _filters(leaf, services=[SERVICE], severities=["error", "fatal"]), _name)
+        totals = self._assert_batched_matches_per_alert([alert])
+        assert totals[_name] == 0
+
+
+class TestHoistedShapeInteractionsSeeded(_HoistingSweepBase):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        _seed_sweep_rows(cls.team.id)
+
+    @parameterized.expand([("_".join(pair), pair) for pair in SHAPE_PAIRS])
+    def test_shape_pair_same_alert(self, _name: str, pair: tuple[str, str]):
+        leaves = [SHAPE_CLASSES[s] for s in pair]
+        alert = _make_alert(self.team, _filters(*leaves, services=[SERVICE], severities=["error", "fatal"]), _name)
+        self._assert_batched_matches_per_alert([alert])
+
+    @parameterized.expand([("_".join(pair), pair) for pair in SHAPE_PAIRS])
+    def test_shape_pair_across_cohort(self, _name: str, pair: tuple[str, str]):
+        # The hoisted WHERE ORs the two alerts' predicates together, so shapes
+        # interact across alerts too, not only within one alert's AND.
+        alerts = [
+            _make_alert(self.team, _filters(SHAPE_CLASSES[s], services=[SERVICE], severities=["error", "fatal"]), s)
+            for s in pair
+        ]
+        self._assert_batched_matches_per_alert(alerts)
+
+
+class TestHoistedShapeInteractionsEmptyScan(_HoistingSweepBase):
+    @parameterized.expand([("_".join(pair), pair) for pair in SHAPE_PAIRS])
+    def test_shape_pair_same_alert(self, _name: str, pair: tuple[str, str]):
+        leaves = [SHAPE_CLASSES[s] for s in pair]
+        alert = _make_alert(self.team, _filters(*leaves, services=[SERVICE], severities=["error", "fatal"]), _name)
+        totals = self._assert_batched_matches_per_alert([alert])
+        assert all(t == 0 for t in totals.values())
+
+    @parameterized.expand([("_".join(pair), pair) for pair in SHAPE_PAIRS])
+    def test_shape_pair_across_cohort(self, _name: str, pair: tuple[str, str]):
+        alerts = [
+            _make_alert(self.team, _filters(SHAPE_CLASSES[s], services=[SERVICE], severities=["error", "fatal"]), s)
+            for s in pair
+        ]
+        totals = self._assert_batched_matches_per_alert(alerts)
+        assert all(t == 0 for t in totals.values())
+
+    @parameterized.expand([("_".join(triple), triple) for triple in SHAPE_TRIPLES])
+    def test_shape_triple_same_alert(self, _name: str, triple: tuple[str, str, str]):
+        leaves = [SHAPE_CLASSES[s] for s in triple]
+        alert = _make_alert(self.team, _filters(*leaves, services=[SERVICE], severities=["error", "fatal"]), _name)
+        totals = self._assert_batched_matches_per_alert([alert])
+        assert all(t == 0 for t in totals.values())
+
+    def test_random_cohort_compositions(self):
+        # Fixed-seed random cohorts probe combinations the pair/triple grids
+        # don't enumerate: mixed cohort sizes, repeated shapes, alerts with and
+        # without service/severity scoping.
+        rng = random.Random(2026)
+        shape_names = sorted(SHAPE_CLASSES)
+        for trial in range(12):
+            alerts = []
+            for i in range(rng.randint(1, 3)):
+                leaves = [SHAPE_CLASSES[rng.choice(shape_names)] for _ in range(rng.randint(1, 3))]
+                services = [SERVICE] if rng.random() < 0.7 else None
+                severities = ["error", "fatal"] if rng.random() < 0.7 else None
+                alerts.append(
+                    _make_alert(
+                        self.team,
+                        _filters(*leaves, services=services, severities=severities),
+                        f"trial{trial}_alert{i}",
+                    )
+                )
+            totals = self._assert_batched_matches_per_alert(alerts)
+            assert all(t == 0 for t in totals.values()), f"trial {trial}"
+
+
+# Adversarial-value property test. Slow (every example round-trips ClickHouse),
+# so gated like the other PBT suites. Run manually with:
+#   RUN_PBT=1 pytest products/logs/backend/test/test_alert_hoisting_sweep.py -k Properties
+if os.environ.get("RUN_PBT"):
+    from hypothesis import (
+        HealthCheck,
+        given,
+        settings as hypothesis_settings,
+        strategies as st,
+    )
+    from hypothesis.extra.django import TestCase as HypothesisDjangoTestCase
+
+    _value_text = st.text(
+        alphabet=st.characters(blacklist_characters="\0", blacklist_categories=["Cs"]),
+        min_size=1,
+        max_size=40,
+    )
+    _safe_regex = st.text(alphabet="abcdef.*|+?()[]\\^$", min_size=1, max_size=20)
+
+    @st.composite
+    def _leaf_st(draw):
+        kind = draw(st.sampled_from(["body", "attr", "resource"]))
+        if kind == "body":
+            operator = draw(st.sampled_from(["exact", "is_not", "icontains", "not_icontains", "regex", "not_regex"]))
+            value = draw(_safe_regex if "regex" in operator else _value_text)
+            return _leaf("message", operator, value)
+        if kind == "attr":
+            operator = draw(st.sampled_from(["exact", "is_not", "icontains", "regex", "is_set", "is_not_set"]))
+            value = None if "set" in operator else draw(_safe_regex if operator == "regex" else _value_text)
+            return _leaf(ATTR_KEY, operator, value, "log_attribute")
+        operator = draw(st.sampled_from(["exact", "is_not", "icontains"]))
+        return _leaf(RESOURCE_KEY, operator, draw(_value_text), "log_resource_attribute")
+
+    _alert_filters_st = st.builds(
+        lambda leaves, services, severities: _filters(*leaves, services=services, severities=severities),
+        st.lists(_leaf_st(), min_size=1, max_size=3),
+        st.sampled_from([None, [SERVICE]]),
+        st.sampled_from([None, ["error", "fatal"]]),
+    )
+
+    class TestHoistedConfigProperties(ClickhouseTestMixin, HypothesisDjangoTestCase, APIBaseTest):
+        # hypothesis's TestCase displaces Django's _pre_setup in the MRO, so the
+        # HTTP test client never gets built; these tests never call the API.
+        CONFIG_AUTO_LOGIN = False
+
+        @hypothesis_settings(
+            max_examples=250,
+            deadline=None,
+            suppress_health_check=[HealthCheck.differing_executors, HealthCheck.too_slow],
+        )
+        @given(cohort=st.lists(_alert_filters_st, min_size=1, max_size=3))
+        def test_hoisted_batched_behaves_like_per_alert(self, cohort: list[dict]):
+            # Property: for ANY customer-authorable config, the hoisted batched
+            # query and the per-alert query either both succeed with identical
+            # results, or both fail. A config that errors identically on both
+            # paths is a customer problem; one that errors only when batched is
+            # ours.
+            alerts = [_make_alert(self.team, filters, f"pbt{i}") for i, filters in enumerate(cohort)]
+
+            singles: dict[str, list] = {}
+            per_alert_error: Exception | None = None
+            for alert in alerts:
+                try:
+                    singles[str(alert.id)] = AlertCheckQuery(
+                        team=self.team, alert=alert, date_from=DATE_FROM, date_to=NCA
+                    ).execute_rolling_checks(nca=NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+                except Exception as e:
+                    per_alert_error = e
+                    break
+
+            # Both construction (e.g. invalid regex rejected while building the
+            # predicate) and execution can raise; either counts, as long as the
+            # batched path fails whenever the per-alert path does.
+            def run_batched():
+                with patch("products.logs.backend.alert_check_query.HOIST_BATCHED_ALERT_PREDICATES", True):
+                    query = BatchedAlertCheckQuery(
+                        team=self.team, alerts=alerts, date_from=DATE_FROM, date_to=NCA, projection_eligible=False
+                    )
+                return query.execute_rolling_checks(nca=NCA, window_minutes=5, cadence_minutes=5, period_count=3)
+
+            if per_alert_error is not None:
+                with pytest.raises(Exception):
+                    run_batched()
+                return
+
+            batched = run_batched()
+            for alert in alerts:
+                assert batched.per_alert[str(alert.id)] == singles[str(alert.id)]


### PR DESCRIPTION
## Problem

- With `LOGS_ALERTING_HOIST_BATCHED_ALERT_PREDICATES` enabled, every log alert with a body/message filter fails its check: ClickHouse rejects the batched query with `ILLEGAL_COLUMN` (code 44, "non constant in source stream but must be constant in result"). Affected alerts fail every cycle and auto-disable after 5 consecutive failures.
- Body filters are the only filter class whose predicate carries an `indexHint(...)` wrapper. Hoisting ([#78985](https://github.com/PostHog/posthog/pull/78985)) duplicates the predicate into the outer WHERE, ClickHouse dedupes the expression shared between WHERE and the `countIf` argument, and the filter step constant-folds one use but not the other.
- This surfaced when the flag was enabled in one production region; the flag is now pinned off everywhere ([charts#14079](https://github.com/PostHog/charts/pull/14079)) until this lands.

## Changes

- The hoisted predicate copies replace `indexHint(...)` calls with constant true (`_StripIndexHints`, a `CloningVisitor`, which also supplies the fresh instances the resolver requires).
- The `countIf` copies keep their hints. The hoisted WHERE loses nothing: the real predicate is in the WHERE clause, where the planner uses it directly.
- Flag default stays off; re-enabling remains a per-environment charts change after this deploys.

> [!NOTE]
> Reproducing the failure needs two ingredients beyond a body filter: a resource-attribute filter (its `resource_fingerprint IN (subquery)` set forces the failing plan) and a scan that selects zero parts, so the constant-folded filter column meets an empty source stream. That is why seeded equivalence tests pass even without the fix, and why production hit it reliably: an alert watching for a rare error often scans a window with no matching parts.

## How did you test this code?

- `test_body_and_resource_filter_with_no_matching_logs` (empty-scan class, no fixture rows): reproduces the production failure on the CI ClickHouse — fails with the exact `ILLEGAL_COLUMN` error without the fix, passes with it, in both standalone and full-file runs.
- `test_hoisted_where_strips_index_hints`: asserts `indexHint(` appears in the `countIf` side and not in the printed outer WHERE. Verified it fails against the unfixed code. Catches any refactor that reintroduces the hint into the hoisted copy, independent of ClickHouse version.
- `test_body_filter_alert_matches_per_alert_path` (parameterized exact/icontains/regex): batched equals per-alert results through both `execute_rolling_checks` and `execute_bucketed` for body-filter alerts, with severity and service legs alongside — the filter shapes that failed in production, invented fixtures. On CH versions where the dedup bug triggers, these fail loudly; on others they pin result equivalence of the stripped-hint shape.
- `test_body_and_resource_attribute_filter_matches_per_alert_path`: with-data equivalence for the combined body plus resource-attribute shape (the filter combination every affected production alert had).
- Config-space sweep (`test_alert_hoisting_sweep.py`, new): every filter operator as single leaves, and every pair/triple of expression shapes (indexHint, attribute map, fingerprint IN/NOT IN subqueries, nested OR groups), each on seeded data and an empty scan, all asserting per-alert equivalence. Against the unfixed code it fails on exactly the incident class and nothing else; the sweep also pinned the trigger boundary (the crash needs a top-level service or severity conjunct alongside the body and resource leaves).
- Property test (RUN_PBT-gated, hypothesis, 250 examples): for any generatable alert config with adversarial values, hoisted-batched behaves exactly like per-alert, including construction-time rejections (invalid regex). Independently rediscovers the incident against the unfixed code.
- Full logs backend suite (317 across the three alert test files) passes locally; repo-wide mypy errors are pre-existing and unrelated.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: internal query shape change behind a default-off env flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude); Jon is the DRI. Follow-up to [#78985](https://github.com/PostHog/posthog/pull/78985) after enabling the flag in one region surfaced the failure.
- Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-pr-descriptions`.
- Regression-test-first: each regression test was confirmed failing against the unfixed code before the fix landed. Root-caused the reproduction conditions by dumping the generated SQL for both shapes and bisecting execution context (settings, distributed layer, fixture data) until the empty-scan trigger emerged.
- Test fixtures (service names, log bodies, filter values) are invented, not derived from production data.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


