### PR TITLE
fix(data-imports): treat missing delta_log checkpoint as a transient race, not a bug

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/errors.py
@@ -88,14 +88,18 @@ def is_transient_delta_maintenance_error(error: BaseException) -> bool:
     if any(needle in text for needle in TRANSIENT_DELTA_MAINTENANCE_ERRORS):
         return True
 
-    # The same race can also take a transaction-log commit file, not just a data file: `reset_table`
-    # (full_refresh) purges the whole table prefix, `_delta_log` included, out from under a still-running
-    # maintenance pass that opened the table before the purge landed. Neither `vacuum()` nor
-    # `optimize.compact()` ever deletes a `_delta_log/*.json` commit file itself, so a missing one here
-    # means something else raced the read rather than the table being corrupt. Matched on the log
-    # directory specifically rather than on "File not found" alone, which a genuinely missing data file
-    # or a truly corrupt table can also raise, and those stay captured.
-    return "File not found" in text and "_delta_log/" in text
+    # The same race can also take a transaction-log commit file or checkpoint, not just a data file:
+    # `reset_table` (full_refresh) purges the whole table prefix, `_delta_log` included, out from under
+    # a still-running maintenance pass that opened the table before the purge landed — or out from under
+    # a concurrent `DeltaTableRef.get_delta_table()` open reading `_last_checkpoint` and then fetching the
+    # checkpoint file it points to. Neither `vacuum()` nor `optimize.compact()` ever deletes a
+    # `_delta_log/*.json` commit file or a `*.checkpoint.parquet` itself, so a missing one here means
+    # something else raced the read rather than the table being corrupt. Matched on the log directory
+    # specifically rather than on "not found" alone, which a genuinely missing data file or a truly
+    # corrupt table can also raise, and those stay captured. Covers both delta-rs's older
+    # `FileNotFoundError`-style message ("File not found: ...") and its Arrow/object_store kernel message
+    # for the same underlying condition ("Object at location ... not found: ... 404 Not Found").
+    return "_delta_log/" in text and "not found" in text
 
 
 # `optimize.compact` bins files to rewrite by their on-disk (compressed) size, targeting

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/table.py
@@ -18,6 +18,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.errors import (
     TransientObjectStoreError,
+    is_transient_delta_maintenance_error,
     is_transient_object_store_error,
 )
 
@@ -163,14 +164,16 @@ class DeltaTableRef:
 
     async def _capture_unless_transient(self, e: Exception) -> None:
         """capture_exception unless `e` is a known-transient object-store blip (see
-        is_transient_object_store_error) — those recover on retry and aren't a defect, so reporting
-        them to error tracking is just noise. A transient blip is re-raised as
-        TransientObjectStoreError instead of letting the original propagate: the activity
-        interceptor reports any uncaught activity exception unless it's a NonReportableError, so a
-        bare re-raise here would still mint a fresh issue at that boundary. Never suppresses the
-        re-raise itself, so Temporal's activity retry policy is unaffected either way.
+        is_transient_object_store_error) or a concurrent-purge race on `_delta_log` (see
+        is_transient_delta_maintenance_error — the open below can lose that same race a maintenance
+        pass can) — those recover on retry and aren't a defect, so reporting them to error tracking
+        is just noise. A transient blip is re-raised as TransientObjectStoreError instead of letting
+        the original propagate: the activity interceptor reports any uncaught activity exception
+        unless it's a NonReportableError, so a bare re-raise here would still mint a fresh issue at
+        that boundary. Never suppresses the re-raise itself, so Temporal's activity retry policy is
+        unaffected either way.
         """
-        if is_transient_object_store_error(e):
+        if is_transient_object_store_error(e) or is_transient_delta_maintenance_error(e):
             await self._logger.awarning(f"get_delta_table: transient object-store error, not reporting: {e}")
             raise TransientObjectStoreError(str(e)) from e
         capture_exception(e)
@@ -236,7 +239,9 @@ class DeltaTableRef:
         OOM-crashed merge — after which every sync fails to open the table and loops. Non-destructive:
         only attempts an open (bypassing the get_delta_table cache). A table that simply doesn't exist is
         not corrupt; an unknown open error is not classified as corrupt, so a transient failure never
