### PR TITLE
fix(data-imports): close the s3 client used to size a synced table

### DIFF
--- a/products/data_warehouse/backend/s3.py
+++ b/products/data_warehouse/backend/s3.py
@@ -12,7 +12,7 @@ import botocore.exceptions
 from products.data_warehouse.backend.s3_proxy import boto_proxy_config_kwargs
 
 
-def get_s3_client(*, endpoint_url: Optional[str] = None):
+def get_s3_client(*, endpoint_url: Optional[str] = None, skip_instance_cache: bool = False):
     # Defaults for localhost dev and test suites
     if settings.USE_LOCAL_SETUP:
         return s3fs.S3FileSystem(
@@ -29,8 +29,18 @@ def get_s3_client(*, endpoint_url: Optional[str] = None):
     # why a caller-supplied endpoint_url keeps its traffic on it. endpoint_url is only forwarded when
     # set: fsspec's instance cache keys on the literal kwargs, so passing endpoint_url=None explicitly
     # would split the shared cached client into a second instance.
+    #
+    # fsspec's instance cache also keys on the calling thread id, so callers invoked from a thread
+    # pool (e.g. Temporal's sync-activity executor) get one cached, never-evicted S3FileSystem per
+    # thread instead of the single shared instance the caching comment above assumes. skip_instance_cache
+    # opts a caller out of that cache entirely for one-off calls where a leaked-forever cache entry
+    # (and the open sockets/file handles it holds) isn't worth the connection-reuse it'd otherwise buy.
     extra = {"endpoint_url": endpoint_url} if endpoint_url is not None else {}
-    return s3fs.S3FileSystem(config_kwargs=boto_proxy_config_kwargs(endpoint_url=endpoint_url), **extra)
+    return s3fs.S3FileSystem(
+        config_kwargs=boto_proxy_config_kwargs(endpoint_url=endpoint_url),
+        skip_instance_cache=skip_instance_cache,
+        **extra,
+    )
 
 
 @contextlib.asynccontextmanager
@@ -87,15 +97,21 @@ async def aget_s3_client(*, fresh_instance: bool = False, endpoint_url: Optional
 
 
 def get_size_of_folder(path: str) -> float:
-    s3 = get_s3_client()
+    # skip_instance_cache: this runs from Temporal's sync-activity thread pool, so the shared
+    # fsspec cache (keyed by thread id, see get_s3_client) would otherwise leak one S3FileSystem
+    # per calling thread forever. A one-off client, closed below, avoids that.
+    s3 = get_s3_client(skip_instance_cache=True)
 
-    files = s3.find(path, detail=True)
-    file_values = files.values() if isinstance(files, dict) else files
+    try:
+        files = s3.find(path, detail=True)
+        file_values = files.values() if isinstance(files, dict) else files
 
-    total_bytes = sum(f["Size"] for f in file_values if f["type"] != "directory")
-    total_mib = total_bytes / (1024 * 1024)
-
-    return total_mib
+        total_bytes = sum(f["Size"] for f in file_values if f["type"] != "directory")
+        return total_bytes / (1024 * 1024)
+    finally:
+        with contextlib.suppress(Exception):
+            if s3._s3 is not None:
+                s3fs.S3FileSystem.close_session(s3.loop, s3._s3creator)
 
 
 def ensure_bucket_exists(s3_url: str, s3_key: str, s3_secret: str, s3_endpoint: Optional[str] = None) -> None:

--- a/products/data_warehouse/backend/tests/test_s3.py
+++ b/products/data_warehouse/backend/tests/test_s3.py
@@ -4,7 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import SimpleTestCase, override_settings
 
-from products.data_warehouse.backend.s3 import aget_s3_client
+from parameterized import parameterized
+
+from products.data_warehouse.backend.s3 import aget_s3_client, get_size_of_folder
 
 
 class TestAgetS3Client(SimpleTestCase):
@@ -29,3 +31,44 @@ class TestAgetS3Client(SimpleTestCase):
 
         fake_s3._s3creator.__aexit__.assert_awaited_once_with(None, None, None)
         fake_s3._s3.close.assert_not_awaited()
+
+
+class TestGetSizeOfFolder(SimpleTestCase):
+    def _mock_s3(self) -> MagicMock:
+        s3 = MagicMock()
+        s3.find.return_value = {
+            "bucket/path/a.parquet": {"Size": 2 * 1024 * 1024, "type": "file"},
+            "bucket/path/": {"Size": 0, "type": "directory"},
+        }
+        s3._s3 = MagicMock()
+        return s3
+
+    @patch("products.data_warehouse.backend.s3.s3fs.S3FileSystem.close_session")
+    @patch("products.data_warehouse.backend.s3.get_s3_client")
+    def test_requests_an_uncached_client_and_computes_size(self, mock_get_s3_client, mock_close_session):
+        # This runs from Temporal's sync-activity thread pool. A shared (thread-keyed) client
+        # would leak one S3FileSystem per calling thread forever; skip_instance_cache=True is
+        # what avoids that.
+        mock_get_s3_client.return_value = self._mock_s3()
+
+        total_mib = get_size_of_folder("s3://bucket/path")
+
+        mock_get_s3_client.assert_called_once_with(skip_instance_cache=True)
+        assert total_mib == 2.0
+
+    @parameterized.expand([("listing_succeeds", None), ("listing_raises", OSError("[Errno 24] Too many open files"))])
+    @patch("products.data_warehouse.backend.s3.s3fs.S3FileSystem.close_session")
+    @patch("products.data_warehouse.backend.s3.get_s3_client")
+    def test_closes_the_session_regardless_of_outcome(self, _name, error, mock_get_s3_client, mock_close_session):
+        s3 = self._mock_s3()
+        if error is not None:
+            s3.find.side_effect = error
+        mock_get_s3_client.return_value = s3
+
+        if error is not None:
+            with self.assertRaises(OSError):
+                get_size_of_folder("s3://bucket/path")
+        else:
+            get_size_of_folder("s3://bucket/path")
+
+        mock_close_session.assert_called_once_with(s3.loop, s3._s3creator)


### PR DESCRIPTION
## Problem

Warehouse import workers can crash with `OSError: Too many open files`, unrelated to the source, table, or sync mode being run. See [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdd5e-03f1-7490-a7fa-fcc85d0ff8bc).

The failure traces to `get_size_of_folder`, which runs once per sync job to measure a table's size in S3.

## Changes

- `get_size_of_folder` created its S3 client through `get_s3_client()`, which fsspec caches per calling thread and never evicts.
- Temporal runs sync activities in a thread pool, so each new worker thread got its own permanently cached client, and that client's open sockets and file handles were never released.
- `get_size_of_folder` now requests an uncached client and closes its session explicitly after the S3 listing, on both success and failure.
- `get_s3_client` gained an opt-in `skip_instance_cache` parameter for this case. Existing callers default to the current caching behavior and are unaffected.

## How did you test this code?

- Added `products/data_warehouse/backend/tests/test_s3.py`: asserts `get_size_of_folder` requests an uncached client, and closes the underlying session after both a successful listing and one that raises — guards the leak this PR fixes.
- Ran `ruff check`, `ruff format --check`, and `mypy` on the changed files; all clean.
- Not run: the Postgres-backed e2e test for `calculate_table_size_activity` (no database available in this environment). It mocks `get_size_of_folder` entirely, so it is unaffected by this change.
- The patch-coverage check flags one uncovered line in `get_s3_client`: the non-local `s3fs.S3FileSystem(...)` construction, reached only when `USE_LOCAL_SETUP` is false. Test settings always set `USE_LOCAL_SETUP=True`, so that branch was equally uncovered before this PR; my change only reformats it across lines and adds `skip_instance_cache` as a passthrough kwarg.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, using PostHog's error-tracking MCP tools to pull the stack trace, sampled event, and Temporal activity context for the issue linked above.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the leak to fsspec's per-thread `AbstractFileSystem` instance cache combined with Temporal's thread-pool execution model for sync activities: each thread that ever ran `calculate_table_size_activity` got its own cached, never-closed `S3FileSystem`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
