### PR TITLE
fix(data-imports): reuse the S3 filesystem in CDP and person-property sinks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/cdp_producer.py
@@ -35,6 +35,7 @@ class CDPProducer:
     logger: FilteringBoundLogger
     _should_run_cache: bool | None
     _table_name_cache: str | None
+    _fs_cache: pa_fs.S3FileSystem | None
 
     def __init__(self, team_id: int, schema_id: str, job_id: str, logger: FilteringBoundLogger) -> None:
         self.team_id = team_id
@@ -43,8 +44,16 @@ class CDPProducer:
         self.logger = logger
         self._should_run_cache = None
         self._table_name_cache = None
+        self._fs_cache = None
 
     def _get_fs(self) -> pa_fs.S3FileSystem:
+        # Cached per instance: stage_chunk() calls this once per chunk, and a producer lives for
+        # a whole sync (potentially thousands of chunks). A fresh S3FileSystem per call opens its
+        # own AWS SDK client/connections that outlive the call, exhausting the process' file
+        # descriptor limit over a long sync.
+        if self._fs_cache is not None:
+            return self._fs_cache
+
         if settings.USE_LOCAL_SETUP:
             ensure_bucket_exists(
                 f"s3://{self._get_path_prefix()}",
@@ -53,13 +62,15 @@ class CDPProducer:
                 settings.OBJECT_STORAGE_ENDPOINT,
             )
 
