### PR TITLE
chore(error-tracking): lower symbol set autovacuum trigger threshold

### DIFF
--- a/products/error_tracking/backend/migrations/0023_symbolset_autovacuum_scale_factor.py
+++ b/products/error_tracking/backend/migrations/0023_symbolset_autovacuum_scale_factor.py
@@ -19,11 +19,11 @@ class Migration(migrations.Migration):
             sql=[
                 # Fail fast rather than queue: this waits behind an in-progress autovacuum
                 # on the same table, and a retry is cheaper than holding the lock request.
-                "SET lock_timeout = '5s'",
+                "SET LOCAL lock_timeout = '5s'",
                 f"ALTER TABLE {TABLE} SET (autovacuum_vacuum_scale_factor = {SCALE_FACTOR})",
             ],
             reverse_sql=[
-                "SET lock_timeout = '5s'",
+                "SET LOCAL lock_timeout = '5s'",
                 f"ALTER TABLE {TABLE} RESET (autovacuum_vacuum_scale_factor)",
             ],
         ),

--- a/products/error_tracking/backend/migrations/0023_symbolset_autovacuum_scale_factor.py
+++ b/products/error_tracking/backend/migrations/0023_symbolset_autovacuum_scale_factor.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+# The table inherits the global autovacuum_vacuum_scale_factor of 0.1. At its current row
+# count that means autovacuum waits for tens of millions of dead tuples before running, so
+# the table carries a large steady-state bloat load from its delete and update churn.
+# 0.02 is a deliberately conservative first step: it lowers the trigger enough to matter
+# while keeping the extra vacuum passes affordable on a table with six indexes.
+TABLE = "posthog_errortrackingsymbolset"
+SCALE_FACTOR = 0.02
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("error_tracking", "0022_drop_redundant_symbolset_team_ref_idx"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                # Fail fast rather than queue: this waits behind an in-progress autovacuum
+                # on the same table, and a retry is cheaper than holding the lock request.
+                "SET lock_timeout = '5s'",
+                f"ALTER TABLE {TABLE} SET (autovacuum_vacuum_scale_factor = {SCALE_FACTOR})",
+            ],
+            reverse_sql=[
+                "SET lock_timeout = '5s'",
+                f"ALTER TABLE {TABLE} RESET (autovacuum_vacuum_scale_factor)",
+            ],
+        ),
+    ]

--- a/products/error_tracking/backend/migrations/max_migration.txt
+++ b/products/error_tracking/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0022_drop_redundant_symbolset_team_ref_idx
+0023_symbolset_autovacuum_scale_factor


### PR DESCRIPTION
## Problem

Autovacuum almost never runs on the symbol set table. Its trigger scales with table size, and the table is big enough that the threshold lands in the tens of millions of dead rows. Meanwhile the table takes constant deletes from the cleanup job and constant updates from symbol resolution, so it stays bloated between runs.

Second layer of a stack. #79780 drops a duplicate index on the same table, which makes each vacuum pass cheaper.

## Changes

- Make autovacuum trigger 5x sooner on this table (scale factor 0.1 to 0.02).
- Fail fast rather than queue if a vacuum is already running.
- Reversible: rolling back restores the inherited default.

The value is a conservative first step, not a tuned optimum. Watch dead-row counts and vacuum duration for a week before going further, and revert if vacuum load costs more than the bloat it removes.

## How did you test this code?

- `sqlmigrate` renders the expected `ALTER TABLE`; the risk analyzer reports nothing blocked.
- No tests: this changes a storage parameter and adds no behavior to assert.
- Not done: I could not measure the effect first. That needs autovacuum timings from the Postgres logs, which I could not read, so I picked the value from the trigger arithmetic and kept it cautious.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Skills invoked: `/django-migrations`, `/stacking-prs`, `/writing-pr-descriptions`.

I (actually Claude) first argued this setting was the main cause of a slow query on the same table. A follow-up measurement did not back that up, so the case here is narrower: bloat control on a high-churn table. Eli asked for it as its own PR so it can be reverted on its own, which fits that uncertainty.
