### PR TITLE
chore(personhog): record probe evidence only where a probe reads it

### DIFF
--- a/rust/personhog-stateright/README.md
+++ b/rust/personhog-stateright/README.md
@@ -28,17 +28,17 @@ web explorer.
 Configurations are deliberately small — state spaces grow
 combinatorially, and protocol bugs are structural, showing up at
 minimum viable scale or not at all.
-The suite explores ~45M states across 31 runs.
+The suite explores ~37M states across 31 runs.
 Its long pole is the two-partition double-zombie pair, which is most of the wall clock on its own:
 
 | Scenario | Unique states | Wall time |
 |---|---|---|
-| `epoch_fenced_two_partitions_double_zombie_is_safe` | 20.3M | 26s |
-| `two_partitions_double_zombie_loses_acked_writes` | 15.3M | 19s |
-| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.6M | 2.9s |
-| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 1.5M | 1.5s |
-| `current_two_partitions_single_zombie_is_safe` | 1.0M | 1.2s |
-| *everything else (26 runs)* | 4.6M | 5s |
+| `epoch_fenced_two_partitions_double_zombie_is_safe` | 16.2M | 21s |
+| `two_partitions_double_zombie_loses_acked_writes` | 12.6M | 15s |
+| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.6M | 3.0s |
+| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 1.1M | 1.0s |
+| `current_two_partitions_single_zombie_is_safe` | 0.9M | 1.0s |
+| *everything else (26 runs)* | 4.0M | 4s |
 
 Roughly: a second partition costs ~20x, a second failure in the budget ~10x, a third pod ~2x.
 Times are release mode, one scenario at a time on 14 cores — a CI runner with 4 slower cores is several times that, so treat them as ratios rather than absolutes.
@@ -60,6 +60,14 @@ Two kinds of change, two different expectations:
   A moved count means the transition relation changed, which was not the intent.
 - A deliberate collapse — dropping a field no guard or property reads back — must **shrink** `unique` while every verdict in `tests/model_tests.rs` stays as it was.
   Each one needs an argument in its commit message for why forgetting that information is a bisimulation, because a collapse that is wrong does not fail loudly: it quietly stops exploring states where a bug could live.
+
+Three kinds of field are worth suspecting when a configuration is too slow, all of them found by asking "who reads this, and when":
+
+- **A history counter.** It only ever grows, and nothing reads its magnitude, so every count reached roots its own copy of the subtree beneath it. Replace it with whatever the logic actually consumes — a flag, a sum, an owner id.
+- **A value only ever read through a function of it.** Two fields compared only via their sum, or only for equality, cost more than the one number or one identity that decides the outcome.
+- **Evidence for a probe that some configurations cannot reach.** A `sometimes` probe guarded to be vacuous outside its own scenario must not have its flag recorded elsewhere: nothing will look at it, and a sticky flag doubles its subtree. Gate the write on the same predicate the probe reads, so the two cannot drift.
+
+Note which way each mistake fails. Recording too little makes a `sometimes` probe find no discovery and `assert_properties` panic — loud. Dropping something a safety property needed is silent, which is why the argument matters more than the measurement.
 
 `generated / unique` is the duplicate-successor ratio, and `depth` is a racing maximum across checker threads, so it varies run to run and means nothing on its own.
 Wall times move by up to 10% between runs of the same binary, so judge a change by its state counts and treat a timing difference under that as no difference.

--- a/rust/personhog-stateright/src/model.rs
+++ b/rust/personhog-stateright/src/model.rs
@@ -169,6 +169,31 @@ fn model_desired_state(pod: PodId, state: &SystemState, partition: Partition) ->
 }
 
 impl HandoffModel {
+    // Whether each cancellation-reachability probe can reach its shape in
+    // this configuration, and therefore whether its evidence flag is worth
+    // recording.
+    //
+    // The flags are sticky, so recording one in a configuration whose probe
+    // can never read it is pure cost: every state that sets it roots a
+    // duplicate of the subtree beneath it, and most configurations set
+    // `cancels` to zero while still reaching `CancelDeadNewOwner`, which is
+    // unbudgeted. Each predicate below is used by both the `properties`
+    // probe and the `cancel_by_replacement` arm that feeds it, so the two
+    // cannot drift apart — and under-recording fails loudly rather than
+    // quietly, since the `sometimes` probe then finds no discovery and
+    // `assert_properties` panics.
+    fn probes_reaffirm(&self) -> bool {
+        // A reaffirm needs a move handoff whose old owner is alive, which
+        // takes a crash and a rejoin to manufacture.
+        self.cancels > 0 && self.rejoins > 0
+    }
+    fn probes_successor_replacement(&self) -> bool {
+        self.cancels > 0
+    }
+    fn probes_stash_racing_cancellation(&self) -> bool {
+        self.cancels > 0 && self.writes > 0
+    }
+
     fn pod_ids(&self) -> impl Iterator<Item = PodId> {
         0..self.pods
     }
@@ -429,10 +454,11 @@ impl HandoffModel {
     ///   state (`Observe`'s no-handoff arm drains to the assignment
     ///   owner, fail-closed), not decided on the deletion event.
     fn cancel_by_replacement(&self, state: &mut SystemState, p: Partition) {
-        if state
-            .routers
-            .values()
-            .any(|r| r.stash.get(&p).is_some_and(|q| !q.is_empty()))
+        if self.probes_stash_racing_cancellation()
+            && state
+                .routers
+                .values()
+                .any(|r| r.stash.get(&p).is_some_and(|q| !q.is_empty()))
         {
             state.cancelled_while_stash_parked = true;
         }
@@ -455,7 +481,9 @@ impl HandoffModel {
                     quorum: BTreeSet::new(),
                 },
             );
-            state.reaffirmed = true;
+            if self.probes_reaffirm() {
+                state.reaffirmed = true;
+            }
             return;
         }
         if let Some(target) = self.target_owner(state, p) {
@@ -475,7 +503,9 @@ impl HandoffModel {
                     quorum,
                 },
             );
-            state.replaced_with_successor = true;
+            if self.probes_successor_replacement() {
+                state.replaced_with_successor = true;
+            }
             return;
         }
         state.handoffs.remove(&p);
