### PR TITLE
perf(error-tracking): drop duplicate symbol set index, lower cleanup concurrency

### DIFF
--- a/products/error_tracking/backend/migrations/0022_drop_redundant_symbolset_team_ref_idx.py
+++ b/products/error_tracking/backend/migrations/0022_drop_redundant_symbolset_team_ref_idx.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+from posthog.migration_helpers import SafeRemoveIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index drops cannot run inside a transaction.
+    atomic = False
+
+    dependencies = [
+        (
+            "error_tracking",
+            "0021_remove_errortrackingsettings_autocapture_exceptions_opt_in",
+        ),
+    ]
+
+    operations = [
+        # Duplicates `unique_ref_per_team` on the same (team_id, ref) columns. The unique
+        # constraint serves every scan the workload issues against those columns, so the
+        # only thing this index still costs is write amplification and ~106 GB.
+        SafeRemoveIndexConcurrently(
+            model_name="errortrackingsymbolset",
+            name="posthog_err_team_id_927574_idx",
+        ),
+    ]

--- a/products/error_tracking/backend/migrations/max_migration.txt
+++ b/products/error_tracking/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0021_remove_errortrackingsettings_autocapture_exceptions_opt_in
+0022_drop_redundant_symbolset_team_ref_idx

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -368,8 +368,9 @@ class ErrorTrackingSymbolSet(UUIDTModel):
             delete_symbol_set_contents(storage_ptr)
 
     class Meta:
+        # No (team_id, ref) index here on purpose: `unique_ref_per_team` below already
+        # provides one on the same columns, so a second is pure write and storage cost.
         indexes = [
-            models.Index(fields=["team_id", "ref"]),
             # Composite covers the cleanup filter's two OR branches: `last_used < cutoff`
             # (leading column) and `last_used IS NULL AND created_at < cutoff` (NULL group
             # then created_at range), so batch cleanup avoids a full PK-ordered scan.

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/test/test_symbol_set_cleanup.py
@@ -205,7 +205,7 @@ class TestSymbolSetCleanupWorkflow:
             delete_unused=True,
             total_per_run=1000000,
             batch_size=10000,
-            parallelism=8,
+            parallelism=4,
             dry_run=False,
         )
 

--- a/products/error_tracking/backend/temporal/symbol_set_cleanup/types.py
+++ b/products/error_tracking/backend/temporal/symbol_set_cleanup/types.py
@@ -7,7 +7,10 @@ class SymbolSetCleanupInputs:
     delete_unused: bool = True
     total_per_run: int = 1000000
     batch_size: int = 10000
-    parallelism: int = 8
+    # Workers contend rather than divide: they take `FOR UPDATE SKIP LOCKED` over the same
+    # ordered range, so each one pays the full traversal and skips what the others hold.
+    # `total_per_run` caps throughput regardless, so fewer workers spend less to reach it.
+    parallelism: int = 4
     dry_run: bool = False
 
 


### PR DESCRIPTION
## Problem

The symbol set table carries two identical indexes on the same columns, so every write pays for both and only one is ever used. The cleanup job on that table also runs more workers than it can use: they all scan the same range and skip past each other's rows instead of splitting the work.

## Changes

- Drop the duplicate index on `(team_id, ref)`. The unique constraint on those columns already covers every lookup it served.
- Remove it from `ErrorTrackingSymbolSet.Meta` too, so it does not get regenerated.
- Lower the cleanup job's worker count from 8 to 4. The per-run row budget is unchanged, so it still deletes the same amount with less duplicated scanning.

The drop uses `SafeRemoveIndexConcurrently`, so it blocks no reads or writes. It can take several minutes to acquire, which is expected.

## How did you test this code?

- `hogli test products/error_tracking/backend/temporal/symbol_set_cleanup/`
- `sqlmigrate` confirms `DROP INDEX CONCURRENTLY`; `makemigrations --check` shows no drift; the risk analyzer rates it `Safe`.
- Updated the one test that pins the worker count. No new tests: this removes an index and lowers a constant.
- Not done: no run against a production-sized table.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Skills invoked: `/django-migrations`, `/stacking-prs`, `/writing-pr-descriptions`.

I (actually Claude) found the duplicate index while looking at an unrelated query on the same database. I also proposed rewriting the cleanup query, then dropped it: the measured gain was smaller than expected and it relied on row ordering that nothing guarantees. Eli set the scope and the worker count.
