### PR TITLE
chore(ci): resize the stateright shard around the faster model checks

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -157,7 +157,12 @@ jobs:
                       "personhog-leader": 115,
                       "personhog-replica": 140,
                       "personhog-router": 38,
-                      "personhog-stateright": 700,
+                      # Re-measure this one after the next master run. The
+                      # previous 700 was calibrated before the model-checker
+                      # work below and understated the observed job by 2.5x
+                      # (1756s, of which 1572s was `cargo test`); this is the
+                      # post-change estimate, not an observation.
+                      "personhog-stateright": 600,
                       "posthog-symbol-data": 19,
                       "property-defs-rs": 136,
                       "posthog-replay-anonymizer": 20,
@@ -295,9 +300,14 @@ jobs:
             matrix: ${{ fromJSON(needs.affected.outputs.matrix) }}
         needs: [changes, affected]
         if: needs.changes.outputs.rust == 'true'
-        runs-on: depot-ubuntu-24.04-4
+        # The stateright shard is the model checker, and both halves of it
+        # scale with cores: one scenario explores multi-threaded with the
+        # machine to itself, the rest explore single-threaded across nextest's
+        # lanes. Depot bills per core-minute, so twice the cores costs nothing
+        # extra as long as the wall clock more than halves.
+        runs-on: ${{ contains(matrix.packages, 'personhog-stateright') && 'depot-ubuntu-24.04-8' || 'depot-ubuntu-24.04-4' }}
         # stateright model checks need more headroom than the other shards
-        timeout-minutes: ${{ contains(matrix.packages, 'personhog-stateright') && 40 || 20 }}
+        timeout-minutes: ${{ contains(matrix.packages, 'personhog-stateright') && 25 || 20 }}
         permissions:
             contents: read
         env:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -157,9 +157,7 @@ jobs:
                       "personhog-leader": 115,
                       "personhog-replica": 140,
                       "personhog-router": 38,
-                      # An estimate rather than a measurement; re-measure it
-                      # after the next master run.
-                      "personhog-stateright": 600,
+                      "personhog-stateright": 220,
                       "posthog-symbol-data": 19,
                       "property-defs-rs": 136,
                       "posthog-replay-anonymizer": 20,
@@ -297,14 +295,8 @@ jobs:
             matrix: ${{ fromJSON(needs.affected.outputs.matrix) }}
         needs: [changes, affected]
         if: needs.changes.outputs.rust == 'true'
-        # The stateright shard is the model checker, and both halves of it
-        # scale with cores: one scenario explores multi-threaded with the
-        # machine to itself, the rest explore single-threaded across nextest's
-        # lanes. Depot bills per core-minute, so twice the cores costs nothing
-        # extra as long as the wall clock more than halves.
-        runs-on: ${{ contains(matrix.packages, 'personhog-stateright') && 'depot-ubuntu-24.04-8' || 'depot-ubuntu-24.04-4' }}
-        # stateright model checks need more headroom than the other shards
-        timeout-minutes: ${{ contains(matrix.packages, 'personhog-stateright') && 25 || 20 }}
+        runs-on: depot-ubuntu-24.04-4
+        timeout-minutes: 20
         permissions:
             contents: read
         env:

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -157,11 +157,8 @@ jobs:
                       "personhog-leader": 115,
                       "personhog-replica": 140,
                       "personhog-router": 38,
-                      # Re-measure this one after the next master run. The
-                      # previous 700 was calibrated before the model-checker
-                      # work below and understated the observed job by 2.5x
-                      # (1756s, of which 1572s was `cargo test`); this is the
-                      # post-change estimate, not an observation.
+                      # An estimate rather than a measurement; re-measure it
+                      # after the next master run.
                       "personhog-stateright": 600,
                       "posthog-symbol-data": 19,
                       "property-defs-rs": 136,

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -7,10 +7,10 @@
 # suite from saturating the runner while a cluster is up.
 [test-groups]
 k3s = { max-threads = 1 }
-# The two-partition double-zombie models are the stateright suite's long
-# pole (roughly 15x anything else in it). Their checkers explore
-# multi-threaded, so each gets the whole thread budget to itself instead
-# of contending with the rest of the suite mid-explore.
+# The two-partition epoch-fenced double zombie is the stateright suite's long
+# pole — 13M states, several times anything else in it. Its checker explores
+# multi-threaded, so it gets the whole thread budget to itself instead of
+# contending with the rest of the suite mid-explore.
 stateright-heavy = { max-threads = 1 }
 
 [[profile.default.overrides]]
@@ -19,7 +19,7 @@ test-group = 'k3s'
 threads-required = 4
 
 [[profile.default.overrides]]
-filter = 'package(personhog-stateright) & test(two_partitions_double_zombie)'
+filter = 'package(personhog-stateright) & test(epoch_fenced_two_partitions_double_zombie_is_safe)'
 test-group = 'stateright-heavy'
 threads-required = "num-cpus"
 
