### PR TITLE
feat(tasks): list all task comments in one request

### DIFF
--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -523,7 +523,7 @@ class CommentErrorSerializer(serializers.Serializer):
 
 
 class CommentPagination(pagination.CursorPagination):
-    ordering = "-created_at"
+    ordering = ("-created_at", "-id")
     page_size = 100
 
 
@@ -538,6 +538,12 @@ class CommentListQueryParamsSerializer(serializers.Serializer):
     item_id = serializers.CharField(required=False, help_text="Filter by the ID of the resource being commented on.")
     task_id = serializers.UUIDField(
         required=False, help_text="Owning task for task, task_artifact, and desktop_canvas comment scopes."
+    )
+    include_task_resources = serializers.BooleanField(
+        required=False,
+        help_text=(
+            "When true with scope=task and task_id, include comments on the task and its artifacts and canvases."
+        ),
     )
     search = serializers.CharField(required=False, help_text="Full-text search within comment content.")
     source_comment = serializers.CharField(required=False, help_text="Filter replies to a specific parent comment.")
@@ -887,7 +893,23 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
             queryset = queryset.filter(deleted=False)
 
         scope = params.get("scope")
-        if scope:
+        include_task_resources = scope == "task" and params.get("include_task_resources") == "true"
+        if include_task_resources:
+            task_id = params.get("task_id")
+            if not _task_comment_target_is_accessible(
+                team_id=self.team_id,
+                user_id=self.request.user.id,
+                task_id=task_id or "",
+                scope="task",
+                item_id=task_id,
+            ):
+                return queryset.none()
+            task_id_string = str(task_id)
+            queryset = queryset.filter(
+                Q(scope="task", item_id=task_id_string)
+                | Q(scope__in=["task_artifact", "desktop_canvas"], item_context__taskId=task_id_string)
+            )
+        elif scope:
             queryset = queryset.filter(scope=scope)
             if scope in TICKET_COMMENT_SCOPES:
                 queryset = self._filter_ticket_scoped_queryset(queryset, params.get("item_id"))
@@ -912,7 +934,7 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
             self._require_ticket_viewer_access_for_pk()
             self._require_task_comment_viewer_access_for_pk()
 
