### PR TITLE
fix(data-imports): stop reporting Meta Ads rate limits as error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -469,17 +469,21 @@ def _raise_meta_api_error(response: Response) -> typing.NoReturn:
 
     Permanent auth/permission failures raise a clean, user-actionable message
     that ``MetaAdsSource.get_non_retryable_errors`` matches on, so the job fails
-    fast instead of burning retries. A momentary backend blip (see
-    ``_is_transient_error``) that has already exhausted its in-process retries is
-    tagged so ``MetaAdsSource.get_retryable_errors`` can keep the self-recovering
-    failure out of error tracking once Temporal retries the activity, excluding
-    anything the shrink ladders can still act on, which ends at
-    ``_raise_shrink_exhausted_error`` instead. The raw response is appended for
-    debugging.
+    fast instead of burning retries. Throttling (see ``_is_rate_limit_error``) and
+    a momentary backend blip (see ``_is_transient_error``) that has already
+    exhausted its in-process retries are both tagged so
+    ``MetaAdsSource.get_retryable_errors`` can keep the self-recovering failure out
+    of error tracking once Temporal retries the activity, excluding anything the
+    shrink ladders can still act on, which ends at ``_raise_shrink_exhausted_error``
+    instead. The raw response is appended for debugging.
     Everything else raises the raw response and stays retryable.
     """
     if _is_permanent_auth_error(response):
         raise Exception(f"{META_AUTH_ERROR_MESSAGE} (Meta API response: {response.status_code} - {response.text})")
+    if _is_rate_limit_error(response):
+        raise Exception(
+            f"{META_RATE_LIMIT_ERROR_MESSAGE} (Meta API response: {response.status_code} - {response.text})"
+        )
     if _is_transient_error(response) and not _should_shrink_request(response):
         raise Exception(f"Meta API request failed (retryable): {response.status_code} - {response.text}")
     raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -39,6 +39,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads import (
     META_AUTH_ERROR_MESSAGE,
+    META_RATE_LIMIT_ERROR_MESSAGE,
     SHRINK_EXHAUSTED_ERROR_MESSAGE,
     MetaAdsAuthError,
     MetaAdsRateLimitError,
@@ -142,11 +143,17 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig], O
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # Meta error codes 1 ("API Unknown") and 2 ("API Service") are momentary backend blips
-        # Meta's own docs recommend simply retrying. `meta_ads._raise_meta_api_error` tags them
-        # with this marker once `_get_with_transient_retry`'s in-process retries are exhausted, so
-        # the eventual Temporal-level retry doesn't page us as a bug.
-        return {"Meta API request failed (retryable)"}
+        return {
+            # Meta error codes 1 ("API Unknown") and 2 ("API Service") are momentary backend blips
+            # Meta's own docs recommend simply retrying. `meta_ads._raise_meta_api_error` tags them
+            # with this marker once `_get_with_transient_retry`'s in-process retries are exhausted, so
+            # the eventual Temporal-level retry doesn't page us as a bug.
+            "Meta API request failed (retryable)",
+            # Meta throttling (rate limiting) — the request itself is fine, Meta just rejected it
+            # for volume. Only waiting helps, and the sync already retries via Temporal, so this
+            # shouldn't page us as a bug either.
+            META_RATE_LIMIT_ERROR_MESSAGE,
+        }
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -1343,6 +1343,24 @@ class TestRetryableErrors:
             _raise_meta_api_error(_mock_response(500, body))
         assert any(pattern in str(exc_info.value) for pattern in patterns)
 
+    @pytest.mark.parametrize("code", sorted(meta_ads_module.META_RATE_LIMIT_ERROR_CODES))
+    def test_rate_limit_error_matches_retryable_pattern(self, code: int) -> None:
+        # Real-world Meta throttling response: code 17 "User request limit reached" with
+        # is_transient: false. It must be tagged retryable rather than falling through to the
+        # generic, unclassified message and getting reported to error tracking on every attempt.
+        body = {
+            "error": {
+                "message": "User request limit reached",
+                "type": "OAuthException",
+                "code": code,
+                "is_transient": False,
+            }
+        }
+        patterns = MetaAdsSource().get_retryable_errors()
+        with pytest.raises(Exception) as exc_info:
+            _raise_meta_api_error(_mock_response(400, body))
+        assert any(pattern in str(exc_info.value) for pattern in patterns)
+
     def test_empty_body_500_matches_retryable_pattern(self) -> None:
         # Meta (or a fronting proxy) occasionally returns a bare 500 with an empty body — no
         # JSON, no error code to classify by. It must still be tagged retryable rather than


### PR DESCRIPTION
## Problem

Meta throttles Ad Accounts making too many API calls ("User request limit reached", Graph API error code 17). Every occurrence during a Meta Ads sync was reported to [error tracking](https://us.posthog.com/project/2/error_tracking/019fdd8b-f23c-7bb2-acd8-dabf5ecbbd44) as an unclassified exception, even though it is a benign, self-recovering rate limit that Temporal already retries.

## Changes

- `_raise_meta_api_error` now recognizes Meta's rate-limit error codes (4, 17, 32, 613) via the existing `_is_rate_limit_error` check, and tags the raised message instead of falling through to the generic, unclassified one.
- `MetaAdsSource.get_retryable_errors` matches that tag. The sync still retries through Temporal, but the failure logs as a warning instead of reaching error tracking.
- The same detection already existed for the account-picker's `_raise_for_meta_error` path. This carries it to the sync path, where it was missing.

## How did you test this code?

- Added 4 parametrized cases to `TestRetryableErrors` (one per rate-limit code: 4, 17, 32, 613), asserting `_raise_meta_api_error` raises a message that `get_retryable_errors()` matches. This is the regression: today a code-17 response falls through to the unclassified branch.
- Ran `test_meta_ads.py` locally: all 145 cases pass.
- Ran `ruff check`, `ruff format --check`, and repo-wide `mypy` on the changed files: clean.
- Not run: a live sync against Meta's API, since that needs real credentials.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None - no user-facing behavior or API changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from a PostHog error tracking webhook, traced the failing frame to `_raise_meta_api_error` in `meta_ads.py`, and found the connector already had rate-limit detection (`_is_rate_limit_error`, `META_RATE_LIMIT_ERROR_CODES`) for the account-listing path but never wired it into the sync path. Invoked `/writing-tests` before adding the regression tests, and `/writing-pr-descriptions` before this body.

[#74274](https://github.com/PostHog/posthog/pull/74274) (draft, open, human-authored) touches the same file to add Prometheus/OTel telemetry for Meta Ads Graph API errors. It computes a `rate_limit` disposition label for metrics but does not tag the raised exception, so it does not close this gap - the two should be reconciled at review time.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*