### PR TITLE
fix(desktop): make comment mention popup opaque

### DIFF
--- a/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
+++ b/products/desktop/packages/ui/src/features/canvas/components/MentionComposer.tsx
@@ -243,7 +243,7 @@ export function MentionComposer({
   return (
     <div className="relative">
       {open && session && (
-        <div className="absolute inset-x-0 bottom-full z-50 mb-1 flex flex-col overflow-hidden rounded-md border border-[var(--gray-a6)] bg-[var(--color-panel-solid)] text-[13px] shadow-lg">
+        <div className="absolute inset-x-0 bottom-full z-50 mb-1 flex flex-col overflow-hidden rounded-md border border-border bg-card text-[13px] text-foreground shadow-lg">
           <div
             role="listbox"
             aria-label="Mention a teammate or agent"


### PR DESCRIPTION
## Problem

Artifact reviewers can see document text through the mention menu, making teammate suggestions difficult to read.

The menu renders outside the Radix theme root, so its Radix panel token is undefined.

## Changes

- Give the mention menu an opaque Quill surface that works across the portal boundary.
- Use Quill border and text tokens at the same boundary.
- Screenshot unavailable: `hogli pr:upload-image` returned HTTP 409 for synthetic before-and-after images.

## How did you test this code?

- `pnpm --filter @posthog/ui typecheck`
- `pnpm --filter @posthog/ui test -- CommentComposer.test.tsx`
- `pnpm --filter @posthog/web build`
- A headless browser confirmed the old token resolves transparent and the Quill card token resolves opaque.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

Not needed. This corrects styling without changing documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pi used repository tools, Playwright, and hogli. The `/writing-pr-descriptions` skill shaped this description.
