### PR TITLE
fix(surveys): persist translated back and submit button copy

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -125,31 +125,28 @@ def _normalize_language_code(raw: str) -> str:
     return raw.strip().lower().replace("_", "-")
 
 
-SURVEY_TRANSLATION_ROOT_FIELDS = (
-    "name",
-    "description",
+# Survey-level (non-question) translatable keys, split by where they live on the model:
+# name/description sit on the survey root, the rest on appearance. Every other translation
+# allow-list is derived from these two tuples so they cannot drift apart.
+SURVEY_TRANSLATION_SURVEY_FIELDS = ("name", "description")
+SURVEY_TRANSLATION_APPEARANCE_FIELDS = (
     "thankYouMessageHeader",
     "thankYouMessageDescription",
     "thankYouMessageCloseButtonText",
     "submitButtonText",
     "backButtonText",
 )
+SURVEY_TRANSLATION_ROOT_FIELDS = SURVEY_TRANSLATION_SURVEY_FIELDS + SURVEY_TRANSLATION_APPEARANCE_FIELDS
 
-# Keep this in sync with SurveyAPISerializer's public runtime contract.
-# Root survey description is intentionally excluded because customers have used it for internal notes.
+# Public API emit contract (SurveyAPISerializer). description is excluded because customers
+# have used it for internal notes; deriving it keeps it in lockstep with the write allow-list.
 SURVEY_API_TRANSLATION_FIELDS = frozenset(SURVEY_TRANSLATION_ROOT_FIELDS) - {"description"}
 FIELDS_NOT_APPLICABLE_TO_EXTERNAL_SURVEYS = [
     "linked_flag_id",
     "targeting_flag_filters",
 ]
 SURVEY_TRANSLATION_DRAFT_FIELDS = ("name", "description", "type", "appearance", "questions", "translations")
-SURVEY_TRANSLATION_DRAFT_APPEARANCE_FIELDS = (
-    "thankYouMessageHeader",
-    "thankYouMessageDescription",
-    "thankYouMessageCloseButtonText",
-    "submitButtonText",
-    "backButtonText",
-)
+SURVEY_TRANSLATION_DRAFT_APPEARANCE_FIELDS = SURVEY_TRANSLATION_APPEARANCE_FIELDS
 SURVEY_TRANSLATION_DRAFT_QUESTION_FIELDS = (
     "id",
     "type",

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -125,16 +125,19 @@ def _normalize_language_code(raw: str) -> str:
     return raw.strip().lower().replace("_", "-")
 
 
+SURVEY_TRANSLATION_ROOT_FIELDS = (
+    "name",
+    "description",
+    "thankYouMessageHeader",
+    "thankYouMessageDescription",
+    "thankYouMessageCloseButtonText",
+    "submitButtonText",
+    "backButtonText",
+)
+
 # Keep this in sync with SurveyAPISerializer's public runtime contract.
 # Root survey description is intentionally excluded because customers have used it for internal notes.
-SURVEY_API_TRANSLATION_FIELDS = frozenset(
-    [
-        "name",
-        "thankYouMessageHeader",
-        "thankYouMessageDescription",
-        "thankYouMessageCloseButtonText",
-    ]
-)
+SURVEY_API_TRANSLATION_FIELDS = frozenset(SURVEY_TRANSLATION_ROOT_FIELDS) - {"description"}
 FIELDS_NOT_APPLICABLE_TO_EXTERNAL_SURVEYS = [
     "linked_flag_id",
     "targeting_flag_filters",
@@ -144,6 +147,8 @@ SURVEY_TRANSLATION_DRAFT_APPEARANCE_FIELDS = (
     "thankYouMessageHeader",
     "thankYouMessageDescription",
     "thankYouMessageCloseButtonText",
+    "submitButtonText",
+    "backButtonText",
 )
 SURVEY_TRANSLATION_DRAFT_QUESTION_FIELDS = (
     "id",
@@ -209,6 +214,10 @@ class GeneratedSurveyRootTranslationSerializer(serializers.Serializer):
     thankYouMessageCloseButtonText = serializers.CharField(
         required=False, allow_blank=True, help_text="Translated thank-you close button text."
     )
+    submitButtonText = serializers.CharField(
+        required=False, allow_blank=True, help_text="Translated submit button label."
+    )
+    backButtonText = serializers.CharField(required=False, allow_blank=True, help_text="Translated back button label.")
 
 
 class GeneratedSurveyQuestionTranslationSerializer(serializers.Serializer):
@@ -1108,13 +1117,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
                 raise serializers.ValidationError(f"Translation for '{raw_lang_code}' must be an object")
 
             cleaned_translation: dict[str, str] = {}
-            for field in [
-                "name",
-                "description",
-                "thankYouMessageHeader",
-                "thankYouMessageDescription",
-                "thankYouMessageCloseButtonText",
-            ]:
+            for field in SURVEY_TRANSLATION_ROOT_FIELDS:
                 if field in translation_data:
                     if not isinstance(translation_data[field], str):
                         raise serializers.ValidationError(

--- a/products/surveys/backend/api/test/test_external_surveys.py
+++ b/products/surveys/backend/api/test/test_external_surveys.py
@@ -196,6 +196,8 @@ class TestExternalSurveys(APIBaseTest):
                     "thankYouMessageHeader": "Gracias",
                     "thankYouMessageDescription": "Agradecemos tus comentarios",
                     "thankYouMessageCloseButtonText": "Cerrar",
+                    "submitButtonText": "Enviar",
+                    "backButtonText": "Atrás",
                 },
                 "fr": {
                     "description": "SENSITIVE: Description interne uniquement",
@@ -234,6 +236,8 @@ class TestExternalSurveys(APIBaseTest):
                 "thankYouMessageHeader": "Gracias",
                 "thankYouMessageDescription": "Agradecemos tus comentarios",
                 "thankYouMessageCloseButtonText": "Cerrar",
+                "submitButtonText": "Enviar",
+                "backButtonText": "Atrás",
             }
         }
         assert survey_data["questions"][0]["translations"]["es"] == {

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -33,11 +33,14 @@ from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.product_analytics.backend.models.insight import Insight
 from products.product_tours.backend.models import ProductTour
 from products.surveys.backend.api.survey import (
+    SURVEY_API_TRANSLATION_FIELDS,
+    GeneratedSurveyRootTranslationSerializer,
     get_survey_api_translations,
     get_surveys_response,
     nh3_clean_with_allow_list,
 )
 from products.surveys.backend.models import MAX_ITERATION_COUNT, Survey, SurveyResponseArchive
+from products.surveys.backend.translation import SurveyRootTranslation
 
 from ee.models.rbac.access_control import AccessControl
 
@@ -3652,6 +3655,20 @@ class TestSurvey(APIBaseTest):
 
         assert results
         assert all("search_match_type" not in r for r in results)
+
+
+class TestSurveyTranslationFieldContracts(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("generated_response_serializer", set(GeneratedSurveyRootTranslationSerializer().fields)),
+            ("llm_output_model", set(SurveyRootTranslation.model_fields)),
+        ]
+    )
+    def test_root_translation_schemas_match_public_api_fields(self, _name, declared_fields):
+        # These two schemas are hand-declared, so they can silently drift from the derived
+        # allow-lists. This locks them to SURVEY_API_TRANSLATION_FIELDS: adding a translatable
+        # survey field without updating them (the omission that dropped the button labels) fails here.
+        assert declared_fields == SURVEY_API_TRANSLATION_FIELDS
 
 
 class TestMultipleChoiceQuestions(APIBaseTest):

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -122,6 +122,8 @@ class TestSurvey(APIBaseTest):
                     "es": {
                         "name": "Encuesta de comentarios",
                         "description": "Ayúdanos a mejorar",
+                        "submitButtonText": "Enviar",
+                        "backButtonText": "Atrás",
                     },
                     "fr": {
                         "name": "Enquête de satisfaction",
@@ -138,6 +140,8 @@ class TestSurvey(APIBaseTest):
         assert survey.translations is not None
         assert survey.translations["es"]["name"] == "Encuesta de comentarios"
         assert survey.translations["fr"]["name"] == "Enquête de satisfaction"
+        assert survey.translations["es"]["submitButtonText"] == "Enviar"
+        assert survey.translations["es"]["backButtonText"] == "Atrás"
 
         # Verify inline question translations
         questions = cast(list[dict[str, Any]], survey.questions)

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -1948,6 +1948,10 @@ export interface GeneratedSurveyRootTranslationApi {
     thankYouMessageDescription?: string
     /** Translated thank-you close button text. */
     thankYouMessageCloseButtonText?: string
+    /** Translated submit button label. */
+    submitButtonText?: string
+    /** Translated back button label. */
+    backButtonText?: string
 }
 
 /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -34841,6 +34841,10 @@ export namespace Schemas {
       thankYouMessageDescription?: string;
       /** Translated thank-you close button text. */
       thankYouMessageCloseButtonText?: string;
+      /** Translated submit button label. */
+      submitButtonText?: string;
+      /** Translated back button label. */
+      backButtonText?: string;
     }
 
     /**


### PR DESCRIPTION
## Problem

Someone who translates a survey's **Back** button into another language sees the field empty again after they save and reopen the survey.

- The base-language label sticks, because it lives on `appearance` rather than in `translations`.
- The survey write path accepted only five translation keys. `backButtonText` and `submitButtonText` were not among them, so it dropped them on every save.
- The editor and the AI translation generator both produce those keys, so the gap was only in the API.
- Respondents still see a working Back button in every language. It falls back to the base label.

## Changes

- `SURVEY_TRANSLATION_ROOT_FIELDS` now lists every translatable root field, and the write path validates against that one list.
- The public survey payload now carries both button keys. It still omits `description`, which customers use for internal notes.
- The AI translation draft now includes both source labels, so a generated translation can cover them.
- Regenerated frontend and MCP types pick up the two new response fields.
- No backfill is needed. The dropped values never reached the database.

No UI changed, so there is no screenshot.

## How did you test this code?

- I extended `test_can_create_survey_with_translations`. It catches the write path dropping button copy. No existing test asserted that a button key survives a save.
- I extended `test_safe_translations_are_exposed_without_survey_description`. It catches the public payload dropping button copy.
- I ran the `products/surveys/backend` suite against a Postgres and ClickHouse I stood up in the sandbox, and it passes.
- Not checked: SDK rendering. That code lives in `posthog-js`, and I did not reproduce the original report in a browser.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None. No doc lists the translatable survey fields.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually the PostHog Slack app, running Claude) traced a report of unsaved survey translations to the API write path, rather than to the editor where it was first suspected. I checked the editor wiring and the AI translation generator first; both already emit the button keys, which narrowed the fix to the allow-lists in `products/surveys/backend/api/survey.py`.

I found four places the button keys were missing, not one: the write validator, the public emit list, the AI draft payload, and the generated-translation response schema. Fixing only the write path would have persisted the values without shipping them to clients.

Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-pr-descriptions`.

The originating material was a customer support conversation. Nothing from it appears in this diff or description: the test data uses invented Portuguese and Spanish strings, and the problem is described in product terms only.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1786120455487389)*
