### PR TITLE
fix(signals): open inbox-initiated PRs under the user's GitHub identity

### DIFF
--- a/products/signals/frontend/inbox/inboxTaskKickoffLogic.ts
+++ b/products/signals/frontend/inbox/inboxTaskKickoffLogic.ts
@@ -11,6 +11,7 @@ import { OriginProduct } from 'products/posthog_ai/frontend/types/taskTypes'
 import {
     ClaudeRuntimeAdapterEnumApi,
     ClaudeTaskRunCreateSchemaApi,
+    PrAuthorshipModeEnumApi,
     ReasoningEffortEnumApi,
     RunSourceEnumApi,
     TaskExecutionModeEnumApi,
@@ -86,11 +87,17 @@ async function createReportTask(
     } as Parameters<typeof api.tasks.create>[0])
 
     // Kick off a cloud run so the task actually executes — creating it alone lands the user on a
-    // "This task hasn't been run yet" screen. `run_source` ties the run to the report and makes any
-    // PR bot-authored server-side, mirroring the auto-start pipeline's `create_and_run_task`.
+    // "This task hasn't been run yet" screen. `run_source` ties the run to the report.
     const runOptions = {
         run_source: RunSourceEnumApi.SignalReport,
         signal_report_id: report.id,
+        // A person asked for this PR, so it should be theirs rather than the bot's, unlike the
+        // reports the auto-start pipeline acts on unprompted. Only implementation runs claim
+        // authorship: a discussion never opens a PR, and asking for a GitHub identity it doesn't
+        // need would block teams that have none.
+        ...(relationship === SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP
+            ? { pr_authorship_mode: PrAuthorshipModeEnumApi.User }
+            : {}),
         // Interactive, not the default background: the user lands on the run page right away, and the
         // agent-server only relays AskUserQuestion (and other approval prompts) to the client on
         // non-background runs — a background run's questions are parked and never rendered as a form.

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -3543,7 +3543,6 @@ def bootstrap_task_run(
     """
     from products.tasks.backend.temporal.process_task.utils import (  # noqa: PLC0415 — keep temporalio off the api import path
         PrAuthorshipMode,
-        RunSource,
         cache_github_user_token,
         get_provider_for_runtime_adapter,
         get_reasoning_effort_error,
@@ -3570,8 +3569,6 @@ def bootstrap_task_run(
     initial_permission_mode = validated_data.get("initial_permission_mode")
     imported_mcp_servers = validated_data.get("imported_mcp_servers")
     relayed_mcp_servers = validated_data.get("relayed_mcp_servers")
-    if run_source == RunSource.SIGNAL_REPORT:
-        pr_authorship_mode = PrAuthorshipMode.BOT
 
     extra_state: dict | None = None
     if initial_permission_mode is not None:
@@ -5025,7 +5022,6 @@ def run_task(
     from products.tasks.backend.logic.services.staged_artifacts import get_task_staged_artifacts  # noqa: PLC0415
     from products.tasks.backend.temporal.process_task.utils import (  # noqa: PLC0415 — keep temporalio off the api import path
         PrAuthorshipMode,
-        RunSource,
         cache_github_user_token,
         get_provider_for_runtime_adapter,
         get_reasoning_effort_error,
@@ -5109,8 +5105,6 @@ def run_task(
     initial_permission_mode = validated_data.get("initial_permission_mode")
     imported_mcp_servers = validated_data.get("imported_mcp_servers")
     relayed_mcp_servers = validated_data.get("relayed_mcp_servers")
-    if run_source == RunSource.SIGNAL_REPORT:
-        pr_authorship_mode = PrAuthorshipMode.BOT
 
     runtime_state_fields = {
         "pr_authorship_mode": pr_authorship_mode,

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -21,6 +21,7 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_github_credential_source,
     get_imported_mcp_server_configs,
     get_models_for_runtime_adapter,
+    get_pr_authorship_mode,
     get_relayed_mcp_server_names,
     get_sandbox_github_token,
     get_sandbox_ph_mcp_configs,
@@ -536,6 +537,19 @@ class TestFetchUserMcpServerConfigs(TestCase):
         assert len(configs) == 2
         assert configs[0].name == "Linear"
         assert configs[1].name == "Notion"
+
+
+class TestGetPrAuthorshipMode(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("recorded_mode_wins", {"run_source": "signal_report", "pr_authorship_mode": "user"}, "user"),
+            ("unrecorded_run_defaults_to_bot", {"run_source": "signal_report"}, "bot"),
+            ("unrecorded_rerun_defaults_to_bot", {}, "bot"),
+        ]
+    )
+    def test_signal_report_authorship(self, _name: str, state: dict, expected: str) -> None:
+        task = MagicMock(spec=Task, origin_product=Task.OriginProduct.SIGNAL_REPORT)
+        assert get_pr_authorship_mode(task, state).value == expected
 
 
 class TestGetGitIdentityEnvVars(TestCase):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -1278,16 +1278,17 @@ def get_pr_authorship_mode(task: Task, state: dict[str, Any] | None = None) -> P
 
     Newer cloud runs store the mode in ``TaskRun.state``. Older user-created
     runs fall back to user authorship so they still get a human git identity.
+
+    A mode recorded on the run wins over every default below, so a caller that asked for
+    user authorship keeps it. The auto-start pipeline records ``BOT`` for its own runs;
+    a signal-report run with nothing recorded is bot-authored too.
     """
     from products.tasks.backend.models import Task as TaskModel
 
     run_state = parse_run_state(state)
-    if run_state.run_source == RunSource.SIGNAL_REPORT:
-        return PrAuthorshipMode.BOT
     if run_state.pr_authorship_mode is not None:
         return run_state.pr_authorship_mode
-
-    if task.origin_product == TaskModel.OriginProduct.SIGNAL_REPORT:
+    if run_state.run_source == RunSource.SIGNAL_REPORT:
         return PrAuthorshipMode.BOT
 
     return (

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -80,7 +80,7 @@ from products.tasks.backend.presentation.serializers import (
     TASK_RUN_PDF_ARTIFACT_MAX_SIZE_BYTES,
     TaskRunLivingArtifactChartRequestSerializer,
 )
-from products.tasks.backend.temporal.process_task.utils import get_cached_github_user_token
+from products.tasks.backend.temporal.process_task.utils import get_cached_github_user_token, get_pr_authorship_mode
 
 
 def _grant_user_github_access(user: User, *, refresh_ttl_seconds: int = 15897600) -> UserIntegration:
@@ -3684,6 +3684,23 @@ class TestTaskAPI(BaseTaskAPITest):
         assert response.status_code == status.HTTP_200_OK
         task.refresh_from_db()
         assert task.github_user_integration_id == user_integration.id
+        mock_workflow.assert_called_once()
+
+    @parameterized.expand([("requested_user", {"pr_authorship_mode": "user"}, "user"), ("unspecified", {}, "bot")])
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_run_endpoint_signal_report_authorship(self, _name, extra_payload, expected_mode, mock_workflow):
+        task = self.create_task(created_by=self.user)
+        _grant_user_github_access(self.user)
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"mode": "interactive", "run_source": "signal_report", **extra_payload},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        task_run = TaskRun.objects.get(id=response.json()["latest_run"]["id"])
+        assert get_pr_authorship_mode(task_run.task, task_run.state).value == expected_mode
         mock_workflow.assert_called_once()
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")


### PR DESCRIPTION
## Problem

A person who clicks "Create PR" on a report in the inbox gets a PR from posthog[bot]. The PR does not come from that person.

- The commits show the author as "PostHog Desktop <code@posthog.com>".
- The task has `origin_product: signal_report`. The two run endpoints set the authorship mode to bot for every such task.
- The endpoints ignored the mode that the client sent. The desktop app sent `pr_authorship_mode: "user"`, and the server replaced it.
- The auto-start pipeline does not use these endpoints. It calls `Task.create_and_run`, which records bot authorship directly.
- Only HTTP requests reach the two endpoints. Each such request has a signed-in user.

## Changes

- The inbox now asks for user authorship. A PR that a person asks for gets that person's GitHub identity, and their name on the commits.
- Reports from the auto-start pipeline still open bot PRs. This PR does not change that path.
- I removed the two statements in `products/tasks/backend/facade/api.py` that set bot authorship for `run_source == signal_report`. I did not add a condition to keep them. The auto-start pipeline cannot reach these statements. A client that sends no mode still gets bot authorship one layer below.
- `get_pr_authorship_mode` now reads the recorded mode before every default. An explicit request from the client reaches the sandbox.
- Only implementation runs ask for user authorship. "Ask AI" opens no PR. A team with no GitHub integration must keep access to it.
- The server uses bot authorship when the user has no linked GitHub account. User-created tasks already work this way.

The buttons and the flow look the same. There is no visual change.

Two surfaces keep bot authorship. Both are out of scope for this PR:

- The mobile app. Its run options have no authorship field.
- A repeat run of an inbox task from the task detail page.

## How did you test this code?

I used automated tests only. I did not start the app, and I did not open a real PR. The identity on a real PR is therefore unverified.

- `TestGetPrAuthorshipMode` catches a change that lets the signal-report default replace a recorded mode. Such a change sends every inbox PR back to the bot.
- `test_run_endpoint_signal_report_authorship` catches a return of the override at the API layer. It also holds the second case: a request that sends no mode must still get bot authorship.
- `test_workflow.py` has one failure about the sandbox image source. The same failure happens on a clean checkout. It is not related to this PR.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael asked which GitHub identity an "Ask AI" task uses. I (actually Claude Opus 5, in Claude Code) followed the identity path through the code, then made the change in a worktree.

Skills invoked: `/writing-tests`, `/simplify`, `/writing-pr-descriptions`, `/asd-ste100`.

My first version kept the two statements and added `and pr_authorship_mode is None` to each one. The `/simplify` review rejected this design. The default protects a path that the auto-start pipeline cannot reach. It also forces every client to send a mode, to escape a rule that exists for an absent caller. The same review found a second problem: user authorship on a discussion run returns a 400 error for a team with no GitHub integration. The changes above correct both problems.

This PR contains no material from the agent session that is not already public.
