### PR TITLE
chore(personhog): drop stateright write ids and the read counter

### DIFF
--- a/rust/personhog-stateright/README.md
+++ b/rust/personhog-stateright/README.md
@@ -28,17 +28,17 @@ web explorer.
 Configurations are deliberately small — state spaces grow
 combinatorially, and protocol bugs are structural, showing up at
 minimum viable scale or not at all.
-The suite explores ~83M states across 31 runs.
+The suite explores ~47M states across 31 runs.
 Its long pole is the two-partition double-zombie pair, which is most of the wall clock on its own:
 
 | Scenario | Unique states | Wall time |
 |---|---|---|
-| `epoch_fenced_two_partitions_double_zombie_is_safe` | 39.3M | 55s |
-| `two_partitions_double_zombie_loses_acked_writes` | 29.8M | 39s |
-| `cancellation_with_live_owner_reaffirms_and_resumes` | 3.5M | 4.0s |
-| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 2.1M | 1.9s |
-| `current_two_partitions_single_zombie_is_safe` | 1.8M | 2.0s |
-| *everything else (26 runs)* | 6.9M | 7s |
+| `epoch_fenced_two_partitions_double_zombie_is_safe` | 21.1M | 25s |
+| `two_partitions_double_zombie_loses_acked_writes` | 15.9M | 20s |
+| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.8M | 3.0s |
+| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 1.6M | 1.5s |
+| `current_two_partitions_single_zombie_is_safe` | 1.0M | 1.1s |
+| *everything else (26 runs)* | 2.6M | 5s |
 
 Roughly: a second partition costs ~20x, a second failure in the budget ~10x, a third pod ~2x.
 Times are release mode, one scenario at a time on 14 cores — a CI runner with 4 slower cores is several times that, so treat them as ratios rather than absolutes.

--- a/rust/personhog-stateright/src/model.rs
+++ b/rust/personhog-stateright/src/model.rs
@@ -379,7 +379,7 @@ impl HandoffModel {
         if visible < state.changelogs[&partition].len {
             state.stale_strong_read = true;
         }
-        state.reads_served = state.reads_served.saturating_add(1);
+        state.read_served = true;
         true
     }
 
