### PR TITLE
chore(personhog): merge the stateright warm cutoff and accept count

### DIFF
--- a/rust/personhog-stateright/README.md
+++ b/rust/personhog-stateright/README.md
@@ -28,17 +28,17 @@ web explorer.
 Configurations are deliberately small — state spaces grow
 combinatorially, and protocol bugs are structural, showing up at
 minimum viable scale or not at all.
-The suite explores ~47M states across 31 runs.
+The suite explores ~45M states across 31 runs.
 Its long pole is the two-partition double-zombie pair, which is most of the wall clock on its own:
 
 | Scenario | Unique states | Wall time |
 |---|---|---|
-| `epoch_fenced_two_partitions_double_zombie_is_safe` | 21.1M | 25s |
-| `two_partitions_double_zombie_loses_acked_writes` | 15.9M | 20s |
-| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.8M | 3.0s |
-| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 1.6M | 1.5s |
-| `current_two_partitions_single_zombie_is_safe` | 1.0M | 1.1s |
-| *everything else (26 runs)* | 2.6M | 5s |
+| `epoch_fenced_two_partitions_double_zombie_is_safe` | 20.3M | 26s |
+| `two_partitions_double_zombie_loses_acked_writes` | 15.3M | 19s |
+| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.6M | 2.9s |
+| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 1.5M | 1.5s |
+| `current_two_partitions_single_zombie_is_safe` | 1.0M | 1.2s |
+| *everything else (26 runs)* | 4.6M | 5s |
 
 Roughly: a second partition costs ~20x, a second failure in the budget ~10x, a third pod ~2x.
 Times are release mode, one scenario at a time on 14 cores — a CI runner with 4 slower cores is several times that, so treat them as ratios rather than absolutes.
@@ -62,6 +62,7 @@ Two kinds of change, two different expectations:
   Each one needs an argument in its commit message for why forgetting that information is a bisimulation, because a collapse that is wrong does not fail loudly: it quietly stops exploring states where a bug could live.
 
 `generated / unique` is the duplicate-successor ratio, and `depth` is a racing maximum across checker threads, so it varies run to run and means nothing on its own.
+Wall times move by up to 10% between runs of the same binary, so judge a change by its state counts and treat a timing difference under that as no difference.
 
 ## Coupling to production (drift prevention)
 

--- a/rust/personhog-stateright/src/model.rs
+++ b/rust/personhog-stateright/src/model.rs
@@ -272,8 +272,7 @@ impl HandoffModel {
                 WarmState {
                     for_handoff,
                     epoch: log.epoch,
-                    cutoff: log.len,
-                    accepted: 0,
+                    visible: log.len,
                 }
             };
             let pod = state.pods.get_mut(&x).unwrap();
@@ -305,8 +304,7 @@ impl HandoffModel {
                     WarmState {
                         for_handoff,
                         epoch: log.epoch,
-                        cutoff,
-                        accepted: 0,
+                        visible: cutoff,
                     }
                 };
                 let pod = state.pods.get_mut(&x).unwrap();
@@ -346,10 +344,9 @@ impl HandoffModel {
     }
 
     /// Serve a strong read at pod `x`, if it can (running, partition
