### PR TITLE
fix(oauth): send the state parameter to the API unchanged

### DIFF
--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.test.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.test.ts
@@ -1,11 +1,13 @@
 import { MOCK_DEFAULT_USER } from 'lib/api.mock'
 
+import { decodeParams } from 'kea-router'
+
 import { userLogic } from 'scenes/userLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import { oauthAuthorizeLogic } from './oauthAuthorizeLogic'
+import { describeOAuthError, oauthAuthorizeLogic } from './oauthAuthorizeLogic'
 
 describe('oauthAuthorizeLogic', () => {
     let logic: ReturnType<typeof oauthAuthorizeLogic.build>
@@ -291,5 +293,109 @@ describe('oauthAuthorizeLogic', () => {
         logic.actions.setRequiredAccessLevel('team')
         expect(logic.values.selectedOrganization).toBe(expectedOrg)
         expect(logic.values.oauthAuthorization.scoped_teams).toEqual(expectedTeams)
+    })
+
+    // Opaque client-owned params must reach the API byte-for-byte, whatever they look like.
+    describe('OAuth parameter passthrough', () => {
+        const JSON_STATE = '{"flow_id":"5a8f3d48-c841-4375-b06d-5c828c86282d","provider":"posthog"}'
+
+        let sentBody: Record<string, any>
+
+        beforeEach(() => {
+            sentBody = {}
+            useMocks({
+                post: {
+                    '/oauth/authorize/': async ({ request }) => {
+                        sentBody = (await request.json()) as Record<string, any>
+                        // No `redirect_to`, so the logic does not navigate the test page away.
+                        return {}
+                    },
+                },
+            })
+        })
+
+        const authorizeWithSearch = async (search: string): Promise<Record<string, any>> => {
+            // `replaceState` rather than `router.actions.push`: push rebuilds the search string
+            // from kea-router's decoded values, so it cannot reproduce a raw inbound URL.
+            window.history.replaceState({}, '', `/oauth/authorize${search}`)
+            await logic.asyncActions.cancel().catch(() => undefined)
+            return sentBody
+        }
+
+        it('sends a JSON state as the verbatim string the client provided', async () => {
+            const search = `?client_id=abc&state=${encodeURIComponent(JSON_STATE)}`
+            // This is what kea-router hands to `searchParams` — the value we must not send.
+            expect(decodeParams(search, '?').state).toEqual({
+                flow_id: '5a8f3d48-c841-4375-b06d-5c828c86282d',
+                provider: 'posthog',
+            })
+
+            const body = await authorizeWithSearch(search)
+            expect(body.state).toBe(JSON_STATE)
+            expect(body.client_id).toBe('abc')
+        })
+
+        it.each([
+            ['a boolean-like state', 'true'],
+            ['a numeric state with a leading zero', '0123'],
+            ['an array-like state', '[1,2]'],
+        ])('sends %s unchanged', async (_name, state) => {
+            const body = await authorizeWithSearch(`?state=${encodeURIComponent(state)}`)
+            expect(body.state).toBe(state)
+        })
+
+        it('sends null for a parameter the client omitted', async () => {
+            const body = await authorizeWithSearch('?client_id=abc')
+            expect(body.state).toBeNull()
+            expect(body.nonce).toBeNull()
+        })
+    })
+
+    describe('describeOAuthError', () => {
+        it('names the parameter that the serializer rejected', () => {
+            expect(describeOAuthError({ state: ['Not a valid string.'] })).toBe(
+                'The application sent an incorrect authorization request. ' +
+                    'The parameter "state" is not correct: Not a valid string.'
+            )
+        })
+
+        it('describes every rejected parameter', () => {
+            expect(describeOAuthError({ state: ['Not a valid string.'], scope: ['Unknown scope.'] })).toBe(
+                'The application sent an incorrect authorization request. ' +
+                    'The parameter "state" is not correct: Not a valid string. ' +
+                    'The parameter "scope" is not correct: Unknown scope.'
+            )
+        })
+
+        it('uses a non-field error as its own sentence', () => {
+            expect(describeOAuthError({ non_field_errors: ['The request expired.'] })).toBe(
+                'The application sent an incorrect authorization request. The request expired.'
+            )
+        })
+
+        // `/oauth/authorize/` also fails with the RFC 6749 envelope (views.py:1274). Its keys
+        // are not parameter names, and `ApiError.message` would show the code, not the prose.
+        it('prefers the description over the code in an OAuth error envelope', () => {
+            expect(
+                describeOAuthError({
+                    error: 'access_denied',
+                    error_description: 'This organization has disabled AI data processing.',
+                })
+            ).toBe('This organization has disabled AI data processing.')
+        })
+
+        it.each([
+            ['no body', undefined],
+            ['a null body', null],
+            ['a plain string body', 'Bad Request'],
+            ['an array body', ['Bad Request']],
+            ['a body without messages', { state: [] }],
+            // Would otherwise read as a parameter named "error".
+            ['an envelope with no description', { error: 'invalid_client' }],
+            // DRF always sends a list, so a bare string is not a field error.
+            ['a non-list field value', { state: 'Not a valid string.' }],
+        ])('returns null for %s, so the caller falls back', (_name, data) => {
+            expect(describeOAuthError(data)).toBeNull()
+        })
     })
 })

