### PR TITLE
feat(tasks): attribute run artifact uploads to their uploader

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2798,6 +2798,8 @@ def finalize_task_run_artifact_uploads(
 ) -> tuple[list[dict] | None, str | None]:
     """Verify directly-uploaded S3 objects and attach them to the run manifest.
 
+    ``uploaded_by`` is server-derived and authoritative. ``source`` remains a client-declared organizational hint.
+
     Returns ``(finalized_entries, error)``: ``(None, None)`` when the run isn't found,
     ``(None, error_message)`` on a validation failure, else ``(finalized_entries, None)``.
     """

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2788,7 +2788,13 @@ def prepare_task_run_artifact_uploads(
 
 
 def finalize_task_run_artifact_uploads(
-    run_id: str | UUID, task_id: str | UUID, team_id: int, *, artifacts: list[dict]
+    run_id: str | UUID,
+    task_id: str | UUID,
+    team_id: int,
+    *,
+    artifacts: list[dict],
+    uploaded_by: Literal["agent", "user"],
+    uploaded_by_user_id: int | None,
 ) -> tuple[list[dict] | None, str | None]:
     """Verify directly-uploaded S3 objects and attach them to the run manifest.
 
@@ -2852,6 +2858,9 @@ def finalize_task_run_artifact_uploads(
             uploaded_at=django_timezone.now().isoformat(),
             metadata=artifact.get("metadata"),
         )
+        entry["uploaded_by"] = uploaded_by
+        if uploaded_by == "user" and uploaded_by_user_id is not None:
+            entry["uploaded_by_user_id"] = uploaded_by_user_id
         manifest.append(entry)
         new_entries.append(entry)
         finalized_entries.append(entry)

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -283,12 +283,10 @@ class TaskRunArtifactResponseSerializer(serializers.Serializer):
     uploaded_by = serializers.ChoiceField(
         choices=["agent", "user"],
         required=False,
-        allow_null=True,
         help_text="Whether the artifact version was uploaded by the task agent or an interactive user.",
     )
     uploaded_by_user_id = serializers.IntegerField(
         required=False,
-        allow_null=True,
         help_text="User id for an interactive user upload. Absent for agent uploads and legacy entries.",
     )
     dismissed_at = serializers.CharField(
@@ -303,13 +301,6 @@ class TaskRunArtifactResponseSerializer(serializers.Serializer):
             "and is not persisted on the manifest."
         ),
     )
-
-    def to_representation(self, instance: dict[str, Any]) -> dict[str, Any]:
-        data = super().to_representation(instance)
-        for field_name in ("uploaded_by", "uploaded_by_user_id"):
-            if field_name not in instance:
-                data.pop(field_name, None)
-        return data
 
 
 class TaskRunDetailSerializer(DataclassSerializer):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -280,6 +280,17 @@ class TaskRunArtifactResponseSerializer(serializers.Serializer):
     )
     storage_path = serializers.CharField(help_text="S3 object key for the artifact")
     uploaded_at = serializers.CharField(help_text="Timestamp when the artifact was uploaded")
+    uploaded_by = serializers.ChoiceField(
+        choices=["agent", "user"],
+        required=False,
+        allow_null=True,
+        help_text="Whether the artifact version was uploaded by the task agent or an interactive user.",
+    )
+    uploaded_by_user_id = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        help_text="User id for an interactive user upload. Absent for agent uploads and legacy entries.",
+    )
     dismissed_at = serializers.CharField(
         required=False,
         help_text="Timestamp when a user dismissed the artifact. Absent while the artifact is shown.",

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -304,6 +304,13 @@ class TaskRunArtifactResponseSerializer(serializers.Serializer):
         ),
     )
 
+    def to_representation(self, instance: dict[str, Any]) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        for field_name in ("uploaded_by", "uploaded_by_user_id"):
+            if field_name not in instance:
+                data.pop(field_name, None)
+        return data
+
 
 class TaskRunDetailSerializer(DataclassSerializer):
     """Detail response for a task run.

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -45,7 +45,7 @@ from posthog.permissions import (
 from posthog.rate_limit import CodeInviteThrottle, TaskRunChartRenderThrottle
 from posthog.renderers import ServerSentEventRenderer
 from posthog.schema_migrations.upgrade import upgrade
-from posthog.temporal.oauth import POSTHOG_CODE_OAUTH_APP_CLIENT_IDS
+from posthog.temporal.oauth import POSTHOG_CODE_OAUTH_APP_CLIENT_IDS, SANDBOX_OAUTH_APP_CLIENT_IDS
 from posthog.utils import absolute_uri
 
 from products.exports.backend.facade.api import render_png_export
@@ -1058,11 +1058,12 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         authenticator = self.request.successful_authenticator
         if not isinstance(authenticator, OAuthAccessTokenAuthentication):
             return False
-        application = authenticator.access_token.application
-        return bool(
-            application is not None
-            and application.client_id in POSTHOG_CODE_OAUTH_APP_CLIENT_IDS
-            and authenticator.access_token.sandbox_task_id == UUID(task_id)
+        access_token = authenticator.access_token
+        application = access_token.application
+        if application is None or application.client_id not in SANDBOX_OAUTH_APP_CLIENT_IDS:
+            return False
+        return access_token.sandbox_task_id == UUID(task_id) or "internal_run:read" in get_authenticator_scopes(
+            authenticator
         )
 
     # Actions that only read run state. Everything else mutates or drives the

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1054,6 +1054,17 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     def _user_id(self) -> int | None:
         return getattr(self.request.user, "id", None)
 
+    def _is_sandbox_agent_request(self, task_id: str) -> bool:
+        authenticator = self.request.successful_authenticator
+        if not isinstance(authenticator, OAuthAccessTokenAuthentication):
+            return False
+        application = authenticator.access_token.application
+        return bool(
+            application is not None
+            and application.client_id in POSTHOG_CODE_OAUTH_APP_CLIENT_IDS
+            and authenticator.access_token.sandbox_task_id == UUID(task_id)
+        )
+
     # Actions that only read run state. Everything else mutates or drives the
     # run, so it requires task control (not just visibility): public-channel
     # visibility lets teammates watch a run, never command it. connection_token
@@ -1620,8 +1631,14 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     )
     def artifacts_finalize_upload(self, request, pk=None, **kwargs):
         task_id = self._ensure_task_accessible()
+        is_agent_upload = self._is_sandbox_agent_request(task_id)
         finalized_entries, error = tasks_facade.finalize_task_run_artifact_uploads(
-            pk, task_id, self.team_id, artifacts=request.validated_data["artifacts"]
+            pk,
+            task_id,
+            self.team_id,
+            artifacts=request.validated_data["artifacts"],
+            uploaded_by="agent" if is_agent_upload else "user",
+            uploaded_by_user_id=None if is_agent_upload else self._user_id(),
         )
         if finalized_entries is None and error is None:
             raise NotFound()

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1062,8 +1062,8 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         application = access_token.application
         if application is None or application.client_id not in SANDBOX_OAUTH_APP_CLIENT_IDS:
             return False
-        return access_token.sandbox_task_id == UUID(task_id) or "internal_run:read" in get_authenticator_scopes(
-            authenticator
+        return access_token.sandbox_task_id == UUID(task_id) or "internal_run:read" in (
+            get_authenticator_scopes(authenticator) or []
         )
 
     # Actions that only read run state. Everything else mutates or drives the

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -4693,6 +4693,30 @@ _OTHER_PR_URL = "https://github.com/posthog/posthog-js/pull/2"
 
 
 class TestTaskRunAPI(BaseTaskAPITest):
+    def _sandbox_oauth_client(self, task_id: uuid.UUID) -> APIClient:
+        application = OAuthApplication.objects.create(
+            name="Task sandbox agent",
+            client_id=ARRAY_APP_CLIENT_ID_DEV,
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            algorithm="RS256",
+            redirect_uris="https://example.com/callback",
+            organization=self.organization,
+            user=self.user,
+        )
+        access_token = OAuthAccessToken.objects.create(
+            user=self.user,
+            application=application,
+            token=f"pha_task_agent_{uuid.uuid4().hex}",
+            expires=django_timezone.now() + timedelta(hours=1),
+            scope="task:read task:write",
+            scoped_teams=[self.team.id],
+            sandbox_task_id=task_id,
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
+        return client
+
     def _create_run_for_origin(self, origin_product: Task.OriginProduct) -> tuple[Task, TaskRun]:
         task = Task.objects.create(
             team=self.team,
@@ -6584,6 +6608,8 @@ class TestTaskRunAPI(BaseTaskAPITest):
                         "source": "user_attachment",
                         "storage_path": storage_path,
                         "content_type": "application/pdf",
+                        "uploaded_by": "agent",
+                        "uploaded_by_user_id": 999999,
                     }
                 ]
             },
@@ -6612,6 +6638,67 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(artifact["size"], 4096)
         self.assertEqual(artifact["content_type"], "application/pdf")
         self.assertEqual(artifact["storage_path"], storage_path)
+        self.assertEqual(artifact["uploaded_by"], "user")
+        self.assertEqual(artifact["uploaded_by_user_id"], self.user.id)
+
+    @patch("posthog.storage.object_storage.head_object")
+    @patch("posthog.storage.object_storage.tag")
+    def test_finalize_artifact_uploads_attributes_sandbox_oauth_to_agent(self, mock_tag, mock_head_object):
+        mock_head_object.return_value = {"ContentLength": 4096, "ContentType": "text/markdown"}
+        task = self.create_task()
+        run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
+        artifact_id = uuid.uuid4().hex
+        storage_path = f"{run.get_artifact_s3_prefix()}/{artifact_id[:8]}_report.md"
+
+        response = self._sandbox_oauth_client(task.id).post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/artifacts/finalize_upload/",
+            {
+                "artifacts": [
+                    {
+                        "id": artifact_id,
+                        "name": "report.md",
+                        "type": "output",
+                        "source": "agent_output",
+                        "storage_path": storage_path,
+                        "content_type": "text/markdown",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_head_object.assert_called_once_with(storage_path)
+        mock_tag.assert_called_once()
+        run.refresh_from_db()
+        artifact = run.artifacts[0]
+        self.assertEqual(artifact["uploaded_by"], "agent")
+        self.assertNotIn("uploaded_by_user_id", artifact)
+
+    def test_retrieve_run_accepts_legacy_artifacts_without_upload_attribution(self):
+        task = self.create_task()
+        run = TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            status=TaskRun.Status.COMPLETED,
+            artifacts=[
+                {
+                    "id": "legacy-artifact",
+                    "name": "report.md",
+                    "type": "output",
+                    "storage_path": "tasks/artifacts/legacy/report.md",
+                    "uploaded_at": "2026-01-01T00:00:00+00:00",
+                }
+            ],
+        )
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        artifact = response.json()["artifacts"][0]
+        self.assertEqual(artifact["id"], "legacy-artifact")
+        self.assertIsNone(artifact["uploaded_by"])
+        self.assertIsNone(artifact["uploaded_by_user_id"])
 
     @patch("posthog.storage.object_storage.head_object")
     def test_finalize_artifact_uploads_rejects_invalid_storage_path(self, mock_head_object):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -31,7 +31,7 @@ from posthog.models.user_integration import UserIntegration
 from posthog.models.utils import generate_random_token_personal
 from posthog.scopes import MCP_BUILT_IN_AGENT_SCOPE
 from posthog.storage import object_storage
-from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV
+from posthog.temporal.oauth import ARRAY_APP_CLIENT_ID_DEV, POSTHOG_AI_APP_CLIENT_ID_DEV
 from posthog.utils import absolute_uri
 
 from products.slack_app.backend.models import SlackThreadTaskMapping
@@ -4693,10 +4693,17 @@ _OTHER_PR_URL = "https://github.com/posthog/posthog-js/pull/2"
 
 
 class TestTaskRunAPI(BaseTaskAPITest):
-    def _sandbox_oauth_client(self, task_id: uuid.UUID) -> APIClient:
+    def _sandbox_oauth_client(
+        self,
+        task_id: uuid.UUID,
+        *,
+        client_id: str = ARRAY_APP_CLIENT_ID_DEV,
+        bound: bool = True,
+        internal_scope: bool = False,
+    ) -> APIClient:
         application = OAuthApplication.objects.create(
-            name="Task sandbox agent",
-            client_id=ARRAY_APP_CLIENT_ID_DEV,
+            name="Task artifact uploader",
+            client_id=client_id,
             client_type=OAuthApplication.CLIENT_PUBLIC,
             authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
             algorithm="RS256",
@@ -4709,9 +4716,9 @@ class TestTaskRunAPI(BaseTaskAPITest):
             application=application,
             token=f"pha_task_agent_{uuid.uuid4().hex}",
             expires=django_timezone.now() + timedelta(hours=1),
-            scope="task:read task:write",
+            scope=f"task:read task:write{' internal_run:read' if internal_scope else ''}",
             scoped_teams=[self.team.id],
-            sandbox_task_id=task_id,
+            sandbox_task_id=task_id if bound else None,
         )
         client = APIClient()
         client.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token.token}")
@@ -6641,16 +6648,40 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(artifact["uploaded_by"], "user")
         self.assertEqual(artifact["uploaded_by_user_id"], self.user.id)
 
+    @parameterized.expand(
+        [
+            ("bound_code_sandbox", ARRAY_APP_CLIENT_ID_DEV, True, False, "agent"),
+            ("legacy_code_sandbox", ARRAY_APP_CLIENT_ID_DEV, False, True, "agent"),
+            ("posthog_ai_sandbox", POSTHOG_AI_APP_CLIENT_ID_DEV, True, False, "agent"),
+            ("interactive_code_oauth", ARRAY_APP_CLIENT_ID_DEV, False, False, "user"),
+            ("third_party_oauth", "artifact-client", False, False, "user"),
+        ]
+    )
     @patch("posthog.storage.object_storage.head_object")
     @patch("posthog.storage.object_storage.tag")
-    def test_finalize_artifact_uploads_attributes_sandbox_oauth_to_agent(self, mock_tag, mock_head_object):
+    def test_finalize_artifact_uploads_attributes_oauth_from_server_provenance(
+        self,
+        _name: str,
+        client_id: str,
+        bound: bool,
+        internal_scope: bool,
+        expected_uploader: str,
+        mock_tag,
+        mock_head_object,
+    ) -> None:
         mock_head_object.return_value = {"ContentLength": 4096, "ContentType": "text/markdown"}
         task = self.create_task()
         run = TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.IN_PROGRESS)
         artifact_id = uuid.uuid4().hex
         storage_path = f"{run.get_artifact_s3_prefix()}/{artifact_id[:8]}_report.md"
+        client = self._sandbox_oauth_client(
+            task.id,
+            client_id=client_id,
+            bound=bound,
+            internal_scope=internal_scope,
+        )
 
-        response = self._sandbox_oauth_client(task.id).post(
+        response = client.post(
             f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/artifacts/finalize_upload/",
             {
                 "artifacts": [
@@ -6672,8 +6703,11 @@ class TestTaskRunAPI(BaseTaskAPITest):
         mock_tag.assert_called_once()
         run.refresh_from_db()
         artifact = run.artifacts[0]
-        self.assertEqual(artifact["uploaded_by"], "agent")
-        self.assertNotIn("uploaded_by_user_id", artifact)
+        self.assertEqual(artifact["uploaded_by"], expected_uploader)
+        if expected_uploader == "agent":
+            self.assertNotIn("uploaded_by_user_id", artifact)
+        else:
+            self.assertEqual(artifact["uploaded_by_user_id"], self.user.id)
 
     def test_retrieve_run_accepts_legacy_artifacts_without_upload_attribution(self):
         task = self.create_task()

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -6697,8 +6697,8 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         artifact = response.json()["artifacts"][0]
         self.assertEqual(artifact["id"], "legacy-artifact")
-        self.assertIsNone(artifact["uploaded_by"])
-        self.assertIsNone(artifact["uploaded_by_user_id"])
+        self.assertNotIn("uploaded_by", artifact)
+        self.assertNotIn("uploaded_by_user_id", artifact)
 
     @patch("posthog.storage.object_storage.head_object")
     def test_finalize_artifact_uploads_rejects_invalid_storage_path(self, mock_head_object):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1415,6 +1415,17 @@ export interface TaskRunArtifactMetadataApi {
     schema_version: number
 }
 
+/**
+ * * `agent` - agent
+ * * `user` - user
+ */
+export type UploadedByEnumApi = (typeof UploadedByEnumApi)[keyof typeof UploadedByEnumApi]
+
+export const UploadedByEnumApi = {
+    Agent: 'agent',
+    User: 'user',
+} as const
+
 export interface TaskRunArtifactResponseApi {
     /** Stable identifier for the artifact within this run */
     id?: string
@@ -1434,6 +1445,16 @@ export interface TaskRunArtifactResponseApi {
     storage_path: string
     /** Timestamp when the artifact was uploaded */
     uploaded_at: string
+    /** Whether the artifact version was uploaded by the task agent or an interactive user.
+     *
+     * * `agent` - agent
+     * * `user` - user */
+    uploaded_by?: UploadedByEnumApi | null
+    /**
+     * User id for an interactive user upload. Absent for agent uploads and legacy entries.
+     * @nullable
+     */
+    uploaded_by_user_id?: number | null
     /** Timestamp when a user dismissed the artifact. Absent while the artifact is shown. */
     dismissed_at?: string
     /** Stable download URL for the artifact. Populated on the finalize-upload response so the caller can link to the file; it redirects to a fresh presigned URL on each request and is not persisted on the manifest. */

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1449,12 +1449,9 @@ export interface TaskRunArtifactResponseApi {
      *
      * * `agent` - agent
      * * `user` - user */
-    uploaded_by?: UploadedByEnumApi | null
-    /**
-     * User id for an interactive user upload. Absent for agent uploads and legacy entries.
-     * @nullable
-     */
-    uploaded_by_user_id?: number | null
+    uploaded_by?: UploadedByEnumApi
+    /** User id for an interactive user upload. Absent for agent uploads and legacy entries. */
+    uploaded_by_user_id?: number
     /** Timestamp when a user dismissed the artifact. Absent while the artifact is shown. */
     dismissed_at?: string
     /** Stable download URL for the artifact. Populated on the finalize-upload response so the caller can link to the file; it redirects to a fresh presigned URL on each request and is not persisted on the manifest. */

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -456,6 +456,9 @@ tools:
     tasks-runs-artifacts-finalize-upload-create:
         operation: tasks_runs_artifacts_finalize_upload_create
         enabled: false
+        description: >
+            Finalize a task run artifact uploaded through a prepared form. Before revising a file under the same name,
+            read its latest version because an interactive user may have edited it since the agent's last upload.
     tasks-runs-artifacts-prepare-upload-create:
         operation: tasks_runs_artifacts_prepare_upload_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -49991,6 +49991,18 @@ export namespace Schemas {
       schema_version: number;
     }
 
+    /**
+     * * `agent` - agent
+     * * `user` - user
+     */
+    export type UploadedByEnum = typeof UploadedByEnum[keyof typeof UploadedByEnum];
+
+
+    export const UploadedByEnum = {
+      Agent: 'agent',
+      User: 'user',
+    } as const;
+
     export interface TaskRunArtifactResponse {
       /** Stable identifier for the artifact within this run */
       id?: string;
@@ -50010,6 +50022,16 @@ export namespace Schemas {
       storage_path: string;
       /** Timestamp when the artifact was uploaded */
       uploaded_at: string;
+      /** Whether the artifact version was uploaded by the task agent or an interactive user.
+       *
+       * * `agent` - agent
+       * * `user` - user */
+      uploaded_by?: UploadedByEnum | null;
+      /**
+         * User id for an interactive user upload. Absent for agent uploads and legacy entries.
+         * @nullable
+         */
+      uploaded_by_user_id?: number | null;
       /** Timestamp when a user dismissed the artifact. Absent while the artifact is shown. */
       dismissed_at?: string;
       /** Stable download URL for the artifact. Populated on the finalize-upload response so the caller can link to the file; it redirects to a fresh presigned URL on each request and is not persisted on the manifest. */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50026,12 +50026,9 @@ export namespace Schemas {
        *
        * * `agent` - agent
        * * `user` - user */
-      uploaded_by?: UploadedByEnum | null;
-      /**
-         * User id for an interactive user upload. Absent for agent uploads and legacy entries.
-         * @nullable
-         */
-      uploaded_by_user_id?: number | null;
+      uploaded_by?: UploadedByEnum;
+      /** User id for an interactive user upload. Absent for agent uploads and legacy entries. */
+      uploaded_by_user_id?: number;
       /** Timestamp when a user dismissed the artifact. Absent while the artifact is shown. */
       dismissed_at?: string;
       /** Stable download URL for the artifact. Populated on the finalize-upload response so the caller can link to the file; it redirects to a fresh presigned URL on each request and is not persisted on the manifest. */


### PR DESCRIPTION
## Problem

Artifact versions do not record whether an agent or user uploaded them, so the desktop cannot explain who created an edited version.

## Changes

- The finalize endpoint derives upload attribution from the authenticated request.
- Sandbox-bound PostHog Code and PostHog AI OAuth uploads become agent uploads.
- Interactive uploads include the authenticated user ID.
- Optional response fields keep legacy manifest entries compatible.
- Agent guidance tells uploaders to read the latest version before revising a file.

> [!NOTE]
> This backend layer is inert until the desktop layer ships. It must deploy before the desktop PR merges.

## How did you test this code?

- The full task API suite guards user attribution, agent attribution, spoofing, idempotency, and legacy manifests.
- Repo-wide mypy checks the new facade and serializer contract.
- OpenAPI generation verifies the frontend and MCP schemas.
- `ci:preflight --fix` passes deterministic checks on current master.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Updated the artifact upload tool guidance. The backend behavior remains inert until the desktop layer ships.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented this layer with repository and GitHub tooling. Skills invoked: `/stacking-prs`, `/improving-drf-endpoints`, `/implementing-mcp-tools`, `/writing-tests`, and `/writing-pr-descriptions`.

The implementation keeps attribution server-derived and stores it in the existing JSON manifest. No migration or request field was added.