@@ -33,10 +33,11 @@ fail-fast = false
 [profile.ci.junit]
 path = "junit.xml"
 
-# The two-partition double-zombie model checks each saturate every core
-# (stateright spawn_bfs); running them concurrently on a small CI runner
-# roughly doubles both. Requiring all test threads runs them one at a
-# time with the full machine each.
+# Same reservation under the CI profile. Its sibling
+# `two_partitions_double_zombie_loses_acked_writes` used to be reserved too,
+# but it only asserts a counterexample exists and now stops at one, which
+# leaves it a few seconds long — reserving the machine for it just serialized
+# it against the rest of the suite for nothing.
 [[profile.ci.overrides]]
-filter = 'package(personhog-stateright) and (test(two_partitions_double_zombie_loses_acked_writes) or test(epoch_fenced_two_partitions_double_zombie_is_safe))'
+filter = 'package(personhog-stateright) and test(epoch_fenced_two_partitions_double_zombie_is_safe)'
 threads-required = "num-cpus"

--- a/rust/personhog-stateright/README.md
+++ b/rust/personhog-stateright/README.md
@@ -77,8 +77,22 @@ Everything asserting that a property *holds* still explores exhaustively — an 
 The rule for touching one of these tests: adding an assertion that a discovery is *absent* means moving that run back to `explore`.
 The early exit makes the run prove less, not less well.
 
+### How the threads are divided
+
+Every checker explores with as many threads as the machine has, and `.config/nextest.toml` reserves the whole thread budget for the one scenario big enough to want it (`epoch_fenced_two_partitions_double_zombie_is_safe`) so it does not contend with the rest of the suite mid-explore.
+
+Two things worth knowing before tuning this.
+BFS parallelizes poorly here — 14 checker threads buy under a 3x speedup — so a checker asking for every core does not get every core's worth of work done.
+And a single-threaded BFS reports the *shortest* path to each discovery, which makes a failure far easier to read, so there is a real argument for exploring the small scenarios on one thread and letting nextest supply the parallelism instead.
+
+That argument has not been measured on a CI-sized machine, and it is not measurable on a large one: reducing nextest's lane count on a 14-core laptop just idles cores rather than emulating a 4-core runner.
+Reserving judgement until it can be measured where it matters.
+
 `generated / unique` is the duplicate-successor ratio, and `depth` is a racing maximum across checker threads, so it varies run to run and means nothing on its own.
 Wall times move by up to 10% between runs of the same binary, so judge a change by its state counts and treat a timing difference under that as no difference.
+
+Only the exhaustive runs have stable counts.
+A run that stops at its counterexample (see below) reports how far it happened to get, which depends on thread count and scheduling, so its numbers are informational and not a gate.
 
 ## Coupling to production (drift prevention)
 

--- a/rust/personhog-stateright/tests/model_tests.rs
+++ b/rust/personhog-stateright/tests/model_tests.rs
@@ -726,34 +726,29 @@ fn fencing_and_lease_gated_reads_together_close_the_double_zombie() {
         ..base()
     };
     // The two arms below that expect a stale read stop at it; the arm that
-    // asserts none exists has to explore everything.
-    let stale_reads_reachable = |variant, gated| {
+    // asserts none exists has to explore everything. Each arm reports under
+    // its own label, so their state counts stay comparable separately.
+    let stale_reads_reachable = |scenario, variant, gated| {
         cfg(variant, gated)
-            .explore_until(
-                "fencing_and_lease_gated_reads_together_close_the_double_zombie",
-                &["strong_reads_complete"],
-            )
-            .discovery("strong_reads_complete")
-            .is_some()
-    };
-    let stale_reads = |variant, gated| {
-        cfg(variant, gated)
-            .explore("fencing_and_lease_gated_reads_together_close_the_double_zombie")
+            .explore_until(scenario, &["strong_reads_complete"])
             .discovery("strong_reads_complete")
             .is_some()
     };
 
     assert!(
-        stale_reads_reachable(Variant::Current, true),
+        stale_reads_reachable("read_gate_alone", Variant::Current, true),
         "the read gate alone must not close it: the honest owner serves a read missing the \
          zombie's lost write"
     );
     assert!(
-        stale_reads_reachable(Variant::EpochFenced, false),
+        stale_reads_reachable("fencing_alone", Variant::EpochFenced, false),
         "fencing alone must not close it: the zombie still answers reads"
     );
     assert!(
-        !stale_reads(Variant::EpochFenced, true),
+        cfg(Variant::EpochFenced, true)
+            .explore("fencing_and_read_gate_together")
+            .discovery("strong_reads_complete")
+            .is_none(),
         "together they must close it"
     );
 }
