### PR TITLE
fix(data-imports): stop reporting posthog-db blips as error noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/cdp_producer.py
@@ -144,12 +144,17 @@ class CDPProducer:
                     trigger__type="data-warehouse-table",
                     trigger__table_name=dot_notated_table_name,
                 ).exists()
-            except DjangoOperationalError as e:
+            except (DjangoOperationalError, OSError) as e:
                 # This queries PostHog's own database, not the source being synced. A transient
                 # failure reaching it (e.g. a DNS blip resolving our host) stringifies with the
                 # same wording a customer's misconfigured source host would, which the source's
                 # `get_non_retryable_errors` would misclassify as non-retryable and permanently
                 # stop a healthy sync. Re-raise clear of those substrings so it stays retryable.
+                # A bare OSError (e.g. "Too many open files") reaches here unwrapped rather than as
+                # a DjangoOperationalError when the worker runs out of file descriptors while
+                # opening the connection's selector, before libpq has anything to report — same
+                # transient condition, different exception type depending on which connect step it
+                # hits, so both need the same reclassification.
                 raise PostHogInternalDatabaseError(
                     "Failed to check hog function/workflow triggers in PostHog's database"
                 ) from e

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_cdp_producer.py
@@ -292,7 +292,19 @@ async def test_should_run_with_both_hog_function_and_flow(team):
 
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
-async def test_should_run_posthog_database_connection_failure_stays_retryable(team):
+@pytest.mark.parametrize(
+    "error_cls,message",
+    [
+        (DjangoOperationalError, "[Errno -2] Name or service not known"),
+        # Fd exhaustion opening the connection's selector surfaces as a bare OSError, unwrapped by
+        # Django, rather than a DjangoOperationalError — same transient condition, different
+        # exception type depending on which connect step runs out of file descriptors first.
+        (OSError, "[Errno 24] Too many open files"),
+    ],
+)
+async def test_should_run_posthog_database_connection_failure_stays_retryable(
+    error_cls: type[Exception], message: str, team
+):
     # `should_run` queries PostHog's own database (HogFunction/HogFlow), not the
     # source being synced. A transient connection failure there (e.g. a DNS blip resolving our
     # host) surfaces the same "Name or service not known" wording a customer's misconfigured