-            return pa_fs.S3FileSystem(
+            self._fs_cache = pa_fs.S3FileSystem(
                 access_key=settings.DATAWAREHOUSE_LOCAL_ACCESS_KEY,
                 secret_key=settings.DATAWAREHOUSE_LOCAL_ACCESS_SECRET,
                 endpoint_override=settings.OBJECT_STORAGE_ENDPOINT,
             )
+        else:
+            self._fs_cache = pa_fs.S3FileSystem()
 
-        return pa_fs.S3FileSystem()
+        return self._fs_cache
 
     def _get_path_prefix(self) -> str:
         return f"{settings.DATAWAREHOUSE_BUCKET}/cdp_producer/{self.team_id}/{self.schema_id}/{self.job_id}"

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink.py
@@ -56,8 +56,16 @@ class PersonPropertyRowSink:
         self._attempt_token = str(int(time.time()))
         self._projection: list[PersonPropertySourceProjection] | None = None
         self._projection_resolved = False
+        self._fs_cache: pa_fs.S3FileSystem | None = None
 
     def _get_fs(self) -> pa_fs.S3FileSystem:
+        # Cached per instance: stage_chunk() calls this once per chunk, and a sink lives for a
+        # whole sync (potentially thousands of chunks). A fresh S3FileSystem per call opens its
+        # own AWS SDK client/connections that outlive the call, exhausting the process' file
+        # descriptor limit over a long sync.
+        if self._fs_cache is not None:
+            return self._fs_cache
+
         if settings.USE_LOCAL_SETUP:
             ensure_bucket_exists(
                 f"s3://{self._get_path_prefix()}",
@@ -65,13 +73,15 @@ class PersonPropertyRowSink:
                 settings.DATAWAREHOUSE_LOCAL_ACCESS_SECRET,
                 settings.OBJECT_STORAGE_ENDPOINT,
             )
-            return pa_fs.S3FileSystem(
+            self._fs_cache = pa_fs.S3FileSystem(
                 access_key=settings.DATAWAREHOUSE_LOCAL_ACCESS_KEY,
                 secret_key=settings.DATAWAREHOUSE_LOCAL_ACCESS_SECRET,
                 endpoint_override=settings.OBJECT_STORAGE_ENDPOINT,
             )
+        else:
+            self._fs_cache = pa_fs.S3FileSystem()
 
-        return pa_fs.S3FileSystem()
+        return self._fs_cache
 
     def _get_schema_prefix(self) -> str:
         return f"{settings.DATAWAREHOUSE_BUCKET}/person_property_sync/{self.team_id}/{self.schema_id}"

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
@@ -177,6 +177,23 @@ async def test_stage_chunk_filenames_are_unique_per_attempt():
     assert len(set(paths)) == 2
 
 
+def test_get_fs_reuses_the_same_filesystem_across_calls():
+    # stage_chunk() calls _get_fs() once per chunk over a whole sync (potentially thousands of
+    # chunks); constructing a fresh S3FileSystem per call leaks its underlying connections/file
+    # descriptors until the process runs out of them.
+    sink = _sink()
+
+    with (
+        patch(f"{_MODULE}.pa_fs.S3FileSystem") as mock_s3_filesystem,
+        patch(f"{_MODULE}.ensure_bucket_exists"),
+    ):
+        first = sink._get_fs()
+        second = sink._get_fs()
+
+    mock_s3_filesystem.assert_called_once()
+    assert first is second
+
+
 @pytest.mark.asyncio
 async def test_clear_tolerates_missing_prefixes():
     # First sync of a schema has nothing staged anywhere; clearing must not fail the sync.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/person_property_row_sink_test.py
@@ -3,7 +3,10 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.conf import settings
+
 import pyarrow as pa
+from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.external_product_hooks import (
     PersonPropertySourceProjection,
@@ -177,13 +180,16 @@ async def test_stage_chunk_filenames_are_unique_per_attempt():
     assert len(set(paths)) == 2
 
 
-def test_get_fs_reuses_the_same_filesystem_across_calls():
+@parameterized.expand([("local_setup", True), ("non_local_setup", False)])
+def test_get_fs_reuses_the_same_filesystem_across_calls(_name, use_local_setup):
     # stage_chunk() calls _get_fs() once per chunk over a whole sync (potentially thousands of
     # chunks); constructing a fresh S3FileSystem per call leaks its underlying connections/file
-    # descriptors until the process runs out of them.
+    # descriptors until the process runs out of them. Both branches build their own S3FileSystem,
+    # so both must cache it.
     sink = _sink()
 
     with (
+        patch.object(settings, "USE_LOCAL_SETUP", use_local_setup),
         patch(f"{_MODULE}.pa_fs.S3FileSystem") as mock_s3_filesystem,
         patch(f"{_MODULE}.ensure_bucket_exists"),
     ):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_cdp_producer.py
@@ -7,11 +7,13 @@ import pytest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings
 from django.db.utils import OperationalError as DjangoOperationalError
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 from asgiref.sync import sync_to_async
+from parameterized import parameterized
 
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
@@ -879,13 +881,16 @@ def _make_producer(job_id: str) -> CDPProducer:
     return CDPProducer(team_id=1, schema_id="schema_1", job_id=job_id, logger=mock.AsyncMock())
 
 
-def test_get_fs_reuses_the_same_filesystem_across_calls():
+@parameterized.expand([("local_setup", True), ("non_local_setup", False)])
+def test_get_fs_reuses_the_same_filesystem_across_calls(_name, use_local_setup):
     # stage_chunk() calls _get_fs() once per chunk over a whole sync (potentially thousands of
     # chunks); constructing a fresh S3FileSystem per call leaks its underlying connections/file
-    # descriptors until the process runs out of them.
+    # descriptors until the process runs out of them. Both branches build their own S3FileSystem,
+    # so both must cache it.
     producer = _make_producer("job_1")
 
     with (
+        patch.object(settings, "USE_LOCAL_SETUP", use_local_setup),
         patch(
             "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer.pa_fs.S3FileSystem"
         ) as mock_s3_filesystem,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_cdp_producer.py
@@ -879,6 +879,27 @@ def _make_producer(job_id: str) -> CDPProducer:
     return CDPProducer(team_id=1, schema_id="schema_1", job_id=job_id, logger=mock.AsyncMock())
 
 
+def test_get_fs_reuses_the_same_filesystem_across_calls():
+    # stage_chunk() calls _get_fs() once per chunk over a whole sync (potentially thousands of
+    # chunks); constructing a fresh S3FileSystem per call leaks its underlying connections/file
+    # descriptors until the process runs out of them.
+    producer = _make_producer("job_1")
+
+    with (
+        patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer.pa_fs.S3FileSystem"
+        ) as mock_s3_filesystem,
+        patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer.ensure_bucket_exists"
+        ),
+    ):
+        first = producer._get_fs()
+        second = producer._get_fs()
+
+    mock_s3_filesystem.assert_called_once()
+    assert first is second
+
+
 def test_build_event_id_is_a_valid_uuid():
     event_id = _make_producer("job_1")._build_event_id({"id": 1, "name": "Alice"})
     assert str(uuid.UUID(event_id)) == event_id


### PR DESCRIPTION
## Problem

Warehouse import workers occasionally crash with `OSError: [Errno 24] Too many open files`, unrelated to the source or table being synced. See the [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fdd61-d894-74a3-8575-12b949aa7e7c) — both sampled occurrences fail while `s3fs` lazily loads one of botocore's own bundled service-model files, which only happens once the process has no file descriptors left to open anything with.

- `CDPProducer._get_fs()` and `PersonPropertyRowSink._get_fs()` each build a fresh `pyarrow.fs.S3FileSystem()` on every call.
- `stage_chunk()` calls `_get_fs()` once per synced chunk, and a producer/sink instance lives for a whole table sync — potentially thousands of chunks.
- Each `S3FileSystem` opens its own AWS SDK connections that outlive the call, so a long sync leaks one filesystem's file descriptors per chunk until the worker process runs out.

Related but different: [#79800](https://github.com/PostHog/posthog/pull/79800) closes a separate file-descriptor leak (an uncached, never-closed `s3fs` client in `get_size_of_folder`) against a different sampled issue. Both contribute to the same class of `OSError` across different code paths.

## Changes

- Cache the `S3FileSystem` on the `CDPProducer`/`PersonPropertyRowSink` instance so it's built once per sync and reused for every chunk, instead of rebuilt per chunk.

## How did you test this code?

- Added a test per sink asserting `_get_fs()` returns the same filesystem instance across repeated calls and constructs it only once - guards the per-chunk leak this PR fixes.
- Ran `ruff check`/`ruff format` on the changed files: clean.
- Ran `mypy` on the two changed source files directly: clean. A repo-wide `mypy` run was in progress when this PR was opened; will push a follow-up if it surfaces anything.
- Ran the non-database tests in both affected test files (18 passed, including the 2 new ones). The rest of those files need a live Postgres, which isn't available in this sandbox - those failures are pre-existing and unrelated to this change (they fail identically on `master`).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - internal pipeline fix, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, using PostHog's error-tracking MCP tools to pull the issue, its stack trace, and sampled event context.
- Skills invoked: `/writing-tests`, `/writing-pr-descriptions`.
- Traced the crash site (`s3fs`/botocore loading a service-model file) back through `prepare_s3_files_for_querying`, then searched the rest of the sync's hot path for other resource construction that could exhaust file descriptors first, which led to the per-chunk `S3FileSystem` construction in both chunk sinks.
- Searched open PRs (excluding the bot account) and the maintainer's own open PRs for a prior fix; found the related-but-distinct leak fix noted above, no duplicate of this one.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*