@@ -1407,19 +1437,19 @@ impl Model for HandoffModel {
                 // `assert_properties` stays usable across the matrix.
                 m.reads == 0 || s.read_served
             }),
-            // Replacement-cancellation reachability. Guards make each
-            // probe vacuous outside the configs shaped to reach it, so
-            // `assert_properties` stays usable across the matrix.
-            // A reaffirm needs a move handoff whose old owner is alive —
-            // which takes a crash *and* a rejoin to manufacture.
+            // Replacement-cancellation reachability. Each probe is vacuous
+            // outside the configurations shaped to reach it, so
+            // `assert_properties` stays usable across the matrix — and the
+            // same predicate decides whether its evidence flag is recorded
+            // at all, so a vacuous probe costs no state space.
             Property::<Self>::sometimes("cancellation_reaffirms", |m, s| {
-                m.cancels == 0 || m.rejoins == 0 || s.reaffirmed
+                !m.probes_reaffirm() || s.reaffirmed
             }),
             Property::<Self>::sometimes("cancellation_replaces_with_successor", |m, s| {
-                m.cancels == 0 || s.replaced_with_successor
+                !m.probes_successor_replacement() || s.replaced_with_successor
             }),
             Property::<Self>::sometimes("cancellation_races_a_parked_stash", |m, s| {
-                m.cancels == 0 || m.writes == 0 || s.cancelled_while_stash_parked
+                !m.probes_stash_racing_cancellation() || s.cancelled_while_stash_parked
             }),
             // Liveness: every full run ends quiescent and converged —
             // no handoffs in flight, every assignment served by a warm,


### PR DESCRIPTION
## Problem

Twenty-six of the 31 checker runs recorded evidence for probes those runs cannot reach, and each flag they set doubled the states beneath it.

Fourth of six commits shrinking the `personhog-stateright` shard. Stacked on #79899. This one is not in the original plan: I found it while measuring the others.

- `SystemState` carries three sticky flags: `reaffirmed`, `replaced_with_successor`, `cancelled_while_stash_parked`.
- Each is read by exactly one `sometimes` property, guarded to be vacuous unless the configuration can reach that scenario (`cancels > 0`, plus `rejoins > 0` or `writes > 0`).
- Every other configuration still recorded them, and being sticky each one split otherwise-identical states.
- That covers both heavy runs, because `CancelDeadNewOwner` is unbudgeted and reaches `cancel_by_replacement` even at `cancels: 0`.

## Changes

- Each write is gated on the predicate its probe reads.
- Both sides call the same `probes_*` method, so the writer and the reader cannot drift apart.

> [!NOTE]
> This fails safe. Recording too little makes the `sometimes` probe find no discovery, and `assert_properties` panics. The dangerous direction is dropping something a safety property needed, and no safety property reads these flags.

## How did you test this code?

State space 45.4M to 37.4M unique states (0.82x), suite wall clock 55.1s to 46.0s (1.20x).

The result splits exactly where it should, which is the check that the gating tracks the probes. The three configurations with every probe active report **byte-identical** counts: `cancellation_with_live_owner_reaffirms_and_resumes`, `cancellation_with_dead_owner_replaces_atomically`, `deadline_cancellation_by_replacement_is_safe_and_live`. Every `cancels: 0` configuration shrinks by 11 to 20%.

Not verified: the effect on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The README gains the three field shapes worth suspecting when a configuration is too slow, since this one was a new shape: evidence for a probe that some configurations cannot reach.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Eli directed the work and approved adding this commit to the series after I found it.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

I found this by asking "who reads this field, and when" of every remaining field, after the approved plan's collapses turned out smaller than estimated. I also checked `Pod.claims_authority` the same way and found no win: under `ClaimDetection::Prompt` it equals `registered` by construction, so it adds no states.

Nothing in this PR draws on material outside this repository.
