### PR TITLE
chore(devex): expose hogli on PATH in non-interactive flox shells

### DIFF
--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -224,6 +224,12 @@ export GOMODCACHE="$GOPATH/pkg/mod"
 # can't expand $FLOX_ENV_CACHE). Used below for uv sync + the hogli symlink.
 export UV_PROJECT_ENVIRONMENT="$FLOX_ENV_CACHE/venv"
 
+# `flox activate -- <cmd>` (command mode, how agents and scripts run things) never
+# sources the [profile] scripts, so the venv activation there doesn't apply and
+# hogli/python/ruff/pytest all come back "command not found". Exports from this
+# hook do propagate, so put the venv on PATH here rather than in [profile] alone.
+export PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
+
 # ── Direnv first-time setup (interactive only) ─────────────────────
 if [[ "$_interactive" == true ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]]; then
   read -p "$(echo -e "${C_BOLD}direnv${C_RESET} recommended for auto-activation. Set up now? (Y/n) ")" -n 1 -r

--- a/.flox/env/on-activate.sh
+++ b/.flox/env/on-activate.sh
@@ -224,12 +224,12 @@ export GOMODCACHE="$GOPATH/pkg/mod"
 # can't expand $FLOX_ENV_CACHE). Used below for uv sync + the hogli symlink.
 export UV_PROJECT_ENVIRONMENT="$FLOX_ENV_CACHE/venv"
 
-# `flox activate -- <cmd>` (command mode, how agents and scripts run things) never
-# sources the [profile] scripts, so the venv activation there doesn't apply and
-# hogli/python/ruff/pytest all come back "command not found". Exports from this
-# hook do propagate, so put the venv on PATH here rather than in [profile] alone.
-export PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
-
+# In `flox activate -- <cmd>` mode, Flox does not source [profile], so the uv venv
+# is not on PATH. Add it here so non-interactive commands can find hogli and
+# Python tooling.
+if [[ "$_interactive" != true ]] && [[ ":$PATH:" != *":$UV_PROJECT_ENVIRONMENT/bin:"* ]]; then
+  export PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"
+fi
 # ── Direnv first-time setup (interactive only) ─────────────────────
 if [[ "$_interactive" == true ]] && ! command -v direnv >/dev/null 2>&1 && [[ ! -f "$FLOX_ENV_CACHE/.hush-direnv" ]]; then
   read -p "$(echo -e "${C_BOLD}direnv${C_RESET} recommended for auto-activation. Set up now? (Y/n) ")" -n 1 -r


### PR DESCRIPTION
## Problem

- Anyone running `hogli` outside an interactive shell gets `bash: hogli: command not found`, including every coding agent following the `flox activate -- bash -c "<command>"` guidance in AGENTS.md.
- `hogli` is a symlink inside the uv venv at `.flox/cache/venv/bin/`.
- Only the `[profile]` scripts in `.flox/env/manifest.toml` put that venv on PATH, by sourcing `bin/activate`.
- `flox activate -- <cmd>` runs in command mode, which never sources `[profile]`.
- `python`, `ruff`, `pytest` and `mypy` are missing the same way.

## Changes

- `.flox/env/on-activate.sh` now exports `PATH="$UV_PROJECT_ENVIRONMENT/bin:$PATH"`.
- Exports from `hook.on-activate` reach command mode, unlike `[profile]`, so the hook is the one place that covers both shell kinds.
- The `[profile]` scripts keep their own venv activation. They also repair a missing `hogli` symlink, which PATH alone cannot do.

The fix lands on the next cold activation of an environment. A live activation reuses its cached environment and skips the hook.

## How did you test this code?

No automated tests. This is shell setup that runs before any test harness.

I (actually Claude) reproduced the failure and verified the mechanism in a scratch flox environment:

<details>
<summary>Transcript</summary>

Failure, from a clean shell in the repo root:

```
$ flox activate -- bash -c "command -v hogli || echo HOGLI_MISSING; echo PATHHEAD=..."
HOGLI_MISSING
PATHHEAD=/Users/.../.flox/run/aarch64-darwin.posthog-dev/bin:...   # no venv
```

Exports from the hook do survive command mode:

```
$ flox activate -- bash -c "echo UVPE=$UV_PROJECT_ENVIRONMENT; echo GOPATH=$GOPATH"
UVPE=/Users/.../.flox/cache/venv
GOPATH=/Users/.../.flox/cache/go
```

A throwaway flox environment with only a PATH export in `hook.on-activate`:

```
$ flox activate -- bash -c 'command -v hogli && hogli'
/tmp/floxprobe/fakebin/hogli
HOGLI_OK
```

</details>

I could not re-run the repo's own hook to confirm end to end. flox reuses a live cached activation, so the hook does not fire until every attached process exits. Reviewers on a cold environment will hit the new path directly.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via Claude Code) investigated a recurring `hogli: command not found` report and wrote this change. Skills invoked: `/writing-pr-descriptions`.

The first draft also exported `VIRTUAL_ENV`. I dropped it: venv shebangs already point at the venv python, `UV_PROJECT_ENVIRONMENT` already steers `uv`, and setting `VIRTUAL_ENV` to a directory that does not exist yet would warn during the hook's own `uv sync`.

Two findings left out of this PR. AGENTS.md recommends the exact `flox activate --` form that triggers the bug, so it is worth a note once this lands. Separately, stale directories under `.claude/worktrees/` hold venvs whose `hogli` symlink dangles, because git already pruned the worktree; a cold activation repairs those on its own.