@@ -835,17 +830,14 @@ fn prompt_detection_is_what_makes_the_read_gate_hold() {
     // asserts there is none, so it has to explore everything.
     assert!(
         cfg(ClaimDetection::Delayed)
-            .explore_until(
-                "prompt_detection_is_what_makes_the_read_gate_hold",
-                &["strong_reads_complete"],
-            )
+            .explore_until("delayed_claim_detection", &["strong_reads_complete"])
             .discovery("strong_reads_complete")
             .is_some(),
         "a claim outliving its lease must still leave stale reads reachable"
     );
     assert!(
         cfg(ClaimDetection::Prompt)
-            .explore("prompt_detection_is_what_makes_the_read_gate_hold")
+            .explore("prompt_claim_detection")
             .discovery("strong_reads_complete")
             .is_none(),
         "dropping the claim with the registration must close them"


### PR DESCRIPTION
## Problem

The stateright shard was the slowest job in Rust CI, and its configuration was sized for a model checker that the six commits below made 24x cheaper.

- `Test Rust (personhog-stateright)` took [29m16s on the last master run](https://github.com/PostHog/posthog/actions/runs/31050585733), against 7m25s to 11m57s for every other Rust shard.
- 1572s of that 1756s job was one `cargo test` step.
- The shard weight of `700` understated the real job by 2.5x, and the packer balances every other Rust shard against these numbers.
- The whole-machine reservation covered two tests, one of which no longer needs it.

## Changes

- The weight drops from 700 to 220. The weights model `cargo test` seconds, and this crate's isolated step measured 64s on 8 cores, so 220 is deliberately conservative rather than tight.
- The whole-machine reservation narrows to `epoch_fenced_two_partitions_double_zombie_is_safe`. Its sibling `two_partitions_double_zombie_loses_acked_writes` now stops at its counterexample and runs in about 4 seconds, so reserving the machine only serialized it against the rest of the suite.
- Each arm of the two multi-configuration verdict tests gets its own `STATERIGHT_REPORT` label. Three fencing configurations shared one label and two claim-detection configurations shared another, so their state counts could not be compared apart.

The runner and the timeout stay as they are, which is a reversal. I first gave the shard 8 cores and a 25-minute timeout. Then I measured it, and the job is now dominated by fixed setup rather than by the checks, so the second four cores buy about a minute for roughly 60% more Depot credits. Details under testing.

## How did you test this code?

Measured on this branch's own CI, which carries the whole stack:

| | before | after |
|---|---|---|
| `Run cargo test` | 1572s | **64s** |
| whole job | 1756s (29m16s) | **215s (3m35s)** |

The [step breakdown](https://github.com/PostHog/posthog/actions/runs/31212375007/job/92978337049) is what drove the reversal: 150s of the 215s is fixed cost every shard pays (databases 49s, repo setup 32s, checkout, Python), and only 64s scales with cores. That measurement was taken on 8 cores, so the 4-core figure this PR ships will be somewhat higher, and it is visible on this PR's own checks.

The weight change is visible in this PR's own checks, and it exposes something worth a follow-up. The packer no longer isolates the crate: it now shares a shard with seven others, which ran 14m8s with `cargo test` at 632s. That bucket's declared weights sum to 360s, so it is over-filled — but not because of this crate. `ingestion-consumer` is weighted 13, and two of the eight are absent from the table and fall back to a default. Recalibrating those is outside this PR.

That leaves the shard at 14m8s under the standard 20-minute timeout. The margin is the same one every other Rust shard already runs with, and the previous arrangement was a dedicated 29-minute job, so this is a smaller and more ordinary risk rather than a new one.

The relabelled tests pass locally in the release profile. I did not verify the nextest override resolution, because nextest is not installed on this machine. Per [the nextest docs](https://nexte.st/docs/configuration/per-test-overrides/), profile overrides resolve per setting and fall back to `profile.default`, so the `stateright-heavy` group membership still applies under `--profile ci`. Worth confirming with `cargo nextest show-config test-groups --profile ci`.

I also tested and rejected a change to the checker thread budget. Giving the small scenarios one thread each and letting nextest supply the parallelism is attractive, because BFS here buys under a 3x speedup from 14 threads and a single-threaded BFS reports shortest counterexample paths. Measured at four nextest lanes it came out 1.3x slower, but that measurement is invalid: cutting lanes on a 14-core laptop idles cores rather than emulating a 4-core runner. The question is open rather than answered, and the README records it that way.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

The README records the two measurement facts this work turned up: only exhaustive runs have stable state counts, and the thread-budget question is unmeasured.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude Opus 5) wrote this. Eli directed the work and asked me to validate the runner bump rather than assume it, which is what led to dropping it.

Skills invoked: `/stacking-prs`, `/writing-pr-descriptions`.

Two things changed across the session. The 8-core bump went in on an argument about core-minutes being cost-neutral if wall clock halved; once the real job time came back at 3m35s that condition was not met, so it came out again. And Greptile flagged a change-history comment on the weight, correctly per AGENTS.md, so the reasoning moved from the code into this description.

On validating the runner size: the suggestion was to check the production charts and Terraform repositories. Those describe the production Kubernetes fleet, and Depot Actions runners are ephemeral CI VMs from Depot's own account, so nothing there governs them. That turned out not to matter, since the bump is not shipping.

Nothing in this PR draws on material outside this repository.
