### PR TITLE
fix(data-imports): stop reporting file-descriptor exhaustion as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -1,4 +1,5 @@
 import uuid
+import errno
 import socket
 import asyncio
 import datetime as dt
@@ -474,6 +475,20 @@ async def _handle_import_error(
     if isinstance(error, OperationalError | InterfaceError):
         await logger.awarning(error_msg)
         await logger.adebug("Transient app-DB error - re-raising for Temporal retry")
+        raise NonReportableError(error_msg) from error
+
+    # A raw OSError with errno EMFILE/ENFILE ("Too many open files") means the worker process hit
+    # its file-descriptor limit while establishing a new connection. psycopg3's connect path builds
+    # a `selectors.DefaultSelector()` directly (psycopg/waiting.py's `wait_conn`), so descriptor
+    # exhaustion there surfaces as a bare OSError rather than being wrapped into psycopg's/Django's
+    # OperationalError the way other connection failures are — including when the connection being
+    # opened is to our own app DB, the case the comment above `ExternalDataSchema.objects...get()`
+    # in postgres/source.py assumes always arrives as OperationalError. A burst of concurrent syncs
+    # on one worker exhausting descriptors is a transient capacity blip, not a customer/source
+    # config problem, so classify it the same way.
+    if isinstance(error, OSError) and error.errno in (errno.EMFILE, errno.ENFILE):
+        await logger.awarning(error_msg)
+        await logger.adebug("Transient file-descriptor exhaustion - re-raising for Temporal retry")
         raise NonReportableError(error_msg) from error
 
     # Cross-source non-retryable errors (missing primary key on an incremental table, bad SSH tunnel

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -1,4 +1,5 @@
 import uuid
+import errno
 import contextlib
 from datetime import datetime
 from typing import Any, cast
@@ -372,6 +373,62 @@ async def test_app_db_connection_error_reraised_as_non_reportable(_name: str, er
     assert exc_info.value.__cause__ is error
     logger.awarning.assert_awaited_once()
     logger.aexception.assert_not_awaited()
+
+
+@parameterized.expand(
+    [
+        ("emfile", errno.EMFILE),
+        ("enfile", errno.ENFILE),
+    ]
+)
+@pytest.mark.asyncio
+async def test_file_descriptor_exhaustion_reraised_as_non_reportable(_name: str, error_errno: int):
+    # psycopg3 builds a `selectors.DefaultSelector()` directly on its connect path, so hitting the
+    # worker's file-descriptor limit while opening a new connection (including one to our own app
+    # DB, e.g. postgres/source.py's schema lookup) surfaces as a bare OSError rather than a
+    # Django OperationalError. It's a transient capacity blip, so it must be re-raised as
+    # NonReportableError rather than the bare exception, which the activity interceptor would
+    # still capture.
+    error = OSError(error_errno, "Too many open files")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(NonReportableError) as exc_info:
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    assert exc_info.value.__cause__ is error
+    logger.awarning.assert_awaited_once()
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unrelated_oserror_is_reraised_for_activity_retry():
+    # An OSError with an unrelated errno (e.g. disk full) is not the same transient
+    # file-descriptor-exhaustion condition above, so it must still fall through to the generic
+    # capture-and-reraise path rather than being swallowed as non-reportable.
+    error = OSError(errno.ENOSPC, "No space left on device")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(OSError) as exc_info:
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    assert exc_info.value is error
+    logger.aexception.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A Postgres source sync occasionally fails with `OSError: [Errno 24] Too many open files` while it looks up sync metadata from PostHog's own app database, and every occurrence gets reported to [error tracking](https://us.posthog.com/project/2/error_tracking/019fdd5d-49f0-7c70-9e8d-8c4df3ffa7c9) as a defect.

- `postgres/source.py`'s `source_for_pipeline` already assumes a transient failure reaching our own app DB there surfaces as a Django `OperationalError`, which `_handle_import_error` re-raises as `NonReportableError` so Temporal keeps retrying without the noise.
- psycopg3 builds a `selectors.DefaultSelector()` directly on its connect path (`psycopg/waiting.py`'s `wait_conn`). Hitting the worker's file-descriptor limit there raises a bare `OSError`, which is never wrapped into `OperationalError`, so it falls through the existing classification and gets reported as a real bug.
- This isn't Postgres-specific: any source opening a new connection during a sync activity can hit the same limit the same way.

Related but different: [#79800](https://github.com/PostHog/posthog/pull/79800) closes an actual file-descriptor leak (an uncached S3 client) that can contribute to this exhaustion. This PR only fixes how the resulting `OSError` gets classified once it happens, regardless of what caused it.

## Changes

- Classify `OSError` with errno `EMFILE`/`ENFILE` in `_handle_import_error` the same way as `OperationalError`/`InterfaceError`: log a warning and re-raise as `NonReportableError`, so Temporal still retries but error tracking stays quiet.

## How did you test this code?

- Added 2 parameterized cases (`EMFILE`, `ENFILE`) to `test_import_data_sync.py` confirming the error is re-raised as `NonReportableError` with the original `OSError` as cause, and not logged via `aexception`.
- Added 1 case confirming an unrelated `OSError` (e.g. disk full) still falls through to the generic report-and-reraise path, guarding against over-widening the classification.
- Ran the full `test_import_data_sync.py`: 23 passed. One pre-existing test in the same file errors on a missing local Postgres connection, unrelated to this change (it needs a live DB not available in this sandbox).
- Ran `ruff check` and `ruff format --check` on both changed files: clean.
- Not run: `mypy` (repo-wide run wasn't completed in this session) and `hogli ci:preflight`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal error classification only, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, using PostHog's error-tracking MCP tools to pull the issue, its stack trace, and a sampled event's properties for the linked issue above.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the failure through the Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`) into `source_for_pipeline`'s Django ORM lookup, then into psycopg3's connect path to confirm exactly where the unwrapped `OSError` originates.
- Searched open PRs (excluding the bot account) and the maintainer's own open PRs for a prior fix; found the related-but-distinct leak fix noted above, no duplicate of this specific classification gap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*