-    /// warmed). Sets the staleness flag when the pod's visible prefix
-    /// (warm cutoff + own accepted writes) is behind the changelog — the
-    /// read returned state missing at least one acked write. Returns
-    /// whether the read was served.
+    /// warmed). Sets the staleness flag when the pod's visible prefix is
+    /// behind the changelog — the read returned state missing at least one
+    /// acked write. Returns whether the read was served.
     fn serve_read(&self, state: &mut SystemState, x: PodId, partition: Partition) -> bool {
         let pod = &state.pods[&x];
         if !pod.running {
@@ -375,8 +372,7 @@ impl HandoffModel {
         let Some(warm) = pod.warmed.get(&partition) else {
             return false;
         };
-        let visible = warm.cutoff.saturating_add(warm.accepted);
-        if visible < state.changelogs[&partition].len {
+        if warm.visible < state.changelogs[&partition].len {
             state.stale_strong_read = true;
         }
         state.read_served = true;
@@ -405,7 +401,8 @@ impl HandoffModel {
 
         let pod = state.pods.get_mut(&x).unwrap();
         if let Some(warm) = pod.warmed.get_mut(&partition) {
-            warm.accepted = warm.accepted.saturating_add(1);
+            // Its own write is immediately visible to it.
+            warm.visible = warm.visible.saturating_add(1);
         }
         if !pod.registered {
             pod.zombie_writes_left = pod.zombie_writes_left.saturating_sub(1);

--- a/rust/personhog-stateright/src/types.rs
+++ b/rust/personhog-stateright/src/types.rs
@@ -52,13 +52,17 @@ pub struct WarmState {
     /// `init_transactions` under the `EpochFenced` variant; the broker
     /// rejects produces bearing a stale epoch).
     pub epoch: u8,
-    /// The changelog HWM captured at warm time — everything below it is
-    /// visible to this pod's cache.
-    pub cutoff: u8,
-    /// Writes this pod itself accepted since warming. `cutoff + accepted`
-    /// is the pod's visible prefix of the changelog; a strong read served
-    /// while `changelog.len` exceeds it returns stale data.
-    pub accepted: u8,
+    /// How much of the changelog this pod's cache reflects: the HWM
+    /// captured at warm time, plus every write it has accepted since. A
+    /// strong read served while `changelog.len` exceeds this returns state
+    /// missing at least one acked write.
+    ///
+    /// The two halves are deliberately one number. Nothing reads them
+    /// apart — the cutoff is never consulted on its own, and the accept
+    /// count only ever advances the same total — so keeping them separate
+    /// would only split behaviorally identical states (warmed at 1 and
+    /// accepted nothing, versus warmed at 0 and accepted one).
+    pub visible: u8,
 }
 
 /// A warm caught between its two steps, under the rejected read-first
@@ -215,9 +219,9 @@ pub struct SystemState {
     /// in-flight handoff, clobbering it — the overlap
     /// `plan_partial_rebalance`'s pinning must make unreachable.
     pub double_planned_handoff: bool,
-    /// Set when a strong read is served by a pod whose visible prefix
-    /// (`cutoff + accepted`) is behind the changelog — the read returned
-    /// state missing at least one acked write.
+    /// Set when a strong read is served by a pod whose `WarmState::visible`
+    /// prefix is behind the changelog — the read returned state missing at
+    /// least one acked write.
     pub stale_strong_read: bool,
 
     // ── reachability flags (probe evidence, history encoding) ──


### PR DESCRIPTION
## Problem

`WarmState` split behaviorally identical states: a pod warmed at HWM 1 having accepted nothing looked different from one warmed at 0 having accepted one write.

Third of six commits shrinking the `personhog-stateright` shard. Stacked on #79898.

- `WarmState.cutoff` held the changelog HWM captured at warm time.
- `WarmState.accepted` held the writes the pod accepted since.
- The only consumer, `serve_read`, compares their sum against the changelog length. The only writer advances that same total.

## Changes

- The two fields become one `visible` field: the prefix of the changelog this pod's cache reflects.
- `PendingWarm.cutoff` stays. That one is a captured read, not a running total.

## How did you test this code?

State space 47.1M to 45.4M unique states (0.96x). Verdicts unchanged.

The wall-clock gain (1.02x) is below the measurement floor, so this lands for the state reduction and the simpler type, not for a timing claim. The same binary run twice varies by up to 1.08x on the machine used here, which is now recorded in the README so nobody reads noise as a result.

The collapse is small only because every current configuration sets `writes` to 1 or 2. It grows with the write budget.

Not verified: the effect on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

README sizing table refreshed. This also corrects the "everything else" row, which #79898 computed from the wrong subtotal.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Eli directed the work.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

The first measurement of this change looked 6% *slower*, which prompted running the same binary twice to establish a noise floor. That is where the 1.08x figure comes from, and it changed how the rest of the stack reports timing.

Nothing in this PR draws on material outside this repository.