-        triggers a destructive revive.
+        triggers a destructive revive. A recognized transient blip (see is_transient_object_store_error,
+        is_transient_delta_maintenance_error) is excluded the same way — otherwise a concurrent purge
+        racing this open would misread as corruption and trigger a needless destructive revive.
         """
         delta_uri = await self._get_delta_table_uri()
         storage_options = self._get_credentials()
@@ -250,7 +255,9 @@ class DeltaTableRef:
         try:
             await asyncio.to_thread(deltalake.DeltaTable, table_uri=delta_uri, storage_options=storage_options)
             return False
-        except (deltalake.exceptions.DeltaError, FileNotFoundError):
+        except (deltalake.exceptions.DeltaError, FileNotFoundError) as e:
+            if is_transient_object_store_error(e) or is_transient_delta_maintenance_error(e):
+                return False
             return True
         except Exception:
             return False

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_delta_errors.py
@@ -99,8 +99,21 @@ class TestIsTransientDeltaMaintenanceError:
                 ),
                 True,
             ),
-            # "File not found" outside the log directory must not match, because a data file missing for
-            # some other reason is a real failure to capture, not this specific log-commit race.
+            # The same race can take a checkpoint instead of a commit JSON, surfaced through delta-rs's
+            # Arrow/object_store kernel message shape (a plain 404/NoSuchKey GET failure) rather than the
+            # older "File not found: ..." shape above — both mean the same thing when scoped to `_delta_log/`.
+            (
+                "missing_delta_log_checkpoint_object_store_kernel_message",
+                deltalake.exceptions.DeltaError(
+                    "Kernel error: Arrow error: External: Object at location "
+                    "dlt/team_1_source_2/table/_delta_log/00000000000000000099.checkpoint.parquet not found: "
+                    "Error performing GET https://s3.example.com/bucket/.../00000000000000000099.checkpoint.parquet "
+                    "in 10.9ms - Server returned non-2xx status code: 404 Not Found: NoSuchKey"
+                ),
+                True,
+            ),
+            # "not found" outside the log directory must not match, because a data file missing for some
+            # other reason is a real failure to capture, not this specific log-commit race.
             ("file_not_found_outside_delta_log", deltalake.exceptions.DeltaError("File not found: some/file"), False),
             # Other DeltaErrors are real failures (e.g. a genuinely corrupt log) and must still be captured.
             ("unrelated_delta_error", deltalake.exceptions.DeltaError("no protocol found in delta log"), False),

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta/test/test_table.py
@@ -213,6 +213,40 @@ class TestGetDeltaTableUnrecoverableErrors:
             cast(AsyncMock, table_ref._logger.awarning).assert_awaited_once()
             assert table_ref.is_first_sync is False
 
+    @pytest.mark.asyncio
+    async def test_open_transient_delta_log_race_is_not_captured_but_still_reraised(self):
+        """A concurrent `reset_table` purge (a full_refresh sync, or this same open racing another
+        attempt) can take a `_delta_log` checkpoint file out from under this open between `_last_checkpoint`
+        pointing to it and delta-rs fetching it, surfacing as a DeltaError for a missing checkpoint object
+        (see is_transient_delta_maintenance_error). That's not table corruption, so it must not be
+        captured or trigger the unrecoverable-table wipe — it must propagate as TransientObjectStoreError
+        so Temporal retries the sync."""
+        table_ref = DeltaTableRef(resource_name="t", job=MagicMock(), logger=make_logger())
+        delta_uri = "s3://bucket/team_id/job_id/t"
+
+        checkpoint_race_error = deltalake.exceptions.DeltaError(
+            "Kernel error: Arrow error: External: Object at location "
+            "dlt/team_1_source_2/table/_delta_log/00000000000000000099.checkpoint.parquet not found: "
+            "Error performing GET https://s3.example.com/... - Server returned non-2xx status code: "
+            "404 Not Found: NoSuchKey"
+        )
+        module = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table"
+        with (
+            patch.object(table_ref, "_get_delta_table_uri", AsyncMock(return_value=delta_uri)),
+            patch(f"{module}.deltalake.DeltaTable") as mock_delta_table,
+            patch(f"{module}._purge_s3_prefix", AsyncMock()) as mock_purge,
+            patch(f"{module}.capture_exception") as mock_capture,
+        ):
+            mock_delta_table.is_deltatable.return_value = True
+            mock_delta_table.side_effect = checkpoint_race_error
+
+            with pytest.raises(TransientObjectStoreError):
+                await table_ref.get_delta_table()
+
+            mock_capture.assert_not_called()
+            mock_purge.assert_not_awaited()
+            assert table_ref.is_first_sync is False
+
 
 class TestIsTableCorrupted:
     _MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta.table"
@@ -230,6 +264,20 @@ class TestIsTableCorrupted:
             ("delta_error_is_corrupt", True, deltalake.exceptions.DeltaError("no protocol"), True),
             ("file_not_found_is_corrupt", True, FileNotFoundError("missing data file"), True),
             ("unknown_error_not_corrupt", True, ValueError("transient"), False),
+            # A concurrent purge racing this same open (see is_transient_delta_maintenance_error) is a
+            # DeltaError too, but must not read as corrupt — that would trigger a needless destructive
+            # revive (full non-billable resync) for what a plain retry would have resolved on its own.
+            (
+                "transient_delta_log_race_not_corrupt",
+                True,
+                deltalake.exceptions.DeltaError(
+                    "Kernel error: Arrow error: External: Object at location "
+                    "dlt/team_1_source_2/table/_delta_log/00000000000000000099.checkpoint.parquet not found: "
+                    "Error performing GET https://s3.example.com/... - Server returned non-2xx status code: "
+                    "404 Not Found: NoSuchKey"
+                ),
+                False,
+            ),
         ]
     )
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A data warehouse sync can fail with a DeltaError when a table open races a concurrent full-refresh purge, even though a plain retry would succeed. That race also gets misread by the corruption check as a broken table, which can trigger a needless full, non-billable resync of a table that was never broken.

Seen in production: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdd42-d1ef-7bd2-a89e-ab00e938f334), a single occurrence during a Stripe sync, failing inside shared Delta pipeline code rather than the source connector.

## Changes

- `_purge_s3_prefix`'s full-refresh reset can delete a table's `_delta_log` checkpoint file between `get_delta_table()` reading `_last_checkpoint` and fetching the checkpoint it points to.
- delta-rs surfaces that as a `DeltaError` from its Arrow/object_store kernel (a plain 404/`NoSuchKey` GET failure). The pipeline already recognized this same class of race for maintenance operations (vacuum/optimize), but only when the message used delta-rs's older `FileNotFoundError`-style text, not this kernel message shape.
- `is_transient_delta_maintenance_error` (`errors.py`) now matches both message shapes.
- `get_delta_table` (`table.py`) treats the race as transient: it logs a warning and retries via `TransientObjectStoreError` instead of reporting it to error tracking.
- `is_table_corrupted` (`table.py`) excludes the same race from its corruption check, so it can no longer trigger a destructive revive.

## How did you test this code?

- Added a case to `test_delta_errors.py`'s parameterized suite covering the Arrow/object_store kernel message shape for a missing checkpoint file, and asserted the older shape and out-of-log-directory cases still hold.
- Added a regression test in `test_table.py` asserting `get_delta_table` re-raises this race as `TransientObjectStoreError` without calling `capture_exception` or wiping the table.
- Added a parameterized case to `TestIsTableCorrupted` asserting the race is not classified as corrupt.
- Ran the full `delta` package test suite (184 tests) and a repo-wide `mypy --cache-fine-grained .`; both clean.
- Confirmed no open human-authored PR already fixes this (searched by exception type, module path, and the maintainer's own open PRs).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal pipeline error-classification fix, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue details, sampled event, stack trace) to confirm the exact failing frame and message shape, then read the shared Delta pipeline code (`errors.py`, `table.py`, `maintenance.py`, `ops.py`) to find the existing precedent for classifying concurrent-purge races as transient. No skills from this repo's skill set were invoked for the fix itself; `/writing-tests` and `/writing-pr-descriptions` were invoked before adding tests and writing this description, per this repo's CLAUDE.md.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*