### PR TITLE
chore(personhog): model the broker fence as its holder, not an epoch

### DIFF
--- a/rust/personhog-stateright/README.md
+++ b/rust/personhog-stateright/README.md
@@ -28,17 +28,17 @@ web explorer.
 Configurations are deliberately small — state spaces grow
 combinatorially, and protocol bugs are structural, showing up at
 minimum viable scale or not at all.
-The suite explores ~37M states across 31 runs.
+The suite explores ~34M states across 31 runs.
 Its long pole is the two-partition double-zombie pair, which is most of the wall clock on its own:
 
 | Scenario | Unique states | Wall time |
 |---|---|---|
-| `epoch_fenced_two_partitions_double_zombie_is_safe` | 16.2M | 21s |
-| `two_partitions_double_zombie_loses_acked_writes` | 12.6M | 15s |
-| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.6M | 3.0s |
-| `epoch_fenced_resume_after_cancelled_handoff_stays_live` | 1.1M | 1.0s |
-| `current_two_partitions_single_zombie_is_safe` | 0.9M | 1.0s |
-| *everything else (26 runs)* | 4.0M | 4s |
+| `epoch_fenced_two_partitions_double_zombie_is_safe` | 13.1M | 20s |
+| `two_partitions_double_zombie_loses_acked_writes` | 12.6M | 16s |
+| `cancellation_with_live_owner_reaffirms_and_resumes` | 2.6M | 3.9s |
+| `current_two_partitions_single_zombie_is_safe` | 0.9M | 1.4s |
+| `probe_dual_role_pod_is_reachable_and_safe` | 0.7M | 1.1s |
+| *everything else (26 runs)* | 3.7M | 4s |
 
 Roughly: a second partition costs ~20x, a second failure in the budget ~10x, a third pod ~2x.
 Times are release mode, one scenario at a time on 14 cores — a CI runner with 4 slower cores is several times that, so treat them as ratios rather than absolutes.
@@ -99,7 +99,7 @@ queue — mapped to named production behavior for review:
 | `Action::ClientWrite` | The raw proxy leader path: stash if stashing, else forward to the table entry; leader admission = warmed + unfenced (`try_begin`) |
 | `Action::CrashRestartWithinTtl` | Process death + same-name restart before lease expiry: registration and assignments survive, memory wiped |
 | `Action::LeaseExpire` / `SelfFence` | Lease loss with the bounded zombie window before the keepalive self-fences (fix 1); same pair for routers, where lease loss also drops them from the freeze quorum |
-| `Changelog.epoch` under `Variant::EpochFenced` | Kafka transactional-producer fencing: warming = `init_transactions`, bumping the broker epoch; stale-epoch produces are rejected before any client ack |
+| `Changelog.epoch_holder` under `Variant::EpochFenced` | Kafka transactional-producer fencing: warming = `init_transactions`, which takes the fence from whoever held it; a produce from a fenced-out producer is rejected before any client ack |
 
 Full elimination of the second table would mean deterministic
 simulation — a trait seam over `PersonhogStore` with an in-memory

--- a/rust/personhog-stateright/src/model.rs
+++ b/rust/personhog-stateright/src/model.rs
@@ -244,15 +244,19 @@ impl HandoffModel {
         if !pod.registered && pod.zombie_writes_left == 0 {
             return false;
         }
-        let Some(warm) = pod.warmed.get(&partition) else {
+        if !pod.warmed.contains_key(&partition) {
             return false;
-        };
+        }
         if pod.fenced.contains(&partition) {
             return false;
         }
         match self.variant {
             Variant::Current => true,
-            Variant::EpochFenced => warm.epoch == state.changelogs[&partition].epoch,
+            // The broker accepts one producer per partition — whichever
+            // acquired the fence most recently. A warmed pod that is no
+            // longer the holder would be producing under a fenced-out
+            // producer, and the broker rejects it before any client ack.
+            Variant::EpochFenced => state.changelogs[&partition].epoch_holder == Some(x),
         }
     }
 
