### PR TITLE
chore(personhog): stop existential runs at their counterexample

### DIFF
--- a/rust/personhog-stateright/README.md
+++ b/rust/personhog-stateright/README.md
@@ -28,17 +28,17 @@ web explorer.
 Configurations are deliberately small — state spaces grow
 combinatorially, and protocol bugs are structural, showing up at
 minimum viable scale or not at all.
-The suite explores ~34M states across 31 runs.
-Its long pole is the two-partition double-zombie pair, which is most of the wall clock on its own:
+The suite explores ~24M states across 31 runs.
+Its long pole is the two-partition epoch-fenced double zombie, which is more than half the wall clock on its own:
 
 | Scenario | Unique states | Wall time |
 |---|---|---|
-| `epoch_fenced_two_partitions_double_zombie_is_safe` | 13.1M | 20s |
-| `two_partitions_double_zombie_loses_acked_writes` | 12.6M | 16s |
+| `epoch_fenced_two_partitions_double_zombie_is_safe` | 13.1M | 19s |
+| `two_partitions_double_zombie_loses_acked_writes` | 3.7M | 4.0s |
 | `cancellation_with_live_owner_reaffirms_and_resumes` | 2.6M | 3.9s |
 | `current_two_partitions_single_zombie_is_safe` | 0.9M | 1.4s |
-| `probe_dual_role_pod_is_reachable_and_safe` | 0.7M | 1.1s |
-| *everything else (26 runs)* | 3.7M | 4s |
+| `probe_dual_role_pod_is_reachable_and_safe` | 0.7M | 1.2s |
+| *everything else (26 runs)* | 3.4M | 4s |
 
 Roughly: a second partition costs ~20x, a second failure in the budget ~10x, a third pod ~2x.
 Times are release mode, one scenario at a time on 14 cores — a CI runner with 4 slower cores is several times that, so treat them as ratios rather than absolutes.
@@ -68,6 +68,14 @@ Three kinds of field are worth suspecting when a configuration is too slow, all 
 - **Evidence for a probe that some configurations cannot reach.** A `sometimes` probe guarded to be vacuous outside its own scenario must not have its flag recorded elsewhere: nothing will look at it, and a sticky flag doubles its subtree. Gate the write on the same predicate the probe reads, so the two cannot drift.
 
 Note which way each mistake fails. Recording too little makes a `sometimes` probe find no discovery and `assert_properties` panic — loud. Dropping something a safety property needed is silent, which is why the argument matters more than the measurement.
+
+### Runs that stop early
+
+A run that only asserts a counterexample *exists* does not need the rest of the space, so those call `explore_until` with the discoveries they assert and stop there.
+Everything asserting that a property *holds* still explores exhaustively — an `always` property is only proven by exhaustion, and stateright's default stopping condition never fires on these models anyway, since a safety property that holds never produces a discovery to stop on.
+
+The rule for touching one of these tests: adding an assertion that a discovery is *absent* means moving that run back to `explore`.
+The early exit makes the run prove less, not less well.
 
 `generated / unique` is the duplicate-successor ratio, and `depth` is a racing maximum across checker threads, so it varies run to run and means nothing on its own.
 Wall times move by up to 10% between runs of the same binary, so judge a change by its state counts and treat a timing difference under that as no difference.

--- a/rust/personhog-stateright/tests/model_tests.rs
+++ b/rust/personhog-stateright/tests/model_tests.rs
@@ -28,7 +28,7 @@
 use std::time::Instant;
 
 use personhog_stateright::model::{ClaimDetection, HandoffModel, Variant, WarmOrder};
-use stateright::{Checker, Model};
+use stateright::{Checker, HasDiscoveries, Model};
 
 /// Every checker explores in parallel: stateright defaults to a single
 /// thread, which left the largest models (the two-partition
@@ -39,12 +39,12 @@ fn parallelism() -> usize {
     std::thread::available_parallelism().map_or(1, Into::into)
 }
 
-/// Exhaustive exploration, plus optional size reporting.
+/// How every test in this file runs its checker, with optional size
+/// reporting.
 ///
-/// Every test explores through this method so the size of each scenario
-/// can be reported from the *real* test configurations — a separate
-/// config list would drift from what CI actually runs. Set
-/// `STATERIGHT_REPORT` to print them:
+/// Going through one place means the size of each scenario can be reported
+/// from the *real* test configurations — a separate config list would drift
+/// from what CI actually runs. Set `STATERIGHT_REPORT` to print them:
 ///
 /// ```sh
 /// STATERIGHT_REPORT=1 cargo test -p personhog-stateright --release -- --nocapture --test-threads=1
