### PR TITLE
feat(data-catalog): add metric markdown editor module

### DIFF
--- a/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.test.tsx
+++ b/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.test.tsx
@@ -103,6 +103,28 @@ describe('RichMarkdownEditor', () => {
         expect(counter).toHaveClass('text-danger')
     })
 
+    it.each([
+        [undefined, ['Write', 'Preview', 'Markdown'], []],
+        [['write', 'preview'] as const, ['Write', 'Preview'], ['Markdown']],
+    ])('renders the requested tabs (%p)', (tabs, expectedVisible, expectedHidden) => {
+        render(
+            <RichMarkdownEditor
+                value="hello"
+                tabs={tabs ? [...tabs] : undefined}
+                extensions={[]}
+                markdownToDoc={() => ({ type: 'doc', content: [] })}
+                docToMarkdown={() => 'hello'}
+            />
+        )
+
+        for (const label of expectedVisible) {
+            expect(screen.getByText(label)).toBeInTheDocument()
+        }
+        for (const label of expectedHidden) {
+            expect(screen.queryByText(label)).not.toBeInTheDocument()
+        }
+    })
+
     it('exposes strikethrough in the write toolbar', () => {
         render(
             <RichMarkdownEditor

--- a/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.tsx
+++ b/frontend/src/lib/components/MarkdownEditor/rich/RichMarkdownEditor.tsx
@@ -19,6 +19,10 @@ import { useRichContentEditor } from 'lib/components/RichContentEditor'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 
+export type RichMarkdownEditorTab = 'write' | 'preview' | 'markdown'
+
+const ALL_TABS: RichMarkdownEditorTab[] = ['write', 'preview', 'markdown']
+
 export type RichMarkdownEditorProps = {
     value?: string
     onChange?: (value: string) => void
@@ -32,6 +36,12 @@ export type RichMarkdownEditorProps = {
     renderPreview?: (markdown: string) => JSX.Element
     /** When true, focuses the editor once the ProseMirror view is mounted (default false to avoid stealing focus). */
     autoFocus?: boolean
+    /** Toolbar toggles. Disable image upload when the extension set has no Image node, so uploads can't insert an unsupported node. */
+    controls?: {
+        imageUpload?: boolean
+    }
+    /** Which tabs to show, in order. Defaults to all three. */
+    tabs?: RichMarkdownEditorTab[]
 }
 
 export function RichMarkdownEditor({
@@ -46,8 +56,10 @@ export function RichMarkdownEditor({
     docToMarkdown,
     renderPreview,
     autoFocus = false,
+    controls,
+    tabs = ALL_TABS,
 }: RichMarkdownEditorProps): JSX.Element {
-    const [activeTab, setActiveTab] = useState<'write' | 'preview' | 'markdown'>('write')
+    const [activeTab, setActiveTab] = useState<RichMarkdownEditorTab>('write')
     const [linkUrl, setLinkUrl] = useState('')
     const [showLinkPopover, setShowLinkPopover] = useState(false)
     const dropRef = useRef<HTMLDivElement>(null)
@@ -108,7 +120,7 @@ export function RichMarkdownEditor({
         <LemonTabs
             activeKey={activeTab}
             onChange={(key) => {
-                const nextTab = key as 'write' | 'preview' | 'markdown'
+                const nextTab = key as RichMarkdownEditorTab
                 setActiveTab(nextTab)
 
                 // Keep parent value in sync before showing preview/markdown tabs.
@@ -118,7 +130,7 @@ export function RichMarkdownEditor({
             }}
             tabs={[
                 {
-                    key: 'write',
+                    key: 'write' as const,
                     label: 'Write',
                     content: (
                         <div ref={dropRef} className="RichMarkdownEditor border rounded overflow-hidden">
@@ -155,6 +167,7 @@ export function RichMarkdownEditor({
                                         editor={editor}
                                         alternativeDropTargetRef={dropRef}
                                         emojiPopoverDataAttr="rich-markdown-editor-emoji-popover"
+                                        showImageUpload={controls?.imageUpload ?? true}
                                     />
                                 </div>
                                 <div className="flex shrink-0 items-center border-l border-primary pl-2">
@@ -175,7 +188,7 @@ export function RichMarkdownEditor({
                     ),
                 },
                 {
-                    key: 'preview',
+                    key: 'preview' as const,
                     label: 'Preview',
                     content: currentMarkdown ? (
                         (renderPreview?.(currentMarkdown) ?? <LemonMarkdown>{currentMarkdown}</LemonMarkdown>)
@@ -184,7 +197,7 @@ export function RichMarkdownEditor({
                     ),
                 },
                 {
-                    key: 'markdown',
+                    key: 'markdown' as const,
                     label: 'Markdown',
                     content: currentMarkdown ? (
                         <pre className="RichMarkdownEditor__rawPreview">{currentMarkdown}</pre>
@@ -192,7 +205,7 @@ export function RichMarkdownEditor({
                         <i>Nothing to preview</i>
                     ),
                 },
-            ]}
+            ].filter((tab) => tabs.includes(tab.key))}
         />
     )
 }

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -69,6 +69,15 @@ export default defineConfig(({ mode }) => {
                 public: resolve(__dirname, 'src/assets'),
                 // Required for production builds — @posthog/icons is in the pnpm store, not node_modules root
                 '@posthog/icons': resolve(__dirname, 'node_modules/@posthog/icons'),
+                // These @tiptap packages live only in frontend/node_modules, which products/*/frontend
+                // files can't reach by walking up from their own directory. Alias each package
+                // individually: a blanket '@tiptap' prefix would also rewrite the imports *inside*
+                // tiptap packages (e.g. starter-kit importing @tiptap/extension-code) to paths that
+                // don't exist under frontend/node_modules.
+                '@tiptap/core': resolve(__dirname, 'node_modules/@tiptap/core'),
+                '@tiptap/react': resolve(__dirname, 'node_modules/@tiptap/react'),
+                '@tiptap/pm': resolve(__dirname, 'node_modules/@tiptap/pm'),
+                '@tiptap/extension-placeholder': resolve(__dirname, 'node_modules/@tiptap/extension-placeholder'),
                 products: resolve(__dirname, '../products'),
                 '@posthog/shared-onboarding': resolve(__dirname, '../docs/onboarding'),
                 '@posthog/shared-onboarding/*': resolve(__dirname, '../docs/onboarding/*'),

--- a/products/data_catalog/frontend/common.ts
+++ b/products/data_catalog/frontend/common.ts
@@ -26,6 +26,9 @@ export function validateMetricName(name: string): string | undefined {
 // Mirrors MAX_DESCRIPTION_LENGTH enforced in products/data_catalog/backend/logic/validation.py.
 export const METRIC_DESCRIPTION_MAX_LENGTH = 1000
 
+// Mirrors MAX_MARKDOWN_DEFINITION_LENGTH enforced in products/data_catalog/backend/logic/validation.py.
+export const METRIC_MARKDOWN_MAX_LENGTH = 20000
+
 export function validateMetricDescription(description: string): string | undefined {
     if (description.length > METRIC_DESCRIPTION_MAX_LENGTH) {
         return `Keep the description under ${METRIC_DESCRIPTION_MAX_LENGTH} characters. Say what the metric means in a few sentences.`

--- a/products/data_catalog/frontend/components/MetricMarkdownEditor.tsx
+++ b/products/data_catalog/frontend/components/MetricMarkdownEditor.tsx
@@ -1,0 +1,58 @@
+import { Placeholder } from '@tiptap/extension-placeholder'
+import { Extensions } from '@tiptap/react'
+import { useState } from 'react'
+
+import { RichMarkdownEditor } from 'lib/components/MarkdownEditor/rich/RichMarkdownEditor'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { LemonTextAreaMarkdown } from 'lib/lemon-ui/LemonTextArea/LemonTextAreaMarkdown'
+
+import { METRIC_MARKDOWN_MAX_LENGTH } from '../common'
+import { METRIC_MARKDOWN_EXTENSIONS, metricMarkdownConverter } from './metricMarkdown'
+
+const METRIC_MARKDOWN_EDITOR_EXTENSIONS: Extensions = [
+    ...METRIC_MARKDOWN_EXTENSIONS,
+    Placeholder.configure({ placeholder: 'Describe how to calculate this metric, step by step' }),
+]
+
+export interface MetricMarkdownEditorProps {
+    value: string | undefined
+    onChange: (value: string) => void
+}
+
+export function MetricMarkdownEditor({ value, onChange }: MetricMarkdownEditorProps): JSX.Element {
+    // Decided once on mount: agent-authored definitions can contain markdown the rich schema
+    // drops, and editing those in ProseMirror would silently rewrite the saved definition,
+    // so they stay on the plain textarea.
+    const [useLegacyEditor] = useState(() => !metricMarkdownConverter.isRoundTripSafe(value))
+
+    if (useLegacyEditor) {
+        return (
+            <LemonTextAreaMarkdown
+                value={value}
+                onChange={onChange}
+                maxLength={METRIC_MARKDOWN_MAX_LENGTH}
+                minRows={8}
+                maxRows={30}
+                data-attr="data-catalog-metric-markdown-editor-legacy"
+            />
+        )
+    }
+
+    return (
+        <RichMarkdownEditor
+            value={value}
+            onChange={onChange}
+            minRows={8}
+            maxRows={30}
+            maxLength={METRIC_MARKDOWN_MAX_LENGTH}
+            dataAttr="data-catalog-metric-markdown-editor"
+            extensions={METRIC_MARKDOWN_EDITOR_EXTENSIONS}
+            markdownToDoc={metricMarkdownConverter.markdownToDoc}
+            docToMarkdown={metricMarkdownConverter.docToMarkdown}
+            renderPreview={(markdown) => <LemonMarkdown disableImages>{markdown}</LemonMarkdown>}
+            controls={{ imageUpload: false }}
+            tabs={['write', 'preview']}
+            autoFocus
+        />
+    )
+}

--- a/products/data_catalog/frontend/components/MetricMarkdownEditorField.tsx
+++ b/products/data_catalog/frontend/components/MetricMarkdownEditorField.tsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react'
+
+import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { lazyWithRetry } from 'lib/utils/retryImport'
+
+import type { MetricMarkdownEditorProps } from './MetricMarkdownEditor'
+
+// TipTap and the converter are a heavy chunk; load them only once a definition is being edited.
+// The round-trip-safety check also lives inside the lazy module for the same reason.
+const LazyMetricMarkdownEditor = lazyWithRetry(() =>
+    import('./MetricMarkdownEditor').then((m) => ({ default: m.MetricMarkdownEditor }))
+)
+
+export function MetricMarkdownEditorField(props: MetricMarkdownEditorProps): JSX.Element {
+    return (
+        <Suspense
+            fallback={
+                <div
+                    className="flex min-h-[12rem] w-full items-center justify-center rounded border border-primary bg-surface-secondary"
+                    aria-busy
+                    data-attr="data-catalog-metric-markdown-editor-suspense-fallback"
+                >
+                    <Spinner className="text-2xl" />
+                </div>
+            }
+        >
+            <LazyMetricMarkdownEditor {...props} />
+        </Suspense>
+    )
+}

--- a/products/data_catalog/frontend/components/metricMarkdown.test.ts
+++ b/products/data_catalog/frontend/components/metricMarkdown.test.ts
@@ -1,0 +1,24 @@
+import { metricMarkdownConverter } from './metricMarkdown'
+
+describe('metricMarkdown', () => {
+    it('round-trips a sql fence with its language tag', () => {
+        const markdown = 'Run this query:\n\n```sql\nSELECT count() FROM events\n```'
+
+        const doc = metricMarkdownConverter.markdownToDoc(markdown)
+        const codeBlock = doc.content?.find((node) => node.type === 'codeBlock')
+        expect(codeBlock?.attrs?.language).toBe('sql')
+
+        const serialized = metricMarkdownConverter.docToMarkdown(doc)
+        expect(serialized).toContain('```sql')
+        expect(serialized).toContain('SELECT count() FROM events')
+        expect(metricMarkdownConverter.isRoundTripSafe(markdown)).toBe(true)
+    })
+
+    it('keeps images out of the schema and flags them as not round-trip safe', () => {
+        const agentAuthored = '# Metric\n\n![chart](https://example.com/chart.png)'
+
+        const doc = metricMarkdownConverter.markdownToDoc(agentAuthored)
+        expect(JSON.stringify(doc)).not.toContain('"type":"image"')
+        expect(metricMarkdownConverter.isRoundTripSafe(agentAuthored)).toBe(false)
+    })
+})

--- a/products/data_catalog/frontend/components/metricMarkdown.ts
+++ b/products/data_catalog/frontend/components/metricMarkdown.ts
@@ -1,0 +1,8 @@
+import { MARKDOWN_BASE_EDITABLE_EXTENSIONS } from 'lib/components/MarkdownEditor/shared/markdownExtensions'
+import { createTiptapMarkdownConverter } from 'lib/utils/markdown'
+
+// No Image extension: definitions render with `disableImages` and agents consume the raw
+// markdown, so an uploaded image would have no surface anywhere downstream.
+export const METRIC_MARKDOWN_EXTENSIONS = [...MARKDOWN_BASE_EDITABLE_EXTENSIONS]
+
+export const metricMarkdownConverter = createTiptapMarkdownConverter(METRIC_MARKDOWN_EXTENSIONS)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,9 @@
             "@posthog/replay-shared/*": ["./common/replay-shared/src/*"],
             "@posthog/quill-charts": ["./packages/quill/packages/charts/src/index.ts"],
             "@posthog/quill-charts/*": ["./packages/quill/packages/charts/src/*"],
+            // @tiptap/* is installed under frontend/node_modules only, which product files
+            // (products/*/frontend) can't reach by walking up from their own directory.
+            "@tiptap/*": ["./frontend/node_modules/@tiptap/*"],
             // Needed to access the subpath since torph didn't set up types properly
             "torph/react": ["./frontend/node_modules/torph/dist/react/index"],
             // use-debounce@9.0.3 only exposes types under `node`/`browser` conditions,


### PR DESCRIPTION
## Problem

Markdown metric definitions are edited in a plain textarea, and the create modal hides the markdown option "until its editor UI is polished".
This PR is the base layer of a 4-PR stack that un-holds markdown metrics: it adds the rich editor module for the data catalog without wiring it into any surface yet.

## Changes

- `MetricMarkdownEditor` wraps the TipTap `RichMarkdownEditor` with a catalog-specific extension set. No Image extension, matching the `disableImages` rendering of definitions.
- If the saved markdown would not survive a ProseMirror round trip, the component falls back to the plain textarea. Agent-authored definitions must never be rewritten silently by the editor.
- `MetricMarkdownEditorField` lazy-loads the editor, and the round-trip check runs inside the lazy chunk, so TipTap stays out of the scene bundle.
- `RichMarkdownEditor` gains a `controls.imageUpload` toggle, default on, so text cards are unchanged.
- `@tiptap/*` resolves from `frontend/node_modules` for files under `products/`: a tsconfig `paths` entry (tsgo and esbuild) and per-package Vite aliases. A blanket `@tiptap` prefix alias broke Vite dep optimization by rewriting imports inside the tiptap packages themselves, so the aliases are per package.
- `METRIC_MARKDOWN_MAX_LENGTH = 20000` mirrors the backend cap in `validation.py`.
- `RichMarkdownEditor` gains a `tabs` prop, defaulting to all three tabs. The metric editor shows Write and Preview only: the raw Markdown tab duplicates the Write tab for a definition this short. Text cards are unchanged.

No visible change in this PR; the editor is wired into the metric scene in the next PR of the stack.

## How did you test this code?

- `metricMarkdown.test.ts`: a ```sql fence keeps its language tag through a round trip (agents read that raw fence from `information_schema.metrics`), and image markdown parses to no image node and is flagged not round-trip safe (the exact trigger of the textarea fallback).
- Exercised in the browser against the local dev stack as part of the stack's end-to-end run (see the top PR).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code implemented this from an approved plan (enable markdown-based semantic layer metrics with the existing rich editor). Skills invoked: /writing-tests, /writing-code-comments, /writing-user-facing-copy, /writing-pr-descriptions. The `@tiptap` resolution wiring was added mid-implementation after the typecheck and Vite dev server showed products files could not resolve the packages; the first attempt (blanket prefix alias) crashed Vite dep optimization and was narrowed to per-package aliases.