@@ -493,8 +493,6 @@ impl HandoffModel {
             return false;
         }
         if router.stashing.contains(&partition) {
-            let id = state.next_write_id;
-            state.next_write_id += 1;
             state
                 .routers
                 .get_mut(&r)
@@ -502,7 +500,7 @@ impl HandoffModel {
                 .stash
                 .entry(partition)
                 .or_default()
-                .push(StashedRequest::Write(id));
+                .push(StashedRequest::Write);
             return true;
         }
         let Some(target) = router.table.get(&partition).copied() else {
@@ -980,7 +978,7 @@ impl HandoffModel {
                     };
                     for entry in parked {
                         match entry {
-                            StashedRequest::Write(_) => {
+                            StashedRequest::Write => {
                                 if self.write_capable(state, new_owner, p) {
                                     self.accept_write(state, new_owner, p);
                                 }
@@ -1023,7 +1021,7 @@ impl HandoffModel {
                     for entry in parked {
                         let Some(owner) = assignment else { continue };
                         match entry {
-                            StashedRequest::Write(_) => {
+                            StashedRequest::Write => {
                                 if self.write_capable(state, owner, p) {
                                     self.accept_write(state, owner, p);
                                 }
@@ -1100,8 +1098,7 @@ impl Model for HandoffModel {
             rejoins_left: self.rejoins,
             router_joins_left: self.router_joins,
             cancels_left: self.cancels,
-            next_write_id: 0,
-            reads_served: 0,
+            read_served: false,
             lost_acked_write: false,
             double_planned_handoff: false,
             stale_strong_read: false,
@@ -1411,7 +1408,7 @@ impl Model for HandoffModel {
             Property::<Self>::sometimes("some_strong_read_served", |m, s| {
                 // Vacuously discoverable in configs without reads, so
                 // `assert_properties` stays usable across the matrix.
-                m.reads == 0 || s.reads_served > 0
+                m.reads == 0 || s.read_served
             }),
             // Replacement-cancellation reachability. Guards make each
             // probe vacuous outside the configs shaped to reach it, so

--- a/rust/personhog-stateright/src/types.rs
+++ b/rust/personhog-stateright/src/types.rs
@@ -13,7 +13,6 @@ pub type Partition = u8;
 /// Identity of one handoff attempt — production `HandoffState.handoff_id`.
 /// Acks echo it and quorum checks only count matching acks.
 pub type HandoffId = u8;
-pub type WriteId = u8;
 
 /// The production phase enum, used directly: a new phase added to the
 /// protocol breaks the model's exhaustive matches at compile time.
@@ -136,9 +135,16 @@ pub struct Router {
 }
 
 /// One parked leader-path request.
+///
+/// Deliberately identity-free. A parked write is only ever drained or
+/// dropped, never matched against a particular client, so carrying a write
+/// id would add a dimension to the state space that nothing reads — two
+/// otherwise-identical states would differ only in how many writes had ever
+/// been parked. Order and count still matter, and the per-partition `Vec`
+/// keeps both.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum StashedRequest {
-    Write(WriteId),
+    Write,
     StrongRead,
 }
 
@@ -192,10 +198,11 @@ pub struct SystemState {
     pub router_joins_left: u8,
     /// Deadline cancellations the checker may still inject.
     pub cancels_left: u8,
-    pub next_write_id: WriteId,
-    /// Count of strong reads actually served (reachability evidence for
-    /// the read properties).
-    pub reads_served: u8,
+    /// Whether any strong read was actually served (reachability evidence
+    /// for the read properties). A flag rather than a count: nothing reads
+    /// how many, and a count would split otherwise-identical states by
+    /// their read history.
+    pub read_served: bool,
 
     // ── violation flags (history-free invariant encoding) ──────
     /// Set when a write is acked by a pod while a *different* pod that


### PR DESCRIPTION
## Problem

The model checker explored 1.8x more states than the protocol has, because two fields recorded history nothing reads back.

Second of six commits shrinking the `personhog-stateright` shard, the slowest job in Rust CI. Stacked on #79896.

- `StashedRequest::Write` carried a `WriteId` from a monotonic `next_write_id`.
- Both drain sites matched it as `_`, and no property looks inside a stash beyond emptiness.
- `next_write_id` never reset, so two identical states differed by how many writes had ever been parked, and each count rooted its own subtree.
- `reads_served: u8` was only ever tested as `> 0`.

## Changes

- `StashedRequest::Write` becomes a unit variant. The per-partition `Vec` still records drain order and count, so the parked requests behave identically.
- `next_write_id` and the `WriteId` alias are gone.
- `reads_served: u8` becomes `read_served: bool`, which also drops a `saturating_add` that silently capped at 255.

Forgetting information nothing consumes is a bisimulation, so every verdict is unchanged.

## How did you test this code?

State space 83.5M to 47.1M unique states (0.56x), suite wall clock 108.8s to 56.2s (1.94x).

Nearly all of it is the write ids: at `writes: 2` a parked write was one of three distinguishable symbols instead of one.

The verdict tests are the check that the collapse is sound. A collapse that hides a bug shows up as a missing counterexample in `current_protocol_double_zombie_loses_acked_writes`, `epoch_fenced_read_first_ordering_loses_acked_writes`, or the `Delayed` arm of `prompt_detection_is_what_makes_the_read_gate_hold`. A collapse that goes too far shows up as a `sometimes` probe finding no discovery.

Not verified: the effect on CI. Local wall times come from a 14-core laptop.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

README sizing table refreshed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Eli directed the work.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

This was the largest single win in the stack and the plan had it third, estimated at 1.5 to 3x fewer states. It landed at 1.8x. The write ids were the surprise: the plan treated them as a minor cleanup.

Nothing in this PR draws on material outside this repository.