--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
@@ -110,20 +110,58 @@ const isNativeProtocol = (url: string): boolean => {
 
 type OAuthAuthorizeResult = { redirectTo: string; isNative: boolean }
 
+// `/oauth/authorize/` fails in two shapes, and `ApiError` reads neither usefully: the RFC 6749
+// §4.1.2.1 envelope `{ error, error_description }`, where it surfaces the machine code rather
+// than the prose, and DRF serializer errors `{ "<field>": ["<message>"] }`, where it finds no
+// key at all and falls back to the transport text ("Non-OK response [POST ...] (status 400: )").
+export const describeOAuthError = (data: unknown): string | null => {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+        return null
+    }
+    const body = data as Record<string, unknown>
+
+    if (typeof body.error_description === 'string' && body.error_description) {
+        return body.error_description
+    }
+
+    const sentences: string[] = []
+    for (const [field, value] of Object.entries(body)) {
+        // DRF always reports field errors as a list, which is what tells them apart from the
+        // envelope above — `{ error: 'access_denied' }` is not a parameter named "error".
+        if (!Array.isArray(value)) {
+            continue
+        }
+        const messages = value.filter((message): message is string => typeof message === 'string' && !!message)
+        if (!messages.length) {
+            continue
+        }
+        const text = messages.join(' ')
+        sentences.push(field === 'non_field_errors' ? text : `The parameter "${field}" is not correct: ${text}`)
+    }
+    if (!sentences.length) {
+        return null
+    }
+    return ['The application sent an incorrect authorization request.', ...sentences].join(' ')
+}
+
 const oauthAuthorize = async (
     values: OAuthAuthorizationFormValues & { allow: boolean; scopes: string[] }
 ): Promise<OAuthAuthorizeResult | null> => {
+    // Not kea-router's `searchParams`: it JSON-parses object-like values and coerces numbers
+    // and booleans, and its own `location.search` is re-encoded from those. RFC 6749 A.5 allows
+    // any printable ASCII in `state`, so a raw-JSON state must reach the API byte-for-byte.
+    const params = new URLSearchParams(window.location.search)
     try {
         const response = await api.create('/oauth/authorize/', {
-            client_id: router.values.searchParams['client_id'],
-            redirect_uri: router.values.searchParams['redirect_uri'],
-            response_type: router.values.searchParams['response_type'],
-            state: router.values.searchParams['state'],
+            client_id: params.get('client_id'),
+            redirect_uri: params.get('redirect_uri'),
+            response_type: params.get('response_type'),
+            state: params.get('state'),
             scope: values.scopes.join(' '),
-            code_challenge: router.values.searchParams['code_challenge'],
-            code_challenge_method: router.values.searchParams['code_challenge_method'],
-            nonce: router.values.searchParams['nonce'],
-            claims: router.values.searchParams['claims'],
+            code_challenge: params.get('code_challenge'),
+            code_challenge_method: params.get('code_challenge_method'),
+            nonce: params.get('nonce'),
+            claims: params.get('claims'),
             scoped_organizations: values.access_type === 'organizations' ? values.scoped_organizations : [],
             scoped_teams: values.access_type === 'teams' ? values.scoped_teams : [],
             access_level:
@@ -139,7 +177,11 @@ const oauthAuthorize = async (
         }
         return null
     } catch (error: any) {
-        const detail = error?.detail || error?.message || 'Something went wrong while authorizing the application'
+        const detail =
+            error?.detail ||
+            describeOAuthError(error?.data) ||
+            error?.message ||
+            'PostHog could not authorize the application.'
         lemonToast.error(detail)
         throw error
     }
@@ -826,6 +868,9 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
         redirectDomain: [
             (s) => [s.oauthApplication],
             (): string => {
+                // Stays on kea-router: a redirect_uri is always a URL, which `parseValue` leaves
+                // alone, and only the request payload needs verbatim bytes. Reading
+                // `window.location` here would break under Storybook's in-memory history.
                 const redirectUri = router.values.searchParams['redirect_uri'] as string
                 if (!redirectUri) {
                     return ''


### PR DESCRIPTION
Hooman tl;dr: A PostHog user (not writing out the name so it's not indexed) reported to me the following problem:

<img width="664" height="1028" alt="Screenshot 2026-08-07 at 13 13 01@2x" src="https://github.com/user-attachments/assets/1e601e3a-2d29-40f6-9482-295063011336" />

Turns out they were sending OAuth `state` as a search param in URL-encoded JSON, not in base64-encoded JSON. But this is technically legal. I _think_ PostHog should support both URL-encoded and base64.

Also, the other problem was just that this error was opaque as hell. The OAuth error handling wasn't formatting anything. 

## Problem

A client sent this authorization request, and the API returned 400:

```json
{ "state": ["Not a valid string."] }
```

The client put raw JSON in `state`:

```
?state={"flow_id":"5a8f3d48-...","provider":"posthog","payload":"ocWhphbe..."}
```

The consent screen read its OAuth parameters from kea-router's decoded `searchParams`. kea-router decodes each parameter with its own `parseValue`. That function parses a JSON-like value into an object. It also changes a numeric value to a number, and `true` or `false` to a boolean. The serializer declares `state` as a `CharField`, and DRF rejects an object and a boolean.

RFC 6749 Appendix A.5 permits every printable ASCII character in `state`. Raw JSON is therefore a legal value, and this defect belongs to PostHog. Most clients encode their `state` with base64, so they never met this failure.

A numeric `state` fails in a worse way. DRF accepts a number and changes it to a string, so `?state=0123` becomes `"123"`. The API returns 200, the client receives a `state` that does not match the one it sent, and its CSRF check fails.

## Changes

**1. Send the OAuth parameters unchanged.** `oauthAuthorize` builds one `URLSearchParams` from `window.location.search` and reads the request parameters off it. The consent screen is a fresh page load, so the browser holds the exact string that the client sent. `router.values.location.search` is not a safe substitute: kea-router rebuilds that string from the decoded values, so `?state=0123` becomes `?state=123`.

Only the request payload reads `window.location`. The `redirectDomain` selector stays on kea-router, because a redirect_uri is always a URL that `parseValue` leaves alone, and because Storybook runs the router on an in-memory history that never touches `window.location`.

**2. Show the error that DRF returned.** `ApiError` reads only `error`, `detail` and `message`. A serializer error has none of these keys, so the consent screen showed the transport text instead:

> Non-OK response [POST /oauth/authorize/] (status 400: )

`describeOAuthError` now reads the response body:

> The application sent an incorrect authorization request. The parameter "state" is not correct: Not a valid string.

This applies to every serializer error on this endpoint, not only to `state`.

The endpoint also fails with the RFC 6749 §4.1.2.1 envelope `{ error, error_description }` (`views.py:1274`, and a 403 at `views.py:213`). `ApiError` picks up `error`, which is the machine code. The function now returns `error_description`, which is the prose. It tells the two shapes apart by value type, because DRF always reports a field error as a list.

## Verification

- 41 tests pass in `oauthAuthorizeLogic.test.ts`, including 16 new ones.
- The parameter tests cover a JSON `state`, a boolean-like `state`, an array-like `state`, a numeric `state` with a leading zero, and an omitted parameter.
- The error tests cover both response shapes, and the cases where the function must fall through to `ApiError.message`.
- `oxlint` and `oxfmt` report no problems. The typechecker reports the same 307 pre-existing errors before and after this change.

## Notes

Error tracking holds one matching issue: [Non-OK response [POST /oauth/authorize/] (status 400: )](https://us.posthog.com/project/2/error_tracking/019fd3d0-44e4-7bc1-8a19-b5f171ac002f). Do not read a rate from it. The bucket starts on 2026-08-05, when `api-error.ts` started to capture these errors, and its fingerprint excludes the response body. Every 400 on this endpoint therefore lands in one bucket, whatever its cause. Change 2 does not alter the fingerprint, but it does put the reason in front of the user.