-        if params.get("item_id"):
+        if params.get("item_id") and not include_task_resources:
             queryset = queryset.filter(item_id=params.get("item_id"))
 
         if params.get("search"):

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -38,6 +38,7 @@ from posthog.models.comment.utils import (
 from posthog.models.integration import Integration, SlackIntegration
 from posthog.tasks.comment_slack_sync import backfill_comment_slack_thread
 from posthog.tasks.email import send_discussions_mentioned
+from posthog.utils import str_to_bool
 
 from products.conversations.backend import reply_dedupe
 
@@ -893,22 +894,24 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
             queryset = queryset.filter(deleted=False)
 
         scope = params.get("scope")
-        include_task_resources = scope == "task" and params.get("include_task_resources") == "true"
+        include_task_resources = scope == "task" and str_to_bool(params.get("include_task_resources"))
         if include_task_resources:
             task_id = params.get("task_id")
+            if not task_id:
+                raise exceptions.ValidationError({"task_id": "Task ID is required when including task resources."})
             if not _task_comment_target_is_accessible(
                 team_id=self.team_id,
                 user_id=self.request.user.id,
-                task_id=task_id or "",
+                task_id=task_id,
                 scope="task",
                 item_id=task_id,
             ):
                 return queryset.none()
-            task_id_string = str(task_id)
             queryset = queryset.filter(
-                Q(scope="task", item_id=task_id_string)
-                | Q(scope__in=["task_artifact", "desktop_canvas"], item_context__taskId=task_id_string)
+                Q(scope="task", item_id=task_id)
+                | Q(scope__in=["task_artifact", "desktop_canvas"], item_context__taskId=task_id)
             )
+            params.pop("item_id", None)
         elif scope:
             queryset = queryset.filter(scope=scope)
             if scope in TICKET_COMMENT_SCOPES:
@@ -934,7 +937,7 @@ class CommentViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelV
             self._require_ticket_viewer_access_for_pk()
             self._require_task_comment_viewer_access_for_pk()
 
-        if params.get("item_id") and not include_task_resources:
+        if params.get("item_id"):
             queryset = queryset.filter(item_id=params.get("item_id"))
 
         if params.get("search"):

--- a/posthog/api/comments.py
+++ b/posthog/api/comments.py
@@ -524,8 +524,15 @@ class CommentErrorSerializer(serializers.Serializer):
 
 
 class CommentPagination(pagination.CursorPagination):
-    ordering = ("-created_at", "-id")
+    ordering = ("-created_at",)
     page_size = 100
+
+    def get_ordering(self, request: Request, queryset: QuerySet, view: Any) -> tuple[str, ...]:
+        if request.query_params.get("scope") == "task" and str_to_bool(
+            request.query_params.get("include_task_resources")
+        ):
+            return ("-created_at", "-id")
+        return self.ordering
 
 
 class CommentListQueryParamsSerializer(serializers.Serializer):

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -181,9 +181,10 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         Comment.objects.create(
             team=self.team,
             created_by=other,
-            scope="task",
-            item_id=str(task.id),
-            content="Private task comment",
+            scope="desktop_canvas",
+            item_id="019fddea-b2ac-7000-8527-6b45a615cf4f",
+            item_context={"taskId": str(task.id)},
+            content="Private canvas comment",
         )
 
         response = self.client.get(
@@ -193,6 +194,39 @@ class TestComments(APIBaseTest, QueryMatchingTest):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["results"] == []
+
+    @parameterized.expand(["true", "True", "1"])
+    def test_task_wide_comment_list_accepts_boolean_query_values(self, include_task_resources: str) -> None:
+        task = self._task_artifact_target()
+        artifact_comment = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            content="Artifact comment",
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/comments",
+            {
+                "scope": "task",
+                "task_id": str(task.id),
+                "include_task_resources": include_task_resources,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [row["id"] for row in response.json()["results"]] == [str(artifact_comment.id)]
+
+    def test_task_wide_comment_list_requires_task_id(self) -> None:
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/comments",
+            {"scope": "task", "include_task_resources": "true"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["attr"] == "task_id"
 
     def test_task_comment_list_without_task_resources_keeps_single_target_behavior(self) -> None:
         task = self._task_artifact_target()

--- a/posthog/api/test/test_comments.py
+++ b/posthog/api/test/test_comments.py
@@ -97,6 +97,162 @@ class TestComments(APIBaseTest, QueryMatchingTest):
         )
         assert [row["id"] for row in with_task.json()["results"]] == [created.json()["id"]]
 
+    def test_task_wide_comment_list_includes_all_task_resources_and_excludes_unrelated_comments(self) -> None:
+        task = self._task_artifact_target()
+        other_task = self._task_artifact_target()
+        other_team = self.organization.teams.create(name="Other comment team")
+        task_root = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task",
+            item_id=str(task.id),
+            content="Task comment",
+        )
+        artifact_root = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            content="Artifact comment",
+        )
+        reply = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            source_comment=artifact_root,
+            content="Artifact reply",
+        )
+        canvas = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="desktop_canvas",
+            item_id="019fddea-b2ac-7000-8527-6b45a615cf4f",
+            item_context={"taskId": str(task.id)},
+            content="Canvas comment",
+        )
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id), "is_emoji": True},
+            content="👍",
+        )
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task",
+            item_id=str(other_task.id),
+            content="Another task",
+        )
+        Comment.objects.create(
+            team=other_team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            content="Another team",
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/comments",
+            {
+                "scope": "task",
+                "task_id": str(task.id),
+                "include_task_resources": "true",
+                "exclude_emoji_reactions": "true",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {row["id"] for row in response.json()["results"]} == {
+            str(task_root.id),
+            str(artifact_root.id),
+            str(reply.id),
+            str(canvas.id),
+        }
+
+    def test_task_wide_comment_list_is_empty_without_task_visibility(self) -> None:
+        other = User.objects.create_and_join(self.organization, "private-list-owner@posthog.com", "password")
+        task = self._task_artifact_target(public=False, creator=other)
+        Comment.objects.create(
+            team=self.team,
+            created_by=other,
+            scope="task",
+            item_id=str(task.id),
+            content="Private task comment",
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/comments",
+            {"scope": "task", "task_id": str(task.id), "include_task_resources": "true"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["results"] == []
+
+    def test_task_comment_list_without_task_resources_keeps_single_target_behavior(self) -> None:
+        task = self._task_artifact_target()
+        task_comment = Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task",
+            item_id=str(task.id),
+            content="Task comment",
+        )
+        Comment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            scope="task_artifact",
+            item_id="artifact-1",
+            item_context={"taskId": str(task.id)},
+            content="Artifact comment",
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/comments",
+            {"scope": "task", "task_id": str(task.id), "item_id": str(task.id)},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [row["id"] for row in response.json()["results"]] == [str(task_comment.id)]
+
+    def test_task_wide_comment_cursor_paginates_equal_timestamps_without_gaps(self) -> None:
+        task = self._task_artifact_target()
+        comments = Comment.objects.bulk_create(
+            [
+                Comment(
+                    team=self.team,
+                    created_by=self.user,
+                    scope="task" if index % 2 == 0 else "task_artifact",
+                    item_id=str(task.id) if index % 2 == 0 else "artifact-1",
+                    item_context=None if index % 2 == 0 else {"taskId": str(task.id)},
+                    content=f"Comment {index}",
+                )
+                for index in range(101)
+            ]
+        )
+        Comment.objects.filter(id__in=[comment.id for comment in comments]).update(created_at=timezone.now())
+        query = {
+            "scope": "task",
+            "task_id": str(task.id),
+            "include_task_resources": "true",
+        }
+
+        first = self.client.get(f"/api/projects/{self.team.id}/comments", query)
+        second = self.client.get(first.json()["next"])
+        returned_ids = [row["id"] for row in first.json()["results"] + second.json()["results"]]
+
+        assert first.status_code == status.HTTP_200_OK
+        assert second.status_code == status.HTTP_200_OK
+        assert len(returned_ids) == 101
+        assert len(set(returned_ids)) == 101
+        assert set(returned_ids) == {str(comment.id) for comment in comments}
+        assert second.json()["next"] is None
+
     def test_task_comments_list_artifacts_comments_and_one_comment(self) -> None:
         task = self._task_artifact_target()
         task_run_model = apps.get_model("tasks", "TaskRun")

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -1561,6 +1561,10 @@ export type CommentsListParams = {
      */
     cursor?: string
     /**
+     * When true with scope=task and task_id, include comments on the task and its artifacts and canvases.
+     */
+    include_task_resources?: boolean
+    /**
      * Filter by the ID of the resource being commented on.
      * @minLength 1
      */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -80143,6 +80143,10 @@ export namespace Schemas {
      */
     cursor?: string;
     /**
+     * When true with scope=task and task_id, include comments on the task and its artifacts and canvases.
+     */
+    include_task_resources?: boolean;
+    /**
      * Filter by the ID of the resource being commented on.
      * @minLength 1
      */

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -377,6 +377,12 @@ export const CommentsListQueryParams = /* @__PURE__ */ zod.object({
             "When kind=task, restrict to open (incomplete) or completed tasks. Ignored when kind is not 'task'. Defaults to 'any' (no filter).\n\n\* `any` - any\n\* `open` - open\n\* `completed` - completed"
         ),
     cursor: zod.string().optional().describe('The pagination cursor value.'),
+    include_task_resources: zod
+        .boolean()
+        .optional()
+        .describe(
+            'When true with scope=task and task_id, include comments on the task and its artifacts and canvases.'
+        ),
     item_id: zod.string().min(1).optional().describe('Filter by the ID of the resource being commented on.'),
     kind: zod
         .enum(['any', 'comment', 'task'])

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -485,6 +485,7 @@ const commentsList = (): ToolBase<typeof CommentsListSchema, Schemas.PaginatedCo
             query: {
                 completed: params.completed,
                 cursor: params.cursor,
+                include_task_resources: params.include_task_resources,
                 item_id: params.item_id,
                 kind: params.kind,
                 scope: params.scope,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/comments-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/comments-list.json
@@ -10,6 +10,10 @@
             "description": "The pagination cursor value.",
             "type": "string"
         },
+        "include_task_resources": {
+            "description": "When true with scope=task and task_id, include comments on the task and its artifacts and canvases.",
+            "type": "boolean"
+        },
         "item_id": {
             "description": "Filter by the ID of the resource being commented on.",
             "minLength": 1,


### PR DESCRIPTION
## Problem

Desktop clients must request comments separately for each task resource, repeating access checks and pagination work.

## Changes

- The comments endpoint accepts an explicit task-wide option and checks task visibility once.
- The combined response includes task, artifact, canvas, and reply comments while preserving existing single-target behavior.
- Cursor pagination uses comment IDs to order comments with equal timestamps consistently.
- Generated OpenAPI and MCP types expose the new option.

```mermaid
flowchart LR
    A[Desktop client] --> B[One request per resource]
    B --> C[One access check per request]
```

```mermaid
flowchart LR
    A[Desktop client] --> B[One task-wide request]
    B --> C[One task visibility check]
```

## How did you test this code?

- Extended the comment API suite to guard task isolation, visibility, emoji filtering, existing queries, and complete cursor pagination.
- Ran `hogli test posthog/api/test/test_comments.py`.
- Ran repository-wide Ruff and mypy checks.
- Ran `hogli ci:preflight --fix`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The generated OpenAPI schema documents the opt-in query parameter. No separate user documentation changes are needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

GPT-5.6 implemented and tested this change with pi and repository tooling. It invoked `/stacking-prs`, `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-pr-descriptions`.

The change uses the established task visibility facade and the accepted task-resource ownership fields. No session-only or customer material appears in the public artifacts.