### PR TITLE
chore(clickhouse): drop precalculated warpstream kafka engine tables

### DIFF
--- a/posthog/clickhouse/hcl/golden/local-multi/ingestion_medium.hcl
+++ b/posthog/clickhouse/hcl/golden/local-multi/ingestion_medium.hcl
@@ -286,39 +286,6 @@ database "posthog" {
     }
   }
 
-  table "kafka_precalculated_person_properties_ws" {
-    column "team_id" {
-      type = "Int64"
-    }
-    column "distinct_id" {
-      type = "String"
-    }
-    column "person_id" {
-      type = "UUID"
-    }
-    column "condition" {
-      type = "String"
-    }
-    column "matches" {
-      type = "Bool"
-    }
-    column "source" {
-      type = "String"
-    }
-    engine "kafka" {
-      broker_list          = "warpstream_calculated_events"
-      topic_list           = "kafka_topic_list = 'clickhouse_precalculated_person_properties'"
-      group_name           = "kafka_group_name = 'clickhouse_precalculated_person_properties_ws'"
-      format               = "kafka_format = 'JSONEachRow'"
-      num_consumers        = 1
-      max_block_size       = 1000000
-      skip_broken_messages = 100
-      poll_timeout_ms      = 1000
-      poll_max_batch_size  = 100000
-      flush_interval_ms    = 7500
-    }
-  }
-
   table "kafka_session_replay_features" {
     column "session_id" {
       type = "String"
@@ -1861,47 +1828,6 @@ SELECT
   _timestamp,
   _offset
 FROM posthog.kafka_precalculated_person_properties
-SQL
-
-    column "team_id" {
-      type = "Int64"
-    }
-    column "distinct_id" {
-      type = "String"
-    }
-    column "person_id" {
-      type = "UUID"
-    }
-    column "condition" {
-      type = "String"
-    }
-    column "matches" {
-      type = "Bool"
-    }
-    column "source" {
-      type = "String"
-    }
-    column "_timestamp" {
-      type = "Nullable(DateTime)"
-    }
-    column "_offset" {
-      type = "UInt64"
-    }
-  }
-
-  materialized_view "precalculated_person_properties_ws_mv" {
-    to_table = "posthog.writable_precalculated_person_properties"
-    query    = <<SQL
-SELECT
-  team_id,
-  distinct_id,
-  person_id,
-  condition,
-  matches,
-  source,
-  _timestamp,
-  _offset
-FROM posthog.kafka_precalculated_person_properties_ws
 SQL
 
     column "team_id" {

--- a/posthog/clickhouse/hcl/golden/local-single/all.hcl
+++ b/posthog/clickhouse/hcl/golden/local-single/all.hcl
@@ -3904,39 +3904,6 @@ database "posthog" {
     }
   }
 
-  table "kafka_precalculated_person_properties_ws" {
-    column "team_id" {
-      type = "Int64"
-    }
-    column "distinct_id" {
-      type = "String"
-    }
-    column "person_id" {
-      type = "UUID"
-    }
-    column "condition" {
-      type = "String"
-    }
-    column "matches" {
-      type = "Bool"
-    }
-    column "source" {
-      type = "String"
-    }
-    engine "kafka" {
-      broker_list          = "warpstream_calculated_events"
-      topic_list           = "kafka_topic_list = 'clickhouse_precalculated_person_properties'"
-      group_name           = "kafka_group_name = 'clickhouse_precalculated_person_properties_ws'"
-      format               = "kafka_format = 'JSONEachRow'"
-      num_consumers        = 1
-      max_block_size       = 1000000
-      skip_broken_messages = 100
-      poll_timeout_ms      = 1000
-      poll_max_batch_size  = 100000
-      flush_interval_ms    = 7500
-    }
-  }
-
   table "kafka_property_values" {
     column "team_id" {
       type = "Int64"
@@ -20797,47 +20764,6 @@ SELECT
   _timestamp,
   _offset
 FROM posthog.kafka_precalculated_person_properties
-SQL
-
-    column "team_id" {
-      type = "Int64"
-    }
-    column "distinct_id" {
-      type = "String"
-    }
-    column "person_id" {
-      type = "UUID"
-    }
-    column "condition" {
-      type = "String"
-    }
-    column "matches" {
-      type = "Bool"
-    }
-    column "source" {
-      type = "String"
-    }
-    column "_timestamp" {
-      type = "Nullable(DateTime)"
-    }
-    column "_offset" {
-      type = "UInt64"
-    }
-  }
-
-  materialized_view "precalculated_person_properties_ws_mv" {
-    to_table = "posthog.writable_precalculated_person_properties"
-    query    = <<SQL
-SELECT
-  team_id,
-  distinct_id,
-  person_id,
-  condition,
-  matches,
-  source,
-  _timestamp,
-  _offset
-FROM posthog.kafka_precalculated_person_properties_ws
 SQL
 
     column "team_id" {

--- a/posthog/clickhouse/hcl/roles/ingestion_medium/local/tables.hcl
+++ b/posthog/clickhouse/hcl/roles/ingestion_medium/local/tables.hcl
@@ -286,39 +286,6 @@ database "posthog" {
     }
   }
 
-  table "kafka_precalculated_person_properties_ws" {
-    column "team_id" {
-      type = "Int64"
-    }
-    column "distinct_id" {
-      type = "String"
-    }
-    column "person_id" {
-      type = "UUID"
-    }
-    column "condition" {
-      type = "String"
-    }
-    column "matches" {
-      type = "Bool"
-    }
-    column "source" {
-      type = "String"
-    }
-    engine "kafka" {
-      broker_list          = "warpstream_calculated_events"
-      topic_list           = "kafka_topic_list = 'clickhouse_precalculated_person_properties'"
-      group_name           = "kafka_group_name = 'clickhouse_precalculated_person_properties_ws'"
-      format               = "kafka_format = 'JSONEachRow'"
-      num_consumers        = 1
-      max_block_size       = 1000000
-      skip_broken_messages = 100
-      poll_timeout_ms      = 1000
-      poll_max_batch_size  = 100000
-      flush_interval_ms    = 7500
-    }
-  }
-
   table "kafka_session_replay_features" {
     column "session_id" {
       type = "String"
@@ -1512,47 +1479,6 @@ SELECT
   _timestamp,
   _offset
 FROM posthog.kafka_precalculated_person_properties
-SQL
-
-    column "team_id" {
-      type = "Int64"
-    }
-    column "distinct_id" {
-      type = "String"
-    }
-    column "person_id" {
-      type = "UUID"
-    }
-    column "condition" {
-      type = "String"
-    }
-    column "matches" {
-      type = "Bool"
-    }
-    column "source" {
-      type = "String"
-    }
-    column "_timestamp" {
-      type = "Nullable(DateTime)"
-    }
-    column "_offset" {
-      type = "UInt64"
-    }
-  }
-
-  materialized_view "precalculated_person_properties_ws_mv" {
-    to_table = "posthog.writable_precalculated_person_properties"
-    query    = <<SQL
-SELECT
-  team_id,
-  distinct_id,
-  person_id,
-  condition,
-  matches,
-  source,
-  _timestamp,
-  _offset
-FROM posthog.kafka_precalculated_person_properties_ws
 SQL
 
     column "team_id" {

--- a/posthog/clickhouse/hcl/sql/local-multi/ingestion_medium.sql
+++ b/posthog/clickhouse/hcl/sql/local-multi/ingestion_medium.sql
@@ -81,14 +81,6 @@ CREATE TABLE posthog.kafka_precalculated_person_properties (
   matches Bool,
   source String
 ) ENGINE = Kafka() SETTINGS kafka_broker_list = 'msk_cluster', kafka_flush_interval_ms = 7500, kafka_format = 'kafka_format = \'JSONEachRow\'', kafka_group_name = 'kafka_group_name = \'clickhouse_precalculated_person_properties\'', kafka_max_block_size = 1000000, kafka_num_consumers = 1, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_skip_broken_messages = 100, kafka_topic_list = 'kafka_topic_list = \'clickhouse_precalculated_person_properties\'';
-CREATE TABLE posthog.kafka_precalculated_person_properties_ws (
-  team_id Int64,
-  distinct_id String,
-  person_id UUID,
-  condition String,
-  matches Bool,
-  source String
-) ENGINE = Kafka() SETTINGS kafka_broker_list = 'warpstream_calculated_events', kafka_flush_interval_ms = 7500, kafka_format = 'kafka_format = \'JSONEachRow\'', kafka_group_name = 'kafka_group_name = \'clickhouse_precalculated_person_properties_ws\'', kafka_max_block_size = 1000000, kafka_num_consumers = 1, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_skip_broken_messages = 100, kafka_topic_list = 'kafka_topic_list = \'clickhouse_precalculated_person_properties\'';
 CREATE TABLE posthog.kafka_session_replay_features (
   session_id String,
   team_id Int64,
@@ -537,16 +529,6 @@ CREATE MATERIALIZED VIEW posthog.precalculated_person_properties_mv TO posthog.w
   _timestamp,
   _offset
 FROM posthog.kafka_precalculated_person_properties;
-CREATE MATERIALIZED VIEW posthog.precalculated_person_properties_ws_mv TO posthog.writable_precalculated_person_properties (team_id Int64, distinct_id String, person_id UUID, condition String, matches Bool, source String, _timestamp Nullable(DateTime), _offset UInt64) AS SELECT
-  team_id,
-  distinct_id,
-  person_id,
-  condition,
-  matches,
-  source,
-  _timestamp,
-  _offset
-FROM posthog.kafka_precalculated_person_properties_ws;
 CREATE MATERIALIZED VIEW posthog.session_replay_features_mv TO posthog.writable_session_replay_features (session_id String, team_id Int64, distinct_id String, min_first_timestamp DateTime64(6, 'UTC'), max_last_timestamp DateTime64(6, 'UTC'), event_count Int64, mouse_position_count Int64, mouse_sum_x Float64, mouse_sum_x_squared Float64, mouse_sum_y Float64, mouse_sum_y_squared Float64, mouse_distance_traveled Float64, mouse_direction_change_count Int64, mouse_velocity_sum Float64, mouse_velocity_sum_of_squares Float64, mouse_velocity_count Int64, scroll_event_count Int64, total_scroll_magnitude Float64, scroll_direction_reversal_count Int64, rapid_scroll_reversal_count Int64, scroll_to_top_count Int64, click_count Int64, keypress_count Int64, mouse_activity_count Int64, rage_click_count Int64, dead_click_count Int64, backspace_count Int64, inter_action_gap_count Int64, inter_action_gap_sum_ms Float64, inter_action_gap_sum_of_squares_ms Float64, max_idle_gap_ms Float64, long_idle_gap_count Int64, quick_back_count Int64, page_visit_count Int64, unique_url_count AggregateFunction(uniqCombinedArray(12), Array(String)), login_path_visit_count Int64, signup_path_visit_count Int64, checkout_path_visit_count Int64, cart_path_visit_count Int64, billing_path_visit_count Int64, settings_path_visit_count Int64, account_path_visit_count Int64, error_path_visit_count Int64, not_found_path_visit_count Int64, admin_path_visit_count Int64, dashboard_path_visit_count Int64, onboarding_path_visit_count Int64, cancel_path_visit_count Int64, refund_path_visit_count Int64, console_error_count Int64, console_error_after_click_count Int64, console_warn_count Int64, network_request_count Int64, network_failed_request_count Int64, network_4xx_count Int64, network_5xx_count Int64, network_request_duration_sum Float64, network_request_duration_sum_of_squares Float64, network_request_duration_count Int64, mutation_count Int64, viewport_resize_count Int64, touch_event_count Int64, max_scroll_y Float64, unique_click_target_count AggregateFunction(uniqCombinedArray(12), Array(Int64)), unique_form_field_count AggregateFunction(uniqCombinedArray(12), Array(Int64)), text_selection_count Int64, selection_copy_count Int64, is_deleted UInt8) AS SELECT
   session_id,
   team_id,

--- a/posthog/clickhouse/hcl/sql/local-single/all.sql
+++ b/posthog/clickhouse/hcl/sql/local-single/all.sql
@@ -695,14 +695,6 @@ CREATE TABLE posthog.kafka_precalculated_person_properties (
   matches Bool,
   source String
 ) ENGINE = Kafka() SETTINGS kafka_broker_list = 'msk_cluster', kafka_flush_interval_ms = 7500, kafka_format = 'kafka_format = \'JSONEachRow\'', kafka_group_name = 'kafka_group_name = \'clickhouse_precalculated_person_properties\'', kafka_max_block_size = 1000000, kafka_num_consumers = 1, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_skip_broken_messages = 100, kafka_topic_list = 'kafka_topic_list = \'clickhouse_precalculated_person_properties\'';
-CREATE TABLE posthog.kafka_precalculated_person_properties_ws (
-  team_id Int64,
-  distinct_id String,
-  person_id UUID,
-  condition String,
-  matches Bool,
-  source String
-) ENGINE = Kafka() SETTINGS kafka_broker_list = 'warpstream_calculated_events', kafka_flush_interval_ms = 7500, kafka_format = 'kafka_format = \'JSONEachRow\'', kafka_group_name = 'kafka_group_name = \'clickhouse_precalculated_person_properties_ws\'', kafka_max_block_size = 1000000, kafka_num_consumers = 1, kafka_poll_max_batch_size = 100000, kafka_poll_timeout_ms = 1000, kafka_skip_broken_messages = 100, kafka_topic_list = 'kafka_topic_list = \'clickhouse_precalculated_person_properties\'';
 CREATE TABLE posthog.kafka_property_values (
   team_id Int64,
   property_type LowCardinality(String),
@@ -4835,16 +4827,6 @@ CREATE MATERIALIZED VIEW posthog.precalculated_person_properties_mv TO posthog.w
   _timestamp,
   _offset
 FROM posthog.kafka_precalculated_person_properties;
-CREATE MATERIALIZED VIEW posthog.precalculated_person_properties_ws_mv TO posthog.writable_precalculated_person_properties (team_id Int64, distinct_id String, person_id UUID, condition String, matches Bool, source String, _timestamp Nullable(DateTime), _offset UInt64) AS SELECT
-  team_id,
-  distinct_id,
-  person_id,
-  condition,
-  matches,
-  source,
-  _timestamp,
-  _offset
-FROM posthog.kafka_precalculated_person_properties_ws;
 CREATE MATERIALIZED VIEW posthog.property_values_mv TO posthog.property_values (team_id Int64, property_type LowCardinality(String), property_key String, property_value String, property_count UInt64, last_seen DateTime) AS SELECT
   team_id,
   property_type,

--- a/posthog/clickhouse/migrations/0308_drop_warpstream_calculated_events_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0308_drop_warpstream_calculated_events_kafka_engines.py
@@ -1,0 +1,76 @@
+from posthog import settings
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.cohortmembership.sql import (
+    DROP_COHORT_MEMBERSHIP_WS_KAFKA_TABLE_SQL,
+    DROP_COHORT_MEMBERSHIP_WS_MV_SQL,
+)
+from posthog.models.precalculated_events.sql import (
+    DROP_PRECALCULATED_EVENTS_WS_KAFKA_TABLE_SQL,
+    DROP_PRECALCULATED_EVENTS_WS_MV_SQL,
+)
+from posthog.models.precalculated_person_properties.sql import (
+    DROP_PRECALCULATED_PERSON_PROPERTIES_WS_KAFKA_TABLE_SQL,
+    DROP_PRECALCULATED_PERSON_PROPERTIES_WS_MV_SQL,
+)
+
+# Drop every Kafka engine table bound to the `warpstream_calculated_events` named
+# collection, so that cluster can be decommissioned.
+#
+# It carries three topics, each with a `_ws` Kafka engine table and MV:
+#
+#   clickhouse_prefiltered_events               -> kafka_precalculated_events_ws
+#   clickhouse_precalculated_person_properties  -> kafka_precalculated_person_properties_ws
+#   cohort_membership_changed                   -> kafka_cohort_membership_ws
+#
+# On cloud none of the three topics has a producer any more, so all six objects read
+# nothing. Off-cloud the person-properties pair still consumes the local topic (see below).
+# They have to go before the named collection is removed from the ClickHouse config: a
+# Kafka engine table whose named collection has disappeared error-loops on every poll.
+#
+# Within each pair the MV is dropped first so it stops feeding its writable table, then
+# the Kafka engine table.
+#
+# The guards differ because the creating migrations differed. Both precalculated pairs
+# were created unconditionally by 0229, so they are dropped unconditionally. 0243 then
+# dropped the events pair everywhere and recreated it cloud-only, because off-cloud the
+# `warpstream_calculated_events` collection resolves to the same brokers as `msk_cluster`
+# and the pair double-writes. It left `kafka_precalculated_person_properties_ws` behind,
+# which this drop finally removes. `kafka_cohort_membership_ws` was created cloud-only by
+# 0245, so its drop keeps that guard.
+#
+# Only the Kafka engine tables and their MVs go. The `precalculated_events`,
+# `precalculated_person_properties` and `cohort_membership` data tables stay, as do the
+# MSK-fed Kafka tables that do not resolve this named collection.
+
+operations = [
+    run_sql_with_exceptions(
+        DROP_PRECALCULATED_EVENTS_WS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        DROP_PRECALCULATED_EVENTS_WS_KAFKA_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        DROP_PRECALCULATED_PERSON_PROPERTIES_WS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+    run_sql_with_exceptions(
+        DROP_PRECALCULATED_PERSON_PROPERTIES_WS_KAFKA_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_MEDIUM],
+    ),
+] + (
+    []
+    if settings.CLOUD_DEPLOYMENT not in ("US", "EU", "DEV")
+    else [
+        run_sql_with_exceptions(
+            DROP_COHORT_MEMBERSHIP_WS_MV_SQL(),
+            node_roles=[NodeRole.INGESTION_MEDIUM],
+        ),
+        run_sql_with_exceptions(
+            DROP_COHORT_MEMBERSHIP_WS_KAFKA_TABLE_SQL(),
+            node_roles=[NodeRole.INGESTION_MEDIUM],
+        ),
+    ]
+)

--- a/posthog/clickhouse/migrations/0308_drop_warpstream_calculated_events_kafka_engines.py
+++ b/posthog/clickhouse/migrations/0308_drop_warpstream_calculated_events_kafka_engines.py
@@ -1,10 +1,5 @@
-from posthog import settings
 from posthog.clickhouse.client.connection import NodeRole
 from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
-from posthog.models.cohortmembership.sql import (
-    DROP_COHORT_MEMBERSHIP_WS_KAFKA_TABLE_SQL,
-    DROP_COHORT_MEMBERSHIP_WS_MV_SQL,
-)
 from posthog.models.precalculated_events.sql import (
     DROP_PRECALCULATED_EVENTS_WS_KAFKA_TABLE_SQL,
     DROP_PRECALCULATED_EVENTS_WS_MV_SQL,
@@ -14,34 +9,32 @@ from posthog.models.precalculated_person_properties.sql import (
     DROP_PRECALCULATED_PERSON_PROPERTIES_WS_MV_SQL,
 )
 
-# Drop every Kafka engine table bound to the `warpstream_calculated_events` named
-# collection, so that cluster can be decommissioned.
-#
-# It carries three topics, each with a `_ws` Kafka engine table and MV:
+# Drop the two precalculated Kafka engine tables bound to the
+# `warpstream_calculated_events` named collection, on the way to decommissioning that
+# cluster:
 #
 #   clickhouse_prefiltered_events               -> kafka_precalculated_events_ws
 #   clickhouse_precalculated_person_properties  -> kafka_precalculated_person_properties_ws
-#   cohort_membership_changed                   -> kafka_cohort_membership_ws
 #
-# On cloud none of the three topics has a producer any more, so all six objects read
-# nothing. Off-cloud the person-properties pair still consumes the local topic (see below).
+# On cloud neither topic has a producer any more, so all four objects read nothing.
 # They have to go before the named collection is removed from the ClickHouse config: a
 # Kafka engine table whose named collection has disappeared error-loops on every poll.
 #
 # Within each pair the MV is dropped first so it stops feeding its writable table, then
 # the Kafka engine table.
 #
-# The guards differ because the creating migrations differed. Both precalculated pairs
-# were created unconditionally by 0229, so they are dropped unconditionally. 0243 then
-# dropped the events pair everywhere and recreated it cloud-only, because off-cloud the
-# `warpstream_calculated_events` collection resolves to the same brokers as `msk_cluster`
-# and the pair double-writes. It left `kafka_precalculated_person_properties_ws` behind,
-# which this drop finally removes. `kafka_cohort_membership_ws` was created cloud-only by
-# 0245, so its drop keeps that guard.
+# Both pairs were created unconditionally by 0229, so both drops are unconditional. 0243
+# then dropped the events pair everywhere and recreated it cloud-only, because off-cloud
+# the `warpstream_calculated_events` collection resolves to the same brokers as
+# `msk_cluster` and the pair double-writes. It left
+# `kafka_precalculated_person_properties_ws` behind, which this drop finally removes.
 #
-# Only the Kafka engine tables and their MVs go. The `precalculated_events`,
-# `precalculated_person_properties` and `cohort_membership` data tables stay, as do the
-# MSK-fed Kafka tables that do not resolve this named collection.
+# `kafka_cohort_membership_ws` reads from the same collection but is deliberately left
+# in place here; it is dropped separately.
+#
+# Only the Kafka engine tables and their MVs go. The `precalculated_events` and
+# `precalculated_person_properties` data tables stay, as do the MSK-fed Kafka tables that
+# do not resolve this named collection.
 
 operations = [
     run_sql_with_exceptions(
@@ -60,17 +53,4 @@ operations = [
         DROP_PRECALCULATED_PERSON_PROPERTIES_WS_KAFKA_TABLE_SQL(),
         node_roles=[NodeRole.INGESTION_MEDIUM],
     ),
-] + (
-    []
-    if settings.CLOUD_DEPLOYMENT not in ("US", "EU", "DEV")
-    else [
-        run_sql_with_exceptions(
-            DROP_COHORT_MEMBERSHIP_WS_MV_SQL(),
-            node_roles=[NodeRole.INGESTION_MEDIUM],
-        ),
-        run_sql_with_exceptions(
-            DROP_COHORT_MEMBERSHIP_WS_KAFKA_TABLE_SQL(),
-            node_roles=[NodeRole.INGESTION_MEDIUM],
-        ),
-    ]
-)
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0307_logs_pattern_kafka
+0308_drop_warpstream_calculated_events_kafka_engines

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
+                  ([e__person.properties___fish] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,6 +44,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -111,7 +121,17 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -168,8 +188,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -178,6 +198,16 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+           LEFT JOIN
+             (SELECT person.id AS id,
+                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+              FROM person
+              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                            (SELECT person.id AS id, max(person.version) AS version
+                                                             FROM person
+                                                             WHERE equals(person.team_id, 99999)
+                                                             GROUP BY person.id
+                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -294,7 +324,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -326,7 +373,24 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
+        LEFT JOIN
+          (SELECT person.id AS id,
+                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
+           FROM person
+           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                         (SELECT person.id AS id, max(person.version) AS version
+                                                          FROM person
+                                                          WHERE equals(person.team_id, 99999)
+                                                          GROUP BY person.id
+                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)

--- a/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
+++ b/products/product_analytics/backend/tests/api/__snapshots__/test_insight.ambr
@@ -34,7 +34,7 @@
                   e.`$window_id` AS `$window_id`,
                   if(equals(e.event, 'user signed up'), 1, 0) AS step_0,
                   if(equals(e.event, 'user did things'), 1, 0) AS step_1,
-                  ([e__person.properties___fish] AS value) AS prop_basic,
+                  ([replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', '')] AS value) AS prop_basic,
                   prop_basic AS prop
            FROM events AS e
            LEFT OUTER JOIN
@@ -44,16 +44,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0)), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -121,17 +111,7 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
+           WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up')), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
      GROUP BY breakdown
@@ -188,8 +168,8 @@
                   e.uuid AS uuid,
                   e.`$session_id` AS `$session_id`,
                   e.`$window_id` AS `$window_id`,
-                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_0,
-                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0))), 1, 0) AS step_1
+                  if(and(equals(e.event, 'user signed up'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_0,
+                  if(and(equals(e.event, 'user did things'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0))), 1, 0) AS step_1
            FROM events AS e
            LEFT OUTER JOIN
              (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
@@ -198,16 +178,6 @@
               WHERE equals(person_distinct_id_overrides.team_id, 99999)
               GROUP BY person_distinct_id_overrides.distinct_id
               HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-           LEFT JOIN
-             (SELECT person.id AS id,
-                     replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-              FROM person
-              WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                            (SELECT person.id AS id, max(person.version) AS version
-                                                             FROM person
-                                                             WHERE equals(person.team_id, 99999)
-                                                             GROUP BY person.id
-                                                             HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
            WHERE and(equals(e.team_id, 99999), and(and(greaterOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')), lessOrEquals(e.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(e.event, tuple('user did things', 'user signed up'))), or(equals(step_0, 1), equals(step_1, 1))))
         GROUP BY aggregation_target
         HAVING ifNull(greaterOrEquals(step_reached, 0), 0))
@@ -324,24 +294,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(greater(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)
@@ -373,24 +326,7 @@
        (SELECT count() AS total,
                toStartOfDay(toTimeZone(e.timestamp, 'UTC')) AS day_start
         FROM events AS e
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS e__override ON equals(e.distinct_id, e__override.distinct_id)
-        LEFT JOIN
-          (SELECT person.id AS id,
-                  replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(person.properties, 'fish'), ''), 'null'), '^"|"$', '') AS properties___fish
-           FROM person
-           WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
-                                                         (SELECT person.id AS id, max(person.version) AS version
-                                                          FROM person
-                                                          WHERE equals(person.team_id, 99999)
-                                                          GROUP BY person.id
-                                                          HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS e__person ON equals(if(not(empty(e__override.distinct_id)), e__override.person_id, e.person_id), e__person.id)
-        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(e__person.properties___fish, '%fish%'), 0)))
+        WHERE and(equals(e.team_id, 99999), greaterOrEquals(e.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2012-01-08 00:00:00', 'UTC')), toIntervalDay(1))), lessOrEquals(e.timestamp, assumeNotNull(toDateTime('2012-01-15 23:59:59', 'UTC'))), equals(e.event, '$pageview'), and(ifNull(less(accurateCastOrNull(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.properties, 'int_value'), ''), 'null'), '^"|"$', ''), 'Int64'), 10), 0), ifNull(like(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(e.person_properties, 'fish'), ''), 'null'), '^"|"$', ''), '%fish%'), 0)))
         GROUP BY day_start)
      GROUP BY day_start
      ORDER BY day_start ASC)


### PR DESCRIPTION
## Problem

Nobody can decommission the `warpstream-calculated-events` cluster while ClickHouse still holds Kafka engine tables against it. Those tables serve no one: both precalculated topics lost their producers, so the four objects reading them consume nothing.

They cannot just be left behind. A Kafka engine table whose named collection has been removed from the ClickHouse config error-loops on every poll, so the tables have to go before the collection does.

## Changes

Drops the Kafka engine table and its materialized view for each of the two precalculated topics.

| Topic | Kafka engine table |
| --- | --- |
| `clickhouse_prefiltered_events` | `kafka_precalculated_events_ws` |
| `clickhouse_precalculated_person_properties` | `kafka_precalculated_person_properties_ws` |

Within each pair the materialized view is dropped first, so it stops feeding its writable table before the Kafka table disappears.

Both drops are unconditional, because `0229` created both pairs unconditionally. `0243` later dropped the events pair everywhere and recreated it cloud-only, since off-cloud `warpstream_calculated_events` resolves to the same brokers as `msk_cluster` and the pair double-writes. That migration left `kafka_precalculated_person_properties_ws` behind, which this drop finally removes. Every statement is `DROP TABLE IF EXISTS`, so the migration is idempotent either way.

`kafka_cohort_membership_ws` reads from the same collection but stays. It is dropped separately, so its removal lands with the cohort work that owns it rather than inside a migration about precalculated tables.

Data tables are untouched. `precalculated_events` and `precalculated_person_properties` both stay, as do the MSK-fed Kafka tables, which resolve a different named collection and are unaffected by this cluster going away.

## How did you test this code?

- `hogli ci:preflight --strict` on the push: ruff lint, ruff format, and the migration conflict check all pass.
- Confirmed all four imported `DROP_*_SQL` helpers exist on `master`, so the migration needs no model change.

Not done: the migration was never run against a real ClickHouse, and no automated test exercises it.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code). Skills invoked: `/clickhouse-migrations` for the original migration, `/writing-pr-descriptions` for this body. Also read `posthog/clickhouse/migrations/AGENTS.md` for the node-role and guard conventions.

The migration started as cohort-membership-only, widened to all three topics on the same named collection, then narrowed to the two precalculated pairs so the cohort drop can ship on its own schedule.

Kept migration-only per `AGENTS.md`. The matching consumer removal is a separate PR, and the now-unused SQL builders stay in place so no already-applied migration needs rewriting.

Part of a cross-repo decommission, with companion PRs in `PostHog/charts` and `posthog-cloud-infra`. This one is safe to land first and independently.