@@ -292,11 +296,10 @@ impl HandoffModel {
             let warm = {
                 let log = state.changelogs.get_mut(&partition).unwrap();
                 if self.variant == Variant::EpochFenced {
-                    log.epoch = log.epoch.wrapping_add(1);
+                    log.epoch_holder = Some(x);
                 }
                 WarmState {
                     for_handoff,
-                    epoch: log.epoch,
                     visible: log.len,
                 }
             };
@@ -325,10 +328,9 @@ impl HandoffModel {
                 // the gap sits beyond it, invisible forever.
                 let warm = {
                     let log = state.changelogs.get_mut(&partition).unwrap();
-                    log.epoch = log.epoch.wrapping_add(1);
+                    log.epoch_holder = Some(x);
                     WarmState {
                         for_handoff,
-                        epoch: log.epoch,
                         visible: cutoff,
                     }
                 };
@@ -856,23 +858,13 @@ impl HandoffModel {
                 } else if pod.fenced.contains(&p) {
                     mutate(last, |state| {
                         // `resume_partition`. Under EpochFenced the
-                        // cancelled handoff's target may have bumped the
-                        // broker epoch past this pod's producer;
-                        // production re-acquires the fence before
-                        // re-admitting writes, or every write would fail
-                        // as fenced until the next handoff.
+                        // cancelled handoff's target may have taken the
+                        // broker fence from this pod's producer;
+                        // production re-acquires it before re-admitting
+                        // writes, or every write would fail as fenced
+                        // until the next handoff.
                         if self.variant == Variant::EpochFenced {
-                            let log = state.changelogs.get_mut(&p).unwrap();
-                            log.epoch = log.epoch.wrapping_add(1);
-                            let epoch = log.epoch;
-                            state
-                                .pods
-                                .get_mut(&x)
-                                .unwrap()
-                                .warmed
-                                .get_mut(&p)
-                                .unwrap()
-                                .epoch = epoch;
+                            state.changelogs.get_mut(&p).unwrap().epoch_holder = Some(x);
                         }
                         state.pods.get_mut(&x).unwrap().fenced.remove(&p);
                     })

--- a/rust/personhog-stateright/src/types.rs
+++ b/rust/personhog-stateright/src/types.rs
@@ -48,10 +48,6 @@ pub struct WarmState {
     /// whose cache may predate writes accepted since, and is released
     /// and rebuilt.
     pub for_handoff: Option<HandoffId>,
-    /// The Kafka transactional-producer epoch held (production:
-    /// `init_transactions` under the `EpochFenced` variant; the broker
-    /// rejects produces bearing a stale epoch).
-    pub epoch: u8,
     /// How much of the changelog this pod's cache reflects: the HWM
     /// captured at warm time, plus every write it has accepted since. A
     /// strong read served while `changelog.len` exceeds this returns state
@@ -153,16 +149,24 @@ pub enum StashedRequest {
 }
 
 /// The Kafka changelog for one partition, reduced to what the safety
-/// invariants need: an append counter (the HWM) and the producer epoch
-/// the broker currently accepts.
+/// invariants need: an append counter (the HWM) and who currently holds
+/// the broker's producer fence.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Changelog {
     /// Number of records appended (the HWM).
     pub len: u8,
-    /// Broker-side producer epoch. Bumped by each warm under the
-    /// `EpochFenced` variant (production: `init_transactions` fencing);
-    /// ignored by `Current`.
-    pub epoch: u8,
+    /// The pod whose transactional producer the broker currently accepts,
+    /// under `Variant::EpochFenced` (production: the latest
+    /// `init_transactions` wins and every earlier producer is fenced out).
+    /// Always `None` under `Current`, which has no broker-side fence.
+    ///
+    /// This is an owner rather than an epoch number because nothing
+    /// compares epochs for order — the single consumer asks whether *this*
+    /// pod's producer is the live one. A counter would have split states
+    /// that differ only in how many fences had been acquired along the way,
+    /// and, being a `u8`, would eventually have wrapped a stale epoch onto
+    /// a live one and admitted a write it should reject.
+    pub epoch_holder: Option<PodId>,
 }
 
 /// The entire distributed system. One value = one node in the explored


### PR DESCRIPTION
## Problem

The broker producer epoch was a counter, so states reached by different numbers of fence acquisitions looked different even when nothing about them was.

Fifth of six commits shrinking the `personhog-stateright` shard. Stacked on #79900.

- `Changelog.epoch` and `WarmState.epoch` were monotonic `u8`s, bumped by every warm and every resume under `Variant::EpochFenced`.
- They had one consumer: `write_capable`, asking whether a warmed pod's producer epoch still equals the broker's.
- Every bump is immediately claimed by the pod that made it, so at most one pod can ever match. That is an owner, not a number.

## Changes

- `Changelog` carries `epoch_holder: Option<PodId>`, set only under `Variant::EpochFenced`.
- `WarmState` loses its epoch entirely.
- `write_capable` compares `epoch_holder == Some(x)`.

> [!NOTE]
> This also removes a latent wrong verdict. `wrapping_add` on a `u8` meant that after 256 acquisitions a stale epoch would alias the live one, and `write_capable` would admit a produce the broker rejects. Unreachable at today's budgets, and waiting for anyone who raises them. An `Option<PodId>` cannot alias.

## How did you test this code?

State space 37.4M to 33.7M unique states (0.90x). Wall clock unchanged at 1.00x, which is expected: the reduction lands entirely on the `EpochFenced` configurations, and the largest `Current` one is untouched.

The result splits exactly along that line, which is the check that the rewrite is faithful. All 19 `Current` runs report **byte-identical** counts, because the fields were constants there. All 12 `EpochFenced` runs shrink, the biggest test from 16.2M to 13.1M.

Not verified: the effect on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The README's production-coupling table now names `Changelog.epoch_holder` and describes fencing as taking the fence from whoever held it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Eli directed the work.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

The invariant that makes this exact — every bump is claimed by its bumper — I verified by reading all three assignment sites rather than assuming it. The `wrapping_add` aliasing hazard turned up in the same pass.

Nothing in this PR draws on material outside this repository.
