### PR TITLE
fix(ai-observability): correct PostHogSpanProcessor option and pin AI SDK version

### DIFF
--- a/docs/onboarding/ai-observability/aws-bedrock.tsx
+++ b/docs/onboarding/ai-observability/aws-bedrock.tsx
@@ -91,7 +91,7 @@ export const getAWSBedrockSteps = (ctx: OnboardingComponentsContext): StepDefini
                                       }),
                                       spanProcessors: [
                                         new PostHogSpanProcessor({
-                                          apiKey: '<ph_project_token>',
+                                          projectToken: '<ph_project_token>',
                                           host: '<ph_client_api_host>',
                                         }),
                                       ],

--- a/docs/onboarding/ai-observability/instructor.tsx
+++ b/docs/onboarding/ai-observability/instructor.tsx
@@ -108,7 +108,7 @@ export const getInstructorSteps = (ctx: OnboardingComponentsContext): StepDefini
                                       }),
                                       spanProcessors: [
                                         new PostHogSpanProcessor({
-                                          apiKey: '<ph_project_token>',
+                                          projectToken: '<ph_project_token>',
                                           host: '<ph_client_api_host>',
                                         }),
                                       ],

--- a/docs/onboarding/ai-observability/vercel-ai.tsx
+++ b/docs/onboarding/ai-observability/vercel-ai.tsx
@@ -21,9 +21,19 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
                     <CodeBlock
                         language="bash"
                         code={dedent`
-                            npm install @posthog/ai @ai-sdk/openai ai @opentelemetry/sdk-node @opentelemetry/resources zod
+                            npm install @posthog/ai "ai@^6" "@ai-sdk/openai@^3" @opentelemetry/sdk-node @opentelemetry/resources zod
                         `}
                     />
+
+                    <Blockquote>
+                        <Markdown>
+                            **AI SDK version:** this integration requires AI SDK v5 or v6. AI SDK v7 removed its
+                            OpenTelemetry instrumentation, so it no longer emits the `ai.*` spans that
+                            `PostHogSpanProcessor` reads, and `telemetry.metadata` is no longer accepted. Installing
+                            `ai` without a version constraint gets you v7, which will not produce any events. Pin
+                            `ai@^6` with the matching `@ai-sdk/openai@^3` until PostHog ships v7 support.
+                        </Markdown>
+                    </Blockquote>
                 </>
             ),
         },
@@ -51,7 +61,7 @@ export const getVercelAISteps = (ctx: OnboardingComponentsContext): StepDefiniti
                               }),
                               spanProcessors: [
                                 new PostHogSpanProcessor({
-                                  apiKey: '<ph_project_token>',
+                                  projectToken: '<ph_project_token>',
                                   host: '<ph_client_api_host>',
                                 }),
                               ],


### PR DESCRIPTION
## Problem

Someone following the Vercel AI observability install guide gets no data, and the setup snippet doesn't even typecheck.

Two independent breakages:

1. **Wrong option name.** The Node snippets on the Vercel AI, Instructor, and AWS Bedrock pages construct `new PostHogSpanProcessor({ apiKey: ... })`. `@posthog/ai@8.7.0` expects `projectToken` — `apiKey` is not in `PostHogSpanProcessorOptions`. The `opentelemetry.tsx` and `convex.tsx` pages already use `projectToken`, so these three were the outliers. (The Python snippets on the same pages use `api_key`, which is correct for the Python SDK and is left alone.)

2. **AI SDK v7 has no OpenTelemetry.** The install step said `npm install ... ai ...` with no version constraint. `ai@latest` is now 7.x, and v7 removed OpenTelemetry entirely — `@opentelemetry/api` is gone from its dependencies and there are zero OTel references in the shipped bundle. `PostHogSpanProcessor` has no `ai.*` spans to read, so the integration silently produces nothing. v7 also dropped `metadata` from `TelemetryOptions`, so the `posthog_distinct_id` / `posthog_environment` pattern the guide teaches no longer compiles.

## Changes

- `apiKey` → `projectToken` in the Node snippets for `vercel-ai.tsx`, `instructor.tsx`, and `aws-bedrock.tsx`.
- Vercel AI install step pins `ai@^6` and `@ai-sdk/openai@^3`. The pairing matters: `@ai-sdk/openai@4` resolves `@ai-sdk/provider@^4` (the v7 line), while `ai@6` pins `@ai-sdk/provider@3.0.14`, so installing both unpinned yields a mismatched pair.
- Adds a note explaining that v5 and v6 are supported and v7 is not yet, so the pin doesn't read as arbitrary.

This documents the current constraint rather than fixing it. Real v7 support needs work in `@posthog/ai` against v7's new telemetry-integrations API, which is not in scope here.

## How did you test this code?

Docs-only change; no automated tests were run. Verified the claims in two throwaway npm projects with `tsc --strict`:

<details>
<summary>Verification</summary>

- `ai@7.0.57` + the current documented snippet → `TS2353: 'apiKey' does not exist in type 'PostHogSpanProcessorOptions'` and `TS2353: 'metadata' does not exist in type 'TelemetryOptions<...>'`.
- `ai@6.0.246` + `@ai-sdk/openai@3.0.91` + `projectToken` → typechecks clean.
- `ai@7` package.json dependencies: `@ai-sdk/gateway`, `@ai-sdk/provider`, `@ai-sdk/provider-utils` — no `@opentelemetry/api`. `grep -c opentelemetry node_modules/ai/dist/index.js` → 0.
- `ai@6` and `ai@5` both list `@opentelemetry/api` and both expose `metadata` on their telemetry settings type.

No live API calls were made, so end-to-end event capture was not verified.
</details>

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a weekly docs-feedback digest in Slack; a reader reported the Vercel AI guide was inaccurate against AI SDK v7. Investigating that turned up the unrelated `apiKey`/`projectToken` error, which was then swept across the other affected onboarding pages.

The v7 finding was checked against installed package types rather than release notes, which is what surfaced the second failure (`telemetry.metadata`) beyond the reported one. No repo skills were invoked.

Worth a second opinion on the pin: an alternative is to leave the install command unpinned and only warn, but that leaves the default `npm install` path broken.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C076K2A8UF4/p1785769265064479?thread_ts=1785769265.064479&cid=C076K2A8UF4)*