@@ -55,23 +55,57 @@ fn parallelism() -> usize {
 /// deliberate collapse must shrink it while every verdict below is
 /// unchanged.
 trait Explore {
+    /// Explore the whole reachable state space. Required by any run that
+    /// asserts a property *holds* — an `always` property is only proven by
+    /// exhaustion.
     fn explore(self, scenario: &str) -> impl Checker<HandoffModel>;
+
+    /// Explore only until `wanted` have all been discovered.
+    ///
+    /// For a run that asserts a counterexample *exists*, exhaustive search
+    /// is wasted after the counterexample turns up — and stateright's
+    /// default stopping condition never fires here. It waits for every
+    /// property to be discovered, but a discovery for an `always` property
+    /// is a violation, so the safety properties that hold never produce
+    /// one, and `converges_to_stable` keeps the checker waiting regardless.
+    ///
+    /// Only use this where every assertion is existential. A run that also
+    /// asserts a discovery is *absent* needs the whole space, and adding
+    /// such an assertion to one of these tests means putting it back on
+    /// [`Explore::explore`].
+    fn explore_until(self, scenario: &str, wanted: &[&'static str]) -> impl Checker<HandoffModel>;
 }
 
 impl Explore for HandoffModel {
     fn explore(self, scenario: &str) -> impl Checker<HandoffModel> {
         let start = Instant::now();
         let checker = self.checker().threads(parallelism()).spawn_bfs().join();
-        if std::env::var_os("STATERIGHT_REPORT").is_some() {
-            println!(
-                "STATERIGHT_REPORT\t{scenario}\tunique={}\tgenerated={}\tdepth={}\telapsed={:?}",
-                checker.unique_state_count(),
-                checker.state_count(),
-                checker.max_depth(),
-                start.elapsed(),
-            );
-        }
+        report(scenario, start, &checker);
         checker
+    }
+
+    fn explore_until(self, scenario: &str, wanted: &[&'static str]) -> impl Checker<HandoffModel> {
+        let start = Instant::now();
+        let checker = self
+            .checker()
+            .threads(parallelism())
+            .finish_when(HasDiscoveries::AllOf(wanted.iter().copied().collect()))
+            .spawn_bfs()
+            .join();
+        report(scenario, start, &checker);
+        checker
+    }
+}
+
+fn report(scenario: &str, start: Instant, checker: &impl Checker<HandoffModel>) {
+    if std::env::var_os("STATERIGHT_REPORT").is_some() {
+        println!(
+            "STATERIGHT_REPORT\t{scenario}\tunique={}\tgenerated={}\tdepth={}\telapsed={:?}",
+            checker.unique_state_count(),
+            checker.state_count(),
+            checker.max_depth(),
+            start.elapsed(),
+        );
     }
 }
 
@@ -149,8 +183,10 @@ fn current_protocol_single_zombie_pod_is_safe() {
 /// but sits beyond the warm HWM, invisible to the new owner forever.
 #[test]
 fn current_protocol_double_zombie_loses_acked_writes() {
-    let checker =
-        model(Variant::Current, 2, 1).explore("current_protocol_double_zombie_loses_acked_writes");
+    let checker = model(Variant::Current, 2, 1).explore_until(
+        "current_protocol_double_zombie_loses_acked_writes",
+        &["no_lost_acked_write", "no_split_write_acceptance"],
+    );
     assert!(
         checker.discovery("no_lost_acked_write").is_some(),
         "the double zombie must produce an acked-write-loss counterexample"
@@ -199,7 +235,10 @@ fn epoch_fenced_read_first_ordering_loses_acked_writes() {
         warm_order: WarmOrder::ReadFirst,
         ..model(Variant::EpochFenced, 2, 1)
     }
-    .explore("epoch_fenced_read_first_ordering_loses_acked_writes");
+    .explore_until(
+        "epoch_fenced_read_first_ordering_loses_acked_writes",
+        &["no_lost_acked_write"],
+    );
     assert!(
         checker.discovery("no_lost_acked_write").is_some(),
         "read-before-fence must produce an acked-write-loss counterexample"
@@ -302,7 +341,10 @@ fn two_partitions_double_zombie_loses_acked_writes() {
         zombie_window: 1,
         ..base()
     }
-    .explore("two_partitions_double_zombie_loses_acked_writes");
+    .explore_until(
+        "two_partitions_double_zombie_loses_acked_writes",
+        &["no_lost_acked_write"],
+    );
     assert!(checker.discovery("no_lost_acked_write").is_some());
 }
 
@@ -683,6 +725,17 @@ fn fencing_and_lease_gated_reads_together_close_the_double_zombie() {
         zombie_window: 1,
         ..base()
     };
+    // The two arms below that expect a stale read stop at it; the arm that
+    // asserts none exists has to explore everything.
+    let stale_reads_reachable = |variant, gated| {
+        cfg(variant, gated)
+            .explore_until(
+                "fencing_and_lease_gated_reads_together_close_the_double_zombie",
+                &["strong_reads_complete"],
+            )
+            .discovery("strong_reads_complete")
+            .is_some()
+    };
     let stale_reads = |variant, gated| {
         cfg(variant, gated)
             .explore("fencing_and_lease_gated_reads_together_close_the_double_zombie")
@@ -691,12 +744,12 @@ fn fencing_and_lease_gated_reads_together_close_the_double_zombie() {
     };
 
     assert!(
-        stale_reads(Variant::Current, true),
+        stale_reads_reachable(Variant::Current, true),
         "the read gate alone must not close it: the honest owner serves a read missing the \
          zombie's lost write"
     );
     assert!(
-        stale_reads(Variant::EpochFenced, false),
+        stale_reads_reachable(Variant::EpochFenced, false),
         "fencing alone must not close it: the zombie still answers reads"
     );
     assert!(
@@ -747,7 +800,10 @@ fn a_lapsed_claim_that_never_returns_fails_stability() {
         zombie_window: 1,
         ..base()
     }
-    .explore("a_lapsed_claim_that_never_returns_fails_stability");
+    .explore_until(
+        "a_lapsed_claim_that_never_returns_fails_stability",
+        &["converges_to_stable"],
+    );
     assert!(
         checker.discovery("converges_to_stable").is_some(),
         "an owner that refuses its own reads while looking alive to the coordinator \
@@ -765,27 +821,33 @@ fn a_lapsed_claim_that_never_returns_fails_stability() {
 /// does.
 #[test]
 fn prompt_detection_is_what_makes_the_read_gate_hold() {
-    let stale_reads = |detection| {
-        HandoffModel {
-            variant: Variant::EpochFenced,
-            lease_gated_reads: true,
-            claim_recovers: true,
-            claim_detection: detection,
-            crashes: 2,
-            zombie_window: 1,
-            ..base()
-        }
-        .explore("prompt_detection_is_what_makes_the_read_gate_hold")
-        .discovery("strong_reads_complete")
-        .is_some()
+    let cfg = |detection| HandoffModel {
+        variant: Variant::EpochFenced,
+        lease_gated_reads: true,
+        claim_recovers: true,
+        claim_detection: detection,
+        crashes: 2,
+        zombie_window: 1,
+        ..base()
     };
 
+    // The Delayed arm expects a stale read and stops at it; the Prompt arm
+    // asserts there is none, so it has to explore everything.
     assert!(
-        stale_reads(ClaimDetection::Delayed),
+        cfg(ClaimDetection::Delayed)
+            .explore_until(
+                "prompt_detection_is_what_makes_the_read_gate_hold",
+                &["strong_reads_complete"],
+            )
+            .discovery("strong_reads_complete")
+            .is_some(),
         "a claim outliving its lease must still leave stale reads reachable"
     );
     assert!(
-        !stale_reads(ClaimDetection::Prompt),
+        cfg(ClaimDetection::Prompt)
+            .explore("prompt_detection_is_what_makes_the_read_gate_hold")
+            .discovery("strong_reads_complete")
+            .is_none(),
         "dropping the claim with the registration must close them"
     );
 }


### PR DESCRIPTION
## Problem

Seven checker runs assert only that a counterexample *exists*, and each explored the entire state space to do it.

Sixth and last of the model-checker commits shrinking the `personhog-stateright` shard. Stacked on #79901.

Stateright's default stopping condition cannot fire on this model:

- It waits for every property to be discovered.
- A discovery for an `always` property is a violation, so the safety properties that hold never produce one.
- `converges_to_stable` is an `eventually` property, which keeps the checker waiting regardless.

## Changes

- Those runs go through a new `Explore::explore_until`, which sets `finish_when(HasDiscoveries::AllOf(..))` for exactly the discoveries the test asserts.
- Everything asserting a property *holds* still explores exhaustively. An `always` property is only proven by exhaustion.
- The two mixed tests keep their exhaustive arm. The fencing complementarity verdict and the prompt-detection verdict both assert a stale read is *absent* in one arm, and only the arms expecting one stop early.

> [!WARNING]
> This is the one way to weaken these tests by accident. Adding an "asserts absent" check to a run that stops early means moving it back to `explore`. The README and the method's own doc comment both say so.

## How did you test this code?

State space 33.7M to 24.4M unique states (0.73x), suite wall clock 46.2s to 34.0s (1.36x).

Almost all of it is `two_partitions_double_zombie_loses_acked_writes`, until now the second most expensive run in the suite: 12.6M to 3.7M states, 15.9s to 4.0s.

The early exit cannot weaken an existential assertion, because the assertion is satisfied by the discovery the run stops at. What it does give up is the incidental proof about the run's other properties, which is why it is limited to runs that assert nothing about them.

**Cumulative over the six commits: 83.5M to 24.4M states, 139.9s to 34.0s (4.1x).**

Not verified: the effect on CI.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The README gains a section on which runs stop early and the rule for touching them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Eli directed the work and asked for this to be explained before approving it.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

The reduction is bounded by BFS depth: the checker still explores every state shallower than the counterexample, which is why the small runs shrink by only 40% while the heavy one shrinks by 71%.

Nothing in this PR draws on material outside this repository.