@@ -313,7 +325,7 @@ async def test_should_run_posthog_database_connection_failure_stays_retryable(te
     with patch(
         "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer.HogFunction.objects"
     ) as mock_hog_function_objects:
-        mock_hog_function_objects.filter.side_effect = DjangoOperationalError("[Errno -2] Name or service not known")
+        mock_hog_function_objects.filter.side_effect = error_cls(message)
         with pytest.raises(PostHogInternalDatabaseError) as exc_info:
             await producer.should_run()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -65,6 +65,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceInputs, SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.exceptions import CDCHandledExternally
+from products.warehouse_sources.backend.temporal.data_imports.util import PostHogInternalDatabaseError
 from products.warehouse_sources.backend.temporal.data_imports.workload_report import aworkload_reporting
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
@@ -470,8 +471,10 @@ async def _handle_import_error(
     # a raw driver connection, never Django's ORM, so this exception type can only mean a transient
     # connection-pool blip on our side (e.g. a PgBouncer query_wait_timeout under load), not a
     # customer data or config problem. Same classification already used for app-DB blips in
-    # delta_table_ref.is_transient_maintenance_error.
-    if isinstance(error, OperationalError | InterfaceError):
+    # delta_table_ref.is_transient_maintenance_error. PostHogInternalDatabaseError is the same
+    # condition already reclassified by shared pipeline code (e.g. cdp_producer's should_run check)
+    # specifically so it wouldn't be mistaken for a customer-side failure here — honor that by type.
+    if isinstance(error, OperationalError | InterfaceError | PostHogInternalDatabaseError):
         await logger.awarning(error_msg)
         await logger.adebug("Transient app-DB error - re-raising for Temporal retry")
         raise NonReportableError(error_msg) from error

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -26,7 +26,10 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.res
     RESTClientNonRetryableError,
     RESTClientRetryableError,
 )
-from products.warehouse_sources.backend.temporal.data_imports.util import NonRetryableException
+from products.warehouse_sources.backend.temporal.data_imports.util import (
+    NonRetryableException,
+    PostHogInternalDatabaseError,
+)
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import import_data_sync as module
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.import_data_sync import (
     ImportDataActivityInputs,
@@ -345,6 +348,11 @@ async def test_rest_client_retryable_error_logged_as_warning_without_source_opt_
     [
         ("operational_error", OperationalError, "query_wait_timeout"),
         ("interface_error", InterfaceError, "connection already closed"),
+        # Raised by shared pipeline code (e.g. cdp_producer's should_run check) when a lookup
+        # against PostHog's own app DB fails — already reclassified clear of wording a customer's
+        # misconfigured source host would produce, so it must get the same NonReportableError
+        # treatment as the Django exception types above, not fall through to the default branch.
+        ("posthog_internal_database_error", PostHogInternalDatabaseError, "Failed to check hog function triggers"),
     ]
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A data warehouse sync fails and gets captured in [error tracking](https://us.posthog.com/project/2/error_tracking/019fdd5d-4834-7a33-a39f-01735e779658) with `OperationalError: [Errno 24] Too many open files`, raised from `cdp_producer.py`'s internal check against PostHog's own database.

- The failure is worker-side file-descriptor exhaustion, not a customer or source problem. The interrupted query (`should_run`) only reads PostHog's own `HogFunction`/`HogFlow` tables.
- `cdp_producer.py` already reclassifies this class of failure as `PostHogInternalDatabaseError` so it stays retryable and isn't reported as noise, but it only catches the Django-wrapped `OperationalError` variant. Fd exhaustion during connect can instead raise a bare `OSError`, before libpq has anything to wrap.
- `_handle_import_error` never recognized `PostHogInternalDatabaseError` at all, so even the correctly-reclassified case fell through to the default branch and got reported to error tracking on every occurrence.

## Changes

- Catch `OSError` alongside `DjangoOperationalError` in `cdp_producer.py`'s `should_run` check, so fd exhaustion during connect reclassifies the same way a DNS blip already does.
- Recognize `PostHogInternalDatabaseError` in `_handle_import_error`, treating it like Django's `OperationalError`/`InterfaceError`: log a warning and re-raise as `NonReportableError`, keeping it retryable and out of error tracking.

## How did you test this code?

- Extended `test_should_run_posthog_database_connection_failure_stays_retryable` in `test_cdp_producer.py` with an `OSError` case alongside the existing DNS-blip case, confirming both reclassify to `PostHogInternalDatabaseError` and stay clear of the source's non-retryable error list.
- Added a `posthog_internal_database_error` case to `test_app_db_connection_error_reraised_as_non_reportable` in `test_import_data_sync.py`, confirming it re-raises as `NonReportableError` like the existing Django exception cases.
- Ran both full test files locally: 58 passed.
- Ran `ruff check`/`ruff format --check` on the changed files: clean.
- Ran a repo-wide `mypy --cache-fine-grained .`: no issues found.
- Not run: `hogli ci:preflight` (hogli isn't installed in this sandbox).

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None — internal error classification only, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from the linked error-tracking issue: pulled the stack trace and sync-context properties via the PostHog MCP error-tracking tools, traced the exception through `cdp_producer.py`'s `should_run` check and `import_data_sync.py`'s `_handle_import_error`, and confirmed against Django's `DatabaseErrorWrapper` and the installed psycopg source exactly which connect step raises a bare `OSError` versus a wrapped `OperationalError`. Invoked `/writing-tests` before adding test cases (switching one from `parameterized.expand` to `pytest.mark.parametrize` after the former didn't compose with the `team` fixture on an async test) and `/writing-pr-descriptions` for this body. Searched open PRs (excluding the bot account) and the maintainer's own open PRs for a prior fix; found none addressing this exact classification gap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*