### PR TITLE
chore(ci): name a lane for the paths trunk lanes still widened on

### DIFF
--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -189,9 +189,22 @@ const TRIPWIRE_RULES = [
     ['.oxlintrc.json', JAVASCRIPT],
     ['.oxfmtrc*', JAVASCRIPT],
     ['.nvmrc', JAVASCRIPT],
+    ['postcss.config.js', JAVASCRIPT],
+    ['.stylelintrc.js', JAVASCRIPT],
+    ['.stylelintignore', JAVASCRIPT],
+    ['.kearc', JAVASCRIPT],
+    // The posthog wizard's event schema, whose only output is
+    // frontend/src/lib/posthog-typed.ts. Nothing in Python reads it.
+    ['posthog.json', JAVASCRIPT],
     ['mypy.ini', PYTHON],
     ['pytest.ini', PYTHON],
     ['conftest.py', PYTHON],
+    ['manage.py', PYTHON],
+    ['pytest_boot_gc.py', PYTHON],
+    ['dagster_cloud.yaml', PYTHON],
+    // Serves the Django app in the production image, so the module paths it
+    // names are the ones a Python change can rename out from under it.
+    ['unit.json.tpl', PYTHON],
 
     // Lockfiles and workspace manifests stay universal. pnpm-workspace.yaml
     // lists frontend, nodejs, services, tools, products, and three rust node
@@ -213,6 +226,9 @@ const TRIPWIRE_RULES = [
     ['.github/**', UNIVERSAL],
     ['docker-compose*.yml', UNIVERSAL],
     ['Dockerfile*', UNIVERSAL],
+    // Decides what lands in the build context of every image built from the
+    // repository root, so it belongs with the Dockerfiles above.
+    ['.dockerignore', UNIVERSAL],
     ['proto/**', UNIVERSAL],
     // schema.json generates posthog/schema.py, and both sides are committed.
     ['frontend/src/queries/schema.json', UNIVERSAL],
@@ -236,7 +252,11 @@ const TRIPWIRE_RULES = [
     // change lands on both sides of the fe/py split at once.
     ['tools/openapi-codegen/**', UNIVERSAL],
     // Ownership data read by the backend, frontend, and script suites alike.
+    // The root owners.yaml is the fallback every path resolves through when no
+    // nearer file claims it, so it has the same readers as the tooling. A
+    // product's own owners.yaml is not here: it keeps its product lane.
     ['tools/owners/**', UNIVERSAL],
+    ['owners.yaml', UNIVERSAL],
     ['.test_durations', UNIVERSAL],
     ['.test_quarantine.json', UNIVERSAL],
     // bin/ appears in the backend, frontend, and E2E path filters alike.
@@ -245,13 +265,23 @@ const TRIPWIRE_RULES = [
     // Holds the Depot-runner copies of the workflows and composite actions in
     // .github/, so it decides what runs for everyone the same way.
     ['.depot/**', UNIVERSAL],
+    // Names the Depot project every container build and runner is billed and
+    // cached against. rust/depot.json is deliberately not here: it configures
+    // builds of that workspace only, and the rust rules below hold it to them.
+    ['depot.json', UNIVERSAL],
     // The toolchain every suite runs inside. ci-python.yml gates on
     // .flox/env/manifest.toml for that reason.
     ['.flox/**', UNIVERSAL],
+    // The environment every suite runs inside: hogli loads .env.development and
+    // .env.services before starting anything, the sandbox image bakes the same
+    // pair, and .envrc activates the flox environment above. The two .example
+    // files ride along rather than earning a rule of their own.
+    ['.env*', UNIVERSAL],
     // ClickHouse, Postgres, and Temporal configuration mounted by every
     // docker-compose file, so it defines the services all the suites test
-    // against.
+    // against. The collector config is mounted the same way, from the root.
     ['docker/**', UNIVERSAL],
+    ['otel-collector-config*.yaml', UNIVERSAL],
     // duckgres.yaml is mounted into the same stack, and intent-map.yaml steers
     // bin/sandbox and hogli, both already tripwires.
     ['devenv/**', UNIVERSAL],
@@ -265,6 +295,11 @@ const TRIPWIRE_RULES = [
 // being guessed at.
 const COMMON_PYTHON = ['hogql_parser', 'hogvm', 'ingestion', 'migration_utils', 'plugin_transpiler', 'alerting']
 const COMMON_FRONTEND = ['esbuilder', 'storybook', 'tailwind', 'replay-shared', 'replay-headless']
+
+// Subdirectories of common/ that both language families read. Test data owned
+// by neither: the ai-multimodal fixtures are loaded by a product's Playwright
+// spec and recorded by a Python script sitting beside them.
+const COMMON_FULLSTACK = ['fixtures']
 
 // Tools that own their whole test story and that no suite imports, so they can
 // hold a lane of their own. Everything else under tools/ falls through to the
@@ -285,10 +320,15 @@ const TOOLS_INDEPENDENT = [
 ]
 
 // Top-level trees that hold a lane instead of falling through to ALL, keyed by
-// directory. Every entry names the suite that would catch a conflict in it, and
-// a tree nobody has placed here still widens, so the list grows by decision
-// rather than by default.
+// the first path segment, which is the directory for a tree and the file name
+// for a file sitting at the repository root. Every entry names the suite that
+// would catch a conflict in it, and a tree nobody has placed here still widens,
+// so the list grows by decision rather than by default.
 const STANDALONE_TREES = new Map([
+    // The cargo-dist workspace, whose only member is cli/. It decides what the
+    // released posthog-cli artifacts contain, and ci-cli.yml builds those from
+    // services/mcp sources, so it takes the same pair cli/ does.
+    ['dist-workspace.toml', ['cli', 'svc:mcp']],
     // A cargo workspace of its own (cli/Cargo.lock, outside rust/ and outside
     // the pnpm workspace). ci-cli.yml also builds it from services/mcp sources,
     // so the two trees have to share a lane.
@@ -334,8 +374,32 @@ const REPO_CONFIG_DIRS = [
     '.vscode',
     '.zed',
 ]
-for (const dir of REPO_CONFIG_DIRS) {
-    STANDALONE_TREES.set(dir, ['repo-config'])
+
+// The same class of file, one per root path rather than one per tree: the
+// ignore and rule files belonging to the directories above, the VCS settings,
+// the review bot's config, and the license. No suite reads any of them, and the
+// tools that do — direnv, watchman, the worktree helpers, the desktop MCP
+// client — either run outside CI or are driven by bin/, which is universal and
+// so overlaps this lane already.
+//
+// .dockerignore and the .env files are deliberately not here. Both are read by
+// something that every suite runs inside, and both are tripwires above.
+const REPO_CONFIG_FILES = [
+    '.cursorignore',
+    '.cursorrules',
+    '.editorconfig',
+    '.git-blame-ignore-revs',
+    '.gitattributes',
+    '.gitignore',
+    '.mcp.json',
+    '.watchmanconfig',
+    '.worktreeinclude',
+    '.worktreelink',
+    'LICENSE',
+    'greptile.json',
+]
+for (const entry of [...REPO_CONFIG_DIRS, ...REPO_CONFIG_FILES]) {
+    STANDALONE_TREES.set(entry, ['repo-config'])
 }
 
 // Supports the three forms used in TRIPWIRES: `**` spanning directories, `*`
@@ -1128,10 +1192,21 @@ function addRustLanes(targets, context) {
     return true
 }
 
-const TRIPWIRE_DOMAIN_LANES = new Map([
+// The nodejs lane on its own. No tripwire resolves to it — a file that can
+// break the ingestion suite can almost always break more than that — but the
+// rust rules below need to name it without dragging in the frontend.
+const NODE = 'node'
+
+function addNodeLanes(targets) {
+    targets.add('node:ingestion')
+    return true
+}
+
+const DOMAIN_LANES = new Map([
     [PYTHON, addPythonLanes],
     [JAVASCRIPT, addJavaScriptLanes],
     [RUST, addRustLanes],
+    [NODE, addNodeLanes],
     [PRODUCT_SURFACE, addProductSurfaceLanes],
 ])
 
@@ -1139,8 +1214,44 @@ const TRIPWIRE_DOMAIN_LANES = new Map([
 // to abandon the per-file accumulation and report the whole set.
 function applyTripwireDomain(domain, file, targets, context) {
     const resolved = domain === SEMGREP ? (context.semgrepDomains || new Map()).get(file) || UNIVERSAL : domain
-    const addLanes = TRIPWIRE_DOMAIN_LANES.get(resolved)
+    const addLanes = DOMAIN_LANES.get(resolved)
     return addLanes ? addLanes(targets, context) : false
+}
+
+// Paths under rust/ that belong to no crate, and the domains that read them. A
+// crate directory answers for itself; these do not, so each entry is a decision
+// and a subdirectory nobody has placed here still widens.
+const RUST_NON_CRATE_RULES = [
+    // posthog/conftest.py replays these files to build the persons database
+    // every backend test runs against, so the schema they declare is Python's
+    // as much as it is Rust's.
+    ['rust/persons_migrations/', [RUST, PYTHON]],
+    // The cyclotron tables the nodejs CDP consumers read and write.
+    ['rust/cyclotron-node-migrations/', [RUST, NODE]],
+    ['rust/behavioral_cohorts_migrations/', [RUST]],
+    ['rust/flags_read_store_migrations/', [RUST]],
+    // The entrypoints of the sqlx-migrate image, which applies every set above.
+    // rust/affected-services declares the same grouping in
+    // NON_CRATE_IMAGE_TRIGGERS, and this list has to stay a superset of it.
+    ['rust/bin/', [RUST, PYTHON, NODE]],
+    // Cargo and nextest settings: every crate compiles and tests under them.
+    ['rust/.cargo/', [RUST]],
+    ['rust/.config/', [RUST]],
+]
+
+// A file sitting directly at rust/ configures the cargo workspace itself — the
+// Dockerfiles its images build from, the compose stack, the dotfiles, the
+// license — so the crates are its readers. That reasoning does not extend to a
+// subdirectory, which could hold anything, so one the rules above do not name
+// returns false and widens.
+function applyRustNonCrateLanes(file, targets, context) {
+    const rule = RUST_NON_CRATE_RULES.find(([prefix]) => file.startsWith(prefix))
+    const isWorkspaceRoot = file.split('/').length === 2
+    if (!rule && !isWorkspaceRoot) {
+        return false
+    }
+    const domains = rule ? rule[1] : [RUST]
+    return domains.every((domain) => DOMAIN_LANES.get(domain)(targets, context))
 }
 
 function computeTargets(changedFiles, context) {
@@ -1276,6 +1387,14 @@ function computeTargets(changedFiles, context) {
                 allFeProducts()
                 continue
             }
+            // A file at the root of common/ is the tree's own package marker,
+            // shared by whichever subdirectories import it, so it takes both
+            // families rather than guessing at one.
+            if (segments.length === 2 || COMMON_FULLSTACK.includes(segments[1])) {
+                allPyProducts()
+                allFeProducts()
+                continue
+            }
             return everything(context)
         }
         if (top === 'rust') {
@@ -1286,10 +1405,22 @@ function computeTargets(changedFiles, context) {
             const crate = rustGraph.byDir.find(
                 (entry) => file.startsWith(`rust/${entry.dir}/`) || file === `rust/${entry.dir}`
             )
-            if (!crate) {
+            if (crate) {
+                targets.add(rustCrate(crate.name))
+                continue
+            }
+            if (!applyRustNonCrateLanes(file, targets, context)) {
                 return everything(context)
             }
-            targets.add(rustCrate(crate.name))
+            continue
+        }
+        // A file at the root of products/ is shared by all of them: the package
+        // marker, the conftest every product's tests collect, the database
+        // routing map, the lint config. It cannot be held to one product, and
+        // nothing outside the two language families reads any of it.
+        if (top === 'products' && segments.length === 2) {
+            allPyProducts()
+            allFeProducts()
             continue
         }
         if (top === 'products' && segments.length > 2) {

--- a/.github/scripts/trunk-impacted-targets.js
+++ b/.github/scripts/trunk-impacted-targets.js
@@ -193,8 +193,11 @@ const TRIPWIRE_RULES = [
     ['.stylelintrc.js', JAVASCRIPT],
     ['.stylelintignore', JAVASCRIPT],
     ['.kearc', JAVASCRIPT],
-    // The posthog wizard's event schema, whose only output is
-    // frontend/src/lib/posthog-typed.ts. Nothing in Python reads it.
+    // State the posthog-cli schema command writes for this repo, recording the
+    // hash and output path of the generated event definitions. cli/ reads and
+    // rewrites it (cli/src/experimental/schema.rs), and its only generated
+    // output here is frontend/src/lib/posthog-typed.ts, both of which the
+    // javascript domain covers. Nothing in Python reads it.
     ['posthog.json', JAVASCRIPT],
     ['mypy.ini', PYTHON],
     ['pytest.ini', PYTHON],
@@ -377,10 +380,10 @@ const REPO_CONFIG_DIRS = [
 
 // The same class of file, one per root path rather than one per tree: the
 // ignore and rule files belonging to the directories above, the VCS settings,
-// the review bot's config, and the license. No suite reads any of them, and the
-// tools that do — direnv, watchman, the worktree helpers, the desktop MCP
-// client — either run outside CI or are driven by bin/, which is universal and
-// so overlaps this lane already.
+// the review bot's config, and the license. No suite reads any of them. The
+// tools that do read them (direnv, watchman, the worktree helpers, the desktop
+// MCP client) either run outside CI or are driven by bin/, which is universal
+// and so overlaps this lane already.
 //
 // .dockerignore and the .env files are deliberately not here. Both are read by
 // something that every suite runs inside, and both are tripwires above.
@@ -1192,9 +1195,9 @@ function addRustLanes(targets, context) {
     return true
 }
 
-// The nodejs lane on its own. No tripwire resolves to it — a file that can
-// break the ingestion suite can almost always break more than that — but the
-// rust rules below need to name it without dragging in the frontend.
+// The nodejs lane on its own. No tripwire resolves to it, because a file that
+// can break the ingestion suite can almost always break more than that. The
+// rust rules below still need to name it without dragging in the frontend.
 const NODE = 'node'
 
 function addNodeLanes(targets) {
@@ -1239,9 +1242,9 @@ const RUST_NON_CRATE_RULES = [
     ['rust/.config/', [RUST]],
 ]
 
-// A file sitting directly at rust/ configures the cargo workspace itself — the
+// A file sitting directly at rust/ configures the cargo workspace itself (the
 // Dockerfiles its images build from, the compose stack, the dotfiles, the
-// license — so the crates are its readers. That reasoning does not extend to a
+// license), so the crates are its readers. That reasoning does not extend to a
 // subdirectory, which could hold anything, so one the rules above do not name
 // returns false and widens.
 function applyRustNonCrateLanes(file, targets, context) {

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -845,8 +845,9 @@ test('tool caches beside the products are not products', () => {
 })
 
 // A file at the root of products/ or common/ belongs to no single product or
-// subtree, which used to send it to the full set. Both language families is the
-// honest ceiling: nothing under rust/, nodejs/, or services/ reads any of them.
+// subtree, which used to send it to the full set. Both language families
+// together are the honest ceiling: nothing under rust/, nodejs/, or services/
+// reads any of them.
 test('shared files at the root of products and common claim both language families', () => {
     const bothFamilies = [
         'py:core',

--- a/.github/scripts/trunk-impacted-targets.test.js
+++ b/.github/scripts/trunk-impacted-targets.test.js
@@ -216,6 +216,46 @@ test('the generated frontend product artifacts claim only the frontend lanes', (
 
 // A workflow decides which suites run, so the suite it defines is the radius.
 // ci-frontend.yml was the single most common reason a PR widened.
+// Configuration files at the repository root are the other half of the same
+// story the workflows tell: a tool's own settings can only fail the code that
+// tool reads, so they no longer serialize a PR against the whole repo.
+test('single-language root configuration claims that language', () => {
+    const javascript = computeTargets(['.oxlintrc.json'], CONTEXT)
+    for (const file of ['postcss.config.js', '.stylelintrc.js', '.stylelintignore', '.kearc', 'posthog.json']) {
+        assert.deepEqual(computeTargets([file], CONTEXT), javascript, file)
+    }
+    const python = computeTargets(['mypy.ini'], CONTEXT)
+    for (const file of ['manage.py', 'pytest_boot_gc.py', 'dagster_cloud.yaml', 'unit.json.tpl']) {
+        assert.deepEqual(computeTargets([file], CONTEXT), python, file)
+    }
+})
+
+// Root files whose reader is the stack, the image, or the ownership data every
+// suite runs on. The narrowing above stops here: these keep the full set, but
+// by decision rather than for want of a rule.
+test('stack and image configuration at the root stays universal', () => {
+    for (const file of [
+        '.env.development',
+        '.env.services',
+        '.envrc',
+        '.dockerignore',
+        'depot.json',
+        'owners.yaml',
+        'otel-collector-config.dev.yaml',
+    ]) {
+        assert.equal(tripwireDomain(file), UNIVERSAL, file)
+        assert.deepEqual(computeTargets([file], CONTEXT), EVERYTHING, file)
+    }
+    // A product's own ownership file is not the root one and keeps its lane.
+    assert.notDeepEqual(computeTargets(['products/alpha/owners.yaml'], CONTEXT), EVERYTHING)
+})
+
+// cargo-dist packages the CLI, which ci-cli.yml builds from services/mcp
+// sources, so the manifest belongs in the same lane as both.
+test('the cargo-dist manifest shares the cli lane', () => {
+    assert.deepEqual(computeTargets(['dist-workspace.toml'], CONTEXT), computeTargets(['cli/src/main.rs'], CONTEXT))
+})
+
 test('a single-language workflow claims that language rather than everything', () => {
     assert.deepEqual(
         computeTargets(['.github/workflows/ci-frontend.yml'], CONTEXT),
@@ -319,9 +359,20 @@ test('every target the rules can emit appears in the enumerated universe', () =>
         'tools/pr-approval-agent/policy.py',
         'common/hogvm/x.py',
         'common/storybook/x.ts',
+        'common/__init__.py',
+        'common/fixtures/ai-multimodal/screenshot.png',
         'rust/shared/src/lib.rs',
+        'rust/Dockerfile',
+        'rust/persons_migrations/x.sql',
+        'rust/cyclotron-node-migrations/x.sql',
+        'rust/bin/migrate-persons',
         'products/alpha/backend/api.py',
         'products/beta/frontend/Scene.tsx',
+        'products/db_routing.yaml',
+        'dist-workspace.toml',
+        'LICENSE',
+        'manage.py',
+        'posthog.json',
         'README.md',
         '.oxlintrc.json',
         'mypy.ini',
@@ -405,7 +456,22 @@ test('stamphog policy files claim the suite that validates them', () => {
 // these PRs are rare, and the alternative is a lane per tree for files that
 // cannot change any test's outcome.
 test('editor and agent configuration shares one lane', () => {
-    for (const file of ['.vscode/launch.json', '.zed/debug.json', '.husky/pre-commit', '.claude/settings.json']) {
+    for (const file of [
+        '.vscode/launch.json',
+        '.zed/debug.json',
+        '.husky/pre-commit',
+        '.claude/settings.json',
+        // The same class of file, one per root path rather than one per tree.
+        '.cursorignore',
+        '.editorconfig',
+        '.gitattributes',
+        '.gitignore',
+        '.mcp.json',
+        '.watchmanconfig',
+        '.worktreeinclude',
+        'LICENSE',
+        'greptile.json',
+    ]) {
         assert.deepEqual(computeTargets([file], CONTEXT), ['repo-config'], file)
     }
     // Markdown in those trees is still prose, so a PR that only reorganizes an
@@ -437,6 +503,60 @@ test('an unresolvable rust crate graph reports every crate instead of narrowing'
 
 test('a rust path outside every known crate widens', () => {
     assert.deepEqual(computeTargets(['rust/not-a-crate/file.rs'], CONTEXT), EVERYTHING)
+})
+
+// The crate lanes are the ceiling for anything configuring the workspace as a
+// whole, and a file sitting at rust/ is that by construction: the Dockerfiles
+// its images build from, the compose stack, the dotfiles, the license.
+test('workspace-level rust files claim the crates rather than everything', () => {
+    const crates = ['rust:crate:consumer', 'rust:crate:shared', 'rust:crate:unrelated']
+    for (const file of [
+        'rust/Dockerfile',
+        'rust/docker-compose.yml',
+        'rust/depot.json',
+        'rust/owners.yaml',
+        'rust/LICENSE',
+        'rust/.env',
+        'rust/.cargo/config.toml',
+        'rust/.config/nextest.toml',
+    ]) {
+        assert.deepEqual(computeTargets([file], CONTEXT), crates, file)
+    }
+})
+
+// The migration sets under rust/ define schemas that suites outside Rust run
+// against, so holding them to the crate lanes would put a schema change in a
+// parallel lane with the code reading it.
+test('rust migration sets claim the suites that read their schema', () => {
+    // posthog/conftest.py replays these to build the persons database every
+    // backend test runs against.
+    const persons = computeTargets(['rust/persons_migrations/20260206000001_add_last_seen_at.sql'], CONTEXT)
+    assert.equal(persons.includes('py:core'), true)
+    assert.equal(persons.includes('py:product:alpha'), true)
+    assert.equal(persons.includes('rust:crate:shared'), true)
+    assert.equal(persons.includes('fe:core'), false)
+    assert.notDeepEqual(persons, EVERYTHING)
+
+    // The cyclotron tables the nodejs CDP consumers read and write, and nothing
+    // in the frontend, so the nodejs lane rides along on its own.
+    const cyclotron = computeTargets(['rust/cyclotron-node-migrations/20260303000001_initial.sql'], CONTEXT)
+    assert.equal(cyclotron.includes('node:ingestion'), true)
+    assert.equal(cyclotron.includes('rust:crate:shared'), true)
+    assert.equal(cyclotron.includes('fe:core'), false)
+    assert.equal(cyclotron.includes('py:core'), false)
+
+    // The migrate entrypoints apply every set, so they take the union.
+    const entrypoint = computeTargets(['rust/bin/migrate-persons'], CONTEXT)
+    assert.equal(entrypoint.includes('py:core'), true)
+    assert.equal(entrypoint.includes('node:ingestion'), true)
+    assert.equal(entrypoint.includes('rust:crate:shared'), true)
+
+    // A set nothing outside Rust reads stays inside the crate lanes.
+    assert.deepEqual(computeTargets(['rust/behavioral_cohorts_migrations/x.sql'], CONTEXT), [
+        'rust:crate:consumer',
+        'rust:crate:shared',
+        'rust:crate:unrelated',
+    ])
 })
 
 test('reverseClosure walks transitively and excludes unrelated nodes', () => {
@@ -722,6 +842,36 @@ test('tool caches beside the products are not products', () => {
     for (const name of ['surveys', 'error_tracking', 'desktop']) {
         assert.equal(isProductDirectory(name), true, name)
     }
+})
+
+// A file at the root of products/ or common/ belongs to no single product or
+// subtree, which used to send it to the full set. Both language families is the
+// honest ceiling: nothing under rust/, nodejs/, or services/ reads any of them.
+test('shared files at the root of products and common claim both language families', () => {
+    const bothFamilies = [
+        'py:core',
+        'py:product:alpha',
+        'py:product:beta',
+        'py:product:gamma',
+        'fe:core',
+        'fe:product:alpha',
+        'fe:product:beta',
+        'fe:product:gamma',
+    ].sort()
+    for (const file of [
+        'products/__init__.py',
+        'products/conftest.py',
+        'products/db_routing.yaml',
+        'products/ruff.toml',
+        'common/__init__.py',
+        // Fixture data a product's Playwright spec loads and a Python recorder
+        // beside it writes.
+        'common/fixtures/ai-multimodal/generation-event.json',
+    ]) {
+        assert.deepEqual(computeTargets([file], CONTEXT), bothFamilies, file)
+    }
+    // An unrecognized subtree of common/ is still unclassified.
+    assert.deepEqual(computeTargets(['common/unrecognized/x.ts'], CONTEXT), EVERYTHING)
 })
 
 test('a product file that is neither backend nor frontend claims both domains', () => {


### PR DESCRIPTION
## Problem

A PR that only edits a rust SQL migration, a repo dotfile, or a file shared by every product gets no parallel lane in the merge queue.
It waits behind every other PR.

- The target computation reports the lanes a PR claims, and Trunk runs two PRs in parallel only when their lane sets are disjoint.
- A path that reaches the end of the rules unclaimed claims all 258 lanes, because a set that is too narrow lets conflicting PRs land side by side.
- 87 of the repository's tracked files reached that fall-through, over four clusters: 49 under `rust/`, 28 at the repository root, 8 under `tools/`, 8 at the root of `products/` and `common/`.

## Changes

Each cluster now has a rule that names the suites reading it. The count of unclaimed files drops from 87 to 8, and the files that claim all 258 lanes drop from 599 to 529.

| Paths | Now claims | Reader |
| --- | --- | --- |
| `rust/persons_migrations/**` | rust crates, python | `posthog/conftest.py` replays these to build the persons database every backend test runs against |
| `rust/cyclotron-node-migrations/**` | rust crates, `node:ingestion` | the cyclotron tables the nodejs CDP consumers read and write |
| `rust/bin/migrate-*` | rust crates, python, node | the sqlx-migrate entrypoints, which apply every migration set |
| `rust/<file>`, `rust/.cargo/`, `rust/.config/` | rust crates | cargo workspace configuration |
| `products/<file>`, `common/<file>`, `common/fixtures/**` | both language families | shared by every product, or read from both sides |
| `.kearc`, `postcss.config.js`, `manage.py`, `dagster_cloud.yaml`, 5 more | one language | single-language toolchain configuration, like `.oxlintrc.json` above them |
| `.gitignore`, `.editorconfig`, `LICENSE`, 9 more | `repo-config` | the existing editor and agent lane. No suite reads any of them |
| `.env*`, `.dockerignore`, `owners.yaml`, 3 more | every lane, by rule | the environment, image context, and ownership data every suite runs on |

> [!NOTE]
> A narrowing here can only be wrong in the direction that breaks master.
> So each rule names the reader that justifies it, rather than inferring a radius from the path.

- A subdirectory of `rust/` that no rule names still widens, so a new one does not silently narrow.
- The 8 files still falling through are the test-selection scripts directly under `tools/`. They decide what runs for every suite, and an existing rule widens them on purpose.
- I (actually Claude) added a `node` domain so the rust rules can name the ingestion lane without pulling in the frontend.

Three calls are worth a reviewer's attention:

- A file directly at `rust/` claims the crate lanes on the reasoning that it configures the cargo workspace. A future non-Rust reader of such a file would break that.
- `rust/cyclotron-node-migrations` claims node but not python. The e2e stack also applies it, which is the residual e2e risk the script already documents.
- `.gitignore` and `.gitattributes` sit in `repo-config`, which assumes no CI check depends on them. The generated-drift checks compare tracked files, so they do not.

## How did you test this code?

- 6 new cases in `.github/scripts/trunk-impacted-targets.test.js`, one per cluster above.
- Each new case catches a rule narrowing a path further than its readers allow. No existing case covered these paths at all.
- The new paths join the existing invariant test that every emitted target appears in the enumerated universe. A target missing there makes a widened PR disjoint from the PR claiming it, which is the silent way this script breaks master.
- I ran the rule set over all 42,927 tracked files to produce the before and after counts above. That is where the 87 and the 8 come from.
- Not run: CI. The literal `ALL` sentinel stays unreachable from any tracked path, which was already true before this change.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) audited the script first, at the request to find which paths still expand to `ALL`, then closed the gaps the audit found.
The audit separated two things that question conflates.
No tracked path reaches the literal `ALL` sentinel, and 599 files widened to the enumerated 258-target set.
Skills invoked: `/writing-pr-descriptions`.

The first plan mapped every root dotfile to its own rule. I collapsed the inert ones onto the existing `repo-config` lane instead, which is what the script already does for `.vscode` and `.claude`.
`rust/owners.yaml` was going to be universal alongside `tools/owners/**`; it takes the rust lanes instead, since it scopes ownership inside that workspace only.
