### PR TITLE
fix(surveys): send button labels to AI translation drafts

### DIFF
--- a/frontend/src/scenes/surveys/surveyLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveyLogic.test.ts
@@ -332,6 +332,38 @@ describe('translation validation', () => {
         })
         expect(logic.values.aiGeneratedTranslationFields).toEqual(['translations.es.thankYouMessageHeader'])
     })
+
+    it('sends appearance submit and back button labels in the AI translation draft', async () => {
+        // Guards the button-label gap: if these drop out of the draft payload, "Translate with AI"
+        // never sees them as source and silently can't translate the submit/back buttons.
+        const generateTranslations = surveysGenerateTranslationsCreate as jest.MockedFunction<
+            typeof surveysGenerateTranslationsCreate
+        >
+        generateTranslations.mockResolvedValue({
+            translations: {},
+            questions: [],
+            generated_field_paths: [],
+            trace_id: 'trace-1',
+        })
+        const survey = {
+            ...createPersistedSurvey(),
+            appearance: {
+                ...createPersistedSurvey().appearance,
+                submitButtonText: 'Submit',
+                backButtonText: 'Back',
+            },
+        } as Survey
+
+        await expectLogic(logic, () => {
+            logic.actions.loadSurveySuccess(survey)
+            logic.actions.generateTranslationDrafts('es')
+        }).toFinishAllListeners()
+
+        const draftSurvey = generateTranslations.mock.calls[0][2].survey as Record<string, unknown>
+        expect(draftSurvey.appearance).toEqual(
+            expect.objectContaining({ submitButtonText: 'Submit', backButtonText: 'Back' })
+        )
+    })
 })
 
 describe('set response-based survey branching', () => {

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -184,6 +184,8 @@ type SurveyTranslationDraftPayload = {
         thankYouMessageHeader?: string
         thankYouMessageDescription?: string
         thankYouMessageCloseButtonText?: string
+        submitButtonText?: string
+        backButtonText?: string
     }
     questions?: SurveyTranslationDraftQuestion[]
     translations?: Survey['translations']
@@ -235,6 +237,8 @@ function getSurveyTranslationDraftPayload(survey: Survey | NewSurvey): SurveyTra
             thankYouMessageHeader: survey.appearance?.thankYouMessageHeader,
             thankYouMessageDescription: survey.appearance?.thankYouMessageDescription,
             thankYouMessageCloseButtonText: survey.appearance?.thankYouMessageCloseButtonText,
+            submitButtonText: survey.appearance?.submitButtonText,
+            backButtonText: survey.appearance?.backButtonText,
         },
         questions: survey.questions.map((question, index): SurveyTranslationDraftQuestion => {
             const draftQuestion: SurveyTranslationDraftQuestion = {
@@ -3363,6 +3367,8 @@ export const surveyLogic = kea<surveyLogicType>([
                         key: 'thankYouMessageCloseButtonText',
                         defaultValue: survey.appearance?.thankYouMessageCloseButtonText,
                     },
+                    { key: 'submitButtonText', defaultValue: survey.appearance?.submitButtonText },
+                    { key: 'backButtonText', defaultValue: survey.appearance?.backButtonText },
                 ]
 
                 // Get all languages


### PR DESCRIPTION
## Problem

Translating a survey's Submit or Back button with "Translate with AI" returns nothing for those labels — the model never receives them as source, so it silently leaves them untranslated.

The editor strips `submitButtonText` and `backButtonText` from the draft it sends to the generate-translations endpoint, so there is no button copy to translate.

The backend already accepts these fields in the draft (#79777). Only the editor payload was missing them.

## Changes

- Send `submitButtonText` and `backButtonText` in the AI translation draft payload (`getSurveyTranslationDraftPayload`).
- Add both to the survey-level translation completeness checks, so empty or placeholder translations for them are flagged like the other survey-level fields.
- No UI change — payload and validation logic only, so no screenshot.

This is the editor half of the button-label fix; #79777 is the backend half. It takes effect once #79777 lands.

Deferred: there is still no per-language editor for the appearance-level `submitButtonText`. Per-question `buttonText` already covers the common submit-label case, so that UI is left for a separate change if wanted.

## How did you test this code?

- Added one `surveyLogic` test asserting the draft payload carries both button labels. Regression it catches: if either field drops out of the payload builder again, AI-translate silently stops covering that button. No existing test asserted the payload's appearance contents for these fields.
- Not run locally: this sandbox has no frontend toolchain (no `pnpm` / `node_modules`), so I did not run typecheck, jest, or lint. Relying on CI.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) opened this while reviewing #79777. That PR fixes the backend persistence of translated button labels; this closes the editor-side gap so "Translate with AI" actually feeds those labels to the model.

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-pr-descriptions`.

The originating work was a survey-translation support ticket. Nothing from it is in this diff: the test uses invented strings, and the change is described in product terms only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
