### PR TITLE
fix(data-imports): retry postgres connects that fail as "connection is bad" with no detail

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -257,6 +257,17 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # retry must catch it. Match the stable prefix + reason and leave pgcat's non-transient reasons
     # (e.g. BadConfig) to surface.
     "could not get connection from the pool - allserversdown",
+    # psycopg's own message when `PQconnectStart` reports the connection BAD before the handshake
+    # ever begins and libpq has no server-reported error text to attach (see
+    # `psycopg.generators._connect` / `psycopg.pq.misc._clean_error_message`). Unlike every other
+    # connect-time failure — which completes enough of the protocol to get an actual message, e.g.
+    # "FATAL: password authentication failed" — this one is a purely local failure before any bytes
+    # reach the network, typically the worker running out of a local resource needed to open a new
+    # socket (file descriptors, ephemeral ports). Transient: the condition clears once the worker's
+    # resource pressure eases, so a fresh connect attempt after backoff usually succeeds. The literal
+    # "no error details available" suffix is the signal — libpq only omits the message in this local,
+    # pre-handshake case, so it never matches a genuine (and permanent) server-reported rejection.
+    "connection is bad: no error details available",
 )
 
 # Supavisor (Supabase's connection pooler) doesn't surface a dropped upstream connection with a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1670,6 +1670,11 @@ class TestIsConnectionDroppedError:
             # Supavisor XX000 InternalError_ codes above. Transient — a banned server rejoins on a
             # passing health check or once its ban expires — so the reconnect must catch it.
             psycopg.errors.SystemError("could not get connection from the pool - AllServersDown"),
+            # psycopg's own message when `PQconnectStart` reports the connection BAD before the
+            # handshake begins and libpq has no server-reported error text to attach — a purely
+            # local pre-handshake failure (e.g. the worker briefly out of file descriptors), not a
+            # server-side rejection. Transient; the reconnect must catch it.
+            psycopg.OperationalError("connection is bad: no error details available"),
         ],
     )
     def test_connection_dropped_errors_are_detected(self, error):
@@ -1702,6 +1707,10 @@ class TestIsConnectionDroppedError:
             # transient Erlang-tuple "{:error, :econnrefused}" — broadening the match to a plain
             # "refused" substring would wrongly retry it.
             psycopg.OperationalError('connection to server at "10.0.0.1", port 5432 failed: Connection refused'),
+            # A "connection is bad" failure that *does* carry a server-reported detail is a genuine,
+            # permanent rejection — only the "no error details available" variant (a purely local,
+            # pre-handshake failure) is transient, so the match must not broaden to the bare prefix.
+            psycopg.OperationalError("connection is bad: FATAL: password authentication failed"),
         ],
     )
     def test_unrelated_errors_are_not_detected(self, error):


### PR DESCRIPTION
## Problem

A Postgres source sync fails and gets captured in [error tracking](https://us.posthog.com/project/2/error_tracking/019fdd5d-f2d3-77a1-81a1-22523fa39fea) with `OperationalError: connection is bad: no error details available`, raised in `_connect_with_options_fallback` while opening a fresh read connection.

psycopg raises this specific message only when libpq reports the connection `BAD` before the handshake starts and has no server-reported error text to attach - a local, pre-handshake failure (most likely the worker briefly out of file descriptors or another local resource), not a rejection from the source database. The existing connect-time retry only recognises drops that complete enough of the protocol to carry an actual message (auth failures, dead sockets, pooler refusals), so this one falls straight through to a full Temporal activity retry instead of the lightweight in-process reconnect every other transient drop gets.

## Changes

- Add the exact `"connection is bad: no error details available"` message to the transient connection-dropped signatures in `postgres.py`, so `_connect_with_dropped_retry` retries it in-process with backoff.
- The match is on the full message, not a `"connection is bad"` prefix, since a genuine server-reported detail on that prefix (e.g. an auth failure) is a permanent error and must keep failing fast.

## How did you test this code?

Added two cases to `TestIsConnectionDroppedError` in `test_postgres.py`:
- a positive case confirming the new message is now classified as a transient drop
- a negative case confirming a `"connection is bad: <detail>"` message with an actual server-reported detail stays unmatched, guarding against loosening the match to the bare prefix

Ran the full `TestIsConnectionDroppedError` class and the broader connect-retry test groups in `test_postgres.py` locally - all pass except two pre-existing tests that need a live Postgres test database not available in this sandbox (unrelated to this change; they fail identically on master).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error classification only, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from the error-tracking issue linked above: pulled the issue, its stack trace and `code_variables`, traced the exception to `_connect_with_options_fallback` in `postgres.py`, and confirmed against the installed psycopg source (`generators.py` / `pq/misc.py`) exactly when it raises this message. Invoked `/writing-tests` before adding test cases and `/writing-pr-descriptions` before writing this body. Searched open PRs (excluding the bot account) and the maintainer's own open PRs for a prior fix; found none addressing this exact classification.